### PR TITLE
fix(workflows): leave a failed run on screen

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -91,6 +91,8 @@ import { LastRunChip, RunHistoryPanel } from "@/views/workflows/RunHistoryPanel"
 import { WorkflowIndex, type IndexMode } from "@/views/workflows/WorkflowIndex";
 import { CopilotPanel } from "@/views/workflows/CopilotPanel";
 import { classifyRunError } from "@/views/workflows/run-error";
+import { runFailureFrom, type RunFailure } from "@/views/workflows/run-failure";
+import { RunFailurePanel } from "@/views/workflows/RunFailurePanel";
 import { RunResultPanel } from "@/views/workflows/RunResultPanel";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 import { type NodeOutputView, nodeOutputFor } from "@/views/workflows/run-output";
@@ -221,6 +223,28 @@ export function WorkflowsView({
   const [loadingList, setLoadingList] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [result, setResult] = useState<WorkflowRunResult | null>(null);
+  // Issue #1007: the run POST that was rejected, held on screen.
+  //
+  // `result` is the drawer for a run that produced something, and it can only
+  // be set from a settled body — which on the failure path never arrives. So a
+  // failed run mounted no surface at all and the console returned to its
+  // resting state behind a four-second toast. This is that outcome's drawer,
+  // and it is state rather than a toast for the same reason `conflict` and
+  // `runRefusal` are: reading it, finding the history row, and fixing the graph
+  // all take longer than a toast lasts.
+  const [runFailure, setRunFailure] = useState<RunFailure | null>(null);
+  // Issue #1007: the dispatch this console is waiting on — when Run was pressed,
+  // and whether it was a test run.
+  //
+  // What acknowledges the click in the history drawer. Between pressing Run and
+  // the host journaling a row there was nothing there at all, which for a run
+  // that takes minutes is most of its life. Rendered as one optimistic row, and
+  // dropped the moment the host's own row for the same run lands — that row
+  // carries the per-node trail this one cannot.
+  const [pendingRun, setPendingRun] = useState<{
+    startedAtMillis: number;
+    dryRun: boolean;
+  } | null>(null);
   // Issue #154: what the operator is asking this run to work on. `ranWith` is
   // pinned when the run is dispatched so the result panel echoes the request the
   // shown output came from, not whatever has been typed since.
@@ -333,6 +357,12 @@ export function WorkflowsView({
   // because the `run()` catch reads it synchronously and it must not itself
   // trigger a render. Reset at the top of every `run()`.
   const sawOwnRunStartRef = useRef(false);
+  // Issue #1007: the id that run became, when the live fold got far enough to
+  // tell us. A ref for exactly the reasons above — the `run()` catch reads it
+  // synchronously, and `activeRunId` is not in that callback's closure. It is
+  // what lets a failed POST hand the history fetch a run id to pull forward,
+  // rather than leaving the operator to guess which row was theirs.
+  const ownRunIdRef = useRef<string | null>(null);
   // The run whose cancel came back 404, if any.
   //
   // Deliberately a run id rather than a boolean. A 404 is ambiguous — either
@@ -597,6 +627,7 @@ export function WorkflowsView({
     let live = true;
     setLoadingGraph(true);
     setResult(null);
+    setRunFailure(null);
     setSelectedNodeId(null);
     (async () => {
       try {
@@ -756,6 +787,15 @@ export function WorkflowsView({
     // neither leaks into the new run's triage (issue #528).
     setRunRefusal(null);
     sawOwnRunStartRef.current = false;
+    ownRunIdRef.current = null;
+    // Issue #1007: the LAST run's detail goes with the last run's marks.
+    // `overlayRun` was cleared here from the start and `result` never was, so a
+    // second run that failed left the first run's nodes, output and "Requested:"
+    // line on screen — presented, with nothing to say otherwise, as the new
+    // run's detail. `ranWith` is only pinned on success (below), so the echo was
+    // stale in the same way.
+    setResult(null);
+    setRunFailure(null);
     // Issue #371/#382: clear the previous run's marks and seed the trigger as
     // done immediately, so the canvas responds to the click rather than waiting
     // on the first frame. The `workflow_run_started` frame re-sets the same thing
@@ -773,6 +813,22 @@ export function WorkflowsView({
     // Trimmed once here so the echoed request and the payload the host receives
     // can never disagree.
     const asked = request.trim();
+    // Issue #1007: the browser's own clock, not the host's. It is what the
+    // failure panel measures against and what the optimistic history row counts
+    // from, and both are on screen before the host has said anything at all.
+    const startedAtMillis = Date.now();
+    setPendingRun({ startedAtMillis, dryRun });
+    // Issue #1007: say the click landed. A synchronous run holds its request
+    // open for the whole run, so the only other acknowledgement — the success
+    // toast — arrives minutes later, with a button spinner and an optimistic
+    // canvas in between and nothing that names the workflow. `info`, not
+    // `loading`: a loading toast has no duration, and the console's toast
+    // ceiling (#933) would dismiss it mid-run anyway.
+    toast.info(
+      dryRun
+        ? `Test-running “${graph?.name ?? selectedId}” — nothing will be sent.`
+        : `Running “${graph?.name ?? selectedId}”…`,
+    );
     try {
       // Issue #528: run SYNCHRONOUSLY — no `detach`. The run's full `output` is
       // carried ONLY by this settled 200 body; the journal, SSE, and runs list
@@ -840,11 +896,39 @@ export function WorkflowsView({
           "The run continues on the host — watch the canvas; the outcome lands in History.",
         );
         setRunsTick((n) => n + 1);
+        // Issue #1007: and OPEN the place that sentence points at. Telling
+        // somebody the outcome lands in History while History is shut — it is
+        // closed by default and nothing ever opened it — is the same dead end as
+        // the failure toast: the drawer holds the only durable record of a run
+        // whose response was lost, and it has to be on screen for that to count.
+        setHistoryOpen(true);
+        setAwaitingRunId(ownRunIdRef.current);
       } else {
         toast.error(e instanceof Error ? e.message : "could not run the workflow");
+        // Issue #1007: the toast is now the *notification*, not the record. The
+        // panel is what survives it, built from the structured error rather than
+        // from its message — a code the host gave us reads differently from one
+        // synthesised off a status line, and the panel says which it had.
+        setRunFailure(
+          runFailureFrom(e, {
+            startedAtMillis,
+            atMillis: Date.now(),
+            request: asked,
+            dryRun,
+          }),
+        );
         // A run that failed is journaled too (#228), and is the outcome most
         // worth finding again later — so refresh the history on this path as well.
         setRunsTick((n) => n + 1);
+        // Issue #1007: open the drawer that refresh feeds, so the journaled row
+        // — the per-node trail, which names the step it died on — is on screen
+        // rather than one click away behind a toolbar toggle. And hand the
+        // history fetch the run id when the live fold got far enough to give us
+        // one: it pulls that row forward onto the canvas (#371) for exactly the
+        // console this matters most on, the one whose stream never delivered a
+        // frame to paint from.
+        setHistoryOpen(true);
+        setAwaitingRunId(ownRunIdRef.current);
         // Drop the optimistic frontier so a failed run does not leave a node
         // pulsing "running" forever. The fold owns anything actually reported.
         setOptimistic(null);
@@ -1164,6 +1248,8 @@ export function WorkflowsView({
   useEffect(() => {
     if (!starting || !liveRun || !liveRun.active || liveRun.scheduled) return;
     sawOwnRunStartRef.current = true;
+    // Issue #1007: the same seed, kept for the catch below.
+    ownRunIdRef.current = liveRun.runId;
     if (activeRunId === null) setActiveRunId(liveRun.runId);
   }, [starting, liveRun, activeRunId]);
 
@@ -1237,6 +1323,11 @@ export function WorkflowsView({
     setActiveRunId(null);
     setResult(null);
     setRunRefusal(null);
+    // Issue #1007: and the failed run's drawer, for exactly the same reason —
+    // it names a run of the workflow being left, and left up it would read as
+    // the newly-selected one's.
+    setRunFailure(null);
+    setPendingRun(null);
     // Issue #863: the adopted run belonged to the workflow being left. Holding
     // it across the switch would keep painting one graph's trail onto another's
     // canvas the moment the two share a node id.
@@ -1391,6 +1482,45 @@ export function WorkflowsView({
   const onNodeClick = useCallback((_: unknown, node: Node) => {
     setSelectedNodeId(node.id);
   }, []);
+
+  // Issue #1007: what the history drawer renders — the host's rows, with one
+  // optimistic row on top while this console has a run in flight that the host
+  // has not journaled yet.
+  //
+  // Deliberately NOT folded into `runs`: everything else that reads that list
+  // reads it as the host's record. The last-run chip, the copilot's grounding,
+  // the in-flight seed and the settled-run set would all be reasoning about a
+  // row the host has never seen.
+  const historyRows = useMemo<WorkflowRunOutcome[]>(() => {
+    // A dry run journals nothing (#542), so a row for it would appear in "Run
+    // history" and then vanish when the request settles — worse than the button
+    // spinner it was meant to improve on.
+    if (!pendingRun || pendingRun.dryRun) return runs;
+    // Settled, either way: `starting` is the POST still open, `activeRunId` the
+    // run this console adopted from the live fold. With neither, the journal is
+    // the whole answer and a synthetic row could only contradict it.
+    if (!starting && !activeRunId) return runs;
+    // The host's own row for this run has arrived. It carries the per-node
+    // trail, so it supersedes this one rather than sitting under it.
+    if (activeRunId && runs.some((r) => r.runId === activeRunId)) return runs;
+    return [
+      {
+        // `seq` is this list's React key and the id `selectedRunSeq` compares
+        // against, so it has to be stable and unable to collide with a real
+        // journal position. Negative is both.
+        seq: -1,
+        atMillis: pendingRun.startedAtMillis,
+        startedAtMillis: pendingRun.startedAtMillis,
+        workflowId: selectedId ?? "",
+        scheduled: false,
+        runId: activeRunId ?? undefined,
+        deliveries: [],
+        pendingApprovals: [],
+        running: true,
+      },
+      ...runs,
+    ];
+  }, [runs, pendingRun, starting, activeRunId, selectedId]);
 
   // `runs` already holds only the selected workflow's runs, newest first — the
   // host filters and orders them. Re-filtering here would be a second source of
@@ -1601,9 +1731,9 @@ export function WorkflowsView({
             >
               <History className="mr-1.5 size-4" />
               History
-              {runs.length > 0 && (
+              {historyRows.length > 0 && (
                 <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-3xs font-normal">
-                  {runs.length}
+                  {historyRows.length}
                 </Badge>
               )}
             </Button>
@@ -1939,9 +2069,21 @@ export function WorkflowsView({
         />
       )}
 
+      {/* Issue #1007: the same slot, for the outcome that had no surface at all.
+          The two are mutually exclusive by construction — `run()` clears both on
+          dispatch and only one of its arms sets one — so they are rendered as
+          siblings rather than as a branch. */}
+      {runFailure && (
+        <RunFailurePanel
+          failure={runFailure}
+          onClose={() => setRunFailure(null)}
+        />
+      )}
+
       {historyOpen && historySupported && (
         <RunHistoryPanel
-          runs={runs}
+          runs={historyRows}
+          graph={graph}
           workflowName={selected?.name ?? selectedId ?? ""}
           onClose={() => setHistoryOpen(false)}
           selectedRunSeq={overlayRun?.seq ?? null}

--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -1,0 +1,102 @@
+// The drawer a FAILED run leaves behind (issue #1007).
+//
+// `RunResultPanel` next door is the surface for a run that produced something,
+// and it can only mount when the settled body arrives — which on the failure
+// path it never does. So a failed run had no drawer, no row and no error text:
+// the console went back to its resting state behind a toast that lasted four
+// seconds. This is the same slot, for the outcome that had nothing in it.
+//
+// Deliberately a panel and not a toast, on the same rule the version-conflict
+// banner and the inference refusal already follow: an outcome the operator has
+// to act on — read the message, look at the history row, fix the graph, run it
+// again — must outlive the glance.
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+import { formatDuration } from "./run-health";
+import type { RunFailure } from "./run-failure";
+
+export function RunFailurePanel({
+  failure,
+  onClose,
+}: {
+  failure: RunFailure;
+  onClose: () => void;
+}) {
+  // How long the operator waited before this came back. The number a failure
+  // most needs beside it: a run that died in 200ms was refused, and one that
+  // died after four minutes got somewhere first.
+  const ranFor = Math.max(0, failure.atMillis - failure.startedAtMillis);
+  return (
+    <div className="border-t bg-card/60" data-testid="workflow-run-failure">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">Run failed</span>
+          {failure.dryRun && (
+            <Badge
+              variant="outline"
+              className="border-primary/40 bg-primary/10 text-primary"
+            >
+              Test run — nothing was sent
+            </Badge>
+          )}
+          {/* Only a code the HOST gave us. See `RunFailure.code`. */}
+          {failure.code && (
+            <Badge
+              variant="outline"
+              className="h-4 px-1.5 font-mono text-3xs font-normal"
+              data-testid="workflow-run-failure-code"
+            >
+              {failure.code}
+            </Badge>
+          )}
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Dismiss
+        </Button>
+      </div>
+      <div className="max-h-72 overflow-auto px-4 pb-3">
+        <Alert variant="destructive" className="py-2">
+          <AlertDescription
+            className="text-xs"
+            data-testid="workflow-run-failure-message"
+          >
+            {failure.message}
+          </AlertDescription>
+        </Alert>
+        <p className="mt-2 text-2xs text-muted-foreground">
+          Failed after {formatDuration(ranFor)} ·{" "}
+          {new Date(failure.atMillis).toLocaleString()}
+          {/* A status is worth printing only when it says something the message
+              does not. `0` is the client's "the request never completed", which
+              the sentence below already states in words. */}
+          {failure.status != null && failure.status > 0
+            ? ` · HTTP ${failure.status}`
+            : ""}
+        </p>
+        {/* Issue #154's echo, for the same reason the result drawer carries it:
+            the operator has usually typed something else by now, so the box is
+            not the record of what this run was asked for. */}
+        {failure.request && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Requested:</span>{" "}
+            {failure.request}
+          </p>
+        )}
+        {/* Two genuinely different next steps, and collapsing them sends the
+            operator to the wrong place. A host that answered has journaled the
+            run (#228), so its per-node trail is one drawer down. Something that
+            gave up in between may have left no run at all — and telling someone
+            to look in History for a row that does not exist is how a transport
+            failure comes to read as a missing feature. */}
+        <p className="mt-2 text-2xs text-muted-foreground">
+          {failure.fromHost
+            ? "The host records failed runs, so this one is in Run history below with the step it stopped at."
+            : "The request didn't complete, so the host may or may not have started this run. Run history below is the answer either way."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -5,22 +5,28 @@
 // further out again, to `run-health.ts`, because the workflow cards need the
 // same reading — see that file's header.
 
+import { useEffect, useState } from "react";
+
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type {
   DeliveryReport,
   DeliveryStatus,
+  WorkflowGraph,
   WorkflowRunNode,
   WorkflowRunOutcome,
 } from "@/api/workflows";
 
-import { failedNodeOf } from "./graph";
+import { failedNodeOf, nodeName } from "./graph";
 import {
   awaitingCount,
   decidableApprovalCount,
+  formatDuration,
   isBlocked,
+  isRunning,
   relativeTime,
+  runDuration,
   runTone,
   undeliveredCount,
 } from "./run-health";
@@ -150,6 +156,7 @@ export function LastRunChip({ run }: { run: WorkflowRunOutcome }) {
  * console reload and a run nobody was watching. */
 export function RunHistoryPanel({
   runs,
+  graph,
   workflowName,
   onClose,
   selectedRunSeq,
@@ -159,6 +166,12 @@ export function RunHistoryPanel({
   fixReason,
 }: {
   runs: WorkflowRunOutcome[];
+  /**
+   * The selected workflow's graph, for turning a node id into the name the
+   * operator gave it (issue #1007). `null` while it loads or after a failed
+   * read, which {@link nodeName} degrades to the raw id for.
+   */
+  graph: WorkflowGraph | null;
   workflowName: string;
   onClose: () => void;
   /** The run currently overlaid on the canvas, if any (issue #371). */
@@ -184,6 +197,10 @@ export function RunHistoryPanel({
   // button (not just the in-flight one's) while `fixingRunSeq` is set turns
   // that race into "wait your turn".
   const anyFixInFlight = fixingRunSeq != null;
+  // Issue #1007: a clock, ticking only while a row is actually in flight. The
+  // elapsed time on a running row is the console's acknowledgement that the
+  // click did something, and it is only true if it moves.
+  const now = useRunningClock(runs.some(isRunning));
   return (
     <div className="border-t bg-card/60" data-testid="workflow-run-history">
       <div className="flex items-center justify-between px-4 py-2">
@@ -212,6 +229,8 @@ export function RunHistoryPanel({
               <RunHistoryRow
                 key={run.seq}
                 run={run}
+                graph={graph}
+                now={now}
                 selected={run.seq === selectedRunSeq}
                 onSelect={() => onSelectRun(run)}
                 onFixWithCopilot={onFixWithCopilot}
@@ -234,6 +253,8 @@ export function RunHistoryPanel({
  * live canvas by definition cannot cover because nobody was watching. */
 function RunHistoryRow({
   run,
+  graph,
+  now,
   selected,
   onSelect,
   onFixWithCopilot,
@@ -242,6 +263,10 @@ function RunHistoryRow({
   fixReason,
 }: {
   run: WorkflowRunOutcome;
+  /** The selected workflow's graph, for node ids → names (issue #1007). */
+  graph: WorkflowGraph | null;
+  /** The clock a still-running row counts against (issue #1007). */
+  now: number;
   selected: boolean;
   onSelect: () => void;
   /** Correct this run's workflow with the copilot (issue #840, PR-3). */
@@ -269,6 +294,7 @@ function RunHistoryRow({
   // worse than a parked one — there is no card to click.
   const unparkable = blocked.reduce((n, b) => n + (b.unparkable ?? 0), 0);
   const failedNode = failedNodeOf(run);
+  const duration = runDuration(run, now);
   return (
     <div
       className={`rounded-lg border bg-background/40 p-2 ${
@@ -284,6 +310,18 @@ function RunHistoryRow({
         <span className="text-2xs text-muted-foreground">
           {new Date(run.atMillis).toLocaleString()} ·{" "}
           {relativeTime(run.atMillis)}
+          {/* Issue #1007: how long it took, which nothing on this surface said.
+              A run that failed in 200ms was refused before it started; one that
+              failed after four minutes got somewhere first, and the two want
+              different next moves. `null` on a row journaled before #371, whose
+              only recorded time is its finish. */}
+          {duration != null && (
+            <span data-testid="workflow-run-duration">
+              {" · "}
+              {isRunning(run) ? "running for " : "took "}
+              {formatDuration(duration)}
+            </span>
+          )}
         </span>
         {/* Issue #880: what the run PARKED, in those words. A blocked run's
             `pendingApprovals` names the nodes it stopped at, which is a
@@ -352,9 +390,18 @@ function RunHistoryRow({
             {/* Name the node when the trail names one — the engine reports a
                 failing node as an errored step, so this is exact. When it does
                 not (a graph that would not compile, a capability that could not
-                be built), say nothing about nodes rather than guessing. */}
+                be built), say nothing about nodes rather than guessing.
+
+                Issue #1007: the NAME the operator gave the node, not its raw
+                id. The engine's trail is keyed by id, so this line named `n_3`
+                while the run drawer's timeline, the canvas and the overlay
+                banner all named "Draft the digest" for the same step.
+                `nodeName` falls back to the id when the graph is not loaded,
+                and a graph edited since the run can only give back the id it
+                no longer holds — both of which are the old reading, never a
+                wrong name. */}
             {failedNode
-              ? `This run failed at “${failedNode}”: `
+              ? `This run failed at “${nodeName(graph, failedNode)}”: `
               : "This run failed: "}
             {run.error}
             {/* Issue #840 (PR-3): correct the workflow with the copilot. Offered
@@ -564,4 +611,25 @@ function RunNodeChip({ node }: { node: WorkflowRunNode }) {
       </span>
     </span>
   );
+}
+
+/**
+ * A once-a-second clock, live only while something on screen is counting
+ * against it (issue #1007).
+ *
+ * Gated rather than always-on: the history drawer sits under the canvas for as
+ * long as the operator leaves it open, and a settled row's duration is a fixed
+ * number that re-rendering every second cannot change.
+ */
+function useRunningClock(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    // Read once on the way in too: the interval's first tick is a second away,
+    // and a row that mounts already running should not show a stale elapsed.
+    setNow(Date.now());
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, [active]);
+  return now;
 }

--- a/frontend/src/views/workflows/run-failure.ts
+++ b/frontend/src/views/workflows/run-failure.ts
@@ -1,0 +1,89 @@
+// The durable record of a run this console dispatched and the host rejected
+// (issue #1007).
+//
+// Pure and React-free for the same reason `run-error.ts` is: before this, a
+// failed run's entire trace on screen was `toast.error(e.message)` — four
+// seconds of prose over a console that had otherwise returned to its resting
+// state. A value is what makes "the failure is still there" something a test
+// can assert, and what lets the panel say more than a toast had room for.
+//
+// `run-error.ts` decides WHICH failure this was; this decides what is left on
+// screen once it has. The two are deliberately separate: the triage has three
+// answers and only one of them lands here.
+
+import { ApiError } from "@/api/types";
+
+/** Everything the failure panel renders, captured at the moment of the catch. */
+export interface RunFailure {
+  /**
+   * The prose the operator reads. Never empty: a thrown non-Error, or an Error
+   * whose message is blank, still has to say something — a panel with no
+   * sentence in it is the vanishing toast again, only quieter.
+   */
+  message: string;
+  /**
+   * The host's structured code, and ONLY when it came from the host's own
+   * `{error, code}` envelope (issue #380's `fromHost`). A code synthesised from
+   * a status line names the status, not the fault, and printing it beside the
+   * message would dress a proxy timeout up as a host verdict.
+   */
+  code?: string;
+  /**
+   * The HTTP status, when the request completed at all. `0` is the client's
+   * marker for "it never did" and is kept rather than normalised away — it is
+   * the difference between a host that answered and a connection that died.
+   */
+  status?: number;
+  /** Whether the host itself refused, rather than something between it and the
+   * browser giving up. Decides which of the two closing sentences is true. */
+  fromHost: boolean;
+  /** When the operator pressed Run, so the panel can say how long it ran for. */
+  startedAtMillis: number;
+  /** When the failure was caught. */
+  atMillis: number;
+  /** What the operator asked this run for (issue #154); `""` when nothing. */
+  request: string;
+  /** A test run (issue #542) — this failure spent nothing and sent nothing. */
+  dryRun: boolean;
+}
+
+/** What the caller knows that the thrown value does not. */
+export interface RunFailureContext {
+  startedAtMillis: number;
+  atMillis: number;
+  request: string;
+  dryRun: boolean;
+}
+
+/**
+ * Builds the panel's record from whatever `runWorkflow` threw.
+ *
+ * Reads the STRUCTURED shape where there is one and degrades to the message
+ * otherwise — the same rule the triage next door follows, for the same reason:
+ * a `fetch` that rejects with a `TypeError`, a mocked client that throws a
+ * string, and a host 500 all have to leave the operator with a panel.
+ */
+export function runFailureFrom(e: unknown, ctx: RunFailureContext): RunFailure {
+  const base = {
+    startedAtMillis: ctx.startedAtMillis,
+    atMillis: ctx.atMillis,
+    request: ctx.request,
+    dryRun: ctx.dryRun,
+  };
+  if (e instanceof ApiError) {
+    return {
+      ...base,
+      message: e.message || `The host answered ${e.status} with no explanation.`,
+      code: e.fromHost ? e.code : undefined,
+      status: e.status,
+      fromHost: e.fromHost,
+    };
+  }
+  return {
+    ...base,
+    message:
+      (e instanceof Error ? e.message : String(e ?? "")) ||
+      "The run failed, and nothing said why.",
+    fromHost: false,
+  };
+}

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -175,3 +175,40 @@ export function runTone(run: WorkflowRunOutcome): {
 export function isRunning(run: WorkflowRunOutcome): boolean {
   return run.running === true;
 }
+
+/**
+ * How long a run took, in milliseconds — `null` when the host recorded no
+ * start (a row journaled before #371 carries only its finish, and a duration
+ * measured from nothing would be the age of the epoch).
+ *
+ * Issue #1007: `startedAtMillis` has been on the wire since #371 and no
+ * workflow surface read it, so every run reported *when* it happened and none
+ * reported how long it took — the one number that tells a run that hung from
+ * one that failed immediately.
+ *
+ * `now` is passed in rather than read here so a still-running row ticks against
+ * the same clock as everything else on screen, and so this stays pure.
+ */
+export function runDuration(
+  run: WorkflowRunOutcome,
+  now: number = Date.now(),
+): number | null {
+  if (run.startedAtMillis == null) return null;
+  // A run in flight has no end yet, so the honest reading is "so far".
+  const end = isRunning(run) ? now : run.atMillis;
+  const ms = end - run.startedAtMillis;
+  // Host clock and browser clock are different clocks, so a live row can come
+  // out negative for the first second or two. Report nothing rather than "-1s".
+  return ms >= 0 ? ms : null;
+}
+
+/** A duration in the console's compact form: `840ms`, `12.4s`, `3m 07s`. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  // Rounded to whole seconds FIRST, so the minute and the second can never
+  // disagree — `${Math.floor(ms / 60_000)}m ${Math.round(…)}s` renders "3m 60s"
+  // for anything within half a second of the minute.
+  const total = Math.round(ms / 1000);
+  return `${Math.floor(total / 60)}m ${String(total % 60).padStart(2, "0")}s`;
+}

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph, WorkflowRunOutcome } from "@/api/workflows";
+import { ApiError } from "@/api/types";
+
+/**
+ * A failed run leaves something on screen (issue #1007).
+ *
+ * The reported symptom is an absence, and an absence is the one thing the pure
+ * helpers next door cannot pin. `classifyRunError` already decides *which*
+ * failure a rejected POST was, and it was right — the console then took that
+ * verdict and rendered nothing with it. `RunResultPanel` is the only surface
+ * that shows run detail and it mounts from a settled body, which the failure
+ * path by definition never has, so the console dropped back to its resting
+ * state behind a four-second toast.
+ *
+ * So this file renders the view, the way `task-blocked-card.test.ts` earns its
+ * exception to the pure-function rule: the claim under test is about what
+ * survives the toast, and the only place that is true is the DOM.
+ *
+ * Two claims, both from the issue:
+ *
+ *  1. a rejected run leaves a persistent failure drawer, and opens the History
+ *     drawer that holds the journaled row; and
+ *  2. dispatching a run clears the previous run's result drawer, so run #1's
+ *     nodes and "Requested:" line are never presented as run #2's detail.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// The canvas is a React Flow instance, and React Flow measures its container on
+// mount. jsdom has no layout and no `ResizeObserver`, so these three stubs are
+// what let the view render at all — none of them is under test.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+const { RunHistoryPanel } = await import("@/views/workflows/RunHistoryPanel");
+const { runFailureFrom } = await import("@/views/workflows/run-failure");
+const { formatDuration, runDuration } = await import("@/views/workflows/run-health");
+
+const GRAPH: WorkflowGraph = {
+  id: "digest",
+  name: "Weekly digest",
+  nodes: [
+    { id: "start", kind: "trigger", name: "Monday morning" },
+    { id: "n_3", kind: "agent", name: "Draft the digest", agent: "writer" },
+  ],
+  edges: [{ from: "start", to: "n_3" }],
+};
+
+/** A client whose run POST is whatever the test hands it. */
+function fakeClient(post: () => Promise<unknown>): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return [{ id: GRAPH.id, name: GRAPH.name }];
+      if (path.includes("/workflows/runs")) return [];
+      return GRAPH;
+    },
+    post,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” button in:\n${container.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+async function clickRun() {
+  await act(async () => {
+    button("Run").click();
+  });
+}
+
+beforeEach(async () => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function mount(post: () => Promise<unknown>) {
+  await act(async () => {
+    root.render(
+      createElement(WorkflowsView, { client: fakeClient(post), company: "acme" }),
+    );
+  });
+}
+
+describe("a rejected run POST leaves run detail on screen", () => {
+  it("raises a failure drawer carrying the host's message and code", async () => {
+    await mount(async () => {
+      throw new ApiError(500, "engine_failed", "the writer agent has no model", true);
+    });
+    await clickRun();
+
+    const panel = container.querySelector('[data-testid="workflow-run-failure"]');
+    expect(panel).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="workflow-run-failure-message"]')?.textContent,
+    ).toContain("the writer agent has no model");
+    // The structured code, shown only because the host's own envelope carried it.
+    expect(
+      container.querySelector('[data-testid="workflow-run-failure-code"]')?.textContent,
+    ).toContain("engine_failed");
+    // Still a toast — but it is now the notification, not the record.
+    expect(toasts.error).toHaveBeenCalled();
+  });
+
+  it("opens the History drawer, where the journaled failure row lands", async () => {
+    // Closed by default (`historyOpen`), and before this nothing ever opened it —
+    // which is how a run that WAS journaled still reached the operator as nothing.
+    await mount(async () => {
+      throw new ApiError(500, "engine_failed", "boom", true);
+    });
+    expect(container.querySelector('[data-testid="workflow-run-history"]')).toBeNull();
+
+    await clickRun();
+    expect(container.querySelector('[data-testid="workflow-run-history"]')).not.toBeNull();
+  });
+
+  it("also opens it when the connection dropped mid-run", async () => {
+    // The other half of the issue: this path's toast points at History ("the
+    // outcome lands in History") while History was shut.
+    await mount(async () => {
+      throw new ApiError(0, "network", "connection lost", false);
+    });
+    await clickRun();
+    expect(container.querySelector('[data-testid="workflow-run-history"]')).not.toBeNull();
+  });
+
+  it("acknowledges the dispatch itself, before the host has answered", async () => {
+    let release: (() => void) | null = null;
+    await mount(
+      () =>
+        new Promise((_, reject) => {
+          release = () => reject(new ApiError(500, "engine_failed", "boom", true));
+        }),
+    );
+    // With the drawer open, the run is a row from the moment it is dispatched
+    // rather than from whenever the host journals it — which on the synchronous
+    // path is the end of the run, i.e. all of it.
+    await act(async () => {
+      button("History").click();
+    });
+    expect(container.querySelectorAll('[data-testid="workflow-run-row"]')).toHaveLength(0);
+
+    await clickRun();
+    // The click is answered by name, not only by a button spinner and a canvas.
+    expect(toasts.info).toHaveBeenCalledWith(expect.stringContaining("Weekly digest"));
+    const rows = container.querySelectorAll('[data-testid="workflow-run-row"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("running");
+    // Counting from the dispatch, so the wait has a number on it.
+    expect(
+      container.querySelector('[data-testid="workflow-run-duration"]')?.textContent,
+    ).toContain("running for");
+    await act(async () => {
+      release?.();
+    });
+  });
+});
+
+describe("dispatching a run clears the previous run's detail", () => {
+  it("drops the result drawer so a stale run is never shown as the new one's", async () => {
+    // Run #1 succeeds and leaves its drawer up; run #2 fails. Before this, that
+    // drawer stayed — with run #1's output and "Requested:" line — and was the
+    // only run detail on screen, so it read as run #2's.
+    let attempt = 0;
+    await mount(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        return { runId: "r1", output: { n_3: "the digest" }, pendingApprovals: [] };
+      }
+      throw new ApiError(500, "engine_failed", "boom", true);
+    });
+
+    await clickRun();
+    expect(container.querySelector('[data-testid="workflow-run-result"]')).not.toBeNull();
+
+    await clickRun();
+    expect(container.querySelector('[data-testid="workflow-run-result"]')).toBeNull();
+    expect(container.querySelector('[data-testid="workflow-run-failure"]')).not.toBeNull();
+  });
+});
+
+describe("the history row names the node the operator named", () => {
+  it("prints the node's display name on the failure line, not its raw id", async () => {
+    // The engine's trail is keyed by node id, and this line printed it verbatim
+    // while the run drawer's own timeline — and the canvas, and the overlay
+    // banner — all said “Draft the digest”.
+    const failed: WorkflowRunOutcome = {
+      seq: 7,
+      atMillis: Date.now(),
+      startedAtMillis: Date.now() - 12_400,
+      workflowId: GRAPH.id,
+      scheduled: false,
+      runId: "r9",
+      deliveries: [],
+      pendingApprovals: [],
+      error: "the writer agent has no model",
+      nodes: [
+        { nodeId: "start", status: "ok", elapsedMs: 1 },
+        { nodeId: "n_3", status: "error", elapsedMs: 12_000 },
+      ],
+    };
+    await act(async () => {
+      root.render(
+        createElement(RunHistoryPanel, {
+          runs: [failed],
+          graph: GRAPH,
+          workflowName: GRAPH.name,
+          onClose: () => {},
+          selectedRunSeq: null,
+          onSelectRun: () => {},
+        }),
+      );
+    });
+    const row = container.querySelector('[data-testid="workflow-run-row"]');
+    expect(row?.textContent).toContain("This run failed at “Draft the digest”");
+    expect(row?.textContent).not.toContain("failed at “n_3”");
+    // …and says how long it took, which nothing on this surface did before.
+    expect(
+      container.querySelector('[data-testid="workflow-run-duration"]')?.textContent,
+    ).toContain("12.4s");
+  });
+});
+
+describe("what the failure panel is built from", () => {
+  const CTX = { startedAtMillis: 1_000, atMillis: 3_400, request: "", dryRun: false };
+
+  it("keeps the host's code only when the host's own envelope carried it", () => {
+    const fromHost = runFailureFrom(new ApiError(409, "engine_failed", "no", true), CTX);
+    expect(fromHost.code).toBe("engine_failed");
+    // A code synthesised off a status line names the status, not the fault, and
+    // printing it beside the message dresses a proxy timeout up as a verdict.
+    const fromProxy = runFailureFrom(new ApiError(502, "bad_gateway", "no", false), CTX);
+    expect(fromProxy.code).toBeUndefined();
+    expect(fromProxy.fromHost).toBe(false);
+  });
+
+  it("still has a sentence for a thrown non-Error, or an Error with no message", () => {
+    // The whole point of the panel is that it is never blank — a panel with
+    // nothing in it is the vanishing toast again, only quieter.
+    expect(runFailureFrom("kaboom", CTX).message).toBe("kaboom");
+    expect(runFailureFrom(new Error(""), CTX).message).not.toBe("");
+    expect(runFailureFrom(new ApiError(500, "x", "", true), CTX).message).toContain("500");
+  });
+});
+
+describe("how long a run took", () => {
+  it("measures a settled run from its start to its finish", () => {
+    const run = {
+      startedAtMillis: 1_000,
+      atMillis: 13_400,
+    } as WorkflowRunOutcome;
+    expect(formatDuration(runDuration(run, 99_999)!)).toBe("12.4s");
+  });
+
+  it("measures a running run against now, and reports nothing without a start", () => {
+    const running = { startedAtMillis: 1_000, atMillis: 1_000, running: true } as WorkflowRunOutcome;
+    expect(runDuration(running, 6_000)).toBe(5_000);
+    // Two different clocks: a live row read a moment early comes out negative,
+    // and "-1s" is worse than no number at all.
+    expect(runDuration(running, 0)).toBeNull();
+    // A row journaled before #371 records only its finish.
+    expect(runDuration({ atMillis: 10 } as WorkflowRunOutcome, 20)).toBeNull();
+  });
+
+  it("never renders a sixtieth second", () => {
+    expect(formatDuration(840)).toBe("840ms");
+    expect(formatDuration(179_800)).toBe("3m 00s");
+    expect(formatDuration(187_000)).toBe("3m 07s");
+  });
+});


### PR DESCRIPTION
## Summary

A rejected run POST rendered nothing. `RunResultPanel` is the only surface that shows run detail and it mounts from a settled body, which the failure path by definition never has — so the console dropped back to its resting state behind a four-second `toast.error`, with the History drawer that holds the journaled row closed by default and nothing to open it.

- **A failed run now leaves a drawer.** A new `RunFailurePanel` (`views/workflows/RunFailurePanel.tsx`) built from the structured `ApiError` by a pure `runFailureFrom` (`views/workflows/run-failure.ts`): the message, the host's code *only* when its own envelope carried one, the status, how long it ran before failing, and the request it was asked for. Persistent, on the same rule the version-conflict banner and the inference refusal already follow.
- **…and opens History**, where the run the host journaled lands with its per-node trail, handing the history fetch the run id (`awaitingRunId`) when the live fold got far enough to name one. The `connection-lost` path opens it too — its toast already said "the outcome lands in History" while History was shut.
- **`run()` clears `result`** beside `overlayRun`. It never did, so a second run that failed left run #1's nodes, output and "Requested:" line on screen as the only run detail there.
- **The click is acknowledged**: a dispatch-time `toast.info` naming the workflow, an optimistic running row in the history drawer (dropped the moment the host's own row for that run arrives; skipped for a dry run, which journals nothing), and elapsed time counted from `startedAtMillis` — on the wire since #371 and read by no workflow surface until now.
- **Small detail losses**: the history failure line prints the node's *name* rather than its raw id (the run timeline, the canvas and the overlay banner already did), and every row shows its duration.

Deliberately out of scope: board rows and approval links (#1014), and the other workflow defects in #1005/#1006/#1008–#1017.

## Commands run

From `frontend/`:

```
$ npm run typecheck
> tsc -b --noEmit
(clean)

$ npm test
Test Files  88 passed (88)
     Tests  902 passed (902)
```

Rust was not built or tested — this change is frontend-only.

## Tests

`frontend/test/unit/workflow-run-failure.test.ts` (11 tests). It renders `WorkflowsView` under jsdom, the way `task-blocked-card.test.ts` earns its exception to the pure-function rule: the claim is about what survives the toast, and the only place that is true is the DOM. It pins the failure drawer and its code badge, History opening on both the failure and connection-lost paths, the dispatch toast and the optimistic running row, the stale-result clear (run #1 succeeds, run #2 fails, run #1's drawer must be gone), the node name on the failure line, and the pure `runFailureFrom` / `runDuration` / `formatDuration` branches.

Closes #1007