### PR TITLE
fix(console): show the workflow create dialog working, and announce a refusal

### DIFF
--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -587,8 +587,31 @@ export function WorkflowCreateDialog({
     };
   }, [open, editing, client, company]);
 
+  /**
+   * Retires the submit-time banner because the draft it described is gone
+   * (issue #1005).
+   *
+   * `error` is the verdict on ONE graph — the client checks' first complaint or
+   * the host's rejection — so it stops being true the moment the author changes
+   * that graph. Left up it reads as the verdict on the graph now on screen, and
+   * the next failed Create is indistinguishable from the last one: same text,
+   * no new event.
+   *
+   * Every handler that mutates the draft calls this, structural ones included.
+   * The banner routinely names something an add or a remove fixes ("Add at
+   * least one node.", a duplicate node id, an edge pointing at nothing), so a
+   * split where only the field edits clear it leaves the complaint up through
+   * exactly the action that answers it. Field-level `fieldErrors` are NOT
+   * touched here — those are scoped to their own control and each clears on its
+   * own edit.
+   */
+  function clearSubmitError() {
+    setError(null);
+  }
+
   function addNode() {
     setNodes((rows) => [...rows, blankNode()]);
+    clearSubmitError();
   }
 
   /** Edits the name and drops the stale submit banner with it — `validate()`
@@ -596,16 +619,25 @@ export function WorkflowCreateDialog({
    * looking straight at a complaint they have already addressed (#1005). */
   function changeName(value: string) {
     setName(value);
-    setError(null);
+    clearSubmitError();
+  }
+
+  /** Same for the id, which is what `validate()` complains about FIRST (missing,
+   * or not a safe id) and the most common 409 from the host — so it is the
+   * banner an author is most often looking at while fixing its cause. */
+  function changeId(value: string) {
+    setId(value);
+    clearSubmitError();
+  }
+
+  function changeDescription(value: string) {
+    setDescription(value);
+    clearSubmitError();
   }
 
   function updateNode(key: string, fields: Partial<DraftNode>) {
     setNodes((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
-    // The submit banner described the graph as it was before this edit — from
-    // the client checks or from the host — so it goes the moment the author
-    // starts changing that graph (issue #1005). Leaving it up means the next
-    // failed Create is indistinguishable from the last one.
-    setError(null);
+    clearSubmitError();
     // Clear whatever the edit invalidated. This MUST stay in step with
     // `changeKind`: that reset exists so the draft never holds a value whose
     // control is off screen, and an error is a value too — leaving one behind
@@ -656,6 +688,7 @@ export function WorkflowCreateDialog({
         r.key === nodeKey ? { ...r, configDraft: { ...r.configDraft, [key]: value } } : r,
       ),
     );
+    clearSubmitError();
     setFieldErrors((prev) => {
       const k = errorKey(nodeKey, `config:${key}`);
       if (!(k in prev)) return prev;
@@ -694,6 +727,7 @@ export function WorkflowCreateDialog({
   function removeNode(key: string) {
     const removed = nodes.find((n) => n.key === key);
     setNodes((rows) => rows.filter((r) => r.key !== key));
+    clearSubmitError();
     // The row is gone, so its errors have nothing left to point at.
     setFieldErrors((prev) => {
       const next = Object.fromEntries(
@@ -710,17 +744,17 @@ export function WorkflowCreateDialog({
 
   function addEdge() {
     setEdges((rows) => [...rows, { key: nextKey(), from: "", to: "", label: "" }]);
+    clearSubmitError();
   }
 
   function updateEdge(key: string, fields: Partial<DraftEdge>) {
     setEdges((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
-    // Same reasoning as `updateNode`: the banner belongs to the graph the
-    // author has just stopped having.
-    setError(null);
+    clearSubmitError();
   }
 
   function removeEdge(key: string) {
     setEdges((rows) => rows.filter((r) => r.key !== key));
+    clearSubmitError();
   }
 
   /** Client-side validation, mirroring the host's checks so most mistakes
@@ -904,9 +938,10 @@ export function WorkflowCreateDialog({
         setDescription(graph.description ?? "");
         setNodes(draftNodes(graph));
         setEdges(draftEdges(graph));
-        // A fresh draft clears both the submit banner and the per-field blur
-        // errors — they belonged to whatever was on screen before.
-        setError(null);
+        // A fresh draft replaces the whole graph, so it clears both the submit
+        // banner and the per-field blur errors — they belonged to whatever was
+        // on screen before.
+        clearSubmitError();
         setFieldErrors({});
         setDraftSummary(banners.summary);
         // Any host corrections (issue #813) — e.g. a role→id rewrite — so the
@@ -1200,131 +1235,147 @@ export function WorkflowCreateDialog({
           </div>
         )}
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="grid gap-2">
-            <Label htmlFor={`${formId}-id`}>Id</Label>
-            {/* Read-only in edit mode, not merely rejected on save: the id keys
-                the saved graph, the scheduler and every past run, so the host
-                answers 400 to a rename. Letting an author type a new one and
-                then refusing it would be a trap. */}
-            <Input
-              id={`${formId}-id`}
-              value={id}
-              onChange={(e) => setId(e.target.value)}
-              readOnly={editing}
-              aria-readonly={editing || undefined}
-              className={editing ? "text-muted-foreground" : undefined}
-              placeholder="e.g. campaign_pipeline"
-            />
-            {editing && (
-              <p className="text-2xs leading-snug text-muted-foreground">
-                A workflow&apos;s id can&apos;t change. It keys the saved graph, its
-                schedule and its run history.
-              </p>
-            )}
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor={`${formId}-name`}>Name</Label>
-            <Input
-              id={`${formId}-name`}
-              value={name}
-              onChange={(e) => changeName(e.target.value)}
-              placeholder="e.g. Campaign pipeline"
-            />
-          </div>
-        </div>
-        <div className="grid gap-2">
-          <Label htmlFor={`${formId}-desc`}>Description</Label>
-          <Textarea
-            id={`${formId}-desc`}
-            rows={2}
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="What does this workflow do?"
-          />
-        </div>
+        {/*
+          Every control that can change the draft goes dead while a save is in
+          flight (issue #1005). `submit()` snapshots the graph before it awaits,
+          so an edit landing during the round trip is in neither the request nor
+          the result — and on success the dialog closes, taking that edit with
+          it. The operator would have watched themselves type it.
 
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <Label>Nodes</Label>
-            {/* Off while a save is in flight (issue #1005): the graph being
-                posted is the one on screen, and a row added mid-write is in
-                neither the request nor the result. */}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={addNode}
-              disabled={submitting}
-            >
-              <Plus className="size-3.5" /> Add node
-            </Button>
-          </div>
-          <div className="space-y-2">
-            {nodes.map((n) => (
-              <NodeRow
-                key={n.key}
-                node={n}
-                client={client}
-                company={company}
-                roster={roster}
-                wiredChannels={wiredChannels}
-                workflows={workflows}
-                createMode={!editing}
-                errors={{
-                  schedule: fieldErrors[errorKey(n.key, "schedule")],
-                  destinationTarget: fieldErrors[errorKey(n.key, "destinationTarget")],
-                }}
-                configErrors={Object.fromEntries(
-                  configFieldSpecs(n.kind).map((s) => [
-                    s.key,
-                    fieldErrors[errorKey(n.key, `config:${s.key}`)],
-                  ]),
-                )}
-                onValidateField={(field, value) => validateField(n.key, field, value)}
-                onConfigChange={(key, value) => updateConfigField(n.key, key, value)}
-                onChange={(fields) => updateNode(n.key, fields)}
-                onRemove={() => removeNode(n.key)}
+          A `fieldset` rather than a `disabled` prop threaded through `NodeRow`,
+          `EdgeRow`, `ScheduleField` and `NodeConfigFields`: `disabled`
+          propagates natively to every form control underneath, so a control
+          added later is covered by construction rather than by remembering.
+          `display: contents` keeps it out of the layout — the grids below still
+          see their own children.
+        */}
+        <fieldset disabled={submitting} className="contents">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid gap-2">
+              <Label htmlFor={`${formId}-id`}>Id</Label>
+              {/* Read-only in edit mode, not merely rejected on save: the id keys
+                  the saved graph, the scheduler and every past run, so the host
+                  answers 400 to a rename. Letting an author type a new one and
+                  then refusing it would be a trap. */}
+              <Input
+                id={`${formId}-id`}
+                value={id}
+                onChange={(e) => changeId(e.target.value)}
+                readOnly={editing}
+                aria-readonly={editing || undefined}
+                className={editing ? "text-muted-foreground" : undefined}
+                placeholder="e.g. campaign_pipeline"
               />
-            ))}
-            {nodes.length === 0 && (
-              <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
-                No nodes yet.
-              </p>
-            )}
+              {editing && (
+                <p className="text-2xs leading-snug text-muted-foreground">
+                  A workflow&apos;s id can&apos;t change. It keys the saved graph, its
+                  schedule and its run history.
+                </p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor={`${formId}-name`}>Name</Label>
+              <Input
+                id={`${formId}-name`}
+                value={name}
+                onChange={(e) => changeName(e.target.value)}
+                placeholder="e.g. Campaign pipeline"
+              />
+            </div>
           </div>
-        </div>
+          <div className="grid gap-2">
+            <Label htmlFor={`${formId}-desc`}>Description</Label>
+            <Textarea
+              id={`${formId}-desc`}
+              rows={2}
+              value={description}
+              onChange={(e) => changeDescription(e.target.value)}
+              placeholder="What does this workflow do?"
+            />
+          </div>
 
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <Label>Edges</Label>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={addEdge}
-              disabled={nodes.length < 2 || submitting}
-            >
-              <Plus className="size-3.5" /> Add edge
-            </Button>
-          </div>
           <div className="space-y-2">
-            {edges.map((e) => (
-              <EdgeRow
-                key={e.key}
-                edge={e}
-                nodeIds={nodes.map((n) => n.id.trim()).filter(Boolean)}
-                onChange={(fields) => updateEdge(e.key, fields)}
-                onRemove={() => removeEdge(e.key)}
-              />
-            ))}
-            {edges.length === 0 && (
-              <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
-                No edges yet — nodes won&apos;t be connected.
-              </p>
-            )}
+            <div className="flex items-center justify-between">
+              <Label>Nodes</Label>
+              {/* Off while a save is in flight (issue #1005): the graph being
+                  posted is the one on screen, and a row added mid-write is in
+                  neither the request nor the result. */}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addNode}
+                disabled={submitting}
+              >
+                <Plus className="size-3.5" /> Add node
+              </Button>
+            </div>
+            <div className="space-y-2">
+              {nodes.map((n) => (
+                <NodeRow
+                  key={n.key}
+                  node={n}
+                  client={client}
+                  company={company}
+                  roster={roster}
+                  wiredChannels={wiredChannels}
+                  workflows={workflows}
+                  createMode={!editing}
+                  errors={{
+                    schedule: fieldErrors[errorKey(n.key, "schedule")],
+                    destinationTarget: fieldErrors[errorKey(n.key, "destinationTarget")],
+                  }}
+                  configErrors={Object.fromEntries(
+                    configFieldSpecs(n.kind).map((s) => [
+                      s.key,
+                      fieldErrors[errorKey(n.key, `config:${s.key}`)],
+                    ]),
+                  )}
+                  onValidateField={(field, value) => validateField(n.key, field, value)}
+                  onConfigChange={(key, value) => updateConfigField(n.key, key, value)}
+                  onChange={(fields) => updateNode(n.key, fields)}
+                  onRemove={() => removeNode(n.key)}
+                />
+              ))}
+              {nodes.length === 0 && (
+                <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
+                  No nodes yet.
+                </p>
+              )}
+            </div>
           </div>
-        </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Edges</Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addEdge}
+                disabled={nodes.length < 2 || submitting}
+              >
+                <Plus className="size-3.5" /> Add edge
+              </Button>
+            </div>
+            <div className="space-y-2">
+              {edges.map((e) => (
+                <EdgeRow
+                  key={e.key}
+                  edge={e}
+                  nodeIds={nodes.map((n) => n.id.trim()).filter(Boolean)}
+                  onChange={(fields) => updateEdge(e.key, fields)}
+                  onRemove={() => removeEdge(e.key)}
+                />
+              ))}
+              {edges.length === 0 && (
+                <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
+                  No edges yet — nodes won&apos;t be connected.
+                </p>
+              )}
+            </div>
+          </div>
+        </fieldset>
 
         {error && (
           // Wrapper carries the ref/focus target so it works regardless of

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -14,7 +14,7 @@
 // second one would drift the moment either side grew a field.
 
 import { useEffect, useId, useRef, useState } from "react";
-import { History, Plus, RotateCcw, Sparkles, Trash2 } from "lucide-react";
+import { History, Loader2, Plus, RotateCcw, Sparkles, Trash2 } from "lucide-react";
 
 import {
   CREATABLE_NODE_KINDS,
@@ -584,8 +584,21 @@ export function WorkflowCreateDialog({
     setNodes((rows) => [...rows, blankNode()]);
   }
 
+  /** Edits the name and drops the stale submit banner with it — `validate()`
+   * and the host both complain about the name, so an author fixing one is
+   * looking straight at a complaint they have already addressed (#1005). */
+  function changeName(value: string) {
+    setName(value);
+    setError(null);
+  }
+
   function updateNode(key: string, fields: Partial<DraftNode>) {
     setNodes((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
+    // The submit banner described the graph as it was before this edit — from
+    // the client checks or from the host — so it goes the moment the author
+    // starts changing that graph (issue #1005). Leaving it up means the next
+    // failed Create is indistinguishable from the last one.
+    setError(null);
     // Clear whatever the edit invalidated. This MUST stay in step with
     // `changeKind`: that reset exists so the draft never holds a value whose
     // control is off screen, and an error is a value too — leaving one behind
@@ -694,6 +707,9 @@ export function WorkflowCreateDialog({
 
   function updateEdge(key: string, fields: Partial<DraftEdge>) {
     setEdges((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
+    // Same reasoning as `updateNode`: the banner belongs to the graph the
+    // author has just stopped having.
+    setError(null);
   }
 
   function removeEdge(key: string) {
@@ -902,18 +918,36 @@ export function WorkflowCreateDialog({
     }
   }
 
+  /**
+   * Raise the submit-time banner and take the operator to it (issue #1005).
+   *
+   * Issue #813 gave the CLIENT-validation failure this treatment: the banner
+   * sits inline in a scrollable dialog with the Create button below it, so on a
+   * long graph the message lands off-screen and the button just looks dead.
+   * A host rejection has exactly the same geometry and was getting none of it,
+   * so both branches go through here rather than one of them setting `error`
+   * on its own — the version that skips this is the one that reads as nothing
+   * happening. The scroll/focus runs the frame AFTER the state change, because
+   * `errorRef` points at a node that does not exist until the banner renders.
+   */
+  function showError(message: string) {
+    setError(message);
+    requestAnimationFrame(() => {
+      errorRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+      errorRef.current?.focus();
+    });
+  }
+
   async function submit() {
+    // Re-entrancy guard (issue #1005). The Create button disables while a write
+    // is in flight, but `disabled` is a property of one DOM node: a second click
+    // landing in the same tick as the first, an Enter keypress, or any future
+    // caller would otherwise post the graph twice — and for create that means
+    // two workflows, or a 409 the operator did nothing to earn.
+    if (submitting) return;
     const problem = validate();
     if (problem) {
-      setError(problem);
-      // Issue #813: the banner sits inline in a scrollable dialog and the Create
-      // button is below it, so on a long graph the message can land off-screen —
-      // the button then looks dead. Bring it into view and focus it (announced,
-      // deterministic — no timer) the frame after it renders.
-      requestAnimationFrame(() => {
-        errorRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
-        errorRef.current?.focus();
-      });
+      showError(problem);
       return;
     }
     setSubmitting(true);
@@ -989,7 +1023,7 @@ export function WorkflowCreateDialog({
       }
       onOpenChange(false);
     } catch (e) {
-      setError(
+      showError(
         e instanceof Error
           ? e.message
           : workflow
@@ -1010,7 +1044,13 @@ export function WorkflowCreateDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => !submitting && onOpenChange(o)}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+      {/* `aria-busy` while a save is in flight (issue #1005): the dialog stays
+          on screen and mostly interactive during the round trip, so without it
+          a screen reader has nothing to say the form is mid-write. */}
+      <DialogContent
+        className="max-h-[85vh] overflow-y-auto sm:max-w-2xl"
+        aria-busy={submitting}
+      >
         <DialogHeader>
           <DialogTitle>{editing ? "Edit workflow" : "New workflow"}</DialogTitle>
           <DialogDescription>
@@ -1087,7 +1127,11 @@ export function WorkflowCreateDialog({
               value={copilotPrompt}
               onChange={(e) => setCopilotPrompt(e.target.value)}
               placeholder="e.g. Every Monday morning, have the writer draft the weekly digest and email it to the team."
-              disabled={drafting || echoing}
+              // Also dead while a create is in flight (issue #1005): drafting
+              // replaces the whole form, and the graph being posted is the one
+              // on screen — so a draft landing mid-write would leave the
+              // operator looking at a graph that is not the one they created.
+              disabled={drafting || echoing || submitting}
             />
             <div className="flex items-center justify-between gap-2">
               <p className="text-2xs leading-snug text-muted-foreground">
@@ -1100,10 +1144,14 @@ export function WorkflowCreateDialog({
                 variant="outline"
                 size="sm"
                 onClick={() => void runDraft()}
-                disabled={drafting || echoing || !copilotPrompt.trim()}
+                disabled={drafting || echoing || submitting || !copilotPrompt.trim()}
                 data-testid="workflow-copilot-draft"
               >
-                <Sparkles className="mr-1 size-3.5" />
+                {drafting ? (
+                  <Loader2 className="mr-1 size-3.5 animate-spin" />
+                ) : (
+                  <Sparkles className="mr-1 size-3.5" />
+                )}
                 {drafting ? "Drafting…" : "Draft it"}
               </Button>
             </div>
@@ -1164,7 +1212,7 @@ export function WorkflowCreateDialog({
             <Input
               id={`${formId}-name`}
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => changeName(e.target.value)}
               placeholder="e.g. Campaign pipeline"
             />
           </div>
@@ -1183,7 +1231,16 @@ export function WorkflowCreateDialog({
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label>Nodes</Label>
-            <Button type="button" variant="outline" size="sm" onClick={addNode}>
+            {/* Off while a save is in flight (issue #1005): the graph being
+                posted is the one on screen, and a row added mid-write is in
+                neither the request nor the result. */}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addNode}
+              disabled={submitting}
+            >
               <Plus className="size-3.5" /> Add node
             </Button>
           </div>
@@ -1230,7 +1287,7 @@ export function WorkflowCreateDialog({
               variant="outline"
               size="sm"
               onClick={addEdge}
-              disabled={nodes.length < 2}
+              disabled={nodes.length < 2 || submitting}
             >
               <Plus className="size-3.5" /> Add edge
             </Button>
@@ -1259,6 +1316,14 @@ export function WorkflowCreateDialog({
           <div
             ref={errorRef}
             tabIndex={-1}
+            // Announced, not merely rendered (issue #1005): `assertive`
+            // because the write the operator just asked for did not happen,
+            // and `showError`'s focus move is the only other thing that
+            // reports it. `role="alert"` already implies the live region;
+            // both are stated so a later refactor of one does not silently
+            // take the other with it.
+            role="alert"
+            aria-live="assertive"
             data-testid="create-error"
             className="outline-none"
           >
@@ -1324,7 +1389,11 @@ export function WorkflowCreateDialog({
                         disabled={restoringId !== null || submitting}
                         aria-label={`Restore ${rev.name}`}
                       >
-                        <RotateCcw className="mr-1 size-3.5" />
+                        {restoringId === rev.id ? (
+                          <Loader2 className="mr-1 size-3.5 animate-spin" />
+                        ) : (
+                          <RotateCcw className="mr-1 size-3.5" />
+                        )}
                         {restoringId === rev.id ? "Restoring…" : "Restore"}
                       </Button>
                     </li>
@@ -1344,6 +1413,7 @@ export function WorkflowCreateDialog({
             disabled={submitting}
             data-testid="workflow-dialog-submit"
           >
+            {submitting && <Loader2 className="mr-1.5 size-4 animate-spin" />}
             {editing
               ? submitting
                 ? "Saving…"

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -417,6 +417,13 @@ export function WorkflowCreateDialog({
    * itself. Degrades to a free-text id field when the host offers no list. */
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
   const [submitting, setSubmitting] = useState(false);
+  /** The same "a write is in flight" fact as `submitting`, held where `submit()`
+   * can read it SYNCHRONOUSLY (issue #1005). `submitting` is captured from the
+   * render that produced the handler, so two calls landing before React commits
+   * `setSubmitting(true)` — a double activation, an Enter keypress arriving with
+   * a click, any caller added later — would both read `false` and both post. The
+   * state stays because the render needs it; the ref is what actually guards. */
+  const submittingRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   /** The submit-time error banner, so a failed submit can scroll it into view
    * and focus it rather than leave the message off-screen (#813 defect 6). */
@@ -940,16 +947,24 @@ export function WorkflowCreateDialog({
 
   async function submit() {
     // Re-entrancy guard (issue #1005). The Create button disables while a write
-    // is in flight, but `disabled` is a property of one DOM node: a second click
-    // landing in the same tick as the first, an Enter keypress, or any future
-    // caller would otherwise post the graph twice — and for create that means
-    // two workflows, or a 409 the operator did nothing to earn.
-    if (submitting) return;
+    // is in flight, but `disabled` is a property of one DOM node: a second
+    // activation landing in the same tick as the first, an Enter keypress, or
+    // any future caller would otherwise post the graph twice — and for create
+    // that means two workflows, or a 409 the operator did nothing to earn.
+    //
+    // It reads the REF, not `submitting`: the state value here is the one from
+    // the render that built this closure, so two calls in the same tick would
+    // both see `false` and the guard would pass twice. The ref is written below
+    // before the first `await`, which makes it true for every later caller.
+    if (submittingRef.current) return;
     const problem = validate();
     if (problem) {
       showError(problem);
       return;
     }
+    // Set before the first `await` — after `validate()`, so a draft the client
+    // rejects never latches the guard and the operator can fix it and retry.
+    submittingRef.current = true;
     setSubmitting(true);
     setError(null);
     const graph: WorkflowGraph = {
@@ -1038,6 +1053,7 @@ export function WorkflowCreateDialog({
         onConflict?.(e.message);
       }
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   }

--- a/frontend/test/unit/workflow-create-feedback.test.ts
+++ b/frontend/test/unit/workflow-create-feedback.test.ts
@@ -153,25 +153,27 @@ describe("the create dialog while a create is in flight", () => {
     );
   });
 
-  it("posts once when the operator clicks Create twice", async () => {
+  it("posts once when the operator clicks Create twice in one tick", async () => {
     const post = vi.fn(() => new Promise<never>(() => {}));
     await open(stubClient(post));
     await fillValidDraft();
 
+    // BOTH clicks inside ONE `act`, deliberately. React commits state at the
+    // end of the block, so the button is still enabled for the second one and
+    // `submit()` is genuinely re-entered — which is the only way to reach the
+    // guard. Split across two `act`s the first commit has landed, `disabled` is
+    // set, React drops the event on the disabled fiber, and the assertion below
+    // passes for a reason that has nothing to do with `submit()`.
+    //
+    // So this is the assertion that pins `submittingRef`: against a guard
+    // reading the `submitting` STATE both calls see the pre-commit `false` and
+    // this fails with two posts.
     await act(async () => {
       submitButton().click();
-    });
-    await act(async () => {
       submitButton().click();
     });
 
     expect(post).toHaveBeenCalledTimes(1);
-    // What stopped the second click here is the `disabled` attribute — React
-    // drops events on a disabled fiber, so no test driving this button can
-    // reach `submit()` a second time. That is exactly why the `if (submitting)
-    // return;` guard inside `submit()` is not redundant with this assertion:
-    // `disabled` is a property of one DOM node, and the guard is what holds for
-    // a keyboard activation, a re-render race, or any caller added later.
   });
 });
 

--- a/frontend/test/unit/workflow-create-feedback.test.ts
+++ b/frontend/test/unit/workflow-create-feedback.test.ts
@@ -70,15 +70,17 @@ function submitButton(): HTMLButtonElement {
 
 /** Sets a controlled input the way a keystroke would: through the native value
  * setter, so React's own descriptor sees the change and `onChange` fires. */
-function type(selector: string, value: string) {
-  const input = inDialog<HTMLInputElement>(selector);
-  expect(input, `no input matching ${selector}`).toBeTruthy();
+function type(selector: string, value: string, nth = 0) {
+  const input = Array.from(
+    document.querySelectorAll<HTMLInputElement>(`[data-slot="dialog-content"] ${selector}`),
+  )[nth];
+  expect(input, `no input matching ${selector} at index ${nth}`).toBeTruthy();
   const setter = Object.getOwnPropertyDescriptor(
     HTMLInputElement.prototype,
     "value",
   )!.set!;
   setter.call(input, value);
-  input!.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
 async function open(client: OpenCompanyClient) {
@@ -151,6 +153,33 @@ describe("the create dialog while a create is in flight", () => {
     expect(inDialog<HTMLButtonElement>('[data-testid="workflow-copilot-draft"]')!.disabled).toBe(
       true,
     );
+    // ...including the fields themselves, which the `fieldset` covers. Matched
+    // with `:disabled` rather than `.disabled`, deliberately: a control inside a
+    // disabled fieldset IS disabled — it matches the pseudo-class and receives
+    // no events — but its own IDL property stays false, because the `disabled`
+    // content attribute is on the ancestor. Asserting `.disabled` here would
+    // read false and hide a working lock.
+    for (const [what, selector] of [
+      ["the workflow id", '[placeholder="e.g. campaign_pipeline"]'],
+      ["the workflow name", '[placeholder="e.g. Campaign pipeline"]'],
+      ["the description", '[placeholder="What does this workflow do?"]'],
+      ["a node id", '[aria-label="Node id"]'],
+      ["a node name", '[placeholder="display name"]'],
+      ["the node kind select", '[aria-label="Node kind"]'],
+      ["the remove-node button", '[aria-label="Remove node"]'],
+    ] as const) {
+      const el = inDialog<HTMLElement>(selector);
+      expect(el, `no control matching ${selector}`).toBeTruthy();
+      expect(el!.matches(":disabled"), `${what} stayed live under the request`).toBe(true);
+    }
+
+    // Not merely styled: the row really cannot be removed from the graph being
+    // posted. A disabled fieldset swallows the event rather than dispatching it.
+    const rowsBefore = document.querySelectorAll('[aria-label="Remove node"]').length;
+    await act(async () => {
+      inDialog<HTMLButtonElement>('[aria-label="Remove node"]')!.click();
+    });
+    expect(document.querySelectorAll('[aria-label="Remove node"]').length).toBe(rowsBefore);
   });
 
   it("posts once when the operator clicks Create twice in one tick", async () => {
@@ -220,33 +249,91 @@ describe("the create dialog when the host refuses", () => {
     expect(submitButton().disabled).toBe(false);
   });
 
+  /** Rejects, so the banner is up and the form is live again to edit. */
+  async function submitAndGetRefused() {
+    await open(
+      stubClient(() =>
+        Promise.reject(new ApiError(400, "bad_request", "that id is taken", true)),
+      ),
+    );
+    await fillValidDraft();
+    await act(async () => {
+      submitButton().click();
+    });
+    expect(inDialog('[data-testid="create-error"]')).toBeTruthy();
+  }
+
   // The complaint was about the graph as it was, so any edit to that graph
   // retires it; leaving it up would make the next failure indistinguishable
-  // from this one. Both entry points are covered because they are separate
-  // code paths — the name is top-level state, a node row goes through
-  // `updateNode`.
+  // from this one. Each case below is a separate handler in the component —
+  // the id and the name are top-level state, a node row goes through
+  // `updateNode` — so they are covered separately rather than assumed.
   for (const [what, selector] of [
+    ["the id", '[placeholder="e.g. campaign_pipeline"]'],
     ["the name", '[placeholder="e.g. Campaign pipeline"]'],
     ["a node", '[placeholder="display name"]'],
   ] as const) {
     it(`drops the stale banner as soon as the operator edits ${what}`, async () => {
-      await open(
-        stubClient(() =>
-          Promise.reject(new ApiError(400, "bad_request", "that id is taken", true)),
-        ),
-      );
-      await fillValidDraft();
+      await submitAndGetRefused();
 
       await act(async () => {
-        submitButton().click();
-      });
-      expect(inDialog('[data-testid="create-error"]')).toBeTruthy();
-
-      await act(async () => {
-        type(selector, "Something else");
+        type(selector, "something_else");
       });
 
       expect(inDialog('[data-testid="create-error"]')).toBeNull();
     });
   }
+
+  // Structural edits too, which is the case that actually bites: the banner
+  // routinely names something an add or a remove is the fix for ("Add at least
+  // one node.", a duplicate id, an edge pointing at nothing), so leaving it up
+  // through exactly the action that answers it is the worst version of a stale
+  // message — the operator fixes the problem and the complaint does not move.
+  it("drops the stale banner as soon as the operator adds a node", async () => {
+    await submitAndGetRefused();
+
+    await act(async () => {
+      button("Add node").click();
+    });
+
+    expect(inDialog('[data-testid="create-error"]')).toBeNull();
+  });
+
+  it("drops the stale banner as soon as the operator adds an edge", async () => {
+    await submitAndGetRefused();
+
+    // Add edge is `disabled` until the graph has two nodes to connect, so the
+    // second node is authored first — and that add clears the banner on its
+    // own, hence the fresh refusal below to put it back.
+    await act(async () => {
+      button("Add node").click();
+    });
+    await act(async () => {
+      type('[aria-label="Node id"]', "second_node", 1);
+    });
+    await act(async () => {
+      type('[placeholder="display name"]', "Second node", 1);
+    });
+    await act(async () => {
+      submitButton().click();
+    });
+    expect(inDialog('[data-testid="create-error"]')).toBeTruthy();
+    expect(button("Add edge").disabled).toBe(false);
+
+    await act(async () => {
+      button("Add edge").click();
+    });
+
+    expect(inDialog('[data-testid="create-error"]')).toBeNull();
+  });
+
+  it("drops the stale banner as soon as the operator removes a node", async () => {
+    await submitAndGetRefused();
+
+    await act(async () => {
+      inDialog<HTMLButtonElement>('[aria-label="Remove node"]')!.click();
+    });
+
+    expect(inDialog('[data-testid="create-error"]')).toBeNull();
+  });
 });

--- a/frontend/test/unit/workflow-create-feedback.test.ts
+++ b/frontend/test/unit/workflow-create-feedback.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
+
+/**
+ * What the create dialog says while it is working, and when it refuses (#1005).
+ *
+ * The three claims here are all about a moment that does not exist in any pure
+ * helper: the window between the click and the host's answer. `validate()` can
+ * be tested without a document because it maps a draft to a string; "the form
+ * looks busy", "the draft survives a rejection" and "two clicks post once" are
+ * properties of a mounted component holding an unresolved promise, so they earn
+ * a jsdom render for the same reason `setup-wizard-finish-gate` does.
+ *
+ * They are also the three the operator actually notices. Before #1005 the
+ * dialog's entire in-flight vocabulary was the word "Creating…" on one button,
+ * and a host rejection landed in a banner that nothing scrolled to and no
+ * screen reader announced — a create that failed was indistinguishable from a
+ * create that was still going.
+ */
+
+/** The one call this suite cares about. `createWorkflow` is a thin wrapper over
+ * `client.post`, so stubbing the client rather than the module keeps the real
+ * request path — including the id/name trimming `submit()` does — in the test. */
+function stubClient(post: (path: string, body?: unknown) => Promise<unknown>) {
+  return {
+    scopeFor: () => "/api/companies/acme",
+    // Every GET the dialog fires on open is an optional picker source (roster,
+    // sub-workflow list, wired channels, cognition path) and each has a
+    // degrade-on-failure path, so one rejection stands in for "this host offers
+    // none of them" and leaves the form fully authorable.
+    get: () => Promise.reject(new Error("not offered by this host")),
+    listTeam: () => Promise.reject(new Error("not offered by this host")),
+    post,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let onOpenChange: ReturnType<typeof vi.fn>;
+
+/** The dialog renders through a portal, so it is on `document`, not `container`. */
+function inDialog<T extends Element>(selector: string): T | null {
+  return document.querySelector<T>(`[data-slot="dialog-content"] ${selector}`);
+}
+
+function dialogContent(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+  expect(el, "the dialog did not render").toBeTruthy();
+  return el as HTMLElement;
+}
+
+function button(label: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-slot="dialog-content"] button'),
+  ).find((b) => b.textContent?.trim().startsWith(label));
+  expect(match, `no button labeled "${label}"`).toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
+function submitButton(): HTMLButtonElement {
+  return inDialog<HTMLButtonElement>('[data-testid="workflow-dialog-submit"]')!;
+}
+
+/** Sets a controlled input the way a keystroke would: through the native value
+ * setter, so React's own descriptor sees the change and `onChange` fires. */
+function type(selector: string, value: string) {
+  const input = inDialog<HTMLInputElement>(selector);
+  expect(input, `no input matching ${selector}`).toBeTruthy();
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(input, value);
+  input!.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function open(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(WorkflowCreateDialog, {
+        open: true,
+        onOpenChange,
+        client,
+        company: "acme",
+        workflow: null,
+      }),
+    );
+  });
+}
+
+/** The smallest draft `validate()` accepts: the starter trigger node already
+ * carries an id and a name, so only the graph's own id and name are missing. */
+async function fillValidDraft() {
+  await act(async () => {
+    type('[placeholder="e.g. campaign_pipeline"]', "campaign_pipeline");
+  });
+  await act(async () => {
+    type('[placeholder="e.g. Campaign pipeline"]', "Campaign pipeline");
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  // jsdom does no layout and ships no `scrollIntoView`; `showError` calls it on
+  // the next frame, where a throw would be an unhandled rejection rather than a
+  // test failure. Stubbed, not asserted — WHERE the page scrolls is a browser
+  // property and belongs to the e2e suite.
+  Element.prototype.scrollIntoView = vi.fn();
+  onOpenChange = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the create dialog while a create is in flight", () => {
+  it("shows a spinner and stops the form being edited under the request", async () => {
+    // Never settles: the assertions below are about the window between the
+    // click and the answer, which is the whole point.
+    const post = vi.fn(() => new Promise<never>(() => {}));
+    await open(stubClient(post));
+    await fillValidDraft();
+
+    expect(dialogContent().getAttribute("aria-busy")).toBe("false");
+    expect(submitButton().querySelector(".animate-spin")).toBeNull();
+
+    await act(async () => {
+      submitButton().click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(dialogContent().getAttribute("aria-busy")).toBe("true");
+    expect(submitButton().querySelector(".animate-spin")).toBeTruthy();
+    expect(submitButton().disabled).toBe(true);
+    // The graph being posted is the one on screen, so every control that would
+    // change it is off for the duration.
+    expect(button("Add node").disabled).toBe(true);
+    expect(button("Add edge").disabled).toBe(true);
+    expect(inDialog<HTMLButtonElement>('[data-testid="workflow-copilot-draft"]')!.disabled).toBe(
+      true,
+    );
+  });
+
+  it("posts once when the operator clicks Create twice", async () => {
+    const post = vi.fn(() => new Promise<never>(() => {}));
+    await open(stubClient(post));
+    await fillValidDraft();
+
+    await act(async () => {
+      submitButton().click();
+    });
+    await act(async () => {
+      submitButton().click();
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    // What stopped the second click here is the `disabled` attribute — React
+    // drops events on a disabled fiber, so no test driving this button can
+    // reach `submit()` a second time. That is exactly why the `if (submitting)
+    // return;` guard inside `submit()` is not redundant with this assertion:
+    // `disabled` is a property of one DOM node, and the guard is what holds for
+    // a keyboard activation, a re-render race, or any caller added later.
+  });
+});
+
+describe("the create dialog when the host refuses", () => {
+  it("keeps the dialog open with the draft intact and announces the reason", async () => {
+    const post = vi.fn(() =>
+      Promise.reject(new ApiError(409, "conflict", "a workflow named “Campaign pipeline” already exists", true)),
+    );
+    await open(stubClient(post));
+    await fillValidDraft();
+
+    await act(async () => {
+      submitButton().click();
+    });
+
+    const banner = inDialog<HTMLElement>('[data-testid="create-error"]');
+    expect(banner).toBeTruthy();
+    expect(banner!.textContent).toContain("already exists");
+    // Announced, not merely rendered: the banner can be well below the fold on
+    // a long graph, so being in the DOM is not the same as being reported.
+    expect(banner!.getAttribute("role")).toBe("alert");
+    expect(banner!.getAttribute("aria-live")).toBe("assertive");
+    // ...and taken to, on the frame after it renders. This is the treatment the
+    // client-validation branch already had and the server branch did not, which
+    // is the whole of #1005's "a failed create is never announced": on a long
+    // graph the banner renders below the fold and nothing moves to it.
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+    // The dialog never asked to close, and what the operator typed is still
+    // there to fix — a rejected create must not cost them the graph.
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(inDialog<HTMLInputElement>('[placeholder="e.g. campaign_pipeline"]')!.value).toBe(
+      "campaign_pipeline",
+    );
+    expect(inDialog<HTMLInputElement>('[placeholder="e.g. Campaign pipeline"]')!.value).toBe(
+      "Campaign pipeline",
+    );
+
+    // ...and the form is live again, so the fix can be made and retried.
+    expect(dialogContent().getAttribute("aria-busy")).toBe("false");
+    expect(submitButton().disabled).toBe(false);
+  });
+
+  // The complaint was about the graph as it was, so any edit to that graph
+  // retires it; leaving it up would make the next failure indistinguishable
+  // from this one. Both entry points are covered because they are separate
+  // code paths — the name is top-level state, a node row goes through
+  // `updateNode`.
+  for (const [what, selector] of [
+    ["the name", '[placeholder="e.g. Campaign pipeline"]'],
+    ["a node", '[placeholder="display name"]'],
+  ] as const) {
+    it(`drops the stale banner as soon as the operator edits ${what}`, async () => {
+      await open(
+        stubClient(() =>
+          Promise.reject(new ApiError(400, "bad_request", "that id is taken", true)),
+        ),
+      );
+      await fillValidDraft();
+
+      await act(async () => {
+        submitButton().click();
+      });
+      expect(inDialog('[data-testid="create-error"]')).toBeTruthy();
+
+      await act(async () => {
+        type(selector, "Something else");
+      });
+
+      expect(inDialog('[data-testid="create-error"]')).toBeNull();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

The workflow create dialog was the only write surface in the console that never showed it was working, and a create the host refused was never announced. Pressing **Create** swapped one button label to "Creating…" while the copilot box, the node rows, **Add node**, **Add edge** and every input stayed live; a rejection put a banner somewhere in a long scrolling dialog with nothing scrolling to it and nothing reporting it — indistinguishable from a create still in flight.

- `Loader2 … animate-spin` on Create/Save, on "Drafting…" and on "Restoring…", matching the sibling surfaces (`WorkflowsView.tsx`, `CreateTaskDialog.tsx`) — this file had zero spinners.
- `aria-busy={submitting}` on `DialogContent`, and the copilot block, **Add node** and **Add edge** disable while submitting: the graph being posted is the one on screen.
- The `requestAnimationFrame(scroll + focus)` treatment #813 gave the *client-validation* branch is lifted into a `showError(message)` helper now used by **both** that branch and the server-error branch. The banner gains `role="alert"` / `aria-live="assertive"`.
- `if (submitting) return;` at the top of `submit()`, so double-submit is guarded in code and not only by one DOM node's `disabled`.
- Editing a node, an edge or the name retires the stale banner, so the next failure is not confusable with the last.

## Tests

First component spec for this dialog — the seven existing workflow specs only cover pure helpers. It follows the repo's established jsdom render idiom (`react-dom/client` + `act`, as in `setup-wizard-finish-gate.test.ts` / `provider-detail-render.test.ts`) rather than introducing React Testing Library, which this project does not depend on.

`frontend/test/unit/workflow-create-feedback.test.ts` covers:

- the pending state during a create — `aria-busy`, the spinner, and Create / Add node / Add edge / Draft all disabled;
- a refused create keeping the dialog open with the draft intact, the banner announced, and `scrollIntoView` called (this is the assertion that fails if the server branch goes back to a bare `setError`);
- a double-click firing exactly one POST;
- the banner clearing when the name or a node is edited.

Each assertion was mutation-checked against the pre-fix code and fails without the corresponding change.

## Commands run

Frontend only — the Rust toolchain on this machine is mid-update, so no `cargo` was run.

```
$ npm run typecheck     # tsc -b --noEmit — clean
$ npm run typecheck:unit # tsc -p tsconfig.unit.json — clean
$ npm test              # vitest run
  Test Files  88 passed (88)
       Tests  896 passed (896)
```

## Deliberately out of scope

Kept to #1005. The id auto-slug, the copilot clobber guard, and the client/server validation parity work all live in #1006–#1017 and are untouched.

Closes #1005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear loading indicators while workflows are being saved or drafted.
  * Prevented duplicate submissions and disabled editing actions during saves.
  * Improved error announcements, automatically bringing submission errors into view.
  * Cleared outdated errors when workflow details are edited.

* **Bug Fixes**
  * Preserved the workflow draft and restored form controls after failed submissions.

* **Tests**
  * Added coverage for loading states, duplicate-submission prevention, error handling, and draft preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->