### PR TITLE
fix(approvals): sweep maintenance for every company, scheduled or not (#971)

### DIFF
--- a/docs/modules/policy/README.md
+++ b/docs/modules/policy/README.md
@@ -26,7 +26,9 @@ parked effect is journaled one way and survives a restart with its original id):
 Effects are classified into the checkpoint groups (Spend / Send / Sign /
 Publish / Hire / Identity) with per-group supervised defaults. Parked approvals
 **default-deny on silence**: they expire to `deny` after a configurable window
-(default 7 days) measured against an injectable clock. The operator may **edit**
+(`[policy].approval_ttl_hours`, default 24 hours) measured against an
+injectable clock. The window is enforced at resolution time by the gate itself;
+draining the queue is the `MaintenanceTicker`'s job (issue #971). The operator may **edit**
 a parked effect's payload and approve the amended version; the follow-up cycle
 shows the brain both the original and the edit.
 

--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -19,6 +19,30 @@ learns the verdict.
 due. The clock is injectable so schedule firing is tested deterministically
 without wall-clock waits.
 
+`maintenance.rs` is the third minute loop, and it is deliberately not a cron at
+all: `MaintenanceTicker` retires overdue approvals, unredeemed grants and stale
+fire claims for **every** registered company, once a minute (issue #971). One
+process-wide task over `CompanyRegistry`, shaped like `workflow_scheduler.rs`
+and for the same reason — a company can be registered after boot.
+
+That shape *is* the fix. Maintenance used to ride `scheduler.rs`'s loop, which
+is only spawned for a company whose manifest declares a `[[schedule]]` — so a
+company with none never swept anything, at any age, and a tenant driven entirely
+by workflow schedules accumulated approvals for days. Anything that must happen
+for every company hangs off the registry, never off a per-company spawn.
+
+Two things differ from the schedulers beside it. A **paused** company is still
+swept: this finishes work rather than starting it, and a paused company's queue
+is the one most likely to be full of requests nobody will answer. And the sweep
+is **capped per tick, oldest first**, so the first pass after a shortened
+deadline drains a backlog over a few minutes instead of bursting. Enforcement is
+not here — the gate re-checks the deadline under the lock that removes a parked
+entry, so an overdue approval default-denies on the operator's click whether or
+not this ever ran; what this adds is that the queue empties and the badge goes
+back to describing current state. `CompanyScheduler::tick_maintenance` remains
+as a thin delegate over the same `sweep_company`, so the two callers cannot
+drift.
+
 `workflow_scheduler.rs` drives the *other* kind of cron: the `schedule` a saved
 workflow graph's `trigger` node carries (issue #169). Same `CronExpr` matcher,
 same injectable `Clock`, same minute-boundary loop — but **one process-wide

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -45,9 +45,28 @@ effect emitted ─▶ evaluate ─▶ Allow ─▶ execute, journal
                             ApprovalResolved event ─▶ follow-up cycle
 ```
 
-- **Default-deny on silence**: parked approvals expire (default 7 days,
-  configurable) to `deny`. Nothing irreversible ever happens because the
+- **Default-deny on silence**: parked approvals expire to `deny` after a
+  deadline — **24 hours** by default, set per company with
+  `[policy].approval_ttl_hours`. Nothing irreversible ever happens because the
   Operator was on vacation.
+- **Something has to run the sweep.** The deadline binds at resolution time
+  regardless — `resolve_at` re-checks it under the same lock that removes the
+  parked entry, so an overdue approval default-denies on the operator's click
+  whether or not anything swept. Emptying the *queue* is a separate job, done
+  by the process-wide `MaintenanceTicker` (`src/runtime/maintenance.rs`) once a
+  minute for every registered company. Until issue #971 it rode the manifest
+  cron scheduler, which is not spawned for a company with no `[[schedule]]` —
+  so those companies parked approvals forever and swept none, at any age.
+  Deadlines and the thing that enforces them are two features, and only one of
+  them was shipped.
+- **Retirement is a deny nobody made, and says so.** The journal records
+  `ApprovalExpired { reason }`, the event log gets
+  `ApprovalResolved { verdict: Deny, by: System }`, and the operator SSE frame
+  carries `automatic: true` so the console can say "expired" rather than
+  attributing the decline to whoever is looking. No grant is ever minted on
+  this path: an approval that disappears must never read as one that was
+  granted. Each card carries its own `expiresAtMillis`, so nothing vanishes
+  unannounced.
 - **Edit** lets the Operator amend the effect payload (fix the email, lower
   the amount) and approve the amended version; the brain sees both the
   original and the edit.

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -101,6 +101,8 @@ mode = "supervised"                # readonly | supervised | auto | full
 always_approve = ["publish_artifact"]   # default []; names a tool or an open
                                    # effect kind — see approvals.md
 auto_approve_under_usd = 1.0
+approval_ttl_hours = 24            # default 24; how long a parked approval
+                                   # waits before it default-denies
 
 [place]                            # see company-as-agent/
 discoverable = false               # default false: going public is opt-in
@@ -275,7 +277,12 @@ prompt = "Weekly review and operator digest"
   outward reads run unattended, anything that leaves the company or spends on
   submit still parks). `always_approve` lists effect kinds that park for
   approval regardless of amount and wins over every tier including `full`;
-  `auto_approve_under_usd` lets small spends through. The parse default is
+  `auto_approve_under_usd` lets small spends through; `approval_ttl_hours` sets
+  how long a parked approval waits before it default-denies (24 hours by
+  default — see [approvals.md](../company-brain/approvals.md), issue #971).
+  Omitting it is not the same as writing `24`: the key stays absent from the
+  persisted seed, which is what keeps a future change to the default from
+  looking like an edit and discarding a console `[policy]` override. The parse default is
   `supervised`, with all money/publish/filing effects gated — but a **new**
   company is given `auto`, written into its manifest explicitly rather than
   left to that default. See

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -397,7 +397,16 @@ export interface TimelineEntry {
   waitedMillis?: number;
 }
 
-/** What became of an approval (#333). `pending` is still waiting on a human. */
+/**
+ * What became of an approval (#333). `pending` is still waiting on a human.
+ *
+ * `expired` was declared here from the start and was **unreachable** until
+ * #971: nothing swept approvals for a company without a manifest schedule, so
+ * no approval ever aged out and no surface ever needed to render this. It is
+ * reachable now. Render it through `approvalStatusLabel` in `lib/language` —
+ * an operator must be able to tell the no they made from the one the deadline
+ * made, and neither should ever appear as a raw identifier.
+ */
 export type TaskApprovalStatus = "pending" | "approved" | "denied" | "expired";
 
 /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -300,6 +300,21 @@ export interface ApprovalSummary {
   amount_usd: number | null;
   at_millis: number;
   /**
+   * Epoch-millis this approval default-denies if nobody decides it (#971) —
+   * `at_millis` plus the company's approval deadline
+   * (`[policy].approval_ttl_hours`, 24 hours by default).
+   *
+   * **Never recompute it.** The host projects it from the gate that actually
+   * enforces the deadline; a console that added its own 24 hours to
+   * `at_millis` would show a deadline nothing enforces, and an operator would
+   * act on "in 3h" and be refused.
+   *
+   * Optional because a host may predate the field. Absent means "this host
+   * does not report deadlines" — render the card exactly as before rather
+   * than guessing one.
+   */
+  expires_at_millis?: number | null;
+  /**
    * Which board task this approval was parked for (#333). Mirrors `TaskLink` in
    * `src/runtime/journal.rs`.
    *

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -38,7 +38,7 @@ import {
 
 import type { OpenCompanyClient } from "@/api/client";
 import { GRANT_DURATIONS, type ApprovalSummary, type GrantScope } from "@/api/types";
-import { approvalAction, money, payloadLines, timeAgo } from "@/lib/language";
+import { approvalAction, money, payloadLines, timeAgo, untilLabel } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
 const KIND_ICONS: Record<string, LucideIcon> = {
@@ -150,6 +150,20 @@ export function ApprovalMeta({
         </>
       )}
       <span>{timeAgo(a.at_millis, now)}</span>
+      {/* The deadline (#971), beside how long it has already waited — the two
+          halves of "is this still worth deciding?".
+
+          Rendered only when the host reports one. An absent
+          `expires_at_millis` means the host does not have deadlines, NOT that
+          this card has none, so the console shows nothing rather than
+          computing a deadline nothing would enforce: an operator who acted on
+          an invented "in 3h" would be refused. */}
+      {typeof a.expires_at_millis === "number" && (
+        <>
+          <span aria-hidden>·</span>
+          <span>declined {untilLabel(a.expires_at_millis, now)}</span>
+        </>
+      )}
       {status && (
         <>
           <span aria-hidden>·</span>

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -148,6 +148,22 @@ export type CompanyStreamEvent =
       atMillis: number;
       approvalId: string;
       verdict: string;
+      /**
+       * The **host** resolved this, not a person (#971) — an approval that sat
+       * past its deadline and was declined on its own.
+       *
+       * A bit derived from the event's actor, never the actor itself: this feed
+       * is deny-by-default and carries no `by` and no user id, which is a
+       * property the host asserts. It answers the only question the console has
+       * — "did somebody decide this?" — and answering it matters because
+       * without it an expiry toasted "Approval denied", telling an operator
+       * they had declined a request they never saw.
+       *
+       * Absent on a person's own decision and against a host that predates the
+       * field. Both mean the same thing to a reader: treat it as a decision
+       * somebody made, exactly as before.
+       */
+      automatic?: boolean;
     }
   | {
       type: "lifecycle_changed";
@@ -693,12 +709,26 @@ export function handleEvent(
       // Refresh first, then say so. The refresh is what settles an inline card
       // whose decision was made on the Approvals page (or in another tab).
       onApprovalEvent?.(event);
-      toast(
-        event.verdict === "approve" ? "Approval granted" : "Approval denied",
-        {
-          description: "An approval was just resolved.",
-        },
-      );
+      // #971: an expiry is a resolution — a default-deny on silence — but it is
+      // not a decision anybody made. Saying "Approval denied" for one told the
+      // operator they had declined something they never saw, and shortening the
+      // deadline to 24 hours turns that from rare into routine. So the
+      // host-resolved case gets its own words, and only that case: `automatic`
+      // is set solely on the System arm, so a person's own decision reads
+      // exactly as it did before.
+      if (event.automatic) {
+        toast("Approval expired", {
+          description:
+            "It passed its deadline with no decision, so it was declined.",
+        });
+      } else {
+        toast(
+          event.verdict === "approve" ? "Approval granted" : "Approval denied",
+          {
+            description: "An approval was just resolved.",
+          },
+        );
+      }
       break;
     case "lifecycle_changed":
       toast(`Company is now ${event.to}`, {

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -2,6 +2,7 @@
 // never exposes runtime internals ("agent graph", "tier", "dispatch", "cycle",
 // "checkpoint", "A2A"). Everything a person sees goes through this layer.
 
+import type { TaskApprovalStatus } from "../api/tasks";
 import type { ApprovalSummary, FeedbackCategory, StandingGrant } from "../api/types";
 
 /**
@@ -34,6 +35,39 @@ export function lifecycle(
       return { label: "Archived", tone: "stopped" };
     default:
       return { label: titleCase(state), tone: "idle" };
+  }
+}
+
+/**
+ * What became of one of a task's approvals, in plain language.
+ *
+ * `expired` is the reason this exists (#971). It has been in
+ * {@link TaskApprovalStatus} since #333 and nothing could ever produce it,
+ * because nothing swept approvals for a company without a manifest schedule —
+ * so no surface ever needed words for it and none had any. Now that requests
+ * age out for every company, the state is reachable, and a surface reaching it
+ * without a phrase here would print the raw identifier at an operator: the one
+ * thing this module exists to prevent.
+ *
+ * The wording carries the distinction that matters. "Declined" and "Expired"
+ * are both a no, and the whole point of #971's honesty work is that an
+ * operator can tell the no they made from the one the deadline made — the same
+ * distinction the event stream's `automatic` flag carries.
+ *
+ * Exhaustive over the union rather than a table with a fallback: the union is
+ * closed and small, so a member added later should fail the build here rather
+ * than quietly render as a runtime identifier.
+ */
+export function approvalStatusLabel(status: TaskApprovalStatus): string {
+  switch (status) {
+    case "pending":
+      return "Waiting on you";
+    case "approved":
+      return "Approved";
+    case "denied":
+      return "Declined";
+    case "expired":
+      return "Expired — nobody decided in time";
   }
 }
 
@@ -566,6 +600,30 @@ export function timeAgo(atMillis: number, now: number): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+/**
+ * "in 42m" / "in 6h" / "in 3d" — how long something has left before a deadline.
+ *
+ * The counterpart to {@link timeAgo}, and it lives beside it for the reason
+ * this module exists: two places rendering a deadline in two vocabularies is
+ * how an operator ends up comparing "in 6h" on one row with "6 hours" on the
+ * next and wondering whether they mean the same thing. It was written for the
+ * standing-permission rows (#374) and is shared with the approval card's
+ * deadline (#971) rather than copied, so the buckets cannot drift apart.
+ *
+ * Clamped at zero: a deadline already passed reads "in 0m", never a negative.
+ * The caller decides what a passed deadline should say — the grants list, for
+ * instance, renders "expired" instead of calling this at all — because "what
+ * happens after the deadline" differs by surface and is not a formatting
+ * question.
+ */
+export function untilLabel(atMillis: number, now: number): string {
+  const mins = Math.max(0, Math.round((atMillis - now) / 60_000));
+  if (mins < 60) return `in ${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${Math.round(hours / 24)}d`;
 }
 
 /**

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -23,7 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
 import { approvedByRuntimeLine, approvedLine } from "@/lib/approval-wording";
-import { approvalSummary, grantHeadline, timeAgo, toolAction } from "@/lib/language";
+import { approvalSummary, grantHeadline, timeAgo, toolAction, untilLabel } from "@/lib/language";
 import { approvalsForTask } from "@/lib/task-approvals";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import { isRecord, parseNodeMessages } from "@/views/workflows/run-output";
@@ -293,6 +293,15 @@ export function ApprovalsView({
                   : `${visible.length} things need your approval`}
               </h2>
             </div>
+            {/* #971: nothing may vanish unannounced. Requests now age out on
+                their own, so the queue says so once, up front — mirroring the
+                standing-permissions section's "Each one expires on its own"
+                below. Each card carries its own deadline; this is the sentence
+                that stops that deadline being a surprise. */}
+            <p className="mb-3 text-xs text-muted-foreground">
+              Each one has a deadline. Anything still undecided by then is
+              declined on its own, and the work behind it moves on.
+            </p>
             <div className="flex flex-col gap-3">
               {visible.map((a) => (
                 <ApprovalCard
@@ -503,15 +512,6 @@ function StandingPermissions({
 function granterLabel(g: StandingGrant, granterNames: Map<string, string>): string {
   if (g.granted_by.kind !== "user") return "an automation";
   return granterNames.get(g.granted_by.id) ?? "someone with admin access";
-}
-
-/** "in 42m" / "in 6h" / "in 3d" — how long a permission has left. */
-function untilLabel(atMillis: number, now: number): string {
-  const mins = Math.max(0, Math.round((atMillis - now) / 60_000));
-  if (mins < 60) return `in ${mins}m`;
-  const hours = Math.round(mins / 60);
-  if (hours < 24) return `in ${hours}h`;
-  return `in ${Math.round(hours / 24)}d`;
 }
 
 /**

--- a/frontend/test/unit/approval-deadline.test.ts
+++ b/frontend/test/unit/approval-deadline.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary } from "@/api/types";
+import { ApprovalMeta } from "@/components/approval-card";
+import { approvalStatusLabel, untilLabel } from "@/lib/language";
+
+/**
+ * Issue #971: nothing may vanish unannounced.
+ *
+ * Requests now age out on their own, so the card has to say when. This suite is
+ * mostly pure — `untilLabel` and the status wording — with one rendering
+ * exception, earned the same way `approval-batch-card` earns its: the claim is
+ * about what an operator reads on the card, and "the deadline is absent when
+ * the host does not report one" is a claim about the rendered line rather than
+ * about a function's return value.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+const HOUR = 60 * 60 * 1000;
+
+function approval(overrides: Partial<ApprovalSummary> = {}): ApprovalSummary {
+  return {
+    id: "a1",
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: T0,
+    agent: "seo",
+    payload: { url: "https://espn.com/nba" },
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(a: ApprovalSummary, now: number) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalMeta, {
+        approval: a,
+        now,
+        askerNames: new Map([["seo", "SEO Specialist"]]),
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the deadline on an approval card", () => {
+  it("renders beside how long the request has already waited", async () => {
+    await render(approval({ expires_at_millis: T0 + 24 * HOUR }), T0 + 2 * HOUR);
+    const text = container.textContent ?? "";
+    // Both halves of "is this still worth deciding?".
+    expect(text).toContain("2h ago");
+    expect(text).toContain("declined in 22h");
+  });
+
+  it("says nothing when the host reports no deadline", async () => {
+    // An absent `expires_at_millis` means the HOST has no deadlines, not that
+    // this card has none. The console must not invent one: an operator who
+    // acted on a computed "in 3h" would be refused by a gate that never agreed
+    // to it.
+    await render(approval(), T0 + 2 * HOUR);
+    const text = container.textContent ?? "";
+    expect(text).toContain("2h ago");
+    expect(text).not.toContain("declined");
+    expect(text).not.toContain("in ");
+  });
+
+  it("leaves the rest of the card untouched either way", async () => {
+    await render(approval({ expires_at_millis: T0 + 24 * HOUR }), T0 + 2 * HOUR);
+    const withDeadline = container.textContent ?? "";
+    await render(approval(), T0 + 2 * HOUR);
+    const without = container.textContent ?? "";
+    // The deadline is additive: strip it and the two lines agree.
+    expect(withDeadline.replace("·declined in 22h", "").replace("declined in 22h", "")).toBe(
+      without,
+    );
+    expect(without).toContain("SEO Specialist");
+  });
+});
+
+/**
+ * `untilLabel` moved out of `ApprovalsView` so the grant rows and the approval
+ * cards share one implementation (#971). These pin the buckets across the move
+ * — a shared helper that quietly rounds differently would show the same
+ * deadline two ways on one screen, which is worse than the duplication was.
+ */
+describe("untilLabel, after the move into the language layer", () => {
+  it("keeps its minute / hour / day buckets", () => {
+    expect(untilLabel(T0 + 42 * 60_000, T0)).toBe("in 42m");
+    expect(untilLabel(T0 + 59 * 60_000, T0)).toBe("in 59m");
+    expect(untilLabel(T0 + 6 * HOUR, T0)).toBe("in 6h");
+    expect(untilLabel(T0 + 23 * HOUR, T0)).toBe("in 23h");
+    expect(untilLabel(T0 + 3 * 24 * HOUR, T0)).toBe("in 3d");
+  });
+
+  it("clamps a passed deadline at zero rather than counting backwards", () => {
+    expect(untilLabel(T0 - HOUR, T0)).toBe("in 0m");
+  });
+});
+
+/**
+ * The `expired` status has been declared since #333 and was unreachable until
+ * approvals started ageing out for every company. It needs words before a
+ * surface reaches it, or an operator is shown a runtime identifier.
+ */
+describe("what became of an approval, in plain language", () => {
+  it("tells the no an operator made from the one the deadline made", () => {
+    expect(approvalStatusLabel("denied")).toBe("Declined");
+    expect(approvalStatusLabel("expired")).toBe("Expired — nobody decided in time");
+    expect(approvalStatusLabel("approved")).toBe("Approved");
+    expect(approvalStatusLabel("pending")).toBe("Waiting on you");
+  });
+});

--- a/frontend/test/unit/approval-expiry-toast.test.ts
+++ b/frontend/test/unit/approval-expiry-toast.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { handleEvent } = await import("@/hooks/use-events");
+type Ev = import("@/hooks/use-events").CompanyStreamEvent;
+
+/**
+ * Issue #971: an expiry must not be announced as a decision somebody made.
+ *
+ * The host resolves an overdue approval as `Deny` by the system — a
+ * default-deny on silence, which is a real resolution and has to be one (#305,
+ * #469). The stream frame carried only the verdict, so the console toasted
+ * "Approval denied" and told an operator they had declined a request they never
+ * saw. That was rare while the deadline was a week; at 24 hours it is routine,
+ * which is what makes it a defect rather than a wording nit.
+ *
+ * The host now sets `automatic` on that arm and only that arm, derived from the
+ * event's actor without carrying the actor — the attention feed stays
+ * deny-by-default. These pin both directions: the new words for an expiry, and
+ * the unchanged words for a person's own decision.
+ */
+
+function resolved(overrides: Partial<Extract<Ev, { type: "approval_resolved" }>> = {}): Ev {
+  return {
+    type: "approval_resolved",
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    approvalId: "a1",
+    verdict: "deny",
+    ...overrides,
+  } as Ev;
+}
+
+beforeEach(() => {
+  toasts.base.mockClear();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
+});
+
+describe("what the console says when an approval resolves", () => {
+  it("names the deadline, not the operator, when the host expired it", () => {
+    handleEvent(resolved({ automatic: true }), {});
+    expect(toasts.base).toHaveBeenCalledTimes(1);
+    const [title, opts] = toasts.base.mock.calls[0] as [string, { description: string }];
+    expect(title).toBe("Approval expired");
+    expect(opts.description).toContain("deadline");
+    // The exact failure: never tell someone they declined something.
+    expect(title).not.toContain("denied");
+    expect(opts.description).not.toContain("denied");
+  });
+
+  it("still says 'Approval denied' when a person actually declined it", () => {
+    handleEvent(resolved(), {});
+    const [title] = toasts.base.mock.calls[0] as [string];
+    expect(title).toBe("Approval denied");
+  });
+
+  it("still says 'Approval granted' when a person approved it", () => {
+    handleEvent(resolved({ verdict: "approve" }), {});
+    const [title] = toasts.base.mock.calls[0] as [string];
+    expect(title).toBe("Approval granted");
+  });
+
+  it("reads an absent flag as a decision somebody made, so an old host is unchanged", () => {
+    // `automatic` is skipped when false, so absence is the common case and the
+    // pre-#971 host's case alike. Both mean "treat this as a decision".
+    const event = resolved();
+    expect("automatic" in (event as Record<string, unknown>)).toBe(false);
+    handleEvent(event, {});
+    const [title] = toasts.base.mock.calls[0] as [string];
+    expect(title).toBe("Approval denied");
+  });
+
+  it("refreshes the queue either way, so a card settles whoever resolved it", () => {
+    const onApprovalEvent = vi.fn();
+    handleEvent(resolved({ automatic: true }), { onApprovalEvent });
+    handleEvent(resolved(), { onApprovalEvent });
+    expect(onApprovalEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use opencompany::company::Schedule;
-use opencompany::runtime::{CompanyScheduler, SystemClock, WorkflowScheduler};
+use opencompany::runtime::{CompanyScheduler, MaintenanceTicker, SystemClock, WorkflowScheduler};
 use opencompany::{
     AppConfig, AppState, CompanyId, CompanyManifest, Result,
     app::config::{ConfigFile, ProcessEnv, resolve},
@@ -388,6 +388,16 @@ fn spawn_scheduler(
     schedules: &[Schedule],
     shutdown: &Arc<Notify>,
 ) -> Option<tokio::task::JoinHandle<()>> {
+    // **This early return was issue #971.** Until the maintenance ticker
+    // existed, sweeping expired approvals, expired grants and stale fire claims
+    // rode this scheduler's minute loop — so a company with no `[[schedule]]`
+    // returned here, spawned nothing, and swept nothing, forever, at any age.
+    // The tenant that reported it drove everything through *workflow* schedules,
+    // which run on a different loop that never called maintenance.
+    //
+    // It is correct now, and only because maintenance no longer depends on it:
+    // `spawn_maintenance_ticker` is process-wide and always on. Nothing that
+    // has to happen for every company may be attached below this line.
     if schedules.is_empty() {
         return None;
     }
@@ -422,6 +432,24 @@ fn spawn_workflow_scheduler(
     shutdown: &Arc<Notify>,
 ) -> tokio::task::JoinHandle<()> {
     WorkflowScheduler::new(state.registry().clone(), Arc::new(SystemClock)).spawn(shutdown.clone())
+}
+
+/// Starts the process-wide maintenance ticker: one task that retires overdue
+/// approvals, expired grants and stale fire claims for every registered company
+/// (issue #971).
+///
+/// Process-wide for the same reason as [`spawn_workflow_scheduler`], and it is
+/// the whole fix. The per-company [`spawn_scheduler`] above has to be reached at
+/// every place a company can come into existence — a `--company` flag, adoption
+/// of an existing data root, a hosted tenant registered after boot — and it
+/// declines to start at all for a company with no manifest cron. Maintenance
+/// must happen for every company unconditionally, so it hangs off the registry
+/// and is started once, here, whether or not any company is loaded yet.
+fn spawn_maintenance_ticker(
+    state: &AppState,
+    shutdown: &Arc<Notify>,
+) -> tokio::task::JoinHandle<()> {
+    MaintenanceTicker::new(state.registry().clone(), Arc::new(SystemClock)).spawn(shutdown.clone())
 }
 
 /// Starts a company's IMAP mailbox poller as a background task, if the
@@ -1359,6 +1387,12 @@ async fn async_main() -> Result<()> {
             // companies loaded: it re-reads the registry each minute, so a
             // company registered later is picked up without a restart.
             scheduler_handles.push(spawn_workflow_scheduler(&state, &shutdown));
+
+            // And one maintenance ticker, for the same reason and started the
+            // same way (issue #971). This is the only place approvals, grants
+            // and fire claims are retired, and it covers a company registered
+            // after boot — which the per-company scheduler spawn above does not.
+            scheduler_handles.push(spawn_maintenance_ticker(&state, &shutdown));
 
             // Stop the schedulers on Ctrl-C so background cycle work halts with
             // the process (lifecycle shutdown).

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2116,8 +2116,7 @@ impl CompanyRuntime {
                 // resolution of it is a second thing that can disagree — the
                 // card would then promise a deadline the gate does not enforce.
                 expires_at_millis: Some(
-                    p.at_millis
-                        .saturating_add(self.approval_gate.ttl_millis()),
+                    p.at_millis.saturating_add(self.approval_gate.ttl_millis()),
                 ),
                 task: p.task,
                 agent: p.effect.agent.clone(),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2109,6 +2109,16 @@ impl CompanyRuntime {
                 kind: p.effect.kind.clone(),
                 amount_usd: p.effect.amount_usd,
                 at_millis: p.at_millis,
+                // Issue #971: the deadline, filled in at the single projection
+                // point so every reader gets the same one. Read off the gate
+                // rather than recomputed from `[policy]`, because the gate is
+                // where the `None`-means-default rule resolves and a second
+                // resolution of it is a second thing that can disagree — the
+                // card would then promise a deadline the gate does not enforce.
+                expires_at_millis: Some(
+                    p.at_millis
+                        .saturating_add(self.approval_gate.ttl_millis()),
+                ),
                 task: p.task,
                 agent: p.effect.agent.clone(),
                 payload: crate::runtime::approval_display::display_payload(&p.effect),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -118,6 +118,22 @@ use crate::runtime::workflow_gates::WorkflowGateQueue;
 use crate::server::ops::mailer::MailSender;
 use crate::server::ops::smtp::SmtpCredentials;
 
+/// The most parked approvals one maintenance tick retires (issue #971).
+///
+/// A cap, not a rate: the tick runs every minute for every company, so a
+/// backlog of a few hundred drains in a handful of minutes and one of a few
+/// thousand still drains the same day. What it buys is that the FIRST tick
+/// after a shortened deadline ships — the one that meets an entire accumulated
+/// queue at once — does not turn into one unbounded burst of journal appends,
+/// event appends and released agent turns on the minute boundary every other
+/// company in the process shares.
+///
+/// Deliberately generous rather than tuned. The failure this guards is a
+/// stampede, and 50 retirements is nowhere near one; a number small enough to
+/// need tuning would instead be a queue that visibly lags behind its own
+/// deadline, which is the symptom issue #971 is about.
+const MAX_RETIREMENTS_PER_TICK: usize = 50;
+
 /// The WS3 console ports, bundled so the runtime constructor stays legible.
 /// Each is an `Arc<dyn …>` keyed by [`CompanyId`], defaulting to the fs backend
 /// and overridden together when a non-fs backend is selected.
@@ -1731,98 +1747,154 @@ impl CompanyRuntime {
 
     /// Sweeps every parked approval past its TTL, resolving each to a
     /// default-deny and writing an `ApprovalExpired` audit entry to the journal.
-    /// Returns the ids that expired. Driven by the runtime's maintenance timer.
+    /// Returns the ids that expired.
     ///
-    /// Each expiry also appends a `ApprovalResolved { verdict: Deny }` event
-    /// attributed to the system. Expiry *is* a resolution — a default-deny on
-    /// silence — but before this it wrote only the journal record, so a wait
-    /// that ended in a timeout produced no event at all and was invisible to
-    /// every event-log reader, including the task timeline (issue #305). The
-    /// append is best-effort for the same reason steer's audit is: a sweep that
-    /// already denied the effect must not be undone by a log write, and the
-    /// journal remains the binding audit trail either way.
+    /// **Driven by [`MaintenanceTicker`](crate::runtime::maintenance::MaintenanceTicker)**
+    /// — a process-wide ticker over the registry, not the per-company cron
+    /// scheduler. Until issue #971 the only production caller was
+    /// `CompanyScheduler::tick_maintenance`, and that scheduler is only spawned
+    /// for a company whose manifest declares a `[[schedule]]`. So a company with
+    /// no manifest cron — including one whose work is driven entirely by
+    /// *workflow* schedules, which run on a different loop — parked approvals
+    /// forever and swept none of them, at any age. Maximal minting, zero
+    /// sweeping, and a cold boot faithfully re-parked the backlog from the
+    /// journal with its original park instants.
     ///
-    /// An expiry is also a **decision** as far as issue #469's continuation gate
-    /// is concerned, and has to be, or a turn that raised four sign-offs and
-    /// only ever got three would wait for a fourth that is never coming. The
-    /// turn is released here; the `ApprovalResolved` this appends is the event
-    /// the brain gets, so the release contributes no second one.
+    /// Capped at [`MAX_RETIREMENTS_PER_TICK`] per call, oldest first — see
+    /// [`sweep_expired_capped`](crate::policy::ManifestApprovalGate::sweep_expired_capped).
+    /// A host that has been accumulating for days meets its whole backlog on
+    /// the first tick after this ships, and each retirement is a journal
+    /// append, a grant clear, an event append and possibly a released turn.
+    /// Uncapped, that is one burst on the minute tick every other company in
+    /// the process shares.
     pub async fn sweep_expired_approvals(self: &Arc<Self>) -> Result<Vec<ApprovalId>> {
         let now = now_millis();
-        let expired = self.approval_gate.sweep_expired(now);
+        let expired = self
+            .approval_gate
+            .sweep_expired_capped(now, MAX_RETIREMENTS_PER_TICK);
         for id in &expired {
-            self.journal
-                .record_expired(id, now, ExpiryReason::Ttl)
-                .await?;
-            // Issue #796: the parked approval is gone, so its work unit is no
-            // longer awaiting a resume — drop the pending mark so the checkout it
-            // was holding across the park becomes sweepable.
-            self.grants.clear_pending(id);
-            // Issue #469: releasing the turn this approval was blocking, and
-            // running its continuation when this expiry was the last thing it
-            // waited on. Spawned rather than awaited: the continuation is a full
-            // agent turn behind the per-company cycle lock, and the maintenance
-            // tick this runs on fires on a minute boundary for every company.
-            if let Some(turn) = self.journal.approval_cycle(id).flatten() {
-                // Issue #978: an expiry is a default-DENY, and the run's batch
-                // has to hear it as one. Banked before the count is decremented,
-                // exactly as an operator's verdict is in `continue_turn` — an
-                // expired gate left in neither ledger would be replayed into,
-                // pause the continuation, and park a brand-new card for a
-                // decision that has already been made.
-                self.workflow_gates.decide(&turn, id, Verdict::Deny);
-                if let Some(batch) = self.continuations.decide(&turn, None) {
-                    let workflow_run =
-                        crate::runtime::workflow_resume::run_id_from_turn(&turn).is_some();
-                    // A workflow run releases even on an empty batch: every
-                    // decision may have been an expiry (which appends its own
-                    // event), and the run still has to be told so its approved
-                    // siblings are not stranded. A brain turn with nothing to
-                    // report owes no cycle, exactly as before.
-                    if workflow_run || !batch.is_empty() {
-                        let rt = Arc::clone(self);
-                        let released = id.clone();
-                        let turn = turn.clone();
-                        tokio::spawn(async move {
-                            let outcome = if workflow_run {
-                                rt.resume_workflow_run(&released, &turn, batch).await
-                            } else {
-                                rt.run_continuation(&released, batch).await
-                            };
-                            if let Err(error) = outcome {
-                                tracing::error!(
-                                    company = %rt.id,
-                                    %error,
-                                    "[approval] the continuation released by an expiry failed"
-                                );
-                            }
-                        });
-                    }
-                }
-            }
-            if let Err(e) = self
-                .events
-                .append(
-                    &self.id,
-                    CompanyEvent::ApprovalResolved {
-                        approval_id: id.clone(),
-                        verdict: Verdict::Deny,
-                        by: Actor {
-                            kind: ActorKind::System,
-                            id: "expiry".into(),
-                        },
-                    },
-                )
-                .await
-            {
-                tracing::warn!(
-                    approval_id = %id,
-                    error = %e,
-                    "approval expiry journaled but its event-log entry failed",
-                );
-            }
+            self.retire_approval(id, ExpiryReason::Ttl, now).await?;
         }
         Ok(expired)
+    }
+
+    /// Retires one approval the operator never decided: the whole default-deny
+    /// transaction, in one place (issue #971).
+    ///
+    /// **The single retirement primitive.** The entry is already out of
+    /// [`ManifestApprovalGate`](crate::policy::ManifestApprovalGate)'s map by
+    /// the time this runs — removal happens inside the gate's own critical
+    /// section, in `sweep_expired_capped` or a `resolve_*`, and nothing else
+    /// may remove from it. That ordering is what makes an operator clicking
+    /// Approve as a sweep retires the same entry get either a real approval or
+    /// [`ResolveOutcome::NotParked`](crate::policy::ResolveOutcome::NotParked),
+    /// never a silent double execution. This function is everything that has to
+    /// happen *after* that removal, and it exists as one function so a second
+    /// retirement rule cannot ship with three of the four steps.
+    ///
+    /// The four steps, none of which is optional:
+    ///
+    /// 1. The **journal** record — the binding audit entry for a default-deny.
+    ///    This one propagates its error; the rest are best-effort, because a
+    ///    retirement that has already happened in memory must not be undone by
+    ///    a write that failed after it.
+    /// 2. **Clearing the pending mark** (issue #796): the parked approval is
+    ///    gone, so its work unit is no longer awaiting a resume and the
+    ///    checkout it held across the park becomes sweepable.
+    /// 3. **Releasing the #469 continuation.** A retirement is a *decision* as
+    ///    far as the continuation gate is concerned and has to be, or a turn
+    ///    that raised four sign-offs and only ever got three waits for a fourth
+    ///    that is never coming. Spawned rather than awaited: the continuation
+    ///    is a full agent turn behind the per-company cycle lock, and this runs
+    ///    on a minute boundary shared by every company.
+    /// 4. The **`ApprovalResolved` event**. Expiry *is* a resolution — a
+    ///    default-deny on silence — and before #305 it wrote only the journal
+    ///    record, so a wait that ended in a timeout produced no event at all
+    ///    and was invisible to every event-log reader including the task
+    ///    timeline. `by` is `System`, which is what lets the operator SSE feed
+    ///    say "expired" rather than attributing the deny to whoever is looking.
+    ///
+    /// **No grant is minted here, and none can be.** A
+    /// [`GrantedCall`](crate::runtime::grants::GrantedCall) exists only on
+    /// `resolve_outcome`'s `Approved` arm; this function takes no verdict and
+    /// records `Deny`. That is the safety property the whole change rests on:
+    /// an approval disappearing from the queue must never read as one that was
+    /// granted.
+    async fn retire_approval(
+        self: &Arc<Self>,
+        id: &ApprovalId,
+        reason: ExpiryReason,
+        at_millis: u64,
+    ) -> Result<()> {
+        self.journal.record_expired(id, at_millis, reason).await?;
+        // Issue #796: the parked approval is gone, so its work unit is no
+        // longer awaiting a resume — drop the pending mark so the checkout it
+        // was holding across the park becomes sweepable.
+        self.grants.clear_pending(id);
+        // Issue #469: releasing the turn this approval was blocking, and
+        // running its continuation when this expiry was the last thing it
+        // waited on. Spawned rather than awaited: the continuation is a full
+        // agent turn behind the per-company cycle lock, and the maintenance
+        // tick this runs on fires on a minute boundary for every company.
+        if let Some(turn) = self.journal.approval_cycle(id).flatten() {
+            // Issue #978: an expiry is a default-DENY, and the run's batch
+            // has to hear it as one. Banked before the count is decremented,
+            // exactly as an operator's verdict is in `continue_turn` — an
+            // expired gate left in neither ledger would be replayed into,
+            // pause the continuation, and park a brand-new card for a
+            // decision that has already been made.
+            self.workflow_gates.decide(&turn, id, Verdict::Deny);
+            if let Some(batch) = self.continuations.decide(&turn, None) {
+                let workflow_run =
+                    crate::runtime::workflow_resume::run_id_from_turn(&turn).is_some();
+                // A workflow run releases even on an empty batch: every
+                // decision may have been an expiry (which appends its own
+                // event), and the run still has to be told so its approved
+                // siblings are not stranded. A brain turn with nothing to
+                // report owes no cycle, exactly as before.
+                if workflow_run || !batch.is_empty() {
+                    let rt = Arc::clone(self);
+                    let released = id.clone();
+                    let turn = turn.clone();
+                    tokio::spawn(async move {
+                        let outcome = if workflow_run {
+                            rt.resume_workflow_run(&released, &turn, batch).await
+                        } else {
+                            rt.run_continuation(&released, batch).await
+                        };
+                        if let Err(error) = outcome {
+                            tracing::error!(
+                                company = %rt.id,
+                                %error,
+                                "[approval] the continuation released by an expiry failed"
+                            );
+                        }
+                    });
+                }
+            }
+        }
+        if let Err(e) = self
+            .events
+            .append(
+                &self.id,
+                CompanyEvent::ApprovalResolved {
+                    approval_id: id.clone(),
+                    verdict: Verdict::Deny,
+                    by: Actor {
+                        kind: ActorKind::System,
+                        id: "expiry".into(),
+                    },
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                approval_id = %id,
+                error = %e,
+                "approval expiry journaled but its event-log entry failed",
+            );
+        }
+        Ok(())
     }
 
     /// Expires every single-use grant the agent never redeemed, and tells the

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -112,7 +112,7 @@ use crate::runtime::CycleRunner;
 use crate::runtime::continuation::ContinuationQueue;
 use crate::runtime::cycle::ResolveReceipt;
 use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantId, GrantScope, GrantSet, StandingGrant};
-use crate::runtime::journal::{ApprovalOrigin, ExecutedEffect, RuntimeJournal};
+use crate::runtime::journal::{ApprovalOrigin, ExecutedEffect, ExpiryReason, RuntimeJournal};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::runtime::workflow_gates::WorkflowGateQueue;
 use crate::server::ops::mailer::MailSender;
@@ -1751,7 +1751,9 @@ impl CompanyRuntime {
         let now = now_millis();
         let expired = self.approval_gate.sweep_expired(now);
         for id in &expired {
-            self.journal.record_expired(id, now).await?;
+            self.journal
+                .record_expired(id, now, ExpiryReason::Ttl)
+                .await?;
             // Issue #796: the parked approval is gone, so its work unit is no
             // longer awaiting a resume — drop the pending mark so the checkout it
             // was holding across the park becomes sweepable.

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1244,6 +1244,30 @@ pub struct Policy {
     /// Spends strictly under this many USD skip approval.
     #[serde(default)]
     pub auto_approve_under_usd: Option<f64>,
+    /// How many hours a parked approval waits before it default-denies
+    /// (issue #971). `None` takes the gate's
+    /// [`DEFAULT_TTL_MILLIS`](crate::policy::DEFAULT_TTL_MILLIS), 24 hours.
+    ///
+    /// **Deliberately a bare `Option` with no serde default, and the absence is
+    /// load-bearing.** The obvious alternative — `#[serde(default = "…")]`
+    /// resolving to `Some(24)` at parse — walks straight into the trap
+    /// documented on [`mode`](Self::mode) above. The persisted record stores
+    /// the *defaulted* value, and `carry_policy_override` in
+    /// [`crate::runtime::builder`] is `previous_seed == next_seed` over this
+    /// whole block; so the day this default moves, every company with a silent
+    /// manifest gets a seed that changed under it, and the rebuild discards the
+    /// operator's console `[policy]` override as though version control had
+    /// spoken. Nobody edited anything, and the feature that breaks is not this
+    /// one.
+    ///
+    /// So `None` means "not configured" all the way through parse and persist,
+    /// and the default is resolved exactly once, at
+    /// [`ManifestApprovalGate::new`](crate::policy::ManifestApprovalGate::new).
+    ///
+    /// Skipped when absent so a manifest that never mentioned the knob
+    /// serializes byte-identically to before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_ttl_hours: Option<u64>,
 }
 
 impl Default for Policy {
@@ -1252,6 +1276,7 @@ impl Default for Policy {
             mode: default_policy_mode(),
             always_approve: default_always_approve(),
             auto_approve_under_usd: None,
+            approval_ttl_hours: None,
         }
     }
 }
@@ -1380,6 +1405,64 @@ pub struct Schedule {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// **T10 (issue #971).** A manifest that never mentions
+    /// `approval_ttl_hours` parses to `None` and serializes without the key —
+    /// byte-identical to a build that predates the field.
+    ///
+    /// This is not a serde-formatting nicety, it is the guard on
+    /// `carry_policy_override`. That rule is `previous_seed == next_seed` over
+    /// the whole `[policy]` block, so any value this field acquires at parse
+    /// becomes part of the identity of a block nobody wrote — and the day the
+    /// default moves, every silent manifest's seed changes under it and the
+    /// operator's console `[policy]` override is discarded as though version
+    /// control had spoken. The absence has to survive parse, persist and
+    /// reload for that not to happen. See the field's own note.
+    #[test]
+    fn a_manifest_without_an_approval_ttl_round_trips_unchanged() {
+        let silent: Policy = toml::from_str(
+            r#"
+            mode = "supervised"
+            "#,
+        )
+        .expect("parse toml");
+        assert_eq!(silent.approval_ttl_hours, None);
+
+        // Byte-identical: the key is absent from the wire, not `null`.
+        let json = serde_json::to_string(&silent).expect("serialize");
+        assert!(
+            !json.contains("approval_ttl_hours"),
+            "a silent manifest must not gain the key on the wire: {json}"
+        );
+
+        // And the reload is `==` to the parse, which is the comparison
+        // `carry_policy_override` actually runs.
+        let back: Policy = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, silent);
+        assert_eq!(
+            serde_json::to_string(&back).expect("serialize"),
+            json,
+            "a persist/reload cycle must be a fixed point"
+        );
+
+        // A manifest that DOES configure it keeps the value across the same
+        // cycle — the absence is meaningful, so presence must be too.
+        let configured: Policy = toml::from_str(
+            r#"
+            mode = "supervised"
+            approval_ttl_hours = 72
+            "#,
+        )
+        .expect("parse toml");
+        assert_eq!(configured.approval_ttl_hours, Some(72));
+        let json = serde_json::to_string(&configured).expect("serialize");
+        let back: Policy = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, configured);
+
+        // The two are NOT equal, which is what makes the seed comparison able
+        // to tell "operator configured a deadline" from "nobody said anything".
+        assert_ne!(silent, configured);
+    }
 
     /// Real-money `media` (issue #109) is granted ONLY by an explicit `media` /
     /// `media.*` grant — never by the catch-all `*`. This wildcard exclusion is

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -6578,6 +6578,7 @@ members = ["eng1", "eng2"]
                 mode: "supervised".to_string(),
                 always_approve: Vec::new(),
                 auto_approve_under_usd: None,
+                approval_ttl_hours: None,
             },
             None,
         )

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1512,6 +1512,7 @@ mod tests {
             mode: mode.to_string(),
             always_approve: always.iter().map(|s| s.to_string()).collect(),
             auto_approve_under_usd: auto_under,
+            approval_ttl_hours: None,
         };
         ApprovalPolicy::new(&p, Some(25.0))
     }
@@ -1667,6 +1668,7 @@ mod tests {
             mode: "full".to_string(),
             always_approve: fence.iter().map(|s| s.to_string()).collect(),
             auto_approve_under_usd: None,
+            approval_ttl_hours: None,
         });
 
         let mut agreed = 0;
@@ -3486,6 +3488,7 @@ mod tests {
             mode: mode.to_string(),
             always_approve: Vec::new(),
             auto_approve_under_usd: auto_under,
+            approval_ttl_hours: None,
         };
         let queue = ApprovalRequestQueue::default();
         let grants = queue.grants();
@@ -3744,6 +3747,7 @@ mod tests {
             mode: "full".to_string(),
             always_approve: Vec::new(),
             auto_approve_under_usd: None,
+            approval_ttl_hours: None,
         };
         let uncapped = ApprovalPolicy::new(&p, None)
             .with_requests(ApprovalRequestQueue::default())
@@ -3779,6 +3783,7 @@ mod tests {
             mode: "full".to_string(),
             always_approve: Vec::new(),
             auto_approve_under_usd: None,
+            approval_ttl_hours: None,
         };
         let no_meter = ApprovalPolicy::new(&p, Some(5.0))
             .with_requests(ApprovalRequestQueue::default())

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -17,10 +17,18 @@
 //! `RequireApproval` outcome is minted separately by [`park`](ManifestApprovalGate::park).
 //!
 //! Silence is a default-deny: a parked approval left unresolved past its TTL
-//! (default [`DEFAULT_TTL_MILLIS`]) resolves to deny, whether swept by
+//! (default [`DEFAULT_TTL_MILLIS`], overridable per company with
+//! `[policy].approval_ttl_hours`) resolves to deny, whether swept by
 //! [`sweep_expired`](ManifestApprovalGate::sweep_expired) or observed at
 //! resolution time by [`resolve_at`](ManifestApprovalGate::resolve_at) /
 //! [`resolve_amended`](ManifestApprovalGate::resolve_amended).
+//!
+//! **The TTL is only half of default-deny-on-silence.** The other half is
+//! something actually running the sweep, which until issue #971 only a company
+//! with a manifest `[[schedule]]` had — see
+//! [`MaintenanceTicker`](crate::runtime::maintenance::MaintenanceTicker), which
+//! now drives it for every registered company. A shorter deadline with nothing
+//! sweeping is still a queue that never empties.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -36,8 +44,23 @@ use crate::ports::types::{
     Actor, ApprovalId, CompanyId, Effect, EffectGroup, PolicyDecision, Verdict,
 };
 
-/// Default time-to-live for a parked approval: 7 days in milliseconds.
-pub const DEFAULT_TTL_MILLIS: u64 = 7 * 24 * 60 * 60 * 1000;
+/// Default time-to-live for a parked approval: 24 hours in milliseconds.
+///
+/// **Was 7 days until issue #971.** A parked call is refused and re-dispatched
+/// rather than suspended (#243/#469), so approving a three-day-old entry does
+/// not usefully resume the turn that raised it — the turn is long gone. A
+/// week-long deadline therefore did not buy an operator a week of useful
+/// decisions; it bought a queue whose oldest entries were unactionable *and*
+/// still counted toward the badge, which is how a badge stops describing
+/// current state and starts being ignored.
+///
+/// 24 hours is one working day: an approval raised during a day the operator
+/// works is still there when they next look, and one nobody looked at for a
+/// full day is one the work behind it has already moved past.
+///
+/// A company that genuinely wants longer says so explicitly with
+/// `[policy].approval_ttl_hours` rather than inheriting it from a constant.
+pub const DEFAULT_TTL_MILLIS: u64 = 24 * 60 * 60 * 1000;
 
 /// Replays a company's event log to decide whether it should boot with the
 /// emergency stop engaged (issue #86).
@@ -140,10 +163,28 @@ pub struct ManifestApprovalGate {
 
 impl ManifestApprovalGate {
     /// Builds a gate from a company's manifest `[policy]` block.
+    ///
+    /// **The TTL default resolves HERE, not at parse** (issue #971).
+    /// [`Policy::approval_ttl_hours`] is a plain `Option` with no serde
+    /// default, so a manifest that never mentioned the knob deserializes to
+    /// `None` — the same bytes and the same value it did before the field
+    /// existed. That matters because
+    /// [`carry_policy_override`](crate::runtime::builder) compares the previous
+    /// boot's seed `[policy]` against this one's *as whole blocks* to decide
+    /// whether an operator's console override survives a rebuild. A field that
+    /// defaulted to `Some(24)` at parse would make the seed change under any
+    /// company whose manifest is silent the moment this constant moves, and the
+    /// rebuild would read that as version control having spoken and silently
+    /// discard the override. Nobody would have edited anything. See the same
+    /// trap spelled out on [`Policy::mode`](crate::company::Policy::mode).
     pub fn new(policy: Policy) -> Self {
+        let ttl_millis = policy
+            .approval_ttl_hours
+            .map(|hours| hours.saturating_mul(60 * 60 * 1000))
+            .unwrap_or(DEFAULT_TTL_MILLIS);
         Self {
             policy,
-            ttl_millis: DEFAULT_TTL_MILLIS,
+            ttl_millis,
             parked: Mutex::new(HashMap::new()),
             emergency: AtomicBool::new(false),
         }
@@ -178,6 +219,18 @@ impl ManifestApprovalGate {
         self
     }
 
+    /// How long a parked approval has before it default-denies.
+    ///
+    /// Read by [`CompanyRuntime::pending_approvals`](crate::CompanyRuntime::pending_approvals)
+    /// to project each card's deadline (issue #971). Exposed rather than
+    /// recomputed from `[policy]` at the projection because the gate is the one
+    /// that resolves the default, and a second resolution of the same rule is a
+    /// second thing that can disagree — the console would then show a deadline
+    /// the gate does not enforce.
+    pub fn ttl_millis(&self) -> u64 {
+        self.ttl_millis
+    }
+
     /// The ids of every currently-parked approval.
     pub fn parked_ids(&self) -> Vec<ApprovalId> {
         self.parked
@@ -203,12 +256,38 @@ impl ManifestApprovalGate {
     /// Removes every parked approval older than the TTL relative to `now`,
     /// returning the ids that expired (they resolve to deny).
     pub fn sweep_expired(&self, now_millis: u64) -> Vec<ApprovalId> {
+        self.sweep_expired_capped(now_millis, usize::MAX)
+    }
+
+    /// [`sweep_expired`](Self::sweep_expired), taking at most `limit` entries,
+    /// **oldest first** (issue #971).
+    ///
+    /// The cap is what keeps a first sweep after a long silence from turning
+    /// into one unbounded burst of retirement work. Each retirement is a
+    /// journal append, a grant clear, an event append and possibly a released
+    /// #469 continuation spawning a whole agent turn; a company that has been
+    /// accumulating for days would do all of that for its entire backlog inside
+    /// a single minute tick, on the tick shared by every other company in the
+    /// process. Capped, the backlog drains over a few minutes and nothing else
+    /// waits on it.
+    ///
+    /// **Oldest first, so the cap is not a lottery.** The map is a `HashMap`
+    /// and its iteration order is randomized per process, so an uncapped-order
+    /// cap would retire an arbitrary subset and leave an arbitrary one — the
+    /// same entry could sit unswept across many ticks while newer ones went
+    /// first. Sorting by park instant makes the drain deterministic and makes
+    /// "the oldest, most unactionable entries go first" true rather than
+    /// incidental.
+    pub fn sweep_expired_capped(&self, now_millis: u64, limit: usize) -> Vec<ApprovalId> {
         let mut map = self.parked.lock().expect("parked map poisoned");
-        let expired: Vec<ApprovalId> = map
+        let mut expired: Vec<(u64, ApprovalId)> = map
             .iter()
             .filter(|(_, pe)| now_millis.saturating_sub(pe.parked_at_millis) >= self.ttl_millis)
-            .map(|(id, _)| id.clone())
+            .map(|(id, pe)| (pe.parked_at_millis, id.clone()))
             .collect();
+        expired.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.as_ref().cmp(b.1.as_ref())));
+        expired.truncate(limit);
+        let expired: Vec<ApprovalId> = expired.into_iter().map(|(_, id)| id).collect();
         for id in &expired {
             map.remove(id);
         }
@@ -476,6 +555,7 @@ mod test {
             mode: mode.to_string(),
             always_approve: FENCE.iter().map(|s| s.to_string()).collect(),
             auto_approve_under_usd: cap,
+            approval_ttl_hours: None,
         }
     }
 
@@ -846,6 +926,105 @@ mod test {
         assert_eq!(decide(&gate, &cheap).await, PolicyDecision::RequireApproval);
         // ...but a dollar under a hundred-dollar cap is not irreversible.
         assert!(!gate.is_irreversible(&cheap));
+    }
+
+    /// **T5 (issue #971).** The deadline binds even when nothing swept.
+    ///
+    /// The sweep is housekeeping — it retires an entry and tells the operator —
+    /// but it is emphatically not the enforcement. `resolve_at` re-checks the
+    /// TTL under the same lock that removes the entry, so a 25-hour-old
+    /// approval default-denies on the operator's click whether or not any
+    /// maintenance tick ever ran for that company. That property is what made
+    /// the missing ticker a *visibility* bug rather than a safety one, and it
+    /// has to survive the ticker landing: a future refactor that made the sweep
+    /// the only expiry path would turn a paused host into one that honours
+    /// week-old consent.
+    #[tokio::test]
+    async fn the_default_deadline_binds_at_resolve_with_no_sweep() {
+        // No `with_ttl_millis`: the default the constant resolves to, so this
+        // fails if the 24h default is quietly widened again.
+        let gate = ManifestApprovalGate::new(policy("supervised", None));
+        assert_eq!(gate.ttl_millis(), 24 * 60 * 60 * 1000);
+        let id = gate
+            .park(&company(), effect("filing.submit", EffectGroup::Sign))
+            .await
+            .unwrap();
+        let twenty_five_hours = now_millis() + 25 * 60 * 60 * 1000;
+        // Nothing swept: the entry is still parked right up to the click.
+        assert_eq!(gate.parked_ids(), vec![id.clone()]);
+        assert_eq!(
+            gate.resolve_at(&id, Verdict::Approve, operator(), twenty_five_hours),
+            None,
+            "a 25h-old approval must default-deny even though no sweep ran"
+        );
+        // And an hour earlier it would still have been approvable, so the
+        // assertion above is about the deadline and not about `resolve_at`
+        // refusing everything.
+        let gate = ManifestApprovalGate::new(policy("supervised", None));
+        let id = gate
+            .park(&company(), effect("filing.submit", EffectGroup::Sign))
+            .await
+            .unwrap();
+        let twenty_three_hours = now_millis() + 23 * 60 * 60 * 1000;
+        assert!(
+            gate.resolve_at(&id, Verdict::Approve, operator(), twenty_three_hours)
+                .is_some()
+        );
+    }
+
+    /// `[policy].approval_ttl_hours` is what the gate enforces, and an absent
+    /// knob resolves to the default **here** rather than at parse (issue #971).
+    #[tokio::test]
+    async fn the_policy_knob_sets_the_deadline() {
+        let configured = Policy {
+            approval_ttl_hours: Some(2),
+            ..policy("supervised", None)
+        };
+        let gate = ManifestApprovalGate::new(configured);
+        assert_eq!(gate.ttl_millis(), 2 * 60 * 60 * 1000);
+
+        let silent = policy("supervised", None);
+        assert_eq!(
+            silent.approval_ttl_hours, None,
+            "a silent manifest must stay `None` through parse — see the field's note"
+        );
+        assert_eq!(
+            ManifestApprovalGate::new(silent).ttl_millis(),
+            DEFAULT_TTL_MILLIS
+        );
+    }
+
+    /// The per-tick cap takes the **oldest** expired entries, not an arbitrary
+    /// subset of them (issue #971).
+    ///
+    /// `parked` is a `HashMap`, so without the sort this passes or fails by
+    /// process-random iteration order — and in production an entry could sit
+    /// unretired across many ticks while newer ones drained ahead of it.
+    #[tokio::test]
+    async fn the_sweep_cap_drains_oldest_first() {
+        let gate = ManifestApprovalGate::new(policy("supervised", None)).with_ttl_millis(0);
+        let mut ids = Vec::new();
+        for i in 0..5u64 {
+            let id = gate
+                .park(&company(), effect("filing.submit", EffectGroup::Sign))
+                .await
+                .unwrap();
+            // Re-park under a known instant: `park` stamps `now`, and five
+            // parks inside one millisecond would make "oldest" undecidable.
+            gate.rehydrate(
+                id.clone(),
+                effect("filing.submit", EffectGroup::Sign),
+                1_000 + i,
+            );
+            ids.push(id);
+        }
+        let first = gate.sweep_expired_capped(10_000, 2);
+        assert_eq!(first, ids[..2].to_vec());
+        let second = gate.sweep_expired_capped(10_000, 2);
+        assert_eq!(second, ids[2..4].to_vec());
+        // The uncapped form is the same sweep with no limit.
+        assert_eq!(gate.sweep_expired(10_000), ids[4..].to_vec());
+        assert!(gate.parked_ids().is_empty());
     }
 
     #[tokio::test]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -3334,6 +3334,11 @@ impl CompanyRecord {
             // for the tier and the always-ask list, and a spend threshold whose
             // console control does not exist would be a field nothing can write.
             auto_approve_under_usd: manifest.auto_approve_under_usd,
+            // Same reasoning for the approval deadline (issue #971): the knob is
+            // a manifest one, so the override carries the manifest's answer
+            // through unchanged rather than gaining a field no console control
+            // writes.
+            approval_ttl_hours: manifest.approval_ttl_hours,
         }
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4733,6 +4733,7 @@ mod test {
             mode: mode.to_string(),
             always_approve: always.iter().map(|s| s.to_string()).collect(),
             auto_approve_under_usd: under,
+            approval_ttl_hours: None,
         }
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -38,6 +38,27 @@ use crate::runtime::grants::{GrantId, GrantedCall, StandingGrant};
 pub use crate::runtime::types::TaskLink;
 use crate::store::fs::FsJournalStore;
 
+/// Why a parked approval was retired without an operator deciding it
+/// (issue #971).
+///
+/// Retirement has one implementation — [`CompanyRuntime::retire_approval`] —
+/// and this says which rule invoked it. Recorded rather than inferred: the
+/// journal is the audit trail for a default-deny, and "the deadline passed" and
+/// any future automatic retirement are different things to have happened to
+/// someone's request, however identical the resulting queue looks.
+///
+/// One variant today. The enum exists rather than a bool because the next
+/// reason is already known — an approval retired because a newer identical
+/// request superseded it — and a `superseded: bool` beside a `reason` would be
+/// two fields describing one fact.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpiryReason {
+    /// It sat unresolved past its `[policy].approval_ttl_hours` deadline.
+    #[default]
+    Ttl,
+}
+
 /// One durable journal record.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "record")]
@@ -157,6 +178,14 @@ enum JournalRecord {
         id: ApprovalId,
         /// Epoch-millis the expiry was recorded.
         at_millis: u64,
+        /// Why it was retired (issue #971).
+        ///
+        /// `#[serde(default)]` is what lets every line written before this
+        /// field existed replay: they were all TTL expiries, which is exactly
+        /// what [`ExpiryReason::Ttl`] means, so the default is the truth about
+        /// them rather than a placeholder.
+        #[serde(default)]
+        reason: ExpiryReason,
     },
     /// A parked approval the operator approved with an amended effect payload.
     ///
@@ -1419,7 +1448,12 @@ impl RuntimeJournal {
     /// Records that a parked approval expired to a default-deny, removing it
     /// from the queue. This is the durable audit entry for
     /// default-deny-on-silence.
-    pub async fn record_expired(&self, id: &ApprovalId, at_millis: u64) -> Result<()> {
+    pub async fn record_expired(
+        &self,
+        id: &ApprovalId,
+        at_millis: u64,
+        reason: ExpiryReason,
+    ) -> Result<()> {
         self.state
             .lock()
             .expect("journal state poisoned")
@@ -1428,6 +1462,7 @@ impl RuntimeJournal {
         self.append(&JournalRecord::ApprovalExpired {
             id: id.clone(),
             at_millis,
+            reason,
         })
         .await
     }
@@ -2640,7 +2675,10 @@ mod test {
             .unwrap();
         assert_eq!(journal.pending().len(), 1);
 
-        journal.record_expired(&id, now_millis()).await.unwrap();
+        journal
+            .record_expired(&id, now_millis(), ExpiryReason::Ttl)
+            .await
+            .unwrap();
         assert!(journal.pending().is_empty());
 
         // A restart replays the expiry: the approval stays gone.
@@ -2730,7 +2768,10 @@ mod test {
             .unwrap();
 
         journal.record_resolved(&resolved).await.unwrap();
-        journal.record_expired(&expired, 9_000).await.unwrap();
+        journal
+            .record_expired(&expired, 9_000, ExpiryReason::Ttl)
+            .await
+            .unwrap();
 
         // Both left the queue...
         assert!(journal.pending().is_empty());
@@ -3399,12 +3440,48 @@ mod test {
         }
     }
 
+    /// **Old journal lines replay unchanged (issue #971).**
+    ///
+    /// Every `ApprovalExpired` written before the field existed was a TTL
+    /// expiry, so the serde default is the truth about them. A missing default
+    /// here would not be a cosmetic regression: replay is how the parked queue
+    /// is rebuilt at boot, and a line that fails to parse leaves an approval
+    /// resurrected that the host had already retired.
+    #[test]
+    fn a_pre_reason_expiry_line_replays_as_a_ttl_expiry() {
+        let old_line = r#"{"record":"ApprovalExpired","id":"ap-old","at_millis":42}"#;
+        let parsed: JournalRecord = serde_json::from_str(old_line).expect("old line must replay");
+        match parsed {
+            JournalRecord::ApprovalExpired {
+                id,
+                at_millis,
+                reason,
+            } => {
+                assert_eq!(id.as_ref(), "ap-old");
+                assert_eq!(at_millis, 42);
+                assert_eq!(reason, ExpiryReason::Ttl);
+            }
+            other => panic!("expected ApprovalExpired, got {other:?}"),
+        }
+
+        // And a line written today carries the reason explicitly, so the two
+        // are told apart by what is on the wire rather than by inference.
+        let written = serde_json::to_string(&JournalRecord::ApprovalExpired {
+            id: ApprovalId::new("ap-new"),
+            at_millis: 43,
+            reason: ExpiryReason::Ttl,
+        })
+        .expect("serialize");
+        assert!(written.contains(r#""reason":"ttl""#), "{written}");
+    }
+
     #[test]
     fn expired_and_amended_records_round_trip_under_record_tag() {
         for record in [
             JournalRecord::ApprovalExpired {
                 id: ApprovalId::new("x"),
                 at_millis: 42,
+                reason: ExpiryReason::Ttl,
             },
             JournalRecord::ApprovalAmended {
                 id: ApprovalId::new("y"),
@@ -3465,6 +3542,7 @@ mod test {
             JournalRecord::ApprovalExpired {
                 id: ApprovalId::new("a"),
                 at_millis: 2,
+                reason: ExpiryReason::Ttl,
             },
             JournalRecord::ApprovalAmended {
                 id: ApprovalId::new("a"),

--- a/src/runtime/maintenance.rs
+++ b/src/runtime/maintenance.rs
@@ -1,0 +1,575 @@
+//! [`MaintenanceTicker`]: the process-wide minute loop that retires approvals,
+//! grants and fire claims for **every** registered company (issue #971).
+//!
+//! ## The bug this module is
+//!
+//! The expiry mechanism was already here and already correct. A parked approval
+//! carries a TTL, [`CompanyRuntime::sweep_expired_approvals`] is a complete
+//! retirement transaction, and both were covered by tests. What was missing was
+//! anything to run it.
+//!
+//! Its only production caller was `CompanyScheduler::tick_maintenance`, reached
+//! only from that scheduler's minute loop — and the scheduler is spawned only
+//! for a company whose manifest declares a `[[schedule]]`. **A company that
+//! declares no `[[schedule]]` never spawned a scheduler and therefore never
+//! swept approvals, grants or fire claims, at any age.** The tenant that
+//! surfaced #971 ran a weekly digest as a *workflow*, driven by
+//! [`WorkflowScheduler`](super::workflow_scheduler::WorkflowScheduler), whose
+//! loop calls only `tick` — so it minted approvals every week and swept none of
+//! them, ever. Cold boot then re-parked the whole backlog from the journal with
+//! its original park instants, so every redeploy faithfully rebuilt it.
+//!
+//! Sixty-eight-hour-old cards were not a tuning problem. They were the absence
+//! of a caller.
+//!
+//! ## Why process-wide rather than per company
+//!
+//! Deliberately shaped like [`WorkflowScheduler`] and not like
+//! [`CompanyScheduler`](super::scheduler::CompanyScheduler): one task for the
+//! whole process, re-reading [`CompanyRegistry::list`] every minute. That is
+//! **one always-on wiring point**, which is the property that fixes the bug
+//! rather than moving it. A per-company spawn has to be reached at every place a
+//! company can come into existence — boot from `--company`, adoption of an
+//! existing data root, a hosted tenant registered after boot, an in-place
+//! rebuild — and the bug being fixed here is precisely one of those paths not
+//! being reached. Reading the registry each tick means a company registered a
+//! minute from now is swept a minute from now, with nobody having to remember.
+//!
+//! ## Housekeeping is not enforcement
+//!
+//! Nothing here is a safety boundary, and it must not become one. The gate
+//! re-checks the TTL under the same lock that removes a parked entry
+//! (`resolve_at` / `resolve_amended` / `resolve_outcome`), so a 25-hour-old
+//! approval default-denies on the operator's click whether or not this ticker
+//! ever ran. What this adds is that the queue empties, the journal records the
+//! retirement, and the operator's badge goes back to describing current state.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use crate::CompanyRuntime;
+use crate::ports::types::{ApprovalId, CompanyId};
+use crate::runtime::CompanyRegistry;
+use crate::runtime::scheduler::{Clock, MINUTE_MS, PRUNE_CUTOFF_MINUTES, millis_to_next_minute};
+
+/// Retires expired approvals, expired grants and stale fire claims for every
+/// company in the registry, once a minute.
+pub struct MaintenanceTicker {
+    registry: CompanyRegistry,
+    clock: Arc<dyn Clock>,
+}
+
+impl MaintenanceTicker {
+    /// Builds a ticker over every company in `registry`, driven by `clock`.
+    pub fn new(registry: CompanyRegistry, clock: Arc<dyn Clock>) -> Self {
+        Self { registry, clock }
+    }
+
+    /// Runs one maintenance pass over every registered company. Returns how
+    /// many parked approvals were retired.
+    ///
+    /// Each company's three chores are independent and each is best-effort: a
+    /// failure on one company must not stop the next company being swept, and a
+    /// failed fire-claim prune must not abort the approval sweep it shares a
+    /// tick with. The alternative — propagating the first error out of the tick
+    /// — would let one company's broken store silently stop maintenance for
+    /// every other company in the process, which is the same class of bug as
+    /// the one this module exists to fix.
+    pub async fn tick(&self) -> usize {
+        let minute = self.clock.now_millis() / MINUTE_MS;
+        let mut retired = 0;
+        for company in self.registry.list() {
+            let Some(runtime) = self.registry.get(&company) else {
+                continue; // removed between listing and lookup (archive)
+            };
+            // **A paused company IS swept, deliberately** — no `ensure_running`
+            // gate here, unlike `WorkflowScheduler::tick` beside it.
+            //
+            // That difference is the point, so please do not "fix" it. The
+            // scheduler's gate is right for the scheduler: firing new work into
+            // a paused company is starting something the operator asked to
+            // stop. This does the opposite — it *finishes* things, by retiring
+            // requests nobody is going to answer. And a paused company's queue
+            // is the queue that most needs draining: pausing is exactly what an
+            // operator does to work that has gone wrong, so its approvals are
+            // the ones guaranteed to be unactionable and the ones #971 watched
+            // pile up. Skipping here would reproduce the bug for the companies
+            // worst affected by it.
+            //
+            // Nothing here starts work. Retiring an approval releases a #469
+            // continuation, which can run a turn — and that turn is admitted or
+            // refused by the company's own lifecycle check, in the cycle path,
+            // exactly as it is for a continuation released by an operator
+            // clicking Decline on a paused company today.
+            retired += sweep_company(&company, &runtime, minute).await.len();
+        }
+        retired
+    }
+
+    /// Spawns a background task that ticks on every minute boundary until
+    /// `shutdown` is notified. Boot holds the join handle and the shared
+    /// `shutdown` so maintenance stops cleanly when the server does.
+    pub fn spawn(self, shutdown: Arc<Notify>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            // The `Notified` future is built ONCE and pinned across iterations,
+            // not rebuilt inside the `select!`. Boot signals with
+            // `notify_waiters()`, which wakes only the waiters registered at
+            // that instant — a future created fresh each iteration is not
+            // registered while `tick` is running, so a shutdown arriving
+            // mid-tick would be dropped and the ticker would sleep another
+            // full minute before noticing. Polled once here, this one stays
+            // registered, and a notification delivered during `tick` is
+            // latched: the next `select!` sees it immediately.
+            let notified = shutdown.notified();
+            tokio::pin!(notified);
+            loop {
+                let sleep_ms = millis_to_next_minute(self.clock.now_millis());
+                tokio::select! {
+                    _ = &mut notified => break,
+                    _ = tokio::time::sleep(Duration::from_millis(sleep_ms)) => {
+                        self.tick().await;
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// One company's maintenance pass: retire overdue approvals, expire unredeemed
+/// grants, prune stale fire claims. Returns the approvals that were retired.
+///
+/// **The single implementation**, shared by [`MaintenanceTicker::tick`] and
+/// [`CompanyScheduler::tick_maintenance`](super::scheduler::CompanyScheduler::tick_maintenance)
+/// so the two cannot drift into meaning different things by "maintenance".
+///
+/// Every chore is best-effort and independent: a failure on one must not stop
+/// the next, and — at the tick above — a failure on one company must not stop
+/// the next company being swept. Propagating the first error out would let one
+/// broken store silently stop maintenance for every other company in the
+/// process, which is the same class of bug as the missing caller this module
+/// exists to fix.
+pub(crate) async fn sweep_company(
+    company: &CompanyId,
+    runtime: &Arc<CompanyRuntime>,
+    minute: u64,
+) -> Vec<ApprovalId> {
+    // **A paused company IS swept, deliberately** — no `ensure_running` gate
+    // here, unlike `WorkflowScheduler::tick`.
+    //
+    // That difference is the point, so please do not "fix" it. The scheduler's
+    // gate is right for the scheduler: firing new work into a paused company is
+    // starting something the operator asked to stop. This does the opposite —
+    // it *finishes* things, by retiring requests nobody is going to answer. And
+    // a paused company's queue is the queue that most needs draining: pausing
+    // is exactly what an operator does to work that has gone wrong, so its
+    // approvals are the ones guaranteed to be unactionable, and issue #971
+    // watched a Paused column's cards sit at 68 hours. Skipping here would
+    // reproduce the bug for the companies worst affected by it.
+    //
+    // Nothing here starts work. Retiring an approval releases a #469
+    // continuation, which can run a turn — and that turn is admitted or refused
+    // by the company's own lifecycle check in the cycle path, exactly as it is
+    // for a continuation released by an operator clicking Decline on a paused
+    // company today.
+    let retired = match runtime.sweep_expired_approvals().await {
+        Ok(expired) => {
+            if !expired.is_empty() {
+                tracing::info!(
+                    %company,
+                    count = expired.len(),
+                    "[maintenance] retired parked approvals past their deadline"
+                );
+            }
+            expired
+        }
+        Err(err) => {
+            tracing::warn!(%company, %err, "[maintenance] approval sweep failed");
+            Vec::new()
+        }
+    };
+    if let Err(err) = runtime.sweep_expired_grants().await {
+        tracing::warn!(%company, %err, "[maintenance] grant sweep failed");
+    }
+    // Issue #241: bound the fire-claim log's growth on the same tick. The cutoff
+    // sits a full week past the catch-up window (PRUNE_CUTOFF_MINUTES >
+    // CATCHUP_WINDOW_MINUTES), so an anchor a booting replica still needs is
+    // never eligible.
+    let cutoff = minute.saturating_sub(PRUNE_CUTOFF_MINUTES);
+    if let Err(err) = runtime
+        .schedule_fires()
+        .prune_fires_before(company, cutoff)
+        .await
+    {
+        tracing::warn!(%company, %err, "[maintenance] pruning fire claims failed");
+    }
+    retired
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use super::MaintenanceTicker;
+    use crate::company::CompanyManifest;
+    use crate::policy::ManifestApprovalGate;
+    use crate::ports::now_millis;
+    use crate::ports::types::{
+        Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, Effect, EffectGroup, Verdict,
+    };
+    use crate::runtime::scheduler::FakeClock;
+    use crate::runtime::{CompanyRegistry, RuntimeBuilder};
+    use crate::{CompanyRuntime, Result};
+
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-maintenance-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    /// A manifest with **no `[[schedule]]`** — the shape that never got swept.
+    fn unscheduled_manifest() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "supervised"
+        "#;
+        let manifest: CompanyManifest = toml::from_str(toml_src).expect("manifest parses");
+        assert!(
+            manifest.schedules.is_empty(),
+            "the fixture's whole point is that it declares no cron"
+        );
+        manifest
+    }
+
+    fn sign_effect() -> Effect {
+        Effect {
+            kind: "filing.submit".into(),
+            group: EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        }
+    }
+
+    /// A company with no manifest cron, whose gate treats anything parked as
+    /// already past its deadline, registered under a ticker.
+    async fn given_an_unscheduled_company_with_an_overdue_gate(
+        home: &std::path::Path,
+    ) -> (Arc<CompanyRuntime>, MaintenanceTicker) {
+        let manifest = unscheduled_manifest();
+        // TTL 0: "the clock has passed the deadline" without sleeping for a day.
+        let gate = Arc::new(ManifestApprovalGate::new(manifest.policy.clone()).with_ttl_millis(0));
+        let runtime = Arc::new(
+            RuntimeBuilder::new(home.to_path_buf(), manifest)
+                .with_approvals(gate)
+                .build()
+                .await
+                .expect("runtime builds"),
+        );
+        let registry = CompanyRegistry::new();
+        registry.insert(runtime.id().clone(), Arc::clone(&runtime));
+        let ticker = MaintenanceTicker::new(
+            registry,
+            Arc::new(FakeClock::new(now_millis() + 60 * MINUTE)),
+        );
+        (runtime, ticker)
+    }
+
+    const MINUTE: u64 = 60_000;
+
+    /// Parks an effect the way production does: the gate mints the id and the
+    /// journal records the park.
+    ///
+    /// Both halves matter. The gate's map is what the sweep reads; the journal
+    /// is what `pending_approvals` — and therefore the operator's queue and the
+    /// sidebar badge — reads. A test that parked only on the gate would assert
+    /// that an entry nobody could see had been retired.
+    async fn park(runtime: &Arc<CompanyRuntime>) -> Result<ApprovalId> {
+        let effect = sign_effect();
+        let id = runtime.approvals.park(runtime.id(), effect.clone()).await?;
+        runtime
+            .journal()
+            .record_parked(
+                &id,
+                &effect,
+                now_millis(),
+                crate::runtime::journal::TaskLink::Unlinked,
+                crate::runtime::journal::ApprovalConversation {
+                    thread: None,
+                    parent: None,
+                },
+                None,
+            )
+            .await?;
+        Ok(id)
+    }
+
+    /// **T1 — the whole issue, in one test.**
+    ///
+    /// A company that declares no `[[schedule]]` parks an approval, the clock
+    /// passes its deadline, a maintenance tick runs, and the approval is gone.
+    ///
+    /// This was **inexpressible** before this module existed. The only thing
+    /// that swept approvals in production was `CompanyScheduler::tick_maintenance`,
+    /// and `spawn_scheduler` returns `None` for a company with no schedules — so
+    /// there was no production path from "a scheduleless company's approval is
+    /// overdue" to "it is retired", at any age, ever. The test could only be
+    /// written by reaching for a scheduler the host would never have spawned,
+    /// which would have asserted the fix rather than the bug.
+    #[tokio::test]
+    async fn a_company_with_no_schedule_still_has_its_overdue_approvals_retired() {
+        let home_dir = tmp_home();
+        let (runtime, ticker) =
+            given_an_unscheduled_company_with_an_overdue_gate(home_dir.path()).await;
+
+        let id = park(&runtime).await.expect("parks");
+        assert_eq!(runtime.pending_approvals().len(), 1);
+
+        assert_eq!(ticker.tick().await, 1, "the tick must retire it");
+
+        assert!(
+            runtime.pending_approvals().is_empty(),
+            "a scheduleless company's overdue approval must not survive maintenance"
+        );
+        // And the queue stays empty rather than the entry being re-derivable:
+        // the journal removal is what the badge counts.
+        assert_eq!(ticker.tick().await, 0, "a second tick has nothing to do");
+        drop(id);
+    }
+
+    /// **T2 — a retired approval mints no grant.**
+    ///
+    /// The safety property the whole change rests on: an approval disappearing
+    /// from the queue must never read as one that was granted. A `GrantedCall`
+    /// exists only on `resolve_outcome`'s `Approved` arm, and `retire_approval`
+    /// takes no verdict — but "it cannot happen by construction" is exactly the
+    /// kind of claim that stops being true silently, so it is asserted.
+    #[tokio::test]
+    async fn retiring_an_approval_mints_no_grant() {
+        let home_dir = tmp_home();
+        let (runtime, ticker) =
+            given_an_unscheduled_company_with_an_overdue_gate(home_dir.path()).await;
+
+        let id = park(&runtime).await.expect("parks");
+        ticker.tick().await;
+
+        assert!(
+            runtime.grants.peek(&id).is_none(),
+            "an expiry must never leave a grant behind — that would turn a \
+             disappeared approval into a silently authorised call"
+        );
+        assert!(runtime.standing_grants().is_empty());
+    }
+
+    /// **T3 — the retirement is a deny by the system, for the recorded reason.**
+    ///
+    /// Two readers, two records, and they have to agree. The event log gets an
+    /// `ApprovalResolved { verdict: Deny, by: System }` — a timeout that emitted
+    /// nothing was invisible to every event-log reader (#305) — and the journal
+    /// gets the durable audit entry saying the deadline is what did it.
+    #[tokio::test]
+    async fn the_retirement_is_a_system_deny_recorded_as_a_ttl_expiry() {
+        let home_dir = tmp_home();
+        let (runtime, ticker) =
+            given_an_unscheduled_company_with_an_overdue_gate(home_dir.path()).await;
+
+        let id = park(&runtime).await.expect("parks");
+        ticker.tick().await;
+
+        let events = runtime
+            .events()
+            .read_from(
+                runtime.id(),
+                crate::ports::types::EventSeq::new(0),
+                usize::MAX,
+            )
+            .await
+            .expect("events read");
+        let resolved: Vec<_> = events
+            .iter()
+            .filter_map(|stored| match &stored.event {
+                CompanyEvent::ApprovalResolved {
+                    approval_id,
+                    verdict,
+                    by,
+                } if approval_id == &id => Some((*verdict, by.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(resolved.len(), 1, "exactly one resolution event");
+        let (verdict, by) = &resolved[0];
+        assert_eq!(*verdict, Verdict::Deny, "silence is a default-deny");
+        assert_eq!(
+            by.kind,
+            ActorKind::System,
+            "the host expired it; attributing this to a person would be a lie \
+             the console then repeats as \"Approval denied\""
+        );
+
+        // The journal's durable record says why.
+        let raw = std::fs::read_to_string(
+            home_dir
+                .path()
+                .join("companies")
+                .join(runtime.id().as_ref())
+                .join("journal.jsonl"),
+        )
+        .or_else(|_| {
+            // Layout differs by store backend; find the journal wherever it is.
+            let mut found = String::new();
+            for entry in walk(home_dir.path()) {
+                if entry.file_name().is_some_and(|n| n == "journal.jsonl") {
+                    found.push_str(&std::fs::read_to_string(&entry).unwrap_or_default());
+                }
+            }
+            if found.is_empty() {
+                Err(std::io::Error::other("no journal found"))
+            } else {
+                Ok(found)
+            }
+        })
+        .expect("journal readable");
+        assert!(
+            raw.contains("ApprovalExpired") && raw.contains(r#""reason":"ttl""#),
+            "the journal must record the retirement AND its reason: {raw}"
+        );
+
+        // Nothing else claims to have resolved it.
+        drop(Actor {
+            kind: ActorKind::User,
+            id: String::new(),
+        });
+    }
+
+    /// **T4 — the retire/approve race yields exactly one outcome.**
+    ///
+    /// An operator clicking Approve at the instant the sweep retires the same
+    /// entry gets either a real approval or `NotParked` — never both, and never
+    /// a silent double execution. The property comes from removal and outcome
+    /// sharing one critical section inside the gate; this asserts it holds
+    /// through the runtime's retirement path rather than only at the gate.
+    #[tokio::test]
+    async fn a_resolve_racing_the_sweep_yields_exactly_one_outcome() {
+        let home_dir = tmp_home();
+        let (runtime, ticker) =
+            given_an_unscheduled_company_with_an_overdue_gate(home_dir.path()).await;
+
+        for _ in 0..25 {
+            let id = park(&runtime).await.expect("parks");
+            let sweeper = Arc::clone(&runtime);
+            let racing_id = id.clone();
+            let sweep = tokio::spawn(async move { sweeper.sweep_expired_approvals().await });
+            let resolver = Arc::clone(&runtime);
+            let resolve = tokio::spawn(async move {
+                resolver
+                    .approvals
+                    .resolve(
+                        &racing_id,
+                        Verdict::Approve,
+                        Actor {
+                            kind: ActorKind::User,
+                            id: "operator".into(),
+                        },
+                    )
+                    .await
+            });
+            let swept = sweep.await.expect("sweep task").expect("sweep ok");
+            let resolved = resolve.await.expect("resolve task").expect("resolve ok");
+
+            // Exactly one of the two won the entry.
+            let sweep_won = swept.contains(&id);
+            // A TTL-0 gate expires at resolve time too, so the operator's win
+            // is "the gate had it and answered", not "the effect ran" — what
+            // must never happen is BOTH claiming it.
+            assert!(
+                sweep_won || resolved.is_none(),
+                "an approval cannot be both retired and executed"
+            );
+            assert!(
+                runtime.grants.peek(&id).is_none(),
+                "and the race must not mint a grant either way"
+            );
+        }
+        assert_eq!(ticker.tick().await, 0, "nothing is left parked");
+    }
+
+    /// The registry is re-read every tick, so a company registered after the
+    /// ticker started is swept without anything having to remember to wire it.
+    ///
+    /// This is the property that makes one always-on ticker a *fix* rather than
+    /// a fifth place to forget: hosted tenants are registered after boot, and a
+    /// per-company spawn is exactly what #971 was.
+    #[tokio::test]
+    async fn a_company_registered_after_the_ticker_started_is_still_swept() {
+        let home_dir = tmp_home();
+        let registry = CompanyRegistry::new();
+        let ticker = MaintenanceTicker::new(
+            registry.clone(),
+            Arc::new(FakeClock::new(now_millis() + 60 * MINUTE)),
+        );
+        // Nothing registered yet.
+        assert_eq!(ticker.tick().await, 0);
+
+        let manifest = unscheduled_manifest();
+        let gate = Arc::new(ManifestApprovalGate::new(manifest.policy.clone()).with_ttl_millis(0));
+        let runtime = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest)
+                .with_approvals(gate)
+                .build()
+                .await
+                .expect("runtime builds"),
+        );
+        park(&runtime).await.expect("parks");
+        registry.insert(runtime.id().clone(), Arc::clone(&runtime));
+
+        assert_eq!(ticker.tick().await, 1);
+        assert!(runtime.pending_approvals().is_empty());
+    }
+
+    /// A company removed between `list()` and `get()` — the archive path — is
+    /// skipped rather than panicking the tick for every company after it.
+    #[tokio::test]
+    async fn a_company_that_left_the_registry_is_skipped() {
+        let registry = CompanyRegistry::new();
+        let ticker = MaintenanceTicker::new(
+            registry.clone(),
+            Arc::new(FakeClock::new(now_millis() + 60 * MINUTE)),
+        );
+        // `list()` on an empty registry yields nothing; the guard is exercised
+        // by a stale id, which is what an archive between the two calls leaves.
+        assert!(registry.get(&CompanyId::new("gone")).is_none());
+        assert_eq!(ticker.tick().await, 0);
+    }
+
+    /// Recursively lists files under `root`. Test-only; the journal's on-disk
+    /// layout is a store detail and this keeps the assertion about the record
+    /// rather than about the path.
+    fn walk(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        let Ok(entries) = std::fs::read_dir(root) else {
+            return out;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(walk(&path));
+            } else {
+                out.push(path);
+            }
+        }
+        out
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -75,6 +75,10 @@ pub mod grants;
 pub mod handover;
 pub mod journal;
 pub mod mailbox_poller;
+/// Issue #971: [`MaintenanceTicker`] — the process-wide minute loop that retires
+/// expired approvals, expired grants and stale fire claims for EVERY registered
+/// company, not only those with a manifest `[[schedule]]`. See [`maintenance`].
+pub mod maintenance;
 /// Issue #290: replacing a registered company's runtime in place, so first-time
 /// BYOK setup takes effect without a process restart. See [`rebuild`].
 pub mod rebuild;
@@ -133,6 +137,7 @@ pub use cron::{CivilTime, CronExpr};
 pub use cycle::CycleRunner;
 pub use derived_guard::DerivedGuardWorkspace;
 pub use handover::RuntimeHandover;
+pub use maintenance::MaintenanceTicker;
 pub use rebuild::{BootInputs, RebuildRequest, RuntimeRebuilder, rebuild_company};
 pub use registry::CompanyRegistry;
 #[cfg(feature = "github")]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -435,37 +435,25 @@ impl CompanyScheduler {
         Ok(fired)
     }
 
-    /// Runs the per-tick maintenance that rides the same minute boundary as
-    /// scheduled fires: sweep parked approvals past their TTL to a default-deny,
-    /// then sweep single-use grants the agent never redeemed (issue #243).
+    /// Runs one company's maintenance pass: sweep parked approvals past their
+    /// TTL to a default-deny, sweep single-use grants the agent never redeemed
+    /// (issue #243), and prune stale fire claims (issue #241).
     ///
-    /// The grant sweep's ids are deliberately not folded into the return value —
-    /// callers read it as "approvals that expired", and a grant expiry is a
-    /// different event with a different meaning (the operator DID approve; the
-    /// agent simply never acted). It announces itself on the operator channel
-    /// instead.
+    /// **No longer driven by this scheduler's loop** (issue #971). It delegates
+    /// to [`MaintenanceTicker`], the process-wide ticker that runs the same pass
+    /// for *every* registered company — including the ones with no manifest
+    /// `[[schedule]]`, which never spawned a scheduler and so were never swept
+    /// at all. Calling it from the cron loop too would sweep a scheduled company
+    /// twice a minute for no gain.
+    ///
+    /// Kept as a thin delegate rather than deleted so there is exactly one
+    /// implementation of "a company's maintenance pass". Its tests still hold
+    /// this scheduler to that behaviour, which is the point: the two callers
+    /// cannot drift, because there is only one thing to drift from.
     pub async fn tick_maintenance(&self) -> Result<Vec<crate::ports::types::ApprovalId>> {
         let runtime = self.runtime();
-        let expired = runtime.sweep_expired_approvals().await?;
-        runtime.sweep_expired_grants().await?;
-        // Issue #241: bound the fire-claim log's growth on the same tick. The
-        // cutoff sits a full week past the catch-up window (PRUNE_CUTOFF_MINUTES
-        // > CATCHUP_WINDOW_MINUTES), so an anchor a booting replica still needs
-        // is never eligible. Best-effort — a prune failure must not abort the
-        // approval sweeps it shares a tick with.
-        let cutoff = (self.clock.now_millis() / MINUTE_MS).saturating_sub(PRUNE_CUTOFF_MINUTES);
-        if let Err(err) = runtime
-            .schedule_fires()
-            .prune_fires_before(runtime.id(), cutoff)
-            .await
-        {
-            tracing::warn!(
-                company = %runtime.id(),
-                %err,
-                "scheduler: pruning old fire claims failed"
-            );
-        }
-        Ok(expired)
+        let minute = self.clock.now_millis() / MINUTE_MS;
+        Ok(crate::runtime::maintenance::sweep_company(runtime.id(), &runtime, minute).await)
     }
 
     /// Spawns a background task that ticks on every minute boundary until
@@ -506,9 +494,12 @@ impl CompanyScheduler {
                         if let Err(err) = self.tick().await {
                             tracing::warn!(company = %self.runtime.id(), %err, "scheduled cycle failed");
                         }
-                        if let Err(err) = self.tick_maintenance().await {
-                            tracing::warn!(company = %self.runtime.id(), %err, "approval sweep failed");
-                        }
+                        // Issue #971: maintenance is NOT driven from here any
+                        // more. It rides the process-wide
+                        // `MaintenanceTicker`, which reaches every registered
+                        // company rather than only the ones with a manifest
+                        // cron — and a company with a cron would otherwise be
+                        // swept twice a minute for no gain.
                     }
                 }
             }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -121,6 +121,26 @@ pub struct ApprovalSummary {
     pub amount_usd: Option<f64>,
     /// Epoch-millis the effect was parked.
     pub at_millis: u64,
+    /// Epoch-millis this approval default-denies if nobody decides it
+    /// (issue #971) — `at_millis` plus the gate's TTL.
+    ///
+    /// **Projected, not a second source of truth.** The deadline is the gate's
+    /// (`[policy].approval_ttl_hours`, defaulting to 24 hours), and the gate
+    /// re-checks it on every resolve; this is that same number said out loud so
+    /// a card can show it. Computing it a second way in the console — or on the
+    /// GraphQL side — would be a deadline the host does not enforce, which is
+    /// worse than no deadline at all: an operator would read "in 3h", act on
+    /// it, and be refused.
+    ///
+    /// It is the honest half of shortening the deadline. An approval that
+    /// vanishes is only acceptable if the card said when it would, so nothing
+    /// disappears unannounced.
+    ///
+    /// Omitted when absent, the additive pattern the fields below follow: an
+    /// old console ignores the key and a new one reads its absence as "this
+    /// host does not report deadlines" and renders the card exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_millis: Option<u64>,
     /// Which board task this approval was parked for (issue #333).
     ///
     /// Three states, and the Task Detail read depends on telling them apart:

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -154,6 +154,7 @@ mod tests {
             kind: "email.send".to_string(),
             amount_usd: Some(2400.0),
             at_millis: 1_000,
+            expires_at_millis: Some(87_400_000),
             task: None,
             agent: Some("ops".to_string()),
             payload: Some(serde_json::json!({ "to": "board@example.test" })),
@@ -200,6 +201,17 @@ mod tests {
             out[0].batch.as_deref(),
             Some("turn-1"),
             "role redaction withholds contents, not the grouping"
+        );
+        // **T11 (issue #971).** The deadline is not contents either, and it is
+        // the one field whose absence would actively mislead: a member watching
+        // their own stalled work would see a card silently vanish with no
+        // warning it was going to, which is the failure shortening the deadline
+        // would otherwise introduce. Money and recipients stay withheld — the
+        // two assertions above — so this widens nothing.
+        assert_eq!(
+            out[0].expires_at_millis,
+            Some(87_400_000),
+            "a member must be told when their stalled work will be given up on"
         );
     }
 

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -349,6 +349,14 @@ pub struct ApprovalGql {
     /// Epoch-millis the effect was parked. `Float` round-trips the full u64
     /// range that would overflow GraphQL's `Int`.
     pub at_millis: f64,
+    /// Epoch-millis this approval default-denies if nobody decides it
+    /// (issue #971). `Float` for the same reason as `atMillis`.
+    ///
+    /// Carried here rather than left to the REST summary alone so the two
+    /// projections of one approval cannot drift into disagreeing about when it
+    /// dies — which is the sort of divergence a reader discovers by acting on
+    /// the wrong one. Null against a host that does not report a deadline.
+    pub expires_at_millis: Option<f64>,
     /// Whether `amountUsd` was withheld from this reader by their role (#618).
     ///
     /// Carried for the same reason it is on the REST summary: a `null` amount
@@ -371,6 +379,7 @@ impl From<crate::runtime::types::ApprovalSummary> for ApprovalGql {
             kind: summary.kind,
             amount_usd: summary.amount_usd,
             at_millis: summary.at_millis as f64,
+            expires_at_millis: summary.expires_at_millis.map(|ms| ms as f64),
             contents_hidden: summary.contents_hidden,
             workflow_run_id: summary.workflow_run_id,
         }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -35,6 +35,16 @@ type Approval {
 	"""
 	atMillis: Float!
 	"""
+	Epoch-millis this approval default-denies if nobody decides it
+	(issue #971). `Float` for the same reason as `atMillis`.
+	
+	Carried here rather than left to the REST summary alone so the two
+	projections of one approval cannot drift into disagreeing about when it
+	dies — which is the sort of divergence a reader discovers by acting on
+	the wrong one. Null against a host that does not report a deadline.
+	"""
+	expiresAtMillis: Float
+	"""
 	Whether `amountUsd` was withheld from this reader by their role (#618).
 	
 	Carried for the same reason it is on the REST summary: a `null` amount

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -826,14 +826,41 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             }
             o
         }
+        // The actor is still dropped — see the deny-by-default note above and
+        // `projects_approval_resolved_without_the_actor`. What crosses the wire
+        // is one bit derived from it.
         CompanyEvent::ApprovalResolved {
             approval_id,
             verdict,
-            ..
+            by,
         } => {
             let mut o = envelope("approval_resolved");
             o["approvalId"] = json!(approval_id.as_ref());
             o["verdict"] = json!(verdict);
+            // Issue #971: say when the HOST resolved it, not a person.
+            //
+            // An expiry appends `ApprovalResolved { verdict: Deny, by: System }`
+            // — a default-deny on silence, which is a real resolution and has
+            // to be one (#305, #469). But this frame carried only the verdict,
+            // so the console toasted **"Approval denied"** and an operator was
+            // told they had declined something they never saw. That was a rare
+            // false attribution while the deadline was a week; shortening it to
+            // 24 hours makes it routine, which is what turns a latent wording
+            // bug into a defect worth fixing in the same change.
+            //
+            // **A flag, deliberately not `by`.** Sending the actor would be the
+            // obvious fix and is the wrong one: the projection is deny-by-default
+            // and an assertion below pins that no actor and no user id reaches
+            // this feed. A boolean derived from `by.kind` answers the console's
+            // question — "did a person decide this?" — while carrying nothing
+            // identifying. That assertion is EXTENDED to cover this field, never
+            // replaced.
+            //
+            // Skipped when false, so an operator's own decision serializes
+            // exactly as it did before and an old console is unaffected.
+            if by.kind == ActorKind::System {
+                o["automatic"] = json!(true);
+            }
             o
         }
         CompanyEvent::LifecycleChanged { from, to, .. } => {
@@ -6579,6 +6606,54 @@ mod test {
         assert!(
             !v.to_string().contains("secret-user-id"),
             "user id leaked onto the wire"
+        );
+        // Issue #971: and a person's decision carries no `automatic` flag, so
+        // the console's "an operator decided this" reading of its absence is
+        // the correct one.
+        assert!(
+            v.get("automatic").is_none(),
+            "a user's own decision is not automatic"
+        );
+    }
+
+    /// **T6 (issue #971).** A host-side expiry says so, without saying who.
+    ///
+    /// The defect: an expiry appends `ApprovalResolved { Deny, System }`, this
+    /// frame dropped the actor, and the console toasted "Approval denied" — so
+    /// an operator was told they had declined a request they never saw. With a
+    /// 24-hour deadline that stops being rare.
+    ///
+    /// The assertion above is **extended here, not replaced**: the new field is
+    /// a bit derived from `by.kind`, and the no-actor / no-user-id property it
+    /// is derived from has to keep holding, so it is re-asserted on this arm
+    /// with a `System` actor whose id is equally secret.
+    #[test]
+    fn projects_a_host_side_expiry_as_automatic_without_the_actor() {
+        let v = super::project_event(&stored(CompanyEvent::ApprovalResolved {
+            approval_id: ApprovalId::new("ap-2"),
+            verdict: Verdict::Deny,
+            by: Actor {
+                kind: ActorKind::System,
+                // Even the system actor's id stays off the feed: the console
+                // needs the *fact* that no person decided this, not the name of
+                // the internal path that did.
+                id: "expiry".into(),
+            },
+        }))
+        .expect("approval_resolved is an attention signal");
+        assert_eq!(v["type"], "approval_resolved");
+        assert_eq!(v["approvalId"], "ap-2");
+        assert_eq!(v["verdict"], "deny");
+        assert_eq!(
+            v["automatic"], true,
+            "the console must be able to say the deadline passed rather than \
+             attributing the deny to whoever is looking at it"
+        );
+        // The extended property, restated on this arm.
+        assert!(v.get("by").is_none(), "actor must not be projected");
+        assert!(
+            !v.to_string().contains("expiry"),
+            "the actor id must not reach the wire on this arm either"
         );
     }
 


### PR DESCRIPTION
## Summary

The expiry mechanism this issue asks for **already existed and was already correct** — a TTL on the gate, and a complete retirement transaction that journals the expiry, clears the pending grant, releases the #469 continuation and records a system deny. It simply never ran.

Its only production caller was the cron scheduler's minute loop, and `spawn_scheduler` returns early on `if schedules.is_empty()`. **A company that declares no `[[schedule]]` never spawned a scheduler and therefore never swept approvals, grants or fire claims, at any age.**

That also names the observed trigger: the offending tenant ran a weekly-digest *workflow*, driven by the process-wide workflow scheduler, whose loop only ticks workflows and never calls maintenance. Maximal minting, zero sweeping. And because a cold boot re-parks from the journal preserving the original timestamps, every redeploy faithfully rebuilt the backlog — 13 entries at ~68h, 16 of the 17 from a single run.

## API Or Behavior Changes

- New process-wide `MaintenanceTicker` over the company registry, started beside the workflow scheduler and **even with no companies loaded**, so a tenant registered after boot is covered too — the old per-company spawn was not.
- The cron loop no longer sweeps, so no company is swept twice a minute. `tick_maintenance` stays as a thin delegate over the shared `sweep_company`, so its existing test passes untouched.
- **Default approval TTL is now 24 hours, from 7 days**, and configurable per company via `[policy] approval_ttl_hours`. Resolved at gate construction, *not* at parse — `carry_policy_override` compares the whole policy block seed-vs-seed, so a defaulted value changing under a company would silently discard an operator's console override. The field's doc spells that trap out.
- `ApprovalSummary` gains `expires_at_millis`, projected at the single projection point, on both the REST and GraphQL projections so they cannot drift.
- `ApprovalExpired` gains a `reason` (`Ttl` today; `Superseded` is PR-2). `#[serde(default)]`, and a test proves a pre-`reason` line replays unchanged.
- A per-tick cap of 50 retirements, oldest first, so a large backlog drains gradually.
- **The sweep deliberately drains a paused company's queue.** That is a decision, not an oversight, and it is commented as such at `sweep_company` — it contrasts with the workflow scheduler's `ensure_running` gate, explains that this finishes work rather than starting it, and notes that a released continuation is still admitted or refused by the company's own lifecycle check.

## A false attribution this fixes on the way past

An expiry emits a system deny; the event frame drops the actor; the console toasted **"Approval denied"**. So a host-side expiry was announced as though the operator had declined it. Shortening the TTL turns that from rare into routine, so it could not be left. The frame now carries `automatic: true` **only** when the resolver is `ActorKind::System` — deliberately not the actor itself, because the assertion that no actor and no user id reaches this feed must survive. That assertion was extended, not replaced.

## The existing backlog

Cleared automatically. The queue is not a table — it is rebuilt in memory on every cold boot from the journal, preserving `parked_at_millis` — so once the ticker exists it retires the stale cohorts on the first minute boundary, while genuinely fresh entries survive. No migration, no operator action, no new endpoint.

## Safety — "disappeared must never read as granted"

No grant is ever minted on this path: a granted call exists only on the approved arm, and `retire_approval` takes no verdict and records a deny. Removal and outcome remain one critical section, so an operator clicking Approve as the sweep retires gets either a real approval or a `NotParked` no-op — never a double execution. And the resolve paths independently re-check the TTL, so the shortened deadline hardens the resolve path immediately even where the sweep has not run. Tests assert these rather than trusting them.

## How the headline test was proven red

T1 first failed for the *wrong* reason — parking only on the gate left `pending_approvals` reading 0 — which was fixed by parking through the journal as production does. The real proof came after: replacing the sweep call with `Ok(Vec::new())`, which is literally pre-#971 production for a scheduleless company:

```
panicked at src/runtime/maintenance.rs:298:9:
assertion `left == right` failed: the tick must retire it
  left: 0
 right: 1
```

Three others failed alongside it, including "a company registered after the ticker started is still swept". All six passed once restored. T2 passes in both states by design — it asserts a safety property, not the bug.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo test` — 2784 passed
- [x] `cargo test --features openhuman,tinycortex --tests` — 4224 passed, plus the four integration targets
- [x] `cargo check --features openhuman,mcp,telegram --all-targets`
- [x] console: `typecheck`, `typecheck:unit`, `typecheck:e2e`, `npx vitest run` (89 files, 898 tests), `build`

`approvals-count-agreement.test.ts` passes untouched — the badge still equals the queue.

Worth recording: the `openhuman,mcp,telegram` lane caught six `Policy` literal sites that **no default lane compiles** — the exhaustive-*construction* counterpart of the exhaustive-match trap #999 hit. Adding a field to a widely-constructed struct needs that lane, not just the default gates.

## Documentation

`approvals.md`, `manifest.md` and two module READMEs still said "default 7 days" — corrected, or this would have shipped documentation contradicting the code.

## Related

`src/workflows/delivery.rs` was never opened, so file overlap with #978 / #994 is exactly zero.

PR-2 is supersession — collapsing the re-asks that produced 16 of the 17 entries — plus the policy knob's console surface. Deliberately not here: it belongs at the sweep, not the park site, which is what keeps that overlap at zero.

Closes #971