### PR TITLE
feat(workflows): decide a run's parked gates inside the run drawer (#1002)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -377,6 +377,29 @@ export interface ApprovalSummary {
    */
   thread?: string | null;
   /**
+   * Which **workflow run** parked this approval (#880) — the run's correlation
+   * id, the same value `WorkflowRunResult.runId` carries back to the console
+   * that pressed Run.
+   *
+   * The join, and the only one there is: it is what lets a second surface — the
+   * run drawer (#1002) — show the cards *this* run is held on without the host
+   * growing a run-scoped approvals route. Compare it for equality and nothing
+   * else; like every other id here it never reaches the screen.
+   *
+   * **Absent is not "unknown", it is "no workflow run behind this card"** — a
+   * chat turn, a scheduler tick, a task attempt. The host stamps it only for an
+   * *unlinked* park that carries a run id, precisely because `Effect::run_id`
+   * also carries task-attempt ids that must never be read as a workflow run
+   * (`workflow_run_of` in `src/company/runtime.rs`). Absent on a host predating
+   * the field too, and both must read the same way: such a card belongs to the
+   * Approvals page alone, exactly as every approval did before this shipped.
+   *
+   * Snake-case because the REST projection is
+   * (`ApprovalSummary::workflow_run_id` in `src/runtime/types.rs`); the GraphQL
+   * schema camel-cases the same field, and this console reads REST.
+   */
+  workflow_run_id?: string | null;
+  /**
    * Which turn's gated calls this one belongs to (#842) — an opaque key shared
    * by every approval a single agent turn parked.
    *

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1399,6 +1399,29 @@ export function AppShell({
                 runEventTick={workflowRunTick}
                 runEvents={workflowRunEvents}
                 listEventTick={workflowListTick}
+                // Issue #1002: a run that parked cards can be unblocked from
+                // the run drawer, without leaving the run to find the rows in a
+                // flat queue. The SAME feed the Approvals page and the sidebar
+                // badge read, handed over unfiltered — this is a second reader
+                // of one queue, so the page still lists every row and the badge
+                // still counts every row.
+                //
+                // The four maps below are the same console-local state the
+                // inline chat card is given, owned here for the same reason: an
+                // operator who decides in the drawer, steps over to Approvals
+                // and comes back must not find a card that forgot what they did.
+                // Their `decided` half is fed by the `approval_resolved` frame
+                // as well as by this console's own resolves, which is what makes
+                // a decision taken on the page settle in the drawer with no
+                // reload.
+                approvals={feed.approvals}
+                approvalsNow={feed.now}
+                decidingApprovals={decidingApprovals}
+                decidedApprovals={decidedApprovals}
+                failedApprovals={failedApprovals}
+                onDecideApproval={(approval, verdict, scope) =>
+                  void decideApproval(approval, verdict, scope)
+                }
               />
             </Suspense>
           )}

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -561,7 +561,7 @@ function ApprovalCard({
   // No cross-card dimming: another card being decided is not this card's
   // business, and treating it as such is the visual half of the #373 bug.
   return (
-    <Card>
+    <Card data-approval-id={a.id}>
       <CardContent className="flex flex-col gap-3 py-4">
         <ApprovalHeadline
           approval={a}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -49,6 +49,7 @@ import {
 import type { CompanyStreamEvent } from "@/hooks/use-events";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -74,6 +75,10 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
 import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
+// Issue #1002: the run drawer decides a run's parked cards in place, using the
+// same shared approval card the Approvals page and the inline chat card use.
+import { useAskerNames } from "@/components/approval-card";
+import type { DecidedApproval } from "@/views/chat/model";
 import { cn } from "@/lib/utils";
 import type { NodeRunState } from "@/lib/workflow-sample";
 // Issue #303: the canvas arithmetic, the run-state folds and the three drawers
@@ -92,10 +97,17 @@ import { WorkflowIndex, type IndexMode } from "@/views/workflows/WorkflowIndex";
 import { CopilotPanel } from "@/views/workflows/CopilotPanel";
 import { classifyRunError } from "@/views/workflows/run-error";
 import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+import { approvalsForRun } from "@/views/workflows/run-approvals";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 import { type NodeOutputView, nodeOutputFor } from "@/views/workflows/run-output";
 
 const NODE_TYPES = { oc: WorkflowNode };
+
+/** Stable empty defaults, so an omitted approvals prop cannot churn renders. */
+const EMPTY_APPROVALS: ApprovalSummary[] = [];
+const EMPTY_DECIDING: ReadonlyMap<string, Verdict> = new Map();
+const EMPTY_DECIDED: Record<string, DecidedApproval> = {};
+const EMPTY_FAILED: Record<string, string> = {};
 
 /** A stable empty default for `runEvents`, so an omitted prop does not hand the
  * fold a fresh array identity on every render. */
@@ -160,6 +172,12 @@ export function WorkflowsView({
   runEventTick = 0,
   runEvents = EMPTY_RUN_EVENTS,
   listEventTick = 0,
+  approvals = EMPTY_APPROVALS,
+  approvalsNow,
+  decidingApprovals = EMPTY_DECIDING,
+  decidedApprovals = EMPTY_DECIDED,
+  failedApprovals = EMPTY_FAILED,
+  onDecideApproval,
 }: {
   client: OpenCompanyClient;
   company: string | null;
@@ -209,6 +227,38 @@ export function WorkflowsView({
    * the fresh list no longer has.
    */
   listEventTick?: number;
+  /**
+   * The company's parked approvals — the **whole** queue (issue #1002), passed
+   * straight through to the run drawer, which narrows it to the run on screen.
+   *
+   * The same array the Approvals page renders and the sidebar badge counts, and
+   * that is the point: this view is a second *reader* of one queue, so it can
+   * never make the page show less or the badge disagree with it. Live, because
+   * the feed refreshes it on every `approval_resolved` frame — which is what
+   * stops a run drawer calling a step blocked after somebody else cleared it.
+   */
+  approvals?: ApprovalSummary[];
+  /** The feed's clock, for the cards' "waiting N minutes" line. */
+  approvalsNow?: number;
+  /** The verdict an approval is waiting on, keyed by id (issue #1002). */
+  decidingApprovals?: ReadonlyMap<string, Verdict>;
+  /** Verdicts already witnessed, with their last-seen summary (issue #1002). */
+  decidedApprovals?: Record<string, DecidedApproval>;
+  /** Decisions that did not land, keyed by approval id (issue #1002). */
+  failedApprovals?: Record<string, string>;
+  /**
+   * Record one decision on one approval — the shell's handler, which calls the
+   * same per-id `resolveApproval` the Approvals page calls (issue #1002).
+   *
+   * Absent when the caller has not wired the surface, in which case the drawer
+   * renders exactly as it did before #1002: it says the run parked cards and
+   * points at the queue, without offering to decide them.
+   */
+  onDecideApproval?: (
+    approval: ApprovalSummary,
+    verdict: Verdict,
+    scope: GrantScope,
+  ) => void;
 }) {
   const { resolvedTheme } = useTheme();
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
@@ -226,6 +276,16 @@ export function WorkflowsView({
   // shown output came from, not whatever has been typed since.
   const [request, setRequest] = useState("");
   const [ranWith, setRanWith] = useState("");
+  // Issue #1002: the roster read behind the cards' "Asked by" line, keyed to the
+  // approvals of the run on screen rather than to the whole queue — so a console
+  // with a run drawer closed does not fetch the roster for cards it is not
+  // rendering. `useAskerNames` itself is keyed on the asker id set, so this stays
+  // one read per company rather than one per poll.
+  const runApprovalCards = useMemo(
+    () => approvalsForRun(approvals, result?.runId),
+    [approvals, result?.runId],
+  );
+  const askerNames = useAskerNames(client, company, runApprovalCards);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   // Issue #259: the same dialog, hydrated from the selected graph. Separate
@@ -1936,6 +1996,16 @@ export function WorkflowsView({
           graph={graph}
           request={ranWith}
           onClose={() => setResult(null)}
+          // Issue #1002: the whole queue, narrowed by the panel to this run.
+          // Handed in unfiltered on purpose — the Approvals page reads the same
+          // array and must keep showing every row.
+          approvals={approvals}
+          now={approvalsNow}
+          askerNames={askerNames}
+          deciding={decidingApprovals}
+          decided={decidedApprovals}
+          failed={failedApprovals}
+          onDecide={onDecideApproval}
         />
       )}
 

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -8,6 +8,7 @@ import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
 import type {
   WorkflowGraph,
   WorkflowRunNode,
@@ -15,11 +16,39 @@ import type {
 } from "@/api/workflows";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ApprovalRow } from "@/views/chat/ApprovalRow";
+import type { DecidedApproval } from "@/views/chat/model";
 
 import { DeliveryRows } from "./RunHistoryPanel";
 // Issue #596: the per-node parse is now shared with the durable run inspector
 // and the pre-publish approvals card, so it lives in `run-output.ts`.
 import { type NodeResult, parseRunNodes } from "./run-output";
+// Issue #1002: which of the company's parked cards this run is held on.
+import { blockingApprovals, runApprovals, type RunApproval } from "./run-approvals";
+
+/** Stable empty defaults, so an omitted prop cannot churn the card's props. */
+const EMPTY_APPROVALS: ApprovalSummary[] = [];
+const EMPTY_NAMES = new Map<string, string>();
+const EMPTY_DECIDING: ReadonlyMap<string, Verdict> = new Map();
+const EMPTY_DECIDED: Record<string, DecidedApproval> = {};
+const EMPTY_FAILED: Record<string, string> = {};
+const EMPTY_VERDICTS: Record<string, Verdict> = {};
+
+/**
+ * The in-flight verdict for one approval, as its own map.
+ *
+ * Narrowed per row for the reason #373 established one surface over: a decision
+ * in flight on one of a run's cards must not freeze the buttons on the others.
+ * Falls back to a shared empty map so an idle row's props do not churn on every
+ * render of the drawer.
+ */
+function decidingFor(
+  id: string,
+  deciding: ReadonlyMap<string, Verdict>,
+): ReadonlyMap<string, Verdict> {
+  const verdict = deciding.get(id);
+  return verdict ? new Map([[id, verdict]]) : EMPTY_DECIDING;
+}
 
 /** The run-output drawer: one readable card per executed node (the producing
  * agent and its reply, markdown-rendered) plus the branch each condition node
@@ -31,6 +60,13 @@ export function RunResultPanel({
   graph,
   request,
   onClose,
+  approvals = EMPTY_APPROVALS,
+  now,
+  askerNames = EMPTY_NAMES,
+  deciding = EMPTY_DECIDING,
+  decided = EMPTY_DECIDED,
+  failed = EMPTY_FAILED,
+  onDecide,
 }: {
   result: WorkflowRunResult;
   graph: WorkflowGraph | null;
@@ -38,6 +74,46 @@ export function RunResultPanel({
    * nothing, in which case the line is omitted rather than showing a bare dash. */
   request: string;
   onClose: () => void;
+  /**
+   * The company's parked approvals — the **whole** queue (issue #1002), the
+   * same array the Approvals page and the sidebar badge read.
+   *
+   * Handed in whole and narrowed here, deliberately. Nothing upstream filters
+   * it, so this surface cannot make the page show less or the badge disagree
+   * with it: it is a second *reader* of one queue, not a second queue.
+   *
+   * And it is a **live** array — the feed refreshes it on every
+   * `approval_resolved` frame — which is what stops the drawer calling a step
+   * blocked after somebody else cleared it. Optional, so a caller that does not
+   * wire it gets exactly the pre-#1002 drawer.
+   */
+  approvals?: ApprovalSummary[];
+  /** The feed's clock, for the "waiting N minutes" line. Defaults to now. */
+  now?: number;
+  /** Agent id → display name, for the "Asked by" line. */
+  askerNames?: Map<string, string>;
+  /** The verdict an approval is waiting on, keyed by id; empty when idle. */
+  deciding?: ReadonlyMap<string, Verdict>;
+  /**
+   * Verdicts already witnessed, with the last-seen summary — from this drawer,
+   * the Approvals page, or another console over the stream.
+   *
+   * The host drops a resolved approval from the queue at once, so this is what
+   * lets a decided row settle in place rather than blinking out of the panel.
+   */
+  decided?: Record<string, DecidedApproval>;
+  /** Decisions that did not land, keyed by approval id — the message to show. */
+  failed?: Record<string, string>;
+  /**
+   * Record one decision, on one approval, by its own id.
+   *
+   * One ordinary per-id resolve per approval — the same call the Approvals page
+   * makes, through the same client. There is no batch decision on the wire and
+   * none is invented here: each park stays a separate single-use decision, so a
+   * racing operator on the other surface gets a real approval or a `NotParked`
+   * no-op receipt, never a double execution.
+   */
+  onDecide?: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) => void;
 }) {
   const nodeResults = useMemo(
     () => parseRunNodes(result.output, graph),
@@ -58,6 +134,18 @@ export function RunResultPanel({
   // cannot disagree about whether this run stopped for a person.
   const blockedNodes = result.blockedNodes ?? [];
   const parkedCount = result.approvals?.length ?? 0;
+  // Issue #1002. Derived from the LIVE queue, never from `result.approvals` —
+  // that is a receipt of what this run opened (#880) and nothing ever comes back
+  // to flip a row on it, so a panel grounded there would go on calling a step
+  // blocked long after the card was cleared. The receipt is used for the one
+  // thing it *is* authoritative about: which node parked which card.
+  const runRows = useMemo(
+    () => runApprovals(approvals, decided, result.runId, result.approvals),
+    [approvals, decided, result.runId, result.approvals],
+  );
+  const stillWaiting = useMemo(() => blockingApprovals(runRows), [runRows]);
+  /** Whether the drawer is actually offering the decision, not just naming it. */
+  const canDecideHere = runRows.length > 0 && !!onDecide;
 
   return (
     <div className="border-t bg-card/60" data-testid="workflow-run-result">
@@ -145,7 +233,16 @@ export function RunResultPanel({
             {blockedNodes.length === 1 ? "it" : "they"} produced nothing and the
             steps after {blockedNodes.length === 1 ? "it" : "them"} did not run.{" "}
             {parkedCount > 0
-              ? `This run parked ${parkedCount} approval${parkedCount === 1 ? "" : "s"}; decide ${parkedCount === 1 ? "it" : "them"} in Approvals, then run the workflow again — approving does not continue this run.`
+              ? `This run parked ${parkedCount} approval${parkedCount === 1 ? "" : "s"}; decide ${parkedCount === 1 ? "it" : "them"} ${
+                  // Issue #1002: the cards are on this screen now, so say so —
+                  // and keep naming Approvals, because that page is still the
+                  // queue and still holds every one of them. Only claimed when
+                  // the section is actually rendering: a run whose cards this
+                  // console cannot join (an old host that sends back no run id)
+                  // still gets the original sentence rather than a pointer to
+                  // something that is not there.
+                  canDecideHere ? "below or in Approvals" : "in Approvals"
+                }, then run the workflow again — approving does not continue this run.`
               : "Nothing here can be approved; change the policy and run the workflow again."}
           </p>
         )}
@@ -153,6 +250,24 @@ export function RunResultPanel({
           <p className="mb-2 text-xs text-muted-foreground">
             Waiting on: {result.pendingApprovals.join(", ")}
           </p>
+        )}
+
+        {/* Issue #1002: the half the drawer never had — the cards this run is
+            held on, decidable here, scoped to the run on screen. The Approvals
+            page still lists every one of these and stays the queue; this is a
+            second reader of it, narrowed, so an operator does not have to leave
+            the run they are looking at to unblock it. */}
+        {canDecideHere && onDecide && (
+          <RunApprovalsSection
+            rows={runRows}
+            stillWaiting={stillWaiting.length}
+            graph={graph}
+            now={now ?? Date.now()}
+            askerNames={askerNames}
+            deciding={deciding}
+            failed={failed}
+            onDecide={onDecide}
+          />
         )}
 
         {deliveries.length > 0 && <DeliveryRows deliveries={deliveries} />}
@@ -189,6 +304,108 @@ export function RunResultPanel({
             {JSON.stringify(result.output, null, 2)}
           </pre>
         </details>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The cards this run is held on, decidable in place (issue #1002).
+ *
+ * ## One row per approval, per-node, one decision each
+ *
+ * Each row renders the **shipped** approval card — the same
+ * `@/components/approval-card` pieces the Approvals page and the inline chat
+ * card are built from, through `ApprovalRow` — over a single-item list. A
+ * single-item card is exactly what that component rendered before #842
+ * consolidated batches: headline, payload, asker, waiting time and the
+ * grant-scope control, with one Approve and one Decline. Sharing the card
+ * rather than restating it is what keeps two surfaces from offering different
+ * things for one approval, and it means role redaction (#618) reaches here for
+ * free — a member sees "not shown to you" here for the same reason they see it
+ * on the page.
+ *
+ * **No batch gesture, deliberately.** There is no "approve all for this run"
+ * here: a run holds until *every* parked gate is decided only after #994, and
+ * until then run-shaped wording ("the run continues once the remaining N are
+ * decided") would be a claim today's behaviour does not honour. Per-node
+ * resolve is true now and ships now; the grouping folds in with #994's `batch`
+ * field.
+ *
+ * ## What it does not do
+ *
+ * It resolves. It does not re-implement resolving: `onDecide` is the shell's
+ * one handler, calling the one `resolveApproval` the page calls, per id. No
+ * optimistic local state either — a row reads decided only once a verdict has
+ * actually been witnessed, so a stale entry can never be offered for a second
+ * decision from here.
+ */
+function RunApprovalsSection({
+  rows,
+  stillWaiting,
+  graph,
+  now,
+  askerNames,
+  deciding,
+  failed,
+  onDecide,
+}: {
+  rows: RunApproval[];
+  /** How many of them nobody has decided yet. */
+  stillWaiting: number;
+  graph: WorkflowGraph | null;
+  now: number;
+  askerNames: Map<string, string>;
+  deciding: ReadonlyMap<string, Verdict>;
+  failed: Record<string, string>;
+  onDecide: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) => void;
+}) {
+  const nameById = useMemo(
+    () => new Map(graph?.nodes.map((n) => [n.id, n.name]) ?? []),
+    [graph],
+  );
+
+  return (
+    <div
+      className="mb-3 rounded-lg border bg-background/40 p-2"
+      data-testid="workflow-run-approvals"
+      data-still-waiting={stillWaiting}
+    >
+      <p className="text-xs font-medium">
+        {stillWaiting > 0
+          ? `Waiting on you — ${stillWaiting} of ${rows.length} still to decide`
+          : // Every card answered. It must NOT say the run is continuing: an
+            // agent node is not re-enterable, so approving never resumes this
+            // run — the same thing the blocked sentence above says, said again
+            // at the moment the operator has just finished deciding.
+            `All ${rows.length} decided — run the workflow again to continue`}
+      </p>
+      <div className="mt-1 space-y-1">
+        {rows.map((row) => {
+          const node = row.nodeId
+            ? (nameById.get(row.nodeId) ?? row.nodeId)
+            : null;
+          return (
+            <div key={row.approval.id} data-testid="workflow-run-approval">
+              {node && (
+                <p className="px-4 text-3xs uppercase tracking-wide text-muted-foreground">
+                  {node}
+                </p>
+              )}
+              <ApprovalRow
+                approvals={[row.approval]}
+                now={now}
+                askerNames={askerNames}
+                // Narrowed to this row's own approval: a decision in flight on
+                // another card of the same run is not this card's business.
+                deciding={decidingFor(row.approval.id, deciding)}
+                decided={row.verdict ? { [row.approval.id]: row.verdict } : EMPTY_VERDICTS}
+                failed={failed}
+                onDecide={onDecide}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/views/workflows/run-approvals.ts
+++ b/frontend/src/views/workflows/run-approvals.ts
@@ -1,0 +1,126 @@
+// Which of the company's parked approvals belong to the run on screen (#1002).
+//
+// The run drawer already *tells* an operator their run stopped for a person —
+// the parked badge and the "Not finished — …" sentence (#880 / #881) — and gave
+// them nowhere to act: `resolveApproval` was reachable from the Approvals page
+// and the shell alone, so deciding meant leaving the run, finding the row in a
+// flat queue, and coming back. This is the join that lets a second surface ask
+// the same question the page asks, narrowed to one run.
+//
+// ## Purely additive
+//
+// Nothing here filters the queue. These helpers take the queue the Approvals
+// page and the sidebar badge already read (`feed.approvals`) and *select* from
+// it for one run; the page keeps showing every row, and the badge keeps
+// counting every row. An approval no workflow run parked — a chat turn, a
+// scheduler tick, a task attempt — matches nothing here and belongs to the page
+// alone, exactly as it did before this shipped.
+//
+// ## Live, never a snapshot
+//
+// The run body carries its own receipt of what it parked
+// (`WorkflowRunApprovalRow`), and that receipt is deliberately frozen: #880
+// wrote it as "this run opened this card", never as "this card is still
+// waiting". Deriving the drawer's blocking list from it would go stale the
+// instant anyone decided anything, anywhere. So the *rows* come from the live
+// queue and the receipt is used only for the one thing it is authoritative
+// about — which node a card was parked by.
+
+import type { ApprovalSummary, Verdict } from "@/api/types";
+import type { WorkflowRunApprovalRow } from "@/api/workflows";
+import type { DecidedApproval } from "@/views/chat/model";
+
+/** One approval the run on screen is held on, and what has become of it. */
+export interface RunApproval {
+  approval: ApprovalSummary;
+  /**
+   * The verdict already witnessed for it — from this drawer, from the Approvals
+   * page, or from another operator's console over the event stream — or `null`
+   * while it is still waiting on somebody.
+   */
+  verdict: Verdict | null;
+  /**
+   * The agent node whose turn parked it, when the run's receipt named one.
+   * `null` for a card the receipt does not cover (an older host, or a park the
+   * run recorded without node identity).
+   */
+  nodeId: string | null;
+}
+
+/**
+ * The still-queued approvals this run parked.
+ *
+ * `runId` may legitimately be absent — a host predating #371 hands back no run
+ * correlation id — and an absent id joins to **nothing** rather than to
+ * everything. Matching every unlinked approval there would put another run's
+ * cards, and a scheduler's, under this run's steps.
+ */
+export function approvalsForRun(
+  approvals: readonly ApprovalSummary[],
+  runId: string | null | undefined,
+): ApprovalSummary[] {
+  if (!runId) return [];
+  return approvals.filter((a) => a.workflow_run_id === runId);
+}
+
+/** Approval id → the node that parked it, from the run's own receipt (#880). */
+export function nodeByApprovalId(
+  rows: readonly WorkflowRunApprovalRow[] | undefined,
+): Map<string, string> {
+  const byId = new Map<string, string>();
+  for (const row of rows ?? []) {
+    if (row.approvalId && row.nodeId) byId.set(row.approvalId, row.nodeId);
+  }
+  return byId;
+}
+
+/**
+ * Every card this run is (or was) held on, in a stable order.
+ *
+ * Two sources, and both are needed:
+ *
+ *  - the **live queue**, which is the whole point — a card decided anywhere
+ *    leaves it, so the drawer stops calling that step blocked without a reload;
+ *  - the shell's **witnessed decisions**, which keep the last-seen summary of a
+ *    card the queue has already dropped, so the operator's own decision settles
+ *    in place instead of blinking out of the panel. Exactly what the inline chat
+ *    card does with the same map, and for the same reason.
+ *
+ * Ordered by park time then id, which is stable across a refresh: the queue's
+ * array identity changes on every poll, and a list that reordered under the
+ * operator's cursor would be its own bug.
+ */
+export function runApprovals(
+  approvals: readonly ApprovalSummary[],
+  decided: Readonly<Record<string, DecidedApproval>>,
+  runId: string | null | undefined,
+  receipt?: readonly WorkflowRunApprovalRow[],
+): RunApproval[] {
+  if (!runId) return [];
+  const nodes = nodeByApprovalId(receipt);
+  const byId = new Map<string, RunApproval>();
+  for (const approval of approvalsForRun(approvals, runId)) {
+    byId.set(approval.id, {
+      approval,
+      // A decision witnessed while the queue has not yet dropped the row: the
+      // resolve's answer and the feed's next poll are two moments, and for that
+      // gap the row must read as decided rather than offering its buttons again.
+      verdict: decided[approval.id]?.verdict ?? null,
+      nodeId: nodes.get(approval.id) ?? null,
+    });
+  }
+  for (const [id, d] of Object.entries(decided)) {
+    if (byId.has(id) || d.approval.workflow_run_id !== runId) continue;
+    byId.set(id, { approval: d.approval, verdict: d.verdict, nodeId: nodes.get(id) ?? null });
+  }
+  return [...byId.values()].sort(
+    (a, b) =>
+      a.approval.at_millis - b.approval.at_millis ||
+      (a.approval.id < b.approval.id ? -1 : a.approval.id > b.approval.id ? 1 : 0),
+  );
+}
+
+/** The subset still waiting on somebody — what the run is actually held on. */
+export function blockingApprovals(rows: readonly RunApproval[]): RunApproval[] {
+  return rows.filter((r) => r.verdict === null);
+}

--- a/frontend/test/e2e/workflow-inline-approval.spec.ts
+++ b/frontend/test/e2e/workflow-inline-approval.spec.ts
@@ -1,0 +1,280 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issue #1002 — a run parked on a gated node is unblocked
+ * from the workflow window, without leaving it.
+ *
+ * Before this, the run drawer *told* the operator: a "parked N approvals" badge
+ * and a "Not finished — …" sentence. Acting on it meant leaving the run,
+ * finding the row in a flat queue on the Approvals page, deciding it, and
+ * navigating back. `resolveApproval` was reachable from exactly two places, and
+ * neither of them was the screen the operator was already looking at.
+ *
+ * Written in the spirit of `chat-inline-approval.spec.ts`, and asserting the
+ * same four things one surface over: **placement** (a card belongs to the run
+ * that parked it, and must not appear under another), **addition** (the
+ * Approvals page still shows everything, including this one), the **verb** (one
+ * ordinary per-id resolve, never a batch), and **settling** (a decision made on
+ * the page must not leave a stale card offering buttons in the run window).
+ *
+ * The approvals feed, the run body and the event stream are **mocked**, and
+ * deliberately so. Parking a real workflow gate needs an inference backend and
+ * a model that chooses a policy-gated call, and none of what is under test is
+ * the parking. Only the *workflow* itself is real — authored over HTTP against
+ * the live host, so the picker and the Run button are the console's own.
+ *
+ * Like the rest of `test/e2e` this needs a running host; `playwright.config.ts`
+ * brings one up for the `Console E2E` lane (issue #428).
+ */
+
+const COMPANY_SCOPE = "/api/v1/company";
+
+/** The run the console will be handed back, and the id every card joins on. */
+const RUN_ID = "run-e2e-1002";
+
+/** The graph the spec authors, runs, and tears down. */
+const WORKFLOW = { id: "inline_approval_1002", name: "Inline approval 1002" };
+
+/** The card this run parked, on its "spec" node. */
+const PARKED = {
+  id: "appr-run-1002",
+  kind: "external.publish",
+  amount_usd: null,
+  at_millis: Date.now(),
+  task: { link: "unlinked" },
+  agent: "writer",
+  payload: { path: "/notes/quarterly-update.md" },
+  workflow_run_id: RUN_ID,
+};
+
+/**
+ * A card another workflow run parked. It is served on the same queue — nothing
+ * upstream filters it — so it is the leak this surface must not have.
+ */
+const OTHER_RUN = {
+  id: "appr-other-run",
+  kind: "external.publish",
+  amount_usd: null,
+  at_millis: Date.now(),
+  task: { link: "unlinked" },
+  agent: "writer",
+  payload: { path: "/notes/somebody-elses.md" },
+  workflow_run_id: "run-somebody-else",
+};
+
+/** A card no workflow run parked — a chat turn or a scheduler tick. */
+const PAGE_ONLY = {
+  id: "appr-page-only-1002",
+  kind: "email.send",
+  amount_usd: null,
+  at_millis: Date.now(),
+  task: { link: "unlinked" },
+};
+
+/** The settled run body: blocked on "spec", with its frozen park receipt. */
+const BLOCKED_RUN = {
+  output: { nodes: {} },
+  pendingApprovals: ["spec"],
+  runId: RUN_ID,
+  deliveries: [],
+  nodes: [{ nodeId: "spec", status: "blocked", elapsedMs: 1_200 }],
+  blockedNodes: [{ nodeId: "spec", tools: ["publish_artifact"], approvalIds: [PARKED.id] }],
+  approvals: [
+    { nodeId: "spec", tool: "publish_artifact", outcome: "parked", approvalId: PARKED.id },
+  ],
+};
+
+function graphBody() {
+  return {
+    id: WORKFLOW.id,
+    name: WORKFLOW.name,
+    description: "Created by the #1002 e2e spec.",
+    nodes: [
+      { id: "start", kind: "trigger", name: "Start" },
+      { id: "spec", kind: "agent", name: "Draft the note", agent: "ceo" },
+      { id: "done", kind: "output", name: "Report" },
+    ],
+    edges: [
+      { from: "start", to: "spec" },
+      { from: "spec", to: "done" },
+    ],
+  };
+}
+
+test.beforeEach(async ({ page, request }) => {
+  // Skip the first-run tour, whose overlay would swallow the clicks below.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+  const res = await request.post(`${COMPANY_SCOPE}/workflows`, { data: graphBody() });
+  expect(res.ok(), `create ${WORKFLOW.id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+});
+
+test.afterEach(async ({ request }) => {
+  await request.delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW.id}`).catch(() => undefined);
+});
+
+/**
+ * Answer the approvals feed. Matched by suffix rather than by full path, for
+ * the reason the chat spec gives: the console addresses a *named* company while
+ * the host also answers a single-company alias, and a pattern pinned to one of
+ * them stops intercepting — silently — when the deployment shape changes.
+ */
+async function serveApprovals(page: Page, approvals: unknown[]) {
+  await page.route("**/approvals", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(approvals),
+    }),
+  );
+}
+
+/** Hand back a settled, blocked run instead of actually walking the graph. */
+async function serveBlockedRun(page: Page) {
+  await page.route("**/workflows/*/run", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(BLOCKED_RUN),
+    }),
+  );
+}
+
+/** Capture every resolve the console sends, and answer each one. */
+async function captureResolves(page: Page, bodies: unknown[]) {
+  await page.route("**/approvals/*", (route) => {
+    bodies.push({ url: route.request().url(), body: route.request().postDataJSON() });
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ recorded: true, alreadyResolved: false }),
+    });
+  });
+}
+
+function picker(page: Page) {
+  return page.getByRole("combobox").first();
+}
+
+/** Opens Workflows, selects the spec's graph, and runs it. */
+async function runTheWorkflow(page: Page) {
+  await page.goto("/#/workflows");
+  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+  await picker(page).click();
+  await page.getByRole("option", { name: WORKFLOW.name, exact: true }).click();
+  await expect(picker(page)).toContainText(WORKFLOW.name);
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+  await expect(page.getByTestId("workflow-run-result")).toBeVisible({ timeout: 60_000 });
+}
+
+/** The run-scoped approvals section inside the run drawer. */
+function section(page: Page): Locator {
+  return page.getByTestId("workflow-run-approvals");
+}
+
+/** The card for one approval, wherever it is rendered. */
+function card(page: Page, approvalId: string): Locator {
+  return page.locator(`[data-approval-id="${approvalId}"]`);
+}
+
+test("a run's parked card is decidable in the run window, and only that run's", async ({
+  page,
+}) => {
+  await serveApprovals(page, [PARKED, OTHER_RUN, PAGE_ONLY]);
+  await serveBlockedRun(page);
+
+  await runTheWorkflow(page);
+
+  // The card the run is held on, told in full — the same shared approval card
+  // the Approvals page renders, so the payload being consented to is on screen
+  // rather than a bare "approve?".
+  await expect(section(page)).toBeVisible({ timeout: 30_000 });
+  await expect(card(page, PARKED.id)).toBeVisible();
+  await expect(card(page, PARKED.id)).toContainText("/notes/quarterly-update.md");
+  // Named by the step that parked it, by its graph name.
+  await expect(section(page)).toContainText("Draft the note");
+
+  // The trap: the whole queue is handed to this view unfiltered, so the scoping
+  // has to hold on the same render that can see all three. Another run's card
+  // is not this run's business, and a card no run parked belongs to the page.
+  await expect(card(page, OTHER_RUN.id)).toHaveCount(0);
+  await expect(card(page, PAGE_ONLY.id)).toHaveCount(0);
+});
+
+test("the Approvals page still shows everything, including the run's card", async ({ page }) => {
+  // Additive, not a replacement. The page stays the queue and the system of
+  // record — an approval that reached no run window still has to be somewhere,
+  // and the one that did must not have been moved out of the queue to get here.
+  await serveApprovals(page, [PARKED, OTHER_RUN, PAGE_ONLY]);
+
+  await page.goto("/#/approvals");
+  await expect(page.getByText("3 things need your approval")).toBeVisible({ timeout: 30_000 });
+  await expect(card(page, PARKED.id)).toBeVisible();
+});
+
+test("deciding in the run window sends one ordinary resolve, on that card's own id", async ({
+  page,
+}) => {
+  await serveApprovals(page, [PARKED, OTHER_RUN, PAGE_ONLY]);
+  await serveBlockedRun(page);
+  const bodies: unknown[] = [];
+  await captureResolves(page, bodies);
+
+  await runTheWorkflow(page);
+  await card(page, PARKED.id).getByRole("button", { name: "Approve" }).click();
+
+  await expect.poll(() => bodies.length, { timeout: 30_000 }).toBe(1);
+  // One per-id resolve, addressed to this approval — no batch route, no batch
+  // body. Each park stays a separate single-use decision underneath, which is
+  // what makes a racing operator on the Approvals page safe: they get a real
+  // approval or a `NotParked` no-op receipt, never a double execution.
+  expect(bodies[0]).toMatchObject({ body: { verdict: "approve" } });
+  expect(String((bodies[0] as { url: string }).url)).toContain(`/approvals/${PARKED.id}`);
+
+  // The card settles rather than vanishing, so the decision visibly lands.
+  await expect(card(page, PARKED.id)).toContainText(/Approved/, { timeout: 30_000 });
+  await expect(card(page, PARKED.id).getByRole("button", { name: "Approve" })).toHaveCount(0);
+});
+
+test("a decision made on the Approvals page settles the run window, with no reload", async ({
+  page,
+}) => {
+  // The staleness guard, end to end. The run body's park receipt still names
+  // this card — a receipt never flips — so a run window grounded in it would go
+  // on offering two live buttons for a decision that is already made.
+  //
+  // The clearing is driven by what the HOST answers, flipped between polls,
+  // rather than by a resolution frame raced against the drawer opening: this is
+  // the state another operator's decision leaves behind, and the console has to
+  // reach it on its own without a reload.
+  let clearedElsewhere = false;
+  await page.route("**/approvals", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(clearedElsewhere ? [] : [PARKED]),
+    }),
+  );
+  await serveBlockedRun(page);
+
+  await runTheWorkflow(page);
+  await expect(section(page)).toBeVisible({ timeout: 30_000 });
+  await expect(card(page, PARKED.id).getByRole("button", { name: "Approve" })).toBeVisible();
+
+  // Somebody clears it on the Approvals page, or in another console. The host
+  // drops the row from the queue at once.
+  clearedElsewhere = true;
+
+  // No reload, no re-run: this window stops calling the step blocked. The run
+  // body it was rendered from has not changed at all — its `approvals` receipt
+  // and its `blockedNodes` still name this exact card.
+  await expect(card(page, PARKED.id)).toHaveCount(0, { timeout: 30_000 });
+  await expect(section(page)).toHaveCount(0);
+  // …and the drawer is still the drawer: the receipt sentence is untouched,
+  // because a receipt is a true statement about what the run opened.
+  await expect(page.getByTestId("workflow-run-result")).toContainText("parked 1 approval");
+});

--- a/frontend/test/unit/workflow-run-approvals.test.ts
+++ b/frontend/test/unit/workflow-run-approvals.test.ts
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import type { WorkflowRunResult } from "@/api/workflows";
+import type { DecidedApproval } from "@/views/chat/model";
+import { approvalsForRun, runApprovals } from "@/views/workflows/run-approvals";
+import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+
+/**
+ * Deciding a run's parked gates inside the run window (issue #1002).
+ *
+ * The drawer already told the operator their run stopped for a person — the
+ * parked badge and the "Not finished — …" sentence — and gave them nowhere to
+ * act: they had to leave the run, find the row in a flat queue, resolve it, and
+ * come back. This suite pins the three claims that make the second surface
+ * safe rather than merely convenient:
+ *
+ *  1. it is **scoped to the run on screen** — a card another run parked, or one
+ *     no workflow run parked at all, must not appear under these steps;
+ *  2. it **subscribes rather than snapshots** — a card cleared on the Approvals
+ *     page, or by another operator, stops being shown as blocking here with no
+ *     reload. This is the likeliest defect in the whole change, so it is tested
+ *     against a fixture whose frozen receipt still lists the card: an
+ *     implementation reading `result.approvals` passes every other test here
+ *     and fails that one;
+ *  3. it issues **one ordinary per-id resolve per approval** — no batch on the
+ *     wire, no optimistic local state that could offer a settled card again.
+ *
+ * A jsdom render rather than a pure test, and it earns the exception the same
+ * way `approval-batch-card` does: the claims above are only true at the click
+ * and at the re-render. A pure test of the filter can see which rows were
+ * selected, not whether a button was offered for them.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+const RUN = "run-a1b2";
+const OTHER_RUN = "run-zzzz";
+
+function approval(id: string, over: Partial<ApprovalSummary> = {}): ApprovalSummary {
+  return {
+    id,
+    kind: "external.publish",
+    amount_usd: null,
+    at_millis: T0,
+    task: { link: "unlinked" },
+    agent: "writer",
+    payload: { path: `/notes/${id}.md` },
+    workflow_run_id: RUN,
+    ...over,
+  };
+}
+
+/** The card this run's "spec" node parked. */
+const MINE = approval("appr-mine");
+/** The same shape, parked by a different run — the leak this must not have. */
+const THEIRS = approval("appr-theirs", {
+  workflow_run_id: OTHER_RUN,
+  payload: { path: "/notes/theirs.md" },
+});
+/** A card no workflow run parked — a chat turn or a scheduler tick. */
+const PAGE_ONLY = approval("appr-page-only", { workflow_run_id: undefined });
+
+/**
+ * The run body, as the host answers a synchronous run that blocked.
+ *
+ * `approvals` is the run's own **receipt** (#880): a frozen record of what this
+ * run opened, which nothing ever comes back to flip. Every fixture below keeps
+ * it fully populated — including the staleness case — precisely so a panel that
+ * grounded its blocking list there would still find `appr-mine` listed and be
+ * caught.
+ */
+function result(over: Partial<WorkflowRunResult> = {}): WorkflowRunResult {
+  return {
+    output: {},
+    pendingApprovals: ["spec"],
+    runId: RUN,
+    blockedNodes: [
+      { nodeId: "spec", tools: ["publish_artifact"], approvalIds: [MINE.id] },
+    ],
+    approvals: [
+      {
+        nodeId: "spec",
+        tool: "publish_artifact",
+        outcome: "parked",
+        approvalId: MINE.id,
+      },
+    ],
+    ...over,
+  };
+}
+
+interface Decision {
+  id: string;
+  verdict: Verdict;
+  scope: GrantScope;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let decisions: Decision[];
+
+async function render(
+  approvals: ApprovalSummary[],
+  decided: Record<string, DecidedApproval> = {},
+  run: WorkflowRunResult = result(),
+) {
+  await act(async () => {
+    root.render(
+      createElement(RunResultPanel, {
+        result: run,
+        graph: {
+          id: "feature_pipeline",
+          name: "Feature pipeline",
+          nodes: [{ id: "spec", kind: "agent", name: "Draft the note", agent: "writer" }],
+          edges: [],
+        },
+        request: "",
+        onClose: () => {},
+        approvals,
+        now: T0 + 60_000,
+        askerNames: new Map([["writer", "Staff Writer"]]),
+        deciding: new Map(),
+        decided,
+        failed: {},
+        onDecide: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) =>
+          decisions.push({ id: approval.id, verdict, scope }),
+      }),
+    );
+  });
+}
+
+/** The run-scoped approvals section, or `null` when the drawer offers none. */
+function section(): HTMLElement | null {
+  return container.querySelector<HTMLElement>('[data-testid="workflow-run-approvals"]');
+}
+
+/** The card rendered for one approval id, wherever it sits in the drawer. */
+function card(id: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-approval-id="${id}"]`);
+}
+
+/** The approve/decline control on one approval's card, if it is offered one. */
+function control(id: string, label: string): HTMLButtonElement | null {
+  const buttons = [...(card(id)?.querySelectorAll("button") ?? [])];
+  return (
+    (buttons.find((b) => (b.textContent ?? "").includes(label)) as HTMLButtonElement) ?? null
+  );
+}
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  decisions = [];
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the join", () => {
+  it("selects only the cards this run parked", () => {
+    expect(approvalsForRun([MINE, THEIRS, PAGE_ONLY], RUN)).toEqual([MINE]);
+  });
+
+  it("joins to nothing when the host handed back no run id", () => {
+    // A host predating #371 answers with no `runId`. An absent id must match
+    // NOTHING rather than everything — matching every unlinked card there would
+    // put another run's gates, and a scheduler's, under this run's steps.
+    expect(approvalsForRun([MINE, THEIRS, PAGE_ONLY], undefined)).toEqual([]);
+    expect(runApprovals([MINE], {}, null)).toEqual([]);
+  });
+
+  it("keeps a decided card the queue has already dropped", () => {
+    // The host removes a resolved approval from `GET …/approvals` at once, so
+    // the witnessed map is the only thing left to draw the row from — without
+    // it the operator's own decision blinks out of the panel instead of
+    // settling in place.
+    const rows = runApprovals([], { [MINE.id]: { verdict: "approve", approval: MINE } }, RUN);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].verdict).toBe("approve");
+  });
+});
+
+describe("the run drawer's approvals section", () => {
+  it("offers a decision for the card this run parked, naming the step", async () => {
+    await render([MINE]);
+
+    expect(section()).not.toBeNull();
+    // The node the gate is on, by its graph name rather than its id.
+    expect(section()?.textContent).toContain("Draft the note");
+    expect(control(MINE.id, "Approve")).not.toBeNull();
+    expect(control(MINE.id, "Decline")).not.toBeNull();
+    // The same content the Approvals page shows, from the same shared card —
+    // the payload is the thing being consented to.
+    expect(section()?.textContent).toContain("/notes/appr-mine.md");
+  });
+
+  it("offers nothing for a card another run parked, or one no run parked", async () => {
+    // The queue is handed over WHOLE — nothing upstream filters it, which is
+    // what keeps the Approvals page and the badge intact. So the scoping has to
+    // hold here, on the same render that can see all three.
+    await render([MINE, THEIRS, PAGE_ONLY]);
+
+    expect(card(MINE.id)).not.toBeNull();
+    expect(card(THEIRS.id)).toBeNull();
+    expect(card(PAGE_ONLY.id)).toBeNull();
+    expect(section()?.getAttribute("data-still-waiting")).toBe("1");
+  });
+
+  it("resolves on the approval's own id, once, with no batch", async () => {
+    await render([MINE]);
+    await click(control(MINE.id, "Approve")!);
+
+    // One ordinary per-id resolve. There is no batch decision on the wire and
+    // none is invented here: each park stays a separate single-use decision, so
+    // an operator racing on the Approvals page gets a real approval or a
+    // `NotParked` no-op receipt — never a double execution.
+    expect(decisions).toEqual([
+      { id: MINE.id, verdict: "approve", scope: { kind: "once" } },
+    ]);
+  });
+
+  it("declines on its own id too", async () => {
+    await render([MINE]);
+    await click(control(MINE.id, "Decline")!);
+
+    expect(decisions).toEqual([{ id: MINE.id, verdict: "deny", scope: { kind: "once" } }]);
+  });
+
+  it("says the cards are here as well as on the Approvals page", async () => {
+    await render([MINE]);
+
+    // Additive wording: the queue is still named, because it is still the queue
+    // and still holds every one of these rows.
+    expect(container.textContent).toContain("below or in Approvals");
+  });
+
+  it("keeps the pre-#1002 drawer when no decision handler is wired", async () => {
+    await act(async () => {
+      root.render(
+        createElement(RunResultPanel, {
+          result: result(),
+          graph: null,
+          request: "",
+          onClose: () => {},
+          approvals: [MINE],
+        }),
+      );
+    });
+
+    // No handler, no surface — and the sentence goes back to pointing at the
+    // page alone rather than at a section that is not there.
+    expect(section()).toBeNull();
+    expect(container.textContent).toContain("in Approvals");
+    expect(container.textContent).not.toContain("below or in Approvals");
+  });
+});
+
+describe("the staleness guard", () => {
+  it("stops showing a card cleared elsewhere as blocking, with no reload", async () => {
+    await render([MINE]);
+    expect(section()?.getAttribute("data-still-waiting")).toBe("1");
+    expect(control(MINE.id, "Approve")).not.toBeNull();
+
+    // What the operator clearing it on the Approvals page (or another operator,
+    // in another console) produces here: the `approval_resolved` frame refreshes
+    // the feed, the host has already dropped the row, and the shell records the
+    // witnessed verdict. No remount, no reload — the same panel, new props.
+    //
+    // `result` is UNCHANGED, and that is the whole point of the test: its
+    // receipt still lists `appr-mine` as a park this run opened, because a
+    // receipt never flips. A panel that derived its blocking list from
+    // `result.approvals` would still be offering two live buttons here.
+    await render([], { [MINE.id]: { verdict: "approve", approval: MINE } });
+
+    expect(section()?.getAttribute("data-still-waiting")).toBe("0");
+    expect(control(MINE.id, "Approve")).toBeNull();
+    expect(control(MINE.id, "Decline")).toBeNull();
+    // The row does not vanish — the operator has to be able to see the decision
+    // land — but it states the verdict instead of asking again.
+    expect(card(MINE.id)?.textContent).toContain("Approved");
+    expect(section()?.textContent).toContain("run the workflow again");
+  });
+
+  it("is not fooled by the run's own frozen receipt", async () => {
+    // The negative form of the same guard, stated on its own so a regression
+    // names itself: a run whose receipt says it parked a card, whose live queue
+    // no longer carries it and which this console never witnessed being decided
+    // — another tab decided it before this drawer ever opened — offers nothing.
+    await render([]);
+
+    expect(section()).toBeNull();
+    expect(card(MINE.id)).toBeNull();
+    // And the receipt itself still says what it always said, so the sentence
+    // above the section is untouched by any of this.
+    expect(container.textContent).toContain("parked 1 approval");
+  });
+});


### PR DESCRIPTION
## Summary

When a run parks on a gated node, the workflow window already told you — a `N pending approvals` badge and a `Waiting on: <nodes>` line — and gave you no way to act. You had to leave the run, find the entry in a flat queue, resolve it, and navigate back.

This adds a run-scoped approvals section to the run drawer, so the run is unblocked from the window you are already looking at.

**Purely additive.** The Approvals page is unchanged and is not replaced — it stays the queue and the system of record. The badge is unchanged. Nothing is filtered out of the existing list. The queue is handed to the view **whole** and narrowed inside the panel, so this is a second *reader*, not a second queue.

## API Or Behavior Changes

Console only — no backend file, no route, no projection, no schema. #880 already put the parking run id on the approval; the console's TypeScript type simply did not know about it.

- New `RunApprovalsSection` in the run drawer, one row per approval, rendering the **existing** chat approval row (itself built on `@/components/approval-card`), so payload, asker, waiting time, grant scope and #618 role redaction all arrive for free. No second approval card exists.
- Per-row Approve / Decline only. Same handler chat uses, so one ordinary per-id `resolveApproval` per decision — the single-use property is untouched.
- Panel props are all optional, so an unwired caller renders the exact pre-#1002 drawer.
- The #881 sentence now reads "decide them below or in Approvals", and only when the section is actually rendering.

## The staleness guard is the point of this PR

Two surfaces onto one queue means the obvious implementation is wrong: a panel built from the run's own park receipt keeps showing a card that was cleared on the Approvals page, until you reload. The join is therefore derived from the **live queue**, not the receipt.

Proved by replacing the derivation with a receipt-grounded snapshot and re-running:

```
× the staleness guard > stops showing a card cleared elsewhere as blocking, with no reload
  → expected '1' to be '0'
× the staleness guard > is not fooled by the run's own frozen receipt
Tests  3 failed | 8 passed (11)
```

Both fixtures keep the run's receipt **fully populated** while the live queue empties, so a receipt-grounded panel is caught and a subscription-grounded one passes. Restored → 11/11. The e2e mirrors it by flipping what the host answers between polls with the run body untouched.

One judgement worth surfacing: an **absent** run id joins to **nothing**, not everything. A host predating #371 would otherwise drag another run's cards — and the scheduler's — under these steps.

## Tests

`frontend/test/unit/workflow-run-approvals.test.ts` (11) and `frontend/test/e2e/workflow-inline-approval.spec.ts` (4) — placement, the Approvals page still showing everything, exactly one per-id resolve, and settling with no reload. The e2e authors a real workflow over HTTP and mocks only the feed, the run body and the stream, so it needs no live brain.

`frontend/test/unit/approvals-count-agreement.test.ts` passes **unedited** — the badge-equals-queue contract from #932 is intact.

- [x] `npm run typecheck`, `typecheck:unit`, `typecheck:e2e` (all three — the base script skips test directories)
- [x] `npx vitest run` — 898 passed, 88 files
- [x] `npm run build`
- [x] `cargo check` — Rust untouched, proven rather than assumed

No client-side optimistic state: a row reads decided only once a verdict has actually been witnessed, so a stale entry can never be offered twice from here. Resolving from two surfaces at once was already safe — removal and outcome are one critical section in the host — and nothing here bypasses it.

## Documentation

None needed; the reasoning lives in doc comments on the new join module next to the code that depends on it.

## Related

Deliberately **no "approve all" gesture** in this PR — it needed the `batch` field from #994, which merged after this branch was cut. That grouping, and the run-shaped wording ("the run continues once the remaining N are decided"), is the natural follow-up and belongs here rather than on the Approvals page: after #994 a run holds until every parked gate is decided, so approving one of three deliberately does nothing visible. On a flat queue that reads as broken; in the run drawer, with the remaining gates listed, it reads as correct.

Closes #1002