### PR TITLE
fix(workflows): refuse to arm a schedule the graph cannot keep

### DIFF
--- a/docs/modules/server/pausing-workflows.md
+++ b/docs/modules/server/pausing-workflows.md
@@ -34,6 +34,37 @@ all", and putting a re-enable click behind every typo fix is how an operator
 learns to click through it. `a_switched_off_workflow_does_not_fire` and
 `an_edit_that_adds_a_schedule_switches_the_workflow_off` pin the two halves.
 
+**A schedule that cannot run is refused arming (issue #976).** `set_company_workflow_enabled`
+rejects `enabled = true` when the graph carries a trigger schedule and has **no
+node other than its trigger**. Such a graph fires on time, runs nothing and
+reports nothing: on staging `campaign` was one resume away from exactly that.
+
+**Refused at arming, not at save**, and the distinction is the fix. Saving a stub
+mid-authoring is legitimate — the console drops a Start node first and adds
+stages after, `parse_workflow` was made lenient on purpose (issue #661) to allow
+it, and refusing at save would also refuse every existing seed and legacy body on
+its next edit. Saving promises nothing; switching a schedule on promises that
+something happens. Arming is also already the human gate the disarm rule above
+forces a scheduled graph through, and it has the parsed graph in hand for the
+journal name — so the check costs no extra load.
+
+Switching such a workflow **off** stays allowed, on the same principle as the
+unparseable-body case: an operator must always be able to stop a thing. A manual
+(unscheduled) stub is left alone — running one by hand is the author's business,
+and the run says so itself (below).
+
+**A run of a stage-less graph records a notice.** The engine runs such a graph
+happily — no stage fails, because there is no stage — so before this it settled
+as an ordinary finished run, and `QA Test Pipeline` banked six of them. It now
+carries `WorkflowRun.notices` (the issue #638 channel) saying it had nothing to
+run. Deliberately a notice and **not** an error: nothing broke and nothing was
+attempted, so marking it failed would put a half-authored stub into the failure
+count beside runs that genuinely went wrong — the same call issue #925 makes one
+level down with `NoDestinationConfigured`. `WorkflowFile::has_runnable_node` is
+the single predicate behind both halves, for the reason `trigger_schedule` is
+single: two copies that disagreed would let a graph be refused a schedule and
+still run silently, or the reverse.
+
 **In the console.** Each row carries a switch, rendered from `enabled` on the
 list read. Like `editable`, only an explicit `false` counts — a host predating
 issue `#276` sends no field, and `undefined` must not read as paused. A row the

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -131,9 +131,10 @@ pub use types::{
     grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
 };
 pub use workflow_file::{
-    WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,
-    WorkflowFile, WorkflowNodeDef, WorkflowNodeKind, WorkflowRetryDef, list_source_workflows,
-    list_workflows_union, list_workflows_with_globals, load_company_workflows, load_workflow_union,
+    STAGELESS_SCHEDULE_REFUSAL, STAGELESS_WORKFLOW_NOTICE, WORKFLOW_DESTINATION_KINDS,
+    WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
+    WorkflowNodeKind, WorkflowRetryDef, list_source_workflows, list_workflows_union,
+    list_workflows_with_globals, load_company_workflows, load_workflow_union,
     load_workflow_with_globals, parse_workflow,
 };
 // Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1493,16 +1493,49 @@ pub(crate) async fn set_company_workflow_enabled(
     // host cannot read is exactly the kind an operator most wants to stop, and
     // refusing would leave them nothing to do about it. It just journals under
     // its id.
-    let name = crate::company::load_workflow_with_globals(
+    let file = crate::company::load_workflow_with_globals(
         source_dir,
         &record.overlay_workflows,
         &record.manifest.globals.disable,
         wid,
     )
     .ok()
-    .flatten()
-    .map(|file| file.name)
-    .unwrap_or_else(|| wid.to_string());
+    .flatten();
+    let name = file
+        .as_ref()
+        .map(|file| file.name.clone())
+        .unwrap_or_else(|| wid.to_string());
+
+    // Issue #976: arming is where the promise is made, so it is where the
+    // promise is checked. A stage-less graph with a schedule fires on time, runs
+    // nothing and reports nothing — `campaign` on staging is exactly that, one
+    // resume away from a schedule it cannot keep.
+    //
+    // **Refused here rather than at save, deliberately.** Saving a stub
+    // mid-authoring is legitimate and the module is built for it: `parse_workflow`
+    // was made lenient on purpose (#661) so the console can drop a trigger and
+    // add stages afterwards, and refusing an empty graph at save would also
+    // refuse every existing seed and legacy body on its next edit. Saving
+    // promises nothing; switching a schedule on promises that something happens.
+    // This is also the human gate #276 already forces a scheduled graph through,
+    // and it has the parsed graph in hand for the journal name above — so the
+    // check costs no extra load.
+    //
+    // Only `enabled`, and only when a schedule is what is being armed. Switching
+    // such a workflow OFF stays allowed: an operator must always be able to stop
+    // a thing, which is the same call the unparseable-body case above makes.
+    // A manual (unscheduled) graph is left alone — running a stub by hand is the
+    // author's own business, and the run says so through
+    // [`STAGELESS_WORKFLOW_NOTICE`](crate::company::STAGELESS_WORKFLOW_NOTICE).
+    if enabled
+        && let Some(file) = file.as_ref()
+        && file.trigger_schedule().is_some()
+        && !file.has_runnable_node()
+    {
+        return Err(OpenCompanyError::InvalidRequest(
+            crate::company::STAGELESS_SCHEDULE_REFUSAL.to_string(),
+        ));
+    }
 
     if !record.set_workflow_enabled(wid, enabled) {
         return Ok(false);
@@ -2498,6 +2531,138 @@ to = "done"
                 .await
                 .expect_err("name collides with the overlay body");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    /// A graph whose only node is its trigger, carrying a schedule — the
+    /// `campaign` shape from staging (issue #976).
+    fn stageless_scheduled_draft(id: &str, name: &str) -> RawWorkflow {
+        let mut draft = valid_draft(id, name);
+        // Keep only the trigger, and put a schedule on it. This is what the
+        // console produces when somebody drops a Start node, sets a cron, and
+        // saves before adding any stage.
+        draft.nodes.retain(|n| n.kind == "trigger");
+        draft.edges.clear();
+        draft.nodes[0].schedule = Some("0 9 * * *".to_string());
+        draft
+    }
+
+    /// Saving one is **allowed**, and that is the deliberate half of the fix.
+    /// Authoring is incremental: the console drops a Start node first and adds
+    /// stages after, `parse_workflow` was made lenient on purpose (#661) to
+    /// support exactly that, and refusing at save would also refuse every
+    /// existing seed and legacy body on its next edit.
+    #[tokio::test]
+    async fn a_stageless_graph_still_saves() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            stageless_scheduled_draft("campaign", "Campaign"),
+        )
+        .await
+        .expect("a stub mid-authoring is legitimate and must save");
+    }
+
+    /// ...but switching its schedule on is refused. Arming is where the promise
+    /// is made, so it is where the promise is checked: resume this and it fires
+    /// on time, runs nothing, and reports nothing.
+    #[tokio::test]
+    async fn arming_a_stageless_schedule_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            stageless_scheduled_draft("campaign", "Campaign"),
+        )
+        .await
+        .expect("saves");
+
+        let err = set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "campaign",
+            true,
+        )
+        .await
+        .expect_err("a schedule that cannot run must not be armed");
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("no stage to run"),
+            "the operator is told WHAT is wrong: {rendered}"
+        );
+        assert!(
+            rendered.contains("Add at least one node"),
+            "...and the one thing they can do about it: {rendered}"
+        );
+    }
+
+    /// Switching such a workflow **off** stays allowed. An operator must always
+    /// be able to stop a thing — the same call the unparseable-body case makes
+    /// — and a guard that trapped a workflow in the armed state would be worse
+    /// than the silence it replaced.
+    #[tokio::test]
+    async fn a_stageless_schedule_can_still_be_switched_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            stageless_scheduled_draft("campaign", "Campaign"),
+        )
+        .await
+        .expect("saves");
+
+        set_company_workflow_enabled(&company, Some(dir.path()), &store, None, "campaign", false)
+            .await
+            .expect("pausing must never be refused");
+    }
+
+    /// A graph with a real stage arms normally. Without this the refusal above
+    /// would pass against a build that refused every schedule.
+    #[tokio::test]
+    async fn arming_a_scheduled_graph_with_a_stage_still_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let mut draft = valid_draft("greeter", "Greeter");
+        draft.nodes[0].schedule = Some("0 9 * * *".to_string());
+        create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+            .await
+            .expect("saves");
+
+        set_company_workflow_enabled(&company, Some(dir.path()), &store, None, "greeter", true)
+            .await
+            .expect("a graph that can actually run may be armed");
     }
 
     /// A manifest-`enabled` id with no body in either source is shown by the

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -166,7 +166,60 @@ impl WorkflowFile {
             .find(|node| node.kind == WorkflowNodeKind::Trigger && node.schedule.is_some())
             .and_then(|node| node.schedule.as_deref())
     }
+
+    /// Whether this graph has any node that could actually do something
+    /// (issue #976).
+    ///
+    /// A `trigger` says *when* a workflow runs, never *what* it does, so a graph
+    /// whose nodes are all triggers is stage-less: the engine executes it
+    /// happily, no stage fails because there is no stage, and it settles as an
+    /// ordinary finished run. On staging that produced `QA Test Pipeline` with
+    /// six recorded runs that could not have done anything, and `campaign`
+    /// holding a schedule it cannot keep.
+    ///
+    /// Expressed as "is there a non-trigger node" rather than a node **count**,
+    /// which is the tempting shortcut and is wrong twice: a graph of three
+    /// triggers has three nodes and still does nothing, and a legitimate
+    /// one-stage graph (trigger → agent) has only two. What matters is whether
+    /// any node kind *executes*, and every kind except `Trigger` does.
+    ///
+    /// The single definition, shared by the arming refusal in
+    /// `workflow_create.rs` and the run notice in
+    /// [`workflows::runner`](crate::workflows::runner) — for the reason spelled
+    /// out on [`trigger_schedule`](Self::trigger_schedule) just above: two copies
+    /// of a predicate that disagreed would let a graph be refused a schedule and
+    /// still run silently, or the reverse.
+    pub fn has_runnable_node(&self) -> bool {
+        self.nodes
+            .iter()
+            .any(|node| node.kind != WorkflowNodeKind::Trigger)
+    }
 }
+
+/// What a run of a stage-less graph records (issue #976).
+///
+/// Carried as a run **notice**, not an error: an empty graph is not a failure.
+/// Nothing broke and nothing was attempted, so marking the run failed would put
+/// a half-authored stub into the failure count beside runs that genuinely went
+/// wrong — the same call [`DeliveryReason::NoDestinationConfigured`] makes one
+/// level down (issue #925), and the same one #638 already made for the
+/// approval-overflow notice this rides alongside.
+///
+/// A literal, like every other notice: nothing runtime-supplied reaches an
+/// operator surface through it.
+///
+/// [`DeliveryReason::NoDestinationConfigured`]: crate::ports::DeliveryReason::NoDestinationConfigured
+pub const STAGELESS_WORKFLOW_NOTICE: &str = "This workflow has no stage to run — its only node is the trigger that starts it — so this \
+     run did nothing. Add at least one node after the trigger and run it again.";
+
+/// Why arming a stage-less workflow's schedule is refused (issue #976).
+///
+/// Says what is wrong, why it matters, and the one thing the operator can do —
+/// the shape [`DrainedRequests::overflow_notice`](crate::harness::policy::DrainedRequests::overflow_notice)
+/// established for telling somebody their work will not happen.
+pub const STAGELESS_SCHEDULE_REFUSAL: &str = "This workflow has no stage to run — its only node is the trigger that starts it — so a \
+     schedule would fire on time and do nothing. Add at least one node after the trigger, then \
+     switch it on.";
 
 /// A single node in a workflow graph.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -585,3 +585,85 @@ mod pure {
         assert!(run.approvals.is_empty());
     }
 }
+
+// ── a graph with nothing to run (issue #976) ────────────────────────────────
+
+/// The `campaign` / `QA Test Pipeline` shape from staging: a graph whose only
+/// node is the trigger that starts it.
+fn stageless_graph() -> String {
+    r#"
+id = "campaign"
+name = "Campaign"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+"#
+    .to_string()
+}
+
+/// A run of a stage-less graph says so.
+///
+/// This is the half of #976 that is about honesty rather than prevention.
+/// `QA Test Pipeline` had **six recorded runs** that could not have done
+/// anything: the engine runs such a graph happily, no stage fails because there
+/// is no stage, and it settles as an ordinary finished run. A run row that says
+/// nothing is its own small lie — from the run list it is indistinguishable
+/// from a run that did work.
+#[tokio::test]
+async fn a_run_of_a_stageless_graph_says_it_had_nothing_to_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, _journal, _transcript) =
+        run_pipeline_over(dir.path(), &stageless_graph(), Vec::new()).await;
+
+    assert!(
+        run.notices
+            .iter()
+            .any(|n| n.contains("no stage to run") && n.contains("Add at least one node")),
+        "the operator is told the run had nothing to do, and what to do about it: {:?}",
+        run.notices
+    );
+}
+
+/// ...and it is a **notice**, not a failure. An empty graph is not a broken
+/// one: nothing was attempted and nothing went wrong, so putting a
+/// half-authored stub in the failure count beside runs that genuinely failed
+/// would trade one misreading for another. The same call `#638` made for the
+/// approval-overflow notice this rides alongside, and `#925` made one level
+/// down for `NoDestinationConfigured`.
+#[tokio::test]
+async fn a_stageless_run_is_not_recorded_as_a_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, _journal, _transcript) =
+        run_pipeline_over(dir.path(), &stageless_graph(), Vec::new()).await;
+
+    assert!(
+        run.blocked_nodes.is_empty(),
+        "nothing was blocked: {:?}",
+        run.blocked_nodes
+    );
+    assert!(
+        run.pending_approvals.is_empty(),
+        "nothing is waiting on a person: {:?}",
+        run.pending_approvals
+    );
+}
+
+/// An ordinary graph raises no such notice. Without this the assertion above
+/// would pass against a build that notices on every run, which would train an
+/// operator to skip the one that matters.
+#[tokio::test]
+async fn a_graph_with_a_stage_raises_no_stageless_notice() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, _journal, _transcript) = run_pipeline(
+        dir.path(),
+        vec![Turn::Say("Wrote the spec."), Turn::Say("Reviewed it.")],
+    )
+    .await;
+
+    assert!(
+        !run.notices.iter().any(|n| n.contains("no stage to run")),
+        "a graph that can run must stay quiet: {:?}",
+        run.notices
+    );
+}

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -297,6 +297,26 @@ async fn run_workflow_inner(
     // *outside* the capability bundle, so a hard abort that drops the engine future
     // (and with it the bundle and its board claim) still leaves every row already
     // collected readable here: a card is real once written, so it must stay listed.
+    // Issue #976: a graph whose only node is its trigger has nothing to execute.
+    // The engine runs it happily — there is no stage to fail — so it settles as
+    // an ordinary finished run, and a run row that says nothing is its own small
+    // lie: `QA Test Pipeline` on staging banked six of them. Said here, through
+    // the channel #638 built for exactly this shape of fact.
+    //
+    // A notice rather than an error, for the reason `notices` exists at all: an
+    // empty graph is not a failure. Nothing broke, nothing was attempted, and
+    // marking it failed would put a half-authored stub into the failure count
+    // next to runs that genuinely went wrong. Same call `NoDestinationConfigured`
+    // makes one level down (#925) — state the reason instead of leaving it to be
+    // inferred from an absence.
+    if !workflow.has_runnable_node() {
+        notices.push(crate::company::STAGELESS_WORKFLOW_NOTICE.to_string());
+        tracing::warn!(
+            company = %record.id,
+            workflow = %workflow.id,
+            "workflow run: the graph has no runnable node, so this run could not do anything"
+        );
+    }
     let board = super::caps::RunBoard::default();
     // Issue #881 / #880: the two sideways channels an agent node reports through
     // — that it blocked, and what it parked. Owned out here for exactly the


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#976.

A graph whose only node is its trigger has nothing to execute. The engine runs it happily —
no stage fails, because there is no stage — so it saves clean, accepts a schedule, and
settles as an ordinary finished run. On staging that left `campaign` one resume away from a
schedule it cannot keep, and `QA Test Pipeline` with **six recorded runs** that could not
have done anything.

### First: #661 is a coverage gap, not a regression

Worth settling before anything else, because the next person will otherwise assume #661
covered this and go looking for a regression.

The two commits that touched the draft validator under #661 are `1c5863cf` *"enforce
per-kind required config at author time"* and `c3449ab9` *"enforce the #661 rules strictly
on the draft path"*. What they added: a `condition` needs a `field`; branch labels must be
`yes`/`no`; `tool_call` needs a slug; `agent` must name a real roster teammate; collect
every missing-config problem per node.

**Every one of those rules presupposes a node of that kind exists.** A graph of one
`trigger` node has zero conditions, zero tool_calls, zero agents — so all of #661 is
satisfied **vacuously**. It validated the *quality of the nodes present*; this is the
*absence of any node to run*. Nothing regressed; the case was never in scope.

Confirming the issue's other suspicion: there is no node-count guard.
`validate_draft_shape` bounds nodes and edges from **above** (`MAX_WORKFLOW_NODES`,
`MAX_WORKFLOW_EDGES`) and requires **exactly one** trigger — so a lone trigger *passes*.
The only `len() < 2` in the module is an unrelated cycle-detection component check.

### The guard is at arming, not at save

A reviewer will ask why not refuse at save, so: four reasons, and the first is the
important one.

1. **A stub must stay saveable mid-authoring, and the module is already built that way.**
   `parse_workflow` was made lenient **on purpose** — `c3449ab9`'s own commit message moved
   author-time strictness onto the draft path precisely so the console can drop a Start node
   and add stages later. Refusing at save fights that design.
2. Refusing at save would reject **every existing seed and legacy body on its next edit**,
   including what is on staging now.
3. **Saving promises nothing; arming a schedule promises that something happens.** That
   sentence is the issue's whole thesis, and it lands on arming.
4. #276 already routes scheduled graphs through that human gate **disarmed**, and
   `set_company_workflow_enabled` **already loads the parsed graph** for the journal display
   name — so the check costs no extra I/O.

**Pausing is never refused.** Only `enabled = true` is guarded, and only when a trigger
schedule exists. An operator must always be able to stop a thing — the same call the
existing "a body that no longer parses still toggles" rule makes. A guard that trapped a
workflow *armed* would be worse than the silence it fixes. A manual (unscheduled) stub is
left alone too: running one by hand is the author's own business, and the run says so
itself.

### What a run records: a notice, not an error

No new run status. `WorkflowRunFinished.notices` already exists for exactly this shape
(#638), and its own doc reads like it was written for this issue:

> A run has no conversation to speak on… **Separate from `error` on purpose: a run that
> overflowed the cap succeeded, and putting this there would mark it failed and inflate the
> failure count.**

A stage-less run is the same class. **Nothing broke and nothing was attempted**, so marking
it failed would put a half-authored stub into the failure count beside runs that genuinely
went wrong — the same call #925 makes one level down with `NoDestinationConfigured`, which
exists so "routed nothing on purpose" and "never configured a destination" stop being the
same observation. Here the pair is "this run had nothing to do" versus "this run did
nothing". That is what makes `QA Test Pipeline`'s six runs read honestly without
retroactively marking them failed.

### One predicate

`WorkflowFile::has_runnable_node()` sits beside `trigger_schedule()` and inherits its
reasoning: two copies of a predicate that disagreed would let a graph be refused a schedule
and still run silently, or the reverse.

It asks "is there a non-trigger node", **not** a node count. The count is the tempting
shortcut and is wrong twice: a graph of three triggers has three nodes and still does
nothing, while a legitimate one-stage graph (trigger → agent) has only two. What matters is
whether any node kind *executes*, and every kind except `Trigger` does.

## API Or Behavior Changes

New: `WorkflowFile::has_runnable_node()`, and two operator-facing string constants.

Behaviour: `PUT …/workflows/{wid}/enabled` with `{"enabled": true}` now returns 400 for a
scheduled graph with no runnable node. Pausing, saving, editing, and manual runs are
unchanged. A stage-less run gains one `notices` row; every other run is byte-identical.

**Existing staging data is untouched by this PR.** `campaign` stays paused and this guard
would refuse resuming it, which is the intended outcome; cleaning up those rows and the six
recorded runs is a separate human decision.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
      exit 0. `--no-deps` mirrors `ci.yml`; a bare `--all-targets` drowns in vendored lints CI
      never compiles.
- [x] `cargo build --all-targets` — covered by the two test lanes below, which build all
      targets for both feature sets.
- [x] `cargo test` — both halves. Default features: `cargo test --locked`, exit 0. Gated lane:
      `RUST_MIN_STACK=16777216 cargo test --locked --features openhuman,tinycortex --tests`
      → **4230 passed / 0 failed**. `RUST_MIN_STACK` matches `ci.yml:626`; without it a
      pre-existing `harness::brain` test overflows the stack locally.

`scripts/ci/assert-feature-lanes.sh` passes; no new row is owed.

### Revert proof — two, each isolating a half

| Reverted | Result |
| --- | --- |
| the arming refusal block | `arming_a_stageless_schedule_is_refused` **FAILED** |
| the run-notice condition → `if false` | `a_run_of_a_stageless_graph_says_it_had_nothing_to_run` **FAILED** |

**Being straight about the other five.** `a_stageless_graph_still_saves`,
`a_stageless_schedule_can_still_be_switched_off`,
`arming_a_scheduled_graph_with_a_stage_still_works`,
`a_graph_with_a_stage_raises_no_stageless_notice` and
`a_stageless_run_is_not_recorded_as_a_failure` survive both reverts. They are guard tests —
they exist so the fix cannot *over*-fire (refusing every schedule, noticing on every run,
trapping a workflow armed) — not discriminating ones, and I am not counting them as
coverage for the fix itself.

## Documentation

`docs/modules/server/pausing-workflows.md` — the doc that already owns the arming gate and
the #276 disarm rule — gains the refusal, the save-versus-arm reasoning, why pausing is
never refused, and the run-notice decision.
