### PR TITLE
fix(console): show the select popup's truncation at the cut edge (#975)

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -88,6 +88,57 @@ function SelectTrigger({
 const SELECT_POPUP_CLASSES =
   "relative isolate z-50 max-h-(--available-height) max-w-[min(28rem,var(--available-width))] min-w-[min(max(9rem,var(--anchor-width)),28rem,var(--available-width))] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
 
+/**
+ * The shared look of both scroll arrows (issue #975).
+ *
+ * # Why a gradient and not just a chevron
+ *
+ * An arrow was already here and already worked: Base UI mounts it exactly when
+ * the list can scroll further, and a browser measurement confirms it is present
+ * and visible at the moment of truncation. It was still missed in live QA, where
+ * a tester recorded two of a company's eight workflows as *"not inspected due to
+ * dropdown truncation"* — including the healthiest one on the tenant.
+ *
+ * The reason is that it was the **only** signal. Base UI adds
+ * `base-ui-disable-scrollbar` to the list whenever scroll arrows are mounted, so
+ * the native scrollbar is deliberately traded away for the arrow — and the arrow
+ * was a small low-contrast chevron on a flat `bg-popover` strip, below a list
+ * that ended on a clean, uncut row. A list that ends tidily reads as a list that
+ * ended. There was nothing at the cut edge saying otherwise.
+ *
+ * The gradient is what makes the edge itself the affordance: the row under the
+ * arrow fades out instead of stopping square, so the content visibly continues
+ * past the boundary rather than finishing at it. `from-55%` keeps the chevron
+ * sitting on solid `popover` so it loses no contrast, and only the half nearest
+ * the content fades.
+ *
+ * A count beside the trigger (`Workflows 8`) was the issue's other suggestion
+ * and is deliberately **not** what this does. A total tells you how many exist;
+ * it does not tell you that the list in front of you is cut, and it would have
+ * to be added to each of the twenty-odd selects in the console one at a time.
+ * This is one change to the shared primitive and it lands at the point of
+ * truncation, which is where the information was missing.
+ *
+ * `h-7` over the old `py-1`: the gradient needs vertical room to read as a fade
+ * rather than a band, and a fixed height keeps both arrows the same size whether
+ * or not their icon renders.
+ */
+const SELECT_SCROLL_ARROW_CLASSES =
+  "z-10 flex h-7 w-full cursor-default justify-center text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
+
+/**
+ * Exported for `select-scroll-affordance.test.ts`, which cannot reach them any
+ * other way: Base UI mounts a scroll arrow only once it measures the list as
+ * scrollable, and jsdom does no layout — so the arrows never render there, and
+ * rendering the parts standalone throws for want of `SelectRootContext`. The
+ * rule is therefore pinned at its source, and the behavioural proof (a real
+ * Chromium, twelve entries, a constrained viewport) lives in the PR.
+ */
+export const SELECT_SCROLL_UP_ARROW_CLASSES = `${SELECT_SCROLL_ARROW_CLASSES} top-0 items-start bg-gradient-to-b from-popover from-30% to-transparent`
+
+/** The down arrow's mirror. See {@link SELECT_SCROLL_UP_ARROW_CLASSES}. */
+export const SELECT_SCROLL_DOWN_ARROW_CLASSES = `${SELECT_SCROLL_ARROW_CLASSES} bottom-0 items-end bg-gradient-to-t from-popover from-30% to-transparent`
+
 function SelectContent({
   className,
   children,
@@ -189,7 +240,7 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpArrow
       data-slot="select-scroll-up-button"
       className={cn(
-        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        SELECT_SCROLL_UP_ARROW_CLASSES,
         className
       )}
       {...props}
@@ -208,7 +259,7 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownArrow
       data-slot="select-scroll-down-button"
       className={cn(
-        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        SELECT_SCROLL_DOWN_ARROW_CLASSES,
         className
       )}
       {...props}

--- a/frontend/test/unit/select-scroll-affordance.test.ts
+++ b/frontend/test/unit/select-scroll-affordance.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import {
+  SELECT_SCROLL_DOWN_ARROW_CLASSES,
+  SELECT_SCROLL_UP_ARROW_CLASSES,
+} from "@/components/ui/select";
+
+/**
+ * The select popup's truncation affordance (issue #975).
+ *
+ * Live QA on a company with eight workflows recorded two of them as *"not
+ * inspected due to dropdown truncation"* — including Feature Pipeline, the
+ * healthiest workflow on the tenant. The control under-reported the company's
+ * own contents to someone whose job was to enumerate them.
+ *
+ * # What was actually wrong, which is not what it looked like
+ *
+ * A scroll arrow was already there and already worked. Base UI mounts one
+ * exactly when the list can scroll further, and a Chromium measurement confirms
+ * it is present and visible at the moment of truncation. Two things made it
+ * useless anyway:
+ *
+ * 1. Base UI puts `base-ui-disable-scrollbar` on the list whenever scroll arrows
+ *    are mounted — the native scrollbar is deliberately traded away for the
+ *    arrow, so the arrow is the *only* remaining signal.
+ * 2. The arrow was a low-contrast chevron on a flat, **opaque** `bg-popover`
+ *    strip — and that strip painted over the half-clipped next row underneath
+ *    it. The list therefore ended on a clean, uncut row. A list that ends tidily
+ *    reads as a list that ended.
+ *
+ * The clipped row was the affordance all along; the opaque strip was hiding it.
+ * So the fix is a gradient that fades to transparent instead of a band that
+ * covers: the next row shows through, faded, and the boundary reads as a cut.
+ *
+ * # Why this asserts strings
+ *
+ * jsdom does no layout, so Base UI never measures the list as scrollable and the
+ * arrows never mount — and rendering the parts standalone throws for want of
+ * `SelectRootContext`. There is no rendered element to interrogate. What can be
+ * pinned is the rule, and the rule is the whole defect: a revert to an opaque
+ * strip fails here rather than shipping and being missed by a tester again.
+ */
+describe("the select popup's scroll affordance", () => {
+  for (const [name, cls] of [
+    ["down", SELECT_SCROLL_DOWN_ARROW_CLASSES],
+    ["up", SELECT_SCROLL_UP_ARROW_CLASSES],
+  ] as const) {
+    describe(`the ${name} arrow`, () => {
+      it("fades to transparent, so the clipped row underneath shows through", () => {
+        expect(cls).toContain("to-transparent");
+      });
+
+      it("does not paint an opaque band over the list edge", () => {
+        // The exact regression: `bg-popover` as a flat fill covered the very
+        // half-row that says the list continues.
+        expect(cls).not.toMatch(/(^|\s)bg-popover(\s|$)/);
+      });
+
+      it("keeps its chevron on the solid end of the fade", () => {
+        // The gradient is solid for the first 30% at the outer edge and the
+        // chevron is pinned there, so making the strip see-through costs the
+        // icon no contrast.
+        expect(cls).toMatch(/from-30%/);
+        expect(cls).toMatch(name === "down" ? /items-end/ : /items-start/);
+      });
+    });
+  }
+
+  it("fades each arrow away from its own edge", () => {
+    // Direction matters: the down arrow must fade upward into the content above
+    // it and the up arrow downward. Swapping them would fade the popup's own
+    // outer edge into the page and leave the covered row still covered.
+    expect(SELECT_SCROLL_DOWN_ARROW_CLASSES).toContain("bg-gradient-to-t");
+    expect(SELECT_SCROLL_UP_ARROW_CLASSES).toContain("bg-gradient-to-b");
+  });
+
+  it("still pins each arrow to its edge", () => {
+    // Guards the guard: every assertion above would pass against an empty
+    // string, so prove the constants are the arrows' real classes.
+    expect(SELECT_SCROLL_DOWN_ARROW_CLASSES).toMatch(/(^|\s)bottom-0(\s|$)/);
+    expect(SELECT_SCROLL_UP_ARROW_CLASSES).toMatch(/(^|\s)top-0(\s|$)/);
+  });
+});


### PR DESCRIPTION
## Summary

The workflow selector showed ~4–5 of a company's 8 workflows with nothing saying more existed. Live QA
recorded two as *"not inspected due to dropdown truncation"* — including Feature Pipeline, the healthiest
workflow on the tenant, 13 runs. The control under-reported the company's own contents to someone whose job
was to enumerate them.

**The issue's diagnosis — and my own first hypothesis — were both wrong, and measuring is what caught it.**
The issue says there is no affordance. There is one, it mounts at the right moment, and it is visible. My
first guess was that the arrows never mount at all; a Chromium measurement killed that too.

## The two measured facts this rests on

Taking these first, because without them the obvious fix is "add a count badge, add a scrollbar" — which
layers a third signal on top of two working ones and leaves the actual cause untouched.

**1. Base UI trades the native scrollbar away *because* the arrow is meant to be the signal.**

`SelectList` gets `base-ui-disable-scrollbar` whenever scroll arrows are mounted. Measured on the live
component:

```
listClasses:      "p-1 base-ui-disable-scrollbar"
scrollbarWidthPx: 0            // offsetWidth - clientWidth
```

So the arrow is not *a* signal, it is the *only* remaining one. Anything wrong with it is total.

**2. The arrow was an opaque strip painted over the half-clipped next row.**

The arrow was a low-contrast chevron on a flat `bg-popover` band pinned to the bottom edge. Underneath it,
the list was already doing the right thing. Hiding the arrow and screenshotting what it covered:

```
listBottom: 217
rowsNearEdge: [
  { n: 6, t: 166, b: 194, clippedAtListBottom: false },
  { n: 7, t: 194, b: 222, clippedAtListBottom: true   },   <-- cut mid-row at the boundary
  ...
]
```

**"Workflow 7" was there all along, clipped mid-row** — a textbook "content continues" cue. The opaque strip
was painting over exactly it, so the list ended on a clean, uncut row. A list that ends tidily reads as a
list that ended.

## The fix

Stop covering it. Both arrows fade to transparent instead of filling:

```
bottom-0 items-end   bg-gradient-to-t from-popover from-30% to-transparent
top-0    items-start bg-gradient-to-b from-popover from-30% to-transparent
```

The clipped row shows through, faded, so the boundary reads as a cut rather than an end. `from-30%` keeps the
outer 30% solid and the chevron is pinned there (`items-end` / `items-start`), so making the strip
see-through costs the icon no contrast.

One change to the shared primitive, so all ~20 selects in the console get it rather than the workflow picker
alone.

**A count beside the trigger was the issue's other suggestion and is deliberately not what this does.** A
total tells you how many exist; it does not tell you the list in front of you is cut. It would also have to
be added to each select one at a time, and it would sit at the trigger rather than at the point of
truncation, which is where the information was missing.

## API Or Behavior Changes

- Both select scroll arrows fade to transparent instead of painting an opaque band. Visible everywhere
  `SelectContent` is used.
- `SELECT_SCROLL_UP_ARROW_CLASSES` / `SELECT_SCROLL_DOWN_ARROW_CLASSES` are exported for the regression test
  (see Tests for why they have to be).
- No change to when an arrow appears — that is Base UI's, and it was already correct.

## Tests

`frontend/test/unit/select-scroll-affordance.test.ts`, 8 cases pinning: each arrow fades to transparent,
neither carries a flat `bg-popover`, each fades away from its own edge (swapping them would fade the popup's
outer edge into the page and leave the row still covered), and the chevron sits on the solid end.

**Teeth proved by reverting: 7 of the 8 fail** against the old opaque strip. The eighth is the
guard-the-guard case (`top-0` / `bottom-0`), which the old strip also satisfied — reporting 7, not 8.

**Why it asserts strings, stated plainly.** jsdom does no layout, so Base UI never measures the list as
scrollable and **the arrows never mount there**; rendering the parts standalone throws for want of
`SelectRootContext`. There is no rendered element to interrogate. The rule is therefore pinned at its source,
following the same precedent as `select-popup-width.test.ts` (#811) in this file, and the behavioural proof
is the browser work below.

**Browser verification — 12 entries, real Chromium, viewport constrained to force the cut.** It does *not*
reproduce at full viewport height (the popup simply fits), which matches the issue's "not at 6 workflows".

| | before | after |
|---|---|---|
| light | 6 rows, clean end, faint chevron | 6 rows **+ faded clipped "Workflow 7"** under the chevron |
| dark | same | same — `from-popover` and `text-muted-foreground` are theme tokens, so both adapt; chevron measured at `oklch(0.682 …)` on the dark popover |

Up-arrow checked symmetrically by scrolling to the end: it appears, and the down arrow correctly disappears.

- [x] `cargo fmt --all -- --check` — N/A: console-only change, no Rust touched.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: console-only change, no Rust touched.
- [x] `cargo build --all-targets` — N/A: console-only change, no Rust touched.
- [x] `cargo test` — N/A for Rust. The console gates were run instead: `pnpm typecheck` (`tsc -b --noEmit`)
      clean, and `pnpm test` **886 passed / 86 files**. There is no eslint config under `frontend/`, so
      `typecheck` is the lint gate.

## Documentation

The reasoning lives at the code: `SELECT_SCROLL_ARROW_CLASSES` carries why a gradient rather than a chevron
alone, why the scrollbar is not the answer here, and why a count was rejected. The test header records the
two measured facts so the next reader does not have to re-derive them.

Closes tinyhumansai/opencompany#975
