### PR TITLE
fix(harness): say so when a turn stops at its step budget

### DIFF
--- a/docs/modules/openhuman/README.md
+++ b/docs/modules/openhuman/README.md
@@ -55,6 +55,45 @@ runtime override > manifest `[inference]` > managed env default — on every tur
 so a provider switch or key rotation reaches agents on the next turn with no
 rebuild at all.
 
+## The per-turn step budget (issue #926)
+
+An agent turn is bounded by openhuman's `AgentConfig::max_tool_iterations` — the
+number of **model calls** one turn may make, defaulting to 10. It is not a
+deadline and not a sub-agent budget, and it is not the step count the console
+shows: a console "step" is one tool call or one coalesced thinking run
+(`harness::steps::fold_steps`), so a turn stopped at 10 model calls routinely
+renders as ~20 steps. `harness::workflow_build` is the one place OpenCompany
+overrides the cap (`set_max_tool_iterations(7)`); everything else inherits the
+default.
+
+**Hitting the cap is invisible in the reply, by construction.** openhuman does
+not error. It asks the model for a resumable checkpoint with tools disabled
+(`MAX_ITER_CHECKPOINT_INSTRUCTION`) and returns that prose through the same
+`Ok(String)` a finished turn returns. The instruction asks for "Done so far" and
+"Next steps" and never asks the model to mention the limit, so a capped turn
+typically ends on a confident plan — indistinguishable from an agent that
+finished and described what it would do. Only openhuman's deterministic
+*fallback* checkpoint (used when the model's wrap-up call fails or comes back
+empty) names the cap.
+
+So the fact is carried out of band. `Agent::last_turn_hit_cap()` is read in
+`CompanyAgent::run_with_steer` while the agent lock is still held — the same
+place and for the same reason as `last_turn_usage` — and becomes
+`TurnOutcome::exhausted_budget: Option<ExhaustedStepBudget>`. The cap it quotes
+comes off the agent that enforced it, never a constant on this side, because
+callers may override it per agent.
+
+`harness::brain` renders it as **its own operator bubble**, not appended to the
+reply: the reply is the agent's answer and this is the system saying the agent
+was cut off. The wording deliberately mirrors
+`DrainedRequests::overflow_notice` (issue #561) — same "Heads up:" opening, same
+habit of quoting the limit that actually applied, same closing move of telling
+the operator the one thing they can do. Two systems reporting silently-dropped
+work in two different voices is how one of them stops being believed.
+
+The cap itself is **not** raised. Raising it moves the cliff and keeps the
+silence, which is the failure this fixes.
+
 ## Approval parking
 
 openhuman resolves a `ToolPolicyDecision::RequireApproval` **inline**: it blocks

--- a/src/harness/acp_run_turn.rs
+++ b/src/harness/acp_run_turn.rs
@@ -199,7 +199,14 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         }
     }
 
-    TurnOutcome { reply, steps }
+    TurnOutcome {
+        reply,
+        steps,
+        // ACP turns run on the external agent's own loop, which reports no cap
+        // to us. Claiming one would be inventing a limit this turn was never
+        // held to.
+        exhausted_budget: None,
+    }
 }
 
 #[async_trait]

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2540,6 +2540,7 @@ impl HarnessBrain {
                                 &confinement,
                             )
                             .await?;
+                        let exhausted = outcome.exhausted_budget.clone();
                         channel_responses.push(OutboundMessage {
                             message_id: None,
                             // No card, by construction: a confined turn has no
@@ -2551,6 +2552,28 @@ impl HarnessBrain {
                             reply_to: None,
                             steps: outcome.steps,
                         });
+                        // Issue #926: the copilot path runs its turn directly
+                        // rather than through the delegation seam, so it needs
+                        // the same notice explicitly. A confined turn hitting
+                        // the cap is if anything more confusing — the workflow
+                        // copilot's checkpoint reads like a finished design.
+                        if let Some(exhausted) = exhausted {
+                            tracing::warn!(
+                                company = %self.record().id,
+                                workflow = %workflow_id,
+                                cap = exhausted.cap(),
+                                "[harness::brain] confined copilot turn stopped at its model-call \
+                                 cap with work outstanding; telling the operator"
+                            );
+                            channel_responses.push(OutboundMessage {
+                                message_id: None,
+                                task_id: None,
+                                channel: "operator".to_string(),
+                                text: exhausted.notice(),
+                                steps: Vec::new(),
+                                reply_to: None,
+                            });
+                        }
                         continue;
                     }
                     // Route to the addressed desk's lead, else the orchestrator.
@@ -2709,6 +2732,38 @@ impl HarnessBrain {
                         reply_to: None,
                         steps: operator_steps,
                     });
+                    // Issue #926: a turn that ran out of model calls comes back
+                    // as openhuman's cap checkpoint — a done/next digest that
+                    // reads exactly like an agent finishing with a plan. Say
+                    // which one it was.
+                    //
+                    // Its own bubble, for the reason the approvals overflow
+                    // above already gives: the reply is the agent's answer, and
+                    // this is the system saying the agent was cut off. Appending
+                    // it would put a sentence the agent did not write inside the
+                    // agent's own words, and this bubble is the one that must be
+                    // believed.
+                    //
+                    // Pushed AFTER the reply so it reads in the order it
+                    // happened, and no `cap` argument: the notice carries the
+                    // limit the turn was actually stopped against.
+                    if let Some(exhausted) = &turn.exhausted_budget {
+                        tracing::warn!(
+                            company = %self.record().id,
+                            responder = %responder,
+                            cap = exhausted.cap(),
+                            "[harness::brain] turn stopped at its model-call cap with work \
+                             outstanding; telling the operator"
+                        );
+                        channel_responses.push(OutboundMessage {
+                            message_id: None,
+                            task_id: None,
+                            channel: "operator".to_string(),
+                            text: exhausted.notice(),
+                            steps: Vec::new(),
+                            reply_to: None,
+                        });
+                    }
                     channel_responses.extend(turn.bubbles);
                 }
                 CompanyEvent::TaskDispatched { task_id, run_id } => {

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -621,6 +621,76 @@ pub struct TurnOutcome {
     /// The scrubbed, folded processing steps (empty for a memory-served or
     /// tool-less turn — the zero-steps tell).
     pub steps: Vec<TurnStep>,
+    /// Set when this turn stopped because it ran out of model calls rather than
+    /// because the agent was finished (issue #926). `None` on every ordinary
+    /// turn, and on turns that never entered the tool loop at all.
+    pub exhausted_budget: Option<ExhaustedStepBudget>,
+}
+
+/// A turn that stopped at its per-turn model-call cap, carrying the cap it was
+/// stopped against.
+///
+/// # Why this is a type and not a `bool`
+///
+/// Same reason [`DrainedRequests`](crate::harness::policy::DrainedRequests)
+/// carries its `cap` (issue #561): the notice quotes a number, and a caller
+/// holding a bare `true` would have to find that number somewhere else. The
+/// somewhere-else available here is a hard-coded copy of openhuman's default or
+/// the round figure off a step timeline, and either one hands the operator a
+/// confidently-worded, wrong sentence about a limit this turn was not held to.
+/// The cap is read from the agent that enforced it and travels with the fact it
+/// explains.
+///
+/// The field is private for exactly that reason — the only honest value is the
+/// one [`CompanyAgent::run_with_steer`] already had in hand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExhaustedStepBudget {
+    cap: usize,
+}
+
+impl ExhaustedStepBudget {
+    /// Records a turn that stopped at `cap` model calls.
+    pub fn new(cap: usize) -> Self {
+        Self { cap }
+    }
+
+    /// The cap this turn was stopped against.
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// The operator-facing sentence.
+    ///
+    /// Deliberately shaped like
+    /// [`DrainedRequests::overflow_notice`](crate::harness::policy::DrainedRequests::overflow_notice):
+    /// the same "Heads up:" opening, the same habit of quoting the limit that
+    /// actually applied, and the same closing move of telling the operator the
+    /// one thing they can do about it. Two systems telling an operator "your
+    /// work was silently cut short" in two different voices is how one of them
+    /// stops being believed.
+    ///
+    /// What it must NOT say is that the agent finished, or that it is asking a
+    /// question. The reply this notice accompanies is openhuman's cap
+    /// checkpoint — a done/next summary the model writes with tools disabled
+    /// once the loop has already stopped — and read alone it is indistinguishable
+    /// from an agent that chose to stop and describe its plan. That confusion is
+    /// the whole of #926.
+    /// # Wording
+    ///
+    /// It says "anything the reply describes as next steps" rather than "the
+    /// plan above", because a turn can be relayed: the reply the operator ends
+    /// up reading is not always produced by the turn that ran out of steps. The
+    /// sentence has to stay true either way, so it makes a claim about
+    /// outstanding work rather than about which bubble sits above it.
+    pub fn notice(&self) -> String {
+        let cap = self.cap;
+        format!(
+            "Heads up: this turn stopped because it ran out of steps, not because the work was \
+             finished. One turn may make at most {cap} model calls, and this one used all {cap} — \
+             so anything the reply describes as a next step is still outstanding, not done. Send \
+             the agent another message to carry on from here."
+        )
+    }
 }
 
 impl CompanyAgent {
@@ -777,6 +847,27 @@ impl CompanyAgent {
             )
             .await;
 
+        // Issue #926: did this turn stop because it was finished, or because it
+        // ran out of model calls? Read here, in the same lock scope as
+        // `read_turn_usage` above and for the same reason — both are per-turn
+        // state on the agent that the next turn overwrites.
+        //
+        // `last_turn_hit_cap` exists upstream precisely because `turn()` returns
+        // only a `String`: on a cap hit that string is openhuman's checkpoint
+        // summary (a done/next digest written with tools disabled), which is
+        // shaped exactly like an agent finishing with a plan. There is no other
+        // signal in the reply to tell the two apart, so a caller that does not
+        // ask this question cannot answer it later.
+        //
+        // The cap comes off the same agent rather than a constant here: the
+        // number in the notice must be the number that stopped this turn, and
+        // openhuman lets a caller override the cap per agent
+        // (`set_max_tool_iterations`), so a copy kept on this side would be
+        // right only until someone used that.
+        let exhausted_budget = agent
+            .last_turn_hit_cap()
+            .then(|| ExhaustedStepBudget::new(agent.agent_config().max_tool_iterations));
+
         // Detach the sink (drops the only remaining `Sender`, closing the
         // channel), release the agent lock, then drain + fold. A `Hard` error
         // still runs this cleanup before propagating, so the collector never
@@ -787,7 +878,14 @@ impl CompanyAgent {
         let steps = steps::fold_steps(events);
 
         let reply = reply?;
-        Ok((TurnOutcome { reply, steps }, usages))
+        Ok((
+            TurnOutcome {
+                reply,
+                steps,
+                exhausted_budget,
+            },
+            usages,
+        ))
     }
 
     /// Classify one `agent.turn` result for the retry wrapper.
@@ -1878,6 +1976,9 @@ impl HarnessPool {
                             return Some(TurnOutcome {
                                 reply: TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
                                 steps: Vec::new(),
+                                // Refused before any model call, so no step
+                                // budget was spent, let alone exhausted.
+                                exhausted_budget: None,
                             });
                         }
                     }
@@ -2121,6 +2222,9 @@ impl HarnessPool {
                                 return Ok(TurnOutcome {
                                     reply: agent_budget_exhausted_notice(agent_id, cap),
                                     steps: Vec::new(),
+                                    // A spend refusal, not a step-budget one:
+                                    // this turn never entered the tool loop.
+                                    exhausted_budget: None,
                                 });
                             }
                         }

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -939,3 +939,119 @@ async fn a_supervised_turn_reads_its_own_workspace_without_asking() {
         "both reads must have run and fed a result back"
     );
 }
+
+/// A turn that runs out of model calls must come back **saying so** (issue #926).
+///
+/// This is the one test that exercises the whole chain the fix depends on:
+/// openhuman's tool loop actually reaching its cap, `Agent::last_turn_hit_cap`
+/// recording it, and `CompanyAgent::run_with_steer` reading it back out while it
+/// still holds the lock. Nothing here is scripted around — the script simply
+/// never stops asking for tools, which is exactly what the #926 repro did.
+///
+/// Why it needs the real harness rather than a unit test: on a cap hit openhuman
+/// returns its checkpoint text through the *same* `Ok(String)` a finished turn
+/// returns. There is no error, no marker in the reply, and no distinguishing
+/// shape — so a test that stubs the agent cannot tell the two apart either, and
+/// would pass against a build that reports every turn as exhausted.
+#[tokio::test]
+async fn a_turn_that_runs_out_of_model_calls_reports_the_cap_it_hit() {
+    // More tool calls than any cap this agent could be built with, so the loop
+    // is stopped by the budget rather than by the script running dry. Running
+    // off the end would emit `Turn::Say("done")` — a clean finish, and the
+    // silent pass this test exists to prevent.
+    //
+    // The two calls ALTERNATE, and that is load-bearing. Repeating one call
+    // verbatim trips openhuman's no-progress breaker after three identical
+    // batches ("the run is stuck repeating one action"), which halts with its
+    // own root-cause summary and deliberately reports `hit_cap = false`. That
+    // is a different, already-well-reported failure; a script that trips it
+    // would test the breaker and never reach the cap this test is about.
+    // Alternating two distinct successful calls never produces three identical
+    // batches in a row, so the budget is the only thing left to stop the loop.
+    let script_turns: Vec<Turn> = (0..40)
+        .map(|i| {
+            if i % 2 == 0 {
+                Turn::Call {
+                    tool: "workspace_list",
+                    args: json!({}),
+                }
+            } else {
+                Turn::Call {
+                    tool: "workspace_read",
+                    args: json!({ "path": "Standards/Engineering standards.md" }),
+                }
+            }
+        })
+        .collect();
+    let (base_url, _script) = spawn_script(script_turns).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (pool, deps, record, _store) = harness(base_url, "\"workspace\"", dir.path()).await;
+
+    let outcome = pool
+        .run(
+            &record.id,
+            "ceo",
+            "Write a short feature spec for adding CSV export to the usage page.",
+            &deps,
+            None,
+        )
+        .await
+        .expect("a capped turn still returns a reply, which is the whole problem");
+
+    let exhausted = outcome
+        .exhausted_budget
+        .expect("the turn was stopped by its budget and must say so");
+
+    // The cap is read off the agent that enforced it, so it matches the loop's
+    // own accounting rather than a number this side kept a copy of.
+    assert!(
+        exhausted.cap() > 0,
+        "a cap of zero would mean no model call was ever allowed: {}",
+        exhausted.cap()
+    );
+    let notice = exhausted.notice();
+    assert!(
+        notice.contains(&exhausted.cap().to_string()),
+        "the operator is told WHICH limit stopped the turn: {notice}"
+    );
+    // The point of the whole issue: the reply alone reads like a finished plan,
+    // so the fact has to arrive somewhere the reply is not.
+    assert!(
+        notice.contains("ran out of steps"),
+        "the notice must say the turn was cut short, not merely mention a limit: {notice}"
+    );
+}
+
+/// The counterpart, and the one that keeps the notice believable: a turn that
+/// finished because it was done reports no exhausted budget. Without this, a
+/// build that set the flag unconditionally would pass the test above.
+#[tokio::test]
+async fn a_turn_that_finishes_on_its_own_reports_no_exhausted_budget() {
+    let (base_url, _script) = spawn_script(vec![
+        Turn::Call {
+            tool: "workspace_list",
+            args: json!({}),
+        },
+        Turn::Say("Here is the spec."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (pool, deps, record, _store) = harness(base_url, "\"workspace\"", dir.path()).await;
+
+    let outcome = pool
+        .run(&record.id, "ceo", "Write the spec.", &deps, None)
+        .await
+        .expect("turn runs");
+
+    assert!(
+        outcome.reply.contains("Here is the spec."),
+        "the turn really did finish on its own: {}",
+        outcome.reply
+    );
+    assert!(
+        outcome.exhausted_budget.is_none(),
+        "an ordinary turn must stay quiet, or the notice stops being read"
+    );
+}

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -387,6 +387,9 @@ pub(crate) struct OperatorTurn {
     /// on. The resulting claim is incomplete but never wrong, and the bubble's
     /// step timeline still shows every `spawn_task` the turn made.
     pub(crate) spawned_task: Option<String>,
+    /// Set when a turn behind this reply stopped at its per-turn model-call cap
+    /// (issue #926), carrying the cap it stopped against.
+    pub(crate) exhausted_budget: Option<crate::harness::ExhaustedStepBudget>,
 }
 
 /// What a **dispatched card's** turn handed off (issue #204).
@@ -916,6 +919,9 @@ impl<'a> DelegationRunner<'a> {
         // case the relay turn's reply replaces it (below).
         let mut operator_steps = outcome.steps;
         let mut operator_reply = outcome.reply;
+        // Issue #926: whether a turn ran out of model calls travels with the
+        // reply, because that is the only place the operator can be told.
+        let mut operator_exhausted_budget = outcome.exhausted_budget;
         // Settle the direct-answer card from the turn that just ran. Done before
         // the delegation drain because a direct responder queues nothing — it
         // has no delegation tools — so there is no relay turn coming that could
@@ -1030,6 +1036,13 @@ impl<'a> DelegationRunner<'a> {
             }
             operator_reply = relay.reply;
             operator_steps.extend(relay.steps);
+            // The relay's reply is what the operator now reads, so its cap is
+            // the one to quote. `or` rather than a straight replacement: if the
+            // relay finished cleanly but the responder's own turn was cut
+            // short, work is still outstanding and dropping that would restore
+            // exactly the silence #926 is about. The notice is worded to hold
+            // in both cases — see `ExhaustedStepBudget::notice`.
+            operator_exhausted_budget = relay.exhausted_budget.or(operator_exhausted_budget);
         }
         // Drained after the relay, not before it: a relay turn carries the same
         // inline `create_workflow` tool, so draining at the responder's turn
@@ -1053,6 +1066,7 @@ impl<'a> DelegationRunner<'a> {
             steps: operator_steps,
             bubbles,
             spawned_task,
+            exhausted_budget: operator_exhausted_budget,
         })
     }
 
@@ -2870,12 +2884,27 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
         /// the call would be wiped by the pre-turn clear, and one that staged
         /// after would skip the boundary the drain reads.
         authors: Vec<TaskOutputWorkflow>,
+        /// The per-turn model-call cap this turn ran out of, when it did
+        /// (issue #926). `None` — the default — is a turn that finished
+        /// because it was done, which is every other turn in this file.
+        exhausted_cap: Option<usize>,
     }
 
     impl Turn {
         fn reply(reply: &str) -> Self {
             Self {
                 reply: reply.to_string(),
+                ..Self::default()
+            }
+        }
+
+        /// A turn that produced `reply` and then ran out of model calls at
+        /// `cap` (issue #926) — openhuman's cap checkpoint, which is prose
+        /// about what is left to do and carries no other tell.
+        fn exhausted(reply: &str, cap: usize) -> Self {
+            Self {
+                reply: reply.to_string(),
+                exhausted_cap: Some(cap),
                 ..Self::default()
             }
         }
@@ -3105,6 +3134,9 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             TurnOutcome {
                 reply: turn.reply,
                 steps: Vec::new(),
+                exhausted_budget: turn
+                    .exhausted_cap
+                    .map(crate::harness::ExhaustedStepBudget::new),
             }
         }
     }
@@ -3575,6 +3607,108 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty(), "a question is not work");
         assert!(turn.spawned_task.is_none());
+    }
+
+    // ── a turn that ran out of steps (issue #926) ───────────────────────────
+
+    /// The reply an exhausted turn carries is openhuman's cap checkpoint: prose
+    /// about what is still to do, indistinguishable from an agent that finished
+    /// and described its plan. If the fact travels no further than the harness,
+    /// nothing downstream can tell the operator — which is the whole bug.
+    #[tokio::test]
+    async fn a_turn_that_ran_out_of_steps_carries_the_fact_to_the_caller() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::exhausted(
+                "Next steps: write the spec, publish it.",
+                10,
+            )],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "write a feature spec", None)
+            .await
+            .expect("operator message handled");
+
+        let exhausted = turn
+            .exhausted_budget
+            .expect("the turn ran out of steps and the caller must be able to know");
+        assert_eq!(exhausted.cap(), 10);
+    }
+
+    /// The ordinary turn stays quiet. A notice on every reply would train the
+    /// operator to skip the one that matters.
+    #[tokio::test]
+    async fn a_turn_that_finished_normally_reports_no_exhausted_budget() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("here is the spec")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "write a feature spec", None)
+            .await
+            .expect("operator message handled");
+
+        assert!(turn.exhausted_budget.is_none());
+    }
+
+    /// The cap reported is the one the turn was actually stopped against, not a
+    /// constant this side had lying around. Same guarantee
+    /// `the_notice_quotes_the_cap_the_drain_was_taken_against` gives for the
+    /// approvals overflow (#561), and for the same reason: the sentence quotes a
+    /// number, so the number has to be the real one.
+    #[tokio::test]
+    async fn the_cap_reported_is_the_one_the_turn_was_stopped_against() {
+        let fx = Fixture::new();
+        // Deliberately not openhuman's default of 10 — a fixed fallback would
+        // pass this test at 10 and lie at every other cap.
+        let turns = ScriptedTurns::new(&fx, vec![Turn::exhausted("mid-plan", 37)]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "do the thing", None)
+            .await
+            .expect("operator message handled");
+
+        let exhausted = turn.exhausted_budget.expect("the turn ran out of steps");
+        assert_eq!(exhausted.cap(), 37);
+        assert!(
+            exhausted.notice().contains("37"),
+            "the operator is told WHICH limit stopped the turn: {}",
+            exhausted.notice()
+        );
+    }
+
+    /// A relay replaces the operator-facing reply, so a responder turn that ran
+    /// out of steps behind a cleanly-finished relay must not have its fact
+    /// dropped on the floor — work is still outstanding either way, and losing
+    /// it here restores exactly the silence this issue is about.
+    #[tokio::test]
+    async fn a_relay_that_finished_does_not_erase_an_exhausted_responder_turn() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                // The responder queues a hand-off and runs out of steps doing it.
+                Turn {
+                    exhausted_cap: Some(10),
+                    ..Turn::queueing("asking", vec![handoff("what's the status of the build?")])
+                },
+                // The desk answers cleanly.
+                Turn::reply("engineering says it's green"),
+                // ...and so does the relay, whose reply the operator reads.
+                Turn::reply("it's green"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "is the build ok?", None)
+            .await
+            .expect("operator message handled");
+
+        let exhausted = turn
+            .exhausted_budget
+            .expect("the responder ran out of steps; the relay finishing does not undo that");
+        assert_eq!(exhausted.cap(), 10);
     }
 
     /// A hand-off made from inside a **dispatched card** must not open a second


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#926.

A turn that runs out of steps ends by printing **what it was about to do next**, with no
sign it hit a limit and no follow-up. QA has been reporting this as *"agents get
permanently stuck mid-task; replies stop at 'Let me check X' and never follow up."*

### The cap is 10 model calls — not the 20 in the repro

The repro ended at `20 steps · 2 failed`, and the round number is a red herring worth
naming, because it is the first thing anyone will reach for.

A console "step" is one tool call or one coalesced thinking run — `fold_steps`
(`src/harness/steps.rs`) explicitly discards iteration and cost events. **Steps are not
model calls.** The real limit is `AgentConfig::max_tool_iterations`, openhuman's default
of **10** (`vendor/openhuman/src/openhuman/config/schema/agent.rs:413`). It is not a
deadline and not a sub-agent budget. `build_agent` never calls an iteration setter, so it
inherits the default.

That is confirmed by running it, not by arithmetic: the new end-to-end test drives a real
capped turn and the harness reports `ExhaustedStepBudget { cap: 10 }`, with openhuman's
own fallback text reading *"I reached the tool-call limit for this turn (10 steps)"*.

The cap is also **not a single constant** — `harness/workflow_build/agent.rs:128` already
calls `set_max_tool_iterations(7)`. That is why the notice reads the cap off the agent that
enforced it rather than hard-coding a number on this side.

### Why it is silent, precisely

openhuman does not error on a cap hit. At `session/turn/core.rs:1366` it asks the model for
a resumable checkpoint with tools disabled and returns that prose through **the same
`Ok(String)` a finished turn returns**. Upstream's own field doc is explicit: `run_single`
"only returns the checkpoint/final text, **with no other signal** for which case occurred."

The decisive detail is the instruction itself (`turn_checkpoint.rs:45`). It asks the model
for "**Done so far**" and "**Next steps**" and **never asks it to tell the user a limit was
hit**. That is verbatim the repro's *"2. Next steps → …"*. Only openhuman's *deterministic
fallback* checkpoint names the cap, and that runs solely when the model's wrap-up call
fails or returns empty. So the silence is conditional on which checkpoint path ran — and in
the repro the model path ran. That is exactly why this has to be a system-emitted fact
rather than a prompt tweak asking the model to mention it.

### What this does

`Agent::last_turn_hit_cap()` is public and purpose-built (openhuman consumes it itself at
`flows/ops.rs:7111`). It is read in `CompanyAgent::run_with_steer` while the agent lock is
still held — same place and same reason as `last_turn_usage`, since both are per-turn state
the next turn overwrites — and becomes
`TurnOutcome::exhausted_budget: Option<ExhaustedStepBudget>`, threaded through
`OperatorTurn` and rendered by `harness::brain`.

**The cap is not raised.** Raising it moves the cliff and keeps the silence.

`ExhaustedStepBudget` is a type rather than a `bool` for the reason `DrainedRequests`
carries its own `cap` (#561): the notice quotes a number, and a caller holding a bare
`true` would have to find that number somewhere else — a hard-coded copy of openhuman's
default, or the round figure off a step timeline. Either hands the operator a
confidently-worded, wrong sentence about a limit the turn was not held to.

The wording reuses `DrainedRequests::overflow_notice` (#625/#561) deliberately — same
"Heads up:" opening, same habit of quoting the limit that actually applied, same closing
move of telling the operator the one thing they can do. Two systems reporting
silently-dropped work in two different voices is how one of them stops being believed.

It is emitted as **its own operator bubble**, not appended, following the rationale already
written at the approvals-overflow site: the reply is the agent's answer, and this is the
system saying the agent was cut off. Wired on the main operator path and on the confined
copilot path, which bypasses the delegation seam.

Non-loop `TurnOutcome` sites (budget refusals, ACP) set `None` explicitly — an ACP turn runs
on an external agent's loop and must not claim a cap it was never held to.

## API Or Behavior Changes

New public type `harness::ExhaustedStepBudget`; `TurnOutcome` gains
`exhausted_budget: Option<…>` (both behind the existing `openhuman` feature).

Behaviour: one additional operator bubble when a turn stops at its cap. No turn is gated,
refused, or run differently; an ordinary turn is byte-identical and silent.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
      exit 0. `--no-deps` mirrors `ci.yml`; a bare `--all-targets` drowns in vendored lints
      CI never compiles.
- [x] `cargo build --all-targets` — covered by the two test lanes below, which build all
      targets for both feature sets.
- [x] `cargo test` — both halves. Default features: `cargo test --locked`, exit 0. Gated
      lane: `RUST_MIN_STACK=16777216 cargo test --locked --features openhuman,tinycortex --tests`
      → **4188 passed / 0 failed**. `RUST_MIN_STACK` matches `ci.yml:626`; without it a
      pre-existing `harness::brain` test overflows the stack locally.

`scripts/ci/assert-feature-lanes.sh` and `scripts/ci/assert-integration-targets-run.sh` both
pass. No new `feature-lanes.txt` row is owed: the tests sit behind `openhuman`, already
classified `tested` on `openhuman,tinycortex`.

### Revert proof — three, each isolating a different piece

| Reverted | Result |
| --- | --- |
| harness read → hard-wired `None` | `a_turn_that_runs_out_of_model_calls_reports_the_cap_it_hit` **FAILED** |
| `OperatorTurn.exhausted_budget` → `None` | 3 delegation tests **FAILED** |
| relay `.or(responder)` → plain replacement | `a_relay_that_finished_does_not_erase_an_exhausted_responder_turn` **FAILED** |

The negative test (`…finished_normally_reports_no_exhausted_budget`) correctly keeps
passing under all three — it asserts `None`, which is what makes the notice believable.

### Two things worth stating plainly

**The end-to-end test exercises the deterministic fallback checkpoint, not the
model-written one**, because the loopback stub is not a real model. It proves the plumbing
— cap reached → `last_turn_hit_cap` → `TurnOutcome` → cap value — which is what the fix is.
The model-written variant differs only in the prose openhuman returns, which this change
does not read.

**Writing that test surfaced a real trap.** The first version repeated one tool call and
tripped openhuman's no-progress breaker after three identical batches ("the run is stuck
repeating one action"), which halts with its own good root-cause summary and *deliberately*
reports `hit_cap = false`. It would have passed while testing the breaker and never
reaching the cap. The script now alternates two distinct successful calls so the budget is
the only thing left to stop the loop, and the reason is written into the test.

## Documentation

`docs/modules/openhuman/README.md` gains a "The per-turn step budget" section: what the cap
is and is not, why steps ≠ model calls, why the reply cannot carry the fact, where it is
read instead, and why the cap is not raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-turn model-call budget tracking, with a seven-call cap for OpenHuman workflows.
  * Turns that reach the cap now return a resumable checkpoint instead of an error.
  * Operators receive a separate budget-exhaustion notification while the original agent reply remains unchanged.
  * Budget status and the applied cap are preserved across delegated and relayed turns.

* **Bug Fixes**
  * Corrected budget-exhaustion reporting so normally completed and budget-refused turns are not incorrectly marked as exhausted.

* **Documentation**
  * Documented model-call budgets, resumable checkpoints, and operator notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->