### PR TITLE
fix(workflows): stop a run hanging in "running" forever when its finish is never journaled (#1009)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -75,6 +75,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
 import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
 import { cn } from "@/lib/utils";
+import { startVisiblePolling } from "@/lib/visible-poll";
 import type { NodeRunState } from "@/lib/workflow-sample";
 // Issue #303: the canvas arithmetic, the run-state folds and the three drawers
 // moved out when this file passed 1800 lines and was about to grow an index and
@@ -1213,8 +1214,15 @@ export function WorkflowsView({
   const watchingRun = Boolean(activeRunId) || Boolean(liveRun?.active);
   useEffect(() => {
     if (!watchingRun || !historySupported) return;
-    const timer = window.setInterval(() => setRunsTick((n) => n + 1), 2_000);
-    return () => window.clearInterval(timer);
+    // Issue #1009: a bare `setInterval` kept firing in a hidden tab, so a run
+    // wedged "running" (a finish that never journaled) had a background console
+    // re-reading history every 2s forever. `startVisiblePolling` pauses the
+    // cadence while the tab is hidden and resumes — with one immediate read — on
+    // the visible edge, so a backgrounded console stops asking. Foreground
+    // behaviour is unchanged: the same 2s tick, and the backend's #1009
+    // cross-check now settles the row so the next read clears `activeRunId`
+    // (see the effect above) and this poll unmounts on its own.
+    return startVisiblePolling(() => setRunsTick((n) => n + 1), 2_000);
   }, [watchingRun, historySupported]);
 
   // Switching workflow (or company) clears the canvas: another graph's node ids

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -144,6 +144,12 @@ impl From<Result<&WorkflowRun, &str>> for Settled {
     }
 }
 
+/// Returns whether the finish was durably appended. `false` means the append
+/// failed and was swallowed (the run itself is unaffected, exactly as before) —
+/// so a caller that knows the run is otherwise about to disappear from the live
+/// set can escalate the lost record from this helper's `warn` to an `error`
+/// naming the run. Issue #1009 added the return; callers that do not care about
+/// the outcome (the boot sweep, the read-side cross-check) simply ignore it.
 pub async fn record_run_finished(
     events: &Arc<dyn EventLog>,
     company: &CompanyId,
@@ -151,7 +157,7 @@ pub async fn record_run_finished(
     scheduled: bool,
     run_id: &str,
     outcome: Result<&WorkflowRun, &str>,
-) {
+) -> bool {
     // Which fields ride which arm, and why, is documented on `Settled::from`.
     let settled = Settled::from(outcome);
 
@@ -174,7 +180,9 @@ pub async fn record_run_finished(
 
     if let Err(err) = events.append(company, event).await {
         // Swallowed on purpose: the run already happened and its work is valid.
-        // Losing the record is worth a loud line, never a failed run.
+        // Losing the record is worth a loud line, never a failed run. The caller
+        // learns of the loss through the `false` return (issue #1009) and may
+        // escalate it — this helper stays best-effort and never fails the run.
         tracing::warn!(
             %company,
             workflow = %workflow_id,
@@ -182,7 +190,9 @@ pub async fn record_run_finished(
             %err,
             "workflow run outcome could not be journaled; the run itself was unaffected"
         );
+        return false;
     }
+    true
 }
 
 /// Terminates workflow runs a previous host process left open (issue #371).
@@ -1144,5 +1154,59 @@ mod test {
         let (_home, events) = log();
         let company = CompanyId::new("acme");
         assert!(stranded(&events, &company, "digest").await.is_empty());
+    }
+
+    /// An [`EventLog`] whose `append` always fails — the store went away
+    /// mid-run. Issue #1009 uses it to prove the swallowed-append path reports
+    /// its loss instead of only warning.
+    struct FailingAppendLog;
+
+    #[async_trait::async_trait]
+    impl EventLog for FailingAppendLog {
+        async fn append(&self, _id: &CompanyId, _event: CompanyEvent) -> crate::Result<EventSeq> {
+            Err(crate::error::OpenCompanyError::Store(
+                "append failed (test double)".to_string(),
+            ))
+        }
+
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> crate::Result<Vec<crate::ports::types::StoredEvent>> {
+            Ok(Vec::new())
+        }
+
+        fn subscribe(
+            &self,
+            _id: &CompanyId,
+        ) -> futures::stream::BoxStream<'static, crate::ports::types::StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// Issue #1009 (path B): a finish whose append is swallowed reports
+    /// `journaled == false` rather than the silent `()` it used to. The run is
+    /// otherwise unaffected — `record_run_finished` must not panic and must not
+    /// propagate the append error — and a working log reports `true`, so the
+    /// signal the caller escalates on is real both ways.
+    #[tokio::test]
+    async fn a_swallowed_append_reports_it_was_not_journaled() {
+        let company = CompanyId::new("acme");
+        let run = run_with(Vec::new(), Vec::new());
+
+        let failing: Arc<dyn EventLog> = Arc::new(FailingAppendLog);
+        let journaled =
+            record_run_finished(&failing, &company, "digest", false, "run-1", Ok(&run)).await;
+        assert!(
+            !journaled,
+            "a swallowed append reports the finish did not land"
+        );
+
+        let (_home, working) = log();
+        let journaled =
+            record_run_finished(&working, &company, "digest", false, "run-1", Ok(&run)).await;
+        assert!(journaled, "a working log reports the finish landed");
     }
 }

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -47,6 +47,7 @@
 
 use std::sync::Arc;
 
+use futures::future::FutureExt;
 use serde_json::Value;
 use tokio::task::JoinHandle;
 
@@ -57,6 +58,20 @@ use crate::ports::types::CompanyId;
 use crate::ports::{EventLog, WorkflowRun, WorkflowRunContext, WorkflowRunner};
 use crate::runtime::workflow_outcome::record_run_finished;
 use crate::runtime::{RunGuard, RunSupervisor};
+
+/// The error stamped on a run whose task **panicked** before it could journal a
+/// finish (issue #1009).
+///
+/// Phrased, like [`INTERRUPTED_BY_RESTART`](crate::runtime::INTERRUPTED_BY_RESTART),
+/// as a host fact rather than a workflow fault the operator can act on at the
+/// node level: the run's task came apart, and the nodes recorded against it are
+/// the ones that completed before it did. A caught unwind journals this so the
+/// run stops reading `running: true` forever, then re-raises so the run's task
+/// still resolves to a `JoinError`.
+const PANICKED_BEFORE_FINISH: &str = concat!(
+    "this run's task panicked before it finished; ",
+    "the nodes recorded against it are the ones that completed before it stopped"
+);
 
 /// Everything starting a supervised workflow run needs, and nothing else.
 #[derive(Clone)]
@@ -177,7 +192,67 @@ impl WorkflowSpawn {
             // it can still do anything. Dropping on every exit path, unwind
             // included, is why this is a guard rather than a call at the end.
             let _guard = guard;
-            let result = self.runner.run(&self.company, &workflow, input, &ctx).await;
+            // Issue #1009 (path A): the runner future can **unwind** — a panic
+            // in a node, a poisoned lock — and an unwind jumps straight past the
+            // journal write below, so the run's `WorkflowRunStarted` never gets a
+            // matching finish and `GET …/workflows/runs` folds it `running: true`
+            // forever, until the next boot sweep settles it. The console shows a
+            // run that will never stop with a Stop button that cannot help.
+            //
+            // Catching the unwind *here* — inside the task, while `_guard` is
+            // still held, so the finish lands BEFORE the supervisor entry drops
+            // and no read-side rebuild race can open — lets us journal a finish
+            // for the panicked run, then re-raise the exact payload so the task
+            // still resolves to a `JoinError`. That keeps the synchronous mode's
+            // 500 (at the console run route) and the scheduler's `tracing::error`
+            // unchanged: nothing downstream can tell the panic was intercepted.
+            //
+            // Deliberately an in-task catch, not a separate watchdog task: only
+            // this way does the write stay inside the guard's lifetime and change
+            // no sync/detach contract.
+            let result = match std::panic::AssertUnwindSafe(self.runner.run(
+                &self.company,
+                &workflow,
+                input,
+                &ctx,
+            ))
+            .catch_unwind()
+            .await
+            {
+                Ok(result) => result,
+                Err(payload) => {
+                    // A dry run journals nothing on panic either, exactly as the
+                    // clean path below skips its finish — a test run must leave
+                    // no `WorkflowRunFinished` for the history to fold.
+                    if !dry_run {
+                        let journaled = record_run_finished(
+                            &self.events,
+                            &self.company,
+                            &workflow.id,
+                            scheduled,
+                            &ctx.run_id,
+                            Err(PANICKED_BEFORE_FINISH),
+                        )
+                        .await;
+                        // Issue #1009 (path B, surfaced): if even this finish
+                        // could not be appended, the run is right back to reading
+                        // in-flight until the next boot sweep — a state worth an
+                        // error line naming the run, not a swallowed warn.
+                        if !journaled {
+                            tracing::error!(
+                                company = %self.company,
+                                workflow = %workflow.id,
+                                run_id = %ctx.run_id,
+                                "a panicked workflow run's finish could not be journaled; \
+                                 it will read as in-flight until the next boot sweep settles it"
+                            );
+                        }
+                    }
+                    // Re-raise: the JoinHandle still resolves to a JoinError, so
+                    // the synchronous caller still 500s. The finish is durable.
+                    std::panic::resume_unwind(payload);
+                }
+            };
             // Issue #542: a dry run journals NOTHING. The runner already skipped
             // the started + per-node rows; skipping the finish here keeps the
             // pair honest, so a test run leaves no `WorkflowRunFinished` for the
@@ -190,7 +265,7 @@ impl WorkflowSpawn {
                     Ok(run) => Ok(run),
                     Err(err) => Err(err.to_string()),
                 };
-                match outcome {
+                let journaled = match outcome {
                     Ok(run) => {
                         record_run_finished(
                             &self.events,
@@ -200,7 +275,7 @@ impl WorkflowSpawn {
                             &ctx.run_id,
                             Ok(run),
                         )
-                        .await;
+                        .await
                     }
                     Err(err) => {
                         record_run_finished(
@@ -211,12 +286,154 @@ impl WorkflowSpawn {
                             &ctx.run_id,
                             Err(err.as_str()),
                         )
-                        .await;
+                        .await
                     }
+                };
+                // Issue #1009 (path B, surfaced): a swallowed append leaves the
+                // run reading `running: true` until the next boot sweep. The
+                // helper still swallows the append error itself (it must never
+                // fail the run), but a finish that did not land is worth an error
+                // line naming the run — not only the helper's warn — so the hole
+                // is visible in telemetry rather than only at the next restart.
+                if !journaled {
+                    tracing::error!(
+                        company = %self.company,
+                        workflow = %workflow.id,
+                        run_id = %ctx.run_id,
+                        "a finished workflow run could not be journaled; \
+                         it will read as in-flight until the next boot sweep settles it"
+                    );
                 }
             }
             result
         });
         (run_id, handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::types::{CompanyEvent, EventSeq};
+    use crate::store::FsEventLog;
+    use async_trait::async_trait;
+
+    /// A runner whose `run` **panics** — the path-A failure issue #1009 fixes.
+    /// An unwind here used to jump straight past the finish journal, leaving the
+    /// run reading `running: true` until the next boot sweep.
+    struct PanickingRunner;
+
+    #[async_trait]
+    impl WorkflowRunner for PanickingRunner {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            _workflow: &WorkflowFile,
+            _input: Value,
+            _ctx: &WorkflowRunContext,
+        ) -> Result<WorkflowRun> {
+            panic!("the run blew up");
+        }
+    }
+
+    fn empty_workflow() -> WorkflowFile {
+        WorkflowFile {
+            id: "digest".to_string(),
+            name: "Digest".to_string(),
+            description: None,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            global: false,
+        }
+    }
+
+    /// Issue #1009 (path A): a run whose task panics still journals a finish, so
+    /// it stops reading `running: true`.
+    ///
+    /// The watchdog catches the unwind, writes the finish while the guard is
+    /// still held, then re-raises — so both halves hold at once: the JoinHandle
+    /// still resolves to a `JoinError` (the console's synchronous-mode 500 and
+    /// the scheduler's `tracing::error` are unchanged) AND the journal now
+    /// carries a `WorkflowRunFinished` for the run. Before the fix the handle
+    /// still errored but nothing was journaled — this asserts the JOURNAL, which
+    /// is the half the bug was about.
+    #[tokio::test]
+    async fn a_panicking_run_still_journals_its_finish() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-spawn-panic-")
+            .tempdir()
+            .expect("tempdir");
+        let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(dir.path()));
+        let company = CompanyId::new("acme");
+        let spawn = WorkflowSpawn {
+            company: company.clone(),
+            events: events.clone(),
+            supervisor: RunSupervisor::new(),
+            runner: Arc::new(PanickingRunner),
+        };
+
+        let (run_id, handle) = spawn
+            .spawn(empty_workflow(), Value::Null, false, false)
+            .expect("under the default cap");
+
+        let joined = handle.await;
+        assert!(
+            joined.is_err() && joined.unwrap_err().is_panic(),
+            "the panic still propagates to the JoinHandle, preserving the sync-mode 500"
+        );
+
+        let stored = events
+            .read_from(&company, EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read journal");
+        let finished = stored.iter().any(|s| {
+            matches!(
+                &s.event,
+                CompanyEvent::WorkflowRunFinished {
+                    run_id: Some(id),
+                    error: Some(err),
+                    ..
+                } if id == &run_id && err == PANICKED_BEFORE_FINISH
+            )
+        });
+        assert!(
+            finished,
+            "the watchdog journaled a WorkflowRunFinished for the panicked run"
+        );
+    }
+
+    /// A dry (test) run that panics journals **nothing** — the watchdog honours
+    /// the same `dry_run` skip the clean path does, so a test run leaves no
+    /// `WorkflowRunFinished` for the history to fold even when it blows up.
+    #[tokio::test]
+    async fn a_panicking_dry_run_journals_nothing() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-spawn-panic-dry-")
+            .tempdir()
+            .expect("tempdir");
+        let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(dir.path()));
+        let company = CompanyId::new("acme");
+        let spawn = WorkflowSpawn {
+            company: company.clone(),
+            events: events.clone(),
+            supervisor: RunSupervisor::new(),
+            runner: Arc::new(PanickingRunner),
+        };
+
+        let (_run_id, handle) = spawn
+            .spawn(empty_workflow(), Value::Null, false, true)
+            .expect("under the default cap");
+        assert!(handle.await.is_err(), "the panic still propagates");
+
+        let stored = events
+            .read_from(&company, EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read journal");
+        assert!(
+            !stored
+                .iter()
+                .any(|s| matches!(s.event, CompanyEvent::WorkflowRunFinished { .. })),
+            "a dry run journals no finish, panic or not"
+        );
     }
 }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2443,6 +2443,71 @@ async fn list_runs(
         }
     }
 
+    // Issue #1009: cross-check the still-`running` rows against the live run set
+    // and settle the ones nobody is running.
+    //
+    // The fold above marks a start with no finish `running: true`, which is only
+    // ever settled by the boot sweep ([`sweep_interrupted_runs`]). Three ways a
+    // finish never lands — a task that panicked, an append that failed, a host
+    // that died — therefore all read as an eternal spinner *until the next host
+    // restart*, with a Stop button that cannot help and a 2s console poll that
+    // never stops. This closes the gap between restarts: any run the fold thinks
+    // is in flight whose id is **absent** from the supervisor's live set has no
+    // task behind it here and now, so it is journaled a synthetic finish (the
+    // same `INTERRUPTED_BY_RESTART` the boot sweep uses) and flipped in the
+    // in-memory row, so this very response is already self-consistent.
+    //
+    // Keyed strictly on `live()` membership. A run the current process is
+    // genuinely running is registered there and is left untouched — the watchdog
+    // (issue #1009, path A) is what guarantees a *panicking* run never reaches
+    // this predicate, because it journals its own finish before its guard drops.
+    //
+    // The one accepted false positive: a run that survived a live
+    // `rebuild_company` swap is registered on the *old* supervisor and so is
+    // absent from the successor's `live()`, so this could settle a run that is
+    // still walking its graph. Accepted because (i) the watchdog keeps panics out
+    // of this path entirely, (ii) that run's real finish lands later in journal
+    // order and wins the read's last-writer-wins display, and (iii) it is the
+    // same class the boot sweep already accepts — which is why that sweep gates
+    // on the handover being absent (see the runtime builder call site). It never
+    // corrupts the journal: a second, truthful finish simply supersedes it.
+    let live_ids: HashSet<String> = company
+        .runtime
+        .run_supervisor()
+        .live()
+        .into_iter()
+        .map(|(run_id, _workflow_id)| run_id)
+        .collect();
+    for entry in runs.iter_mut() {
+        if !entry.running {
+            continue;
+        }
+        let Some(run_id) = entry.run_id.clone() else {
+            continue;
+        };
+        if live_ids.contains(&run_id) {
+            continue;
+        }
+        // Durable half: append the finish so it survives this response, folds
+        // settled on the next `GET …/workflows/runs`, and stops the boot sweep
+        // from having to. Best-effort by construction — a failed append leaves
+        // the row as the in-memory flip below still makes it, and the next read
+        // simply retries.
+        crate::runtime::record_run_finished(
+            company.runtime.events(),
+            company.id(),
+            &entry.workflow_id,
+            entry.scheduled,
+            &run_id,
+            Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART),
+        )
+        .await;
+        // In-memory half: flip the row this response returns, so the console does
+        // not have to wait for the next poll to stop the spinner.
+        entry.running = false;
+        entry.error = Some(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.to_string());
+    }
+
     // Newest first: a history panel leads with the run that just happened. The
     // `limit` now cuts *runs* rather than journal rows, which is the number the
     // caller was asking about all along.
@@ -4605,27 +4670,35 @@ mod tests {
             );
         }
 
-        /// A run whose host died leaves a start with no finish, and it folds as
-        /// `running: true` with the nodes it did complete. Honest only because
-        /// the boot sweep settles such runs — see `sweep_interrupted_runs`.
+        /// A run the process is genuinely executing — registered on the
+        /// supervisor, so its id is in `live()` — folds as `running: true` with
+        /// the nodes it has completed so far. Since #1009 a start with no finish
+        /// whose id is NOT live is settled on the read instead
+        /// ([`a_run_absent_from_the_live_set_is_settled_by_the_read`]); this pins
+        /// the still-running half of that split, with the guard held across the
+        /// request so the registration stays live for the whole read.
         #[tokio::test]
         async fn run_history_reports_an_unsettled_run_as_running() {
             let home_dir = home();
-            let home = home_dir.path().to_path_buf();
-            let (state, _store, id) = hosted_state(&home).await;
+            let (state, _store, id) = hosted_state(home_dir.path()).await;
 
-            journal_start(&state, &id, "digest", "run-live", false).await;
+            let runtime = state.registry().get(&id).expect("registered");
+            let (ctx, _guard) = runtime
+                .run_supervisor()
+                .begin("digest", false)
+                .expect("under the default cap");
+            journal_start(&state, &id, "digest", &ctx.run_id, false).await;
             journal_node(
                 &state,
                 &id,
                 "digest",
-                "run-live",
+                &ctx.run_id,
                 "ceo",
                 WorkflowNodeStatus::Ok,
             )
             .await;
 
-            let response = router(state)
+            let response = router(state.clone())
                 .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
                 .await
                 .unwrap();
@@ -5617,6 +5690,119 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::CONFLICT);
+        }
+
+        // ── Issue #1009: settle eternal-`running` rows on the read ─────────
+
+        /// Every `WorkflowRunFinished` the company journaled carrying `run_id`.
+        async fn finishes_for(
+            state: &AppState,
+            id: &CompanyId,
+            run_id: &str,
+        ) -> Vec<(Option<String>, bool)> {
+            let runtime = state.registry().get(id).expect("registered");
+            runtime
+                .events()
+                .read_from(id, crate::ports::types::EventSeq::new(0), usize::MAX)
+                .await
+                .expect("read")
+                .into_iter()
+                .filter_map(|s| match s.event {
+                    CompanyEvent::WorkflowRunFinished {
+                        run_id: Some(rid),
+                        error,
+                        cancelled,
+                        ..
+                    } if rid == run_id => Some((error, cancelled)),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        /// **The decisive case (issue #1009, path B).** A run whose start was
+        /// journaled but whose finish never landed — and whose id is absent from
+        /// the live run set — is settled by `list_runs` itself, between boots.
+        ///
+        /// Two halves, both asserted: the returned row is `running: false` +
+        /// `INTERRUPTED_BY_RESTART` (so this very response is self-consistent),
+        /// AND a synthetic finish is **durably appended** so the next read folds
+        /// it settled and the boot sweep has nothing left to do. Before the fix
+        /// the row read `running: true` and nothing was appended.
+        #[tokio::test]
+        async fn a_run_absent_from_the_live_set_is_settled_by_the_read() {
+            let home_dir = home();
+            let (state, _store, id) = hosted_state(home_dir.path()).await;
+
+            // A start with no finish. Nothing is registered on the supervisor,
+            // so this id is absent from `live()`: the process that owned it went
+            // away without journaling a finish.
+            journal_start(&state, &id, "digest", "run-dead", true).await;
+
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(body.as_array().unwrap().len(), 1);
+            // `running` is skip-serialized when false, so a settled row simply
+            // omits it — assert it is not `true` rather than equal to `false`.
+            assert_ne!(
+                body[0]["running"], true,
+                "an absent run is settled on the read, not left spinning: {body}"
+            );
+            assert_eq!(
+                body[0]["error"],
+                crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART
+            );
+
+            // Durable half: exactly one synthetic finish is now in the journal.
+            let finishes = finishes_for(&state, &id, "run-dead").await;
+            assert_eq!(finishes.len(), 1, "exactly one synthetic finish appended");
+            assert_eq!(
+                finishes[0].0.as_deref(),
+                Some(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART)
+            );
+            assert!(!finishes[0].1, "a host-restart settle is not a cancel");
+        }
+
+        /// **The mandatory negative (issue #1009, rebuild/clean guard).** A run
+        /// the current process is genuinely running is registered on the
+        /// supervisor, so its id is in `live()` — and `list_runs` must leave it
+        /// alone: the row stays `running: true` and **nothing** is appended.
+        ///
+        /// This is what keeps the cross-check keyed strictly on `live()`
+        /// membership rather than on "has no finish yet", which would stamp
+        /// `INTERRUPTED_BY_RESTART` on a run still walking its graph and then
+        /// contradict its real finish. The guard is held across the read so the
+        /// registration stays live for the whole request.
+        #[tokio::test]
+        async fn a_run_in_the_live_set_is_left_running() {
+            let home_dir = home();
+            let (state, _store, id) = hosted_state(home_dir.path()).await;
+
+            let runtime = state.registry().get(&id).expect("registered");
+            // Register a live run and HOLD its guard: its id is now in `live()`.
+            let (ctx, _guard) = runtime
+                .run_supervisor()
+                .begin("digest", true)
+                .expect("under the default cap");
+            journal_start(&state, &id, "digest", &ctx.run_id, true).await;
+
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(body.as_array().unwrap().len(), 1);
+            assert_eq!(
+                body[0]["running"], true,
+                "a run the process is running must not be settled from under it"
+            );
+
+            assert!(
+                finishes_for(&state, &id, &ctx.run_id).await.is_empty(),
+                "a live run gets no synthetic finish appended"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

A workflow run could read `running` forever — a pulsing node, a live header, a Stop button that cannot help, and a 2s history poll that never stops — until the host was restarted. The `list_runs` fold marks a start-with-no-finish as `running: true`, and only the boot-time sweep ever settled it, so a long-lived process never self-healed. Three ways a finish never lands are closed at the source and on the read, and the runaway poll is gated.

- **Panic (root cause):** the runner future can unwind (a node panic, a poisoned lock), jumping straight past the finish journal. The run task now catches the unwind *while its guard is still held*, journals the finish, then `resume_unwind`s — so the finish is durable **and** the `JoinHandle` still resolves to a `JoinError` (synchronous-mode 500 and the scheduler's error line are unchanged). A dry run journals nothing, panic or not.
- **Swallowed append:** `record_run_finished` now returns whether the finish was journaled; the spawn call sites escalate a lost record from a `warn` to an `error` naming the run.
- **Between-restart recovery:** `list_runs` cross-checks each still-`running` row against the supervisor's live set and durably appends a synthetic `INTERRUPTED_BY_RESTART` finish for any run nobody is running, flipping the in-memory row so the same response is self-consistent.
- **Console:** the recovery poll moves from a bare `setInterval` to `startVisiblePolling`, so a backgrounded tab stops asking and resumes with one immediate read on the visible edge.

## API Or Behavior Changes

- `GET …/workflows/runs` now settles orphaned `running` rows on read (durable append + in-memory flip) instead of leaving them spinning until the next boot sweep. Rows for genuinely in-flight runs (present in `live()`) are untouched.
- A panicked run now produces a `WorkflowRunFinished` (error: task panicked) where before it produced none.
- `record_run_finished` returns `bool` (was `()`); additive, existing ignore-the-result callers are unaffected.
- **Accepted limitation (documented in-code):** a run that survives a live `rebuild_company` swap is absent from the successor supervisor's `live()` and could be settled early; its real finish lands later and wins last-writer-wins display. Same class the boot sweep already accepts; the panic watchdog keeps the common trigger out of this path entirely.

## Tests

Run in the worktree (Rust gated with the `openhuman,tinycortex` feature lane; frontend is npm):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` **and** `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via the clippy/test compiles)
- [x] `cargo test --locked --features openhuman,tinycortex --lib` for `runtime::workflow_spawn` (2), `runtime::workflow_outcome` (23), `server::ops::workflows::tests` (89) — 0 failed
- [x] frontend `npm run typecheck` + `npm run build`

New red-first coverage (each fails on pre-fix code, passes now):
- a panicking run still journals its finish; a panicking **dry** run journals nothing.
- a swallowed append reports `journaled == false`; a working log reports `true`.
- a run absent from the live set is settled on the read (row settled **and** exactly one synthetic finish durably appended).
- **negative guard:** a run held live via `supervisor.begin` is left `running: true` with nothing appended — pins the cross-check to `live()` membership, not "has no finish yet".

## Documentation

No doc pages needed — behavior is captured in-code (the `list_runs` cross-check comment documents the rebuild-race trade-off and the watchdog's guard-lifetime invariant) and in the test docs.

Closes #1009
