### PR TITLE
fix(chat): stop opening a task card for an ordinary message (#984) — land after #997

### DIFF
--- a/docs/spec/runtime/api-graphql.md
+++ b/docs/spec/runtime/api-graphql.md
@@ -142,10 +142,16 @@ conversational surface) and the `/events` work feed
   the orchestrator — a DM, or any addressed thread — the runner also calls
   `open_direct_work_card`, which defers to `is_trackable_work` rather than to
   `triage_message`. That detector asks "is there any reason NOT to track this?"
-  and so accepts everything except an empty string, a syntactic question, and a
-  short acknowledgement. A message the documented Layer A classified as
-  `Chatter` could therefore still become a card by this door, which is how a
-  board came to hold 78 chat lines in review.
+  and so accepts everything except an empty string, a question **that names no
+  recognised work verb**, and a short acknowledgement.
+
+  The order of those rungs matters and is deliberate: a `WORK_VERBS` hit is
+  checked **before** question syntax, so *"Can you write up the incident
+  review?"* is tracked — it is a question in shape and a request for work in
+  substance, and the substance wins. Only a question with no work verb is
+  excluded. A message the documented Layer A classified as `Chatter` could
+  therefore still become a card by this door, which is how a board came to hold
+  78 chat lines in review.
 
   What closes it is the escalation verdict, which already ran and was
   discarded. On the abstention set only, the model is asked; an `Answer`

--- a/docs/spec/runtime/api-graphql.md
+++ b/docs/spec/runtime/api-graphql.md
@@ -136,6 +136,26 @@ conversational surface) and the `/events` work feed
   `200` with the echo brain's `"You said: …"` rather than an error, so a caller
   that needs a real answer must check `cognition` from `GET {scope}/inference`
   — there is no status code to catch.
+
+  **There is a third card path, and it has the opposite default** (#984). The
+  two above are the route's. When the responder is a desk member rather than
+  the orchestrator — a DM, or any addressed thread — the runner also calls
+  `open_direct_work_card`, which defers to `is_trackable_work` rather than to
+  `triage_message`. That detector asks "is there any reason NOT to track this?"
+  and so accepts everything except an empty string, a syntactic question, and a
+  short acknowledgement. A message the documented Layer A classified as
+  `Chatter` could therefore still become a card by this door, which is how a
+  board came to hold 78 chat lines in review.
+
+  What closes it is the escalation verdict, which already ran and was
+  discarded. On the abstention set only, the model is asked; an `Answer`
+  narrows the claim as before, and a `Chatter` now stands both runner card
+  paths down. It is carried separately from the answering flag because
+  `Chatter` still must not withdraw the model's board tools — taking those away
+  on a maybe turns a triage miss into work silently refused. The verdict can
+  only **subtract** a card: it is consulted nowhere else, and `Work`,
+  `Unavailable`, an unwired escalation or a non-harness build all leave the
+  deterministic decision exactly as it was.
 - **`/events`** is the work feed's backend: each frame is a plain-language
   rendering of an event or executed effect plus the raw payload for
   programmatic consumers. Resumable via `since` (event sequence number).

--- a/src/harness/triage.rs
+++ b/src/harness/triage.rs
@@ -102,6 +102,19 @@ impl TriageVerdict {
         matches!(self, Self::Answer)
     }
 
+    /// Whether the model positively read this message as **conversation**
+    /// (issue #984) — so the deterministic card paths open nothing for it.
+    ///
+    /// [`Work`](Self::Work) and [`Unavailable`](Self::Unavailable) are both
+    /// false, and for the same reason from opposite directions: `Work` is the
+    /// model saying a card is right, and `Unavailable` is the model saying
+    /// nothing at all. Only an explicit `Chatter` may subtract a card, which is
+    /// what keeps every degraded path byte-identical to the behaviour before
+    /// this verdict had a consumer.
+    pub fn is_chatter(&self) -> bool {
+        matches!(self, Self::Chatter)
+    }
+
     /// Reads a model's reply as a verdict, or [`Self::Unavailable`].
     ///
     /// A **closed vocabulary**, matched on the first recognised word rather than

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -309,14 +309,18 @@ pub(crate) struct DeskReply {
     pub(crate) hit_iteration_cap: bool,
 }
 
-/// What was already decided about the operator message a drain belongs to,
-/// before the model said anything (issues #463, #267).
+/// What was already decided about the operator message a drain belongs to
+/// (issues #463, #267, #984).
 ///
-/// Two facts carried together because they answer the same question and because
-/// a pair of bare `bool` parameters at a call site is a swap waiting to happen.
-/// Both default to `false`, which is the honest reading for every drain with no
+/// Facts carried together because they answer the same question and because a
+/// run of bare `bool` parameters at a call site is a swap waiting to happen.
+/// All default to `false`, which is the honest reading for every drain with no
 /// operator message in scope — a dispatched card's turn, the approval
 /// re-dispatch — neither of which has a message to have carded or triaged.
+///
+/// Two of the three are settled before the model says anything; `chatter` is
+/// the exception (issue #984) and is the model's own verdict, which is why it
+/// is a separate field rather than another reading of `answering`.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct MessageContext {
     /// The REST chat handler already opened a To-do card for this message
@@ -328,6 +332,21 @@ pub(crate) struct MessageContext {
     /// question the orchestrator cannot answer alone gets answered — but it
     /// opens no card, because nobody commissioned work.
     pub(crate) answering: bool,
+    /// The lexical layer abstained and the **model** read this message as
+    /// conversation (issue #984).
+    ///
+    /// Distinct from [`answering`](Self::answering) on purpose. That flag also
+    /// narrows the model's own board tools; this one must not, because `Chatter`
+    /// is the ambiguous bucket and withdrawing tools on a maybe is the expensive
+    /// direction. All this does is stand the two deterministic card paths down —
+    /// the paths that would otherwise open a card because
+    /// [`is_trackable_work`]'s default is "everything is work".
+    ///
+    /// Only ever `true` where the lexical layer already abstained, so it can
+    /// **subtract** a card and never mint one. Every degraded path — no harness,
+    /// no escalation wired, an unparseable or slow verdict — leaves it `false`
+    /// and behaves exactly as before.
+    pub(crate) chatter: bool,
 }
 
 /// Whether a drain may run the hand-offs it finds, or must drop them.
@@ -836,6 +855,21 @@ impl<'a> DelegationRunner<'a> {
         // orphan it. `Work` and `Chatter` therefore both leave the gate where
         // the abstention left it, and only `Answer` moves it.
         let mut answering = triage.is_answer();
+        // Issue #984: the same escalation, read for BOTH of its useful answers.
+        //
+        // `Answer` narrows the claim, as it always has. `Chatter` was computed,
+        // logged and thrown away — and it is the verdict that matters here: the
+        // lexical card detector's default is "everything is work", so a message
+        // the model has just read as conversation still opened a card. We had
+        // already paid for the call.
+        //
+        // Carried as its OWN fact rather than by folding it into `answering`.
+        // They are different claims about the turn and only one of them touches
+        // the model's board tools: `Chatter` deliberately does not gate those
+        // (the comment above says why — taking them away on a maybe turns a
+        // triage miss into work the company silently refuses), while it *does*
+        // stand the deterministic card paths down.
+        let mut chatter = false;
         if !answering
             && triaged.abstained()
             && let Some(escalation) = self.triage
@@ -848,6 +882,13 @@ impl<'a> DelegationRunner<'a> {
                      narrowing the claim to answering-only"
                 );
                 answering = true;
+            } else if verdict.is_chatter() {
+                tracing::debug!(
+                    company = %self.company,
+                    "[triage] the lexical layer abstained and the model read this as \
+                     conversation; opening no card for it"
+                );
+                chatter = true;
             }
         }
         // Claim the delegation queue for this turn and its drain (issue #453).
@@ -875,6 +916,7 @@ impl<'a> DelegationRunner<'a> {
         let ctx = MessageContext {
             carded_by_handler,
             answering,
+            chatter,
         };
         // …and *which* card that is, when it is still on the board. Adopting it
         // is what carries "one message, one card" through the publish drain too:
@@ -1717,7 +1759,7 @@ impl<'a> DelegationRunner<'a> {
         assignee: &str,
         request: &str,
         chat_id: Option<&str>,
-        carded_by_handler: bool,
+        ctx: MessageContext,
     ) -> Result<Option<TaskRecord>> {
         let Some(tasks) = self.tasks else {
             return Ok(None);
@@ -1725,12 +1767,32 @@ impl<'a> DelegationRunner<'a> {
         if self.task.is_some() {
             return Ok(None);
         }
+        // Issue #984: the model already read this as conversation, so no card.
+        //
+        // Placed HERE, in the shared helper, rather than beside the `answering`
+        // check in each caller: `answering` differs between the two paths (a
+        // hand-off and a direct ask log different things about a question), but
+        // "the model called this chatter" is one fact about the message and both
+        // paths owe it the same answer. #442 put its stand-down in one caller
+        // only and the other path kept opening cards; this is that lesson.
+        //
+        // Below the `self.task.is_some()` guard deliberately: a dispatched
+        // card's turn has no operator message to have triaged, and `ctx`
+        // defaults to all-false there anyway.
+        if ctx.chatter {
+            tracing::debug!(
+                company = %self.company,
+                assignee = %assignee,
+                "[delegation] not opening a card: the model read this message as conversation"
+            );
+            return Ok(None);
+        }
         // Issue #463: the REST chat handler read the operator's original words
         // and already opened a To-do card for them. One message must not become
         // two cards, whichever of the two card-opening paths below is running —
         // #442 guarded only the direct path, and a recognised imperative that
         // was handed off doubled through this one.
-        if carded_by_handler {
+        if ctx.carded_by_handler {
             tracing::debug!(
                 company = %self.company,
                 assignee = %assignee,
@@ -1822,8 +1884,7 @@ impl<'a> DelegationRunner<'a> {
             );
             return Ok(None);
         }
-        self.open_work_card(member, instruction, chat_id, ctx.carded_by_handler)
-            .await
+        self.open_work_card(member, instruction, chat_id, ctx).await
     }
 
     /// The card for a **desk lead or teammate asked directly** (issue #442,
@@ -1894,8 +1955,7 @@ impl<'a> DelegationRunner<'a> {
             );
             return Ok(None);
         }
-        self.open_work_card(responder, message, chat_id, ctx.carded_by_handler)
-            .await
+        self.open_work_card(responder, message, chat_id, ctx).await
     }
 
     /// Whether a card assigned to `assignee` is assigned to whoever `chat_id`
@@ -2540,7 +2600,15 @@ const TRACK_ALWAYS_WORDS: usize = 25;
 /// The longest an utterance opening with small talk may run before it stops
 /// being small talk. "thanks!" is chatter; "thanks — now pull together the Q3
 /// numbers, the deck and the board memo" is not.
-const SMALLTALK_MAX_WORDS: usize = 6;
+///
+/// Raised from 6 to 8 by issue #984, which is a real trade and not a free one:
+/// every word added here is a short instruction that opens with an
+/// acknowledgement and now goes untracked. 8 is chosen to cover the common
+/// two-clause ack ("noted, thanks — will pick that up tomorrow") without
+/// reaching the length at which a sentence is usually carrying an instruction.
+/// The model layer, not this number, is what handles the long conversational
+/// message; pushing this much higher would buy those at the cost of real work.
+const SMALLTALK_MAX_WORDS: usize = 8;
 
 /// Verbs that name something being **produced or changed**. Their presence is
 /// decisive: whatever else the sentence is doing, it is asking for work.
@@ -2617,6 +2685,28 @@ const SMALLTALK_OPENERS: &[&str] = &[
     "got",
     "haha",
     "lol",
+    // Issue #984: acknowledgement and meta vocabulary. A message opening with
+    // one of these, and staying short, is somebody closing a loop rather than
+    // opening one.
+    //
+    // This list is deliberately NARROWER than the issue proposed. `qa`, `test`
+    // and `ignore` were suggested and are left out on purpose: each of them
+    // opens a legitimate short instruction to a desk — "test the checkout flow
+    // on staging", "ignore the stale rows and rebuild the index" — and this
+    // rung has no way to tell those from chatter. Words that essentially never
+    // open an instruction are safe here; words that often do are exactly the
+    // ones the model layer above exists to judge.
+    "ack",
+    "acked",
+    "fyi",
+    "nvm",
+    "nevermind",
+    "disregard",
+    "oops",
+    "np",
+    "agreed",
+    "indeed",
+    "ditto",
 ];
 
 /// The lowercase alphanumeric word tokens of `text`.
@@ -2806,6 +2896,49 @@ mod tests {
                 !is_trackable_work(chatter),
                 "should NOT be tracked: {chatter:?}"
             );
+        }
+    }
+
+    /// Issue #984 widened the acknowledgement vocabulary and raised the length
+    /// cap from 6 to 8. These are the messages that changed answer.
+    ///
+    /// This rung is the fallback for builds with no triage model, so it is kept
+    /// deliberately timid — it catches the loop-closing ack, not the long
+    /// conversational message. The staging probe in #984 is 15 words and is
+    /// still tracked here on purpose; that one is the model layer's to judge.
+    #[test]
+    fn acknowledgement_vocabulary_is_not_tracked() {
+        for chatter in [
+            "ack",
+            "acked, nothing needed here",
+            "fyi the staging host is back up",
+            "nvm, found it",
+            "nevermind that last one",
+            "disregard the previous message please",
+            "oops wrong thread",
+            "np",
+            "agreed",
+            "indeed, that reads better",
+            "ditto",
+        ] {
+            assert!(
+                !is_trackable_work(chatter),
+                "should NOT be tracked: {chatter:?}"
+            );
+        }
+    }
+
+    /// The trade the widened cap makes, pinned so it stays deliberate: an
+    /// acknowledgement that carries a real instruction is still tracked, because
+    /// a work verb outranks the small-talk rung whatever the length.
+    #[test]
+    fn a_widened_opener_does_not_hide_an_instruction() {
+        for request in [
+            "ack — now draft the Q3 board memo",
+            "fyi, please write up the incident review",
+            "agreed, compile the pricing comparison",
+        ] {
+            assert!(is_trackable_work(request), "should be tracked: {request:?}");
         }
     }
 
@@ -3711,6 +3844,115 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         assert_eq!(cards[0].column, COLUMN_IN_REVIEW);
         assert_eq!(cards[0].origin_chat_id.as_deref(), Some("eng_desk"));
         assert_eq!(turn.spawned_task.as_deref(), Some(cards[0].id.as_str()));
+    }
+
+    /// **Issue #984, the reported probe.** The message that opened a card on
+    /// staging, run through the path that opened it.
+    ///
+    /// `"verifying the Send button responds to a real mouse click. No action
+    /// needed from anyone."` is 15 words, so it clears
+    /// [`SMALLTALK_MAX_WORDS`]; it names no [`WORK_VERBS`] entry (`verifying`
+    /// and `send` are both deliberately absent — `send` is a noun here); and it
+    /// is not interrogative. So [`is_trackable_work`] falls through to its
+    /// "anything else is work" rung and returns true, which is how a message
+    /// that explicitly disclaimed any action became a card assigned to a desk.
+    ///
+    /// The lexical layer cannot fix this without inverting its own default, so
+    /// the model is asked — and having been asked, its answer is now used.
+    #[tokio::test]
+    async fn a_desk_asked_something_the_model_calls_chatter_opens_no_card() {
+        let probe = "verifying the Send button responds to a real mouse click. \
+                     No action needed from anyone.";
+        assert!(
+            crate::company::task_intent::triage_message_detailed(probe).abstained(),
+            "fixture must be a message no lexical rule decides"
+        );
+        assert!(
+            is_trackable_work(probe),
+            "fixture must be one the card detector would otherwise track — that \
+             is the bug this closes"
+        );
+
+        let fx = Fixture::new();
+        let escalation = ScriptedTriage::new(crate::harness::triage::TriageVerdict::Chatter);
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ack")]);
+        let turn = fx
+            .runner(&turns)
+            .with_triage(&escalation)
+            .handle_operator_message("engineer", probe, Some("eng_desk"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            escalation.asked(),
+            vec![probe.to_string()],
+            "the abstention is what gets escalated"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "a message the model read as conversation opens no card"
+        );
+        assert_eq!(turn.spawned_task, None, "and nothing is linked to one");
+    }
+
+    /// The other direction, which is the one that must not regress: the model
+    /// says `work`, and the card is opened exactly as before.
+    ///
+    /// This is what makes the change subtractive-only. `Work` and `Unavailable`
+    /// both leave the deterministic decision alone, so an escalation that is
+    /// slow, unreachable or unparseable cannot cost a card — only an explicit
+    /// `chatter` can.
+    #[tokio::test]
+    async fn a_non_chatter_verdict_still_opens_the_direct_card() {
+        let residue = "the pricing page copy, before Friday if you can";
+        assert!(
+            crate::company::task_intent::triage_message_detailed(residue).abstained(),
+            "fixture must be a message no lexical rule decides"
+        );
+        for verdict in [
+            crate::harness::triage::TriageVerdict::Work,
+            crate::harness::triage::TriageVerdict::Unavailable,
+        ] {
+            let fx = Fixture::new();
+            let escalation = ScriptedTriage::new(verdict);
+            let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+            fx.runner(&turns)
+                .with_triage(&escalation)
+                .handle_operator_message("engineer", residue, Some("eng_desk"))
+                .await
+                .expect("operator message handled");
+            let cards = fx.cards().await;
+            assert_eq!(
+                cards.len(),
+                1,
+                "{verdict:?} must leave the card the abstention would have opened"
+            );
+            assert_eq!(cards[0].assignee, "engineer");
+        }
+    }
+
+    /// With **no escalation wired** — the default build, and any host without a
+    /// triage model — the behaviour is byte-identical to before issue #984.
+    ///
+    /// Named because it is the property that makes this safe to ship: the fix
+    /// consults a model that most deployments do not have, and where it is
+    /// absent nothing about the board changes.
+    #[tokio::test]
+    async fn without_an_escalation_the_probe_still_cards_exactly_as_before() {
+        let probe = "verifying the Send button responds to a real mouse click. \
+                     No action needed from anyone.";
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ack")]);
+        fx.runner(&turns)
+            .handle_operator_message("engineer", probe, Some("eng_desk"))
+            .await
+            .expect("operator message handled");
+        assert_eq!(
+            fx.cards().await.len(),
+            1,
+            "no model, no change — the bug is still here, and that is the point: \
+             this path was not touched"
+        );
     }
 
     /// **Issue #465, the reported card.** A desk asked directly, whose first

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -5197,6 +5197,114 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         );
     }
 
+    /// **Issue #984, the second caller.** `open_work_card` has two callers, and
+    /// the test above this one only drives the direct path. This drives the
+    /// hand-off path: the orchestrator queues `delegate_to_desk` on a message
+    /// the lexical layer abstained on and the model read as `chatter`.
+    ///
+    /// The shape mirrors `a_hand_off_runs_on_a_question_turn_but_opens_no_card`
+    /// exactly, because the requirement is the same one: only the **card**
+    /// stands down. The hand-off is not refused, the desk lead's turn really
+    /// runs, and the relayed answer still reaches the operator — a verdict that
+    /// silenced the company instead of the board would be a worse bug than the
+    /// one #984 reports.
+    ///
+    /// This is the test that would have caught #442's mistake, which put a
+    /// stand-down in one caller and left the other opening cards.
+    #[tokio::test]
+    async fn a_hand_off_of_a_message_the_model_calls_chatter_opens_no_card() {
+        let residue = "the deck looks good to me";
+        assert!(
+            crate::company::task_intent::triage_message_detailed(residue).abstained(),
+            "fixture must be a message no lexical rule decides"
+        );
+        assert!(
+            is_trackable_work(residue),
+            "and one the card detector would otherwise track, or this proves nothing"
+        );
+        let fx = Fixture::new();
+        let escalation = ScriptedTriage::new(crate::harness::triage::TriageVerdict::Chatter);
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling(
+                    "asking engineering",
+                    vec![handoff("take a look at the deck")],
+                ),
+                Turn::reply("looks fine to me too"),
+                Turn::reply("engineering agrees the deck is fine"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .with_triage(&escalation)
+            .handle_operator_message("chief", residue, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::Queued],
+            "a chatter verdict must NOT refuse the hand-off — it does not gate tools"
+        );
+        let calls = turns.calls();
+        assert_eq!(
+            calls.len(),
+            3,
+            "the orchestrator, the desk lead and the relay all ran: {calls:?}"
+        );
+        assert_eq!(
+            calls[1].0, "engineer",
+            "the desk lead really ran: {calls:?}"
+        );
+        assert_eq!(
+            turn.reply, "engineering agrees the deck is fine",
+            "and the operator still gets the relayed answer"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "but the hand-off card stands down: the model read this as conversation"
+        );
+        assert!(
+            turn.spawned_task.is_none(),
+            "and nothing is linked to a card"
+        );
+    }
+
+    /// The paired opposite, for the same reason the question pair is paired: a
+    /// "fix" that simply stopped opening hand-off cards would satisfy the test
+    /// above. A `work` verdict on the same abstaining message still cards.
+    #[tokio::test]
+    async fn the_same_hand_off_on_a_work_verdict_still_opens_its_card() {
+        let residue = "the deck looks good to me";
+        let fx = Fixture::new();
+        let escalation = ScriptedTriage::new(crate::harness::triage::TriageVerdict::Work);
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling(
+                    "asking engineering",
+                    vec![handoff("take a look at the deck")],
+                ),
+                Turn::reply("looks fine to me too"),
+                Turn::reply("engineering agrees the deck is fine"),
+            ],
+        );
+        fx.runner(&turns)
+            .with_triage(&escalation)
+            .handle_operator_message("chief", residue, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(
+            cards.len(),
+            1,
+            "a work verdict leaves the hand-off card the abstention would have opened"
+        );
+        assert_eq!(cards[0].assignee, "engineer");
+    }
+
     /// The same hand-off on a message that is NOT a question still opens its
     /// card, so the suppression above is keyed on the triage rather than having
     /// quietly disabled the #442 card path.


### PR DESCRIPTION
> ## ⚠️ Sequencing — **do not land before #997**
>
> Issue #984 states this directly: *"collides with #982 (same files, same
> regions). Must land after it."* It does collide — **#997 also edits
> `src/runtime/delegation.rs`**, along with `cycle.rs` and `operator.rs`.
>
> This PR is based on `main`, **not** on #997, for a mechanical reason worth
> recording: #997's head lives in the `oxoxDev/opencompany` fork, and GitHub
> requires a PR's base to be a branch in this repository, so it cannot be
> targeted as a base ref. I developed this on top of #997's branch to be sure
> the two compose, then rebased onto `main` — it applied with **no conflicts**,
> and the diff below is only my three files rather than a combined range.
>
> **What a maintainer needs to do:** merge #997 first. Whichever of the two
> lands second may need a trivial rebase in `delegation.rs`; landing this one
> first would push that onto #997, which is the larger change and the one the
> issue says has priority.
>
> Verified against `main` at `7d6eba09` (after #1003).

## It became a card because *no rule matched*, not because one did

This is not a misfiring detector. It is a **default**.

The issue title — "an ordinary message opens a task card" — sends you hunting
for a bad rule, and there isn't one. Here is the reported staging probe walked
through `is_trackable_work` (`src/runtime/delegation.rs:2690`):

> *"verifying the Send button responds to a real mouse click. No action needed
> from anyone."*

| Rung | Test | Result |
| --- | --- | --- |
| 1 | empty? | no — 15 words |
| 2 | past `TRACK_ALWAYS_WORDS` (25)? | no |
| 3 | any `WORK_VERBS` hit? | **no** — `verifying` is not in the list, and `send` is deliberately excluded as "far more often a noun in this domain". Correct here: it was the *Send* button |
| 4 | ends in `?`, or a wh-opener? | no |
| 5 | small talk? | no — 15 words is past the 6-word cap |
| 6 | **anything else** | **→ work** |

Every rung behaved as designed. The card came from rung 6. Stated plainly,
what the detector accepts today is *everything except an empty string, a
syntactic question, and a short greeting* — and it is documented as having
exactly that bias, because it asks "is there any reason NOT to track this?"

That is also why this cannot be fixed by adding words to a list. A message with
no work verb, no interrogative and no greeting is indistinguishable from an
elliptical real request by lexical means — `"the quarterly numbers, by Friday"`
is tracked today and contains no verb at all, and that shape is how people
actually hand work to a desk.

### There is a third card path, and the contract never described it

Two card paths are documented: the REST handler's (Layer A) and the delegation
gate's. The probe hit neither. Because it was desk-addressed, the responder was
a desk member rather than the orchestrator, so the runner also ran
`open_direct_work_card` — which defers to `is_trackable_work` above, whose
default is the opposite of Layer A's.

Hand-tracing the probe through `triage_message_detailed` gives Chatter /
Abstained. **Layer A opened nothing. The third path opened the card.**

## The fix: stop discarding an answer we already paid for

The escalation classifier is wired in production, runs on exactly the
abstention set, and returned Chatter for this probe. The caller then dropped
it — by its own doc: *"`Work` and `Chatter` therefore both leave the gate where
the abstention left it, and only `Answer` moves it."*

So this adds a consumer, not a call: **zero added latency, zero added spend.**
`TriageVerdict::is_chatter()` is now read alongside `is_answer()`, and both
runner card paths stand down on it.

### Why `chatter` is its own field and not folded into `answering`

Because `answering` does a second thing: it narrows the delegation claim, which
**withdraws the model's own board-writing tools** for the turn. `Chatter` must
not do that, and the existing code says why — it is the ambiguous bucket, and
taking board tools away on a maybe "turns a triage miss into work the company
silently refuses to do", which is the expensive direction of this issue's own
tie-breaker.

The two facts are different claims about the turn and only one of them touches
the model's tools. Folding them together would be a one-line "simplification"
that reintroduces a bug the comments have argued against twice.

### Why the guard is in `open_work_card`, not in each caller

`open_direct_work_card` and the hand-off card path both funnel through
`open_work_card`. The `answering` stand-down is per-caller because the two log
different things about a question — but "the model called this chatter" is one
fact about the message and both paths owe it the same answer.

This is #442's lesson applied: that issue put its stand-down in one caller only,
and the other path kept opening cards for exactly the messages it was meant to
stop.

## How it fails safe — subtract-only

**The model is consulted *solely* where the lexical layer already abstained.**
An imperative, a framed request, a work verb, or an explicit `workflow`
deliverable all match an earlier rung and never reach the escalation at all —
so a real work request **cannot be talked out of its card**.

The verdict can only ever remove a card, never mint one. Every degraded path is
byte-identical to today:

| Condition | Behaviour |
| --- | --- |
| `TriageVerdict::Work` | unchanged — card opens |
| `TriageVerdict::Unavailable` (unreachable, slow, unparseable) | unchanged — card opens |
| no escalation wired / non-harness build | unchanged — card opens |
| lexical layer did **not** abstain | model never consulted |

**The failure mode of this change is "the bug comes back", never "work stops
being tracked."** The residual, named honestly: a real ask that the lexical
layer abstains on and the model reads as chatter gets no card. Cost is one
follow-up message — the tie-breaker the intent module already adopts.

## Also: the lexical floor, for builds with no triage model

Widened the acknowledgement vocabulary (`ack`, `acked`, `fyi`, `nvm`,
`nevermind`, `disregard`, `oops`, `np`, `agreed`, `indeed`, `ditto`) and raised
`SMALLTALK_MAX_WORDS` from 6 to 8.

**Deliberately narrower than issue #984 proposed.** It suggested `qa`, `test`
and `ignore`; all three are left out, with the reason in the code. Each opens a
legitimate short instruction — *"test the checkout flow on staging"*, *"ignore
the stale rows and rebuild the index"* — and this rung cannot tell those from
chatter. Words that essentially never open an instruction are safe here; words
that often do are what the model layer exists to judge.

The cap raise is a real trade, not a free one, and is documented as such: every
word added is a short instruction opening with an acknowledgement that now goes
untracked. The 15-word probe is **still tracked by this rung on purpose** —
pushing the cap far enough to catch it would cost real work.

## API Or Behavior Changes

- A desk-addressed message that the lexical layer abstains on and the triage
  model reads as `chatter` no longer opens a task card. Requires a wired
  escalation; no other configuration changes behaviour.
- `MessageContext` gains a `chatter` field (crate-internal).
- `TriageVerdict::is_chatter()` is new.
- Messages opening with the widened acknowledgement vocabulary, up to 8 words,
  are no longer tracked in **every** build.
- Unchanged: Layer A, the delegation claim/board-tool gate, the `workflow`
  deliverable path (#845), and copilot-thread suppression (#416).

## Tests

Gated lane — default features skip this code.

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --no-deps -p opencompany --features openhuman,tinycortex --all-targets -- -D warnings` — mirrors CI's `--no-deps`; no findings in the touched files.
- [x] `cargo check -p opencompany --features openhuman,tinycortex --tests` — clean. Ran `check --tests` rather than `build --all-targets`; same targets type-checked.
- [x] `cargo test -p opencompany --features openhuman,tinycortex` — **4247 passed, 0 failed, 3 ignored.**

### Each new regression test proven to fail with its fix reverted

Three reverts, each applied and run on its own:

| Reverted | Test that fails |
| --- | --- |
| the `ctx.chatter` stand-down in `open_work_card` | `a_desk_asked_something_the_model_calls_chatter_opens_no_card` |
| the acknowledgement vocabulary | `acknowledgement_vocabulary_is_not_tracked` |
| `SMALLTALK_MAX_WORDS` 8 → 6 | `acknowledgement_vocabulary_is_not_tracked` |

The first test also asserts its fixture up front — that the probe abstains
lexically **and** that `is_trackable_work` would otherwise track it — so it
cannot pass by the fixture quietly ceasing to reproduce the bug.

### Three further tests pass with the fix reverted — deliberately, and I am not counting them as coverage

`a_non_chatter_verdict_still_opens_the_direct_card`,
`without_an_escalation_the_probe_still_cards_exactly_as_before`, and
`a_widened_opener_does_not_hide_an_instruction` pin the **fail-safe direction** —
that the change did *not* start dropping cards. A test asserting "this still
works" cannot fail when the fix is removed. They are guard rails, and they are
the ones to look at when judging whether this is safe.

## Documentation

`docs/spec/runtime/api-graphql.md` documented two card paths and said `Chatter`
"neither cards nor gates". Added the third path, its inverted default, and the
subtract-only property of the new verdict consumer.

## Not in this PR

Issue #984 prescribes more than this. Deliberately left out, not forgotten:

- **The operator override.** The composer's intent signal does not reach the
  carding path at all — see the separate issue filed for this; it needs
  `deliverable` threaded through `handle_operator_message` (1 production caller,
  **50 test call sites**) and collides directly with #997.
- **The three-way `Just chat | Do it once | Build me the workflow` composer
  control** and **the dismissable "Card opened" chip** — frontend, and the
  composer control is shared surface with #873/#874.
- **The 78 existing cards.** An operator-driven bulk delete with a reviewed
  selection, as the issue specifies — not an automatic migration.

Refs tinyhumansai/opencompany#984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message triage to distinguish casual conversation from actionable work.
  * Expanded recognition of acknowledgements and short conversational responses.
  * Preserved work-related actions when messages include clear work-oriented language.

* **Bug Fixes**
  * Prevented unnecessary work-card creation for messages identified as casual conversation.
  * Applied consistent card-creation behavior across direct and delegated message handling.
  * Preserved existing behavior when escalation services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->