### PR TITLE
Journal every task attempt status change

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -342,6 +342,17 @@ export function AppShell({
   // React batch still means "re-read" — the frame-loss the workflow canvas had
   // to fold an event window to avoid cannot happen to a tick.
   const [taskEventTick, setTaskEventTick] = useState(0);
+  // Issue #1015: bumped on every `run_status_changed`, so the task detail screen
+  // sees an attempt move rather than waiting up to four seconds for its poll —
+  // and sees it at all while the tab is hidden, which the poll deliberately does
+  // not do. Its own counter rather than a share of `taskEventTick`: this fires
+  // several times per attempt, and folding it in would make the whole board
+  // refetch on every transition of every run.
+  //
+  // A counter, not the payload, for the same reason the tick above is one: the
+  // screen re-reads its own detail, so two frames collapsing inside one React
+  // batch still mean "re-read".
+  const [attemptEventTick, setAttemptEventTick] = useState(0);
   // Issue #327: the latest workspace write, as the Workspace view needs it.
   //
   // The payload-carrying variant of the `taskEventTick` pattern above, and the
@@ -1094,6 +1105,7 @@ export function AppShell({
     pendingApprovals: pending,
     onAgentReply: injectAgentReply,
     onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
+    onRunEvent: useCallback(() => setAttemptEventTick((n) => n + 1), []),
     // Issue #377. Beside the board tick above, not instead of it: a settle both
     // moves a card between columns and needs saying in the conversation the
     // card came from.
@@ -1290,6 +1302,7 @@ export function AppShell({
               // counter the chat's in-flight strip reads, so a card opened from
               // chat lands on the board without a reload.
               taskEventTick={taskEventTick}
+              attemptEventTick={attemptEventTick}
               // Issue #883: a paused card is blocked until every approval its
               // turn parked is decided, and the board's own read carries none
               // of them. This is the feed the sidebar badge already polls, so

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -53,6 +53,32 @@ export type CompanyStreamEvent =
   // the card sits. There is **no title and no note** on purpose — the card's
   // text lives on `GET …/tasks`, and a console reacts to this frame by
   // re-reading that, so the board's content has exactly one source.
+  // One task attempt moved (issue #1015). Before this the task detail screen
+  // could only learn an attempt's status by polling every four seconds — and not
+  // at all while the tab was hidden — which is the surface #581 removed
+  // elsewhere when it replaced the whole-company refetch with Snapshot +
+  // Refresh.
+  //
+  // Deliberately thin, like `task_card_changed` beside it: ids, the status, and
+  // where it came from. There is **no error text** on purpose — a failure reason
+  // is tenant-scoped, so a console reacts to this frame by re-reading the run
+  // row, which is the one place that answers *why*.
+  | {
+      type: "run_status_changed";
+      seq: number;
+      atMillis: number;
+      runId: string;
+      /** Absent for a chat turn, which is an attempt at work with no card. */
+      taskId?: string;
+      /** 1-based attempt ordinal at that card. */
+      attempt: number;
+      /** The status moved to, widened so a word from a newer host is not a type
+       *  error. */
+      status: string;
+      /** The status moved from. Absent on the mint, which has no prior state —
+       *  a presence check, matching `turn_started`'s `parentId`. */
+      from?: string;
+    }
   | {
       type: "task_card_changed";
       seq: number;
@@ -366,6 +392,23 @@ interface Options {
    */
   onTaskEvent?: (event: CompanyStreamEvent) => void;
   /**
+   * Called for each `run_status_changed` frame (issue #1015) so a screen showing
+   * one card's attempts can re-read them the moment one moves, rather than up to
+   * a poll interval later.
+   *
+   * Separate from {@link Options.onTaskEvent} because they answer different
+   * questions: that one is which cards moved on the board, this one is what one
+   * card's attempt is doing. The task detail screen wants the second without
+   * re-reading the whole board on every transition of every run.
+   *
+   * Like {@link Options.onTaskEvent} this subscriber takes a **counter**, not
+   * the payload: it re-reads the detail, so two frames collapsing inside one
+   * React batch still means "re-read". It is therefore immune to frame loss,
+   * and the consumer keeps its poll as the fallback for a frame that never
+   * arrives at all.
+   */
+  onRunEvent?: (event: CompanyStreamEvent) => void;
+  /**
    * Called for each `desk_task_completed` frame (issue #377) so the shell can
    * post a card-linked system marker into the channel the card was raised in.
    *
@@ -470,6 +513,7 @@ export function useEvents(
     pendingApprovals,
     onAgentReply,
     onTaskEvent,
+    onRunEvent,
     onDispatchTerminal,
     onWorkspaceEvent,
     onTurnEvent,
@@ -487,6 +531,10 @@ export function useEvents(
   useEffect(() => {
     onTaskEventRef.current = onTaskEvent;
   }, [onTaskEvent]);
+  const onRunEventRef = useRef(onRunEvent);
+  useEffect(() => {
+    onRunEventRef.current = onRunEvent;
+  }, [onRunEvent]);
   const onDispatchTerminalRef = useRef(onDispatchTerminal);
   useEffect(() => {
     onDispatchTerminalRef.current = onDispatchTerminal;
@@ -551,6 +599,7 @@ export function useEvents(
           handleEvent(event, {
             onAgentReply: onAgentReplyRef.current,
             onTaskEvent: onTaskEventRef.current,
+            onRunEvent: onRunEventRef.current,
             onDispatchTerminal: onDispatchTerminalRef.current,
             onWorkspaceEvent: onWorkspaceEventRef.current,
             onTurnEvent: onTurnEventRef.current,
@@ -596,6 +645,7 @@ export function handleEvent(
   const {
     onAgentReply,
     onTaskEvent,
+    onRunEvent,
     onDispatchTerminal,
     onWorkspaceEvent,
     onTurnEvent,
@@ -640,6 +690,14 @@ export function handleEvent(
     // notification.
     case "task_card_changed":
       onTaskEvent?.(event);
+      break;
+    // Issue #1015, and **no toast** for the reason the board frames above raise
+    // none, more strongly if anything: this fires several times per attempt —
+    // mint, start, settle — on every card and every chat turn. Toasting those
+    // would train the operator to dismiss the toasts that matter. The attempt
+    // row moving on the screen IS the notification.
+    case "run_status_changed":
+      onRunEvent?.(event);
       break;
     // Issue #377: the settle is two facts at once, so it reaches two
     // subscribers. The board gets its tick, exactly as it has since #464 — a

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -272,6 +272,7 @@ export function TaskDetailView({
   client,
   company,
   taskId,
+  attemptEventTick,
   focus,
   parked = EMPTY_PARKED,
   onBack,
@@ -283,6 +284,11 @@ export function TaskDetailView({
   client: OpenCompanyClient;
   company: string | null;
   taskId: string;
+  /**
+   * Bumped on every `run_status_changed` (issue #1015) — the push half of this
+   * screen's liveness, beside the poll below rather than instead of it.
+   */
+  attemptEventTick?: number;
   /**
    * The company's parked approvals, for naming what this card is waiting on
    * (issue #883). Optional and defaulting to empty, which renders the pre-#883
@@ -379,6 +385,36 @@ export function TaskDetailView({
       dispose();
     };
   }, [load]);
+
+  // Issue #1015: the push half. Re-read the detail the moment the host says an
+  // attempt moved, rather than up to `POLL_MS` later — and at all, which the
+  // poll above deliberately does not do while the tab is hidden.
+  //
+  // Its own effect rather than a dependency of the one above, for the reason
+  // `TasksView` gives for the same split (issue #464): folding the tick in there
+  // would tear down and restart the fallback timer on every frame, so a busy
+  // company would keep resetting the interval and the fallback would effectively
+  // stop existing on exactly the companies that need it most.
+  //
+  // The poll STAYS. A frame can be missed — the stream can drop, and the store
+  // swallows an append that fails rather than failing the transition it
+  // describes (`runtime::run_events`) — so the timer is the floor under a
+  // liveness this does not otherwise guarantee.
+  const seenAttemptTick = useRef(attemptEventTick);
+  useEffect(() => {
+    if (attemptEventTick === undefined || attemptEventTick === seenAttemptTick.current) return;
+    // Gated like the poll it complements (issue #581), or the visibility gate
+    // buys nothing on a busy company. Deliberately NOT consumed on the way out:
+    // marking it seen here would drop it, since this effect does not re-run on a
+    // visibility change.
+    if (document.visibilityState === "hidden") return;
+    seenAttemptTick.current = attemptEventTick;
+    let cancelled = false;
+    void load(() => !cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [attemptEventTick, load]);
 
   const worked = useMemo(
     () =>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -122,6 +122,7 @@ export function TasksView({
   client,
   company,
   taskEventTick,
+  attemptEventTick,
   approvals = EMPTY_APPROVALS,
   now,
   onOpenThread,
@@ -137,6 +138,13 @@ export function TasksView({
    * reload.
    */
   taskEventTick?: number;
+  /**
+   * Bumped on every `run_status_changed` (issue #1015), passed straight through
+   * to the detail screen. The board itself does not react to it: an attempt
+   * moving does not move a card, and folding it into `taskEventTick` would
+   * refetch the whole board on every transition of every run.
+   */
+  attemptEventTick?: number;
   /**
    * The company's parked approvals (issue #883), from the shell's existing feed
    * poll. A paused card is blocked until every approval its turn parked has
@@ -310,6 +318,7 @@ export function TasksView({
   if (detailId) {
     return (
       <TaskDetailView
+        attemptEventTick={attemptEventTick}
         client={client}
         company={company}
         taskId={detailId}

--- a/frontend/test/unit/run-status-events.test.ts
+++ b/frontend/test/unit/run-status-events.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { handleEvent } = await import("@/hooks/use-events");
+type Ev = import("@/hooks/use-events").CompanyStreamEvent;
+type Subs = import("@/hooks/use-events").Subscribers;
+
+/**
+ * How a `run_status_changed` frame is routed (issue #1015).
+ *
+ * The frame exists so the task detail screen can be pushed rather than polled —
+ * it sat at `pending`/`running` for up to four seconds after an attempt had
+ * really moved, and did not move at all while the tab was hidden. These pin the
+ * two decisions that are easy to get wrong in the other direction: it must reach
+ * the attempt subscriber, and it must **not** raise a toast or refetch the whole
+ * board, because it fires several times per attempt on every card and every chat
+ * turn.
+ */
+function frame(over: Partial<Extract<Ev, { type: "run_status_changed" }>> = {}): Ev {
+  return {
+    type: "run_status_changed",
+    seq: 1,
+    atMillis: 0,
+    runId: "run-1",
+    taskId: "card-1",
+    attempt: 1,
+    status: "running",
+    from: "pending",
+    ...over,
+  } as Ev;
+}
+
+describe("run_status_changed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reaches the attempt subscriber", () => {
+    const onRunEvent = vi.fn();
+    handleEvent(frame(), { onRunEvent } as Subs);
+    expect(onRunEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises no toast", () => {
+    // Several frames per attempt — mint, start, settle — on every card and
+    // every chat turn. Toasting those would train the operator to dismiss the
+    // toasts that matter; the row moving IS the notification.
+    handleEvent(frame(), { onRunEvent: vi.fn() } as Subs);
+    expect(toasts.base).not.toHaveBeenCalled();
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(toasts.error).not.toHaveBeenCalled();
+    expect(toasts.info).not.toHaveBeenCalled();
+    expect(toasts.warning).not.toHaveBeenCalled();
+  });
+
+  it("does not refetch the board", () => {
+    // `onTaskEvent` re-reads `GET …/tasks`. An attempt moving does not move a
+    // card, so folding this in would refetch the whole board on every
+    // transition of every run — which is the timer load #581 removed.
+    const onTaskEvent = vi.fn();
+    handleEvent(frame(), { onTaskEvent, onRunEvent: vi.fn() } as Subs);
+    expect(onTaskEvent).not.toHaveBeenCalled();
+  });
+
+  it("is delivered for a chat turn, which names no card", () => {
+    // A chat turn is a recorded attempt at work that opens no card, so `taskId`
+    // is absent. The subscriber still hears it: the screen re-reads by run.
+    const onRunEvent = vi.fn();
+    handleEvent(frame({ taskId: undefined, from: undefined, status: "pending" }), {
+      onRunEvent,
+    } as Subs);
+    expect(onRunEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -189,6 +189,21 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Turn {turn_id} did not finish"),
             "turn.failed",
         ),
+        // Issue #1015. Structural only, like every arm here: a minted run id and
+        // two fixed-vocabulary statuses. `error` is deliberately not copied —
+        // it is tenant-scoped, the same reason `TurnFailed` above carries only
+        // its id.
+        CompanyEvent::RunStatusChanged {
+            run_id, from, to, ..
+        } => (
+            Role::System,
+            "board".to_string(),
+            match from {
+                Some(from) => format!("Attempt {run_id}: {from} -> {to}"),
+                None => format!("Attempt {run_id}: {to}"),
+            },
+            "run.status_changed",
+        ),
         CompanyEvent::TaskDispatched { task_id, .. } => (
             Role::System,
             "board".to_string(),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1581,6 +1581,13 @@ fn summarize_event(event: &CompanyEvent) -> String {
         // carry.
         CompanyEvent::TurnStarted { turn_id, .. } => format!("turn accepted: {turn_id}"),
         CompanyEvent::TurnFailed { turn_id, .. } => format!("turn unanswered: {turn_id}"),
+        // Issue #1015. Structural only: the minted id and the status word, a
+        // fixed vocabulary. The failure reason is our own prose about the host
+        // and is tenant-scoped, so it stays off this surface exactly as
+        // `TurnFailed`'s does.
+        CompanyEvent::RunStatusChanged { run_id, to, .. } => {
+            format!("attempt {run_id}: {to}")
+        }
         CompanyEvent::AgentReply { agent_id, .. } => format!("reply from {agent_id}"),
         CompanyEvent::TaskDispatched { task_id, .. } => format!("task dispatched: {task_id}"),
         // Issue #464. Structural only, like every arm here: the id, the change

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -332,6 +332,52 @@ pub enum CompanyEvent {
         /// deliberately **not** projected onto the operator SSE stream.
         error: String,
     },
+    /// One task attempt changed status (issue #1015).
+    ///
+    /// **The whole status machine, from one seam.** Emitted by the store
+    /// decorator that wraps `put_run` — the single write primitive every
+    /// [`RunStatus`](crate::ports::runs::RunStatus) change passes through, since
+    /// `begin_run` and `finish_run` are trait defaults that call it and no
+    /// backend overrides either. So the frame cannot be missed by adding a
+    /// caller, which is what makes this a complete surface rather than a partial
+    /// one.
+    ///
+    /// That matters most for the path the obvious seam misses:
+    /// [`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs) settles
+    /// crash-killed runs by calling `finish_run` **directly**, never through the
+    /// cycle. Emitting from the cycle's call sites would leave exactly those
+    /// runs — the ones whose visibility the reaper exists to provide —
+    /// transitioning in silence.
+    ///
+    /// **Not [`TurnStarted`](Self::TurnStarted)/[`TurnFailed`](Self::TurnFailed)**,
+    /// though `turn_id` and this `run_id` are the same key. Those two are
+    /// appended only on the chat HTTP path and bracket an
+    /// [`OperatorMessage`](Self::OperatorMessage); firing one for a task attempt
+    /// would put a turn in the chat transcript that no one took.
+    ///
+    /// Additive: a new `kind`, absent from every journal written before it.
+    RunStatusChanged {
+        /// The attempt's id — the same id
+        /// [`RunRecord::id`](crate::ports::runs::RunRecord::id) is keyed on.
+        run_id: String,
+        /// The card this attempt is at, when it is a task attempt rather than a
+        /// chat turn. Absent for a chat turn, which belongs to no card.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task_id: Option<String>,
+        /// The attempt ordinal at that card — `1` for the first.
+        attempt: u32,
+        /// The status moved from. Absent when the row is being minted, which is
+        /// the one write with no prior state rather than a transition.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from: Option<String>,
+        /// The status moved to.
+        to: String,
+        /// Why, on a failure. Tenant-scoped like
+        /// [`WorkflowRunFinished::error`](Self::WorkflowRunFinished) and
+        /// deliberately **not** projected onto the operator SSE stream.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     /// An inbound webhook fired.
     WebhookReceived {
         /// The channel the webhook arrived on.
@@ -1372,6 +1418,7 @@ impl CompanyEvent {
             Self::OperatorMessage { .. } => "OperatorMessage",
             Self::TurnStarted { .. } => "TurnStarted",
             Self::TurnFailed { .. } => "TurnFailed",
+            Self::RunStatusChanged { .. } => "RunStatusChanged",
             Self::WebhookReceived { .. } => "WebhookReceived",
             Self::ScheduleFired { .. } => "ScheduleFired",
             Self::A2aTaskReceived { .. } => "A2aTaskReceived",
@@ -1468,6 +1515,22 @@ impl CompanyEvent {
             // history is not kept here at all: for a published deliverable it
             // lives on the artifact chain (#552), and for an ordinary note it
             // is not kept anywhere, which pruning this does not change.
+            // Issue #1015, put through the three questions above rather than
+            // swept in beside its neighbours.
+            //
+            // Is it evidence? No — the `RunRecord` is the record of an attempt's
+            // status, and this frame carries no state the row does not already
+            // hold; it says "the row moved". Does anything point at it? No: it
+            // is joined by `run_id`, which pruning does not disturb, and nothing
+            // is addressed by its sequence. Does anything read it back? No boot
+            // fold consults it — `reap_orphaned_runs` reads the *rows*, by
+            // status, which is why it can settle runs this frame never covered.
+            //
+            // And it is high-volume machine exhaust by construction: several
+            // frames per attempt, one per transition, on every card and every
+            // chat turn. Its entire meaning is "re-read this run", and it is
+            // worthless once the console has.
+            | Self::RunStatusChanged { .. }
             | Self::WorkspaceChanged { .. }
             // Issue #983, and classified deliberately rather than swept in with
             // its neighbours — the doc above asks for all three questions.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1194,7 +1194,15 @@ impl RuntimeBuilder {
                 ledgers: ledgers_for_guard.clone(),
                 facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
                 artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
-                runs: self.runs.unwrap_or_else(|| fs_ops.clone()),
+                // Issue #1015: every attempt status change journals a frame, so
+                // the task screen can be pushed rather than polled. Wrapped here
+                // rather than at the cycle's call sites because
+                // `reap_orphaned_runs` settles crash-killed runs through
+                // `finish_run` directly — see `runtime::run_events`.
+                runs: Arc::new(crate::runtime::run_events::EventingRunStore::new(
+                    self.runs.unwrap_or_else(|| fs_ops.clone()),
+                    events.clone(),
+                )),
                 workflow_revisions: self.workflow_revisions.unwrap_or_else(|| fs_ops.clone()),
                 schedule_fires: self.schedule_fires.unwrap_or_else(|| fs_ops.clone()),
                 workflow_run_outputs: self

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1943,6 +1943,12 @@ fn cycle_task_id(
             // either as a stimulus would make a turn re-trigger itself.
             | CompanyEvent::TurnStarted { .. }
             | CompanyEvent::TurnFailed { .. }
+            // Issue #1015: an attempt row announcing its own move. The same
+            // argument as `TaskCardChanged` directly above, and it matters more
+            // here — the store appends it *after* the status write, and the
+            // write is made by this very cycle, so treating it as a stimulus
+            // would let a run re-trigger itself on every transition it makes.
+            | CompanyEvent::RunStatusChanged { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,
         };
         let Some(candidate) = candidate else { continue };
@@ -2122,6 +2128,12 @@ fn cycle_conversation(
             // either as a stimulus would make a turn re-trigger itself.
             | CompanyEvent::TurnStarted { .. }
             | CompanyEvent::TurnFailed { .. }
+            // Issue #1015: an attempt row announcing its own move. The same
+            // argument as `TaskCardChanged` directly above, and it matters more
+            // here — the store appends it *after* the status write, and the
+            // write is made by this very cycle, so treating it as a stimulus
+            // would let a run re-trigger itself on every transition it makes.
+            | CompanyEvent::RunStatusChanged { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,
         };
         let Some(candidate) = candidate else { continue };

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -89,6 +89,7 @@ pub mod repo_manager;
 /// still stop, so `POST …/workflows/runs/{runId}/cancel` has something to reach.
 /// Compiled in every build: it is a plain map of stop signals and touches no
 /// engine. See [`run_supervisor`].
+pub mod run_events;
 pub mod run_supervisor;
 pub mod scheduler;
 /// Issue #203: the Telegram `getUpdates` long-polling listener — the inbound

--- a/src/runtime/run_events.rs
+++ b/src/runtime/run_events.rs
@@ -1,0 +1,382 @@
+//! The seam that makes every task-attempt status change observable (issue #1015).
+//!
+//! # Why a decorator, and why on `put_run`
+//!
+//! [`RunStatus`](crate::ports::runs::RunStatus) transitions were written by
+//! three paths and journalled by none, so attempt status was poll-only: the task
+//! detail screen re-fetched every four seconds and did not move at all while the
+//! tab was hidden. That is the surface #581 spent its effort removing — it
+//! replaced a five-second whole-company refetch with Snapshot + Refresh — so a
+//! poll-only screen is swimming against the direction the console is going.
+//!
+//! The obvious seam is the cycle's call sites, and it is wrong.
+//! [`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs) settles
+//! crash-killed runs by calling `finish_run` **directly**, never through
+//! `cycle.rs`. Emitting from the cycle would leave exactly those runs — the ones
+//! the reaper exists to make visible — moving in silence, which is the partial
+//! event surface that is worse than none, because a consumer assumes the frames
+//! are complete.
+//!
+//! So the frame is emitted one level down, at the store. [`put_run`] is the
+//! single write primitive: `begin_run` and `finish_run` are **trait defaults**
+//! that call `self.put_run`, no backend overrides either (sqlite, MongoDB and
+//! the filesystem all implement `put_run` and `create_run` only), and nothing
+//! else in the tree calls it. Wrapping it therefore covers every status change
+//! that exists, and — because the defaults dispatch through `self` — covers them
+//! by construction rather than by anyone remembering a call site.
+//!
+//! ## `put_run` emits rather than being sealed
+//!
+//! It is documented as "the backend seam behind the transition methods — **not**
+//! the API … calling it directly is how a run ends up in a state the rest of the
+//! system does not believe in." It stays that escape hatch, and it emits. A
+//! hatch that can skip the legality check but *cannot* skip being observed is
+//! the useful shape: the illegal state still lands, and the log still says it
+//! did. Sealing it instead would have meant reimplementing both transitions
+//! here, which is how the decorator and the port drift apart.
+//!
+//! ## Ordering
+//!
+//! The frame is appended **after** the inner write resolves `Ok`, never before,
+//! so a consumer reacting to it can never read a row that has not landed. The
+//! reverse order would be a worse bug than the polling this replaces: a reader
+//! that re-fetches on the frame would see the *old* status and cache it as
+//! current, and nothing would fire again to correct it.
+//!
+//! An append that fails is logged and swallowed — the status write already
+//! happened and is the durable fact, and turning a journal hiccup into a failed
+//! transition would let an observability concern strand a run. The consumer's
+//! fallback poll is what covers that gap, which is why this does not replace it.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::ports::events::EventLog;
+use crate::ports::runs::{NewRun, RunFilter, RunRecord, RunStepRecord, RunStore};
+use crate::ports::types::{CompanyEvent, CompanyId};
+
+/// Wraps a [`RunStore`] so every status write journals a
+/// [`CompanyEvent::RunStatusChanged`].
+pub struct EventingRunStore {
+    inner: Arc<dyn RunStore>,
+    events: Arc<dyn EventLog>,
+}
+
+impl EventingRunStore {
+    /// Wraps `inner`, journalling to `events`.
+    pub fn new(inner: Arc<dyn RunStore>, events: Arc<dyn EventLog>) -> Self {
+        Self { inner, events }
+    }
+
+    /// Appends the frame for a settled write, or logs why it could not.
+    async fn announce(&self, company: &CompanyId, run: &RunRecord, from: Option<String>) {
+        if let Err(err) = self
+            .events
+            .append(
+                company,
+                CompanyEvent::RunStatusChanged {
+                    run_id: run.id.clone(),
+                    task_id: run.task_id.clone(),
+                    attempt: run.attempt,
+                    from,
+                    to: run.status.as_str().to_string(),
+                    error: run.error.clone(),
+                },
+            )
+            .await
+        {
+            // Swallowed on purpose — see the module note on ordering. The status
+            // write is the durable fact and it already happened.
+            tracing::warn!(
+                company = %company,
+                run = %run.id,
+                status = %run.status,
+                error = %err,
+                "[runs] could not journal an attempt's status change; the row moved anyway"
+            );
+        }
+    }
+}
+
+impl std::fmt::Debug for EventingRunStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventingRunStore").finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl RunStore for EventingRunStore {
+    /// Mints the row, then announces it as a move to `pending` with no `from` —
+    /// the one write that is a birth rather than a transition.
+    async fn create_run(&self, company: &CompanyId, spec: NewRun) -> Result<RunRecord> {
+        let run = self.inner.create_run(company, spec).await?;
+        self.announce(company, &run, None).await;
+        Ok(run)
+    }
+
+    /// **The seam.** Reads the prior status, writes, then announces — and only
+    /// when the status actually moved, so a write that revises cost or step
+    /// count on an already-settled row does not manufacture a transition.
+    ///
+    /// The extra read is the price of naming both ends of the move. A consumer
+    /// applying a frame to a row it already holds needs `from` to tell an
+    /// out-of-order or replayed frame from a live one, which a bare `to` cannot.
+    async fn put_run(&self, company: &CompanyId, run: &RunRecord) -> Result<()> {
+        let before = self
+            .inner
+            .get_run(company, &run.id)
+            .await
+            .ok()
+            .flatten()
+            .map(|prior| prior.status);
+        self.inner.put_run(company, run).await?;
+        if before != Some(run.status) {
+            self.announce(company, run, before.map(|s| s.as_str().to_string()))
+                .await;
+        }
+        Ok(())
+    }
+
+    async fn get_run(&self, company: &CompanyId, id: &str) -> Result<Option<RunRecord>> {
+        self.inner.get_run(company, id).await
+    }
+
+    async fn list_runs(&self, company: &CompanyId, filter: &RunFilter) -> Result<Vec<RunRecord>> {
+        self.inner.list_runs(company, filter).await
+    }
+
+    async fn append_run_step(&self, company: &CompanyId, step: &RunStepRecord) -> Result<()> {
+        self.inner.append_run_step(company, step).await
+    }
+
+    async fn list_run_steps(
+        &self,
+        company: &CompanyId,
+        run_id: &str,
+    ) -> Result<Vec<RunStepRecord>> {
+        self.inner.list_run_steps(company, run_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex as StdMutex;
+
+    use super::*;
+    use crate::ports::events::EventLog;
+    use crate::ports::runs::{RunOutcome, RunStatus, reap_orphaned_runs};
+    use crate::ports::types::EventSeq;
+    use crate::ports::types::StoredEvent;
+    use crate::store::FsOps;
+
+    /// An [`EventLog`] that keeps what it was handed.
+    #[derive(Default)]
+    struct MemLog {
+        events: StdMutex<Vec<CompanyEvent>>,
+    }
+
+    impl MemLog {
+        /// The `(from, to)` pairs journalled so far, in order.
+        fn moves(&self) -> Vec<(Option<String>, String)> {
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|event| match event {
+                    CompanyEvent::RunStatusChanged { from, to, .. } => {
+                        Some((from.clone(), to.clone()))
+                    }
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    #[async_trait]
+    impl EventLog for MemLog {
+        async fn append(&self, _id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+            let mut guard = self.events.lock().unwrap();
+            guard.push(event);
+            Ok(EventSeq::new(guard.len() as u64))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> futures::stream::BoxStream<'static, StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// A wrapped store over a real filesystem backend, plus its log.
+    fn store(dir: &std::path::Path) -> (EventingRunStore, Arc<MemLog>) {
+        let log = Arc::new(MemLog::default());
+        let inner: Arc<dyn RunStore> = Arc::new(FsOps::new(dir));
+        (
+            EventingRunStore::new(inner, log.clone() as Arc<dyn EventLog>),
+            log,
+        )
+    }
+
+    /// The happy path, end to end: mint, start, settle — three frames, each
+    /// naming both ends of its move.
+    #[tokio::test]
+    async fn every_transition_of_an_attempt_is_journalled() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runs, log) = store(dir.path());
+        let company = CompanyId::new("acme");
+
+        runs.create_run(&company, NewRun::for_task("run-1", "card-1", "ceo"))
+            .await
+            .expect("mint");
+        runs.begin_run(&company, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        runs.finish_run(&company, "run-1", RunOutcome::new(RunStatus::Succeeded))
+            .await
+            .expect("finish");
+
+        assert_eq!(
+            log.moves(),
+            vec![
+                (None, "pending".to_string()),
+                (Some("pending".to_string()), "running".to_string()),
+                (Some("running".to_string()), "succeeded".to_string()),
+            ],
+            "a mint and both transitions each journal one frame, naming both ends"
+        );
+    }
+
+    /// **The case the issue's own proposed seam drops.**
+    ///
+    /// `reap_orphaned_runs` settles crash-killed runs by calling `finish_run`
+    /// directly on the store — it never goes through `cycle.rs`. Emitting from
+    /// the cycle's call sites would leave exactly these runs, the ones the
+    /// reaper exists to make visible, moving in silence.
+    #[tokio::test]
+    async fn the_boot_reaper_journals_the_runs_it_settles() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runs, log) = store(dir.path());
+        let company = CompanyId::new("acme");
+
+        runs.create_run(&company, NewRun::for_task("run-1", "card-1", "ceo"))
+            .await
+            .expect("mint");
+        runs.begin_run(&company, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+
+        let reaped = reap_orphaned_runs(&runs, &company).await.expect("reap");
+        assert_eq!(reaped.len(), 1, "the active row is reclaimed: {reaped:?}");
+
+        assert_eq!(
+            log.moves().last().cloned(),
+            Some((Some("running".to_string()), "failed".to_string())),
+            "a run the host died under says so, rather than moving in silence"
+        );
+    }
+
+    /// A write that revises a settled row's cost or step count is not a
+    /// transition and must not manufacture a frame — otherwise a consumer
+    /// applying frames sees a move that never happened.
+    #[tokio::test]
+    async fn a_write_that_does_not_move_the_status_journals_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runs, log) = store(dir.path());
+        let company = CompanyId::new("acme");
+
+        let run = runs
+            .create_run(&company, NewRun::for_task("run-1", "card-1", "ceo"))
+            .await
+            .expect("mint");
+        let before = log.moves().len();
+
+        let mut revised = run.clone();
+        revised.step_count = 7;
+        runs.put_run(&company, &revised).await.expect("revise");
+
+        assert_eq!(
+            log.moves().len(),
+            before,
+            "the status did not move, so nothing claims it did"
+        );
+    }
+
+    /// The frame is appended only after the row is durable, so a consumer
+    /// reacting to it can never read state that has not landed.
+    ///
+    /// Asserted by reading the store from inside the log's own `append`: at the
+    /// moment the frame exists, the row must already carry the status it names.
+    #[tokio::test]
+    async fn the_row_is_durable_before_its_frame_is_appended() {
+        /// Reads the run back the instant a frame is appended.
+        struct ReadsBack {
+            runs: StdMutex<Option<Arc<dyn RunStore>>>,
+            seen: StdMutex<Vec<(String, Option<RunStatus>)>>,
+        }
+
+        #[async_trait]
+        impl EventLog for ReadsBack {
+            async fn append(&self, id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+                if let CompanyEvent::RunStatusChanged { run_id, to, .. } = &event {
+                    let inner = self.runs.lock().unwrap().clone();
+                    let landed = match inner {
+                        Some(runs) => runs.get_run(id, run_id).await.ok().flatten(),
+                        None => None,
+                    };
+                    self.seen
+                        .lock()
+                        .unwrap()
+                        .push((to.clone(), landed.map(|run| run.status)));
+                }
+                Ok(EventSeq::new(1))
+            }
+            async fn read_from(
+                &self,
+                _id: &CompanyId,
+                _seq: EventSeq,
+                _limit: usize,
+            ) -> Result<Vec<StoredEvent>> {
+                Ok(Vec::new())
+            }
+            fn subscribe(
+                &self,
+                _id: &CompanyId,
+            ) -> futures::stream::BoxStream<'static, StoredEvent> {
+                Box::pin(futures::stream::empty())
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn RunStore> = Arc::new(FsOps::new(dir.path()));
+        let log = Arc::new(ReadsBack {
+            runs: StdMutex::new(Some(inner.clone())),
+            seen: StdMutex::new(Vec::new()),
+        });
+        let runs = EventingRunStore::new(inner, log.clone() as Arc<dyn EventLog>);
+        let company = CompanyId::new("acme");
+
+        runs.create_run(&company, NewRun::for_task("run-1", "card-1", "ceo"))
+            .await
+            .expect("mint");
+        runs.begin_run(&company, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+
+        let seen = log.seen.lock().unwrap().clone();
+        assert!(!seen.is_empty(), "frames were appended");
+        for (claimed, landed) in seen {
+            assert_eq!(
+                landed.map(|s| s.as_str().to_string()),
+                Some(claimed.clone()),
+                "a frame claiming `{claimed}` was appended before the row said so"
+            );
+        }
+    }
+}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1089,6 +1089,36 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["turnId"] = json!(turn_id);
             o
         }
+        // Issue #1015: the push half of attempt status. Structural, and for the
+        // same sharper reason as `turn_settled` directly above — `error` is a
+        // failure reason in our own words that can name internals, so the
+        // console learns *that* the attempt moved here and reads *why* from the
+        // run row, which is tenant-scoped.
+        //
+        // `from` rides along so a consumer holding a row can tell a live frame
+        // from a replayed or out-of-order one, which a bare `to` cannot. It is
+        // omitted rather than null on the mint, where there is no prior state —
+        // the same presence-check discipline `turn_started`'s `parentId` uses.
+        CompanyEvent::RunStatusChanged {
+            run_id,
+            task_id,
+            attempt,
+            from,
+            to,
+            ..
+        } => {
+            let mut o = envelope("run_status_changed");
+            o["runId"] = json!(run_id);
+            o["attempt"] = json!(attempt);
+            o["status"] = json!(to);
+            if let Some(task_id) = task_id {
+                o["taskId"] = json!(task_id);
+            }
+            if let Some(from) = from {
+                o["from"] = json!(from);
+            }
+            o
+        }
         // Not an attention signal, or carries a raw payload we never put on the
         // wire — dropped.
         _ => return None,


### PR DESCRIPTION
## Summary

Task attempt status was written by three paths and journalled by none, so the task detail screen could
only **poll**: it sat at `pending`/`running` for up to four seconds after an attempt had really moved,
and did not move at all while the tab was hidden. That is the surface #581 spent its effort removing
when it replaced the five-second whole-company refetch with Snapshot + Refresh — a poll-only screen is
swimming against the direction the console is going.

## The seam: `put_run`, and why that makes this correct by construction

**`put_run` is the single write primitive for every status change in the tree.** Three facts, each
checkable:

1. `begin_run` and `finish_run` are **trait defaults on `RunStore`** whose bodies call `self.put_run`
   (`src/ports/runs.rs:562`, `:593`).
2. **No backend overrides either.** sqlite, MongoDB and the filesystem store implement `put_run` and
   `create_run` and nothing else of the transition surface.
3. **Nothing else in the tree calls `put_run`** — the only two callers are those two defaults.

So decorating `put_run` covers every status change **by construction**, rather than by anyone
remembering six call sites. That is a stronger claim than "events were added at the write paths", and
it is what makes the next section safe rather than lucky: because the defaults dispatch through
`self`, a decorator that overrides only `put_run` sees the transitions too.

### Why not the cycle's call sites — the reaper

The obvious seam is `cycle.rs`, which is what #1015 proposes (`:301`, `:515`, `:3050`). It is wrong.

`reap_orphaned_runs` (`src/ports/runs.rs:684`) settles crash-killed runs by calling `finish_run`
**directly on the store**, never through the cycle. Emitting from the cycle would leave exactly those
runs — the ones whose visibility the reaper exists to provide — transitioning in silence. That is the
partial event surface that is worse than none, because a consumer assumes the frames are complete, and
it would fail in the one case where silence is most harmful.

`the_boot_reaper_journals_the_runs_it_settles` pins it.

### `put_run` stays a documented escape hatch, and it emits

A reviewer's instinct here is to seal it. Two reasons not to.

It is documented as *"the backend seam behind the transition methods — **not** the API … calling it
directly is how a run ends up in a state the rest of the system does not believe in."* It stays that,
and it emits. **A hatch that can skip the legality check but cannot skip being observed is the useful
shape**: the illegal state still lands, and the log still says it did. Sealing it would trade a
visible bad state for an invisible one.

And sealing it would have meant reimplementing `begin_run`/`finish_run` inside the decorator — which
is precisely how a decorator and its port drift apart. Overriding the one primitive they are both
built on keeps a single definition of what a transition is.

## Why not `TurnStarted` / `TurnFailed`

Reuse is the natural suggestion, because `TurnStarted.turn_id` is documented as *"the same id its
`RunRecord` is keyed on"* — the same object, joined by the same key. It still does not fit:

- they are appended **only on the chat HTTP path** (`src/server/operator.rs:1511`), so they do not
  exist for a task attempt at all;
- they **bracket an `OperatorMessage`** — that is their meaning. Firing one for a task attempt would
  put **a turn in the chat transcript that nobody took**;
- they cover accepted/failed, not the status machine (`waiting_approval`, `paused`, `cancelled`).

The `WorkflowRun*` / `WorkflowNode*` frames are a different object — workflow runs, not task attempts.

So this is a new variant, and the surface it joins was **empty rather than partial**: no transition
journalled anything before this, so there was no half-built contract for a new frame to contradict.

## Ordering

The frame is appended **after** the inner write resolves `Ok`, never before. A consumer reacting to it
therefore cannot read a row that has not landed. The reverse order is a worse bug than the polling
this replaces: a reader that re-fetches on the frame would see the **old** status, cache it as current,
and nothing would fire again to correct it.

`the_row_is_durable_before_its_frame_is_appended` proves it by reading the store *from inside the
event log's own `append`* — at the moment the frame exists, the row must already carry the status it
names. It is the only test that fails when the two lines are swapped.

An append that fails is **logged and swallowed**: the status write already happened and is the durable
fact, and turning a journal hiccup into a failed transition would let an observability concern strand
a run. That is exactly why the consumer keeps its poll (below) rather than replacing it.

## API Or Behavior Changes

**New `CompanyEvent::RunStatusChanged { run_id, task_id, attempt, from, to, error }`**, projected to
the operator stream as **`run_status_changed`** with `runId`, `attempt`, `status`, and optional
`taskId` / `from`.

`error` is **not** projected. A failure reason is our own prose about the host and is tenant-scoped, so
the console learns *that* an attempt moved from the frame and reads *why* from the run row — the same
discipline `turn_settled` already applies.

`from` rides along so a consumer holding a row can tell a live frame from a replayed or out-of-order
one, which a bare `to` cannot. It is omitted rather than null on the mint, where there is no prior
state — the presence-check discipline `turn_started`'s `parentId` uses.

Two classifications the compiler forced, both decided rather than swept in:

- **Retention: `Prunable`**, against the three questions the doc comment asks. Not evidence (the
  `RunRecord` is the record of status; the frame carries nothing the row does not). Nothing points at
  it (joined by `run_id`, nothing addressed by its sequence). Nothing reads it back (no boot fold
  consults it — `reap_orphaned_runs` reads the *rows*, by status, which is why it can settle runs this
  frame never covered). And it is high-volume exhaust: several frames per attempt, on every card and
  every chat turn.
- **Neutral in the cycle's trigger scanners**, and this one is load-bearing. The store appends the
  frame *after* a status write made by that very cycle, so treating it as a stimulus would let **a run
  re-trigger itself on every transition it makes**. Same argument as `TaskCardChanged` beside it, and
  sharper.

### Console

`onRunEvent` on `useEvents`, its own counter in the shell, threaded through `TasksView` to
`TaskDetailView`. A counter rather than a payload, like `taskEventTick`: the screen re-reads its own
detail, so two frames collapsing in one React batch still mean "re-read".

Separate from `onTaskEvent` deliberately — an attempt moving does not move a card, and folding it in
would refetch the whole board on every transition of every run, which is the timer load #581 removed.
**No toast**, for the reason the board frames raise none: this fires several times per attempt, and
training the operator to dismiss toasts is how the ones that matter get dismissed.

**The poll stays.** The push half is its own effect (the split `TasksView` uses, for the reason #464
gives: folding it into the polling effect would restart the fallback timer on every frame, so a busy
company would lose the fallback exactly where it is most needed). Visibility-gated like the poll, per
#581. A frame can be lost — the stream can drop, and a failed append is swallowed — so the timer is the
floor under a liveness the frame alone does not guarantee.

## Not in this PR

The issue's secondary ask — optional `runId`/`taskId` on `approval_parked` — is **not** included, and
is largely moot now. Parks settle through `finish_run`, so a run parking for a gate already emits
`RunStatusChanged { to: "waiting_approval", run_id, task_id, .. }`. That correlation was wanted
because there was no other way to apply a park to the right row live; there now is. Happy to add the
fields if a consumer still wants them off the approval frame itself.

## Tests

- [x] `cargo fmt --all -- --check` — PASS.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI's gated form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`.
      PASS. `--no-deps` mirrors CI; an unscoped run drowns in vendored lints CI never sees.
- [x] `cargo build --all-targets` — covered by the clippy and test runs at
      `--features openhuman,tinycortex --all-targets`.
- [x] `cargo test` — **4258 passed / 0 failed** at `--features openhuman,tinycortex --lib`.

Console: `npm run typecheck`, `typecheck:e2e`, `typecheck:unit` all PASS; unit suite **895 passed / 88
files**.

### Proven to fail with the fix reverted

- Stripping the emission from the decorator fails **3 of 4** Rust tests, including
  `the_boot_reaper_journals_the_runs_it_settles` — the case the issue's own proposed seam drops.
- **Swapping the append and the write fails `the_row_is_durable_before_its_frame_is_appended`, and
  only that test** — so it isolates the ordering hazard rather than incidentally covering it.
- Removing the `run_status_changed` dispatch arm fails **2 of 4** console tests.

**Four assertions are negative guards and pass either way** — no toast, no board refetch, and no frame
for a write that revises a settled row's cost without moving its status. Stating that rather than
counting them as coverage.

## Documentation

`src/runtime/run_events.rs` carries the reasoning as module docs: why the store and not the cycle, why
`put_run` is the primitive, why it stays an escape hatch, and the ordering contract. The variant, the
retention arm and the two cycle scanners each state their own decision at the point it is made.

No `docs/` change: no route, launcher behavior or `tiny*` integration changes.

Closes tinyhumansai/opencompany#1015
