### PR TITLE
qa: land the console parity harness in the repo (#987)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,14 @@ cargo check --features tiny
 
 Keep changes focused. Include a short summary, any API or behavior changes, and
 the local verification commands you ran.
+
+## Checking a Release
+
+Local checks answer "does the code work". A release also needs "does the thing
+we deployed work for the operator", which no in-repo test can reach: a stale
+`index.html`, an unwired delivery channel and a missing credential are all
+failures of the deployment rather than of the code.
+
+That pass lives in [`qa/`](qa/README.md) — a console script (`qa/oc-qa.js`) and
+a checklist (`qa/MASTER-QA.md`). Roll the tenant to the commit under test
+first; a tenant on an older image reports bugs `main` has already fixed.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ and the [tiny.place economy](gitbooks/overview/tiny-place.md). Builders should
 start with the [developer section](gitbooks/developers/README.md) — build,
 CLI, architecture, authoring companies, deployment, and configuration.
 
+Checking a release against a deployed tenant is [`qa/`](qa/README.md): a
+zero-dependency console script and the checklist that goes with it.
+
 ## Community
 
 [Discussions](https://github.com/tinyhumansai/opencompany/discussions) is where

--- a/frontend/test/unit/qa-harness.test.ts
+++ b/frontend/test/unit/qa-harness.test.ts
@@ -1,0 +1,405 @@
+/**
+ * The QA harness's judgements, pinned (issue #987).
+ *
+ * `qa/oc-qa.js` is pasted into a browser console, so nothing imports it and
+ * nothing type-checks it. Two things about it are worth a gate anyway:
+ *
+ * 1. **It parses.** A syntax error is discovered by an operator mid-incident,
+ *    which is the worst possible moment and the only moment it is ever run.
+ *
+ * 2. **Its run verdict agrees with the console's.** The harness owns a
+ *    transcription of `run-health.ts`, and a second definition of "did this run
+ *    succeed" is precisely the defect issue #981 filed against the product —
+ *    where the console's TypeScript held the only verdict and every API client
+ *    folding `nodes[].status` scored a dropped report as green. The harness made
+ *    exactly that mistake and scored a delivery-failure run as PASS. Pinning the
+ *    two together is what stops a change to the console's reading from silently
+ *    re-greening a bad run in the harness.
+ *
+ * The script is evaluated in a `vm` sandbox rather than imported: it is an IIFE
+ * that assigns `globalThis.OCQA`, with no `export`, because an `export` would
+ * make it unpasteable — which is the one property it must not lose.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createContext, runInNewContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+
+import { runTone } from "@/views/workflows/run-health";
+import type {
+  DeliveryReport,
+  WorkflowBlockedNode,
+  WorkflowRunOutcome,
+} from "@/api/workflows";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(here, "../../../qa/oc-qa.js");
+
+/** One reported check, as the script emits it. */
+interface Row {
+  check: string;
+  verdict: "PASS" | "WARN" | "FAIL" | "SKIP";
+  value: string;
+  note: string;
+}
+
+/** A minimal `Response` stand-in — the four things `http()` reads. */
+function response(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+    headers: new Headers(headers),
+  };
+}
+
+/** Loads `oc-qa.js` into a sandbox and hands back its `_internals`. */
+function loadHarness(fetchImpl?: (path: string) => Promise<unknown>) {
+  const source = readFileSync(SCRIPT, "utf8");
+  const sandbox: Record<string, unknown> = {
+    console: { log: () => {}, table: () => {} },
+    fetch:
+      fetchImpl ??
+      (async () => {
+        throw new Error("no network in this test");
+      }),
+    setTimeout,
+    clearTimeout,
+    AbortController,
+    Headers: globalThis.Headers,
+    location: { host: "test" },
+  };
+  createContext(sandbox);
+  runInNewContext(source, sandbox);
+  const ocqa = sandbox.OCQA as {
+    version: string;
+    read: (options?: { company?: string }) => Promise<Row[]>;
+    probe: unknown;
+    report: unknown;
+    _internals: {
+      runVerdict: (run: unknown) => string;
+      undeliveredCount: (d: DeliveryReport[]) => number;
+      pendingCount: (d: DeliveryReport[]) => number;
+      awaitingCount: (run: unknown) => number;
+      isBlocked: (run: unknown) => boolean;
+      judgeCacheHeader: (kind: string, header: string | null) => { verdict: string; note: string };
+      age: (atMillis: number, now?: number) => string;
+      notWired: (res: { body: unknown }) => boolean;
+      secs: (ms: number) => string;
+    };
+  };
+  return ocqa;
+}
+
+/** A run outcome with only the fields the verdict reads. */
+function run(overrides: Partial<WorkflowRunOutcome>): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    workflowId: "daily-release-readiness",
+    scheduled: false,
+    deliveries: [],
+    pendingApprovals: [],
+    ...overrides,
+  } as WorkflowRunOutcome;
+}
+
+function delivery(status: DeliveryReport["status"]): DeliveryReport {
+  return { node: "report", kind: "channel", target: "operator", status, detail: "" };
+}
+
+/** A node the run stopped short at, waiting on a person (issue #881). */
+function blocked(nodeId: string): WorkflowBlockedNode {
+  return { nodeId, tools: ["send_email"] };
+}
+
+describe("oc-qa.js loads", () => {
+  it("parses and exposes both entry points", () => {
+    const ocqa = loadHarness();
+    expect(typeof ocqa.read).toBe("function");
+    expect(typeof ocqa.probe).toBe("function");
+    expect(typeof ocqa.report).toBe("function");
+    expect(ocqa.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+describe("read() against a host whose surfaces do not answer", () => {
+  /**
+   * Rule 2 of the harness, end to end: **unreadable is never PASS.**
+   *
+   * The 2026-08-18 pass wrote three checks up as green that had never run, and
+   * a pure-function test cannot catch that — the mistake lives in the plumbing,
+   * where a 404 body decays to `{}` and every field read off it comes back
+   * `undefined`. So this drives the real `read()` over a host that answers
+   * `/healthz`, `/spec` and the company status and 404s everything else, and
+   * asserts nothing downstream claims to have passed.
+   */
+  const reachable: Record<string, unknown> = {
+    "/healthz": { status: "ok" },
+    "/spec": {
+      name: "opencompany",
+      version: "0.1.0",
+      capabilities: ["rest", "graphql"],
+      storage: "memory",
+      instance_id: "abcdef0123456789",
+    },
+    "/api/v1/company": { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+  };
+
+  async function runRead(): Promise<Row[]> {
+    const ocqa = loadHarness(async (path: string) =>
+      path in reachable ? response(200, reachable[path]) : response(404, { error: "not found" }),
+    );
+    return ocqa.read();
+  }
+
+  it("emits exactly the 22 checks the docs claim", async () => {
+    // Pins the number in `qa/README.md` and `qa/MASTER-QA.md` to the code. The
+    // cache-header check expands to three rows on a host that actually serves a
+    // console; here the shell 404s, so it contributes its single SKIP.
+    const rows = await runRead();
+    expect(rows).toHaveLength(22);
+    expect(new Set(rows.map((r) => r.check)).size).toBe(22);
+  });
+
+  it("passes only what it could actually read", async () => {
+    const rows = await runRead();
+    const passed = rows.filter((r) => r.verdict === "PASS").map((r) => r.check);
+    expect(passed.sort()).toEqual(["company-lifecycle", "host"]);
+  });
+
+  it("reports every unreadable surface as untested rather than as passed", async () => {
+    const rows = await runRead();
+    const unreadable = rows.filter((r) => r.check !== "host" && r.check !== "company-lifecycle");
+    // `approval-tier` and `repo-binding` are SKIP by construction, not by 404 —
+    // the tier has no read surface at all and the build binding needs a human.
+    for (const r of unreadable) {
+      expect(r.verdict, `${r.check} judged a surface it never read`).toBe("SKIP");
+    }
+  });
+
+  it("never renders an absent value as a confident zero", async () => {
+    // A 404 body decays to `{}`, so a check that formats `body.count` prints
+    // `undefined` or `0` and reads as a real, healthy reading. Every SKIP row
+    // must say why instead.
+    const rows = await runRead();
+    for (const r of rows.filter((x) => x.verdict === "SKIP")) {
+      expect(r.note, `${r.check} skipped without saying why`).not.toBe("");
+    }
+  });
+});
+
+describe("runVerdict agrees with the console's runTone", () => {
+  /**
+   * Every arm of the precedence order, including the two that only exist
+   * because leaving them out reads as success: a run still in flight and a run
+   * somebody stopped both fall through to green without their own arm.
+   */
+  const cases: Array<{ name: string; run: WorkflowRunOutcome; label: string }> = [
+    { name: "still running", run: run({ running: true }), label: "running" },
+    {
+      name: "running outranks a failure it has not hit yet",
+      run: run({ running: true, error: "boom" }),
+      label: "running",
+    },
+    { name: "errored", run: run({ error: "node exploded" }), label: "failed" },
+    {
+      name: "stopped, judged before its deliveries",
+      run: run({ cancelled: true, deliveries: [delivery("failed")] } as Partial<WorkflowRunOutcome>),
+      label: "stopped",
+    },
+    {
+      // #881: no error, not cancelled, not running, and no report routed — so
+      // before this arm existed it fell through to green and told the operator
+      // a pipeline that delivered nothing had succeeded.
+      name: "stopped short at a gate",
+      run: run({ blockedNodes: [blocked("approve")] }),
+      label: "blocked",
+    },
+    {
+      name: "blocked is judged before the delivery rows",
+      run: run({ blockedNodes: [blocked("approve")], deliveries: [delivery("failed")] }),
+      label: "blocked",
+    },
+    {
+      name: "every node ok but the report was dropped (#981)",
+      run: run({ deliveries: [delivery("failed")] }),
+      label: "not delivered",
+    },
+    {
+      name: "skipped counts as undelivered",
+      run: run({ deliveries: [delivery("skipped")] }),
+      label: "not delivered",
+    },
+    {
+      name: "denied counts as undelivered",
+      run: run({ deliveries: [delivery("denied")] }),
+      label: "not delivered",
+    },
+    {
+      name: "undelivered outranks pending",
+      run: run({ deliveries: [delivery("pending"), delivery("failed")] }),
+      label: "not delivered",
+    },
+    {
+      name: "parked for approval is not a failure",
+      run: run({ deliveries: [delivery("pending")] }),
+      label: "awaiting approval",
+    },
+    {
+      // #846: the gated shape. It never reached an output node, so `deliveries`
+      // is empty and a delivery-only read scored it as a clean run.
+      name: "paused at a gate, having routed no report at all",
+      run: run({ pendingApprovals: ["approve"] }),
+      label: "awaiting approval",
+    },
+    { name: "delivered", run: run({ deliveries: [delivery("sent")] }), label: "ok" },
+    { name: "nothing to deliver", run: run({}), label: "ok" },
+  ];
+
+  /** The console's label for a run, mapped to the harness's verdict word. */
+  const TONE_TO_VERDICT: Record<string, string> = {
+    running: "running",
+    failed: "failed",
+    stopped: "stopped",
+    blocked: "blocked",
+    "not delivered": "undelivered",
+    "awaiting approval": "awaiting-approval",
+    ok: "ok",
+  };
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const { runVerdict } = loadHarness()._internals;
+      // Both halves asserted: the console still reads it the way this table
+      // says, AND the harness agrees with the console. Asserting only the
+      // second would pass vacuously if both drifted together.
+      expect(runTone(c.run).label).toBe(c.label);
+      expect(runVerdict(c.run)).toBe(TONE_TO_VERDICT[c.label]);
+    });
+  }
+
+  it("folds gates and parked reports into one waiting-on-a-person count (#846)", () => {
+    const { awaitingCount } = loadHarness()._internals;
+    // Either half alone is a reading that scored a waiting run as finished.
+    expect(awaitingCount(run({ pendingApprovals: ["a"], deliveries: [] }))).toBe(1);
+    expect(awaitingCount(run({ pendingApprovals: [], deliveries: [delivery("pending")] }))).toBe(1);
+    expect(
+      awaitingCount(run({ pendingApprovals: ["a", "b"], deliveries: [delivery("pending")] })),
+    ).toBe(3);
+    expect(awaitingCount(run({}))).toBe(0);
+  });
+
+  it("counts deliveries the same way the console does", () => {
+    const { undeliveredCount, pendingCount } = loadHarness()._internals;
+    const deliveries = [
+      delivery("sent"),
+      delivery("pending"),
+      delivery("failed"),
+      delivery("skipped"),
+    ];
+    expect(undeliveredCount(deliveries)).toBe(2);
+    expect(pendingCount(deliveries)).toBe(1);
+  });
+
+  it("reports an unknown run as unknown rather than ok", () => {
+    const { runVerdict } = loadHarness()._internals;
+    expect(runVerdict(null)).toBe("unknown");
+  });
+});
+
+describe("judgeCacheHeader — the #979 reading", () => {
+  it("fails an HTML response with no cache-control at all", () => {
+    // The bug exactly: no header means heuristic caching, so the returning
+    // browser keeps yesterday's shell. An absent header must not be a WARN.
+    const { judgeCacheHeader } = loadHarness()._internals;
+    expect(judgeCacheHeader("html", null).verdict).toBe("FAIL");
+    expect(judgeCacheHeader("html", "").verdict).toBe("FAIL");
+  });
+
+  it("fails an HTML response the browser is allowed to reuse", () => {
+    const { judgeCacheHeader } = loadHarness()._internals;
+    expect(judgeCacheHeader("html", "public, max-age=3600").verdict).toBe("FAIL");
+  });
+
+  it("passes an HTML response that revalidates", () => {
+    const { judgeCacheHeader } = loadHarness()._internals;
+    for (const header of ["no-cache", "no-store", "public, max-age=0, must-revalidate"]) {
+      expect(judgeCacheHeader("html", header).verdict, header).toBe("PASS");
+    }
+  });
+
+  it("passes a hashed asset cached long, and only warns when it is not", () => {
+    const { judgeCacheHeader } = loadHarness()._internals;
+    expect(judgeCacheHeader("asset", "public, max-age=31536000, immutable").verdict).toBe("PASS");
+    expect(judgeCacheHeader("asset", "public, max-age=86400").verdict).toBe("PASS");
+    // Never a FAIL: a short-lived hashed asset costs a revalidation, not a
+    // white screen. Only the shell can break the app by being cached.
+    expect(judgeCacheHeader("asset", null).verdict).toBe("WARN");
+    expect(judgeCacheHeader("asset", "public, max-age=60").verdict).toBe("WARN");
+  });
+});
+
+describe("notWired — a feature absent from the build is untested, not failed", () => {
+  /**
+   * Found by running the harness against a real default-feature host: it
+   * answered `POST …/workflows/{id}/run` with
+   * `404 {"code":"not_wired"}` — "this deployment has no workflow runner" —
+   * and the probe scored it FAIL, which would send somebody chasing a graph
+   * that was fine.
+   */
+  it("recognises the typed code", () => {
+    const { notWired } = loadHarness()._internals;
+    expect(notWired({ body: { error: "workflow execution is not wired", code: "not_wired" } })).toBe(
+      true,
+    );
+  });
+
+  it("does not match on the prose, only the code (#248)", () => {
+    // The message is free to be reworded; a check that grepped it would go
+    // quiet the day somebody did, and silently start scoring absent features
+    // as failures again.
+    const { notWired } = loadHarness()._internals;
+    expect(notWired({ body: { error: "workflow execution is not wired in this deployment" } })).toBe(
+      false,
+    );
+    expect(notWired({ body: { error: "boom", code: "internal" } })).toBe(false);
+    expect(notWired({ body: null })).toBe(false);
+  });
+});
+
+describe("secs", () => {
+  it("keeps a sub-second reading legible instead of rounding it to 0.0s", () => {
+    // The live run printed every probe as "0.0s", which reads as a broken
+    // clock rather than a fast host — and latency is one of the values the
+    // chat probe's verdict is formed from.
+    const { secs } = loadHarness()._internals;
+    expect(secs(0)).toBe("0ms");
+    expect(secs(42)).toBe("42ms");
+    expect(secs(999)).toBe("999ms");
+    expect(secs(1000)).toBe("1.0s");
+    expect(secs(6040)).toBe("6.0s");
+    expect(secs(121_000)).toBe("121.0s");
+  });
+});
+
+describe("age", () => {
+  it("reports absent timestamps as n/a rather than as 'just now'", () => {
+    // `memoryStats.factsUpdatedAtMillis` and friends are `0` when nothing has
+    // been written. Rendering that as a fresh timestamp would report an empty
+    // company as an active one.
+    const { age } = loadHarness()._internals;
+    expect(age(0)).toBe("n/a");
+  });
+
+  it("scales from seconds to days", () => {
+    const { age } = loadHarness()._internals;
+    const now = 1_700_000_000_000;
+    expect(age(now - 30_000, now)).toBe("30s");
+    expect(age(now - 5 * 60_000, now)).toBe("5m");
+    expect(age(now - 4 * 3_600_000, now)).toBe("4h");
+    expect(age(now - 3 * 86_400_000, now)).toBe("3d");
+  });
+});

--- a/frontend/test/unit/qa-harness.test.ts
+++ b/frontend/test/unit/qa-harness.test.ts
@@ -43,6 +43,8 @@ interface Row {
   verdict: "PASS" | "WARN" | "FAIL" | "SKIP";
   value: string;
   note: string;
+  /** Tenant content, held apart from `value` so `report()` can withhold it. */
+  detail?: string;
 }
 
 /** A minimal `Response` stand-in — the four things `http()` reads. */
@@ -56,7 +58,7 @@ function response(status: number, body: unknown, headers: Record<string, string>
 }
 
 /** Loads `oc-qa.js` into a sandbox and hands back its `_internals`. */
-function loadHarness(fetchImpl?: (path: string) => Promise<unknown>) {
+function loadHarness(fetchImpl?: (path: string, init?: { method?: string }) => Promise<unknown>) {
   const source = readFileSync(SCRIPT, "utf8");
   const sandbox: Record<string, unknown> = {
     console: { log: () => {}, table: () => {} },
@@ -76,8 +78,8 @@ function loadHarness(fetchImpl?: (path: string) => Promise<unknown>) {
   const ocqa = sandbox.OCQA as {
     version: string;
     read: (options?: { company?: string }) => Promise<Row[]>;
-    probe: unknown;
-    report: unknown;
+    probe: (options?: { company?: string; workflow?: string; dryRun?: boolean }) => Promise<Row[]>;
+    report: (options?: { raw?: boolean }) => string;
     _internals: {
       runVerdict: (run: unknown) => string;
       undeliveredCount: (d: DeliveryReport[]) => number;
@@ -401,5 +403,233 @@ describe("age", () => {
     expect(age(now - 5 * 60_000, now)).toBe("5m");
     expect(age(now - 4 * 3_600_000, now)).toBe("4h");
     expect(age(now - 3 * 86_400_000, now)).toBe("3d");
+  });
+});
+
+describe("a check that throws is contained to its own row", () => {
+  /**
+   * The inverse of "unreadable is never PASS": unreadable must not be able to
+   * report *nothing at all*.
+   *
+   * `http()` promises never to throw, and it keeps that promise — but the
+   * promise stops at the transport. A check still reads fields off the body it
+   * was handed, and a host whose shape has drifted answers 200 with them
+   * absent. Before the boundary, `read()` had no `try`, so one such body threw
+   * out of the whole function: no rows, no summary, nothing printed. Shape
+   * drift on an older tenant is exactly the deployment-era condition this
+   * harness exists to catch, so it is the last place that can afford to go
+   * silent.
+   */
+  const drifted: Record<string, unknown> = {
+    "/healthz": { status: "ok" },
+    "/spec": { name: "opencompany", version: "0.1.0", capabilities: ["rest"], storage: "memory" },
+    "/api/v1/company": { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+    // 200s whose payload is an object where the check expects an array: the
+    // roster reads `team.map`, which is `undefined` here.
+    "/api/v1/company/team": {},
+  };
+
+  async function runDrifted(): Promise<Row[]> {
+    const ocqa = loadHarness(async (path: string) =>
+      path in drifted ? response(200, drifted[path]) : response(404, { error: "not found" }),
+    );
+    return ocqa.read();
+  }
+
+  it("still returns every other check", async () => {
+    const rows = await runDrifted();
+    expect(rows).toHaveLength(22);
+  });
+
+  it("reports the thrower as untested, naming it and saying what threw", async () => {
+    const rows = await runDrifted();
+    const roster = rows.find((r) => r.check === "roster");
+    // SKIP and not FAIL: a check that could not be evaluated has not judged the
+    // surface, the same as one that 404ed.
+    expect(roster?.verdict).toBe("SKIP");
+    expect(roster?.value).toMatch(/^threw: /);
+  });
+
+  it("does not let the throw poison the check downstream of it", async () => {
+    // `tool-catalog` is handed the roster's return value. The boundary hands
+    // back the same empty list the roster's own unreadable path returns, so the
+    // downstream check reports its own verdict rather than a second throw.
+    const rows = await runDrifted();
+    const tools = rows.find((r) => r.check === "tool-catalog");
+    expect(tools?.verdict).toBe("SKIP");
+    expect(tools?.value).not.toMatch(/^threw: /);
+  });
+});
+
+describe("usage-finances against a host that answers without the figures", () => {
+  /**
+   * The concrete instance the boundary above was found through, fixed at the
+   * source too: `/finances` is Phase 1 (`src/server/ops/finances.rs`), so an
+   * older tenant can answer `200 {}`. `f.spentUsd.toFixed(2)` on that is a
+   * `TypeError`.
+   */
+  const reachable: Record<string, unknown> = {
+    "/healthz": { status: "ok" },
+    "/spec": { name: "opencompany", version: "0.1.0", capabilities: ["rest"], storage: "memory" },
+    "/api/v1/company": { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+    "/api/v1/company/usage": { totals: { tokens: 1200, costUsd: 3.5 } },
+    "/api/v1/company/finances": {},
+  };
+
+  async function financesRow(): Promise<Row | undefined> {
+    const ocqa = loadHarness(async (path: string) =>
+      path in reachable ? response(200, reachable[path]) : response(404, { error: "not found" }),
+    );
+    const rows = await ocqa.read();
+    return rows.find((r) => r.check === "usage-finances");
+  }
+
+  it("reads it as untested rather than throwing", async () => {
+    const row = await financesRow();
+    expect(row?.verdict).toBe("SKIP");
+    // Not the boundary catching it — the check itself declining to judge.
+    expect(row?.value).not.toMatch(/^threw: /);
+  });
+
+  it("names the fields that were missing, and never prints an absent figure as $0.00", async () => {
+    // A budget rendered as `$0.00` reads as a company that has spent nothing,
+    // which is a confident answer to a question the host did not answer.
+    const row = await financesRow();
+    expect(row?.note).toContain("spentUsd");
+    expect(row?.value).toContain("finances unread");
+    expect(row?.value).not.toContain("balance $0.00");
+  });
+});
+
+describe("probe() will not choose a workflow to run for real", () => {
+  /**
+   * A real run fires real deliveries — a report into a channel, mail to a real
+   * address. The first version took `flows[0]`, which on a production tenant is
+   * whichever workflow the host happened to list first: a stranger's. There is
+   * no default that is safe to guess, so an unnamed target is SKIP.
+   */
+  const tenant: Record<string, unknown> = {
+    "/healthz": { status: "ok" },
+    "/spec": { name: "opencompany", version: "0.1.0", capabilities: ["rest"], storage: "memory" },
+    "/api/v1/company": { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+    "/api/v1/company/workflows": [{ id: "somebody-elses-workflow" }, { id: "daily-release-readiness" }],
+    "/api/v1/company/desks": [],
+    "/api/v1/company/approvals": [],
+    "/api/v1/company/chat": { responses: [{ text: "Acme." }] },
+  };
+
+  function tenantHarness() {
+    const sent: string[] = [];
+    const ocqa = loadHarness(async (path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET";
+      sent.push(`${method} ${path}`);
+      // The board is method-aware so the card probe behaves as it does against a
+      // real host — a POST creates and a GET lists — rather than throwing and
+      // taking the workflow check with it, which would make these assertions
+      // pass for the wrong reason.
+      if (path === "/api/v1/company/tasks") {
+        return response(200, method === "POST" ? { id: "card-1" } : [{ id: "card-1" }]);
+      }
+      if (path === "/api/v1/company/tasks/card-1") return response(200, { ok: true });
+      return path in tenant ? response(200, tenant[path]) : response(404, { error: "not found" });
+    });
+    return { ocqa, sent };
+  }
+
+  it("leaves the rest of the probe working, so the skip is the only thing missing", async () => {
+    // Guards the fixture as much as the code: if the board probe threw here,
+    // the assertions below would be measuring a dead probe rather than a
+    // declined workflow target.
+    const { ocqa } = tenantHarness();
+    const rows = await ocqa.probe();
+    expect(rows.find((r) => r.check === "probe-board-card")?.verdict).toBe("PASS");
+    expect(rows.find((r) => r.check === "probe-chat")?.verdict).toBe("PASS");
+  });
+
+  it("skips the run, and fires no POST at any workflow, when none is named", async () => {
+    const { ocqa, sent } = tenantHarness();
+    const rows = await ocqa.probe();
+    const row = rows.find((r) => r.check === "probe-workflow-run");
+    expect(row?.verdict).toBe("SKIP");
+    // The load-bearing assertion: not merely reported as skipped, but no run
+    // request left the page.
+    expect(sent.filter((s) => s.includes("/run"))).toEqual([]);
+  });
+
+  it("says how to run one, so the skip is a door rather than a dead end", async () => {
+    const { ocqa } = tenantHarness();
+    const rows = await ocqa.probe();
+    const row = rows.find((r) => r.check === "probe-workflow-run");
+    expect(row?.note).toContain("workflow");
+    expect(row?.note).toContain("dryRun");
+  });
+
+  it("runs the one that is named, and only that one", async () => {
+    const { ocqa, sent } = tenantHarness();
+    await ocqa.probe({ workflow: "daily-release-readiness", dryRun: true });
+    const runs = sent.filter((s) => s.includes("/run"));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toContain("daily-release-readiness");
+    expect(runs[0]).not.toContain("somebody-elses-workflow");
+  });
+
+  it("skips a name the host does not have rather than falling back to the first", async () => {
+    const { ocqa, sent } = tenantHarness();
+    const rows = await ocqa.probe({ workflow: "no-such-workflow" });
+    const row = rows.find((r) => r.check === "probe-workflow-run");
+    expect(row?.verdict).toBe("SKIP");
+    expect(sent.filter((s) => s.includes("/run"))).toEqual([]);
+  });
+});
+
+describe("report() withholds tenant message text", () => {
+  /**
+   * `report()` exists to be pasted into a GitHub issue, and `probe-chat`
+   * collected a real agent reply. The verdict is formed from the shape of the
+   * answer so the table still judges something checkable, and the reply itself
+   * rides in `detail`, which the report drops unless asked.
+   */
+  const tenant: Record<string, unknown> = {
+    "/healthz": { status: "ok" },
+    "/spec": { name: "opencompany", version: "0.1.0", capabilities: ["rest"], storage: "memory" },
+    "/api/v1/company": { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+    "/api/v1/company/desks": [],
+    "/api/v1/company/approvals": [],
+    "/api/v1/company/workflows": [],
+    "/api/v1/company/chat": { responses: [{ text: "Acme, a maker of anvils, per the manifest." }] },
+  };
+
+  async function probed() {
+    const ocqa = loadHarness(async (path: string, init?: { method?: string }) => {
+      if (path === "/api/v1/company/tasks") {
+        return response(200, (init?.method || "GET") === "POST" ? { id: "card-1" } : [{ id: "card-1" }]);
+      }
+      if (path === "/api/v1/company/tasks/card-1") return response(200, { ok: true });
+      return path in tenant ? response(200, tenant[path]) : response(404, { error: "not found" });
+    });
+    const rows = await ocqa.probe();
+    return { ocqa, rows };
+  }
+
+  it("keeps the reply out of the row's own value, judging its shape instead", async () => {
+    const { rows } = await probed();
+    const chat = rows.find((r) => r.check === "probe-chat");
+    expect(chat?.value).not.toContain("anvils");
+    expect(chat?.value).toContain("1 replies");
+    // Still on the operator's own screen: judging whether the company answered
+    // *well* needs the words.
+    expect(chat?.detail).toContain("anvils");
+  });
+
+  it("omits it from the Markdown, and says that it did", async () => {
+    const { ocqa } = await probed();
+    const text = ocqa.report();
+    expect(text).not.toContain("anvils");
+    expect(text).toContain("withheld");
+  });
+
+  it("includes it only when explicitly asked", async () => {
+    const { ocqa } = await probed();
+    expect(ocqa.report({ raw: true })).toContain("anvils");
   });
 });

--- a/frontend/test/unit/qa-harness.test.ts
+++ b/frontend/test/unit/qa-harness.test.ts
@@ -175,8 +175,9 @@ describe("read() against a host whose surfaces do not answer", () => {
   it("reports every unreadable surface as untested rather than as passed", async () => {
     const rows = await runRead();
     const unreadable = rows.filter((r) => r.check !== "host" && r.check !== "company-lifecycle");
-    // `approval-tier` and `repo-binding` are SKIP by construction, not by 404 —
-    // the tier has no read surface at all and the build binding needs a human.
+    // `repo-binding` is SKIP by construction — the build binding needs a human.
+    // `approval-tier` is SKIP here because this host 404s `{scope}/policy`; the
+    // real pass over a readable policy is pinned in the describe below.
     for (const r of unreadable) {
       expect(r.verdict, `${r.check} judged a surface it never read`).toBe("SKIP");
     }
@@ -190,6 +191,93 @@ describe("read() against a host whose surfaces do not answer", () => {
     for (const r of rows.filter((x) => x.verdict === "SKIP")) {
       expect(r.note, `${r.check} skipped without saying why`).not.toBe("");
     }
+  });
+});
+
+describe("read() can verify the approval tier", () => {
+  // `{scope}/policy` is a real read surface (`src/server/ops/policy.rs`, #562):
+  // a GET that `read_policy` answers with the tier actually in force, well
+  // before the approval gate's own resolver rebuilt the roster. These lock
+  // that the row grades it a real PASS instead of always SKIP, and that it
+  // tells a `supervised` tenant with nothing pending apart from a `full` one.
+  function policyHost(extra: Record<string, unknown>) {
+    const reachable: Record<string, unknown> = {
+      "/healthz": { status: "ok" },
+      "/spec": {
+        name: "opencompany",
+        version: "0.1.0",
+        capabilities: ["rest", "graphql"],
+        storage: "memory",
+        instance_id: "abcdef0123456789",
+      },
+      "/api/v1/company": { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+      ...extra,
+    };
+    const ocqa = loadHarness(async (path: string) =>
+      path in reachable ? response(200, reachable[path]) : response(404, { error: "not found" }),
+    );
+    return ocqa;
+  }
+
+  const policyDto = {
+    mode: "supervised",
+    alwaysApprove: [],
+    manifestMode: "full",
+    manifestAlwaysApprove: [],
+    overridden: true,
+    setBy: "alice@acme",
+    setAtMillis: 1_700_000_000_000,
+    tiers: [],
+    takesEffect: "on the next turn",
+  };
+
+  it("passes approval-tier with the tier in force when {scope}/policy answers", async () => {
+    const ocqa = policyHost({ "/api/v1/company/policy": policyDto });
+    const rows = await ocqa.read();
+    const tier = rows.find((r) => r.check === "approval-tier");
+    expect(tier).toBeDefined();
+    expect(tier!.verdict).toBe("PASS");
+    expect(tier!.value).toContain("mode supervised");
+    expect(tier!.value).toContain("manifest full");
+    expect(tier!.value).toContain("overridden by alice@acme");
+  });
+
+  it("distinguishes a full-tier tenant with nothing parked from a missing gate", async () => {
+    const ocqa = policyHost({
+      "/api/v1/company/policy": {
+        mode: "full",
+        alwaysApprove: [],
+        manifestMode: "full",
+        manifestAlwaysApprove: [],
+        overridden: false,
+        tiers: [],
+        takesEffect: "on the next turn",
+      },
+    });
+    const rows = await ocqa.read();
+    const tier = rows.find((r) => r.check === "approval-tier");
+    expect(tier!.verdict).toBe("PASS");
+    expect(tier!.value).toContain("mode full");
+    expect(tier!.note).toContain("no effect ever parks");
+  });
+
+  it("warns when a full tier is nonetheless holding parked effects", async () => {
+    const ocqa = policyHost({
+      "/api/v1/company/policy": {
+        mode: "full",
+        alwaysApprove: [],
+        manifestMode: "full",
+        manifestAlwaysApprove: [],
+        overridden: false,
+        tiers: [],
+        takesEffect: "on the next turn",
+      },
+      "/api/v1/company/approvals": [{ id: "a1", kind: "chase", at_millis: 1_700_000_000_000 }],
+    });
+    const rows = await ocqa.read();
+    const tier = rows.find((r) => r.check === "approval-tier");
+    expect(tier!.verdict).toBe("WARN");
+    expect(tier!.value).toContain("1 parked");
   });
 });
 

--- a/qa/MASTER-QA.md
+++ b/qa/MASTER-QA.md
@@ -6,7 +6,7 @@ a stale tenant reports bugs `main` has already fixed).
 
 Three parts, in this order:
 
-1. [`oc-qa.js`](oc-qa.js) — 22 read-only checks (~10s) and 5 live probes.
+1. [`oc-qa.js`](oc-qa.js) — 22 read-only checks (~10s) and 5 probes, 4 of them live.
 2. [The seven UI checks](#the-seven-ui-checks) a script cannot judge.
 3. [The five persona tasks](#the-five-persona-tasks) and their rubric.
 
@@ -21,17 +21,33 @@ Open the console on a signed-in tenant, paste [`oc-qa.js`](oc-qa.js), then:
 
 ```js
 OCQA.read()      // 22 read-only checks, ~10s, spends nothing
-OCQA.probe()     // 5 live checks — spends tokens and may park approvals
+OCQA.probe()     // 5 checks, 4 of them live — spends tokens, may park approvals
 OCQA.report()    // the last run as Markdown, for the issue
 ```
 
-`OCQA.probe({ dryRun: true })` runs the workflow probe over stubbed effects.
+`probe()` acts on the tenant the tab is signed in to: real chat turns to the
+orchestrator and to up to five desks, and a real board card created and deleted.
+It prints the host and company it is about to act on before it starts.
+
+**It will not choose a workflow for you.** A real run fires real deliveries, so
+bare `OCQA.probe()` reports `probe-workflow-run` as `SKIP`. Name the workflow to
+run one:
+
+```js
+OCQA.probe({ workflow: "<id>" })              // runs it FOR REAL
+OCQA.probe({ workflow: "<id>", dryRun: true })// rehearses it over stubbed effects
+```
+
 Read the verdict back off the response rather than trusting the flag: a host
 that predates test mode ignores it and runs for real, and the script warns when
 that happens.
 
 After `probe()`, check `probe-approval-delta`. The probes can park effects at the
 approvals gate; leaving them there freezes whatever sits behind them.
+
+`OCQA.report()` withholds the tenant message text the probes collected, because
+its output is written to be pasted into an issue. `OCQA.report({ raw: true })`
+includes it — keep that out of anything public.
 
 ## The seven UI checks
 
@@ -126,8 +142,13 @@ An agent with browser access can run parts 1–3. Paste this:
 > 2. Sign in, open the console, paste `qa/oc-qa.js`, run `OCQA.read()`. Report
 >    every row, verdict beside the value it judged. Do not summarise away the
 >    values.
-> 3. Run `OCQA.probe()`. Then check `probe-approval-delta` and resolve anything
->    the probes parked.
+> 3. Run `OCQA.probe()`. This spends real tokens and writes to the tenant, so
+>    confirm the host it names in the console is `<TENANT URL>` before going on.
+>    It reports `probe-workflow-run` as SKIP by design — a real run fires real
+>    deliveries, so re-run it as `OCQA.probe({ workflow: "<id>" })` only with a
+>    workflow you were told to run, and prefer `dryRun: true` unless a real
+>    delivery is what is being checked. Then check `probe-approval-delta` and
+>    resolve anything the probes parked.
 > 4. Walk U1–U7 in the browser. For each, state the claim you falsified and what
 >    you actually saw. If you could not create the conditions for a check, mark
 >    it SKIP — never PASS.

--- a/qa/MASTER-QA.md
+++ b/qa/MASTER-QA.md
@@ -1,0 +1,142 @@
+# Master QA — the release parity pass
+
+What a release check consists of, in one pass. Run it against a tenant **rolled
+to the commit under test** (see [`README.md`](README.md) — this is not optional;
+a stale tenant reports bugs `main` has already fixed).
+
+Three parts, in this order:
+
+1. [`oc-qa.js`](oc-qa.js) — 22 read-only checks (~10s) and 5 live probes.
+2. [The seven UI checks](#the-seven-ui-checks) a script cannot judge.
+3. [The five persona tasks](#the-five-persona-tasks) and their rubric.
+
+A pass is written up as three tallies, and **`SKIP` is reported separately from
+`PASS`**. Untested is not passed — three checks in the 2026-08-18 pass were
+written up as green having never run, which is the single reason this document
+exists in the repo rather than in someone's notes.
+
+## Part 1 — the script
+
+Open the console on a signed-in tenant, paste [`oc-qa.js`](oc-qa.js), then:
+
+```js
+OCQA.read()      // 22 read-only checks, ~10s, spends nothing
+OCQA.probe()     // 5 live checks — spends tokens and may park approvals
+OCQA.report()    // the last run as Markdown, for the issue
+```
+
+`OCQA.probe({ dryRun: true })` runs the workflow probe over stubbed effects.
+Read the verdict back off the response rather than trusting the flag: a host
+that predates test mode ignores it and runs for real, and the script warns when
+that happens.
+
+After `probe()`, check `probe-approval-delta`. The probes can park effects at the
+approvals gate; leaving them there freezes whatever sits behind them.
+
+## The seven UI checks
+
+None of these are visible to an API client. Each is written as a claim to
+falsify, not a thing to look at.
+
+| # | Check | Passes when | Fails as |
+| --- | --- | --- | --- |
+| U1 | **Cold load in a browser that has been here before** | A hard reload and then a *normal* reload both render. Do not clear the cache first — the returning visitor is the case that breaks. | A blank `#root` with `Failed to fetch dynamically imported module` in the console (#979). |
+| U2 | **Board drag** | A card dragged between columns stays in the new column after a full page reload. | It springs back, or the move is local-only and the server never heard it. |
+| U3 | **Approvals resolve** | Approve and deny each remove their card and the effect visibly happens (or visibly does not). | The card stays, or vanishes with nothing behind it. Needs a queued approval — see [Making U3 testable](#making-u3-testable). |
+| U4 | **Run drawer delivery rows** | Opening a run whose report was dropped shows the delivery row and its reason, not a clean green run. | The drawer reads as a success (#981). |
+| U5 | **Live timeline** | A message in flight shows steps arriving, and a reload mid-turn still shows the question. | The reload shows an empty transcript — the turn is invisible (#983). |
+| U6 | **Theme and layout** | Both themes render every view with no clipped text, no invisible-on-invisible, no horizontal body scroll. | Anything unreadable in one theme only. |
+| U7 | **Error honesty** | Disconnect the network and use the app: every surface says what failed. | A spinner forever, or a surface that renders empty as though the answer were "none". |
+
+### Making U3 testable
+
+The 2026-08-18 pass could not run U3: the queue was empty, and the only way to
+fill it was to change the tenant's approval tier — a change to the thing under
+test. Two ways to get a row without that:
+
+- Run a workflow with an `output` node whose destination needs approval; the
+  delivery parks as `pending`.
+- Ask a desk for something with an outward effect (send mail, post to a channel).
+  Under `supervised` and `auto` this parks.
+
+If neither is available, U3 is `SKIP`. Write it up as untested.
+
+## The five persona tasks
+
+Five real requests, one per persona, sent as ordinary chat messages. **Send them
+one at a time.** Five concurrent messages become a serial train behind the
+per-company cycle lock and every one of them times out at the edge (#983) — the
+work still happens, but you learn nothing about quality from a 504.
+
+| # | Persona | Task |
+| --- | --- | --- |
+| P1 | Operator, first day | "What does this company do, and what is it working on right now?" |
+| P2 | Marketer | "Draft a short launch announcement for our newest deliverable and save it to the workspace." |
+| P3 | Analyst | "What have we spent this month, and on what?" |
+| P4 | Ops | "Something in our last workflow run didn't go out. What was it and why?" |
+| P5 | Founder | "Propose one workflow that would save us the most time, and build it." |
+
+### Rubric
+
+Score each turn on four axes, one point each. A turn scores 4 or it is not done.
+
+- **Answered** — it responded to the question asked, not an adjacent one.
+- **Grounded** — every specific claim (a number, a name, a date, a file) traces
+  to something in the tenant. An invented figure fails this axis outright.
+- **Honest** — where it could not know, it said so. A confident answer to an
+  unanswerable question fails even when the answer happens to be right.
+- **Delivered** — the artefact it says it produced exists and can be opened. Check
+  the workspace, the board card, the workflow — do not take the sentence for it.
+
+Score the transcript **after every turn has settled**, not while they run. Four of
+five turns in the 2026-08-18 pass were still running when the pass ended, and the
+partial scores were worth nothing.
+
+## Writing the pass up
+
+Three tallies, kept separate:
+
+```
+read:   N pass / N warn / N fail / N untested
+probe:  N pass / N warn / N fail / N untested
+UI:     U1..U7 each pass / fail / skip
+persona: P1..P5 each scored /4
+```
+
+Then, for every `FAIL`: the check name, the value it judged, and either an issue
+number or a new issue. `OCQA.report()` emits the first two as a Markdown table.
+
+**And one more step, which is the one that gets skipped.** For every bug found by
+something *other* than this harness, ask why the harness missed it and change the
+check that should have caught it. The workflow probe scored a delivery-failure run
+as `PASS` because it judged a run by node status alone — the same mistake the
+product made in #981. Adding a delivery check afterwards was not the fix; changing
+the run check to read `deliveries` was.
+
+## Handing the pass to an agent
+
+An agent with browser access can run parts 1–3. Paste this:
+
+> You are running the OpenCompany release parity pass against `<TENANT URL>`,
+> which is rolled to commit `<SHA>`. Follow `qa/MASTER-QA.md` in the repo.
+>
+> 1. Confirm the tenant is on `<SHA>` before anything else. If you cannot
+>    confirm it, stop and say so — a pass against a stale tenant is worse than
+>    no pass, because it reports fixed bugs as live.
+> 2. Sign in, open the console, paste `qa/oc-qa.js`, run `OCQA.read()`. Report
+>    every row, verdict beside the value it judged. Do not summarise away the
+>    values.
+> 3. Run `OCQA.probe()`. Then check `probe-approval-delta` and resolve anything
+>    the probes parked.
+> 4. Walk U1–U7 in the browser. For each, state the claim you falsified and what
+>    you actually saw. If you could not create the conditions for a check, mark
+>    it SKIP — never PASS.
+> 5. Send P1–P5 **one at a time**, waiting for each to settle. Score each on
+>    answered / grounded / honest / delivered, and verify every deliverable by
+>    opening it.
+> 6. Report three separate tallies, keeping SKIP out of PASS. For every FAIL,
+>    name the check, the value judged, and the issue — existing or new.
+> 7. Finally: for any bug you found outside the script, say which check should
+>    have caught it and what that check must become.
+>
+> Do not fix anything. This pass reports.

--- a/qa/README.md
+++ b/qa/README.md
@@ -80,6 +80,14 @@ CI job.
 Each row reports `PASS` / `WARN` / `FAIL` / `SKIP` **next to the value it judged**,
 so a verdict can be checked rather than trusted.
 
+The `approval-tier` row reads `{scope}/policy` (`src/server/ops/policy.rs`, #562) —
+`read_policy` is a GET that needs no admin token — and reports the tier actually
+in force next to the manifest's tier and any override producing it. On a build
+before that read surface, the row reports what the gate is holding and `SKIP`s
+with the tier unverified. With the tier in hand an empty approvals queue stops
+reading the same for a `supervised` tenant (nothing pending) as for a `full`
+tenant (nothing will ever park).
+
 `SKIP` means the surface could not be read — a 404, an error, a feature absent
 from this build, or a precondition that did not exist. **`SKIP` is untested, not
 passed**, and the summary counts it separately. Writing a skipped check up as
@@ -131,10 +139,6 @@ file loudly rather than silently re-greening a bad run.
 
 Closed when they become testable, and reported as `SKIP` until then:
 
-- **Approval tier.** `[policy].mode` (`readonly` / `supervised` / `auto` / `full`)
-  has no read surface on any API. It decides whether an effect parks at all, so no
-  API client can verify the setting the approvals checks depend on. The
-  `approval-tier` row reports what is observable and states the tier is unverified.
 - **Board drag** (`U2`) and **approvals resolve** (`U3`) are browser-only; U3 also
   needs a queued approval, which the 2026-08-18 pass could not create without
   changing the tenant's approval tier. See MASTER-QA for two ways to get one.

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,0 +1,109 @@
+# `qa/` — the release parity harness
+
+What a release is checked with, in one pass, against a real deployed tenant.
+
+| File | What it is |
+| --- | --- |
+| [`oc-qa.js`](oc-qa.js) | A zero-dependency browser-console script: 22 read-only checks and 5 live probes. |
+| [`MASTER-QA.md`](MASTER-QA.md) | The seven UI checks a script cannot judge, five persona tasks with a rubric, and the prompt that hands the pass to an agent. |
+
+A release checklist points here. Nothing else has to be found first.
+
+## Before anything else: roll the tenant
+
+**The tenant must be on the commit under test.** A tenant running an older image
+reports bugs `main` has already fixed, and the report is worse than no report —
+it costs a re-investigation of closed issues. The first attempt at the
+2026-08-18 pass was misleading for exactly this reason.
+
+`oc-qa.js` prints the build identity in its `repo-binding` row (`name@version`
+plus the company's source-template provenance). No endpoint reports a git SHA,
+so that row stays `SKIP` until a human compares it against the commit under
+test. Confirm it, then start.
+
+## Running it
+
+Open the operator console on a **signed-in** tenant, paste the whole of
+[`oc-qa.js`](oc-qa.js) into the browser console, then:
+
+```js
+OCQA.read()      // 22 read-only checks, ~10s. Spends nothing.
+OCQA.probe()     // 5 live checks. Spends tokens; may park approvals.
+OCQA.report()    // the last run as a Markdown table for an issue
+```
+
+Options: `OCQA.read({ company: "acme" })` pins a company on a multi-company host
+(the scope is auto-detected otherwise); `OCQA.probe({ workflow: "id", dryRun: true })`
+picks the workflow to run and runs it over stubbed effects.
+
+It rides the session cookie of the tab it is pasted into, so there is no token to
+mint or distribute — which is also why it is a console script rather than a
+CI job.
+
+## What the verdicts mean
+
+Each row reports `PASS` / `WARN` / `FAIL` / `SKIP` **next to the value it judged**,
+so a verdict can be checked rather than trusted.
+
+`SKIP` means the surface could not be read — a 404, an error, a feature absent
+from this build, or a precondition that did not exist. **`SKIP` is untested, not
+passed**, and the summary counts it separately. Writing a skipped check up as
+green is the failure mode this harness is shaped against.
+
+A build that answers `{"code": "not_wired"}` — a feature-gated surface saying
+"this deployment has no such machinery" — is `SKIP`, not `FAIL`. A host with no
+workflow runner cannot run a workflow, and scoring that red sends somebody
+chasing a graph that is fine. The typed `code` is what is matched, never the
+prose (issue #248).
+
+`read()` reports **22 checks**. On a host that serves a built console the cache
+check expands into three rows — the shell, the SPA fallback and a hashed asset
+are three separate responses from three code paths — so a full run prints 24.
+
+## The two checks worth keeping even if the rest is deleted
+
+- **`console-cache-headers`** — caught [#979](https://github.com/tinyhumansai/opencompany/issues/979).
+  A cacheable `index.html` white-screens every returning user after a deploy: the
+  stale shell names an entry bundle whose lazy chunks are gone, the SPA fallback
+  answers them with HTML, the dynamic import throws, and the page is blank. There
+  is nothing in the UI to see, because the UI is the thing that failed to load.
+
+  The fix has landed (`src/server/routes.rs` sets `no-cache` on the shell and
+  every SPA fallback, `immutable` on `/assets/*`), so this check is now a
+  **regression guard**: it should read PASS/PASS/PASS on a current build, and a
+  FAIL means a deploy has reintroduced the highest-impact defect the
+  2026-08-18 pass found.
+
+- **`workflow-deliveries`** — caught [#981](https://github.com/tinyhumansai/opencompany/issues/981).
+  A run whose nodes are all `ok` can still have delivered nothing. A delivery
+  failure deliberately does not populate `error` or flip `nodes[].status`, so
+  folding node status scores a dropped report as green.
+
+## Reviewing the harness against what it missed
+
+Extending the harness after a miss is not enough — **the check that missed has to
+change.** The workflow probe originally scored a delivery-failure run as `PASS`
+because it judged a run by node status alone, which is the same mistake #981
+filed against the product. The fix was not "add a delivery check"; it was to make
+the run check read `deliveries`.
+
+`runVerdict` in `oc-qa.js` is a transcription of the console's own
+`frontend/src/views/workflows/run-health.ts`, and `frontend/test/unit/qa-harness.test.ts`
+pins the two together — so a change to how the console reads a run breaks this
+file loudly rather than silently re-greening a bad run.
+
+## Known gaps
+
+Closed when they become testable, and reported as `SKIP` until then:
+
+- **Approval tier.** `[policy].mode` (`readonly` / `supervised` / `auto` / `full`)
+  has no read surface on any API. It decides whether an effect parks at all, so no
+  API client can verify the setting the approvals checks depend on. The
+  `approval-tier` row reports what is observable and states the tier is unverified.
+- **Board drag** (`U2`) and **approvals resolve** (`U3`) are browser-only; U3 also
+  needs a queued approval, which the 2026-08-18 pass could not create without
+  changing the tenant's approval tier. See MASTER-QA for two ways to get one.
+- **Persona quality** was only partly scored in that pass, because four of five
+  turns were still running when it ended.
+  [#983](https://github.com/tinyhumansai/opencompany/issues/983) makes this
+  properly measurable for the first time.

--- a/qa/README.md
+++ b/qa/README.md
@@ -4,7 +4,7 @@ What a release is checked with, in one pass, against a real deployed tenant.
 
 | File | What it is |
 | --- | --- |
-| [`oc-qa.js`](oc-qa.js) | A zero-dependency browser-console script: 22 read-only checks and 5 live probes. |
+| [`oc-qa.js`](oc-qa.js) | A zero-dependency browser-console script: 22 read-only checks and 5 probes, 4 of them live. |
 | [`MASTER-QA.md`](MASTER-QA.md) | The seven UI checks a script cannot judge, five persona tasks with a rubric, and the prompt that hands the pass to an agent. |
 
 A release checklist points here. Nothing else has to be found first.
@@ -28,13 +28,48 @@ Open the operator console on a **signed-in** tenant, paste the whole of
 
 ```js
 OCQA.read()      // 22 read-only checks, ~10s. Spends nothing.
-OCQA.probe()     // 5 live checks. Spends tokens; may park approvals.
+OCQA.probe()     // 5 checks, 4 of them live. Spends tokens; may park approvals.
 OCQA.report()    // the last run as a Markdown table for an issue
 ```
 
 Options: `OCQA.read({ company: "acme" })` pins a company on a multi-company host
-(the scope is auto-detected otherwise); `OCQA.probe({ workflow: "id", dryRun: true })`
-picks the workflow to run and runs it over stubbed effects.
+(the scope is auto-detected otherwise).
+
+### What `probe()` actually does to the tenant
+
+`probe()` is not a read. It sends real chat turns to the orchestrator and to up
+to five desks, and creates and deletes a real board card — on whatever tenant the
+tab is signed in to. It prints that host and company before it starts anything,
+so a probe fired at the wrong tab is visible in the transcript rather than only
+in the consequences.
+
+**It will not choose a workflow for you.** A real run fires real deliveries — a
+report into a channel, mail to a real address — so `probe()` on its own reports
+`probe-workflow-run` as `SKIP` and says so. Name the one you meant:
+
+```js
+OCQA.probe({ workflow: "daily-release-readiness" })              // runs it FOR REAL
+OCQA.probe({ workflow: "daily-release-readiness", dryRun: true })// rehearses it
+```
+
+Read `dryRun` back off the response rather than trusting the flag: a host that
+predates test mode ignores it and runs for real, and the script raises a `WARN`
+when the response comes back without it.
+
+After any `probe()`, check `probe-approval-delta` and resolve whatever the probes
+parked — leaving effects at the gate freezes whatever sits behind them.
+
+### What `report()` leaves out
+
+`OCQA.report()` is written to be pasted into an issue, so it withholds the tenant
+message text a probe collected — `probe-chat` judges the reply's shape in the
+table and keeps the reply itself out of it. The table says how many rows were
+withheld. `OCQA.report({ raw: true })` includes them, for a write-up that is not
+going anywhere public.
+
+Ids are not redacted — company, desk, workflow and delivery targets are what make
+a `FAIL` actionable, and a report without them names no defect. Read the table
+before pasting it somewhere public.
 
 It rides the session cookie of the tab it is pasted into, so there is no token to
 mint or distribute — which is also why it is a console script rather than a

--- a/qa/oc-qa.js
+++ b/qa/oc-qa.js
@@ -561,27 +561,61 @@
   /**
    * The company's approval tier.
    *
-   * **No read surface exists.** `[policy].mode` — `readonly` / `supervised` /
-   * `auto` / `full` — decides whether an effect parks at all, and no REST or
-   * GraphQL route reports it. So this check cannot pass: it reports what can be
-   * observed (whether the gate is wired and has ever held anything) and states
-   * plainly that the tier itself is unverified. A green row here would be the
-   * harness claiming to have checked the single setting that decides whether
-   * any of the approvals checks mean anything.
+   * `{scope}/policy` is a real read surface (`src/server/ops/policy.rs`, #562):
+   * `read_policy` takes only `ScopedCompany` and answers the tier the approval
+   * gate itself reads — `effective_policy()`, resolved ahead of the manifest —
+   * plus the manifest's tier and whether an operator override is producing it.
+   * So this row verifies the single setting the approvals checks depend on
+   * instead of only reporting what the gate is holding. That upgrades the queue
+   * too: an empty queue now reads differently for `supervised` (nothing is
+   * pending) than for `full` (nothing will ever park).
    */
   async function checkApprovalTier(rows, scope, approvals) {
     const caps = await http(`${scope}/capabilities`);
     const grants = caps.ok ? caps.body || {} : {};
-    const observed = [];
-    if (approvals && approvals.length) observed.push(`${approvals.length} effects currently parked`);
-    if (grants.configured) observed.push(`plan ${grants.plan || "custom"}/${grants.period || "?"}`);
+    const policy = await http(`${scope}/policy`);
+    if (!policy.ok) {
+      // Older build without the read surface (#562 shipped after this path
+      // stopped being guessable), or a scope where the route is not mounted.
+      const observed = [];
+      if (approvals && approvals.length) observed.push(`${approvals.length} effects currently parked`);
+      if (grants.configured) observed.push(`plan ${grants.plan || "custom"}/${grants.period || "?"}`);
+      rows.push(
+        row(
+          "approval-tier",
+          SKIP,
+          observed.join(" · ") || "no observable gate activity",
+          `{scope}/policy did not answer (HTTP ${policy.status}) — the tier is unverified on this build`,
+        ),
+      );
+      return;
+    }
+    const p = policy.body || {};
+    const parked = approvals ? approvals.length : 0;
+    const mode = p.mode || "?";
+    const parts = [`mode ${mode}`];
+    if (p.manifestMode && p.manifestMode !== mode) parts.push(`manifest ${p.manifestMode}`);
+    if (p.overridden) parts.push(`overridden by ${p.setBy || "an operator"}`);
+    parts.push(`${parked} parked`);
+    const note = [];
+    if (p.overridden) {
+      note.push(`an override is in force (${p.setBy || "an operator"}${p.setAtMillis ? ` at ${new Date(p.setAtMillis).toISOString()}` : ""}) — the manifest tier is not what runs`);
+    }
+    if (mode === "full" && parked > 0) {
+      rows.push(
+        row(
+          "approval-tier",
+          WARN,
+          parts.join(" · "),
+          `\`full\` tier yet ${parked} effects are parked — the gate should not be holding anything`,
+        ),
+      );
+      return;
+    }
+    if (mode === "full") note.push("full tier — no effect ever parks, so an empty queue is the norm, not a sign of no gate");
+    else if (parked === 0) note.push(`\`${mode}\` tier with nothing pending — an empty queue means nothing is awaiting the gate`);
     rows.push(
-      row(
-        "approval-tier",
-        SKIP,
-        observed.join(" · ") || "no observable gate activity",
-        "[policy].mode has no read surface, so the tier this tenant runs is unverified by any API client",
-      ),
+      row("approval-tier", PASS, parts.join(" · "), note.join(" ")),
     );
   }
 

--- a/qa/oc-qa.js
+++ b/qa/oc-qa.js
@@ -46,11 +46,24 @@
  *
  * ## Usage
  *
- *   OCQA.read()                       // 22 read-only checks, ~10s
+ *   OCQA.read()                       // 22 read-only checks, ~10s. Spends nothing.
  *   OCQA.read({ company: "acme" })    // pin a company in multi-company mode
- *   OCQA.probe()                      // 5 live checks that spend tokens
- *   OCQA.probe({ workflow: "daily-release-readiness", dryRun: true })
+ *
+ *   OCQA.probe()                      // 5 checks, 4 of them live: real chat
+ *                                     // turns, a real board card, real tokens.
+ *                                     // Names the host it is about to act on
+ *                                     // before it starts. The workflow run is
+ *                                     // SKIP until you name one (see below).
+ *   OCQA.probe({ workflow: "daily-release-readiness" })              // + a REAL run
+ *   OCQA.probe({ workflow: "daily-release-readiness", dryRun: true })// + a rehearsal
+ *
  *   OCQA.report()                     // last run, as Markdown to paste in an issue
+ *   OCQA.report({ raw: true })        // ...including the tenant message text
+ *
+ * `probe()` never picks a workflow for you. A real run fires real deliveries —
+ * a report into a channel, mail to a real address — so the fifth check reports
+ * SKIP until you name the workflow you meant. Everything else in `probe()` is
+ * live either way: it spends tokens on whatever tenant the tab is signed in to.
  *
  * Both entry points resolve to an array of rows and also print a table.
  */
@@ -264,8 +277,14 @@
    * Row plumbing
    * ------------------------------------------------------------------ */
 
-  function row(check, verdict, value, note) {
-    return { check, verdict, value: String(value), note: note || "" };
+  function row(check, verdict, value, note, detail) {
+    const r = { check, verdict, value: String(value), note: note || "" };
+    // `detail` carries tenant content — a real agent reply, a real message.
+    // It is worth seeing on the operator's own screen and is exactly what must
+    // not be pasted into a public issue, so it lives in its own field and
+    // `report()` withholds it unless asked for it.
+    if (detail !== undefined && detail !== null && detail !== "") r.detail = String(detail);
+    return r;
   }
 
   /**
@@ -317,6 +336,38 @@
     return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
   }
 
+  /** The host this run is judging, safe to read outside a browser (the unit sandbox). */
+  function hostname() {
+    return global.location ? global.location.host : "unknown";
+  }
+
+  /**
+   * Runs one check, and contains a throw to that check's own row.
+   *
+   * `http()` never throws, which is what the transport docstring promises — but
+   * that defence stops at the transport. A check still reads fields off the
+   * body it got back, and a host whose shape has drifted hands back a 200 whose
+   * fields are simply absent: `f.spentUsd.toFixed(2)` on a `/finances` that
+   * answered `{}` is a `TypeError`, and without a boundary here it takes the
+   * other twenty-one checks and the summary with it. Reporting *nothing* is
+   * louder than a false green but no more useful, and shape drift on an older
+   * tenant is precisely the deployment-era condition this tool exists to catch.
+   *
+   * The row is `SKIP`, never `FAIL`: a check that could not be evaluated has
+   * not judged the surface, and the same rule applies to a check that threw as
+   * to one that 404ed. It carries the message, because a harness bug is the
+   * likeliest cause and it should be reportable without a debugger.
+   */
+  async function attempt(rows, check, fn, empty) {
+    try {
+      return await fn();
+    } catch (err) {
+      const why = (err && err.message) || String(err);
+      rows.push(row(check, SKIP, `threw: ${why}`, `${check} could not be judged — untested, not passed`));
+      return empty === undefined ? null : empty;
+    }
+  }
+
   /* ------------------------------------------------------------------ *
    * Read-only checks (22)
    * ------------------------------------------------------------------ */
@@ -338,7 +389,7 @@
       row(
         "host",
         PASS,
-        `${s.name}@${s.version} · ${location.host} · ${caps}`,
+        `${s.name}@${s.version} · ${hostname()} · ${caps}`,
         `healthz ${health.elapsedMs}ms · storage ${s.storage || "unknown"} · instance ${String(s.instance_id || "").slice(0, 8)}`,
       ),
     );
@@ -774,13 +825,27 @@
     const u = usage.ok ? usage.body || {} : null;
     const f = finances.ok ? finances.body || {} : null;
     const totals = (u && u.totals) || {};
-    const overspent = f && f.budgetUsd > 0 && f.spentUsd > f.budgetUsd;
+    // `/finances` is Phase 1 (`src/server/ops/finances.rs`), so an older tenant
+    // can answer 200 with the figures simply absent. Reading them unguarded is
+    // a `TypeError` on the one deployment this check exists to judge, and an
+    // absent figure rendered as `$0.00` would be worse still: it reads as a
+    // company that has spent nothing rather than one that did not say.
+    const figures = ["spentUsd", "budgetUsd", "balanceUsd"];
+    const missing = f ? figures.filter((k) => typeof f[k] !== "number") : figures;
+    const priced = !!f && missing.length === 0;
+    const overspent = priced && f.budgetUsd > 0 && f.spentUsd > f.budgetUsd;
     rows.push(
       row(
         "usage-finances",
-        !u || !f ? SKIP : overspent ? FAIL : PASS,
-        `${totals.tokens || 0} tokens · $${(totals.costUsd || 0).toFixed(2)} · ${f ? `spent $${f.spentUsd.toFixed(2)}/$${f.budgetUsd.toFixed(2)} · balance $${f.balanceUsd.toFixed(2)}` : "finances unread"}`,
-        overspent ? "spend is past the manifest budget" : !u || !f ? "one of the two surfaces did not answer" : "",
+        !u || !priced ? SKIP : overspent ? FAIL : PASS,
+        `${totals.tokens || 0} tokens · $${(totals.costUsd || 0).toFixed(2)} · ${priced ? `spent $${f.spentUsd.toFixed(2)}/$${f.budgetUsd.toFixed(2)} · balance $${f.balanceUsd.toFixed(2)}` : "finances unread"}`,
+        overspent
+          ? "spend is past the manifest budget"
+          : !u || !f
+            ? "one of the two surfaces did not answer"
+            : priced
+              ? ""
+              : `/finances answered without ${missing.join(", ")} — untested, not passed`,
       ),
     );
   }
@@ -839,8 +904,12 @@
     const rows = [];
     const started = Date.now();
 
-    const spec = await checkHost(rows);
-    await checkConsoleCacheHeaders(rows);
+    // Every check is run through `attempt`, so one that throws on a body whose
+    // shape has drifted costs its own row and not the whole pass. The fallback
+    // handed back is the same empty value the check's own unreadable path
+    // returns, so a throw cannot poison the check downstream of it either.
+    const spec = await attempt(rows, "host", () => checkHost(rows));
+    await attempt(rows, "console-cache-headers", () => checkConsoleCacheHeaders(rows));
 
     const scope = await resolveScope(opts.company);
     if (!scope) {
@@ -848,33 +917,33 @@
       return finish(rows, started, "read");
     }
 
-    const company = await checkLifecycle(rows, scope);
-    const team = await checkRoster(rows, scope);
-    await checkDesks(rows, scope);
-    await checkTaskBoard(rows, scope);
-    await checkWorkspace(rows, scope);
-    const approvals = await checkApprovals(rows, scope);
-    await checkApprovalTier(rows, scope, approvals);
-    await checkConnections(rows, scope);
-    await checkComposio(rows, scope);
+    const company = await attempt(rows, "company-lifecycle", () => checkLifecycle(rows, scope));
+    const team = await attempt(rows, "roster", () => checkRoster(rows, scope), []);
+    await attempt(rows, "desks", () => checkDesks(rows, scope));
+    await attempt(rows, "task-board", () => checkTaskBoard(rows, scope));
+    await attempt(rows, "workspace", () => checkWorkspace(rows, scope));
+    const approvals = await attempt(rows, "approvals-backlog", () => checkApprovals(rows, scope), []);
+    await attempt(rows, "approval-tier", () => checkApprovalTier(rows, scope, approvals));
+    await attempt(rows, "manifest-connections", () => checkConnections(rows, scope));
+    await attempt(rows, "composio-health", () => checkComposio(rows, scope));
     const caps = await http(`${scope}/capabilities`);
-    await checkMcp(rows, scope, spec, caps.ok ? caps.body : null);
-    await checkInference(rows, scope);
-    checkRepoBinding(rows, spec, company);
-    await checkWorkflows(rows, scope);
-    const runs = await checkRunHistory(rows, scope);
-    checkDeliveries(rows, runs);
-    await checkDataHygiene(rows, scope);
-    await checkSkills(rows, scope);
-    await checkUsageAndFinances(rows, scope);
-    await checkChatHistory(rows, scope);
-    await checkToolCatalog(rows, scope, team);
+    await attempt(rows, "mcp-servers", () => checkMcp(rows, scope, spec, caps.ok ? caps.body : null));
+    await attempt(rows, "inference-provider", () => checkInference(rows, scope));
+    await attempt(rows, "repo-binding", () => checkRepoBinding(rows, spec, company));
+    await attempt(rows, "workflows", () => checkWorkflows(rows, scope));
+    const runs = await attempt(rows, "run-history", () => checkRunHistory(rows, scope), []);
+    await attempt(rows, "workflow-deliveries", () => checkDeliveries(rows, runs));
+    await attempt(rows, "data-hygiene", () => checkDataHygiene(rows, scope));
+    await attempt(rows, "skills", () => checkSkills(rows, scope));
+    await attempt(rows, "usage-finances", () => checkUsageAndFinances(rows, scope));
+    await attempt(rows, "chat-history", () => checkChatHistory(rows, scope));
+    await attempt(rows, "tool-catalog", () => checkToolCatalog(rows, scope, team));
 
     return finish(rows, started, "read", scope);
   }
 
   /* ------------------------------------------------------------------ *
-   * OCQA.probe() — five live checks that spend real tokens
+   * OCQA.probe() — five checks, four of them live, that spend real tokens
    * ------------------------------------------------------------------ */
 
   /**
@@ -904,8 +973,14 @@
       row(
         "probe-chat",
         replies.length === 0 ? FAIL : res.elapsedMs > 30000 ? WARN : PASS,
-        `${secs(res.elapsedMs)} · ${replies.length} replies · "${first}"`,
+        `${secs(res.elapsedMs)} · ${replies.length} replies · ${first.length} chars`,
         replies.length === 0 ? "a 200 with no reply is a turn that answered nothing" : "",
+        // The reply itself is real tenant content and `report()` is written to
+        // be pasted into a public issue, so the verdict is formed from the
+        // shape of the answer and the text rides in `detail`, which the report
+        // withholds. It is still on the operator's own screen, where judging
+        // whether the company answered *well* needs it.
+        first ? `"${first}"` : "",
       ),
     );
   }
@@ -970,9 +1045,25 @@
     const list = await http(`${scope}/workflows`);
     if (!list.ok) return push(rows, unread("probe-workflow-run", list, "workflows"));
     const flows = list.body || [];
-    const target = opts.workflow ? flows.find((w) => w.id === opts.workflow) : flows[0];
+    // The target is never chosen for you. A real run fires real effects — a
+    // report to a channel, mail to a real address — and `flows[0]` is whatever
+    // the host happened to list first, which on a production tenant is a
+    // stranger's workflow. Naming it is the operator saying which one; there is
+    // no default that is safe to guess, so the unnamed case is SKIP.
+    if (!opts.workflow) {
+      return push(
+        rows,
+        row(
+          "probe-workflow-run",
+          SKIP,
+          flows.length ? `${flows.length} workflows, none named` : "no workflows",
+          'this check will not choose its own target — pass { workflow: "<id>" } to run one for real, or { workflow: "<id>", dryRun: true } to rehearse it',
+        ),
+      );
+    }
+    const target = flows.find((w) => w.id === opts.workflow);
     if (!target) {
-      return push(rows, row("probe-workflow-run", SKIP, opts.workflow ? `no workflow "${opts.workflow}"` : "no workflows", "nothing to run"));
+      return push(rows, row("probe-workflow-run", SKIP, `no workflow "${opts.workflow}"`, "nothing to run"));
     }
     const body = { input: {} };
     if (opts.dryRun) body.dry_run = true;
@@ -1071,12 +1162,19 @@
       rows.push(row("scope", FAIL, "no company", "sign in first"));
       return finish(rows, started, "probe");
     }
+    // Named before anything fires. These probes spend real tokens and leave
+    // real traces on whatever tenant the tab is signed in to, and the one thing
+    // an operator cannot recover from is not having known which host that was.
+    console.log(
+      `%coc-qa ${VERSION} · probe → ${hostname()} · ${scope} — real turns, real effects, on this tenant.`,
+      "color:#d97706;font-weight:bold",
+    );
     const before = await http(`${scope}/approvals`);
-    await probeChat(rows, scope, opts);
-    await probeDesks(rows, scope, opts);
-    await probeBoardCard(rows, scope);
-    await probeWorkflowRun(rows, scope, opts);
-    await probeApprovalDelta(rows, scope, before.ok ? before.body : []);
+    await attempt(rows, "probe-chat", () => probeChat(rows, scope, opts));
+    await attempt(rows, "probe-desks", () => probeDesks(rows, scope, opts));
+    await attempt(rows, "probe-board-card", () => probeBoardCard(rows, scope));
+    await attempt(rows, "probe-workflow-run", () => probeWorkflowRun(rows, scope, opts));
+    await attempt(rows, "probe-approval-delta", () => probeApprovalDelta(rows, scope, before.ok ? before.body : []));
     return finish(rows, started, "probe", scope);
   }
 
@@ -1092,7 +1190,7 @@
     lastRun = {
       mode,
       scope: scope || null,
-      host: global.location ? global.location.host : "unknown",
+      host: hostname(),
       atMillis: Date.now(),
       elapsedMs: Date.now() - started,
       tally,
@@ -1111,9 +1209,23 @@
     return rows;
   }
 
-  /** The last run as a Markdown table, for pasting straight into an issue. */
-  function report() {
+  /**
+   * The last run as a Markdown table, for pasting straight into an issue.
+   *
+   * Which is the reason for the redaction: this output is written to be moved
+   * out of the tenant and into a public artifact, so the message text a probe
+   * collected does not travel with it. `report({ raw: true })` opts back in for
+   * a private write-up, and the table says when something was withheld rather
+   * than quietly shortening a value.
+   *
+   * Ids — company, desks, workflows, delivery targets — are still in here. They
+   * are what makes a FAIL actionable, and a report with them stripped names no
+   * defect. Read the table before pasting it somewhere public.
+   */
+  function report(options) {
     if (!lastRun) return "No run yet. Call OCQA.read() first.";
+    const raw = !!(options && options.raw);
+    const withheld = lastRun.rows.filter((r) => r.detail).length;
     const lines = [
       `## oc-qa ${VERSION} — \`${lastRun.mode}\` on \`${lastRun.host}\``,
       "",
@@ -1125,7 +1237,15 @@
     ];
     for (const r of lastRun.rows) {
       const cell = (s) => String(s).replace(/\|/g, "\\|");
-      lines.push(`| \`${r.check}\` | ${r.verdict} | ${cell(r.value)} | ${cell(r.note)} |`);
+      const value = raw && r.detail ? `${r.value} · ${r.detail}` : r.value;
+      lines.push(`| \`${r.check}\` | ${r.verdict} | ${cell(value)} | ${cell(r.note)} |`);
+    }
+    if (withheld && !raw) {
+      lines.push("");
+      lines.push(
+        `_${withheld} row${withheld === 1 ? "" : "s"} carried tenant message text, withheld from this report. ` +
+          "`OCQA.report({ raw: true })` includes it — do not paste that into a public issue._",
+      );
     }
     const text = lines.join("\n");
     console.log(text);

--- a/qa/oc-qa.js
+++ b/qa/oc-qa.js
@@ -1,0 +1,1155 @@
+/*
+ * oc-qa.js — the OpenCompany release parity harness (issue #987).
+ *
+ * Paste this whole file into the browser console of a **signed-in** operator
+ * console, then call `OCQA.read()` or `OCQA.probe()`.
+ *
+ * ## Why a console script and not a test
+ *
+ * It rides the session cookie of the tab it is pasted into, so a release can be
+ * checked against a real hosted tenant with no token to mint, distribute or
+ * revoke. Nothing here is a substitute for the suite in `frontend/test/` or
+ * `cargo test`: this answers "is the thing we deployed actually working for the
+ * operator", which no in-repo test can, because the failures it is built around
+ * are failures of the *deployment* (a stale `index.html`, an unwired channel, a
+ * missing credential) rather than of the code.
+ *
+ * ## Zero dependencies, deliberately
+ *
+ * `fetch`, `console` and nothing else. Anything that has to be installed first
+ * will not be run during an incident, which is the moment this is worth most.
+ *
+ * ## Three rules the checks obey
+ *
+ * 1. **A verdict travels with the value it judged.** Every row carries the
+ *    reading the verdict was formed from, so a PASS can be checked rather than
+ *    trusted. A harness whose output is a column of PASSes is unfalsifiable.
+ *
+ * 2. **Unreadable is never PASS.** A surface that 404s, errors, or is absent on
+ *    this build reports `SKIP`, and `SKIP` counts as *untested* in the summary,
+ *    not as passed. The 2026-08-18 pass recorded three checks as passing that
+ *    had never run; that is the miss this rule exists to stop.
+ *
+ * 3. **A check is reviewed against the bug it missed.** `runVerdict` below
+ *    exists because the first version of the workflow check folded
+ *    `nodes[].status` alone and scored a run that delivered nothing as green —
+ *    the same mistake issue #981 filed against the product. Extending the
+ *    harness after a miss is not enough; the check that missed has to change.
+ *
+ * ## The two checks worth keeping even if the rest is deleted
+ *
+ * - `console-cache-headers` — caught #979. A cacheable `index.html` white-screens
+ *   every returning user after a deploy, and there is nothing in the UI to look
+ *   at, because the UI is the thing that failed to load.
+ * - `workflow-deliveries` — caught #981. A run whose nodes are all `ok` can still
+ *   have delivered nothing.
+ *
+ * ## Usage
+ *
+ *   OCQA.read()                       // 22 read-only checks, ~10s
+ *   OCQA.read({ company: "acme" })    // pin a company in multi-company mode
+ *   OCQA.probe()                      // 5 live checks that spend tokens
+ *   OCQA.probe({ workflow: "daily-release-readiness", dryRun: true })
+ *   OCQA.report()                     // last run, as Markdown to paste in an issue
+ *
+ * Both entry points resolve to an array of rows and also print a table.
+ */
+(function (global) {
+  "use strict";
+
+  const VERSION = "1.0.0";
+
+  const PASS = "PASS";
+  const WARN = "WARN";
+  const FAIL = "FAIL";
+  const SKIP = "SKIP";
+
+  /* ------------------------------------------------------------------ *
+   * Transport
+   * ------------------------------------------------------------------ */
+
+  /**
+   * One HTTP call, never throwing. Every failure mode — a non-2xx, a body that
+   * is not JSON, a network error, a timeout — comes back as a value, because a
+   * check that throws takes the other twenty-one with it.
+   */
+  async function http(path, options) {
+    const opts = options || {};
+    const controller = new AbortController();
+    const timeoutMs = opts.timeoutMs || 20000;
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const started = Date.now();
+    try {
+      const res = await fetch(path, {
+        method: opts.method || "GET",
+        credentials: "include",
+        cache: opts.cache || "default",
+        signal: controller.signal,
+        headers: opts.body ? { "content-type": "application/json" } : undefined,
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+      });
+      const text = await res.text();
+      let body = null;
+      try {
+        body = text ? JSON.parse(text) : null;
+      } catch {
+        body = null;
+      }
+      return {
+        ok: res.ok,
+        status: res.status,
+        body,
+        text,
+        headers: res.headers,
+        elapsedMs: Date.now() - started,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        status: 0,
+        body: null,
+        text: "",
+        headers: new Headers(),
+        elapsedMs: Date.now() - started,
+        error: err && err.name === "AbortError" ? `timed out after ${timeoutMs}ms` : String(err),
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * The company route prefix.
+   *
+   * Single-company mode serves `/api/v1/company`; a multi-company host wants
+   * `/api/v1/companies/{id}`. Resolved by asking rather than configured,
+   * because the wrong prefix 404s every check and would read as twenty-two
+   * SKIPs with no clue which knob was wrong.
+   */
+  async function resolveScope(company) {
+    if (company) return `/api/v1/companies/${encodeURIComponent(company)}`;
+    const single = await http("/api/v1/company");
+    if (single.ok) return "/api/v1/company";
+    const list = await http("/api/v1/companies");
+    if (list.ok && Array.isArray(list.body) && list.body.length > 0) {
+      return `/api/v1/companies/${encodeURIComponent(list.body[0].id)}`;
+    }
+    return null;
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Pure judgements — the parts worth unit-testing
+   * ------------------------------------------------------------------ */
+
+  /**
+   * A run's verdict, in the console's own precedence order.
+   *
+   * **This is a transcription of `frontend/src/views/workflows/run-health.ts`,
+   * and it must stay one.** Two independent definitions of "did this run
+   * succeed" is precisely the defect issue #981 filed, and the harness owned
+   * the second copy. `frontend/test/unit/qa-harness.test.ts` pins the two
+   * together so a change to the console's reading breaks this file loudly
+   * rather than silently re-greening a bad run.
+   *
+   * The order IS the check, and every arm below exists because the state it
+   * names had been scoring green:
+   * - `running` first: an unsettled run has neither succeeded nor failed, and
+   *   both colours are claims the host has not made.
+   * - `cancelled` before the delivery reads: a stop somebody asked for is not a
+   *   fault, and a cancelled run has no deliveries to weigh.
+   * - `blocked` (issue #881) before the delivery reads: a run that stopped short
+   *   at a gate carries no `error`, is not `cancelled`, is not `running` and
+   *   routed no report — so before its own arm it fell through every check to
+   *   "ok" and told the operator a pipeline that delivered nothing had
+   *   succeeded.
+   * - `undelivered` before `awaiting-approval`: a report that will not go out
+   *   without a change outranks one waiting on a human.
+   * - `awaiting-approval` reads [`awaitingCount`], not the delivery rows alone
+   *   (issue #846). A run that paused at a `requires_approval` node never
+   *   reached an `output` node, so its `deliveries` are empty and a
+   *   delivery-only read scored the gated case — the common one — as clean.
+   *
+   * These are exactly the seven words issue #981 proposes for a server-side
+   * `WorkflowRunVerdict`. When that lands, delete this and read the host's.
+   */
+  function runVerdict(run) {
+    if (!run) return "unknown";
+    if (run.running === true) return "running";
+    if (run.error) return "failed";
+    if (run.cancelled) return "stopped";
+    if (isBlocked(run)) return "blocked";
+    if (undeliveredCount(run.deliveries) > 0) return "undelivered";
+    if (awaitingCount(run) > 0) return "awaiting-approval";
+    return "ok";
+  }
+
+  /**
+   * Whether this run stopped short because a step is waiting on a person
+   * (issue #881).
+   */
+  function isBlocked(run) {
+    return (run.blockedNodes || []).length > 0;
+  }
+
+  /**
+   * Everything about this run that is waiting on a person: the gates it paused
+   * at **and** the reports it parked (issue #846).
+   *
+   * The two were never read together, and that is what let a run report success
+   * while a human had not answered it.
+   */
+  function awaitingCount(run) {
+    return (run.pendingApprovals || []).length + pendingCount(run.deliveries);
+  }
+
+  /**
+   * Reports that did not land **and will not without a change**. `pending` is
+   * excluded on purpose: it is a report parked for an operator's approval, so
+   * counting it here would score a working approvals queue as a failure.
+   */
+  function undeliveredCount(deliveries) {
+    return (deliveries || []).filter((d) => d.status !== "sent" && d.status !== "pending").length;
+  }
+
+  /** Reports waiting on an operator's verdict rather than on a fix. */
+  function pendingCount(deliveries) {
+    return (deliveries || []).filter((d) => d.status === "pending").length;
+  }
+
+  /**
+   * Judges one `Cache-Control` header. This is the whole of #979 in six lines.
+   *
+   * `kind: "html"` — the shell and every SPA-route fallback. It names the entry
+   * bundle, so a browser allowed to reuse yesterday's copy asks for chunks that
+   * are gone from the new image, the SPA fallback answers them with `index.html`,
+   * the dynamic import throws, and the page is blank. **An absent header is a
+   * FAIL, not a WARN**: absent means heuristic caching, which is the bug.
+   *
+   * `kind: "asset"` — content-hashed, so a long immutable lifetime is both safe
+   * and the point. A missing header only costs revalidation round trips, so it
+   * is a WARN.
+   */
+  function judgeCacheHeader(kind, header) {
+    const value = (header || "").toLowerCase();
+    if (kind === "html") {
+      if (!value) {
+        return { verdict: FAIL, note: "no cache-control: heuristic caching white-screens returning users after a deploy (#979)" };
+      }
+      if (value.includes("no-store") || value.includes("no-cache") || /max-age\s*=\s*0\b/.test(value)) {
+        return { verdict: PASS, note: "revalidated, so the browser always learns the current entry name" };
+      }
+      return { verdict: FAIL, note: "cacheable shell: a returning browser keeps yesterday's entry bundle (#979)" };
+    }
+    if (!value) {
+      return { verdict: WARN, note: "no cache-control on a hashed asset: every load revalidates for nothing" };
+    }
+    const maxAge = /max-age\s*=\s*(\d+)/.exec(value);
+    if (value.includes("immutable") || (maxAge && Number(maxAge[1]) >= 86400)) {
+      return { verdict: PASS, note: "hashed asset cached long, which is safe because the name changes with the bytes" };
+    }
+    return { verdict: WARN, note: "hashed asset cached briefly: safe, but the revalidation is pure cost" };
+  }
+
+  /** A compact "4h" / "12m" for an epoch-millis timestamp. */
+  function age(atMillis, now) {
+    if (!atMillis) return "n/a";
+    const seconds = Math.max(0, Math.round(((now || Date.now()) - atMillis) / 1000));
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+    if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
+    return `${Math.round(seconds / 86400)}d`;
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Row plumbing
+   * ------------------------------------------------------------------ */
+
+  function row(check, verdict, value, note) {
+    return { check, verdict, value: String(value), note: note || "" };
+  }
+
+  /**
+   * Records a row and hands back what this check's caller should see.
+   *
+   * Exists because `return rows.push(r)` returns the array's new **length** — a
+   * number a caller expecting a list will treat as data and then crash on,
+   * taking every check after it down with it. Naming the empty value at each
+   * early return is what keeps a check that could not read its surface from
+   * poisoning the one downstream of it.
+   */
+  function push(rows, r, empty) {
+    rows.push(r);
+    return empty === undefined ? null : empty;
+  }
+
+  /**
+   * The row for a surface that could not be read.
+   *
+   * Always `SKIP`, never `PASS`. A 404 on a feature-gated route is a perfectly
+   * good answer to "does this build have it" and a terrible answer to "does it
+   * work"; conflating the two is what let three checks be written up as passing
+   * in the 2026-08-18 pass when they had never run.
+   */
+  function unread(check, res, what) {
+    const why = res.error ? res.error : `HTTP ${res.status}`;
+    return row(check, SKIP, why, `${what} could not be read — untested, not passed`);
+  }
+
+  /**
+   * Whether the host answered "this deployment has no such machinery".
+   *
+   * A feature-gated surface reports `{"error": …, "code": "not_wired"}` rather
+   * than pretending, and that is a different answer from a broken one: a build
+   * with no workflow runner cannot run a workflow, and scoring it FAIL sends
+   * somebody chasing a graph that is fine. It is `SKIP` — untested, not passed
+   * and not failed.
+   *
+   * Matched on the typed `code` token, never on the prose (issue #248): the
+   * message is free to be reworded, and a harness that greps it would go quiet
+   * the day somebody did.
+   */
+  function notWired(res) {
+    return !!(res.body && res.body.code === "not_wired");
+  }
+
+  /** A duration a human reads at a glance: `840ms`, `4.1s`. */
+  function secs(ms) {
+    return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Read-only checks (22)
+   * ------------------------------------------------------------------ */
+
+  async function checkHost(rows) {
+    const health = await http("/healthz", { cache: "no-store" });
+    if (!health.ok) {
+      rows.push(row("host", FAIL, `HTTP ${health.status || health.error}`, "the host did not answer /healthz — nothing below is meaningful"));
+      return null;
+    }
+    const spec = await http("/spec");
+    if (!spec.ok) {
+      rows.push(row("host", WARN, `healthz ok in ${health.elapsedMs}ms, /spec HTTP ${spec.status}`, "no build identity: a pass cannot name what it judged"));
+      return null;
+    }
+    const s = spec.body || {};
+    const caps = (s.capabilities || []).join("+") || "rest only";
+    rows.push(
+      row(
+        "host",
+        PASS,
+        `${s.name}@${s.version} · ${location.host} · ${caps}`,
+        `healthz ${health.elapsedMs}ms · storage ${s.storage || "unknown"} · instance ${String(s.instance_id || "").slice(0, 8)}`,
+      ),
+    );
+    return s;
+  }
+
+  /**
+   * The console's cache headers — the check that caught #979.
+   *
+   * Fetched with `cache: "reload"` so the browser's own cache cannot answer and
+   * hide the header we came to read.
+   */
+  async function checkConsoleCacheHeaders(rows) {
+    const shell = await http("/", { cache: "reload" });
+    if (!shell.ok) {
+      rows.push(unread("console-cache-headers", shell, "the console shell"));
+      return;
+    }
+    const shellHeader = shell.headers.get("cache-control");
+    const shellVerdict = judgeCacheHeader("html", shellHeader);
+    rows.push(
+      row("console-cache-headers", shellVerdict.verdict, `/ → cache-control: ${shellHeader || "(absent)"}`, shellVerdict.note),
+    );
+
+    // The SPA fallback is a separate response from a separate code path; a shell
+    // that revalidates while `/some/route` does not is the same bug on the path
+    // a returning user actually lands on.
+    const fallback = await http("/__oc-qa-nonexistent-route", { cache: "reload" });
+    if (fallback.ok) {
+      const header = fallback.headers.get("cache-control");
+      const verdict = judgeCacheHeader("html", header);
+      rows.push(
+        row("spa-fallback-cache-headers", verdict.verdict, `unknown route → cache-control: ${header || "(absent)"}`, verdict.note),
+      );
+    }
+
+    const asset = /\/assets\/[A-Za-z0-9._-]+\.js/.exec(shell.text || "");
+    if (!asset) {
+      rows.push(row("asset-cache-headers", SKIP, "no /assets/*.js in the shell", "nothing to judge — a dev server or an unbuilt console"));
+      return;
+    }
+    const assetRes = await http(asset[0], { cache: "reload" });
+    if (!assetRes.ok) {
+      rows.push(row("asset-cache-headers", FAIL, `${asset[0]} → HTTP ${assetRes.status}`, "the shell names an entry bundle the host does not serve — this is the white screen"));
+      return;
+    }
+    const type = assetRes.headers.get("content-type") || "";
+    if (!type.includes("javascript")) {
+      rows.push(
+        row("asset-cache-headers", FAIL, `${asset[0]} → ${type}`, "an asset answered by the SPA fallback: the entry bundle is stale (#979)"),
+      );
+      return;
+    }
+    const assetHeader = assetRes.headers.get("cache-control");
+    const assetVerdict = judgeCacheHeader("asset", assetHeader);
+    rows.push(row("asset-cache-headers", assetVerdict.verdict, `${asset[0]} → cache-control: ${assetHeader || "(absent)"}`, assetVerdict.note));
+  }
+
+  async function checkLifecycle(rows, scope) {
+    const res = await http(scope);
+    if (!res.ok) return push(rows, unread("company-lifecycle", res, "company status"));
+    const c = res.body || {};
+    // `emergency_paused` is deliberately independent of `lifecycle`: chat still
+    // works while a company is stopped, so reading `lifecycle` alone reports a
+    // stopped company as perfectly healthy.
+    const stopped = c.emergency_paused === true;
+    const verdict = c.lifecycle === "running" && !stopped ? PASS : stopped ? FAIL : WARN;
+    rows.push(
+      row(
+        "company-lifecycle",
+        verdict,
+        `${c.name || c.id} · ${c.lifecycle}${stopped ? " · KILL SWITCH ENGAGED" : ""}`,
+        stopped ? "new effects outside the Other group are being denied" : `${c.pending_approvals || 0} approvals pending`,
+      ),
+    );
+    return c;
+  }
+
+  async function checkRoster(rows, scope) {
+    const res = await http(`${scope}/team`);
+    if (!res.ok) return push(rows, unread("roster", res, "the roster"), []);
+    const team = res.body || [];
+    rows.push(
+      row(
+        "roster",
+        team.length > 0 ? PASS : FAIL,
+        `${team.length} teammates: ${team.map((t) => t.id).join(", ") || "(none)"}`,
+        team.length ? "" : "a company with no roster can answer nothing",
+      ),
+    );
+    return team;
+  }
+
+  async function checkDesks(rows, scope) {
+    const res = await http(`${scope}/desks`);
+    if (!res.ok) return push(rows, unread("desks", res, "desks"), []);
+    const desks = res.body || [];
+    const empty = desks.filter((d) => (d.members || []).length === 0);
+    rows.push(
+      row(
+        "desks",
+        desks.length === 0 ? WARN : empty.length ? WARN : PASS,
+        `${desks.length} desks: ${desks.map((d) => `${d.id}(${(d.members || []).length})`).join(", ") || "(none)"}`,
+        empty.length ? `${empty.map((d) => d.id).join(", ")} have no members, so a hand-off to them lands nowhere` : "",
+      ),
+    );
+    return desks;
+  }
+
+  async function checkTaskBoard(rows, scope) {
+    const res = await http(`${scope}/tasks`);
+    if (!res.ok) return push(rows, unread("task-board", res, "the task board"), []);
+    const tasks = res.body || [];
+    const byColumn = {};
+    for (const t of tasks) byColumn[t.column] = (byColumn[t.column] || 0) + 1;
+    const stuck = tasks.filter((t) => t.column === "in_progress" && Date.now() - t.updatedAt > 6 * 3600 * 1000);
+    rows.push(
+      row(
+        "task-board",
+        stuck.length ? WARN : PASS,
+        `${tasks.length} cards · ${Object.entries(byColumn).map(([k, v]) => `${k}:${v}`).join(" ") || "(empty)"}`,
+        stuck.length ? `${stuck.length} in_progress untouched for over 6h — a turn that died leaves exactly this trace (#983)` : "",
+      ),
+    );
+    return tasks;
+  }
+
+  async function checkWorkspace(rows, scope) {
+    const res = await http(`${scope}/workspace`);
+    if (!res.ok) return push(rows, unread("workspace", res, "the workspace tree"), []);
+    const nodes = res.body || [];
+    const files = nodes.filter((n) => n.kind === "file");
+    const newest = files.reduce((max, n) => Math.max(max, n.updatedAt || 0), 0);
+    rows.push(
+      row(
+        "workspace",
+        nodes.length ? PASS : WARN,
+        `${nodes.length} nodes (${files.length} files) · newest ${age(newest)} ago`,
+        nodes.length ? "" : "an empty workspace is fine on a fresh tenant and a red flag on a working one",
+      ),
+    );
+    return nodes;
+  }
+
+  async function checkApprovals(rows, scope) {
+    const res = await http(`${scope}/approvals`);
+    if (!res.ok) {
+      rows.push(unread("approvals-backlog", res, "the approvals queue"));
+      return [];
+    }
+    const approvals = res.body || [];
+    const oldest = approvals.reduce((min, a) => (min === 0 ? a.at_millis : Math.min(min, a.at_millis)), 0);
+    const kinds = [...new Set(approvals.map((a) => a.kind))].join(", ");
+    // Age, not depth, is the signal. A queue of three parked a minute ago is a
+    // company working; a queue of one parked eight days ago is a company whose
+    // operator stopped looking, and every effect behind it is frozen.
+    const ageHours = oldest ? (Date.now() - oldest) / 3600000 : 0;
+    rows.push(
+      row(
+        "approvals-backlog",
+        approvals.length === 0 ? PASS : ageHours > 48 ? FAIL : ageHours > 4 ? WARN : PASS,
+        `${approvals.length} parked${approvals.length ? ` (${kinds}) · oldest ${age(oldest)} ago` : ""}`,
+        ageHours > 4 ? "everything behind this gate is frozen until somebody decides" : "",
+      ),
+    );
+    return approvals;
+  }
+
+  /**
+   * The company's approval tier.
+   *
+   * **No read surface exists.** `[policy].mode` — `readonly` / `supervised` /
+   * `auto` / `full` — decides whether an effect parks at all, and no REST or
+   * GraphQL route reports it. So this check cannot pass: it reports what can be
+   * observed (whether the gate is wired and has ever held anything) and states
+   * plainly that the tier itself is unverified. A green row here would be the
+   * harness claiming to have checked the single setting that decides whether
+   * any of the approvals checks mean anything.
+   */
+  async function checkApprovalTier(rows, scope, approvals) {
+    const caps = await http(`${scope}/capabilities`);
+    const grants = caps.ok ? caps.body || {} : {};
+    const observed = [];
+    if (approvals && approvals.length) observed.push(`${approvals.length} effects currently parked`);
+    if (grants.configured) observed.push(`plan ${grants.plan || "custom"}/${grants.period || "?"}`);
+    rows.push(
+      row(
+        "approval-tier",
+        SKIP,
+        observed.join(" · ") || "no observable gate activity",
+        "[policy].mode has no read surface, so the tier this tenant runs is unverified by any API client",
+      ),
+    );
+  }
+
+  async function checkConnections(rows, scope) {
+    const res = await http(`${scope}/connections`);
+    if (!res.ok) return push(rows, unread("manifest-connections", res, "connections"), []);
+    const conns = res.body || [];
+    const connected = conns.filter((c) => c.connected);
+    const unverified = conns.filter((c) => c.unverified);
+    rows.push(
+      row(
+        "manifest-connections",
+        unverified.length ? WARN : PASS,
+        `${connected.length}/${conns.length} connected: ${connected.map((c) => `${c.provider}${c.via ? `[${c.via.join("/")}]` : ""}`).join(", ") || "(none)"}`,
+        unverified.length
+          ? `${unverified.map((c) => c.provider).join(", ")} could not be checked — "not connected" here means "we do not know"`
+          : "",
+      ),
+    );
+    return conns;
+  }
+
+  async function checkComposio(rows, scope) {
+    const status = await http(`${scope}/composio`);
+    if (!status.ok) return push(rows, unread("composio-health", status, "Composio status"));
+    const s = status.body || {};
+    if (!s.inBuild) {
+      return push(rows, row("composio-health", SKIP, "not in build", "the composio feature is not compiled into this image"));
+    }
+    if (!s.granted) {
+      return push(rows, row("composio-health", PASS, "in build, not granted", "the company does not grant the composio namespace, so nothing is expected to work"));
+    }
+    const conns = await http(`${scope}/composio/connections`);
+    const list = conns.ok ? conns.body || [] : [];
+    const live = list.filter((c) => c.connected);
+    // A `fallback` catalog is a degraded read wearing a healthy shape: eight
+    // starter providers look exactly like the whole set (#397).
+    const degraded = s.catalogSource === "fallback";
+    rows.push(
+      row(
+        "composio-health",
+        !conns.ok ? SKIP : degraded ? WARN : live.length ? PASS : WARN,
+        `credential ${s.credentialSource} · catalog ${s.catalogSource}${s.openMode ? " · open mode" : ""} · ${live.length}/${list.length} toolkits connected`,
+        degraded ? s.catalogNotice || "catalog could not be fetched; this list may be incomplete" : live.length ? "" : "granted with no live connection: every composio tool call will fail",
+      ),
+    );
+  }
+
+  async function checkMcp(rows, scope, spec, capabilities) {
+    const res = await http(`${scope}/mcp/servers`);
+    if (!res.ok) return push(rows, unread("mcp-servers", res, "MCP servers"), []);
+    const servers = res.body || [];
+    const enabled = servers.filter((s) => s.enabled);
+    const unhealthy = enabled.filter((s) => s.health && s.health.status !== "ok");
+    const unauthed = enabled.filter((s) => !s.authConfigured && s.health && s.health.authHint);
+    // #567: the management routes ship in every build, so an operator can add a
+    // server, store a token, watch it probe healthy — on an image that hands
+    // agents no MCP tool at all. `undefined` is unknown, never "absent".
+    const bridge = capabilities && capabilities.mcpInBuild;
+    const bridgeNote = bridge === false ? " · AGENT BRIDGE NOT IN BUILD" : bridge === undefined ? " · bridge unknown" : "";
+    rows.push(
+      row(
+        "mcp-servers",
+        bridge === false && enabled.length ? FAIL : unhealthy.length ? FAIL : unauthed.length ? WARN : PASS,
+        `${enabled.length}/${servers.length} enabled${bridgeNote} · ${enabled.map((s) => `${s.name}:${(s.health && s.health.status) || "unprobed"}`).join(", ") || "(none)"}`,
+        bridge === false && enabled.length
+          ? "servers configured and probing on a build with no agent-side bridge: no agent can call them"
+          : unhealthy.length
+            ? unhealthy.map((s) => `${s.name}: ${s.health.message}`).join(" | ")
+            : unauthed.length
+              ? `${unauthed.map((s) => s.name).join(", ")} report an auth hint with no stored credential`
+              : "",
+      ),
+    );
+    return servers;
+  }
+
+  async function checkInference(rows, scope) {
+    const res = await http(`${scope}/inference`);
+    if (!res.ok) return push(rows, unread("inference-provider", res, "inference status"));
+    const i = res.body || {};
+    // `restartRequired` is the transition every new operator makes: a company
+    // built with no inference source runs the offline echo brain, and saving a
+    // credential afterwards changes neither the brain nor the workflow runner.
+    const echo = i.cognition === "echo";
+    rows.push(
+      row(
+        "inference-provider",
+        i.restartRequired ? FAIL : echo ? FAIL : i.keyConfigured || i.slug === "managed" ? PASS : WARN,
+        `${i.provider}/${i.slug} · ${i.cognition} · source ${i.source} · key ${i.keyConfigured ? "stored" : "absent"}`,
+        i.restartRequired
+          ? "a stored config the running brain predates: only a restart puts it to work (#266)"
+          : echo
+            ? "the offline echo brain: agents will answer, and none of it is real work"
+            : `metering ${i.usageMetering} · models ${Object.keys(i.models || {}).length}`,
+      ),
+    );
+    return i;
+  }
+
+  /**
+   * What this tenant is bound to — the template it was launched from and the
+   * build it is serving.
+   *
+   * This is the check the whole pass rests on. A tenant on an old image reports
+   * bugs `main` has already fixed, which is what made the first attempt at the
+   * 2026-08-18 pass misleading. It cannot be automated into a verdict — no
+   * endpoint reports a git SHA — so it prints the identity for a human to
+   * compare against the commit under test, and stays `SKIP` until they do.
+   */
+  function checkRepoBinding(rows, spec, company) {
+    const p = (company && company.template_provenance) || null;
+    const build = spec ? `${spec.name}@${spec.version}` : "unknown build";
+    rows.push(
+      row(
+        "repo-binding",
+        SKIP,
+        `${build} · template ${p ? `${p.source_id}${p.version ? `@${p.version}` : ""}` : "(none — raw manifest)"}`,
+        "confirm by hand that this is the commit under test; a stale tenant reports bugs main has already fixed",
+      ),
+    );
+  }
+
+  async function checkWorkflows(rows, scope) {
+    const res = await http(`${scope}/workflows`);
+    if (!res.ok) {
+      rows.push(unread("workflows", res, "workflows"));
+      return [];
+    }
+    const flows = res.body || [];
+    const paused = flows.filter((w) => w.enabled === false);
+    rows.push(
+      row(
+        "workflows",
+        flows.length ? PASS : WARN,
+        `${flows.length} workflows${paused.length ? ` · ${paused.length} paused` : ""}: ${flows.map((w) => w.id).join(", ") || "(none)"}`,
+        paused.length ? `paused: ${paused.map((w) => w.id).join(", ")} — saved and runnable by hand, skipped by the scheduler` : "",
+      ),
+    );
+    return flows;
+  }
+
+  async function checkRunHistory(rows, scope) {
+    const res = await http(`${scope}/workflows/runs?limit=50`);
+    if (!res.ok) {
+      rows.push(unread("run-history", res, "run history"));
+      return [];
+    }
+    const runs = res.body || [];
+    const tally = {};
+    for (const r of runs) {
+      const v = runVerdict(r);
+      tally[v] = (tally[v] || 0) + 1;
+    }
+    const bad = (tally.failed || 0) + (tally.undelivered || 0);
+    const newest = runs.reduce((max, r) => Math.max(max, r.atMillis || 0), 0);
+    rows.push(
+      row(
+        "run-history",
+        runs.length === 0 ? WARN : bad ? WARN : PASS,
+        `${runs.length} runs · ${Object.entries(tally).map(([k, v]) => `${k}:${v}`).join(" ") || "(none)"} · newest ${age(newest)} ago`,
+        runs.length === 0 ? "no run has ever been journaled here" : "",
+      ),
+    );
+    return runs;
+  }
+
+  /**
+   * Workflow deliveries — the check that caught #981.
+   *
+   * A run whose nodes are all `ok` can still have delivered nothing: a delivery
+   * failure deliberately does not populate `error` or flip `nodes[].status`, so
+   * folding node status is a green verdict on a dropped report. `deliveries[]`
+   * is the only place this is visible, and nothing in the UI surfaces it beyond
+   * a dot.
+   */
+  function checkDeliveries(rows, runs) {
+    if (!runs || runs.length === 0) {
+      rows.push(row("workflow-deliveries", SKIP, "no runs in history", "nothing to judge — untested, not passed"));
+      return;
+    }
+    const all = runs.flatMap((r) => (r.deliveries || []).map((d) => ({ run: r, d })));
+    const attempted = runs.filter((r) => (r.deliveries || []).length > 0);
+    const dropped = all.filter(({ d }) => d.status !== "sent" && d.status !== "pending");
+    const reasons = [...new Set(dropped.map(({ d }) => d.reason || d.status))];
+    rows.push(
+      row(
+        "workflow-deliveries",
+        dropped.length ? FAIL : all.length ? PASS : WARN,
+        `${attempted.length}/${runs.length} runs attempted delivery · ${dropped.length}/${all.length} reports dropped${reasons.length ? ` (${reasons.join(", ")})` : ""}`,
+        dropped.length
+          ? dropped
+              .slice(0, 3)
+              .map(({ run, d }) => `${run.workflowId}/${d.node} → ${d.target || d.kind}: ${d.detail}`)
+              .join(" | ")
+          : all.length
+            ? ""
+            : "no run has ever attempted a delivery, so the delivery path is unexercised",
+      ),
+    );
+  }
+
+  async function checkDataHygiene(rows, scope) {
+    const res = await http(`${scope}/memory/stats`);
+    if (!res.ok) return push(rows, unread("data-hygiene", res, "memory stats"));
+    const m = res.body || {};
+    rows.push(
+      row(
+        "data-hygiene",
+        PASS,
+        `${m.facts || 0} facts · ${m.agentChunks || 0} chunks (${m.taskOutcomes || 0} outcomes) · last write ${age(m.lastUpdatedAtMillis)} ago`,
+        // `factsUpdatedAtMillis` sits at 0 for any company whose operator never
+        // hand-authored a fact, so it is not the freshness signal.
+        m.lastUpdatedAtMillis ? "" : "nothing has ever been remembered here",
+      ),
+    );
+  }
+
+  async function checkSkills(rows, scope) {
+    const res = await http(`${scope}/skills`);
+    if (!res.ok) return push(rows, unread("skills", res, "skills"));
+    const skills = res.body || [];
+    const on = skills.filter((s) => s.enabled);
+    rows.push(
+      row(
+        "skills",
+        skills.length ? PASS : WARN,
+        `${on.length}/${skills.length} enabled: ${on.map((s) => s.id).join(", ") || "(none)"}`,
+        skills.length ? "" : "no skills installed",
+      ),
+    );
+  }
+
+  async function checkUsageAndFinances(rows, scope) {
+    const usage = await http(`${scope}/usage`);
+    const finances = await http(`${scope}/finances`);
+    if (!usage.ok && !finances.ok) {
+      rows.push(unread("usage-finances", usage, "usage and finances"));
+      return;
+    }
+    const u = usage.ok ? usage.body || {} : null;
+    const f = finances.ok ? finances.body || {} : null;
+    const totals = (u && u.totals) || {};
+    const overspent = f && f.budgetUsd > 0 && f.spentUsd > f.budgetUsd;
+    rows.push(
+      row(
+        "usage-finances",
+        !u || !f ? SKIP : overspent ? FAIL : PASS,
+        `${totals.tokens || 0} tokens · $${(totals.costUsd || 0).toFixed(2)} · ${f ? `spent $${f.spentUsd.toFixed(2)}/$${f.budgetUsd.toFixed(2)} · balance $${f.balanceUsd.toFixed(2)}` : "finances unread"}`,
+        overspent ? "spend is past the manifest budget" : !u || !f ? "one of the two surfaces did not answer" : "",
+      ),
+    );
+  }
+
+  async function checkChatHistory(rows, scope) {
+    const res = await http(`${scope}/chat/history`);
+    if (!res.ok) return push(rows, unread("chat-history", res, "chat history"), []);
+    const msgs = res.body || [];
+    const newest = msgs.reduce((max, m) => Math.max(max, m.atMillis || 0), 0);
+    const mine = msgs.filter((m) => m.mine).length;
+    rows.push(
+      row(
+        "chat-history",
+        msgs.length ? PASS : WARN,
+        `${msgs.length} messages (${mine} operator) · newest ${age(newest)} ago`,
+        msgs.length ? "" : "an empty transcript on a tenant that has been used means messages are not being journaled (#983)",
+      ),
+    );
+    return msgs;
+  }
+
+  /**
+   * The tool catalog the orchestrator actually holds.
+   *
+   * `requested` alone reports the opposite of the truth for a manifest agent
+   * whose `tools` line is empty — that means the company's standard grant, not
+   * "no tools" — so this reads `effective`, which is what the agent runs with.
+   */
+  async function checkToolCatalog(rows, scope, team) {
+    if (!team || team.length === 0) {
+      rows.push(row("tool-catalog", SKIP, "no roster", "nothing to read a grant from"));
+      return;
+    }
+    const orchestrator = team.find((t) => t.isOrchestrator) || team[0];
+    const res = await http(`${scope}/team/${encodeURIComponent(orchestrator.id)}`);
+    if (!res.ok) return push(rows, unread("tool-catalog", res, "the orchestrator's grants"));
+    const detail = res.body || {};
+    const tools = detail.tools || {};
+    const effective = tools.effective || [];
+    rows.push(
+      row(
+        "tool-catalog",
+        effective.length ? PASS : FAIL,
+        `${orchestrator.id}: ${effective.length} effective (requested ${(tools.requested || []).length}, ceiling ${(tools.companyAllow || []).length})`,
+        effective.length ? effective.slice(0, 12).join(", ") : "the orchestrator holds no tools, so it can do nothing but talk",
+      ),
+    );
+  }
+
+  /* ------------------------------------------------------------------ *
+   * OCQA.read()
+   * ------------------------------------------------------------------ */
+
+  async function read(options) {
+    const opts = options || {};
+    const rows = [];
+    const started = Date.now();
+
+    const spec = await checkHost(rows);
+    await checkConsoleCacheHeaders(rows);
+
+    const scope = await resolveScope(opts.company);
+    if (!scope) {
+      rows.push(row("scope", FAIL, "no company", "neither /api/v1/company nor /api/v1/companies answered — sign in first"));
+      return finish(rows, started, "read");
+    }
+
+    const company = await checkLifecycle(rows, scope);
+    const team = await checkRoster(rows, scope);
+    await checkDesks(rows, scope);
+    await checkTaskBoard(rows, scope);
+    await checkWorkspace(rows, scope);
+    const approvals = await checkApprovals(rows, scope);
+    await checkApprovalTier(rows, scope, approvals);
+    await checkConnections(rows, scope);
+    await checkComposio(rows, scope);
+    const caps = await http(`${scope}/capabilities`);
+    await checkMcp(rows, scope, spec, caps.ok ? caps.body : null);
+    await checkInference(rows, scope);
+    checkRepoBinding(rows, spec, company);
+    await checkWorkflows(rows, scope);
+    const runs = await checkRunHistory(rows, scope);
+    checkDeliveries(rows, runs);
+    await checkDataHygiene(rows, scope);
+    await checkSkills(rows, scope);
+    await checkUsageAndFinances(rows, scope);
+    await checkChatHistory(rows, scope);
+    await checkToolCatalog(rows, scope, team);
+
+    return finish(rows, started, "read", scope);
+  }
+
+  /* ------------------------------------------------------------------ *
+   * OCQA.probe() — five live checks that spend real tokens
+   * ------------------------------------------------------------------ */
+
+  /**
+   * A chat round trip.
+   *
+   * Given its own timeout well under the edge's 120s (#983), because the point
+   * is to *measure* the round trip rather than inherit an unbounded wait. A
+   * timeout here is a real finding with a number attached, not a hang.
+   */
+  async function probeChat(rows, scope, opts) {
+    const text = opts.chatText || "QA probe: reply with one short sentence naming this company. Do not open a task.";
+    const res = await http(`${scope}/chat`, { method: "POST", body: { text }, timeoutMs: opts.chatTimeoutMs || 90000 });
+    if (!res.ok) {
+      rows.push(
+        row(
+          "probe-chat",
+          FAIL,
+          `${res.error || `HTTP ${res.status}`} after ${secs(res.elapsedMs)}`,
+          "the turn may still be running invisibly — check chat/history and the board before calling it lost (#983)",
+        ),
+      );
+      return;
+    }
+    const replies = (res.body && res.body.responses) || [];
+    const first = replies[0] ? String(replies[0].text || "").slice(0, 120) : "";
+    rows.push(
+      row(
+        "probe-chat",
+        replies.length === 0 ? FAIL : res.elapsedMs > 30000 ? WARN : PASS,
+        `${secs(res.elapsedMs)} · ${replies.length} replies · "${first}"`,
+        replies.length === 0 ? "a 200 with no reply is a turn that answered nothing" : "",
+      ),
+    );
+  }
+
+  /** One addressed message per desk — the routing every desk claims to support. */
+  async function probeDesks(rows, scope, opts) {
+    const res = await http(`${scope}/desks`);
+    if (!res.ok) return push(rows, unread("probe-desks", res, "desks"));
+    const desks = (res.body || []).filter((d) => (d.members || []).length > 0);
+    if (desks.length === 0) return push(rows, row("probe-desks", SKIP, "no desks with members", "nothing to address"));
+    const results = [];
+    for (const desk of desks.slice(0, opts.maxDesks || 5)) {
+      const r = await http(`${scope}/chat`, {
+        method: "POST",
+        body: { text: "QA probe: in one sentence, what does this desk do?", chat: desk.id },
+        timeoutMs: opts.chatTimeoutMs || 90000,
+      });
+      const replies = (r.body && r.body.responses) || [];
+      results.push({ desk: desk.id, ok: r.ok && replies.length > 0, took: secs(r.elapsedMs) });
+    }
+    const failed = results.filter((r) => !r.ok);
+    rows.push(
+      row(
+        "probe-desks",
+        failed.length ? FAIL : PASS,
+        results.map((r) => `${r.desk}:${r.ok ? "" : "FAIL@"}${r.took}`).join(" · "),
+        failed.length ? `${failed.map((r) => r.desk).join(", ")} did not answer` : "",
+      ),
+    );
+  }
+
+  /** Card create → visible on the board → delete. The board's whole write path. */
+  async function probeBoardCard(rows, scope) {
+    const title = `QA probe card ${new Date().toISOString()}`;
+    const created = await http(`${scope}/tasks`, { method: "POST", body: { title, note: "Created by oc-qa.js. Safe to delete." } });
+    if (!created.ok || !created.body || !created.body.id) {
+      return push(rows, row("probe-board-card", FAIL, `create → ${created.error || `HTTP ${created.status}`}`, "the board cannot take a card"));
+    }
+    const id = created.body.id;
+    const board = await http(`${scope}/tasks`);
+    const visible = board.ok && (board.body || []).some((t) => t.id === id);
+    const removed = await http(`${scope}/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
+    rows.push(
+      row(
+        "probe-board-card",
+        visible && removed.ok ? PASS : FAIL,
+        `create ok · on board ${visible ? "yes" : "NO"} · delete ${removed.ok ? "ok" : `HTTP ${removed.status}`}`,
+        visible ? (removed.ok ? "" : `probe card ${id} was left behind — delete it by hand`) : "a created card the board does not list",
+      ),
+    );
+  }
+
+  /**
+   * One real workflow run, judged to a terminal state.
+   *
+   * Detached, then polled out of history: a synchronous run inherits the edge's
+   * unbounded wait (#983), and the run's own duration is what we are measuring.
+   * The verdict comes from `runVerdict`, so a run that delivered nothing scores
+   * `undelivered` and not `ok` — the mistake the first version of this check made.
+   */
+  async function probeWorkflowRun(rows, scope, opts) {
+    const list = await http(`${scope}/workflows`);
+    if (!list.ok) return push(rows, unread("probe-workflow-run", list, "workflows"));
+    const flows = list.body || [];
+    const target = opts.workflow ? flows.find((w) => w.id === opts.workflow) : flows[0];
+    if (!target) {
+      return push(rows, row("probe-workflow-run", SKIP, opts.workflow ? `no workflow "${opts.workflow}"` : "no workflows", "nothing to run"));
+    }
+    const body = { input: {} };
+    if (opts.dryRun) body.dry_run = true;
+    else body.detach = true;
+    const started = Date.now();
+    const res = await http(`${scope}/workflows/${encodeURIComponent(target.id)}/run`, { method: "POST", body, timeoutMs: 120000 });
+    if (!res.ok) {
+      if (notWired(res)) {
+        return push(
+          rows,
+          row("probe-workflow-run", SKIP, `${target.id} → workflow execution not wired in this deployment`, "this build has no workflow runner — untested, not failed"),
+        );
+      }
+      return push(rows, row("probe-workflow-run", FAIL, `${target.id} → ${res.error || `HTTP ${res.status}`}`, "the run was not accepted"));
+    }
+
+    // A host predating detach ignores the flag and answers the settled run, and
+    // a host predating dry-run ignores that flag and runs FOR REAL. Both are
+    // read back off the response, never assumed from what was asked.
+    if (opts.dryRun && res.body && res.body.dryRun !== true) {
+      rows.push(row("probe-workflow-run", WARN, `${target.id}: dryRun absent from the response`, "this host ignored the flag and ran for real — effects fired"));
+    }
+    if (res.body && res.body.detached !== true) {
+      const settled = { deliveries: (res.body && res.body.deliveries) || [], error: null, running: false };
+      const verdict = runVerdict(settled);
+      return push(rows, 
+        row(
+          "probe-workflow-run",
+          verdict === "ok" ? PASS : verdict === "awaiting-approval" ? WARN : FAIL,
+          `${target.id} → ${verdict} in ${secs(Date.now() - started)} · ${settled.deliveries.length} deliveries`,
+          describeDeliveries(settled.deliveries),
+        ),
+      );
+    }
+
+    const runId = res.body.runId;
+    const deadline = Date.now() + (opts.runTimeoutMs || 300000);
+    let last = null;
+    while (Date.now() < deadline) {
+      await sleep(3000);
+      const history = await http(`${scope}/workflows/runs?workflow=${encodeURIComponent(target.id)}&limit=20`);
+      if (!history.ok) continue;
+      last = (history.body || []).find((r) => r.runId === runId) || null;
+      if (last && last.running !== true) break;
+    }
+    if (!last) {
+      return push(rows, row("probe-workflow-run", SKIP, `${target.id} run ${runId} never appeared in history`, "untested — the run may still be walking its graph"));
+    }
+    const verdict = runVerdict(last);
+    if (verdict === "running") {
+      return push(rows, row("probe-workflow-run", FAIL, `${target.id} → still running after ${secs(Date.now() - started)}`, "did not reach a terminal state inside the probe window"));
+    }
+    rows.push(
+      row(
+        "probe-workflow-run",
+        verdict === "ok" ? PASS : verdict === "awaiting-approval" ? WARN : FAIL,
+        `${target.id} → ${verdict} in ${secs(Date.now() - started)} · ${(last.nodes || []).length} nodes · ${(last.deliveries || []).length} deliveries`,
+        last.error || describeDeliveries(last.deliveries),
+      ),
+    );
+  }
+
+  function describeDeliveries(deliveries) {
+    const dropped = (deliveries || []).filter((d) => d.status !== "sent" && d.status !== "pending");
+    if (dropped.length === 0) return "";
+    return dropped.map((d) => `${d.node} → ${d.target || d.kind}: ${d.reason || d.status} (${d.detail})`).join(" | ");
+  }
+
+  /** Did the probes park anything new at the gate? */
+  async function probeApprovalDelta(rows, scope, before) {
+    const res = await http(`${scope}/approvals`);
+    if (!res.ok) return push(rows, unread("probe-approval-delta", res, "the approvals queue"));
+    const after = res.body || [];
+    const seen = new Set((before || []).map((a) => a.id));
+    const fresh = after.filter((a) => !seen.has(a.id));
+    rows.push(
+      row(
+        "probe-approval-delta",
+        fresh.length ? WARN : PASS,
+        `${fresh.length} newly parked${fresh.length ? `: ${fresh.map((a) => a.kind).join(", ")}` : ""}`,
+        fresh.length ? "the probes left effects at the gate — resolve or deny them before leaving the tenant" : "",
+      ),
+    );
+  }
+
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function probe(options) {
+    const opts = options || {};
+    const rows = [];
+    const started = Date.now();
+    const scope = await resolveScope(opts.company);
+    if (!scope) {
+      rows.push(row("scope", FAIL, "no company", "sign in first"));
+      return finish(rows, started, "probe");
+    }
+    const before = await http(`${scope}/approvals`);
+    await probeChat(rows, scope, opts);
+    await probeDesks(rows, scope, opts);
+    await probeBoardCard(rows, scope);
+    await probeWorkflowRun(rows, scope, opts);
+    await probeApprovalDelta(rows, scope, before.ok ? before.body : []);
+    return finish(rows, started, "probe", scope);
+  }
+
+  /* ------------------------------------------------------------------ *
+   * Output
+   * ------------------------------------------------------------------ */
+
+  let lastRun = null;
+
+  function finish(rows, started, mode, scope) {
+    const tally = { PASS: 0, WARN: 0, FAIL: 0, SKIP: 0 };
+    for (const r of rows) tally[r.verdict] = (tally[r.verdict] || 0) + 1;
+    lastRun = {
+      mode,
+      scope: scope || null,
+      host: global.location ? global.location.host : "unknown",
+      atMillis: Date.now(),
+      elapsedMs: Date.now() - started,
+      tally,
+      rows,
+    };
+    console.table(rows);
+    console.log(
+      `%coc-qa ${VERSION} · ${mode} · ${rows.length} checks in ${secs(Date.now() - started)} — ` +
+        `${tally.PASS} pass, ${tally.WARN} warn, ${tally.FAIL} fail, ${tally.SKIP} untested`,
+      tally.FAIL ? "color:#dc2626;font-weight:bold" : tally.WARN || tally.SKIP ? "color:#d97706" : "color:#059669",
+    );
+    if (tally.SKIP) {
+      console.log("%cSKIP means untested, not passed. Do not write those up as green.", "color:#d97706");
+    }
+    console.log("OCQA.report() → Markdown for an issue.");
+    return rows;
+  }
+
+  /** The last run as a Markdown table, for pasting straight into an issue. */
+  function report() {
+    if (!lastRun) return "No run yet. Call OCQA.read() first.";
+    const lines = [
+      `## oc-qa ${VERSION} — \`${lastRun.mode}\` on \`${lastRun.host}\``,
+      "",
+      `${new Date(lastRun.atMillis).toISOString()} · ${secs(lastRun.elapsedMs)} · ` +
+        `${lastRun.tally.PASS} pass / ${lastRun.tally.WARN} warn / ${lastRun.tally.FAIL} fail / ${lastRun.tally.SKIP} untested`,
+      "",
+      "| Check | Verdict | Value judged | Note |",
+      "| --- | --- | --- | --- |",
+    ];
+    for (const r of lastRun.rows) {
+      const cell = (s) => String(s).replace(/\|/g, "\\|");
+      lines.push(`| \`${r.check}\` | ${r.verdict} | ${cell(r.value)} | ${cell(r.note)} |`);
+    }
+    const text = lines.join("\n");
+    console.log(text);
+    return text;
+  }
+
+  global.OCQA = {
+    version: VERSION,
+    read,
+    probe,
+    report,
+    /** Pure judgements, exposed so `frontend/test/unit/qa-harness.test.ts` can pin them. */
+    _internals: {
+      runVerdict,
+      undeliveredCount,
+      pendingCount,
+      awaitingCount,
+      isBlocked,
+      judgeCacheHeader,
+      age,
+      notWired,
+      secs,
+    },
+  };
+
+  console.log(`oc-qa ${VERSION} loaded. OCQA.read() · OCQA.probe() · OCQA.report()`);
+})(typeof globalThis !== "undefined" ? globalThis : this);


### PR DESCRIPTION
Closes #987.

## Summary

Lands the QA parity harness in the repo, so a release can be checked in one pass without hunting for the script first.

- **`qa/oc-qa.js`** — zero-dependency console script. `OCQA.read()` (22 read-only checks, ~10s), `OCQA.probe()` (5 live checks), `OCQA.report()` (Markdown for an issue). Rides the session cookie, so there is no token to distribute.
- **`qa/MASTER-QA.md`** — the seven UI checks a script cannot judge, the five persona tasks with an answered/grounded/honest/delivered rubric, and the single prompt that hands the pass to an agent.
- **`qa/README.md`** — how to run it, and the roll-the-tenant-first prerequisite.
- Pointers from `README.md` and a new *Checking a Release* section in `CONTRIBUTING.md`.

## Three rules enforced in code, not just described

1. **A verdict prints beside the value it judged**, so a PASS can be checked rather than trusted.
2. **Unreadable is never PASS.** A 404, an error, a feature absent from the build, or a missing precondition is `SKIP` — counted apart from PASS in the summary. A host answering `{"code":"not_wired"}` is included: a build with no workflow runner cannot run a workflow, and scoring that red sends somebody chasing a graph that is fine. Matched on the typed `code`, never the prose (#248).
3. **A check that missed a bug gets changed, not just supplemented.** `runVerdict` reads `deliveries`, `pendingApprovals` and `blockedNodes` in the console's own precedence order (`running → failed → stopped → blocked → undelivered → awaiting-approval → ok`) rather than folding `nodes[].status` — which is the mistake the harness itself made on the very run that found #981.

Those seven words are exactly the `WorkflowRunVerdict` #981 proposes server-side. When it lands, this transcription should be deleted and the host's verdict read instead; the file says so.

## The two checks worth keeping regardless of the rest

- **`console-cache-headers`** — caught #979. Now a regression guard: the fix is in `src/server/routes.rs`, so this reads PASS on a current build and a FAIL means a deploy reintroduced it.
- **`workflow-deliveries`** — caught #981. A run whose nodes are all `ok` can still have delivered nothing.

## Tests

`frontend/test/unit/qa-harness.test.ts` (31 tests) evaluates the script in a `vm` sandbox — it has no `export`, because an `export` would make it unpasteable, which is the one property it must not lose. It:

- pins `runVerdict` against `run-health.ts` case by case, **asserting both halves** (the console still reads it this way, AND the harness agrees) so the two cannot drift together silently;
- covers the `blocked` (#881) and gate-folding (#846) arms, whose absence scores a run that delivered nothing as green;
- pins the `#979` cache reading, including that an *absent* header is FAIL rather than WARN;
- drives the real `read()` over a 404ing host, asserting exactly 22 checks and that nothing unreadable reports PASS.

## Verification

- `npm run typecheck`, `npm run typecheck:unit`, `npm test` (922 tests, 88 files) — all green.
- Driven against a **live host** (`test/e2e/host.sh`, e2e_harness company) in both modes, signing in the way the e2e suite does. That run found three defects in the harness itself, all now fixed and pinned: a `not_wired` build scored FAIL, every duration printed as `0.0s`, and a doubled unit suffix.

## Known gaps, reported as SKIP rather than passed

- **Approval tier.** `[policy].mode` has no read surface on REST or GraphQL, so no API client can verify the setting that decides whether effects park at all. Filed separately.
- **Board drag** and **approvals-resolve** are browser-only; the latter needs a queued approval, which the 2026-08-18 pass could not create without changing the tenant's tier. `MASTER-QA.md` gives two ways to get one.
- **Persona quality** — #983 makes it properly measurable for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)