### PR TITLE
fix(workflows): persist per-node output on failed and blocked runs (#1008)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -626,7 +626,9 @@ export function listWorkflowRuns(
  *
  * `nodes` is the engine's `{ "<node id>": { "items": [ … ] } }` map, bounded for
  * storage; `truncated` says whether any value was clipped to fit the caps, so the
- * inspector can badge it honestly.
+ * inspector can badge it honestly. `partial` says the run FAILED or BLOCKED, so
+ * the map is only what the runner captured from the nodes that finished before
+ * the stop — not a complete outcome (issue #1008).
  */
 export interface WorkflowRunOutputRecord {
   runId: string;
@@ -637,6 +639,13 @@ export interface WorkflowRunOutputRecord {
   nodes: unknown;
   /** Whether any value was clipped to fit the durable size caps. */
   truncated: boolean;
+  /**
+   * Whether this is a partial capture from a run that failed or blocked rather
+   * than a clean settled outcome (issue #1008). Optional so a snapshot written
+   * before this field existed (always a clean settle) reads back as absent,
+   * which the inspector treats as `false`.
+   */
+  partial?: boolean;
 }
 
 /**

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1378,7 +1378,14 @@ export function WorkflowsView({
       if (!overlayOutput.record) return { state: "unavailable" };
       const value = nodeOutputFor(overlayOutput.record.nodes, selectedNode.id);
       if (value === undefined) return { state: "unavailable" };
-      return { state: "present", value, truncated: overlayOutput.record.truncated };
+      // Issue #1008: a failed/blocked run's snapshot is flagged partial; carry it
+      // so the inspector badges the capture. A live run (below) is never partial.
+      return {
+        state: "present",
+        value,
+        truncated: overlayOutput.record.truncated,
+        partial: overlayOutput.record.partial,
+      };
     }
     if (result) {
       const value = nodeOutputFor(result.output, selectedNode.id);

--- a/frontend/src/views/workflows/NodeDetailPanel.tsx
+++ b/frontend/src/views/workflows/NodeDetailPanel.tsx
@@ -165,10 +165,13 @@ function describeDestination(destination: NonNullable<WorkflowNodeModel["destina
  * The Output section of the node inspector (issue #596): what this node produced
  * on the run being inspected — markdown-rendered agent/tool messages, the raw
  * value behind a toggle, a "truncated" badge when the durable snapshot was
- * clipped, and an explicit empty state for a run that predates capture or
- * produced nothing.
+ * clipped, a "partial capture" badge when the run failed or blocked (issue
+ * #1008), and an explicit empty state for a run that genuinely has no snapshot.
+ *
+ * Exported for the unit test that pins the badges and the empty state without
+ * standing up the whole panel.
  */
-function OutputSection({ output }: { output: NodeOutputView }) {
+export function OutputSection({ output }: { output: NodeOutputView }) {
   if (output.state === "loading") {
     return (
       <DetailField label="Output">
@@ -192,6 +195,15 @@ function OutputSection({ output }: { output: NodeOutputView }) {
   return (
     <DetailField label="Output">
       <div className="space-y-2" data-testid="node-output">
+        {output.partial && (
+          <Badge
+            variant="outline"
+            className="border-status-blocked/40 bg-status-blocked-soft font-normal"
+            data-testid="node-output-partial"
+          >
+            partial capture — run failed or blocked
+          </Badge>
+        )}
         {output.truncated && (
           <Badge
             variant="outline"

--- a/frontend/src/views/workflows/run-output.ts
+++ b/frontend/src/views/workflows/run-output.ts
@@ -32,7 +32,19 @@ export interface NodeMessage {
 export type NodeOutputView =
   | { state: "loading" }
   | { state: "unavailable" }
-  | { state: "present"; value: unknown; truncated: boolean };
+  | {
+      state: "present";
+      value: unknown;
+      truncated: boolean;
+      /**
+       * Whether the snapshot this node came from is a PARTIAL capture — the run
+       * failed or blocked rather than settling cleanly (issue #1008). Drives a
+       * badge that distinguishes "run stopped early, here is what it reached"
+       * from a clean result. Optional so a caller that has no partial signal
+       * (a live run's in-memory result) can omit it — absent reads as `false`.
+       */
+      partial?: boolean;
+    };
 
 /** One node's readable, shape-checked result, ready to render. */
 export interface NodeResult {

--- a/frontend/test/unit/node-output-partial.test.ts
+++ b/frontend/test/unit/node-output-partial.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { OutputSection } from "@/views/workflows/NodeDetailPanel";
+import type { NodeOutputView } from "@/views/workflows/run-output";
+
+/**
+ * The node inspector's Output section (issue #1008).
+ *
+ * A failed or blocked run now persists the per-node output it reached, flagged
+ * `partial`. The inspector must badge that capture as partial rather than
+ * silently rendering it as a clean result — and the old "this run predates
+ * output capture" empty state must fire ONLY for a genuinely missing snapshot
+ * (`unavailable`), never for a node that has present output.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(output: NodeOutputView) {
+  act(() => {
+    root.render(createElement(OutputSection, { output }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const presentValue = { items: [{ json: { text: "the draft" } }] };
+
+describe("OutputSection partial badge (issue #1008)", () => {
+  it("renders the partial-capture badge when the snapshot is partial", () => {
+    render({ state: "present", value: presentValue, truncated: false, partial: true });
+    expect(container.querySelector('[data-testid="node-output-partial"]')).not.toBeNull();
+    // A present node NEVER shows the "predates output capture" empty state.
+    expect(container.querySelector('[data-testid="node-output-empty"]')).toBeNull();
+  });
+
+  it("omits the partial badge for a clean settled capture", () => {
+    render({ state: "present", value: presentValue, truncated: false, partial: false });
+    expect(container.querySelector('[data-testid="node-output-partial"]')).toBeNull();
+    expect(container.querySelector('[data-testid="node-output"]')).not.toBeNull();
+  });
+
+  it("omits the partial badge when the field is absent (a live run's result)", () => {
+    render({ state: "present", value: presentValue, truncated: false });
+    expect(container.querySelector('[data-testid="node-output-partial"]')).toBeNull();
+  });
+
+  it("shows the predates-capture empty state only for a genuinely missing snapshot", () => {
+    render({ state: "unavailable" });
+    const empty = container.querySelector('[data-testid="node-output-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain("predates output capture");
+    expect(container.querySelector('[data-testid="node-output-partial"]')).toBeNull();
+  });
+});

--- a/src/ports/run_output.rs
+++ b/src/ports/run_output.rs
@@ -93,7 +93,11 @@ pub const CLIP_MARKER: &str = "…";
 /// `nodes` is the engine's `run.output["nodes"]` map — `{ "<node id>": {
 /// "items": [ … ] } }` — already passed through [`bound_node_output`], so a
 /// reader gets a value that is safe to render whole. `truncated` says whether
-/// any clipping happened, so the console can badge it honestly.
+/// any clipping happened, so the console can badge it honestly. `partial` says
+/// the run **did not settle cleanly** (it failed or blocked), so the map holds
+/// only what the observer captured from the nodes that finished before the
+/// stop — not a complete outcome. Issue #1008: a failed/blocked run used to
+/// persist nothing, so its inspector wrongly claimed the run predated capture.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowRunOutputRecord {
@@ -107,17 +111,29 @@ pub struct WorkflowRunOutputRecord {
     pub nodes: Value,
     /// Whether [`bound_node_output`] clipped any value to fit the caps.
     pub truncated: bool,
+    /// Whether this is a **partial** capture from a run that failed or blocked
+    /// rather than a complete settled outcome (issue #1008). `#[serde(default)]`
+    /// so a record written before this field existed reads back `false` — a
+    /// pre-#1008 snapshot is, by definition, from a run that settled cleanly.
+    #[serde(default)]
+    pub partial: bool,
 }
 
 impl WorkflowRunOutputRecord {
     /// Builds a record from a *raw* node map, bounding it in the process. The
     /// caller hands the engine's `outcome.output["nodes"]` straight in; this is
     /// the one place bounding is applied, so no writer can forget it.
+    ///
+    /// `partial` flags a capture from a run that failed or blocked rather than
+    /// settling cleanly (issue #1008): a clean settle passes `false`, the two
+    /// failure arms pass `true` alongside the node map the progress observer
+    /// accumulated before the stop.
     pub fn from_raw_nodes(
         run_id: impl Into<String>,
         workflow_id: impl Into<String>,
         at_millis: u64,
         raw_nodes: &Value,
+        partial: bool,
     ) -> Self {
         let (nodes, truncated) = bound_node_output(raw_nodes);
         Self {
@@ -126,6 +142,7 @@ impl WorkflowRunOutputRecord {
             at_millis,
             nodes,
             truncated,
+            partial,
         }
     }
 }
@@ -278,12 +295,46 @@ mod test {
             at_millis: 42,
             nodes: serde_json::json!({ "ceo": { "items": ["hi"] } }),
             truncated: false,
+            partial: false,
         };
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.contains("\"runId\""), "{json}");
         assert!(json.contains("\"workflowId\""), "{json}");
         assert!(json.contains("\"atMillis\""), "{json}");
         assert_eq!(record, serde_json::from_str(&json).unwrap());
+    }
+
+    #[test]
+    fn partial_round_trips_and_defaults_false_for_a_pre_feature_payload() {
+        // Issue #1008: a `partial` capture round-trips as camelCase.
+        let record = WorkflowRunOutputRecord {
+            run_id: "run-2".to_string(),
+            workflow_id: "greet".to_string(),
+            at_millis: 7,
+            nodes: serde_json::json!({ "ceo": { "items": ["hi"] } }),
+            truncated: false,
+            partial: true,
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(json.contains("\"partial\":true"), "{json}");
+        assert_eq!(record, serde_json::from_str(&json).unwrap());
+
+        // A payload persisted before this field existed carries no `partial`
+        // key; `#[serde(default)]` reads it back `false` — a pre-#1008 snapshot
+        // is from a run that settled cleanly, so "not partial" is the honest
+        // default.
+        let pre_feature = serde_json::json!({
+            "runId": "old-run",
+            "workflowId": "greet",
+            "atMillis": 1,
+            "nodes": { "ceo": { "items": ["hi"] } },
+            "truncated": false,
+        });
+        let decoded: WorkflowRunOutputRecord = serde_json::from_value(pre_feature).unwrap();
+        assert!(
+            !decoded.partial,
+            "a pre-feature payload with no `partial` key must default to false"
+        );
     }
 
     #[test]
@@ -333,6 +384,7 @@ mod test {
             at_millis: at,
             nodes: Value::Null,
             truncated: false,
+            partial: false,
         };
         let mut recs = vec![rec("a", 10), rec("c", 20), rec("b", 20)];
         sort_newest_first(&mut recs);
@@ -344,10 +396,16 @@ mod test {
     fn from_raw_nodes_bounds_and_flags() {
         let long = "z".repeat(NODE_OUTPUT_ITEM_CHAR_CAP + 10);
         let raw = serde_json::json!({ "n": { "items": [long] } });
-        let record = WorkflowRunOutputRecord::from_raw_nodes("r", "wf", 5, &raw);
+        let record = WorkflowRunOutputRecord::from_raw_nodes("r", "wf", 5, &raw, false);
         assert!(record.truncated, "from_raw_nodes must bound its input");
         assert_eq!(record.run_id, "r");
         assert_eq!(record.workflow_id, "wf");
         assert_eq!(record.at_millis, 5);
+        assert!(!record.partial, "a clean settle passes partial=false");
+
+        // Issue #1008: the failure arms hand `partial=true`; it survives onto
+        // the record unchanged.
+        let flagged = WorkflowRunOutputRecord::from_raw_nodes("r2", "wf", 6, &raw, true);
+        assert!(flagged.partial, "from_raw_nodes must carry partial through");
     }
 }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -4318,6 +4318,7 @@ mod tests {
                     "writer": { "items": [{ "json": { "text": "the draft" } }] }
                 }),
                 truncated: false,
+                partial: false,
             };
             runtime
                 .workflow_run_outputs()

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2039,6 +2039,7 @@ pub async fn assert_workflow_run_output_store(outputs: Arc<dyn WorkflowRunOutput
         at_millis: at,
         nodes: serde_json::json!({ "writer": { "items": [marker] } }),
         truncated: false,
+        partial: false,
     };
 
     // Roundtrip: a stored record reads back byte-identically.

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -478,6 +478,121 @@ async fn a_run_that_parked_a_card_says_so_even_though_it_paused_no_gate_and_rout
     );
 }
 
+/// The graph for the #1008 blocked-arm persist test: an agent node that
+/// SUCCEEDS (`intro`), then one that blocks on a gated tool (`work`).
+///
+/// The preceding success is deliberate — it is what makes "earlier node output
+/// present" a real claim: the observer captures `intro`'s emitted text before
+/// `work` halts the run, and that capture must survive the blocked arm.
+fn intro_then_block_graph() -> String {
+    r#"
+id = "intro_block"
+name = "Intro then block"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "intro"
+kind = "agent"
+name = "Intro"
+summary = "Introduce the project."
+agent = "ceo"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Write the quarterly spec."
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "intro"
+[[edge]]
+from = "intro"
+to = "work"
+[[edge]]
+from = "work"
+to = "done"
+"#
+    .to_string()
+}
+
+/// Issue #1008 (blocked-arm sibling of the runner's failure-arm test): a run
+/// that BLOCKS on an operator (the `#881` halt arm, which returns `Ok` with a
+/// `Null` in-memory output) must STILL persist the per-node output the observer
+/// captured before the block — flagged `partial`, with the earlier successful
+/// node's output present. Before #1008 the blocked arm persisted NOTHING, so
+/// reopening the run showed "this run predates output capture".
+#[tokio::test]
+async fn a_blocked_run_persists_the_partial_output_it_reached() {
+    use crate::ports::run_output::WorkflowRunOutputStore;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(crate::store::FsOps::new(dir.path()));
+
+    let (base_url, _script) = spawn_script_recording(vec![
+        // `intro` node: a plain reply carrying a marker we can find in the
+        // persisted snapshot — proof the earlier node's output was captured.
+        Turn::Say("Introduction complete. BLOCK-MARKER-42."),
+        // `work` node: calls the gated `shell` tool, which parks for approval —
+        // the model is refused inside its tool loop and the run blocks.
+        Turn::Call {
+            tool: "shell",
+            args: json!({ "command": "write-spec" }),
+        },
+        Turn::Say("The spec is blocked pending your approval."),
+    ])
+    .await;
+
+    let (mut deps, _journal) = deps(base_url, dir.path());
+    deps.run_output_store = Some(store.clone());
+    let rec = record();
+    let pool = std::sync::Arc::new(HarnessPool::new());
+    pool.ensure(&rec, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(&intro_then_block_graph()).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+
+    let run = super::runner::run_workflow(
+        pool,
+        deps,
+        &rec,
+        &file,
+        json!({ "request": "the quarterly spec" }),
+        &ctx,
+    )
+    .await
+    .expect("a blocked run settles Ok rather than failing");
+    assert!(
+        run.blocked_nodes.iter().any(|b| b.node_id == "work")
+            || run.pending_approvals.iter().any(|id| id == "work"),
+        "the run must report that `work` blocked: {run:?}"
+    );
+
+    // The decisive assertion: the blocked run persisted a snapshot (was `None`
+    // pre-#1008).
+    let stored = store
+        .get_run_output(&rec.id, &run_id)
+        .await
+        .expect("store read")
+        .expect("a blocked run must still persist the output it reached before blocking");
+    assert!(
+        stored.partial,
+        "a blocked-arm capture must be flagged partial: {stored:?}"
+    );
+    // The earlier successful `intro` node's produced text is in the snapshot.
+    assert!(
+        stored.nodes.to_string().contains("BLOCK-MARKER-42"),
+        "the node that succeeded before the block must be in the partial snapshot: {}",
+        stored.nodes
+    );
+}
+
 #[cfg(test)]
 mod pure {
     use super::*;

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -135,20 +135,33 @@ pub async fn run_workflow(
 /// **same** channel, so the collector sees them in that order and a node's
 /// started event always journals ahead of its finished one.
 ///
-/// Deliberately scalars and no `ExecutionStep`: the engine's step carries the
-/// node's `output` items, and this hop exists partly to make it *impossible* for
-/// that payload to reach the journal — the same stance the live turn frames take
-/// on tool args. A `Started` frame carries the node id alone; the node has not
-/// run, so there is no status or duration to carry either. What is not carried
-/// cannot leak.
+/// Deliberately no whole `ExecutionStep`. A `Started` frame carries the node id
+/// alone; the node has not run, so there is no status, duration, or output to
+/// carry either. What is not carried cannot leak.
+///
+/// A `Finished` frame carries the node's `output` items (issue #1008) **as well
+/// as** its status and duration — but that payload is used for exactly one thing
+/// and is walled off from the journal: the collector accumulates it into a
+/// side map that feeds ONLY the durable, console-facing run-output store on the
+/// **failure/blocked arms**, where the engine returns no `outcome.output` to
+/// persist from. The journal still receives only `{node_id, status,
+/// elapsed_ms}` (see the `Finished` arm of the collector, which builds its
+/// `WorkflowNodeFinished` from those three scalars and never touches `output`) —
+/// the same stance the live turn frames take on tool args. Before #1008 the
+/// failure paths threw this output away, so a failed/blocked run's inspector
+/// wrongly claimed the run predated output capture.
 enum NodeProgress {
     /// A node began executing (issue #382) — the opening bracket. Id only.
     Started { node_id: String },
-    /// A node finished (issue #371) — its status and wall-clock duration.
+    /// A node finished (issue #371) — its status, wall-clock duration, and the
+    /// items it emitted (issue #1008; [`Value::Null`] on an error step). The
+    /// output is consumed only by the run-output persist on the failure arms;
+    /// it never reaches the journal.
     Finished {
         node_id: String,
         status: WorkflowNodeStatus,
         elapsed_ms: u64,
+        output: Value,
     },
 }
 
@@ -193,6 +206,13 @@ impl tinyflows::observability::RunObserver for ProgressObserver {
             // `u128` millis is the engine's type; a node running longer than
             // 584 million years is not the failure mode worth a `Result`.
             elapsed_ms: u64::try_from(step.duration_ms).unwrap_or(u64::MAX),
+            // Issue #1008: the node's emitted items, carried so the collector can
+            // accumulate a partial per-node output map for the failure/blocked
+            // arms (which have no `outcome.output` to persist from). A success
+            // step's `output` is the items array; an error step's is
+            // `Value::Null`. This clone rides the same channel as the scalars
+            // and never touches the journal.
+            output: step.output.clone(),
         });
     }
 }
@@ -359,6 +379,14 @@ async fn run_workflow_inner(
     // The journal is passed to the collector only in that case; `None` there
     // means "collect the rows, write nothing" — the shape the default build and
     // every dry run take.
+    //
+    // Issue #1008: the collector *additionally* accumulates a per-node output
+    // map (`{ "<id>": { "items": [ … ] } }`) from each `Finished` frame's
+    // output. This map exists solely to feed the durable run-output persist on
+    // the failure/blocked arms, where the engine returns no `outcome.output`. It
+    // is returned beside the rows and never journaled — the journal invariant
+    // (no node output) is preserved because the `WorkflowNodeFinished` event is
+    // still built from the three scalars alone.
     let journal_nodes = events.clone().filter(|_| !dry_run);
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<NodeProgress>();
     let collector = tokio::spawn({
@@ -367,6 +395,10 @@ async fn run_workflow_inner(
         let run_id = run_id.clone();
         async move {
             let mut rows: Vec<crate::ports::WorkflowRunNodeRow> = Vec::new();
+            // Issue #1008: node_id -> `{ "items": [ … ] }`, canonical-shaped so
+            // the console's `parseNodeMessages` reads it exactly like a clean
+            // run's `outcome.output["nodes"]`.
+            let mut partial_nodes = serde_json::Map::new();
             while let Some(progress) = rx.recv().await {
                 match progress {
                     // Issue #382: the node's opening bracket. Journaled only when
@@ -397,6 +429,7 @@ async fn run_workflow_inner(
                         node_id,
                         status,
                         elapsed_ms,
+                        output,
                     } => {
                         if let Some(events) = journal_nodes.as_ref() {
                             let event = CompanyEvent::WorkflowNodeFinished {
@@ -417,6 +450,19 @@ async fn run_workflow_inner(
                                 );
                             }
                         }
+                        // Issue #1008: accumulate this node's output into the
+                        // partial map under the canonical `{ "items": [ … ] }`
+                        // shape. A success step's `output` is the items array; an
+                        // error (or any non-array) step contributes an empty
+                        // `items`, so the failing node still appears as "produced
+                        // none" rather than vanishing. Keyed before `node_id`
+                        // moves into the row below.
+                        let items = match output {
+                            Value::Array(_) => output,
+                            _ => Value::Array(Vec::new()),
+                        };
+                        partial_nodes
+                            .insert(node_id.clone(), serde_json::json!({ "items": items }));
                         // Collected for the response on every path — status is
                         // `Copy`, `node_id` moves in after its clone (if any)
                         // went to the event.
@@ -428,7 +474,7 @@ async fn run_workflow_inner(
                     }
                 }
             }
-            rows
+            (rows, partial_nodes)
         }
     });
 
@@ -519,30 +565,37 @@ async fn run_workflow_inner(
     // clone somewhere longer-lived, this would log and move on with an empty
     // trail instead of wedging the run (and the host behind it) forever.
     drop(observer);
-    let nodes: Vec<crate::ports::WorkflowRunNodeRow> =
-        match tokio::time::timeout(PROGRESS_DRAIN_TIMEOUT, collector).await {
-            Ok(Ok(rows)) => rows,
-            Ok(Err(err)) => {
-                tracing::warn!(
-                    company = %record.id,
-                    workflow = %workflow.id,
-                    %run_id,
-                    %err,
-                    "workflow: the node-progress collector did not shut down cleanly"
-                );
-                Vec::new()
-            }
-            Err(_) => {
-                tracing::warn!(
-                    company = %record.id,
-                    workflow = %workflow.id,
-                    %run_id,
-                    "workflow: node progress events did not drain in time; the run's finished \
-                     record may be journaled ahead of them"
-                );
-                Vec::new()
-            }
-        };
+    // Issue #1008: the collector now returns both the response rows and the
+    // accumulated per-node output map. The map feeds ONLY the run-output persist
+    // on the failure/blocked arms below; `nodes` stays the output-free row list
+    // the journal and `WorkflowRun.nodes` carry. A drain failure yields an empty
+    // map, so a persist on that path simply records "produced none".
+    let (nodes, partial_nodes): (
+        Vec<crate::ports::WorkflowRunNodeRow>,
+        serde_json::Map<String, Value>,
+    ) = match tokio::time::timeout(PROGRESS_DRAIN_TIMEOUT, collector).await {
+        Ok(Ok(collected)) => collected,
+        Ok(Err(err)) => {
+            tracing::warn!(
+                company = %record.id,
+                workflow = %workflow.id,
+                %run_id,
+                %err,
+                "workflow: the node-progress collector did not shut down cleanly"
+            );
+            (Vec::new(), serde_json::Map::new())
+        }
+        Err(_) => {
+            tracing::warn!(
+                company = %record.id,
+                workflow = %workflow.id,
+                %run_id,
+                "workflow: node progress events did not drain in time; the run's finished \
+                 record may be journaled ahead of them"
+            );
+            (Vec::new(), serde_json::Map::new())
+        }
+    };
 
     // Resolved only AFTER the drain above, so a cancelled run's completed nodes
     // are journaled exactly like a completed run's before the caller writes the
@@ -564,7 +617,27 @@ async fn run_workflow_inner(
         // reports the error, and the block survives on the approval receipts.
         Some(Err(err)) => {
             let blocked = blocks.take();
+            // Issue #1008: the engine returns no `outcome.output` on this arm, so
+            // the run's per-node output lives ONLY in the map the progress
+            // observer accumulated. Persist that, flagged `partial`, on BOTH the
+            // genuine-failure and the blocked branches — before #1008 both threw
+            // it away, so the inspector wrongly reported "this run predates output
+            // capture" for every failed or blocked run.
+            let partial_output = Value::Object(partial_nodes);
             if blocked.is_empty() || !only_blocked_nodes_errored(&nodes, &blocked) {
+                // A genuine failure. Persist the partial capture so the inspector
+                // shows what the nodes that ran produced. Log-only on a write
+                // error (Part 3): this branch returns `Err`, so there is no
+                // `WorkflowRun` to hang a notice on.
+                let _ = persist_run_output(
+                    run_output_store.as_deref(),
+                    &record.id,
+                    &workflow.id,
+                    &run_id,
+                    &partial_output,
+                    true,
+                )
+                .await;
                 return Err(map_engine_error(err));
             }
             tracing::info!(
@@ -575,6 +648,20 @@ async fn run_workflow_inner(
                 "workflow: the run stopped because a node is waiting on an operator, not because \
                  it failed"
             );
+            // A blocked run DOES return a `WorkflowRun`, so a failed persist adds
+            // an operator-facing notice rather than only a log line (Part 6).
+            if !persist_run_output(
+                run_output_store.as_deref(),
+                &record.id,
+                &workflow.id,
+                &run_id,
+                &partial_output,
+                true,
+            )
+            .await
+            {
+                notices.push(run_output_persist_failed_notice());
+            }
             return Ok(blocked_run(BlockedRun {
                 nodes,
                 blocked,
@@ -606,14 +693,25 @@ async fn run_workflow_inner(
         // show how far the run got and what each finished node made. This is an
         // outcome-bearing arm (unlike the hard-abort return above, which has no
         // outcome and persists nothing).
-        persist_run_output(
+        //
+        // Issue #1008: this is a CLEAN cancel with a real `outcome.output`, so it
+        // persists that canonical map with `partial = false` — the "partial"
+        // flag is reserved for the failure/blocked arms that have no outcome and
+        // fall back to the observer's accumulated capture. A failed write adds an
+        // operator notice (Part 6), since this arm returns a `WorkflowRun`.
+        let raw_nodes = outcome.output.get("nodes").cloned().unwrap_or(Value::Null);
+        if !persist_run_output(
             run_output_store.as_deref(),
             &record.id,
             &workflow.id,
             &run_id,
-            &outcome.output,
+            &raw_nodes,
+            false,
         )
-        .await;
+        .await
+        {
+            notices.push(run_output_persist_failed_notice());
+        }
         return Ok(WorkflowRun {
             output: outcome.output,
             pending_approvals: Vec::new(),
@@ -789,14 +887,23 @@ async fn run_workflow_inner(
     // completion AND the paused-with-`pending_approvals` case both reach here).
     // Best-effort, upstream of the WorkflowRun below so console/scheduled/
     // agent-tool runs all persist through this one site.
-    persist_run_output(
+    //
+    // Issue #1008: a clean settle carries the real `outcome.output`, so it
+    // persists that canonical map with `partial = false`; a failed write adds an
+    // operator notice (Part 6) since this arm returns a `WorkflowRun`.
+    let raw_nodes = outcome.output.get("nodes").cloned().unwrap_or(Value::Null);
+    if !persist_run_output(
         run_output_store.as_deref(),
         &record.id,
         &workflow.id,
         &run_id,
-        &outcome.output,
+        &raw_nodes,
+        false,
     )
-    .await;
+    .await
+    {
+        notices.push(run_output_persist_failed_notice());
+    }
 
     // Issue #881: a node can block and the run still reach here — an author who
     // wrote `on_error = "continue"` or `"route"` asked for the branch to survive
@@ -1010,8 +1117,8 @@ pub(super) fn blocked_notice(blocked: &crate::ports::WorkflowBlockedNode) -> Str
     )
 }
 
-/// Persists a settled run's per-node output to the durable, console-facing
-/// store (issue #596), best-effort.
+/// Persists a run's per-node output to the durable, console-facing store (issue
+/// #596; failure/blocked capture added in #1008), best-effort.
 ///
 /// One helper, called from every outcome-bearing arm of `run_workflow_inner`, so
 /// the bounding + write live in exactly one place. `store` is `None` on the
@@ -1019,40 +1126,64 @@ pub(super) fn blocked_notice(blocked: &crate::ports::WorkflowBlockedNode) -> Str
 /// is logged at `warn` and never fails the run: the run's work is already done
 /// and correct, and losing an inspector snapshot must not discard it.
 ///
-/// The value persisted is `output["nodes"]` — the same capture the in-process
-/// [`RunOutputCache`](crate::harness::orchestrator::RunOutputCache) reads — but
-/// on a **separate** durable store, so the two consumers never share storage.
-/// Bounding happens inside
+/// The caller hands `raw_nodes` — the `{ "<id>": { "items": [ … ] } }` map — in
+/// directly: on the clean arms that is `outcome.output["nodes"]` (the same
+/// capture the in-process
+/// [`RunOutputCache`](crate::harness::orchestrator::RunOutputCache) reads), and
+/// on the failure/blocked arms (issue #1008) it is the map the progress observer
+/// accumulated, flagged `partial`. Bounding happens inside
 /// [`WorkflowRunOutputRecord::from_raw_nodes`](crate::ports::WorkflowRunOutputRecord::from_raw_nodes),
 /// which clips (never refuses) so the durable record always exists.
+///
+/// Returns `true` when the snapshot is safely stored (or there is no store to
+/// store it in — a no-op is not a failure), and `false` only when a store was
+/// present and the write errored. The notice-bearing callers (which return a
+/// `WorkflowRun`) use `false` to add an operator-facing notice; the genuine-`Err`
+/// caller has no `WorkflowRun` to hang one on and lets the `warn!` stand alone
+/// (issue #1008, Part 3).
 async fn persist_run_output(
     store: Option<&dyn crate::ports::run_output::WorkflowRunOutputStore>,
     company: &CompanyId,
     workflow_id: &str,
     run_id: &str,
-    output: &Value,
-) {
+    raw_nodes: &Value,
+    partial: bool,
+) -> bool {
     let Some(store) = store else {
-        return;
+        return true;
     };
-    // The engine's per-node map lives under `output["nodes"]`; a run with no such
-    // key persists an empty map, which the console renders as "produced none".
-    let raw_nodes = output.get("nodes").cloned().unwrap_or(Value::Null);
     let record = crate::ports::WorkflowRunOutputRecord::from_raw_nodes(
         run_id,
         workflow_id,
         crate::ports::now_millis(),
-        &raw_nodes,
+        raw_nodes,
+        partial,
     );
-    if let Err(err) = store.put_run_output(company, &record).await {
-        tracing::warn!(
-            company = %company,
-            workflow = %workflow_id,
-            %run_id,
-            %err,
-            "workflow: could not persist the run's per-node output; the run is unaffected"
-        );
+    match store.put_run_output(company, &record).await {
+        Ok(()) => true,
+        Err(err) => {
+            tracing::warn!(
+                company = %company,
+                workflow = %workflow_id,
+                %run_id,
+                %err,
+                "workflow: could not persist the run's per-node output; the run is unaffected"
+            );
+            false
+        }
     }
+}
+
+/// The operator-facing notice a notice-bearing arm adds when
+/// [`persist_run_output`] could not write the snapshot (issue #1008, Part 3).
+///
+/// The run's result itself is unaffected — this only warns that reopening the
+/// run later may show no output for its nodes, so the black-box silence has a
+/// visible cause instead of masquerading as "this run predates output capture".
+fn run_output_persist_failed_notice() -> String {
+    "This run's per-node output could not be saved, so reopening it later may show no output \
+     for some steps. The run itself was unaffected."
+        .to_string()
 }
 
 /// What a settled run left for the operator to decide.
@@ -1890,6 +2021,97 @@ to = "done"
                 .unwrap()
                 .is_none(),
             "a dry run must persist nothing durable"
+        );
+    }
+
+    /// Issue #1008 (the decisive change): a run whose first node SUCCEEDS and a
+    /// later node FAILS hard (default `on_error = "stop"`, so the engine returns
+    /// `Err`) must STILL persist the per-node output the observer captured before
+    /// the failure — flagged `partial`. Before #1008 this arm returned `Err`
+    /// without persisting anything, so the inspector wrongly claimed the run
+    /// predated output capture.
+    ///
+    /// `start → export (csv_export, succeeds) → boom (bogus_tool, unknown slug →
+    /// hard stop)`: the export node's frame is captured off the progress
+    /// observer, and the run fails on `boom`.
+    #[tokio::test]
+    async fn a_failed_run_persists_the_partial_output_it_reached() {
+        let src = r#"
+id = "partial_fail"
+name = "Partial fail"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "export"
+kind = "tool_call"
+name = "Export"
+[node.config]
+slug = "csv_export"
+[node.config.args]
+filename = "wf-out.csv"
+data = "[{\"name\":\"Ada\"},{\"name\":\"Bob\"}]"
+[[node]]
+id = "boom"
+kind = "tool_call"
+name = "Boom"
+[node.config]
+slug = "bogus_tool"
+[[edge]]
+from = "start"
+to = "export"
+[[edge]]
+from = "export"
+to = "boom"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(FsOps::new(dir.path()));
+        let mut deps = deps(dir.path());
+        deps.run_output_store = Some(store.clone());
+        let rec = tools_record();
+        let file = parse_workflow(src).expect("parses");
+        let ctx = WorkflowRunContext::new(false);
+        let run_id = ctx.run_id.clone();
+
+        let err = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &rec,
+            &file,
+            serde_json::json!({ "seed": 1 }),
+            &ctx,
+        )
+        .await
+        .expect_err("the run fails hard on the unknown-slug node");
+        assert!(
+            err.to_string().contains("bogus_tool") || err.to_string().contains("boom"),
+            "the failure should come from the failing node: {err}"
+        );
+
+        // The decisive assertion: the snapshot exists (was `None` pre-#1008,
+        // because the `Err` arm persisted nothing).
+        let stored = store
+            .get_run_output(&rec.id, &run_id)
+            .await
+            .expect("store read")
+            .expect("a failed run must still persist the output it reached before failing");
+        assert!(
+            stored.partial,
+            "a failure-arm capture must be flagged partial: {stored:?}"
+        );
+        assert_eq!(stored.workflow_id, "partial_fail");
+        assert_eq!(stored.run_id, run_id);
+        // The successful `export` node's output is present under the canonical
+        // `{ items: [...] }` shape the console renders.
+        assert!(
+            stored
+                .nodes
+                .get("export")
+                .and_then(|n| n.get("items"))
+                .is_some(),
+            "the node that succeeded before the failure must be in the partial snapshot: {}",
+            stored.nodes
         );
     }
 


### PR DESCRIPTION
## Summary

Open a failed or blocked run on the canvas, click the node that broke, and the inspector said *"No output for this node — this run predates output capture."* That was false, and missing exactly when the detail matters most.

`persist_run_output` ran only on the success and clean-cancel arms, so both failure paths returned before any snapshot was stored. The engine returns no partial payload on failure (the `Err` arm carries an `EngineError`, and `blocked_run` hardcodes a null output), so per-node output is instead accumulated from the run observer's `on_step_finish` as each node completes — independent of whether the run later fails — and that map is persisted, flagged **partial**, before both the `Err` and blocked returns. Success and clean-cancel persist the same canonical `{ "<node>": { "items": [ … ] } }` map with `partial = false`. The console badges a partial capture in the node inspector.

## API Or Behavior Changes

- A failed or blocked run now stores a per-node output snapshot (the nodes it reached before it stopped), flagged `partial`. Previously it stored nothing and the inspector reported the output as never captured.
- `WorkflowRunOutputRecord` gains a `partial: bool` field (`#[serde(default)]`, camelCase `partial`) — additive; a pre-feature payload deserializes to `partial: false`.
- A `persist_run_output` write-failure now surfaces as a run **notice** on the arms that return a `WorkflowRun` (success / cancel / blocked); the genuine-`Err` arm has no run to carry a notice and stays a log line.
- **Deferred (tracked, out of scope here):** the `Settled::from` journal-listing gap — a genuinely-failed run's history row still zeroes `deliveries`/`board`/`blocked_nodes`/`approvals`. That is listing-completeness (the card and parked approval survive on their own pages), needs a runner→caller port-contract change, and is intentionally left for a follow-up so this change stays the per-node-output data-integrity fix and does not touch `workflow_outcome.rs`.

## Tests

Run in the worktree (Rust gated with the `openhuman,tinycortex` feature lane; frontend is npm):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` **and** `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via the clippy/test compiles)
- [x] `cargo test --locked --features openhuman,tinycortex` — `ports::run_output` 7/7, blocked/failed-arm persist tests, `store::fs_ops` (conformance) 25/25, `server::ops::workflows` 85/85
- [x] frontend `npm run typecheck` + `npm run build` + `npx vitest run` (899 pass, 4 new)

Red-first proof (neutralized the two failure-arm persist calls, recompiled):
- `a_failed_run_persists_the_partial_output_it_reached` **failed** pre-fix (`get_run_output` returned `None`), passes now.
- `a_blocked_run_persists_the_partial_output_it_reached` **failed** pre-fix, passes now.
- the console partial-badge test **failed** with the badge removed, passes now.

## Documentation

No doc pages needed — the partial-capture contract is documented in-code on `persist_run_output`, the observer accumulator, and the record field, and pinned by the tests above.

Closes #1008
