### PR TITLE
fix(chat): author a workflow-copilot reply to the copilot, not the operator channel

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -191,6 +191,35 @@ pub struct HarnessBrain {
     runs: Option<Arc<dyn crate::ports::RunStore>>,
 }
 
+/// The single bubble a workflow-copilot turn returns (issues #416, #966).
+///
+/// Named rather than inlined because its **author** is the load-bearing field
+/// and it was wrong. #885 taught the main operator bubble to carry its
+/// responder and left this branch on `None`, so a genuine copilot reply kept
+/// journaling as `agent_id: "operator"` — the #885 defect still happening, not
+/// history needing a label. A function is what lets that be asserted without
+/// standing up a scripted model endpoint and a whole harness pool.
+///
+/// `CONFINED_AGENT_ID` is deliberately not a roster id (see [`confine`]): it
+/// names no teammate and cannot be addressed. That makes it a **truthful**
+/// author rather than a resolvable one, which is why
+/// `chat_history::is_known_author` has to know it — otherwise this row trades
+/// one wrong answer for a permanent false positive in the attribution audit.
+///
+/// No card, by construction: a confined turn has no `spawn_task` to call, and
+/// the chat handler does not open one from a copilot message either.
+fn confined_bubble(outcome: crate::harness::TurnOutcome) -> OutboundMessage {
+    OutboundMessage {
+        message_id: None,
+        task_id: None,
+        channel: "operator".to_string(),
+        agent: Some(confine::CONFINED_AGENT_ID.to_string()),
+        text: outcome.reply,
+        reply_to: None,
+        steps: outcome.steps,
+    }
+}
+
 impl HarnessBrain {
     /// Builds a harness brain for `record`, answering unaddressed operator
     /// messages with the company orchestrator (the `tier = "orchestrator"` agent,
@@ -2659,18 +2688,7 @@ impl HarnessBrain {
                                 &confinement,
                             )
                             .await?;
-                        channel_responses.push(OutboundMessage {
-                            message_id: None,
-                            // No card, by construction: a confined turn has no
-                            // `spawn_task` to call, and the chat handler does
-                            // not open one from a copilot message either.
-                            task_id: None,
-                            channel: "operator".to_string(),
-                            agent: None,
-                            text: outcome.reply,
-                            reply_to: None,
-                            steps: outcome.steps,
-                        });
+                        channel_responses.push(confined_bubble(outcome));
                         continue;
                     }
                     // Route to the addressed desk's lead, else the orchestrator.
@@ -8729,5 +8747,35 @@ members = ["eng1", "eng2"]
         // work is not a hand-off.
         let parent = cards.iter().find(|c| c.id == "t-parent").expect("parent");
         assert_eq!(parent.column, "in_review");
+    }
+
+    /// Issue #966: a workflow-copilot reply is authored by the copilot.
+    ///
+    /// This is the assertion the #885 fix was missing on this branch. The bubble
+    /// is emitted on the **operator** channel, and before this the author field
+    /// was left `None` — so the journal writer's `channel` fallback stamped
+    /// `agent_id: "operator"` on a reply an agent had genuinely produced.
+    ///
+    /// Asserts the author is *not* the channel, rather than only that it equals
+    /// the constant: the defect's whole shape is the two being conflated, and a
+    /// test that checked equality alone would still pass if `CONFINED_AGENT_ID`
+    /// were ever redefined to `"operator"`.
+    #[test]
+    fn a_copilot_turn_is_authored_by_the_copilot_not_the_operator_channel() {
+        let bubble = confined_bubble(crate::harness::TurnOutcome {
+            reply: "here is what that node does".to_string(),
+            steps: Vec::new(),
+            hit_iteration_cap: false,
+        });
+        assert_eq!(bubble.channel, "operator", "the destination is unchanged");
+        assert_eq!(
+            bubble.agent.as_deref(),
+            Some(crate::ports::CONFINED_AGENT_ID)
+        );
+        assert_ne!(
+            bubble.agent.as_deref(),
+            Some(bubble.channel.as_str()),
+            "author and destination must not be the same value — that conflation is issue #885"
+        );
     }
 }

--- a/src/harness/confine.rs
+++ b/src/harness/confine.rs
@@ -70,7 +70,11 @@ use crate::ports::types::{ChunkAddr, ChunkHit, ChunkMeta, CompanyId, ContextChun
 
 /// The agent id a confined turn runs under. Deliberately not a roster id: it
 /// names no teammate, carries no manifest grants, and cannot be addressed.
-pub const CONFINED_AGENT_ID: &str = "workflow-copilot";
+///
+/// Defined in [`crate::ports::ids`] and re-exported here (issue #966): the
+/// attribution audit needs it in the default build, where this module does not
+/// compile. Every `confine::CONFINED_AGENT_ID` call site keeps working.
+pub use crate::ports::CONFINED_AGENT_ID;
 
 /// What one confined turn is confined **to**.
 ///

--- a/src/ports/ids.rs
+++ b/src/ports/ids.rs
@@ -51,6 +51,20 @@ pub fn generate_id() -> String {
     format!("{millis:012x}-{counter:012x}")
 }
 
+/// The agent id a confined turn runs under (issue #416).
+///
+/// Deliberately **not** a roster id: it names no teammate, carries no manifest
+/// grants, and cannot be addressed.
+///
+/// Lives here rather than in `harness::confine` (issue #966) because the whole
+/// harness is `#[cfg(feature = "openhuman")]`, and the chat-history attribution
+/// audit — which compiles in the default build — has to recognise it as a
+/// *known author*. `confine` re-exports it, so every existing
+/// `confine::CONFINED_AGENT_ID` reference is unchanged. Copying the literal into
+/// the audit instead would create exactly the silent twin the console's
+/// `mapComposioCategory` carries a warning about.
+pub const CONFINED_AGENT_ID: &str = "workflow-copilot";
+
 /// The stem [`agent_slug`] falls back to when a display name yields nothing a
 /// roster id may legally be.
 pub const AGENT_SLUG_FALLBACK: &str = "teammate";

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -50,7 +50,7 @@ pub use context::ContextStore;
 pub use economy::AgentEconomy;
 pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_prune};
 pub use facts::{FactKind, FactRecord, FactStore};
-pub use ids::{AGENT_SLUG_FALLBACK, agent_slug, generate_id, now_millis};
+pub use ids::{AGENT_SLUG_FALLBACK, CONFINED_AGENT_ID, agent_slug, generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use journal::{Durability, JournalStore};
 pub use ledgers::LedgerStore;

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -531,6 +531,24 @@ impl AttributionAudit {
 /// a continuation failed, not an agent speaking. It is indistinguishable from a
 /// #885 row on disk, so it is counted here. The count is therefore an upper
 /// bound; in practice that notice is rare enough not to move it.
+/// Whether a stored `agent_id` names an author we can actually resolve.
+///
+/// The roster, **plus the confined copilot** (issue #966). `CONFINED_AGENT_ID`
+/// is deliberately not a roster id — it names no teammate, carries no manifest
+/// grants and cannot be addressed — but a copilot turn genuinely authored its
+/// reply, so the id is a truthful author rather than a destination that leaked
+/// into the field. Counting it would swap one wrong answer for a permanent
+/// false positive, and would make the audit's number drift upward on a company
+/// doing nothing wrong.
+///
+/// This is the single predicate the audit and any presentation of its result
+/// must share; two copies would let the count and the rendering disagree about
+/// which rows are unknown.
+pub fn is_known_author(agent_id: &str, record: &CompanyRecord) -> bool {
+    agent_id == crate::ports::CONFINED_AGENT_ID
+        || record.resolve_roster_agent_id(agent_id).is_some()
+}
+
 pub async fn channel_attributed_replies(
     runtime: &CompanyRuntime,
     record: &CompanyRecord,
@@ -547,9 +565,7 @@ pub async fn channel_attributed_replies(
             break;
         }
         let last = page[page.len() - 1].seq;
-        audit.fold(&page, |agent_id| {
-            record.resolve_roster_agent_id(agent_id).is_some()
-        });
+        audit.fold(&page, |agent_id| is_known_author(agent_id, record));
         cursor = EventSeq::new(last.value() + 1);
     }
     Ok(audit)
@@ -1208,8 +1224,81 @@ mod test {
         }
 
         /// The roster for these: two real teammates and nothing else.
+        ///
+        /// Deliberately *excludes* the confined copilot, because that is the
+        /// point of `is_known_author` — the copilot is a real author that no
+        /// roster will ever resolve.
         fn on_roster(agent_id: &str) -> bool {
             matches!(agent_id, "engineer" | "product_manager")
+        }
+
+        /// A record whose roster is exactly `on_roster`'s two teammates.
+        ///
+        /// Built so the tests below call the **real** `is_known_author` rather
+        /// than a local restatement of it. The first version of these tests
+        /// re-implemented the predicate in the test module, which meant
+        /// reverting the production function changed nothing and the tests
+        /// passed either way — proving only that the test agreed with itself.
+        fn record() -> CompanyRecord {
+            let src = "[company]\nname = \"Acme\"\n\n[policy]\nmode = \"full\"\n\
+                       \n[[agent]]\nid = \"engineer\"\nrole = \"Worker\"\ntier = \"orchestrator\"\n\
+                       \n[[agent]]\nid = \"product_manager\"\nrole = \"Worker\"\ntier = \"orchestrator\"\n";
+            let manifest: crate::company::CompanyManifest =
+                toml::from_str(src).expect("manifest parses");
+            CompanyRecord {
+                id: crate::ports::types::CompanyId::new("acme"),
+                manifest,
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            }
+        }
+
+        /// Issue #966. A copilot turn genuinely authored its reply, so the id it
+        /// stores is a truthful author — not a destination that leaked into the
+        /// field. Counting it would swap one wrong answer for a permanent false
+        /// positive that climbs on a company doing nothing wrong.
+        #[test]
+        fn the_confined_copilot_is_a_known_author_not_an_affected_row() {
+            let record = record();
+            let mut audit = AttributionAudit::default();
+            audit.fold(
+                &[
+                    reply(1, crate::ports::CONFINED_AGENT_ID),
+                    reply(2, "engineer"),
+                ],
+                |agent_id| is_known_author(agent_id, &record),
+            );
+            assert_eq!(audit.replies, 2);
+            assert_eq!(audit.affected, 0);
+        }
+
+        /// …and it is still not on the roster, which is what makes the widening
+        /// necessary rather than incidental. If `resolve_roster_agent_id` ever
+        /// started answering for it, this says so before the extra arm quietly
+        /// becomes dead code.
+        #[test]
+        fn the_confined_copilot_is_not_reachable_through_the_roster_alone() {
+            let record = record();
+            assert!(
+                record
+                    .resolve_roster_agent_id(crate::ports::CONFINED_AGENT_ID)
+                    .is_none(),
+                "the confined id resolved on the roster; `is_known_author`'s extra arm is now \
+                 unnecessary and this test should be deleted deliberately, not left passing"
+            );
+            assert!(is_known_author(crate::ports::CONFINED_AGENT_ID, &record));
+            assert!(is_known_author("engineer", &record));
+            assert!(!is_known_author("operator", &record));
         }
 
         #[test]


### PR DESCRIPTION
## Summary

A workflow-copilot reply was journaled as though the **operator** had written it.

`#885` established the rule: `CompanyEvent::AgentReply.agent_id` is *"the agent that
produced the reply"*, and `OutboundMessage.channel` is *"the channel to emit on"* — a
destination. It taught the main operator bubble to carry its responder and gave the
journal writers a `channel` fallback for producers that name no author.

The confined copilot turn (#416) is one of those producers. It pushes its bubble on the
operator channel with no author, so the fallback stamps `agent_id: "operator"` on a reply
an agent genuinely produced.

**This is the #885 defect still happening, not history needing a label.** It matters
because #966 is about presenting rows whose author is unrecoverable, and this path was
still *adding* to that set on every copilot turn. There is no point captioning a bucket
that is still filling.

## Why `Refs #966` and not `Closes`

**#966 stays open after this merges.** That issue asks how the console should present desk rows
whose author is permanently unrecoverable; this stops one path from creating more of them.
Marking it resolved here would claim the actual question was answered when only its prerequisite was —
and a cross-referenced PR already shows on the issue timeline as progress, so nothing is
lost by being accurate about which half landed. The presentation half follows as its own
PR, and that one carries the closing keyword.

## What changed

### 1. The copilot turn carries its author

`confined_bubble` names the construction rather than inlining it, for a specific reason:
its **author** is the load-bearing field, it was wrong, and the branch is otherwise
reachable only by standing up a scripted model endpoint and a whole harness pool. A named
function is what lets the fix be asserted at all — see the test note below.

### 2. `CONFINED_AGENT_ID` moves to `ports::ids`

`harness` is `#[cfg(feature = "openhuman")]`. The attribution audit from #965 lives in
`server::chat_history` and compiles in the **default** build, where the harness does not —
and it has to recognise this id. Reading `harness::confine::CONFINED_AGENT_ID` from there
does not compile on the default lane; copying the literal instead would leave two copies
free to drift, which is the hazard the console's `mapComposioCategory` carries a written
warning about.

So the constant lives in the ungated id module beside `generate_id` and `agent_slug`, and
`confine` re-exports it. **Every existing `confine::CONFINED_AGENT_ID` call site is
unchanged.**

### 3. `is_known_author`, and the false positive it prevents

This is the part that would have gone wrong quietly.

`CONFINED_AGENT_ID` is **deliberately not a roster id** — `confine` documents it as naming
no teammate, carrying no manifest grants, and being unaddressable. The audit's rule is *"an
`agent_id` naming no roster teammate"*. So writing the copilot's real id would have made
**every future copilot reply register as affected**, and the blast-radius figure would climb
on a company doing nothing wrong. That number is the one thing in #965 that has to be
trustworthy.

`is_known_author(agent_id, record)` — the roster **plus** the confined copilot — is that
recognition, extracted as the single predicate the audit and any future presentation of its
result must share. Two copies would let the count and the rendering disagree about which
rows are unknown, which is precisely the bug class this whole thread is about.

## API Or Behavior Changes

**No wire change.** No route, no HTTP/GraphQL type, no new field. `Cargo.lock` untouched.

**Behaviour.** A workflow-copilot reply is journaled against `workflow-copilot` instead of
`operator`. Replies journaled before this are not rewritten — their author is unrecoverable
(see #965) and nothing here synthesises one.

**Audit.** The attribution count no longer treats the confined copilot as an affected row.
Existing pre-fix rows are unaffected by that: they store `operator`, not the copilot id.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI does, `--locked --no-deps`,
      both the default lane and `--features openhuman,tinycortex`. Both clean.
- [x] `cargo build --all-targets` — run as `cargo check --locked --all-targets` and the
      gated equivalent. (`check`, not `build`: nothing here is a linker-visible change.)
- [x] `cargo test` — `cargo test --locked --features openhuman,tinycortex --lib`:
      **4281 passed, 0 failed, 3 ignored.**
- [x] `git diff --stat Cargo.lock` — empty.

**Verified after rebasing onto current `main`**, not against the base the branch was cut
from. `src/harness/brain.rs` had moved underneath it in the meantime, so the pre-rebase run
(4257 passing) was against a tree `main` no longer had. The 24-test difference is `main`'s
newer tests arriving with the rebase.

### Every new test was proven to fail with its fix reverted — 3 of 3

| reverted | test that failed |
|---|---|
| `confined_bubble` stops setting the author | `a_copilot_turn_is_authored_by_the_copilot_not_the_operator_channel` |
| `is_known_author` drops the confined arm | `the_confined_copilot_is_a_known_author_not_an_affected_row` |
| …the same revert, on the roster half | `the_confined_copilot_is_not_reachable_through_the_roster_alone` |

**Two of these initially proved nothing, and are recorded because a test that cannot fail is
worse than no test.**

1. The two predicate tests first re-implemented `is_known_author` as a local helper in the
   test module. Reverting the production function changed nothing — they proved only that
   the test agreed with itself. They now build a real `CompanyRecord` and call the actual
   function.
2. The `brain.rs` fix — the live defect, the whole point of this PR — had **no test at all**.
   Reverting it failed nothing. That is the same gap that let #885 happen: nothing tested
   what the write path stores. `confined_bubble` exists so that gap could be closed without
   a full turn harness.

The writer test asserts the author is *not* the channel, not merely that it equals the
constant: the two being conflated is the entire defect, and an equality-only assertion would
still pass if `CONFINED_AGENT_ID` were ever redefined to `"operator"`.

### What is NOT proven, stated rather than claimed as coverage

- **No test drives a copilot turn end to end.** `confined_bubble` is asserted directly; that
  it is *called* on the copilot branch is guarded by the compiler and by reading, not by a
  test. A real one needs the scripted-endpoint harness the `*_turn_test.rs` files use, and
  this PR does not add one.
- **No count against real data.** #965's audit still has no measured blast radius; that needs
  a deployed host, as recorded there.

## Documentation

No spec doc changes. The reasoning lives at the code it governs: `confined_bubble` carries
why it is a named function, `ports::ids` carries why the constant moved out of the harness,
and `is_known_author` carries the false positive it exists to prevent.

Refs tinyhumansai/opencompany#966
