### PR TITLE
Deliver the three desk-bearing templates' pipeline reports

### DIFF
--- a/companies/agentic_marketing_agency/workflows/campaign_pipeline.toml
+++ b/companies/agentic_marketing_agency/workflows/campaign_pipeline.toml
@@ -84,6 +84,14 @@ kind = "output"
 name = "Report back"
 summary = "Summarize what shipped."
 
+# Strategy, because this report closes the loop the brief opened: the strategist
+# turned the client's brief into the angle, and "what shipped" is only meaningful
+# read against it. Creative made the post and already saw it; growth runs
+# acquisition on a campaign this pipeline does not measure.
+[node.destination]
+kind = "channel"
+target = "strategy"
+
 [[edge]]
 from = "brief"
 to = "strategist"

--- a/companies/agentic_software_company/workflows/feature_pipeline.toml
+++ b/companies/agentic_software_company/workflows/feature_pipeline.toml
@@ -77,6 +77,14 @@ kind = "output"
 name = "Ship and report"
 summary = "Release behind approval and report back."
 
+# Go-to-market, not engineering: engineering built the thing and does not need a
+# report of its own work, while docs, devrel and support are the people whose
+# next action depends on knowing what shipped. The pipeline already ends on
+# `docs_writer`, who sits on this desk.
+[node.destination]
+kind = "channel"
+target = "go_to_market"
+
 [[edge]]
 from = "request"
 to = "spec"

--- a/companies/e2e_harness/workflows/committed.toml
+++ b/companies/e2e_harness/workflows/committed.toml
@@ -40,6 +40,13 @@ kind = "output"
 name = "Hand it to the operator"
 summary = "Park the draft for review."
 
+# Content: the one node before this is `writer` producing a written draft, and
+# this harness's other desk is engineering. The draft is the deliverable, so the
+# desk that reviews written work is the audience.
+[node.destination]
+kind = "channel"
+target = "content"
+
 [[edge]]
 from = "start"
 to = "draft"

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -6,6 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
+use super::workflow_file::WorkflowNodeKind;
 use super::{
     CompanyManifest, Tools, grants_chargebee_explicit, grants_composio_explicit,
     grants_media_explicit, grants_paypal_explicit, grants_search_explicit, load_dir_skills,
@@ -598,4 +599,128 @@ fn the_marketing_campaign_preset_is_runnable() {
     assert_eq!(research.config["on_error"], "continue");
 
     assert_eq!(node("publish").config["agent_ref"], "copywriter");
+}
+
+/// Every seeded `output` node either names a destination its own manifest can
+/// resolve, or names none at all — and the ones that name none are exactly the
+/// templates that declare no desk (issue #947).
+///
+/// Two failures this catches, and they are opposite:
+///
+///  1. **A destination that cannot resolve.** A `channel` target is a
+///     [`ChannelAdapter`] id, and the adapters a company gets are one per desk in
+///     its own manifest (`runtime::builder`, issue #837). A target naming a desk
+///     that manifest does not declare parses fine, ships, and fails at run time
+///     on a freshly provisioned tenant — which is the class of bug #947 is about,
+///     one step further along.
+///  2. **A desk-bearing template that quietly loses its destination.** The
+///     allowlist below is the 18 templates that declare no desk and therefore
+///     have nothing to address. It is an allowlist rather than a `!is_empty()`
+///     check so that removing a destination from one of the three that *can*
+///     deliver fails here instead of passing as "well, some have none".
+///
+/// The 18 are tracked in #963: they need desks before they can have
+/// destinations, which is a content judgement per company rather than a stanza,
+/// and `agentic_research_lab` declares no desk deliberately.
+#[test]
+fn every_seeded_output_destination_resolves_against_its_own_manifest() {
+    /// Templates with an `output` node and no desk to deliver it to (#963).
+    const NO_DESK_YET: &[&str] = &[
+        "agentic_accounting_firm",
+        "agentic_consultation_firm",
+        "agentic_customer_support",
+        "agentic_design_studio",
+        "agentic_enterprise_sales",
+        "agentic_game_business",
+        "agentic_game_studio",
+        "agentic_influencer_business",
+        "agentic_law_firm",
+        "agentic_media_company",
+        "agentic_pharma_startup",
+        "agentic_realestate_company",
+        "agentic_recruiting_company",
+        "agentic_research_lab",
+        "agentic_venture_capital",
+        "agentic_venture_studio",
+        "signals_opportunity_studio",
+        "startup_accelerator",
+    ];
+
+    let mut checked = 0;
+    let mut with_destination = 0;
+    for dir in subdirs(&repo_root().join("companies")) {
+        let company = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap()
+            .to_string();
+        let manifest_path = dir.join("company.toml");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let manifest: CompanyManifest =
+            toml::from_str(&std::fs::read_to_string(&manifest_path).unwrap())
+                .unwrap_or_else(|err| panic!("{company}/company.toml: {err}"));
+        let desks: Vec<&str> = manifest
+            .group_chats
+            .iter()
+            .map(|chat| chat.id.as_str())
+            .collect();
+
+        for path in toml_files(&dir.join("workflows")) {
+            let text = std::fs::read_to_string(&path).unwrap();
+            let file =
+                parse_workflow(&text).unwrap_or_else(|err| panic!("{}: {err:?}", path.display()));
+            let label = format!("{company}/{}", path.file_name().unwrap().to_string_lossy());
+
+            for node in file
+                .nodes
+                .iter()
+                .filter(|n| n.kind == WorkflowNodeKind::Output)
+            {
+                checked += 1;
+                let Some(destination) = node.destination.as_ref() else {
+                    assert!(
+                        NO_DESK_YET.contains(&company.as_str()),
+                        "{label} has an output node with no destination, so a run of it \
+                         delivers nothing. Give it a destination, or — if this template \
+                         declares no desk to deliver to — add it to `NO_DESK_YET` and to \
+                         issue #963."
+                    );
+                    assert!(
+                        desks.is_empty(),
+                        "{label} is listed in `NO_DESK_YET` but its manifest declares \
+                         desks {desks:?}, so it has somewhere to deliver. Give its output \
+                         node a destination and drop it from the list."
+                    );
+                    continue;
+                };
+                with_destination += 1;
+                assert_eq!(
+                    destination.kind, "channel",
+                    "{label} uses destination kind `{}`. `owner` reports \
+                     Failed/OwnerFallbackFailed on a tenant with no mailbox — every freshly \
+                     provisioned one — and `email` would hardcode a recipient into a \
+                     shipped template.",
+                    destination.kind
+                );
+                let target = destination.target.as_deref().unwrap_or("");
+                assert!(
+                    desks.contains(&target),
+                    "{label} delivers to channel `{target}`, which is not a desk \
+                     {company}'s manifest declares. A company's channel adapters are one \
+                     per desk, so this resolves nowhere at run time. Declared: {desks:?}"
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        checked, 21,
+        "the seeded output-node count changed; this test and #963's list describe 21"
+    );
+    assert_eq!(
+        with_destination, 3,
+        "exactly the three desk-bearing templates carry a destination today"
+    );
 }


### PR DESCRIPTION
## Summary

21 seeded workflows carry an `output` node and **none declared a destination**, so no template run
could deliver anything. This fixes the three templates that can be fixed, and says plainly why the
other 18 cannot be.

**The issue's central premise does not hold.** #947 states *"Every template defines `[[group_chat]]`
desks"*, and the desk-channel recommendation rests on it. Against `main`, only **3 of the 21**
companies with an output node declare any desk:

```
$ for f in companies/*/company.toml; do echo "$(grep -c '^\[\[group_chat\]\]' $f)  $(basename $(dirname $f))"; done | sort -rn
3  agentic_software_company     engineering, product_design, go_to_market
3  agentic_marketing_agency     strategy, creative, growth
2  e2e_harness                  engineering, content
2  openhuman_demo               (no output-node workflow — not one of the 21)
0  × 18 others
```

The 18 are tracked in #963 with the full reasoning. In short: `owner` reports
`Failed`/`OwnerFallbackFailed` on a tenant with no mailbox (`delivery.rs`'s own test sets
`with_channel = true` and it still fails), `channel` has nothing to target, `email` would hardcode a
recipient into a shipped template, and the operator adapter is explicitly disqualified at
`src/workflows/delivery.rs` — *"its buffer is **not** a workflow delivery surface, so this cannot
report a successful discard."* Giving 18 businesses desks is a content judgement per company, not a
stanza, and folding it in here would restructure them under a delivery heading — the "buried under
diff" problem #947 was itself split from #925 to avoid.

`agentic_research_lab` is desk-less **deliberately** — its manifest says so — so it likely needs a
different answer from the other 17, which is noted on #963.

## The three judgements

One per template, each a decision about *who the report is for*:

| Template | Desk | Why |
|---|---|---|
| `agentic_software_company` / `feature_pipeline` | `go_to_market` | Engineering built the feature and does not need a report of its own work. Docs, devrel and support are the people whose next action depends on knowing what shipped — and the pipeline already ends on `docs_writer`, who sits on this desk. |
| `agentic_marketing_agency` / `campaign_pipeline` | `strategy` | The report closes the loop the brief opened: the strategist turned the client's brief into the angle, and "what shipped" is only meaningful read against it. Creative made the post and already saw it; growth runs acquisition on a campaign this pipeline does not measure. |
| `e2e_harness` / `committed` | `content` | The one node before the output is `writer` producing a written draft, and this harness's only other desk is engineering. The draft is the deliverable. |

## Verified for real, not asserted from the TOML

Built the host, ran it on `e2e_harness` against a **fresh data dir** — a genuinely freshly provisioned
tenant, no mailbox — signed in through the dev-code flow, and ran the workflow:

```
deliveries: [{"node":"done","kind":"channel","target":"content","status":"sent",
              "detail":"posted to the channel","reason":"channel-posted"}]
```

and the report is readable at `GET /api/v1/company/chat/history?desk=content`, the endpoint the
console renders — no canvas involved:

> `[E2E Harness Co] Committed flow — Hand it to the operator` …

**The before/after was run too.** With the destination reverted, on a fresh tenant, the same run gives
`{"kind":"none","status":"skipped","reason":"no-destination-configured"}` and the content desk chat is
`[]`. So both halves of the acceptance criterion are demonstrated rather than argued.

## Relationship to #995

#995 refuses an undeliverable channel destination **at save**, and it does not constrain this PR —
deliberately. Its own guard says why:

> *at TOML parse time: seed templates are parsed with no runtime in hand, and checking there would
> refuse to boot a template on a company whose desks are not resolved yet.*

So seeded templates never pass through that guard. The test below is its counterpart for the surface
it cannot cover, and the three targets here are real desk ids, so they are inside
`deliverable_channel_ids` at run time.

## API Or Behavior Changes

Three seeded templates' `output` nodes gain a `[node.destination]` of `kind = "channel"`. A run of
those workflows now posts its report to a desk chat instead of delivering nothing. No code path
changes; no route, schema or default changes. The other 18 templates are untouched and still deliver
nothing — which #925's `Skipped` / `NoDestinationConfigured` row now reports honestly.

## Tests

`every_seeded_output_destination_resolves_against_its_own_manifest` walks all 21 seeded workflows and
checks each destination against **its own manifest's desks**, because a `channel` target is a
`ChannelAdapter` id and a company's adapters are one per desk. A target naming a desk its manifest
does not declare parses fine, ships, and fails at run time on a fresh tenant — the #947 class of bug
one step further along.

The 18 are an explicit **allowlist**, not an `is_empty()` skip, so it fails in both directions: a
desk-bearing template that loses its destination fails, and a listed template that gains desks fails
until it gets one.

- [x] `cargo fmt --all -- --check` — PASS.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI's gated form,
      `--no-deps --features openhuman,tinycortex --all-targets`. PASS.
- [x] `cargo build --all-targets` — covered by the clippy and test runs above; the host binary was
      also built to drive the live verification.
- [x] `cargo test` — **4279 passed / 0 failed** at `--features openhuman,tinycortex --lib`.

### Proven to fail with the fix reverted

- Removing `feature_pipeline`'s destination → *"…has an output node with no destination, so a run of
  it delivers nothing."*
- Changing its target to `gtm` → *"…delivers to channel `gtm`, which is not a desk
  agentic_software_company's manifest declares. Declared: ["engineering", "product_design",
  "go_to_market"]"*
- End to end, reverted on a fresh tenant: `status: "skipped"`, `reason: "no-destination-configured"`,
  and an empty desk chat.

## Documentation

Each destination carries its judgement as a comment at the node, so the "why this desk" is read where
the choice is made. The test states why the 18 are an allowlist and points at #963.

No `docs/` change: no route, launcher behavior or `tiny*` integration changes.

Closes tinyhumansai/opencompany#947
