### PR TITLE
fix(console): keep the sidebar's attention signal when the rail collapses (#1018)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -30,6 +30,7 @@ import {
   SidebarInset,
   SidebarMenu,
   SidebarMenuBadge,
+  SidebarMenuDot,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
@@ -1192,7 +1193,20 @@ export function AppShell({
                     <span>{item.label}</span>
                   </SidebarMenuButton>
                   {item.view === "approvals" && pending > 0 && (
-                    <SidebarMenuBadge>{pending}</SidebarMenuBadge>
+                    <>
+                      <SidebarMenuBadge>{pending}</SidebarMenuBadge>
+                      {/* Issue #1018: the badge is the sidebar's only attention
+                          signal and `SidebarMenuBadge` hides itself on the
+                          collapsed rail, so a collapsed sidebar said nothing was
+                          waiting. The dot is the same `pending` value rendered
+                          so it survives 32px — not a second source, so it cannot
+                          disagree with the badge or fork the count contract
+                          #932 pins. Exactly one of the two is visible at a
+                          time. */}
+                      <SidebarMenuDot
+                        label={`${pending} ${pending === 1 ? "approval needs" : "approvals need"} you`}
+                      />
+                    </>
                   )}
                 </SidebarMenuItem>
               ))}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -616,6 +616,59 @@ function SidebarMenuBadge({
   )
 }
 
+/**
+ * The attention mark that survives collapse (issue #1018).
+ *
+ * # Why this exists beside `SidebarMenuBadge` rather than replacing it
+ *
+ * [`SidebarMenuBadge`] carries `group-data-[collapsible=icon]:hidden`, and that
+ * is correct: a two-digit count does not fit a 32px rail, which is why upstream
+ * hides it. The defect was that the count was the sidebar's **only** attention
+ * signal, so hiding it hid the fact that anything was waiting at all — a
+ * collapsed rail showing nothing is indistinguishable from all-clear.
+ *
+ * This is the exact mirror of that rule: `hidden` until the rail collapses, then
+ * shown. So precisely one of the two renders at any width — a count while there
+ * is room to read one, a mark when there is not. Both are driven from the same
+ * value, so the collapsed and expanded states can never disagree.
+ *
+ * # Why a dot and not the number
+ *
+ * The same reason the select popup fades its clipped row rather than adding a
+ * count beside its trigger (issue #975): a signal that has to be *read* does not
+ * survive being shrunk. A mark does. What it deliberately does not do is claim
+ * how many — the number stays the badge's job, and the accessible name below is
+ * where the count goes for anyone who cannot see the mark.
+ *
+ * `--status-blocked` is the console's existing "waiting on a person" amber, the
+ * same one the workflow run panel uses for a parked gate, so this introduces no
+ * new colour vocabulary.
+ */
+function SidebarMenuDot({
+  className,
+  label,
+  ...props
+}: React.ComponentProps<"span"> & { label: string }) {
+  return (
+    <span
+      data-slot="sidebar-menu-dot"
+      data-sidebar="menu-dot"
+      // `role="img"` + `aria-label` because a bare coloured span is invisible to
+      // a screen reader, and colour alone is not a signal everyone receives. The
+      // label names WHAT is waiting and HOW MANY, so the information the badge
+      // carried visually is not lost with it.
+      role="img"
+      aria-label={label}
+      title={label}
+      className={cn(
+        "pointer-events-none absolute top-1.5 right-1.5 hidden size-2 rounded-full bg-[var(--status-blocked)] ring-2 ring-sidebar select-none group-data-[collapsible=icon]:block",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
 function SidebarMenuSkeleton({
   className,
   showIcon = false,
@@ -729,6 +782,7 @@ export {
   SidebarMenuAction,
   SidebarMenuBadge,
   SidebarMenuButton,
+  SidebarMenuDot,
   SidebarMenuItem,
   SidebarMenuSkeleton,
   SidebarMenuSub,

--- a/frontend/test/unit/sidebar-attention-dot.test.ts
+++ b/frontend/test/unit/sidebar-attention-dot.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SidebarMenuBadge, SidebarMenuDot } from "@/components/ui/sidebar";
+
+/**
+ * The sidebar's attention signal survives collapse (issue #1018).
+ *
+ * The sidebar had exactly one attention signal — a count on Approvals — and
+ * `SidebarMenuBadge` carries `group-data-[collapsible=icon]:hidden`, so it is
+ * `display: none` the moment the rail collapses to icons. That rule is correct
+ * on its own terms: a two-digit count does not fit a 32px rail, which is why
+ * upstream hides it. The defect is that the count was the *only* signal, so
+ * hiding it hid the fact that anything was waiting at all.
+ *
+ * **A collapsed rail showing nothing is indistinguishable from all-clear**, and
+ * that is the failure: not a missing number, a missing answer to "does anything
+ * need me?".
+ *
+ * # The same rule as the select popup's fade (issue #975)
+ *
+ * Both are controls that hid information without saying they were hiding
+ * anything, and both are answered the same way rather than two ways: **the
+ * signal must survive the constrained form, and must not depend on reading a
+ * number.** There the clipped row is allowed to show through instead of being
+ * painted over; here a mark replaces a count that cannot fit.
+ *
+ * # What this pins, and what it cannot
+ *
+ * jsdom applies no Tailwind, so `display` cannot be computed here — the visible
+ * proof is a real Chromium measurement across both states, recorded in the PR.
+ * What is pinned is the rule: the dot's visibility must be the exact **mirror**
+ * of the badge's, so precisely one of the two shows at any width. A "fix" that
+ * un-hid the badge instead (the thing the issue explicitly warns against) or
+ * dropped the mirror fails here.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function dot(label = "19 approvals need you") {
+  act(() => {
+    root.render(createElement(SidebarMenuDot, { label }));
+  });
+  return container.querySelector('[data-slot="sidebar-menu-dot"]');
+}
+
+describe("the sidebar's collapsed attention dot", () => {
+  it("shows only once the rail has collapsed", () => {
+    const cls = dot()?.className ?? "";
+    expect(cls).toMatch(/(^|\s)hidden(\s|$)/);
+    expect(cls).toContain("group-data-[collapsible=icon]:block");
+  });
+
+  it("is the exact mirror of the badge, so the two never both show", () => {
+    // The badge hides when collapsed; the dot shows only then. If these ever
+    // stop being opposites the rail either says nothing again or says it twice.
+    act(() => {
+      root.render(createElement(SidebarMenuBadge, null, "19"));
+    });
+    const badgeCls =
+      container.querySelector('[data-slot="sidebar-menu-badge"]')?.className ?? "";
+    expect(badgeCls).toContain("group-data-[collapsible=icon]:hidden");
+    expect(dot()?.className ?? "").toContain("group-data-[collapsible=icon]:block");
+  });
+
+  it("names what is waiting, so the signal is not colour alone", () => {
+    // A bare coloured span is invisible to a screen reader, and colour is not a
+    // channel everyone receives. The label carries what the badge carried.
+    const d = dot();
+    expect(d?.getAttribute("role")).toBe("img");
+    expect(d?.getAttribute("aria-label")).toBe("19 approvals need you");
+    // `title` also gives the collapsed rail a hover explanation it did not have.
+    expect(d?.getAttribute("title")).toBe("19 approvals need you");
+  });
+
+  it("does not render the count itself", () => {
+    // The whole point: a number is what could not survive the rail. If the
+    // digits come back, this has become the badge again and will be hidden with
+    // it.
+    expect(dot()?.textContent).toBe("");
+  });
+
+  it("still renders", () => {
+    // Guards the guard: every assertion above passes against nothing.
+    expect(dot()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The sidebar had exactly one attention signal — a numeric badge on **Approvals** — and it is `display: none`
the moment the rail collapses to icons.

**The failure this prevents: a collapsed rail showing nothing is indistinguishable from all-clear.** That is
worse than a missing number. An operator working collapsed had no way to learn that anything needed them
without expanding the sidebar and reading, or navigating tab by tab. Reproduced on
`marketing.staging.opencompany.work` with 19 pending approvals.

`SidebarMenuBadge`'s `group-data-[collapsible=icon]:hidden` is not itself wrong — a two-digit count does not
fit a 32px rail, which is why upstream hides it. The defect is that the count was our **only** signal, so
hiding it hid the fact that anything was waiting at all.

## The fix reads the value that already exists

**No new data source.** The dot renders the same `pending` the badge renders — already in the shell, already
polled, already reconciled against the queue by #932's contract test. A second source would have been the
easy version of this and would have created a new way for the rail to lie; instead the collapsed and
expanded states are two renderings of one number and cannot disagree. The count contract is untouched.

`SidebarMenuDot`'s visibility is the **exact mirror** of the badge's:

| | badge | dot |
|---|---|---|
| rule | `group-data-[collapsible=icon]:hidden` | `hidden` + `group-data-[collapsible=icon]:block` |

So precisely one of the two renders at any width — there is no width where both appear, and none where
neither does.

## Measured, both states, real Chromium

| | `data-collapsible` | badge | dot |
|---|---|---|---|
| **expanded** | `""` | `display: flex`, visible | `display: none` |
| **collapsed** | `"icon"` | `display: none` (upstream rule intact) | **`display: block`, visible** |

Both states report `role="img"` and `aria-label="19 approvals need you"`.

This is the direct answer to the DOM sweep in the issue, which recorded `badgeExistsInDom: true`,
`badgeVisible: false`, `badgeDisplay: "none"` when collapsed.

Visually: the shield gains a small mark at its top-right when collapsed — close to the "green light on the
shield" the reporter asked for. It is amber because `--status-blocked` is already the console's "waiting on a
person" colour (the same one the workflow run panel uses for a parked gate), so this introduces no new colour
vocabulary. Expanded is unchanged: `Approvals  19`.

**Why a dot rather than a smaller number:** a signal that has to be *read* does not survive being shrunk. A
mark does. The dot deliberately renders no digits — how many stays the badge's job.

**`aria-label="19 approvals need you"`** is the part that makes this work for someone not reading pixels: a
bare coloured span is invisible to a screen reader, and colour is not a channel everyone receives. The label
carries what the badge carried, and `title` gives the collapsed rail a hover explanation it did not have.

## Consistency with #975

These two are the same bug in different clothes — controls that hid information without saying they were
hiding anything — and they get **one** rule, not two inventions:

> the signal must survive the constrained form, and must not depend on reading a number.

In #975 (PR #1025) the clipped next row is allowed to show through instead of being painted over by an opaque
strip. Here a mark replaces a count that cannot fit. Both test headers cross-reference the other.

## API Or Behavior Changes

- New `SidebarMenuDot` primitive in `components/ui/sidebar.tsx`. Opt-in; nothing else in the console renders
  one yet.
- The Approvals nav entry shows a dot on the collapsed rail when `pending > 0`. Expanded behaviour is
  byte-identical.
- The badge is **not** un-hidden when collapsed — the issue explicitly warns against that, and a two-digit
  count in a 32px rail is why upstream hides it.

**Deliberately not done:** no attention signal for Tasks or Workflows. No equivalent state exists there, and
guessing one would produce a permanently lit dot — worse than none, because it teaches operators to ignore
all of them. The Chat rollup (the issue's item 2) is real and derivable from the existing `unread` map, but
this is scoped to item 1, the reported gap.

## Tests

`frontend/test/unit/sidebar-attention-dot.test.ts`, 5 cases: the dot shows only once collapsed; it is the
exact mirror of the badge; it names what is waiting (`role`, `aria-label`, `title`); it renders no digits;
and a guard-the-guard that it renders at all.

**Teeth proved by reverting: 2 of the 5 fail** when the mirror rule is dropped — the two that assert
visibility. The other three assert different properties (accessible name, no digits, renders) and correctly
still pass. Reporting 2, not 5.

**The test is collected.** The vitest include glob is `test/unit/**/*.test.ts` — a first draft written as
`.test.tsx` was silently excluded and would have shipped reading as coverage while never running. Rewritten
with `createElement` to match the convention the other tests in this directory use, and confirmed present by
name in the full-suite output (`✓ test/unit/sidebar-attention-dot.test.ts (5 tests)`).

jsdom applies no Tailwind, so `display` cannot be computed there; the visible proof is the Chromium
measurement above. What the unit test pins is the rule — that the two visibility conditions stay opposites.

- [x] `cargo fmt --all -- --check` — N/A: console-only change, no Rust touched.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: console-only change, no Rust touched.
- [x] `cargo build --all-targets` — N/A: console-only change, no Rust touched.
- [x] `cargo test` — N/A for Rust. The console gates were run instead: `pnpm typecheck` (`tsc -b --noEmit`)
      clean, `pnpm test` **883 passed / 86 files**. (883 rather than 886 because this branch is off `main`
      and so does not carry PR #1025's 8 tests, plus the 5 added here.) There is no eslint config under
      `frontend/`, so `typecheck` is the lint gate.

## Documentation

The reasoning is at the code: `SidebarMenuDot` records why it exists beside the badge rather than replacing
it, why a dot rather than the number, and why `--status-blocked`. The call site in `app-shell.tsx` records
that both renderings read one value so they cannot disagree.

Closes tinyhumansai/opencompany#1018
