### PR TITLE
fix(policy): grade git_operations by its operation, not its name

### DIFF
--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -305,6 +305,16 @@ pub(crate) const COMPOSIO_ACTION_KEY: &str = "tool";
 /// name (issue #875).
 pub const SHELL: &str = "shell";
 
+/// The git tool, classified by the `operation` it was handed rather than by
+/// this name (issue #877).
+pub const GIT_OPERATIONS: &str = "git_operations";
+
+/// The argument `git_operations` names its subcommand in. Shared with the
+/// fixtures for the reason [`COMPOSIO_ACTION_KEY`] is: a key hard-coded
+/// separately in a test is a test that stops reaching the classifier without
+/// saying so (issue #470).
+pub(crate) const GIT_OPERATION_KEY: &str = "operation";
+
 /// The argument key [`SHELL`] carries the command line under.
 ///
 /// A required parameter of the vendored tool's schema, so a call that omits it
@@ -779,6 +789,12 @@ pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
     if name == SHELL {
         return shell_consequence(args);
     }
+    // Issue #877: the fourth. `git_operations` is how an agent orients in its own
+    // workspace, and classifying the NAME charged a `git status` the same
+    // interruption as a `git push` to a configured remote.
+    if name == GIT_OPERATIONS {
+        return git_operations_consequence(args);
+    }
     match DECLARED.iter().find(|d| d.tool == name) {
         Some(found) => Consequence {
             group: found.group,
@@ -1182,6 +1198,102 @@ fn shell_consequence(args: &serde_json::Value) -> Consequence {
     }
     gated
 }
+
+/// Classify a `git_operations` call from its `operation` argument (issue #877).
+///
+/// # ⚠️ The exposure this downgrade accepts
+///
+/// **Read this before widening [`GIT_READ_ONLY_OPERATIONS`].** `git_operations`
+/// runs against the agent's own workspace — `GitOperationsTool::new(security,
+/// workspace)` in [`crate::harness::toolbelt::code_tools`] — through the
+/// vendored `run_git_command_in`, which is a bare
+/// `Command::new("git").args(args).current_dir(cwd)` with **no
+/// `GIT_CONFIG_NOSYSTEM`, no `-c` overrides and no environment scrub**. Several
+/// git config keys name a command to run (`core.fsmonitor`, `core.pager`,
+/// `diff.external`, `core.sshCommand`), and the repository config lives in a
+/// directory `file_write` can write to — so a `.git/config` the agent authored
+/// can decide what executes when any of these operations runs.
+///
+/// That is the identical primitive `read_workspace_state` is gated for, and its
+/// note in [`DECLARED`] says to revert that stopgap "once a hardened `run_git`
+/// is vendored, **and not before**", tracking the work at
+/// `tinyhumansai/openhuman#5494`. Downgrading here accepts that exposure for
+/// these six operations ahead of that hardening; it is a deliberate scope
+/// decision recorded on issue #877, not an oversight. When #5494 lands, the two
+/// tools should be reconciled — either both downgraded or both gated — because
+/// today they run the same command against the same directory.
+///
+/// # Fail-closed, by the [`shell_consequence`] template
+///
+/// Five mechanisms, all of which must hold for a call to be downgraded:
+///
+/// 1. The gated verdict is built first and every early return uses it.
+/// 2. A missing or non-string `operation` gates — the tool's own schema
+///    requires it, so such a call could not have run.
+/// 3. Only **affirmative** membership of [`GIT_READ_ONLY_OPERATIONS`]
+///    downgrades. `push`, `pull`, `fetch`, `merge`, `rebase` and `clone` are in
+///    neither upstream list, so they are unclassified — and unclassified gates,
+///    by construction rather than by a rule someone has to remember.
+/// 4. Comparison is exact and case-sensitive, matching upstream's `matches!`.
+/// 5. There is no self-declared hint to honour here, so there is nothing that
+///    could lower the verdict — the escalate-only rule `shell` needs is
+///    satisfied vacuously.
+///
+/// # Why a local list rather than the vendored hook
+///
+/// `Tool::external_effect_with_args` is the only public route into upstream's
+/// judgement, and it is **tier-coupled**:
+///
+/// ```text
+/// self.requires_write_access(operation)
+///     && self.security.gate_decision(CommandClass::Write) == GateDecision::Prompt
+/// ```
+///
+/// Calling it here would import OpenHuman's desktop tier into a gate that
+/// answers the tier question one layer up — and under a policy whose
+/// `gate_decision` is not `Prompt` it returns `false` for a genuine **write**,
+/// i.e. it fails **open**. `requires_write_access` and `is_read_only` are
+/// private inherent methods, so there is no untainted route to borrow.
+///
+/// A second list that can drift is exactly what issue #877 warns against, so
+/// the vendored hook is used as a **test oracle** instead —
+/// `the_read_only_set_matches_the_vendored_classifier` drives it at
+/// `AutonomyLevel::Supervised`, where `gate_decision(Write)` *is* `Prompt` and
+/// the conjunction reduces to the operation test alone. A list that cannot
+/// drift silently is not the failure mode being warned about.
+fn git_operations_consequence(args: &serde_json::Value) -> Consequence {
+    let gated = Consequence {
+        group: EffectGroup::Other,
+        reach: Reach::Consequence,
+        standing: Standing::PerCall,
+    };
+    let Some(operation) = args.get(GIT_OPERATION_KEY).and_then(|v| v.as_str()) else {
+        // The tool's own schema marks `operation` required, so this is a call
+        // that could not have run. Gate it rather than guess.
+        return gated;
+    };
+    if GIT_READ_ONLY_OPERATIONS.contains(&operation) {
+        return Consequence {
+            group: EffectGroup::Other,
+            reach: Reach::Nothing,
+            standing: Standing::PerCall,
+        };
+    }
+    gated
+}
+
+/// The `git_operations` subcommands that only read the repository.
+///
+/// Mirrors the vendored `GitOperationsTool::is_read_only` set exactly. It is a
+/// copy, and the copy is load-bearing — see the "why a local list" note on
+/// [`git_operations_consequence`] for why the vendored hook cannot be called
+/// from here, and `the_read_only_set_matches_the_vendored_classifier` for the
+/// oracle that fails if upstream ever reclassifies one of these.
+///
+/// Everything absent from this list gates, including the operations upstream
+/// itself does not classify (`push`, `pull`, `fetch`, `merge`, `rebase`,
+/// `clone`).
+const GIT_READ_ONLY_OPERATIONS: &[&str] = &["status", "diff", "log", "show", "branch", "rev-parse"];
 
 /// Lexical backstop for [`shell_consequence`]: does any whitespace-separated
 /// token in `command` name a location outside the agent's working directory?
@@ -3036,6 +3148,163 @@ mod tests {
                 "`{command}` must still park under auto"
             );
         }
+    }
+
+    // ── git_operations, graded by its `operation` (issue #877) ─────────────
+
+    fn git(operation: &str) -> Consequence {
+        consequence_of(GIT_OPERATIONS, &json!({ GIT_OPERATION_KEY: operation }))
+    }
+
+    /// Orienting in your own workspace should not cost an operator anything.
+    #[test]
+    fn a_git_read_operation_does_not_park() {
+        for operation in GIT_READ_ONLY_OPERATIONS {
+            let c = git(operation);
+            assert_eq!(
+                c.reach,
+                Reach::Nothing,
+                "`git {operation}` only reads the repository"
+            );
+            assert!(
+                !c.parks_under_auto(),
+                "`git {operation}` must not interrupt anybody"
+            );
+        }
+    }
+
+    /// The writes upstream names still park. Without this the downgrade above
+    /// would pass against a build that stopped gating everything.
+    #[test]
+    fn a_git_write_operation_still_parks() {
+        for operation in ["commit", "add", "checkout", "stash", "reset", "revert"] {
+            let c = git(operation);
+            assert_eq!(c.reach, Reach::Consequence, "`git {operation}` acts");
+            assert!(
+                c.parks_under_auto(),
+                "`git {operation}` must still park under auto"
+            );
+        }
+    }
+
+    /// **The fail-closed requirement.** An operation this classifier does not
+    /// recognise must still ask.
+    ///
+    /// The first six are real git subcommands in **neither** upstream list —
+    /// `requires_write_access` does not name them and `is_read_only` does not
+    /// either — so they are genuinely unclassified rather than merely absent
+    /// from a list somebody forgot to extend. `push` is the one that matters
+    /// most: it reaches a configured remote, which is an address this layer
+    /// never sees. The last two are a typo and an invented name, which is what
+    /// a model produces on a bad day.
+    ///
+    /// This passing is the whole safety argument for the downgrade: membership
+    /// is affirmative, so the failure mode of an unknown operation is an extra
+    /// approval, never a silent act.
+    #[test]
+    fn an_unrecognised_git_operation_still_parks() {
+        for operation in [
+            "push",
+            "pull",
+            "fetch",
+            "merge",
+            "rebase",
+            "clone",
+            "stauts",
+            "frobnicate",
+        ] {
+            let c = git(operation);
+            assert_eq!(
+                c.reach,
+                Reach::Consequence,
+                "`git {operation}` is not provably a read, so it must ask"
+            );
+            assert!(
+                c.parks_under_auto(),
+                "`git {operation}` must park under auto"
+            );
+        }
+    }
+
+    /// An argument that cannot be read gates. The tool's schema marks
+    /// `operation` required, so each of these is a call that could not have run
+    /// — guessing at one would be inventing a verdict for a call that never
+    /// happened.
+    #[test]
+    fn a_git_call_with_no_readable_operation_parks() {
+        for args in [
+            json!({}),
+            json!({ GIT_OPERATION_KEY: null }),
+            json!({ GIT_OPERATION_KEY: 7 }),
+            json!({ GIT_OPERATION_KEY: ["status"] }),
+            json!({ "op": "status" }),
+        ] {
+            let c = consequence_of(GIT_OPERATIONS, &args);
+            assert_eq!(
+                c.reach,
+                Reach::Consequence,
+                "unreadable args must park: {args}"
+            );
+        }
+    }
+
+    /// Case matters, matching upstream's `matches!`. `STATUS` is not `status`,
+    /// and a classifier that normalised case here would be answering a question
+    /// upstream does not ask.
+    #[test]
+    fn git_operation_matching_is_case_sensitive() {
+        for operation in ["STATUS", "Status", "LOG"] {
+            assert_eq!(
+                git(operation).reach,
+                Reach::Consequence,
+                "`{operation}` is not the operation upstream classifies"
+            );
+        }
+    }
+
+    /// **The oracle.** [`GIT_READ_ONLY_OPERATIONS`] is a copy of a vendored
+    /// list, and a copy that can drift silently is exactly what issue #877
+    /// warns against. This drives the vendored judgement directly, so upstream
+    /// reclassifying any of these fails the build here rather than quietly
+    /// widening what runs unattended.
+    ///
+    /// It asserts the safety-relevant direction: **none of the operations this
+    /// crate downgrades is a write upstream**. The converse is not assertable —
+    /// `is_read_only` is a private inherent method — but it is also not the
+    /// dangerous direction: an operation upstream calls read-only that we
+    /// nonetheless gate costs an approval, while the reverse would run a write
+    /// unattended.
+    ///
+    /// `SecurityPolicy::default()` is `AutonomyLevel::Supervised`, where
+    /// `gate_decision(Write)` is `Prompt` — so the tier half of
+    /// `external_effect_with_args`'s conjunction is `true` and the expression
+    /// reduces to `requires_write_access(operation)` alone. That is the only
+    /// configuration in which this hook answers the question this crate is
+    /// asking, which is why the gate itself must not call it (see
+    /// [`git_operations_consequence`]).
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn the_read_only_set_matches_the_vendored_classifier() {
+        use openhuman_core::openhuman::security::SecurityPolicy;
+        use openhuman_core::openhuman::tools::{GitOperationsTool, Tool};
+
+        let policy = std::sync::Arc::new(SecurityPolicy::default());
+        let tool = GitOperationsTool::new(policy, std::path::PathBuf::from("."));
+
+        for operation in GIT_READ_ONLY_OPERATIONS {
+            assert!(
+                !tool.external_effect_with_args(&json!({ GIT_OPERATION_KEY: operation })),
+                "upstream now treats `git {operation}` as a write — this crate is downgrading \
+                 something that acts. Remove it from GIT_READ_ONLY_OPERATIONS."
+            );
+        }
+
+        // And the pairing that proves the oracle is live rather than vacuous: a
+        // known write must come back `true` through the same call.
+        assert!(
+            tool.external_effect_with_args(&json!({ GIT_OPERATION_KEY: "commit" })),
+            "the oracle answered `false` for a commit, so it is not testing anything"
+        );
     }
 
     /// The classifier takes the maximum across segments, so a read cannot carry


### PR DESCRIPTION
## Summary

Part of tinyhumansai/opencompany#877 — the `git_operations` instance.

`git status` and `git push` cost an operator the same interruption, because the gate classified
the **tool name**. `status`, `diff`, `log`, `show`, `branch` and `rev-parse` only read the
repository, and an agent orienting in its own workspace should not have to ask.

This is the fourth argument-graded tool, after `composio_execute` (#441), `web_fetch` (#673) and
`shell` (#875/#876).

## ⚠️ Read this before merging: the exposure this downgrade accepts

Stated up front rather than buried, because it is a deliberate scope decision and whoever merges
this is accepting it.

`code_tools` builds `GitOperationsTool::new(security, workspace)` against **the agent's own
workspace** — the same directory `file_write` writes into. Upstream's `run_git_command_in` is a
bare `Command::new("git").args(args).current_dir(cwd)` with **no `GIT_CONFIG_NOSYSTEM`, no `-c`
overrides and no environment scrub** (I grepped the pinned file for `GIT_CONFIG`, `env_clear` and
`.env(` — there is none). Several git config keys name a command to run — `core.fsmonitor`,
`core.pager`, `diff.external`, `core.sshCommand` — and the repository config lives where the agent
can write it.

That is the identical primitive `read_workspace_state` is gated for. Its note in `DECLARED` says to
revert that stopgap *"once a hardened `run_git` is vendored, **and not before**"*, tracking the work
at `tinyhumansai/openhuman#5494`.

So after this lands, `git_operations status` runs unattended while `read_workspace_state` — which
runs `git status` in the same directory — still parks. **When #5494 lands the two should be
reconciled**, either both downgraded or both gated, because they run the same command against the
same directory. The trade-off is recorded in a `⚠️ The exposure this downgrade accepts` block on the
classifier itself, so it is discoverable from the code and not only from here.

## Why the upstream helper is NOT called from the gate

A reviewer's first instinct will be *"why not just reuse `external_effect_with_args`?"*, and the
answer matters enough that it is written into the classifier's doc comment as well as here —
without it, someone will "simplify" this into a security hole later.

`Tool::external_effect_with_args` is the only **public** route into upstream's judgement, and it is
**tier-coupled**:

```rust
self.requires_write_access(operation)
    && self.security.gate_decision(CommandClass::Write) == GateDecision::Prompt
```

Calling that here would import OpenHuman's desktop tier into a gate that answers the tier question
one layer up — and **under a policy whose `gate_decision` is not `Prompt` it returns `false` for a
genuine write. It fails open.** That is the worst possible direction for a helper whose whole job is
deciding what runs unattended.

There is no untainted route to borrow instead: `requires_write_access` and `is_read_only` are
**private inherent methods** on the tool, not part of any trait.

So the read set is a local copy — and a copy that can drift silently is exactly what #877 warns
against. The vendored hook is therefore used as a **test oracle** rather than a runtime dependency:
`the_read_only_set_matches_the_vendored_classifier` drives it at `SecurityPolicy::default()`, which
is `AutonomyLevel::Supervised` — the one tier where `gate_decision(Write)` *is* `Prompt` and the
conjunction reduces to the operation test alone. Upstream reclassifying any of these fails the build
here. The test also asserts `commit` comes back `true` through the same call, so it cannot pass
vacuously.

That gets upstream's judgement as a cross-check without taking a runtime dependency that can fail
open.

## Fail-closed, and durably so

All five `shell_consequence` mechanisms:

1. The gated verdict is built first and every early return uses it.
2. A missing or non-string `operation` gates — the tool's schema marks it required, so such a call
   could not have run.
3. Only **affirmative** membership of `GIT_READ_ONLY_OPERATIONS` downgrades.
4. Comparison is exact and case-sensitive, matching upstream's `matches!`.
5. There is no self-declared hint here, so the escalate-only rule `shell` needs is satisfied
   vacuously — nothing exists that could lower a verdict.

**`push`, `pull`, `fetch`, `merge`, `rebase` and `clone` are in neither upstream list** —
`requires_write_access` does not name them and `is_read_only` does not either. They gate **by
construction**, not by a rule anyone has to remember to maintain. That is a durability property, not
an implementation detail: an operation added upstream tomorrow gates by default, and `push` — the one
that reaches an address this layer never sees — is covered by the same mechanism as a typo.

## Scope: why only `git_operations`

From the survey on #877, so nobody re-proposes the ones already settled.

**Grading by argument today — three tools**

| Tool | Since | Keyed on |
| --- | --- | --- |
| `composio_execute` | #441 | action slug (`tool` arg) |
| `web_fetch` | #673 | URL host |
| `shell` | #875 / #876 | the command, via vendored `SecurityPolicy::classify_command` |

Everything else — 60-odd `DECLARED` entries — answers from the name.

**Varies by argument, no grader yet**

| Tool | Varies by | Vendored grader | Assessment |
| --- | --- | --- | --- |
| `git_operations` | `operation` | yes (private; see above) | **this PR** |
| `mcp_call_tool`, `mcp_registry_tool_call` | server + tool | none | needs per-server advertised metadata — **a design, not a classifier**; its own issue |
| `http_request`, `curl` | method + host | none | ruled out, below |
| `workspace_write` / `_create` / `_delete` / `_rename` | whose note | none | #877's own lowest rank |
| `file_write`, `edit`, `apply_patch` | path | upstream checks path | already `Grantable`; lower value |

**Ruled out, with reasons**

* **`http_request` / `curl` — settled, do not relitigate.** `consequence.rs:322` already decided it:
  only `web_fetch` gets host scoping because the other two "can mutate, so a host-scoped grant on
  them would consent to *writing* to that host — a different act from the read this issue is about,
  and one nobody asked for."
* **⚠️ #614 is not a precedent for argument grading.** It is *"workflows: an `http_request` node never
  consults `ApprovalPolicy`"* — a **plumbing** fix that made the node reach the gate at all. It has
  already been cited twice as precedent; it is not one.
* **`read_workspace_state` — deliberately gated, and it explains itself** via `denial_reason`
  (`consequence.rs:805`). See the exposure section above.
* **The ~55 remaining name-only tools are not a backlog.** `send_email` is a send whatever its body
  says. Grading them would add parsers whose failure mode — mis-reading an argument as safe — is
  strictly worse than the gate they replace.

## API Or Behavior Changes

New `pub const GIT_OPERATIONS`; `consequence_of` gains a `git_operations` arm.

Behaviour: a `git_operations` call whose `operation` is one of the six read subcommands no longer
parks for approval under `supervised`/`auto`, and is no longer refused under `readonly`. Every other
operation — and any call whose `operation` cannot be read — behaves exactly as before.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
      exit 0. `--no-deps` mirrors `ci.yml`; a bare `--all-targets` drowns in vendored lints CI never
      compiles.
- [x] `cargo build --all-targets` — covered by the two test lanes below, which build all targets for
      both feature sets.
- [x] `cargo test` — both halves. Default features: `cargo test --locked`, exit 0. Gated lane:
      `RUST_MIN_STACK=16777216 cargo test --locked --features openhuman,tinycortex --tests` →
      **4284 passed / 0 failed**. `RUST_MIN_STACK` matches `ci.yml:626`; without it a pre-existing
      `harness::brain` test overflows the stack locally.

`scripts/ci/assert-feature-lanes.sh` passes.

### Revert proof — three, each isolating a different property

| Reverted | Result |
| --- | --- |
| the `consequence_of` dispatcher arm | `a_git_read_operation_does_not_park` **FAILED** |
| allowlist → denylist, missing `operation` defaults to a read | **4 FAILED**, incl. `an_unrecognised_git_operation_still_parks` and `a_git_call_with_no_readable_operation_parks` |
| added `commit` to `GIT_READ_ONLY_OPERATIONS` | `the_read_only_set_matches_the_vendored_classifier` and `a_git_write_operation_still_parks` **FAILED** |

The second is the fail-closed requirement proven directly rather than asserted. It also tripped the
pre-existing `the_auto_tier_line_is_pinned_tool_by_tool` guard, which is that guard working.

## Documentation

`N/A` — no module doc or spec describes the per-tool consequence table; the reasoning that would go
in one lives on the classifier itself, which is where the three existing argument-graded tools keep
theirs. The two blocks worth reading are `⚠️ The exposure this downgrade accepts` and
`Why a local list rather than the vendored hook`, both on `git_operations_consequence`.
