### PR TITLE
fix(connections): retire native OAuth routes

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -53,7 +53,7 @@ why this is not a read/write split: [authority.md](authority.md).
 | `inbox` | `POST …/inboxes/ingest` (HMAC-signed inbound email) |
 | `domain` | `PUT …/domain`, `POST …/domain/verify` |
 | `smtp` | `PUT …/smtp`, `POST …/smtp/test` |
-| `connections` (feature `oauth`) | `POST …/connections/{provider}/start\|disconnect`, `GET /api/v1/oauth/callback` |
+| `connections` (feature `oauth`) | `POST …/connections/{provider}/start` → dated `410` retirement bridge, `POST …/connections/{provider}/disconnect`, `GET /api/v1/oauth/callback` → dated `410` browser landing page (#838; removal #1023) |
 | `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/runs`, `POST …/workflows/cron/preview`, `GET …/workflows/{wid}`, `PUT …/workflows/{wid}`, `DELETE …/workflows/{wid}`, `POST …/workflows/{wid}/run`, `POST …/workflows/runs/{runId}/cancel` |
 
 ### Exporting a task's record (issue #352)

--- a/docs/modules/server/authority.md
+++ b/docs/modules/server/authority.md
@@ -24,7 +24,7 @@ the world as, and which third-party accounts its agents act through:
 | Surface | Admin-scoped |
 |---|---|
 | `composio` | `PUT …/composio/token`, `POST …/composio/authorize`, `DELETE …/composio/connections/{id}`, `PUT`/`DELETE …/composio/connections/{id}/default` |
-| `connections` (`oauth`) | `POST …/connections/{p}/start`, `POST …/connections/{p}/disconnect` |
+| `connections` (`oauth`) | `POST …/connections/{p}/start` (dated `410` retirement bridge), `POST …/connections/{p}/disconnect` |
 | `inference` | `PUT …/inference`, `DELETE …/inference`, `POST …/inference/restart` |
 | `smtp` | `PUT …/smtp`, `POST …/smtp/test` (the caller names the recipient) |
 | `domain` | `PUT …/domain` |

--- a/docs/modules/server/connections.md
+++ b/docs/modules/server/connections.md
@@ -1,66 +1,48 @@
-# Connections: hosted, the self-hosted hatch, and releasing one
+# Connections: hosted providers and releasing legacy native OAuth
 
 Split out of [README.md](README.md) when that file reached the 500-line cap.
-The write routes are `ops::connections` (feature `oauth`) and `ops::composio`;
-the read plane is `ops::connections_read`.
+The read plane is `ops::connections_read`; Composio owns every currently
+actionable provider connection.
 
-## Hosted versus the self-hosted hatch
+## Retired native OAuth
 
-`ops::connections` (feature `oauth`) runs OAuth with **this host's own provider
-application** — a client id/secret an operator registered themselves and handed
-to the process as `OPENCOMPANY_OAUTH_<PROVIDER>_ID` / `_SECRET`. It is a hatch,
-not a deployment mode — the same framing `ops::composio` uses for its BYO token.
-A hosted tenant is injected no `OPENCOMPANY_OAUTH_*` variable at all, so on that
-host `provider_config` resolves nothing and a local Connect can only fail.
+The former native OAuth flow used this host's own provider application, completed
+a real handshake, and stored `oauth/{provider}`. Nothing under `src/harness/`
+can resolve that credential, so a successful native connection never gave an
+agent any capability.
 
-**The console no longer offers this route** (issue #822). The routes below are
-live and unchanged; what changed is that nothing invites an operator down them.
-The reason is #396: `oauth_key(provider)` — `"oauth/{provider}"` — is written by
-the callback and read by *no agent tool*, zero occurrences under `src/harness/`.
-So the hatch worked and conferred nothing, and a self-hoster could register a
-provider application, complete a real handshake, see the tile turn green, and
-give their agents no ability whatsoever. `frontend/src/lib/connections.ts`'s
-`connectRoute` therefore answers `composio`, `managed` or `unavailable` and never
-`native`, and `provider-grid.ts` builds the grid from the backend's Composio
-catalog rather than from the console's own provider metadata.
+The console stopped offering that flow in #828. #838 keeps its endpoints only as
+a bounded compatibility bridge for console bundles cached before #979:
 
-Two things this deliberately does **not** do. It does not remove the routes —
-settling #396 by wiring the credential into the harness makes the offer honest
-again, and reinstating it is one arm in `connectRoute`. And it does not hide a
-credential already stored: a provider `GET …/connections` reports connected keeps
-its tile, its `via: ["native"]` and its Disconnect, whether or not the Composio
-catalog carries it.
-
-The read plane says which it is. `ops::connections_read::connect_route` answers
-one question per provider — *can a Connect click possibly succeed here, and by
-which route?* — as a `credentialSource` tier, stored-wins:
-
-| Tier | When | Console |
+| Route | Until 2026-09-30 | Afterwards |
 | --- | --- | --- |
-| `static` | a token is already stored for this provider (BYO override), **or** this host registered its own provider app *and* has a state signing secret (the hatch) | no local Connect since #822 — Composio's if it has one, else "not available here" |
-| `attested` | no stored token, and the pod carries a platform-**projected** identity (`TINYHUMANS_TOKEN_FILE` naming a file that exists) | "Managed by the platform", no local Connect |
-| `none` | neither | read-only "not available on this host" |
+| `POST …/connections/{provider}/start` | `410 Gone` JSON: explains that native credentials were unreachable by agents, points callers to Composio, and carries a Sunset date | removed by #1023 |
+| `GET /api/v1/oauth/callback` | `410 Gone` HTML: explains to a browser already returning from a provider that nothing was saved | removed by #1023 |
+| `POST …/connections/{provider}/disconnect` | blanks and best-effort revokes a credential written before #828 | stays while legacy credentials exist |
 
-The tier is still the honest answer to *can a Connect click possibly succeed
-here* — it is what the route itself decides by, and `start` still refuses on
-`none`. What #822 changed is that the console stopped acting on `static`: the
-question it renders is no longer "could this succeed" but "would this confer
-anything", and for the native hatch the answer is no until #396 is settled.
+The callback intentionally ignores every query parameter. Once `start` refuses
+it cannot mint a new signed state, but a consent screen opened seconds before a
+deploy can still redirect a real browser afterwards. Explaining that outcome,
+rather than accepting the code or returning a 404, prevents an in-flight
+authorization from creating the same agent-unreachable credential.
 
-**The hatch also needs `OPENCOMPANY_OAUTH_STATE_SECRET`** (issue #318). The
-`state` nonce binds an in-flight authorization to one company, provider and
-expiry, and the callback verifies it before exchanging the code — it is the
-flow's CSRF defence. That signing key used to fall back to a literal baked into
-this repository, which made the value public, identical across every
-unconfigured deployment, and constructible rather than obtainable: verifying it
-proved only that it was well-formed. There is now **no default**. A host with a
-registered provider application but no secret reports `none` rather than
-offering a button whose check is void, `start` refuses with a message naming the
-variable, and the process logs the misconfiguration once — a tile has no room to
-name a variable, and an operator reads logs. Whitespace-only counts as unset, so
-an empty shell expansion gets the closed door rather than a secret of `" "`.
+A native credential already stored remains visible in `GET …/connections` with
+`via: ["native"]` and can be released with Disconnect. It does not satisfy a
+planning prerequisite and must not be read as an agent capability.
 
-`attested` deliberately requires the projected-file tier, not
+`credentialSource: "static"` now means only that a legacy native credential
+exists. A host-level `OPENCOMPANY_OAUTH_<PROVIDER>_ID` / `_SECRET` pair does
+not make a connection route available; it is retained solely for best-effort
+revocation of that historical provider grant.
+
+## Hosted connections
+
+#319 remains the decision point for hosted provider connections. The platform
+backend owns provider applications and token custody; OpenCompany agents reach
+providers through the supported Composio path, never through
+`oauth/{provider}`.
+
+The read projection's `attested` source deliberately requires the projected-file tier, not
 `TinyhumansTokenSource::from_env` as a whole: that resolver also accepts a
 long-lived `TINYHUMANS_API_KEY`, which a self-hoster commonly sets to buy
 inference. Accepting it here would tell such an operator their working Connect
@@ -183,4 +165,3 @@ Composio resolves it for the entity — nothing in this codebase selects, orders
 or defaults an account, and the console's provider detail view says so rather
 than marking one as the default. Changing that means sending a connection id on
 execute, which is a harness change, not a console one.
-

--- a/docs/modules/server/connections.md
+++ b/docs/modules/server/connections.md
@@ -14,7 +14,7 @@ agent any capability.
 The console stopped offering that flow in #828. #838 keeps its endpoints only as
 a bounded compatibility bridge for console bundles cached before #979:
 
-| Route | Until 2026-09-30 | Afterwards |
+| Route | Until 2026-09-30 | Afterward |
 | --- | --- | --- |
 | `POST …/connections/{provider}/start` | `410 Gone` JSON: explains that native credentials were unreachable by agents, points callers to Composio, and carries a Sunset date | removed by #1023 |
 | `GET /api/v1/oauth/callback` | `410 Gone` HTML: explains to a browser already returning from a provider that nothing was saved | removed by #1023 |
@@ -22,7 +22,7 @@ a bounded compatibility bridge for console bundles cached before #979:
 
 The callback intentionally ignores every query parameter. Once `start` refuses
 it cannot mint a new signed state, but a consent screen opened seconds before a
-deploy can still redirect a real browser afterwards. Explaining that outcome,
+deploy can still redirect a real browser afterward. Explaining that outcome,
 rather than accepting the code or returning a 404, prevents an in-flight
 authorization from creating the same agent-unreachable credential.
 
@@ -37,7 +37,7 @@ revocation of that historical provider grant.
 
 ## Hosted connections
 
-#319 remains the decision point for hosted provider connections. The platform
+Issue `#319` remains the decision point for hosted provider connections. The platform
 backend owns provider applications and token custody; OpenCompany agents reach
 providers through the supported Composio path, never through
 `oauth/{provider}`.

--- a/docs/plans/06-connections-domain-email.md
+++ b/docs/plans/06-connections-domain-email.md
@@ -16,24 +16,23 @@ Routes (dual-scoped like all WS3 ops routes, except the callback):
 
 | Method | Path | Behavior |
 |---|---|---|
-| POST | `…/connections/{provider}/start` | → `{url}`: provider authorize URL with a signed `state` nonce (company+provider+expiry), redirect URI from config |
-| GET | `/api/v1/oauth/callback` (unscoped) | verifies `state`, exchanges `code` server-side, stores tokens at `SecretStore["oauth/{provider}"]`, captures the account label, redirects back to the console |
+| POST | `…/connections/{provider}/start` | retirement bridge: `410 native_oauth_retired` through 2026-09-30; it no longer starts a handshake (#838, removal #1023) |
+| GET | `/api/v1/oauth/callback` (unscoped) | retirement browser landing page: `410 Gone` explaining an in-flight authorization was not saved; it does not inspect `state` or exchange `code` |
 | POST | `…/connections/{provider}/disconnect` | best-effort revoke, delete the secret |
 
-- **Callback hosting:** this crate hosts it. In managed deployments the
-  manager may front the same path; `OPENCOMPANY_OAUTH_REDIRECT_BASE`
-  overrides the redirect URI so the authorize URL points wherever the
-  operator's browser can reach (README open question resolution).
-- **Provider app credentials** (client_id/client_secret) are host-level
-  configuration (`OPENCOMPANY_OAUTH_<PROVIDER>_ID/_SECRET`), never
-  per-company; per-company state is tokens only.
+- **Callback hosting:** this crate keeps the unscoped callback through
+  2026-09-30 solely as the explanatory landing page for a browser redirected
+  after deployment. It does not need a redirect base or process callback
+  parameters.
+- **Provider app credentials** (client_id/client_secret) remain host-level
+  configuration only for best-effort revocation of historical credentials;
+  they no longer enable per-company native connections.
 - Read side (GraphQL `connections`): catalog priorities from `[[connection]]`
   manifest intent ∪ connected state from the secret store — `{provider,
   connected, account?, reason?}`. **Account label and connected flag only;
   token material never appears in any response** (feature-tested).
-- Token exchange needs `reqwest` → gate the write routes behind a small
-  `oauth` feature; without it they 404 and the console shows the read-only
-  catalog (existing seam behavior).
+- The `oauth` feature keeps the compatibility and cleanup routes available;
+  `reqwest` is now used only for best-effort revocation, never token exchange.
 
 ### Domain & DNS
 

--- a/docs/plans/06-connections-domain-email.md
+++ b/docs/plans/06-connections-domain-email.md
@@ -114,7 +114,7 @@ WS3 (`InboxStore`, ops scaffolding, SecretStore keys). Feeds WS7
 
 Unit: DNS record generation determinism; mock-resolver verify outcomes.
 Feature: the four-case suite per route plus — no token/password material in
-any serialized response; callback with tampered `state` → 401; inbound hook
+any serialized response; callback with any `state` → dated `410` and no credential write; inbound hook
 with bad HMAC → 401 and no event; smtp test with mock sender. Default build
 compiles with no network crates. Exit per
 [09-verification.md](09-verification.md) WS6 row.

--- a/docs/plans/09-verification.md
+++ b/docs/plans/09-verification.md
@@ -71,10 +71,10 @@ Per-surface additions:
   the TOML on disk; unknown id → null.
 - **Chat threading** — `{message, chat}` routes to the desk and journals
   `AgentReply`; unknown desk → 400; `Chat.history` returns both directions.
-- **Connections** — `start` returns an authorize URL (mock provider config);
-  callback exchanges the signed state and stores the token; `disconnect`
-  clears the secret; **no token material in any response body** (assert
-  serialized JSON).
+- **Connections** — `start` returns the dated `410 native_oauth_retired`
+  response; callback returns a `410` explanatory page without reading `state`
+  or exchanging `code`; `disconnect` clears historical secrets; **no token
+  material in any response body** (assert serialized JSON).
 - **Domain/SMTP** — PUT domain → generated records; verify with mock resolver
   (both outcomes); PUT smtp writes to `SecretStore` and the read surface
   exposes host/username only; smtp test with mock `MailSender`.

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -310,9 +310,8 @@ nothing does not.
 ### Credential-bearing surfaces (feature-gated)
 
 These write secrets to the `SecretStore` and expose only non-secret status.
-The networked half of each (DNS lookup, SMTP send, OAuth token exchange) is
-dependency-inverted behind a trait; when the relevant seam is absent the write
-route `404`s with `{"code":"not_wired"}`.
+The native OAuth compatibility routes below deliberately **do not** write a
+credential: the old credential was unreachable by agents.
 
 ```text
 GET    …/credential                         whether the company has its own key + which tier it presents
@@ -321,9 +320,9 @@ PUT    …/domain                             set the custom domain
 POST   …/domain/verify                       server-side DNS check
 PUT    …/smtp                               store SMTP credentials (secret store)
 POST   …/smtp/test                           send a test email
-POST   …/connections/{provider}/start        begin OAuth (returns authorize URL)   [feature: oauth]
-POST   …/connections/{provider}/disconnect   drop stored OAuth tokens               [feature: oauth]
-GET    /api/v1/oauth/callback                OAuth redirect target (unscoped; state carries the company)  [feature: oauth]
+POST   …/connections/{provider}/start        retired native OAuth bridge → 410 JSON until 2026-09-30  [feature: oauth]
+POST   …/connections/{provider}/disconnect   drop a legacy stored OAuth token  [feature: oauth]
+GET    /api/v1/oauth/callback                retired browser landing page → 410 HTML until 2026-09-30  [feature: oauth]
 ```
 
 `…/credential` is the company's **one** TinyHumans key, presented by every
@@ -331,33 +330,18 @@ surface wired to it (**Composio today**) — see
 [`credentials.md`](credentials.md) for the resolution order, the rotation
 guarantee, and which surfaces are deliberately outside it.
 
-### The OAuth callback always redirects
+### Retired native OAuth callback
 
-`/api/v1/oauth/callback` is reached by a **browser navigation**, so anything it
-returns as a body becomes the page the operator is left on. It therefore never
-answers with JSON. Every outcome redirects to the console's Connections view:
+`/api/v1/oauth/callback` stays reachable for a browser that began consent
+immediately before a deploy. It returns a non-caching `410 Gone` HTML page that
+says the authorization was not saved, why native OAuth cannot make agents able
+to use the provider, and to use Composio instead. It ignores the provider's
+`code` and `state` rather than exchanging or storing them.
 
-- success → `…/connections?connected=<provider>`
-- failure → `…/connections?connect_error=<code>[&provider=<provider>]`
-
-`<code>` is one of a closed set — `denied`, `invalid_request`, `invalid_state`,
-`unknown_company`, `provider_disabled`, `exchange_failed`, `store_failed` — that
-the console maps to operator-facing copy. The provider's own error text is
-logged host-side but never forwarded: it is attacker-influenced and must not
-ride in a URL that lands in browser history and access logs. `provider` is
-appended only when a signature-verified `state` supplies it, so the arms that
-fire before verification omit it.
-
-### Provider catalog vs. configured providers
-
-The console's Connections view offers 11 provider tiles; `well_known()` in
-`server::ops::connections` carries built-in authorize/token URLs for three
-families only (`slack`, `google`/`gmail`, `github`). Every other tile needs
-`OPENCOMPANY_OAUTH_<P>_AUTHORIZE_URL` / `_TOKEN_URL` alongside its `_ID` /
-`_SECRET`, or it is simply not enabled on that host.
-
-This gap is **known and safe**: an unconfigured tile fails at `start` with a
-`400 provider '<p>' is not enabled on this host`, the console shows a toast, and
-the browser never navigates — so there is no broken redirect to come back from.
-Closing the gap (shipping more well-known URLs, or hiding unconfigured tiles) is
-separate work.
+`POST …/connections/{provider}/start` is likewise a `410 Gone` JSON response
+with stable code `native_oauth_retired`, an explanatory message, and
+`removalAfter: "2026-09-30"`. Both temporary endpoints send `Deprecation:
+true` and a `Sunset: Wed, 30 Sep 2026 00:00:00 GMT` header. #1023 removes the
+bridge after the cache compatibility window established by #979; it keeps
+Disconnect and the read projection so tenants can release credentials written
+before #828.

--- a/docs/spec/runtime/credentials.md
+++ b/docs/spec/runtime/credentials.md
@@ -194,12 +194,12 @@ is `managed`, and even then they are the same value for different reasons.
 
 ## What this does not cover
 
-- **The native OAuth catalog.** `…/connections/{provider}/start` still resolves
-  through `HostConnectRoutes` — a stored provider token, else a *projected*
-  instance identity, else this host's own registered provider application. That
-  precedence is unchanged, so `source: "company"` never appears on a native-only
-  provider. That path is entangled with the inert-catalog question in #396 and is
-  left alone deliberately rather than papered over.
+- **Legacy native OAuth credentials.** #838 retires
+  `…/connections/{provider}/start`: through 2026-09-30 it answers a dated
+  `410 native_oauth_retired`, then #1023 removes it. The callback likewise
+  explains an in-flight browser redirect without exchanging its code. Existing
+  `oauth/{provider}` values remain readable and revocable, but no agent can use
+  them and no credential tier treats a configured host provider app as a route.
 - **Chat inference and embeddings.** Both still resolve from the environment via
   `hosted_endpoint_from_env`. Moving them onto this seam is issue #585; when it
   lands they inherit the rotation guarantee by construction, because the seam is

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -229,11 +229,11 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
   plus the credential sections above it (MCP, inference, company key, Composio
   token, channels).
 - **Source:** ✅ real (feature `oauth`) — `Company.connections` (GraphQL) reads
-  manifest intent (`[[connection]]`) + live OAuth status; `POST
-  …/connections/{provider}/start` returns the authorize URL,
-  `…/disconnect` drops tokens, and `GET /api/v1/oauth/callback` completes the
-  flow. Without the `oauth` feature the write routes `404 not_wired` and the
-  console shows the read-only catalog.
+  manifest intent (`[[connection]]`) + legacy native OAuth status. `POST
+  …/connections/{provider}/start` and `GET /api/v1/oauth/callback` are dated
+  410 retirement responses (#838); `…/disconnect` remains so a tenant can
+  release a token written before #828. The supported actionable connection path
+  is Composio.
 - **One list, one answer (issue #582).** The page used to render two provider
   lists — `ComposioSection`'s grid off `GET …/composio/connections`, and a
   categorised grid of eleven hardcoded tiles off `GET …/connections` — which
@@ -261,7 +261,7 @@ The console's models are the response contract. Keep host payloads aligned with:
 
 - `src/api/types.ts` — `CompanyStatus`, `ApprovalSummary`, `ChatResponse`,
   `FeedbackResponse`, `TeamMemberDto`, `InboxDto`, `InboxMessageDto`,
-  `ConnectionState`, `ConnectionStart`.
+  `ConnectionState`.
 - `src/lib/threads.ts` `Thread`/`ThreadContact`,
   `src/lib/tasks-sample.ts` `TaskCard`, `src/lib/skills.ts` `InstalledSkill`,
   `src/lib/workspace.ts` `FsNode`, `src/lib/memory.ts` `MemoryEntry`,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -22,7 +22,6 @@ import {
   type ChatHistoryMessageDto,
   type ChatResponse,
   type CompanyStatus,
-  type ConnectionStart,
   type ConnectionState,
   type CreateDeskInput,
   type DeskDto,
@@ -836,14 +835,6 @@ export class OpenCompanyClient {
    */
   listConnections(company?: string | null): Promise<ConnectionState[]> {
     return this.request<ConnectionState[]>("GET", `${this.scope(company)}/connections`);
-  }
-
-  /** Begin an OAuth connect flow; returns the provider authorize URL to open. */
-  startConnection(provider: string, company?: string | null): Promise<ConnectionStart> {
-    return this.request<ConnectionStart>(
-      "POST",
-      `${this.scope(company)}/connections/${encodeURIComponent(provider)}/start`,
-    );
   }
 
   /** Revoke a connected provider. */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -827,13 +827,11 @@ export interface InboxMessageDto {
  *   by the Composio plane, which brokers through it. The native OAuth catalog
  *   does **not** route through the company key today, so this value does not
  *   appear on a native-only provider — see `api/credential.ts`.
- * - `static` — a token this company already stored, or this host's own
- *   registered provider application (the self-hosted hatch). The handshake
- *   works; the console stopped offering it in issue #822, because what it
- *   stores is read by no agent tool (#396). So this tier now says what the host
- *   *could* do, and `connectRoute` (`lib/connections.ts`) routes such a
- *   provider through Composio or reports it unavailable.
- * - `none` — neither, so no Connect can succeed on this host.
+ * - `static` — a legacy native OAuth token this company already stored. It is
+ *   visible and revocable, but no agent can use it.
+ * - `none` — neither. A registered native provider application also lands
+ *   here: its start route is a dated 410 retirement bridge (issue #838), not a
+ *   connection route.
  */
 export type ConnectionCredentialSource = "attested" | "company" | "static" | "none";
 
@@ -870,12 +868,6 @@ export interface ConnectionState {
    * distinction rather than a confident disconnected state.
    */
   unverified?: boolean;
-}
-
-/** Response of `POST .../connections/{provider}/start`: where to send the user. */
-export interface ConnectionStart {
-  /** The provider's OAuth authorize URL to redirect the operator to. */
-  url: string;
 }
 
 /** The coarse health tier of an MCP server, from a probe. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -180,10 +180,10 @@ const VIEWS: View[] = [...NAV.map((i) => i.view), ...HIDDEN_VIEWS];
 const WORKFLOW_EVENT_WINDOW = 300;
 
 /**
- * Operator-facing copy for a `connect_error` code from the host's OAuth
- * callback (issue #300). The host sends a stable code rather than the
- * provider's own error text — that text is attacker-influenced and may carry
- * credential material, so it never leaves the host's logs.
+ * Operator-facing copy for a legacy `connect_error` query from the former
+ * native OAuth callback (issue #300). The callback now ends in its own dated
+ * explanatory page (#838), but an older bookmarked URL still gets a safe
+ * message rather than raw provider-controlled error text.
  *
  * Every message says what to do next: the whole point of the bounce-back is
  * that a failed handshake is recoverable, not a dead end. An unrecognized code
@@ -448,22 +448,20 @@ export function AppShell({
   // in the feed both surfaces read.
   const pending = feed.status.pending_approvals;
 
-  // OAuth connect bounce-back: the host's callback redirects the browser to
-  // `…/connections?connected={provider}` after storing the token, or to
-  // `…/connections?connect_error={code}[&provider={id}]` when the handshake
-  // failed. Land the operator on the Connections page either way, say what
-  // happened, then strip the params so a refresh doesn't re-fire them. Runs
-  // once; StrictMode's double invoke is harmless because the first run clears
-  // the params the second reads.
+  // A legacy native OAuth callback may have left `connected` or `connect_error`
+  // in a bookmarked URL. Land the operator on Connections, say what happened,
+  // then strip the params so a refresh does not re-fire them. The #838 callback
+  // itself now terminates on its explanatory page and never writes a credential.
+  // Runs once; StrictMode's double invoke is harmless because the first run
+  // clears the params the second reads.
   //
   // Connections is a page of the Settings section now (`#/settings/connections`),
   // so the bounce-back lands there rather than on a top-level view.
   //
-  // The failure half matters as much as the success half: before issue #300 the
-  // host answered a cancelled or expired handshake with a JSON body, which the
-  // browser rendered as the page — a dead end with no way back into the
-  // console. The host now always redirects, so this is where it becomes
-  // recoverable.
+  // Before issue #300 the host answered a cancelled or expired handshake with a
+  // JSON body, which the browser rendered as the page — a dead end with no way
+  // back into the console. Preserve the readable landing for legacy URLs even
+  // though #838 no longer redirects new native OAuth callbacks here.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const connected = params.get("connected");

--- a/frontend/src/lib/connections.ts
+++ b/frontend/src/lib/connections.ts
@@ -9,9 +9,8 @@
 // not connected. The page now renders one grid (`lib/provider-grid.ts`), whose
 // membership is the backend catalog and whose status is `GET …/connections`.
 //
-// What `CONNECTION_PROVIDERS` still owns is what only the console can know:
-// which ids the host's `well_known` table can run a native handshake for, the
-// Composio slug each maps to, and the brand colours.
+// What `CONNECTION_PROVIDERS` still owns is what only the console can know: the
+// Composio slug each id maps to and the brand colours.
 //
 // ## Two routes, one tile (issue #599)
 //
@@ -20,9 +19,8 @@
 //
 //  - **Composio** — the hosted path. Composio runs the OAuth itself and the
 //    resulting connection is a tool belt the agents actually receive.
-//  - **Native** — this host's own registered provider application, the
-//    self-hosted hatch documented on `src/server/ops/connections.rs`. Reported
-//    as `credentialSource: "static"`.
+//  - **Native** — a legacy credential written by the retired host OAuth flow.
+//    It is reported as `credentialSource: "static"`, but no agent can use it.
 //
 // Until #599 every tile hard-routed to native. On a hosted tenant no
 // `OPENCOMPANY_OAUTH_*` variable is injected, so all eleven Connect buttons
@@ -50,10 +48,9 @@
 //    tile, its `via: ["native"]` and its Disconnect (`lib/provider-grid.ts`).
 //    Retracting the invitation is this issue; releasing what was accepted under
 //    it is the operator's call.
-//  - **The host route itself.** `POST …/connections/{provider}/start` and the
-//    callback are untouched — this is the console declining to offer a path,
-//    not the path being removed. Fixing #396 makes the offer honest again, and
-//    reinstating it is then one arm in this function.
+//  - **The retirement bridge.** `POST …/connections/{provider}/start` and the
+//    callback return an explanation until 2026-09-30, rather than silently
+//    404ing a cached pre-#828 bundle. They never write another credential (#838).
 
 export type ConnectionCategory =
   | "Communication"
@@ -69,13 +66,10 @@ export interface ConnectionProvider {
    * `[[connection]] provider = "…"` and the key `GET …/connections` reports
    * status under.
    *
-   * It is also what `disconnectConnection(id)` is called with, and what the
-   * host's `well_known` table keys the native hatch by
-   * (`src/server/ops/connections.rs`; today `slack`, `github`, `google`,
-   * `gmail`). The console no longer *offers* that hatch (issue #822), so this
-   * is now the id of a connection already held rather than of one on offer —
-   * which is why the ids stay aligned to `well_known` even though nothing here
-   * starts a handshake any more.
+   * It is also what `disconnectConnection(id)` is called with. The console
+   * never starts native OAuth: #838 retains only an explanatory compatibility
+   * response for stale bundles, so this id can describe a connection already
+   * held but never one newly offered through the native catalog.
    */
   id: string;
   /**

--- a/frontend/src/tour/state.ts
+++ b/frontend/src/tour/state.ts
@@ -120,9 +120,9 @@ export function setActiveTourStop(view: string | null): void {
  * `ConnectionsView`'s native connect, which set `window.location.href` to the
  * host's authorize URL; that offer is gone, and the Composio sign-in it left
  * behind opens a tab rather than handing the document away. The read half stays
- * wired — `TourController` still honours a marker on mount, and the host still
- * redirects an in-flight handshake back to `/connections?connected=…`, so a
- * marker written by an older bundle is still consumed. Kept, rather than deleted
+ * wired — `TourController` still honours a marker on mount, so a marker written
+ * by an older bundle is consumed when its user returns to the console. Kept,
+ * rather than deleted
  * with its caller, because the next surface that navigates the document away
  * mid-tour needs exactly this and reconstructing it is the harder half.
  */

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "@playwright/test";
 
 /**
- * Issue #300 — an OAuth connection started from inside the onboarding tour.
+ * Issue #300 — a legacy OAuth connection query from inside the onboarding tour.
  *
  * The redirect back from the provider is a **full-page navigation**, so neither
  * half of this can be proven by a unit test: the tour's step state lives in
  * react-joyride's memory and dies with the document, and the failure arms of the
- * host callback used to render a JSON body *as the page*.
+ * host callback used to render a JSON body *as the page*. #838's callback now
+ * has a terminal explanatory page; these cover the console's compatibility
+ * handling for an older callback URL.
  *
  * These specs drive a running host (see `playwright.config.ts` — the harness
  * brings it up, there is no `webServer`). CI does not run Playwright.
@@ -35,9 +37,9 @@ async function tourKey(page: Page): Promise<string> {
   return key!;
 }
 
-test("a cancelled handshake lands back in the console, not on a dead page", async ({ page }) => {
-  // Exactly what the host now redirects to when the operator cancels at the
-  // provider's consent screen. Before the fix this route answered with
+test("a legacy cancelled-handshake query lands in the console, not on a dead page", async ({ page }) => {
+  // This is the query the former callback used after an operator cancelled at
+  // the provider consent screen. Before the original fix it answered with
   // `{"error":"provider returned: access_denied"}` as the document body.
   await page.goto("/connections?connect_error=denied&provider=slack");
 

--- a/frontend/test/unit/connection-route.test.ts
+++ b/frontend/test/unit/connection-route.test.ts
@@ -252,9 +252,8 @@ describe("connectRoute", () => {
   });
 
   it("gives the eight ids with no native backend key a working Composio route", () => {
-    // `well_known()` recognises only slack / google / gmail / github, so these
-    // could never complete a native handshake no matter how the host is
-    // configured. Composio is what makes them connectable at all.
+    // Native OAuth is retired, and these provider ids never had a native route
+    // before it retired. Composio is what makes them connectable at all.
     for (const id of [
       "google-calendar",
       "notion",

--- a/frontend/test/unit/provider-grid.test.ts
+++ b/frontend/test/unit/provider-grid.test.ts
@@ -104,8 +104,8 @@ describe("buildGridProviders", () => {
     const tile = bySlug(providers, "googlecalendar");
     expect(tile.connected).toBe(true);
     // The host id stays distinct from the Composio slug: one is what
-    // `startConnection`/`disconnectConnection` take, the other is what
-    // `composio/authorize` takes, and sending either to the other's route fails.
+    // `disconnectConnection` takes for a historical credential, the other is
+    // what `composio/authorize` takes, and sending either to the other's route fails.
     expect(tile.providerId).toBe("google-calendar");
   });
 

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -1,77 +1,53 @@
-//! OAuth connection lifecycle: start, callback, disconnect — **the self-hosted
-//! hatch**.
+//! Native OAuth credential cleanup, plus the bounded retirement bridge for its
+//! former start and callback routes.
 //!
-//! ## What this module is for
+//! Native OAuth stored a real `oauth/{provider}` secret, but no agent path can
+//! resolve it. The console stopped offering the flow in #828; #838 makes direct
+//! callers honest too. `start` now returns a structured explanation and the
+//! browser callback renders one, without exchanging a code or writing a secret.
 //!
-//! Every provider reached from here is reached with **this host's own provider
-//! application**: an operator registers a client id/secret with Slack / Google /
-//! GitHub themselves and hands them to the process as
-//! `OPENCOMPANY_OAUTH_<PROVIDER>_ID` / `_SECRET`. That is the only way a
-//! standalone checkout of this public repository can complete an OAuth handshake
-//! at all, and it is supported for exactly that reason.
-//!
-//! It is **not** the hosted path, and it is not parity with it. Framed the way
-//! [`ops::composio`](super::composio) frames its BYO token: a hatch, not a
-//! deployment mode. On the platform a company registers nothing and pastes
-//! nothing — the instance already carries a platform-minted, audience-bound
-//! identity, and the connection is attributed through that. A hosted tenant is
-//! injected no `OPENCOMPANY_OAUTH_*` variable at all, so on that host
-//! [`provider_config`] resolves nothing and a Connect can only ever fail here;
-//! the read plane reports that host as `credentialSource: "attested"` and the
-//! console offers no local Connect (issue #319). See
-//! [`ops::connections_read`](super::connections_read) for the resolution order
-//! and the hosted-vs-hatch split.
-//!
-//! Gated behind the `oauth` feature because token exchange needs `reqwest`;
-//! without it these routes are absent (404) and the console shows the read-only
-//! connections catalog. Provider **app** credentials (client id/secret) are
-//! host-level configuration read from the environment
-//! (`OPENCOMPANY_OAUTH_<PROVIDER>_ID` / `_SECRET`); per-company state is tokens
-//! only, and those live in [`SecretStore`](crate::ports::SecretStore) under
-//! `oauth/{provider}` — token material never appears in any response.
-//!
-//! The authorize URL carries a signed `state` nonce binding the flow to one
-//! company + provider + expiry, verified on callback so a tampered `state` is
-//! refused before any token exchange.
-//!
-//! The callback is reached by a **browser navigation**, so it never answers with
-//! a body: every outcome — success, cancellation, a bad nonce, a failed exchange
-//! — redirects to the console's Connections view carrying a stable, non-secret
-//! outcome code. Returning JSON there strands the operator on a blank page with
-//! no route back (issue #300).
+//! The bridge remains through 2026-09-30 for console bundles cached before #979.
+//! Its removal is tracked by #1023. `disconnect` and the read projection stay:
+//! they are the only way for a tenant to release a credential written before the
+//! console offer disappeared.
 
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
-use axum::http::Uri;
-use axum::response::{IntoResponse, Redirect, Response};
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
 
-use crate::AppConfig;
 use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
-use crate::error::OpenCompanyError;
-use crate::ports::normalize_email;
-use crate::ports::now_millis;
-use crate::ports::types::{CompanyId, SecretValue};
+use crate::ports::types::SecretValue;
 use crate::server::error::ApiError;
 use crate::server::ops::{AdminScopedCompany, oauth_key, scoped};
-use crate::server::webhook::{DefaultHashSigner, WebhookSigner};
 
-/// How long a signed `state` nonce stays valid.
-const STATE_TTL_MS: u64 = 10 * 60 * 1000;
+/// The final day the compatibility responses may remain registered.
+const NATIVE_OAUTH_REMOVAL_DATE: &str = "2026-09-30";
+const NATIVE_OAUTH_SUNSET: &str = "Wed, 30 Sep 2026 00:00:00 GMT";
+const NATIVE_OAUTH_RETIREMENT: &str = concat!(
+    "Native OAuth connections are retired because the credentials this flow stored are not reachable by agents. ",
+    "Connect the provider through Composio instead.",
+);
 
-/// Builds the OAuth route fragment.
+/// Builds native OAuth cleanup routes and the temporary retirement bridge.
+///
+/// `start` and `callback` intentionally remain reachable until #1023's removal
+/// date. A cacheable console shell used to leave old bundles calling `start`
+/// after deploy (#979); a 410 that explains the unusable credential is safer
+/// than a 404 that leaves those callers debugging a missing endpoint.
 pub fn router() -> Router<AppState> {
     scoped("/connections/{provider}/start", post(start))
         .merge(scoped(
             "/connections/{provider}/disconnect",
             post(disconnect),
         ))
-        // The callback is unscoped: the signed `state` carries the company id.
+        // The callback is unscoped because it only renders the retirement page.
         .route("/api/v1/oauth/callback", get(callback))
 }
 
@@ -83,48 +59,24 @@ struct ProviderPath {
 }
 
 // ---------------------------------------------------------------------------
-// Provider app configuration (host-level env)
+// Historical credential revocation
 // ---------------------------------------------------------------------------
 
-/// A provider's OAuth endpoints and host-level app credentials.
+/// The host-level app credentials needed to revoke a historical grant.
 struct ProviderConfig {
     client_id: String,
     client_secret: String,
-    authorize_url: String,
-    token_url: String,
-    default_scopes: String,
 }
 
-/// Well-known authorize/token URLs for the built-in providers; overridable per
-/// provider via `OPENCOMPANY_OAUTH_<P>_AUTHORIZE_URL` / `_TOKEN_URL`.
-fn well_known(provider: &str) -> Option<(&'static str, &'static str)> {
-    match provider {
-        "slack" => Some((
-            "https://slack.com/oauth/v2/authorize",
-            "https://slack.com/api/oauth.v2.access",
-        )),
-        "google" | "gmail" => Some((
-            "https://accounts.google.com/o/oauth2/v2/auth",
-            "https://oauth2.googleapis.com/token",
-        )),
-        "github" => Some((
-            "https://github.com/login/oauth/authorize",
-            "https://github.com/login/oauth/access_token",
-        )),
-        _ => None,
-    }
-}
-
-/// Resolves a provider's config from the process environment, or `None` when the
-/// app credentials are not configured (the provider is not enabled on this
-/// host).
+/// Resolves the app credentials needed to revoke a historical provider grant.
+///
+/// They no longer make this host a provider connection endpoint: `start` always
+/// refuses, regardless of whether these values are present.
 fn provider_config(provider: &str) -> Option<ProviderConfig> {
     provider_config_from(provider, &crate::app::config::ProcessEnv)
 }
 
-/// [`provider_config`] over an [`EnvSource`](crate::app::config::EnvSource)
-/// seam, so the "is this provider enabled here?" question is answerable from a
-/// test map without mutating the process environment.
+/// [`provider_config`] over an environment seam for revocation tests.
 fn provider_config_from(
     provider: &str,
     env: &dyn crate::app::config::EnvSource,
@@ -133,486 +85,65 @@ fn provider_config_from(
     let env = |suffix: &str| env.get(&format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
     let client_id = env("ID")?;
     let client_secret = env("SECRET")?;
-    let (default_authorize, default_token) = well_known(provider).unwrap_or(("", ""));
-    let authorize_url = env("AUTHORIZE_URL").unwrap_or_else(|| default_authorize.to_string());
-    let token_url = env("TOKEN_URL").unwrap_or_else(|| default_token.to_string());
-    if authorize_url.is_empty() || token_url.is_empty() {
-        return None;
-    }
     Some(ProviderConfig {
         client_id,
         client_secret,
-        authorize_url,
-        token_url,
-        default_scopes: env("SCOPES").unwrap_or_default(),
     })
-}
-
-/// Whether a Connect for `provider` could reach a provider application on this
-/// host — i.e. whether the hatch is open for it.
-///
-/// This is [`provider_config`]'s own answer rather than a second copy of the
-/// rule: a bare "is `_ID` set?" probe would report a provider enabled even when
-/// no authorize/token URL can be resolved for it, and the console would render a
-/// Connect button that 400s. Read by
-/// [`ops::connections_read`](super::connections_read); never leaks the
-/// credential itself.
-///
-/// A missing [`state_secret_from`] closes the hatch for **every** provider
-/// (issue #318): without a signing secret no nonce can be issued, so no
-/// handshake can complete, and the console should say "not available on this
-/// host" rather than offer a button. The startup warning is what tells the
-/// operator *why* — a tile has no room to name a variable, and an operator
-/// reads logs.
-pub(super) fn provider_app_configured(
-    provider: &str,
-    env: &dyn crate::app::config::EnvSource,
-) -> bool {
-    let has_app = provider_config_from(provider, env).is_some();
-    if has_app && state_secret_from(env).is_none() {
-        warn_half_configured_once(provider);
-        return false;
-    }
-    has_app
-}
-
-/// Says once per process that a provider application is registered but cannot be
-/// used, and names the variable that would fix it.
-///
-/// Once, because this is reached from a read path the console polls: repeating
-/// it per request would bury the line it is trying to make visible. The provider
-/// named is whichever was asked about first — enough to make the message
-/// concrete, and the remedy is the same for all of them.
-fn warn_half_configured_once(provider: &str) {
-    static WARNED: std::sync::Once = std::sync::Once::new();
-    WARNED.call_once(|| {
-        tracing::warn!(
-            provider,
-            "an OAuth provider application is registered but OPENCOMPANY_OAUTH_STATE_SECRET \
-             is unset, so no connection can be completed; set it to a private random value. \
-             Connections are reported as unavailable on this host until then"
-        );
-    });
-}
-
-/// The redirect URI advertised to the provider. `OPENCOMPANY_OAUTH_REDIRECT_BASE`
-/// overrides the origin so the authorize URL points where the operator's
-/// browser can reach the callback (managed deployments front it via the manager).
-fn redirect_uri(state: &AppState) -> String {
-    let base = std::env::var("OPENCOMPANY_OAUTH_REDIRECT_BASE")
-        .unwrap_or_else(|_| state.config().host_base_url());
-    format!("{}/api/v1/oauth/callback", base.trim_end_matches('/'))
-}
-
-/// The host-level secret the `state` nonce is signed with, or `None` when this
-/// host has not been given one.
-///
-/// **There is deliberately no default** (issue #318). A baked-in fallback is
-/// public, identical across every unconfigured deployment, and present in this
-/// repository — so a `state` signed with it can be *constructed* rather than
-/// obtained, and verifying it proves only that the value is well-formed. That
-/// is the whole CSRF property of the nonce, so the honest answer to "no secret
-/// configured" is that this host cannot run OAuth, not that it runs it
-/// unprotected.
-///
-/// Whitespace-only is treated as unset: a deployment that passes the variable
-/// through an unset shell expansion gets the closed door, not a secret of `" "`.
-fn state_secret_from(env: &dyn crate::app::config::EnvSource) -> Option<String> {
-    env.get("OPENCOMPANY_OAUTH_STATE_SECRET")
-        .filter(|value| !value.trim().is_empty())
-}
-
-/// [`state_secret_from`] against the real process environment.
-fn state_secret() -> Option<String> {
-    state_secret_from(&crate::app::config::ProcessEnv)
-}
-
-// ---------------------------------------------------------------------------
-// Console bounce-back
-// ---------------------------------------------------------------------------
-
-/// The console origin the callback bounces the operator's browser back to.
-/// `OPENCOMPANY_CONSOLE_URL` overrides it for deployments that serve the console
-/// from a different origin than the API.
-fn console_base(state: &AppState) -> String {
-    let base =
-        std::env::var("OPENCOMPANY_CONSOLE_URL").unwrap_or_else(|_| state.config().host_base_url());
-    base.trim_end_matches('/').to_string()
-}
-
-/// Sends the operator's browser back to the console's Connections view.
-///
-/// **Every** callback exit goes through here, success and failure alike. A
-/// failure arm that renders a JSON body into the document instead leaves the
-/// operator staring at raw error text on a blank page with no route back — the
-/// dead end reported in issue #300. A redirect keeps them in the console, where
-/// the Connections view can explain what happened and offer a retry.
-fn console_redirect(state: &AppState, params: &str) -> Response {
-    Redirect::to(&format!("{}/connections?{params}", console_base(state))).into_response()
-}
-
-/// Bounces back with a stable, non-secret failure code.
-///
-/// The code is one of a closed set the console maps to operator-facing copy.
-/// The provider's own error text is deliberately **not** propagated: it is
-/// attacker-influenced, unbounded, and may carry credential material — none of
-/// which belongs in a URL that lands in browser history and server access logs.
-///
-/// `provider` is optional because the arms that fire before the signed `state`
-/// is verified cannot always know which provider the flow was for.
-fn connect_error(state: &AppState, code: &str, provider: Option<&str>) -> Response {
-    let mut params = format!("connect_error={}", urlencode(code));
-    if let Some(provider) = provider {
-        params.push_str(&format!("&provider={}", urlencode(provider)));
-    }
-    console_redirect(state, &params)
-}
-
-/// Bounces back on an account mismatch (issue #316: one operator, one
-/// connected account), naming both the account the provider handed back and
-/// the address(es) this company expects, so the console can tell the operator
-/// exactly why the connect was refused.
-///
-/// Built directly on [`console_redirect`] rather than folded into
-/// [`connect_error`]: every other failure code is deliberately detail-free —
-/// the provider's own error text must never ride in the URL (see
-/// `connect_error`'s doc) — but this code's whole point is to name two email
-/// addresses. Only email addresses ever reach this function; token material
-/// never does.
-fn connect_account_mismatch(
-    state: &AppState,
-    provider: &str,
-    connected: &str,
-    expected: &str,
-) -> Response {
-    let params = format!(
-        "connect_error={}&provider={}&connected_account={}&expected_account={}",
-        urlencode("account_mismatch"),
-        urlencode(provider),
-        urlencode(connected),
-        urlencode(expected),
-    );
-    console_redirect(state, &params)
-}
-
-// ---------------------------------------------------------------------------
-// Signed state nonce
-// ---------------------------------------------------------------------------
-
-/// Encodes `company:provider:exp:sig` into an opaque `state` value.
-///
-/// Takes the signing secret rather than reading it, so a caller cannot reach
-/// this without having established that the host has one (issue #318).
-fn encode_state(secret: &str, company: &str, provider: &str, exp: u64) -> String {
-    let payload = format!("{company}:{provider}:{exp}");
-    let sig = DefaultHashSigner.sign(secret, payload.as_bytes());
-    format!("{payload}:{sig}")
-}
-
-/// Verifies and decodes a `state` value into `(company, provider)`, or `None`
-/// when this host has no signing secret, the signature is wrong, or the nonce
-/// has expired.
-///
-/// The no-secret case collapses into the same `None` as a bad signature on
-/// purpose: a host that cannot issue a nonce cannot have issued *this* one, so
-/// there is nothing to distinguish. It also means a host that loses its secret
-/// refuses in-flight callbacks rather than accepting whatever arrives.
-fn decode_state(state: &str) -> Option<(String, String)> {
-    let secret = state_secret()?;
-    let parts: Vec<&str> = state.splitn(4, ':').collect();
-    if parts.len() != 4 {
-        return None;
-    }
-    let (company, provider, exp, sig) = (parts[0], parts[1], parts[2], parts[3]);
-    let payload = format!("{company}:{provider}:{exp}");
-    let expected = DefaultHashSigner.sign(&secret, payload.as_bytes());
-    if sig != expected {
-        return None;
-    }
-    let exp: u64 = exp.parse().ok()?;
-    if now_millis() > exp {
-        return None;
-    }
-    Some((company.to_string(), provider.to_string()))
 }
 
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------
 
-/// The authorize-URL response.
-#[derive(Debug, Serialize)]
-struct StartResponse {
-    /// The provider authorize URL the operator's browser should visit.
-    url: String,
-}
-
-/// Builds the authorize URL for `provider` scoped to `company`.
-fn build_authorize(
-    state: &AppState,
-    company: &CompanyId,
-    provider: &str,
-) -> Result<StartResponse, ApiError> {
-    let Some(config) = provider_config(provider) else {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-            "provider '{provider}' is not enabled on this host"
-        ))));
-    };
-    // Named explicitly rather than folded into the message above: an operator
-    // who has registered a provider application and hit this needs to know the
-    // one remaining variable, not be told the provider is disabled (issue #318).
-    let Some(secret) = state_secret() else {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(
-            "OAuth is not configured on this host: set OPENCOMPANY_OAUTH_STATE_SECRET \
-             to a private random value so the state nonce can be signed"
-                .to_string(),
-        )));
-    };
-    let nonce = encode_state(
-        &secret,
-        company.as_ref(),
-        provider,
-        now_millis() + STATE_TTL_MS,
-    );
-    let redirect = redirect_uri(state);
-    let url = format!(
-        "{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}",
-        config.authorize_url,
-        urlencode(&config.client_id),
-        urlencode(&redirect),
-        urlencode(&config.default_scopes),
-        urlencode(&nonce),
-    );
-    Ok(StartResponse { url })
-}
-
 /// `POST …/connections/{provider}/start` (both scope forms).
 ///
-/// Requires authority over the company (issue #403) — this is the native-hatch
-/// twin of `POST …/composio/authorize`, and the connection it begins is the
-/// company's. Note that the connect-time identity check below
-/// ([`account_mismatch`]) already assumed as much: it compares the connected
-/// account against the company's *admin* addresses. Until now anyone could
-/// reach the flow that check guards; now the two agree.
-async fn start(
-    company: AdminScopedCompany,
-    State(state): State<AppState>,
-    Path(ProviderPath { provider }): Path<ProviderPath>,
-) -> Result<Json<StartResponse>, ApiError> {
-    Ok(Json(build_authorize(&state, company.id(), &provider)?))
+/// This retains its existing admin boundary while cached pre-#828 bundles age
+/// out. It must not issue another signed state: a new handshake would once again
+/// produce a credential that no agent can use.
+async fn start(_company: AdminScopedCompany, Path(_provider): Path<ProviderPath>) -> Response {
+    native_oauth_start_retired()
 }
 
 // ---------------------------------------------------------------------------
 // Callback
 // ---------------------------------------------------------------------------
 
-/// Reads a single query parameter from a raw query string, percent-decoding it.
-fn query_param(uri: &Uri, key: &str) -> Option<String> {
-    let query = uri.query()?;
-    for pair in query.split('&') {
-        if let Some((k, v)) = pair.split_once('=')
-            && k == key
-        {
-            return Some(percent_decode(v));
-        }
-    }
-    None
+/// `GET /api/v1/oauth/callback` remains for a browser redirected by an OAuth
+/// flow that began immediately before this deployment. The callback deliberately
+/// ignores its query: accepting an in-flight signed state would still store the
+/// agent-unreachable credential that retired `start` now refuses to create.
+async fn callback() -> Response {
+    native_oauth_callback_retired()
 }
 
-/// Minimal percent-decode (and `+` → space) for query values.
-fn percent_decode(value: &str) -> String {
-    let bytes = value.replace('+', " ");
-    let bytes = bytes.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%'
-            && i + 2 < bytes.len()
-            && let Ok(byte) = u8::from_str_radix(&value[i + 1..i + 3], 16)
-        {
-            out.push(byte);
-            i += 3;
-            continue;
-        }
-        out.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8_lossy(&out).into_owned()
+fn native_oauth_start_retired() -> Response {
+    (
+        StatusCode::GONE,
+        [("deprecation", "true"), ("sunset", NATIVE_OAUTH_SUNSET)],
+        Json(json!({
+            "code": "native_oauth_retired",
+            "error": NATIVE_OAUTH_RETIREMENT,
+            "removalAfter": NATIVE_OAUTH_REMOVAL_DATE,
+        })),
+    )
+        .into_response()
 }
 
-/// The provider a callback was for, recovered from a **signature-verified**
-/// `state` — used only to enrich a failure bounce-back with the provider name.
-/// An unverified `state` is never trusted for this, so a tampered value simply
-/// yields `None` and the console shows the provider-less message.
-fn provider_from_state(uri: &Uri) -> Option<String> {
-    let raw = query_param(uri, "state")?;
-    decode_state(&raw).map(|(_, provider)| provider)
-}
-
-/// `GET /api/v1/oauth/callback` — verify state, exchange code, store tokens.
-///
-/// Always answers with a redirect into the console (see [`console_redirect`]):
-/// this route is reached by a **browser navigation**, so any body it returns is
-/// rendered as the page the operator is left on.
-async fn callback(State(state): State<AppState>, uri: Uri) -> Response {
-    if let Some(err) = query_param(&uri, "error") {
-        // Log the provider's text host-side for diagnosis; never forward it to
-        // the browser (see `connect_error`).
-        tracing::warn!(provider_error = %err, "oauth callback: provider returned an error");
-        return connect_error(&state, "denied", provider_from_state(&uri).as_deref());
-    }
-    let (Some(code), Some(raw_state)) = (query_param(&uri, "code"), query_param(&uri, "state"))
-    else {
-        return connect_error(
-            &state,
-            "invalid_request",
-            provider_from_state(&uri).as_deref(),
-        );
-    };
-    // A tampered or expired `state` is rejected before any exchange.
-    let Some((company, provider)) = decode_state(&raw_state) else {
-        // No provider: the only claim to one came from the `state` we just
-        // refused to trust.
-        return connect_error(&state, "invalid_state", None);
-    };
-    let Some(runtime) = state.registry().get(&CompanyId::new(&company)) else {
-        return connect_error(&state, "unknown_company", Some(&provider));
-    };
-    let Some(config) = provider_config(&provider) else {
-        return connect_error(&state, "provider_disabled", Some(&provider));
-    };
-
-    match exchange_code(&state, &config, &code).await {
-        Ok(token_json) => {
-            let account = extract_account(&token_json);
-            if let Some((connected, expected)) =
-                account_mismatch(state.config(), &runtime, account.as_deref()).await
-            {
-                tracing::warn!(
-                    provider,
-                    connected = %connected,
-                    "oauth callback: connected account does not match this company's operator"
-                );
-                return connect_account_mismatch(&state, &provider, &connected, &expected);
-            }
-            let stored = json!({ "token": token_json, "account": account });
-            if let Err(err) = runtime
-                .secrets()
-                .set(
-                    runtime.id(),
-                    &oauth_key(&provider),
-                    SecretValue(stored.to_string()),
-                )
-                .await
-            {
-                tracing::warn!(provider, "oauth callback: storing the token failed: {err}");
-                return connect_error(&state, "store_failed", Some(&provider));
-            }
-            // Redirect the browser back to the console connections view.
-            console_redirect(&state, &format!("connected={}", urlencode(&provider)))
-        }
-        Err(err) => {
-            tracing::warn!(provider, "oauth callback: token exchange failed: {err}");
-            connect_error(&state, "exchange_failed", Some(&provider))
-        }
-    }
-}
-
-/// Exchanges an authorization code for tokens at the provider's token endpoint.
-async fn exchange_code(
-    state: &AppState,
-    config: &ProviderConfig,
-    code: &str,
-) -> Result<serde_json::Value, OpenCompanyError> {
-    let client = reqwest::Client::new();
-    let params = [
-        ("grant_type", "authorization_code"),
-        ("code", code),
-        ("client_id", config.client_id.as_str()),
-        ("client_secret", config.client_secret.as_str()),
-        ("redirect_uri", &redirect_uri(state)),
-    ];
-    let resp = client
-        .post(&config.token_url)
-        .header("Accept", "application/json")
-        .form(&params)
-        .send()
-        .await
-        .map_err(|e| OpenCompanyError::Store(format!("oauth token exchange failed: {e}")))?;
-    if !resp.status().is_success() {
-        return Err(OpenCompanyError::Store(format!(
-            "oauth token endpoint returned {}",
-            resp.status()
-        )));
-    }
-    resp.json::<serde_json::Value>()
-        .await
-        .map_err(|e| OpenCompanyError::Store(format!("oauth token response not JSON: {e}")))
-}
-
-/// Extracts a human-friendly account label from a token response, if present.
-fn extract_account(token: &serde_json::Value) -> Option<String> {
-    for key in ["account", "email", "login", "user_login"] {
-        if let Some(value) = token.get(key).and_then(|v| v.as_str()) {
-            return Some(value.to_string());
-        }
-    }
-    // Slack nests the workspace under `team.name`.
-    token
-        .get("team")
-        .and_then(|team| team.get("name"))
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-}
-
-/// Whether `account` — the label [`extract_account`] pulled from a token
-/// response — belongs to someone other than this company's operator (issue
-/// #316: one operator, one connected account).
-///
-/// This enforces identity at **connect time only**. It has no way to detect a
-/// live account swap at the provider after the token is already stored, and
-/// it does not drive a reconnect flow — both are out of scope for this slice.
-///
-/// Refuses to guess whenever the comparison would not be meaningful, and only
-/// ever returns a mismatch on a genuine, comparable email mismatch:
-/// - `account` is `None` — e.g. GitHub's token response carries no `login`,
-///   only `access_token`/`scope`/`token_type`, so there is nothing to
-///   compare. Not a mismatch: stored as today.
-/// - `account` is not shaped like an email — Slack hands back a workspace
-///   name (`team.name`), GitHub a login handle; neither is comparable to an
-///   operator's email address, and a naive `!=` here would refuse every Slack
-///   and GitHub connect. Not a mismatch: stored as today.
-/// - the company has no known operator address, or the lookup itself fails —
-///   there is nothing to compare against. Not a mismatch: stored as today.
-///
-/// Only when `account` is itself a normalizable email address AND the company
-/// has at least one known operator address AND it matches none of them does
-/// this return `Some((connected, expected))` for the caller to refuse with.
-async fn account_mismatch(
-    config: &AppConfig,
-    runtime: &CompanyRuntime,
-    account: Option<&str>,
-) -> Option<(String, String)> {
-    let connected = normalize_email(account?);
-    if connected.is_empty() || !connected.contains('@') {
-        // Not an email at all (a Slack workspace name, a GitHub login) — no
-        // comparable operator address exists to check it against.
-        return None;
-    }
-    let admins = match crate::server::users::routes::bootstrap_admins(config, runtime).await {
-        Ok(admins) => admins,
-        Err(err) => {
-            tracing::warn!(
-                "oauth callback: could not load operator addresses to compare a connected \
-                 account against: {err}"
-            );
-            return None;
-        }
-    };
-    if admins.is_empty() || admins.iter().any(|a| normalize_email(a) == connected) {
-        return None;
-    }
-    Some((connected, admins.join(", ")))
+fn native_oauth_callback_retired() -> Response {
+    let page = format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Native OAuth retired</title></head><body><h1>Native OAuth connection is no longer available</h1><p>{}</p><p>Nothing was saved from this authorization. Use the connection path offered in the OpenCompany console, typically Composio.</p><p>This temporary compatibility page will be removed after {}.</p></body></html>",
+        NATIVE_OAUTH_RETIREMENT, NATIVE_OAUTH_REMOVAL_DATE,
+    );
+    (
+        StatusCode::GONE,
+        [
+            ("cache-control", "no-store"),
+            ("deprecation", "true"),
+            ("sunset", NATIVE_OAUTH_SUNSET),
+        ],
+        Html(page),
+    )
+        .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -745,631 +276,92 @@ async fn disconnect(
     do_disconnect(company.runtime, &provider).await
 }
 
-/// Minimal percent-encoding for URL query values (RFC 3986 unreserved set kept).
-fn urlencode(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for byte in value.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(byte as char)
-            }
-            _ => out.push_str(&format!("%{byte:02X}")),
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
 
-    /// Puts a signing secret in the process environment for the whole test
-    /// binary, and hands it back.
-    ///
-    /// One shared value rather than a per-test one: unlike the provider
-    /// credentials above, `OPENCOMPANY_OAUTH_STATE_SECRET` is host-level, every
-    /// test here needs it set, and a `Once` means concurrent tests cannot race
-    /// the write.
-    ///
-    /// The *absent* case is never tested by unsetting this — that would race
-    /// every other test in the binary. It goes through the
-    /// [`EnvSource`](crate::app::config::EnvSource) seam instead, which is why
-    /// [`state_secret_from`] takes one.
-    fn test_state_secret() -> String {
-        static SET: std::sync::Once = std::sync::Once::new();
-        const VALUE: &str = "test-state-secret";
-        SET.call_once(|| {
-            // SAFETY: written exactly once, and every caller writes the same
-            // value, so there is nothing for a concurrent test to observe
-            // changing.
-            unsafe { std::env::set_var("OPENCOMPANY_OAUTH_STATE_SECRET", VALUE) };
-        });
-        VALUE.to_string()
-    }
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, header};
+    use tower::ServiceExt;
 
-    /// A [`MapEnv`](crate::app::config::MapEnv)-style pair set for a provider
-    /// whose application is registered on this host.
-    fn provider_app_env(provider: &str) -> Vec<(String, String)> {
-        let key = provider.to_ascii_uppercase();
-        vec![
-            (format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid".to_string()),
-            (
-                format!("OPENCOMPANY_OAUTH_{key}_SECRET"),
-                "csec".to_string(),
-            ),
-            (
-                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
-                "http://x/a".to_string(),
-            ),
-            (
-                format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"),
-                "http://x/t".to_string(),
-            ),
-        ]
-    }
+    use crate::ports::types::CompanyId;
+    use crate::{AppConfig, AppState};
 
-    /// Issue #318: with no `OPENCOMPANY_OAUTH_STATE_SECRET` the hatch is shut
-    /// for a provider whose application is otherwise fully registered.
-    ///
-    /// This is the regression that matters. The old code signed the nonce with a
-    /// literal from this source file, so an unconfigured host ran the flow and
-    /// its CSRF check confirmed only that the value was well-formed.
-    #[test]
-    fn without_a_signing_secret_a_registered_provider_is_not_connectable() {
-        let env = crate::app::config::MapEnv::new(provider_app_env("slack"));
-        assert!(
-            !provider_app_configured("slack", &env),
-            "a registered provider with no state secret must not be offered"
-        );
-
-        let mut with_secret = provider_app_env("slack");
-        with_secret.push((
-            "OPENCOMPANY_OAUTH_STATE_SECRET".to_string(),
-            "a-private-value".to_string(),
-        ));
-        let env = crate::app::config::MapEnv::new(with_secret);
-        assert!(
-            provider_app_configured("slack", &env),
-            "the same provider is connectable once the secret is set"
-        );
-    }
-
-    /// A secret that is present but blank is unset. A deployment passing the
-    /// variable through an empty shell expansion gets the closed door rather
-    /// than a host signing every nonce with `" "`.
-    #[test]
-    fn a_blank_signing_secret_counts_as_unset() {
-        for blank in ["", " ", "\t\n "] {
-            let env = crate::app::config::MapEnv::new(vec![(
-                "OPENCOMPANY_OAUTH_STATE_SECRET".to_string(),
-                blank.to_string(),
-            )]);
-            assert!(
-                state_secret_from(&env).is_none(),
-                "{blank:?} must not count as a signing secret"
-            );
-        }
-    }
-
-    /// The nonce is bound to the secret, not merely to its shape: a state issued
-    /// under one secret does not verify under another. Without this, rotating
-    /// the secret would leave old nonces redeemable.
-    #[test]
-    fn a_state_signed_with_another_secret_does_not_verify() {
-        let mine = encode_state(
-            &test_state_secret(),
-            "acme",
-            "slack",
-            now_millis() + STATE_TTL_MS,
-        );
-        let theirs = encode_state(
-            "some-other-hosts-secret",
-            "acme",
-            "slack",
-            now_millis() + STATE_TTL_MS,
-        );
-        assert!(decode_state(&mine).is_some(), "our own nonce verifies");
-        assert!(
-            decode_state(&theirs).is_none(),
-            "a nonce signed elsewhere must not verify here"
-        );
-    }
-
-    #[test]
-    fn state_round_trips_and_rejects_tampering() {
-        let state = encode_state(
-            &test_state_secret(),
-            "acme",
-            "slack",
-            now_millis() + STATE_TTL_MS,
-        );
-        let (company, provider) = decode_state(&state).expect("valid state");
-        assert_eq!(company, "acme");
-        assert_eq!(provider, "slack");
-
-        // A tampered signature fails. Flip the last char to a guaranteed-different
-        // one so the mutation is never a no-op (a blind `push('0')` leaves the
-        // string unchanged — and the assertion flaky — whenever it already ends
-        // in '0').
-        let mut tampered = state.clone();
-        let last = tampered.pop().expect("encoded state is non-empty");
-        tampered.push(if last == '0' { '1' } else { '0' });
-        assert_ne!(tampered, state, "tamper must actually change the state");
-        assert!(decode_state(&tampered).is_none());
-    }
-
-    #[test]
-    fn expired_state_is_rejected() {
-        let state = encode_state(
-            &test_state_secret(),
-            "acme",
-            "slack",
-            now_millis().saturating_sub(1),
-        );
-        assert!(decode_state(&state).is_none());
-    }
-
-    #[test]
-    fn urlencode_escapes_reserved() {
-        assert_eq!(urlencode("a b/c"), "a%20b%2Fc");
-        assert_eq!(urlencode("plain-id_1.0~"), "plain-id_1.0~");
-    }
-
-    #[test]
-    fn extract_account_reads_common_fields() {
+    #[tokio::test]
+    async fn start_returns_an_expiring_structured_retirement_error() {
+        let response = native_oauth_start_retired();
+        assert_eq!(response.status(), StatusCode::GONE);
         assert_eq!(
-            extract_account(&json!({ "email": "ceo@acme.test" })),
-            Some("ceo@acme.test".to_string())
+            response.headers().get("deprecation").unwrap(),
+            "true",
+            "a caller must learn this is a bounded compatibility response"
         );
         assert_eq!(
-            extract_account(&json!({ "team": { "name": "Acme" } })),
-            Some("Acme".to_string())
+            response.headers().get("sunset").unwrap(),
+            NATIVE_OAUTH_SUNSET,
+            "the response itself names when the bridge is removed"
         );
-        assert_eq!(extract_account(&json!({ "access_token": "x" })), None);
-    }
 
-    // ---- callback bounce-back (issue #300) ---------------------------------
-
-    use crate::AppConfig;
-
-    /// Drives `callback` with a raw query string and returns the response.
-    async fn call_callback(state: AppState, query: &str) -> Response {
-        let uri: Uri = format!("/api/v1/oauth/callback?{query}")
-            .parse()
-            .expect("valid uri");
-        callback(State(state), uri).await
-    }
-
-    /// The `Location` header of a redirect response, asserting it *is* one.
-    fn location(resp: &Response) -> String {
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["code"], "native_oauth_retired");
+        assert_eq!(body["removalAfter"], NATIVE_OAUTH_REMOVAL_DATE);
         assert!(
-            resp.status().is_redirection(),
-            "expected a redirect, got {}",
-            resp.status()
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("not reachable by agents"),
+            "{body}"
         );
-        resp.headers()
-            .get("location")
-            .expect("redirect carries a Location")
-            .to_str()
-            .expect("ascii location")
-            .to_string()
     }
 
-    /// Every failure arm must bounce the browser back to the console's
-    /// Connections view — never render a JSON body into the document, which is
-    /// the dead end issue #300 reports.
     #[tokio::test]
-    async fn callback_failures_redirect_to_console_connections() {
-        let state = AppState::new(AppConfig::default());
-        for query in [
-            "error=access_denied",
-            "code=abc",  // missing state
-            "state=xyz", // missing code
-            "code=abc&state=not-a-valid-state",
-        ] {
-            let resp = call_callback(state.clone(), query).await;
-            let loc = location(&resp);
-            assert!(
-                loc.contains("/connections?"),
-                "{query} did not bounce to the console: {loc}"
-            );
-            assert!(
-                loc.contains("connect_error="),
-                "{query} carried no failure code: {loc}"
-            );
-        }
-    }
-
-    /// A cancel at the consent screen maps to `denied`, and — because the
-    /// `state` is signature-verified — names the provider so the console can say
-    /// which tile failed.
-    #[tokio::test]
-    async fn callback_denied_names_provider_from_verified_state() {
-        let state = AppState::new(AppConfig::default());
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            "slack",
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(
-            state,
-            &format!("error=access_denied&state={}", urlencode(&nonce)),
-        )
-        .await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=denied"), "{loc}");
-        assert!(loc.contains("provider=slack"), "{loc}");
-        // The provider's own error text is host-side only: it is
-        // attacker-influenced and must never ride in a URL.
-        assert!(
-            !loc.contains("access_denied"),
-            "raw provider error leaked into Location: {loc}"
-        );
-    }
-
-    /// Without a verifiable `state` there is no trustworthy provider claim, so
-    /// the bounce-back carries the code alone.
-    #[tokio::test]
-    async fn callback_denied_without_state_omits_provider() {
-        let state = AppState::new(AppConfig::default());
-        let resp = call_callback(state, "error=access_denied").await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=denied"), "{loc}");
-        assert!(!loc.contains("provider="), "{loc}");
-    }
-
-    /// A tampered `state` must not be mined for a provider name — the only
-    /// claim to one came from the value we just refused to trust.
-    #[tokio::test]
-    async fn callback_tampered_state_reports_invalid_state_only() {
-        let state = AppState::new(AppConfig::default());
-        let mut nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            "slack",
-            now_millis() + STATE_TTL_MS,
-        );
-        let last = nonce.pop().expect("non-empty");
-        nonce.push(if last == '0' { '1' } else { '0' });
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=invalid_state"), "{loc}");
-        assert!(!loc.contains("provider="), "{loc}");
-    }
-
-    /// An expired nonce is a recoverable state (the operator simply took too
-    /// long), so it bounces back rather than dead-ending on a 401 body.
-    #[tokio::test]
-    async fn callback_expired_state_redirects() {
-        let state = AppState::new(AppConfig::default());
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            "slack",
-            now_millis().saturating_sub(1),
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        assert!(
-            location(&resp).contains("connect_error=invalid_state"),
-            "expired state must bounce back"
-        );
-    }
-
-    /// A signed state for a company this host doesn't run.
-    #[tokio::test]
-    async fn callback_unknown_company_redirects() {
-        let state = AppState::new(AppConfig::default());
-        let nonce = encode_state(
-            &test_state_secret(),
-            "ghost",
-            "slack",
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=unknown_company"), "{loc}");
-        assert!(loc.contains("provider=slack"), "{loc}");
-    }
-
-    /// A registered company, but the provider has no app credentials on this
-    /// host — the catalog/backend gap the console shows 11 tiles for.
-    #[tokio::test]
-    async fn callback_unconfigured_provider_redirects() {
-        let (runtime, _home) = test_runtime().await;
-        let state = AppState::new(AppConfig::default());
-        state.registry().insert(CompanyId::new("acme"), runtime);
-        let provider = unique_provider();
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            &provider,
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=provider_disabled"), "{loc}");
-        assert!(loc.contains(&format!("provider={provider}")), "{loc}");
-    }
-
-    /// A token endpoint that cannot be reached must bounce back too — and the
-    /// authorization code must not ride along into browser history or logs.
-    #[tokio::test]
-    async fn callback_exchange_failure_redirects_without_leaking_code() {
-        // Bind then drop to obtain a port with nothing listening on it.
-        let dead = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let dead_addr = dead.local_addr().unwrap();
-        drop(dead);
-
-        let (runtime, _home) = test_runtime().await;
-        let state = AppState::new(AppConfig::default());
-        state.registry().insert(CompanyId::new("acme"), runtime);
-        let provider = unique_provider();
-        let key = provider.to_ascii_uppercase();
-        // SAFETY: unique per-test provider name → no cross-test env collision.
-        unsafe {
-            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid");
-            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_SECRET"), "csec");
-            std::env::set_var(
-                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
-                "http://x/a",
-            );
-            std::env::set_var(
-                format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"),
-                format!("http://{dead_addr}/token"),
-            );
-        }
-
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            &provider,
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(
-            state,
-            &format!("code=CANARY-authz-code&state={}", urlencode(&nonce)),
-        )
-        .await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=exchange_failed"), "{loc}");
-        assert!(
-            !loc.contains("CANARY-authz-code"),
-            "authorization code leaked into Location: {loc}"
-        );
-
-        unsafe {
-            for suffix in ["ID", "SECRET", "AUTHORIZE_URL", "TOKEN_URL"] {
-                std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
-            }
-        }
-    }
-
-    // ---- account identity at connect time (issue #316) --------------------
-
-    /// Builds an isolated in-memory company runtime whose manifest names
-    /// `admins` as `[users].admins` — the operator addresses a connected
-    /// account is checked against.
-    async fn test_runtime_with_admins(admins: &[&str]) -> (Arc<CompanyRuntime>, tempfile::TempDir) {
-        let home = tempfile::Builder::new()
-            .prefix("oc-acct-")
-            .tempdir()
-            .expect("tempdir");
-        let admins_toml = admins
-            .iter()
-            .map(|a| format!("{a:?}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let manifest: CompanyManifest = toml::from_str(&format!(
-            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[users]\nadmins = [{admins_toml}]\n"
-        ))
-        .unwrap();
-        let runtime = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
-            .with_id(CompanyId::new("acme"))
-            .build()
+    async fn callback_ends_an_inflight_flow_without_accepting_its_code() {
+        let response = router()
+            .with_state(AppState::new(AppConfig::default()))
+            .oneshot(
+                Request::get(
+                    "/api/v1/oauth/callback?code=CANARY-authz-code&state=CANARY-signed-state",
+                )
+                .body(Body::empty())
+                .unwrap(),
+            )
             .await
             .unwrap();
-        (Arc::new(runtime), home)
-    }
 
-    /// Spins up a local HTTP server that answers every POST with `body` as
-    /// JSON, standing in for a provider's token endpoint. Returns the address
-    /// to point `OPENCOMPANY_OAUTH_<P>_TOKEN_URL` at.
-    async fn mock_token_endpoint(body: serde_json::Value) -> std::net::SocketAddr {
-        let app = Router::new().route(
-            "/token",
-            post(move || {
-                let body = body.clone();
-                async move { Json(body) }
-            }),
+        assert_eq!(response.status(), StatusCode::GONE);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
         );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        addr
-    }
-
-    /// Registers a unique provider's app credentials pointing its token URL at
-    /// `addr`, and returns the provider name + env key so the caller can clean
-    /// up afterwards.
-    fn configure_provider_env(addr: std::net::SocketAddr) -> (String, String) {
-        let provider = unique_provider();
-        let key = provider.to_ascii_uppercase();
-        // SAFETY: unique per-test provider name → no cross-test env collision.
-        unsafe {
-            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid");
-            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_SECRET"), "csec");
-            std::env::set_var(
-                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
-                "http://x/a",
-            );
-            std::env::set_var(
-                format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"),
-                format!("http://{addr}/token"),
-            );
-        }
-        (provider, key)
-    }
-
-    fn clear_provider_env(key: &str) {
-        unsafe {
-            for suffix in ["ID", "SECRET", "AUTHORIZE_URL", "TOKEN_URL"] {
-                std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
-            }
-        }
-    }
-
-    /// A connected account matching the company's operator address connects
-    /// and stores as before — the baseline this slice must not break.
-    #[tokio::test]
-    async fn callback_matching_account_connects_and_stores() {
-        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
-        let state = AppState::new(AppConfig::default());
-        state
-            .registry()
-            .insert(CompanyId::new("acme"), runtime.clone());
-
-        let addr = mock_token_endpoint(json!({ "email": "ada@example.com" })).await;
-        let (provider, key) = configure_provider_env(addr);
-
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            &provider,
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(
-            loc.contains(&format!("connected={provider}")),
-            "expected a matching account to connect: {loc}"
-        );
-        assert!(!loc.contains("connect_error="), "{loc}");
-
-        let stored = runtime
-            .secrets()
-            .get(runtime.id(), &oauth_key(&provider))
-            .await
-            .unwrap()
-            .expect("token stored");
-        assert!(
-            stored.expose().contains("ada@example.com"),
-            "stored secret missing the connected account: {}",
-            stored.expose()
-        );
-
-        clear_provider_env(&key);
-    }
-
-    /// A connected account that is a comparable email but matches none of the
-    /// company's operator addresses is refused: nothing is stored, and the
-    /// redirect names both the connected and expected addresses (issue #316).
-    #[tokio::test]
-    async fn callback_mismatched_email_account_is_refused() {
-        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
-        let state = AppState::new(AppConfig::default());
-        state
-            .registry()
-            .insert(CompanyId::new("acme"), runtime.clone());
-
-        let addr = mock_token_endpoint(json!({ "email": "eve@example.com" })).await;
-        let (provider, key) = configure_provider_env(addr);
-
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            &provider,
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(loc.contains("connect_error=account_mismatch"), "{loc}");
-        assert!(loc.contains(&format!("provider={provider}")), "{loc}");
-        assert!(
-            loc.contains(&urlencode("eve@example.com")),
-            "redirect must name the connected account: {loc}"
+        assert_eq!(
+            response.headers().get("sunset").unwrap(),
+            NATIVE_OAUTH_SUNSET
         );
         assert!(
-            loc.contains(&urlencode("ada@example.com")),
-            "redirect must name the expected operator address: {loc}"
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("text/html")
         );
 
+        let body = String::from_utf8(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(body.contains("Native OAuth connection is no longer available"));
+        assert!(body.contains("Nothing was saved from this authorization"));
+        assert!(body.contains(NATIVE_OAUTH_REMOVAL_DATE));
         assert!(
-            is_blanked(&runtime, &provider).await,
-            "a mismatched account must not be stored"
+            !body.contains("CANARY"),
+            "the callback neither accepts nor reflects its former OAuth inputs: {body}"
         );
-
-        clear_provider_env(&key);
-    }
-
-    /// GitHub's token response carries no `login` at all — just
-    /// `access_token`/`scope`/`token_type` — so [`extract_account`] returns
-    /// `None`. With nothing to compare, the connect must still succeed; this
-    /// is the regression guard for the "cannot compare, so do not refuse"
-    /// rule.
-    #[tokio::test]
-    async fn callback_token_without_account_still_connects() {
-        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
-        let state = AppState::new(AppConfig::default());
-        state
-            .registry()
-            .insert(CompanyId::new("acme"), runtime.clone());
-
-        let addr = mock_token_endpoint(json!({
-            "access_token": "gho_mock",
-            "scope": "repo",
-            "token_type": "bearer",
-        }))
-        .await;
-        let (provider, key) = configure_provider_env(addr);
-
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            &provider,
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(
-            loc.contains(&format!("connected={provider}")),
-            "an account-less token response must still connect: {loc}"
-        );
-        assert!(!loc.contains("connect_error="), "{loc}");
-
-        clear_provider_env(&key);
-    }
-
-    /// Slack's token response names the workspace under `team.name`, not the
-    /// operator's address. A label that isn't shaped like an email is not
-    /// comparable, so the connect must still succeed — a naive `!=` here
-    /// would break every Slack connect.
-    #[tokio::test]
-    async fn callback_non_email_account_still_connects() {
-        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
-        let state = AppState::new(AppConfig::default());
-        state
-            .registry()
-            .insert(CompanyId::new("acme"), runtime.clone());
-
-        let addr = mock_token_endpoint(json!({ "team": { "name": "Acme Workspace" } })).await;
-        let (provider, key) = configure_provider_env(addr);
-
-        let nonce = encode_state(
-            &test_state_secret(),
-            "acme",
-            &provider,
-            now_millis() + STATE_TTL_MS,
-        );
-        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
-        let loc = location(&resp);
-        assert!(
-            loc.contains(&format!("connected={provider}")),
-            "a non-email account label must still connect: {loc}"
-        );
-        assert!(!loc.contains("connect_error="), "{loc}");
-
-        clear_provider_env(&key);
     }
 
     // ---- disconnect / best-effort revoke ----------------------------------

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -1,38 +1,34 @@
 //! Read-only connection status (`GET …/connections`).
 //!
-//! Deliberately **un-gated**: connection *status* is readable even when the
-//! token-exchanging OAuth write routes ([`ops::connections`](super::connections),
-//! the `oauth` feature) are not compiled. Without this route the console's
+//! Deliberately **un-gated**: connection *status* is readable even when native
+//! OAuth cleanup routes ([`ops::connections`](super::connections), the `oauth`
+//! feature) are not compiled. Without this route the console's
 //! `GET …/connections` 404s and the page falls back to the read-only
 //! "connections unavailable" banner; with it the console renders real
-//! per-provider state and lights up the Connect buttons.
+//! per-provider state.
 //!
 //! Every field here is a **non-secret projection** — the provider id, a
-//! `connected` boolean, an optional account label, and the credential tier the
-//! Connect would route through — mirroring the GraphQL `Company.connections`
+//! `connected` boolean, an optional account label, and a credential-source tier
+//! — mirroring the GraphQL `Company.connections`
 //! resolver
 //! ([`resolve_connections`](crate::server::graphql::connections::resolve_connections)).
 //! The stored OAuth token material never appears in the response or any log.
 //!
-//! ## Hosted versus the self-hosted hatch (issue #319)
+//! ## Hosted connections and retired native OAuth (issues #319, #838)
 //!
-//! [`connect_route`] answers one question per provider: *can a Connect click
-//! possibly succeed on this host, and by which route?* It reports a
+//! [`connect_route`] reports a
 //! [`CredentialSource`] tier — the same vocabulary
 //! [`ops::composio`](super::composio) already uses, so the two console surfaces
 //! read the same to an operator:
 //!
 //! * `attested` — the pod carries a platform-projected identity, so connections
 //!   are the platform's to run. Nothing to register here, and the console offers
-//!   no local Connect. A hosted tenant is injected no `OPENCOMPANY_OAUTH_*`
-//!   variable, so a local Connect on such a host could only ever fail; reporting
-//!   the tier makes that failure unreachable from the console rather than a
-//!   400 the operator has to interpret.
-//! * `static` — either a token this company already stored (a BYO override), or
-//!   this host's own registered provider application: the **self-hosted hatch**
-//!   documented on [`ops::connections`](super::connections). Connect works
-//!   exactly as it does today.
-//! * `none` — neither, so no Connect can succeed and the console says so.
+//!   no local Connect.
+//! * `static` — a legacy native OAuth token this company already stored. It
+//!   remains visible and revocable, but no agent can use it.
+//! * `none` — no stored legacy credential or hosted path. A configured native
+//!   provider app is included here: #838 retired its start route rather than
+//!   reporting a route that can no longer create a usable connection.
 //!
 //! ### Provider mapping, for when the hosted route lands
 //!
@@ -70,8 +66,8 @@ struct ConnectionStateDto {
     provider: String,
     /// Whether a non-empty OAuth token is stored for this provider.
     connected: bool,
-    /// Which route a Connect for this provider would take on this host — see
-    /// [`connect_route`]. A tier name, never a credential and never a path.
+    /// The source of this provider's connection state — see [`connect_route`].
+    /// A tier name, never a credential and never a path.
     credential_source: CredentialSource,
     /// The connected account label, when known — never token material. Omitted
     /// when not connected or when the stored blob carries no account.
@@ -88,19 +84,17 @@ struct ConnectionStateDto {
     unverified: bool,
 }
 
-/// Can a Connect click for `provider` possibly succeed on this host, and by
-/// which route?
+/// Reports the connection source for one provider.
 ///
 /// Stored-wins, mirroring [`ops::composio`](super::composio)'s precedence:
 ///
 /// 1. a token already stored for this provider → [`CredentialSource::Static`]
-///    (the BYO override — whatever else the host offers, this company is
-///    already connected through its own grant);
+///    (a legacy native credential, visible and revocable but not agent-usable);
 /// 2. else a platform-projected instance identity →
 ///    [`CredentialSource::Attested`];
-/// 3. else this host's own registered provider application →
-///    [`CredentialSource::Static`] (the self-hosted hatch);
-/// 4. else [`CredentialSource::None`].
+/// 3. else [`CredentialSource::None`]. A host provider app is deliberately not
+///    a route: native `start` is retired until its compatibility endpoint is
+///    removed (#1023).
 ///
 /// Step 2 is deliberately restricted to the **projected-file** tier.
 /// [`TinyhumansTokenSource::from_env`] also resolves a long-lived
@@ -119,8 +113,8 @@ struct ConnectionStateDto {
 /// type rather than restating the precedence, so what the tests exercise is the
 /// same code the request path runs.
 #[cfg(test)]
-fn connect_route(provider: &str, stored: bool, env: &dyn EnvSource) -> CredentialSource {
-    HostConnectRoutes::resolve(env).route(provider, stored, env)
+fn connect_route(_provider: &str, stored: bool, env: &dyn EnvSource) -> CredentialSource {
+    HostConnectRoutes::resolve(env).route(stored)
 }
 
 /// The host-level half of [`connect_route`], resolved once.
@@ -158,15 +152,12 @@ impl HostConnectRoutes {
 
     /// The full precedence for one provider, given the already-resolved
     /// host-level facts.
-    fn route(&self, provider: &str, stored: bool, env: &dyn EnvSource) -> CredentialSource {
+    fn route(&self, stored: bool) -> CredentialSource {
         if stored {
             return CredentialSource::Static;
         }
         if self.attested {
             return CredentialSource::Attested;
-        }
-        if host_provider_app_configured(provider, env) {
-            return CredentialSource::Static;
         }
         CredentialSource::None
     }
@@ -175,24 +166,9 @@ impl HostConnectRoutes {
     /// entry point the two read projections — this module and the GraphQL
     /// [`resolve_connections`](crate::server::graphql::connections::resolve_connections)
     /// — share, so they cannot drift apart.
-    pub(crate) fn route_from_env(&self, provider: &str, stored: bool) -> CredentialSource {
-        self.route(provider, stored, &crate::app::config::ProcessEnv)
+    pub(crate) fn route_from_env(&self, _provider: &str, stored: bool) -> CredentialSource {
+        self.route(stored)
     }
-}
-
-/// Whether this host has a provider application registered for `provider`,
-/// delegated to the hatch module so the rule lives in exactly one place.
-#[cfg(feature = "oauth")]
-fn host_provider_app_configured(provider: &str, env: &dyn EnvSource) -> bool {
-    super::connections::provider_app_configured(provider, env)
-}
-
-/// Without the `oauth` feature the token-exchanging write routes are not
-/// compiled at all (they 404), so no local Connect can succeed on this host no
-/// matter what the environment holds.
-#[cfg(not(feature = "oauth"))]
-fn host_provider_app_configured(_provider: &str, _env: &dyn EnvSource) -> bool {
-    false
 }
 
 /// Builds the connection-status route fragment (both scope forms).
@@ -675,10 +651,11 @@ mod tests {
     }
 
     /// The precedence matrix from [`connect_route`], driven through the env seam
-    /// so nothing mutates the process environment: stored wins, else a projected
-    /// platform identity, else this host's own provider app, else nothing.
+    /// so nothing mutates the process environment: stored wins, then a projected
+    /// platform identity, then nothing. A configured native provider app is no
+    /// longer a route after #838.
     #[test]
-    fn connect_route_follows_stored_then_attested_then_hatch() {
+    fn connect_route_never_advertises_a_retired_native_provider_app() {
         use crate::app::config::MapEnv;
 
         let dir = tempfile::Builder::new()
@@ -691,17 +668,13 @@ mod tests {
             crate::company::credentials::TOKEN_FILE_ENV,
             path.display().to_string(),
         )]);
-        // An obviously fake host provider application — the self-hosted hatch.
-        // The state signing secret is part of the hatch being *open*: without
-        // one no nonce can be issued, so no handshake can complete (issue #318).
-        let hatch = MapEnv::new([
+        let retired_native_app = MapEnv::new([
             ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
             ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
-            ("OPENCOMPANY_OAUTH_STATE_SECRET", "a-private-value"),
         ]);
 
-        // 1. A stored token is the BYO override and outranks everything else,
-        //    including a projected platform identity.
+        // 1. A historical stored token is still visible and revocable. It
+        //    outranks every host-level source for that description.
         assert_eq!(
             connect_route("github", true, &projected),
             CredentialSource::Static
@@ -711,8 +684,8 @@ mod tests {
             CredentialSource::Static
         );
 
-        // 2. Nothing stored + a projected platform identity → the platform owns
-        //    the connection, for every provider (the identity is host-level).
+        // 2. Nothing stored + a projected platform identity → the platform
+        //    owns the connection, for every provider (the identity is host-level).
         assert_eq!(
             connect_route("github", false, &projected),
             CredentialSource::Attested
@@ -722,21 +695,13 @@ mod tests {
             CredentialSource::Attested
         );
 
-        // 3. No platform identity, but this host registered its own provider
-        //    application → the hatch is open and Connect works as it does today.
-        //    Only for the provider it was registered for.
-        if cfg!(feature = "oauth") {
-            assert_eq!(
-                connect_route("github", false, &hatch),
-                CredentialSource::Static
-            );
-        }
         assert_eq!(
-            connect_route("slack", false, &hatch),
-            CredentialSource::None
+            connect_route("github", false, &retired_native_app),
+            CredentialSource::None,
+            "a configured native app must not be offered after its start route retires"
         );
 
-        // 4. Neither → no Connect can succeed on this host.
+        // 3. Neither → no connection route exists on this host.
         assert_eq!(
             connect_route("github", false, &MapEnv::default()),
             CredentialSource::None
@@ -764,37 +729,6 @@ mod tests {
             CredentialSource::None,
             "a static inference key must not be read as a platform connection route"
         );
-
-        // Same operator, with their own GitHub app registered: the hatch stays
-        // open and still reads `static`, not `attested`.
-        if cfg!(feature = "oauth") {
-            let with_hatch = MapEnv::new([
-                (crate::company::credentials::API_KEY_ENV, "th_fake_key"),
-                ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
-                ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
-                ("OPENCOMPANY_OAUTH_STATE_SECRET", "a-private-value"),
-            ]);
-            assert_eq!(
-                connect_route("github", false, &with_hatch),
-                CredentialSource::Static,
-                "the self-hosted hatch must keep working when an inference key is also set"
-            );
-
-            // Issue #318: the same operator without a state signing secret. The
-            // provider application is fully registered, and the hatch is still
-            // shut — an unsigned-nonce flow has no CSRF check worth the name, so
-            // the honest answer is that no Connect can succeed here.
-            let no_state_secret = MapEnv::new([
-                (crate::company::credentials::API_KEY_ENV, "th_fake_key"),
-                ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
-                ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
-            ]);
-            assert_eq!(
-                connect_route("github", false, &no_state_secret),
-                CredentialSource::None,
-                "a registered provider app with no state signing secret is not connectable"
-            );
-        }
 
         // And a `TINYHUMANS_TOKEN_FILE` naming a path that does not exist
         // degrades to the static tier inside the resolver — which is likewise


### PR DESCRIPTION
## Summary

- Part of #838.
- Retire the native OAuth start and callback flow that could create credentials no agent can use.
- Keep an actionable, dated compatibility response for cached pre-#828 console bundles and preserve legacy credential disconnect/read access.

## API Or Behavior Changes

- `POST …/connections/{provider}/start` returns `410 native_oauth_retired` JSON with a deprecation sunset of 2026-09-30.
- `GET /api/v1/oauth/callback` returns a no-store `410` HTML explanation and ignores callback input, so an in-flight authorization cannot write a credential.
- A configured native provider app no longer reports as a usable connection route; existing stored native credentials remain visible and revocable.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets --no-deps -- -D warnings`
- [x] `cargo build --locked --all-targets`
- [x] `cargo test --locked`
- [x] `cargo check --locked --features openhuman,mcp,telegram --all-targets`
- [x] `npm --prefix frontend run typecheck`
- [x] `npm --prefix frontend run typecheck:unit`
- [x] `npm --prefix frontend run typecheck:e2e`
- [x] `npm --prefix frontend run build`
- [x] `npx vitest run test/unit/connection-route.test.ts test/unit/provider-grid.test.ts` (52 passed)

## Documentation

- Updated the server connections, authority, credential, write-plane, plan, and console architecture documentation.
- Follow-up removal is tracked in #1023.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hosted provider connections as the supported authorization path.
  * Preserved disconnect functionality for removing legacy OAuth credentials.

* **Bug Fixes**
  * Retired native OAuth start and callback flows with clear temporary `410 Gone` responses through September 30, 2026.
  * Prevented retired callbacks from processing, exchanging, or storing OAuth data.
  * Existing legacy credentials remain visible for revocation but are not offered as usable agent capabilities.

* **Documentation**
  * Updated connection, API, frontend, and verification guidance to reflect the retired native OAuth experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->