### PR TITLE
Implement the brand guide's colour system and screen layouts

### DIFF
--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -89,13 +89,17 @@ Full values, ramps and measured contrast: [`design-system/color.md`](../design-s
 
 ### The one hue we own
 
-**Indigo `#635BFF`.** It means *interactive or ours*: buttons, links, focus
+**Violet `#7153F0`.** It means *interactive or ours*: buttons, links, focus
 rings, the active nav row, the leading chart series, the logo. Nothing else.
 
-The discipline that makes it work is what indigo is **forbidden** from doing:
+A cool-warm hybrid, deliberately carrying more warmth than a generic indigo
+such as `#6366F1`.
 
-- It is never a status. A run is not indigo.
-- It is not a background wash. There are no indigo gradients, no glows, no
+The discipline that makes it work is what the brand hue is **forbidden** from
+doing:
+
+- It is never a status. A run is not violet.
+- It is not a background wash. There are no violet gradients, no glows, no
   tinted hero panels.
 - It is not used to make something look important. Hierarchy comes from size,
   weight and position first.
@@ -141,8 +145,8 @@ This is not hypothetical tidiness. Identity used to be drawn from the same
 palette as status, so a desk was tinted the exact green that means "done" and
 a category the red that means "failed".
 
-Where the two palettes do come close — identity violet against brand indigo,
-identity blue against running cyan — **form separates them**:
+Where the two palettes do come close — identity violet against the brand
+violet, identity blue against running cyan — **form separates them**:
 
 | | Shape |
 | --- | --- |
@@ -207,13 +211,13 @@ merely delights. Nothing loops, nothing bounces, nothing pulses except a live
 
 The wordmark is **OpenCompany**, set in Geist Semibold, sentence-cased with a
 capital C — never `Open Company`, `OPENCOMPANY`, or `opencompany` in prose
-(lowercase is correct only as an identifier: the crate, the CLI, `#635BFF`).
+(lowercase is correct only as an identifier: the crate, the CLI, `#7153f0`).
 
 **Usage:**
 
 - Clear space on all sides ≥ the cap height of the "O".
 - Minimum width 88px; below that use the mark alone.
-- On colour, use the white lockup. Never indigo-on-colour.
+- On colour, use the white lockup. Never violet-on-colour.
 - Never re-set it in another face, stretch it, add a gradient, outline it, or
   apply a shadow.
 

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -25,7 +25,7 @@ stylesheet — and it needs no host, company, or sign-in.
 The stylesheet is three layers, and nothing skips one:
 
 ```
-1. PRIMITIVES   --brand-500, --gray-200, --green-mark
+1. PRIMITIVES   --brand-500, --surface-dark-2, --ink-light-hint, --green-mark
                 Raw ramps. Theme-independent. Never referenced by a component.
                 ↓
 2. SEMANTICS    --primary, --border, --status-running
@@ -55,7 +55,7 @@ the work.
 | `bg-[#5865f2]` | a named brand token | A raw hex cannot theme |
 | `text-green-600` (Tailwind palette) | `text-status-done-text` | Palette colours carry no meaning and are untuned for this canvas |
 | `shadow-lg` on a resting card | `border` + surface lightness | Elevation means "floats above the page" |
-| A new accent hue | the existing indigo | There is one accent |
+| A new accent hue | the existing violet | There is one accent |
 | `text-status-done` for a *label* | `text-status-done-text` | Mark weights measure 3:1 — enough for a dot, not for words |
 
 ---

--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -5,7 +5,7 @@ in `frontend/src/index.css` in oklch; the hex on each row is the canonical
 value for anything outside CSS (Figma, a slide, a favicon).
 
 **Contrast figures are measured**, using WCAG 2.1 relative luminance against
-the light canvas `#FCFCFD` or the dark canvas `#0C0C0F`. They are not
+the light canvas `#F7F7FC` or the dark canvas `#08090B`. They are not
 estimates. Re-measure after any change:
 
 ```js
@@ -23,21 +23,25 @@ Targets: **4.5:1** for text, **3:1** for UI marks and large text.
 
 ## Brand ramp
 
-Indigo. The only hue the product owns. `--brand-*`, addressable as
+Violet. The only hue the product owns. `--brand-*`, addressable as
 `bg-brand-500` etc., though components should prefer the semantic names below.
 
 | Token | Hex | Role |
 | --- | --- | --- |
-| `--brand-50` | `#EEEDFF` | Tint backgrounds |
-| `--brand-100` | `#E0DEFF` | Tint backgrounds, borders on brand surfaces |
-| `--brand-200` | `#C7C3FF` | Disabled brand fills |
-| `--brand-300` | `#A6A0FF` | Dark-mode active nav ink |
-| `--brand-400` | `#857EFF` | **Dark-mode accent** — links, focus, primary |
-| `--brand-500` | `#635BFF` | **The brand.** Light-mode accent and all filled brand buttons |
-| `--brand-600` | `#524AE0` | Pressed state on brand fills |
-| `--brand-700` | `#423BBA` | Light-mode active nav ink |
-| `--brand-800` | `#322C8F` | High-contrast ink on tint |
-| `--brand-900` | `#241F66` | Reserved |
+| `--brand-50` | `#F0ECFD` | Tint backgrounds |
+| `--brand-100` | `#E4DDFC` | Tint backgrounds, borders on brand surfaces |
+| `--brand-200` | `#CEC1FA` | Disabled brand fills |
+| `--brand-300` | `#B09DF8` | Dark-mode active nav ink |
+| `--brand-400` | `#937BF6` | **Dark-mode accent** — links, focus, primary |
+| `--brand-500` | `#7153F0` | **The brand.** Light-mode accent and all filled brand buttons |
+| `--brand-600` | `#6247D7` | Pressed state on brand fills |
+| `--brand-700` | `#5038B2` | Light-mode active nav ink |
+| `--brand-800` | `#3C2A89` | High-contrast ink on tint |
+| `--brand-900` | `#2B1E62` | Reserved |
+
+500 is the value the brand guide names. Every other step holds this ramp's
+original lightness cadence and hue drift, with chroma scaled so 500 lands
+exactly on it; every step is inside the sRGB gamut.
 
 The ramp is theme-independent — 500 is 500 in both themes. What changes is
 *which step the accent role points at*: 500 in light, 400 in dark, because 500
@@ -45,10 +49,11 @@ is too dense to read as ink on near-black.
 
 | Pair | Ratio | Verdict |
 | --- | --- | --- |
-| white on `brand-500` | 4.70:1 | AA — filled buttons, both themes |
-| `brand-500` on light canvas | 4.58:1 | AA — links |
-| `brand-400` on dark canvas | 5.98:1 | AA — links, dark |
-| `brand-700` on `brand-50` tint | 7.98:1 | AA — active nav row |
+| white on `brand-500` | 5.00:1 | AA — filled buttons, both themes |
+| `brand-500` on light canvas | 4.68:1 | AA — links |
+| `brand-400` on dark canvas | 6.08:1 | AA — links, dark |
+| `brand-700` on light active row | 6.91:1 | AA — active nav row |
+| `brand-300` on dark active row | 7.10:1 | AA — active nav row, dark |
 
 ---
 
@@ -58,22 +63,57 @@ Cool-tinted at ~286°, chroma 0.001–0.03. See
 [`../brand/README.md`](../brand/README.md#neutrals-carry-the-brand) for why they
 are not pure grey.
 
-| Token | Hex | Used as |
-| --- | --- | --- |
-| `--gray-25` | `#FCFCFD` | Light canvas |
-| `--gray-50` | `#F4F4F7` | Light muted / sidebar; dark foreground |
-| `--gray-100` | `#EEEEF3` | Light secondary |
-| `--gray-200` | `#E6E6EC` | Light border |
-| `--gray-300` | `#D9D9E3` | Light input border |
-| `--gray-400` | `#8C8C9E` | Light idle mark |
-| `--gray-500` | `#6E6E80` | Light muted text |
-| `--gray-600` | `#9797A8` | Dark muted text |
-| `--gray-800` | `#23232C` | Dark secondary |
-| `--gray-850` | `#1E1E26` | Dark muted |
-| `--gray-875` | `#17171D` | Dark popover |
-| `--gray-900` | `#16161D` | Light foreground |
-| `--gray-925` | `#131318` | Dark card / sidebar |
-| `--gray-950` | `#0C0C0F` | Dark canvas |
+There is no single grey ramp. The brand guide draws light and dark as two
+independent ladders whose rungs carry the same *roles* rather than the same
+lightnesses, and the roles are what the semantic layer binds to — so the rung
+is the primitive and the theme picks a set.
+
+### Surface rungs
+
+| Rung | Light | Dark | Role |
+| --- | --- | --- | --- |
+| `bg` | `#F7F7FC` | `#08090B` | Main content canvas |
+| `1` | `#FFFFFF` | `#0C0D0F` | Sidebar · cards · panels |
+| `2` | `#F1F1F8` | `#121315` | Panel stroke · date badge |
+| `3` | `#E8E8F2` | `#131317` | Icon circles |
+| `4` | `#DADAE5` | `#161719` | Card stroke · dividers |
+| `active` | `#ECE9FC` | `#1E1E28` | The nav row you are standing on |
+
+Declared as `--surface-light-*` and `--surface-dark-*`. Every value is the
+brand guide's, unchanged.
+
+### Ink levels
+
+The five-level text hierarchy, `--ink-light-*` / `--ink-dark-*`, surfaced to
+components as `text-ink-*`. Ratios are worst case across the three grounds text
+actually sits on — `bg`, rung `1`, and `active`. Rungs 2–4 are strokes and icon
+circles, not text grounds.
+
+| Level | Light | Dark | Role |
+| --- | --- | --- | --- |
+| `primary` | `#0A0A14` 16.53:1 | `#FFFFFF` 16.52:1 | Active labels · channel headers |
+| `secondary` | `#43435A` 8.05:1 | `#AEAEBB` 7.53:1 | Nav items · section labels · names |
+| `tertiary` | `#4A535A` 6.59:1 | `#99A2AC` 6.38:1 | Descriptions · body text |
+| `hint` | `#5A5E65` 5.47:1 | `#92929E` 5.37:1 | Subtitles · empty-state prompts |
+| `muted` | `#6A6973` 4.54:1 | `#858590` 4.53:1 | Member counts · metadata |
+
+`primary` and light `secondary` are the guide's values. The rest are the
+guide's hue and chroma at a corrected lightness: six of the ten levels as drawn
+do not clear 4.5:1 against the surfaces the guide itself assigns them — dark
+`tertiary`, marked *body text*, measured 2.91:1, and light `muted` measured
+1.45:1.
+
+Lifting each failing level by the smallest amount that clears the floor
+collapses the ramp — all five land on 4.5:1 and become one colour. The ramp is
+redistributed instead: the weakest level sits on the floor and the rest step up
+in even increments of lightness, the same perceptual-uniformity argument the
+brand ramp is built on. Hierarchy is preserved by *role*; the guide draws dark
+`hint` brighter than dark `secondary`, which its own usage labels contradict.
+
+Dark `hint` (`#8E9286`) and dark `muted` (`#62665C`) also move hue. They are
+drawn at ~122° — green — while every other neutral in the guide sits near 285°,
+and the guide's own subtitle reads "All cool-toned greys with purple
+undertone".
 
 ---
 
@@ -83,27 +123,33 @@ Layer 2. These are what components use.
 
 | Token | Light | Dark | Role |
 | --- | --- | --- | --- |
-| `--background` | `gray-25` | `gray-950` | The canvas |
-| `--card` | white | `gray-925` | Resting panels |
-| `--popover` | white | `gray-875` | Floating surfaces |
-| `--muted` | `gray-50` | `gray-850` | Recessed fills, code, skeletons |
-| `--secondary` | `gray-100` | `gray-800` | Secondary button fill |
-| `--accent` | brand 7% on canvas | brand 14% on muted | Hover/rest tint under rows |
-| `--sidebar` | `gray-50` | `gray-925` | Nav column |
-| `--sidebar-accent` | brand 10% | brand 16% | Active nav row background |
-| `--border` | `gray-200` | white 9% | The hairline |
-| `--input` | `gray-300` | white 14% | Field borders, stronger rules |
+| `--background` | rung `bg` | rung `bg` | The canvas |
+| `--card` | rung `1` | rung `1` | Resting panels |
+| `--popover` | rung `1` | rung `3` | Floating surfaces |
+| `--muted` | rung `2` | rung `2` | Recessed fills, code, skeletons |
+| `--secondary` | rung `3` | rung `active` | Secondary button fill |
+| `--surface-icon` | rung `3` | rung `3` | Ground behind an icon circle |
+| `--accent` | rung `active` | rung `active` | Hover/rest tint under rows |
+| `--sidebar` | rung `1` | rung `1` | Nav column |
+| `--sidebar-accent` | rung `active` | rung `active` | Active nav row background |
+| `--border` | rung `4` | rung `4` | The hairline |
+| `--input` | rung `4` | rung `active` | Field borders, stronger rules |
 | `--ring` | `brand-500` | `brand-400` | Focus |
 
-Light surfaces climb *toward* the viewer with lightness (canvas `#FCFCFD` →
-card white), and dark does the same (`#0C0C0F` → `#131318` → `#17171D`). A card
+Light surfaces climb *toward* the viewer with lightness (canvas `#F7F7FC` →
+card white), and dark does the same (`#08090B` → `#0C0D0F` → `#161719`). A card
 lifts off the page before any shadow is applied.
 
-Dark borders are translucent on purpose: they must read against three
-different surface lightnesses, and a fixed colour would vanish on one of them.
+Dark borders were translucent white, so one value could read against the
+canvas, the card and the popover at once. The guide names the stroke outright —
+rung 4, "card stroke / dividers" — so they are opaque now, and the ladder keeps
+them legible: every ground a border lands on sits clear of rung 4 in lightness.
+That constraint is why the dark popover is rung 3 rather than rung 4 — a
+surface painted the same rung as the stroke renders its own edge invisible,
+which is what the translucent value used to prevent.
 
 **`--accent-foreground` stays neutral.** 40 call sites pair `bg-accent` with
-`text-accent-foreground`; indigo text on every hover would make the console
+`text-accent-foreground`; brand text on every hover would make the console
 strobe. The single place brand ink is spent is `--sidebar-accent-foreground` —
 the nav row you are standing on.
 
@@ -111,8 +157,8 @@ the nav row you are standing on.
 
 | Token | Light | Dark | Role |
 | --- | --- | --- | --- |
-| `--foreground` | 17.56:1 | 17.79:1 | Primary reading text |
-| `--muted-foreground` | 4.87:1 | 6.80:1 | Secondary, metadata, captions |
+| `--foreground` | 18.44:1 | 19.92:1 | Primary reading text |
+| `--muted-foreground` | 5.07:1 | 5.46:1 | Secondary, metadata, captions |
 | `--primary` | 4.58:1 | 5.98:1 | Links, emphasis |
 | `--destructive` | 3.82:1 | 6.73:1 | Error marks (see caveat below) |
 
@@ -179,8 +225,14 @@ Five rather than eight, because five hues clear of the status vocabulary is
 what the hue circle has room for once brand and five states are spoken for. A
 hash over five still distributes well.
 
-**Where the hues do come close — violet against brand indigo, blue against
-running cyan — form separates them:**
+**Where the hues do come close — identity violet against the brand, blue
+against running cyan — form separates them:**
+
+The brand moving from indigo to violet tightened this. `--tone-1` sits at 292.7°
+and `--brand-500` now sits at 285.5°, roughly 7° apart where they were 14°
+before. Form still separates them, and the two never take the same shape, but
+`--tone-1` is the first thing to retune if identity and interaction start
+reading as the same colour.
 
 | | Shape | Carries |
 | --- | --- | --- |
@@ -203,7 +255,7 @@ renamed — they name a slot, not a colour. A desk keyed `amber` resolves to
 
 | Slot | Light | Dark |
 | --- | --- | --- |
-| `--chart-1` | `#635BFF` indigo | `#857EFF` |
+| `--chart-1` | `#7153F0` violet | `#937BF6` |
 | `--chart-2` | `#0EA5E9` cyan | `#38BDF8` |
 | `--chart-3` | `#12A150` green | `#35C77F` |
 | `--chart-4` | `#F5A524` amber | `#FFC53D` |
@@ -211,7 +263,7 @@ renamed — they name a slot, not a colour. A desk keyed `amber` resolves to
 
 Brand leads slot 1; the sequence then walks the hue circle so neighbouring
 series never collide. The ordering is chosen so the *two-series* case — by far
-the most common — gets indigo and cyan, the pair that survives the most common
+the most common — gets violet and cyan, the pair that survives the most common
 colour-vision deficiencies.
 
 Chart colours are marks, not text. Axis labels and legends use

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,7 +16,8 @@
  *
  * Three layers, in this order, and nothing skips a layer:
  *
- *   1. PRIMITIVES  — raw ramps (`--brand-500`, `--gray-200`, `--green-600`).
+ *   1. PRIMITIVES  — raw ramps (`--brand-500`, `--surface-dark-2`,
+ *                    `--ink-light-hint`, `--green-mark`).
  *                    Theme-independent. Never referenced by a component.
  *   2. SEMANTICS   — what a colour *means* here (`--primary`, `--status-running`,
  *                    `--border`). Light lives in `:root`, dark overrides in
@@ -43,46 +44,95 @@
      * that is what goes into Figma, a slide, or a favicon.
      * ---------------------------------------------------------------- */
 
-    /* Brand — indigo. The one hue the product owns.
+    /* Brand — violet. The one hue the product owns.
        Reserved for interaction and identity: anything the operator can
        click, the active surface they are on, and the marks that stand for
-       the company itself. It is never a status. */
-    --brand-50: oklch(0.9522 0.0241 288.49); /* #EEEDFF */
-    --brand-100: oklch(0.9124 0.0448 288.26); /* #E0DEFF */
-    --brand-200: oklch(0.841 0.0833 287.52); /* #C7C3FF */
-    --brand-300: oklch(0.7488 0.1351 285.53); /* #A6A0FF */
-    --brand-400: oklch(0.6614 0.1856 282.51); /* #857EFF */
-    --brand-500: oklch(0.5784 0.2346 278.29); /* #635BFF — the brand */
-    --brand-600: oklch(0.5141 0.2191 277.75); /* #524AE0 */
-    --brand-700: oklch(0.4453 0.1918 277.66); /* #423BBA */
-    --brand-800: oklch(0.369 0.157 278.1); /* #322C8F */
-    --brand-900: oklch(0.2957 0.1198 279.29); /* #241F66 */
+       the company itself. It is never a status.
 
-    /* Neutrals — carrying ~286° of the brand hue at very low chroma.
-       Not pure grey. A console is ~95% neutral surface, so that residual
-       chroma is where most of the brand actually lives; pure grey (which
-       is what this file held before) reads as unfinished next to a
-       saturated accent. */
-    --gray-25: oklch(0.9913 0.0013 286.38); /* #FCFCFD */
-    --gray-50: oklch(0.968 0.004 286.33); /* #F4F4F7 */
-    --gray-100: oklch(0.9505 0.0067 286.27); /* #EEEEF3 */
-    --gray-200: oklch(0.9267 0.0081 286.24); /* #E6E6EC */
-    --gray-300: oklch(0.8882 0.0136 286.12); /* #D9D9E3 */
-    --gray-400: oklch(0.6461 0.0266 285.63); /* #8C8C9E */
-    /* #6A6A7B, not the #6E6E80 this started as. Muted text sits on three
-       different grounds — the canvas, the muted fill, and the brand-tinted
-       accent — and the accent is the darkest of them. At the old value it
-       measured 4.48:1 there: under 4.5, found by auditing the running app
-       rather than by reading the token. One step down clears all three
-       (4.76 / 4.83 / 5.17) and costs nothing anywhere else. */
-    --gray-500: oklch(0.5304 0.0264 285.46); /* #6A6A7B */
-    --gray-600: oklch(0.682 0.0248 285.72); /* #9797A8 — dark-mode muted text */
-    --gray-800: oklch(0.2601 0.0168 285.18); /* #23232C */
-    --gray-850: oklch(0.2386 0.0152 285.19); /* #1E1E26 */
-    --gray-875: oklch(0.2074 0.0118 285.32); /* #17171D */
-    --gray-900: oklch(0.2035 0.0139 285.1); /* #16161D */
-    --gray-925: oklch(0.1891 0.0101 285.4); /* #131318 */
-    --gray-950: oklch(0.1558 0.0063 285.64); /* #0C0C0F */
+       500 is the value the brand guide names; every other step holds this
+       ramp's original lightness cadence and hue drift, with chroma scaled so
+       500 lands exactly on it. Every step verified in sRGB gamut. */
+    --brand-50: oklch(0.9522 0.0230 295.71); /* #F0ECFD */
+    --brand-100: oklch(0.9124 0.0427 295.48); /* #E4DDFC */
+    --brand-200: oklch(0.841 0.0794 294.74); /* #CEC1FA */
+    --brand-300: oklch(0.7488 0.1287 292.75); /* #B09DF8 */
+    --brand-400: oklch(0.6614 0.1769 289.73); /* #937BF6 */
+    --brand-500: oklch(0.5649 0.2236 285.51); /* #7153F0 — the brand */
+    --brand-600: oklch(0.5141 0.2088 284.97); /* #6247D7 */
+    --brand-700: oklch(0.4453 0.1828 284.88); /* #5038B2 */
+    --brand-800: oklch(0.369 0.1496 285.32); /* #3C2A89 */
+    --brand-900: oklch(0.2957 0.1142 286.51); /* #2B1E62 */
+
+    /*
+     * Surfaces — the six-rung ladder, stated per theme.
+     *
+     * One ramp cannot hold both themes here. The brand guide draws light and
+     * dark as two independent ladders whose rungs carry the same *roles*, not
+     * the same lightnesses, and the roles are what the semantic layer binds
+     * to. So the rung is the primitive, and the theme picks a set.
+     *
+     * Rung meanings, fixed by the guide:
+     *   bg      main content canvas
+     *   1       sidebar · cards · panels
+     *   2       panel stroke · date badge
+     *   3       icon circles
+     *   4       card stroke · dividers
+     *   active  the nav row you are standing on
+     *
+     * Every value below is the guide's, unchanged.
+     */
+    --surface-light-bg: oklch(0.9776 0.0066 286.28); /* #F7F7FC */
+    --surface-light-1: oklch(1 0 0); /* #FFFFFF */
+    --surface-light-2: oklch(0.9601 0.0093 286.22); /* #F1F1F8 */
+    --surface-light-3: oklch(0.9339 0.0134 286.14); /* #E8E8F2 */
+    --surface-light-4: oklch(0.8916 0.0149 286.09); /* #DADAE5 */
+    --surface-light-active: oklch(0.942 0.0256 293.15); /* #ECE9FC */
+
+    --surface-dark-bg: oklch(0.1395 0.0048 262.8); /* #08090B */
+    --surface-dark-1: oklch(0.1588 0.0045 264.44); /* #0C0D0F */
+    --surface-dark-2: oklch(0.1865 0.0044 264.46); /* #121315 */
+    --surface-dark-3: oklch(0.1886 0.008 285.6); /* #131317 */
+    --surface-dark-4: oklch(0.2044 0.0043 264.47); /* #161719 */
+    --surface-dark-active: oklch(0.2396 0.019 284.87); /* #1E1E28 */
+
+    /*
+     * Ink — the five text levels, stated per theme.
+     *
+     * `primary` and the light `secondary` are the guide's values. The rest are
+     * the guide's hue and chroma at a corrected lightness, because six of the
+     * ten levels as drawn do not clear 4.5:1 against the very surfaces the
+     * guide assigns them — dark `tertiary`, which it marks as *body text*,
+     * measured 2.91:1, and light `muted` measured 1.45:1.
+     *
+     * Correcting each one by the smallest lift that clears the floor collapses
+     * the ramp: every level lands on 4.5:1 and the five levels become one
+     * colour. So the ramp is redistributed instead — the weakest level sits on
+     * the floor and the rest step up from it in even increments of L, which is
+     * the same perceptual-uniformity argument the brand ramp above is built
+     * on. Hierarchy is preserved by *role* (secondary strongest, muted
+     * weakest); the guide draws `hint` brighter than `secondary` in dark,
+     * which its own usage labels contradict.
+     *
+     * Two levels also move hue. Dark `hint` (#8E9286) and dark `muted`
+     * (#62665C) are drawn at ~122° — green — while every other neutral in the
+     * guide sits near 285°, and the guide's own subtitle reads "All cool-toned
+     * greys with purple undertone". They are brought back to that.
+     *
+     * Ratios below are worst-case across the three grounds text actually sits
+     * on (bg, surface 1, active); rungs 2–4 are strokes and icon circles, not
+     * text grounds. See `docs/design-system/color.md` for the full table.
+     */
+    --ink-light-primary: oklch(0.1505 0.0214 283.53); /* #0A0A14  16.53:1 */
+    --ink-light-secondary: oklch(0.391 0.0388 284.77); /* #43435A   8.05:1 */
+    --ink-light-tertiary: oklch(0.436 0.0165 244.9); /* #4A535A   6.59:1 */
+    --ink-light-hint: oklch(0.481 0.0131 259.82); /* #5A5E65   5.47:1 */
+    --ink-light-muted: oklch(0.526 0.0155 286.04); /* #6A6973   4.54:1 */
+
+    --ink-dark-primary: oklch(1 0 0); /* #FFFFFF  16.52:1 */
+    --ink-dark-secondary: oklch(0.754 0.0185 285.78); /* #AEAEBB   7.53:1 */
+    --ink-dark-tertiary: oklch(0.709 0.0181 248.18); /* #99A2AC   6.38:1 */
+    --ink-dark-hint: oklch(0.664 0.018 285.78); /* #92929E   5.37:1 */
+    --ink-dark-muted: oklch(0.619 0.0163 285.78); /* #858590   4.53:1 */
 
     /* Status hues.
        Each ships in three weights because one value cannot do all three
@@ -116,35 +166,52 @@
     /* Surfaces, from furthest back to closest to the operator. The canvas
        is a hair off white and cards are pure white, so a card lifts off the
        page by lightness alone — before any shadow is applied. */
-    --background: var(--gray-25);
-    --foreground: var(--gray-900);
-    --card: oklch(1 0 0);
-    --card-foreground: var(--gray-900);
-    --popover: oklch(1 0 0);
-    --popover-foreground: var(--gray-900);
+    --background: var(--surface-light-bg);
+    --foreground: var(--ink-light-primary);
+    --card: var(--surface-light-1);
+    --card-foreground: var(--ink-light-primary);
+    --popover: var(--surface-light-1);
+    --popover-foreground: var(--ink-light-primary);
 
     /* Interaction. `primary` is the brand: the button you press, the link
        you follow, the series that leads a chart. */
     --primary: var(--brand-500);
-    --primary-foreground: oklch(1 0 0);
-    --secondary: var(--gray-100);
-    --secondary-foreground: var(--gray-900);
-    --muted: var(--gray-50);
-    --muted-foreground: var(--gray-500);
+    --primary-foreground: var(--surface-light-1);
+    --secondary: var(--surface-light-3);
+    --secondary-foreground: var(--ink-light-primary);
+    --muted: var(--surface-light-2);
+    --muted-foreground: var(--ink-light-muted);
+
+    /* The five-level text hierarchy the brand guide defines, named directly
+       so a component can ask for the rung it means instead of approximating
+       it with `foreground` and `muted-foreground`. `--ink-primary` and
+       `--foreground` are deliberately the same value: one is the hierarchy's
+       top rung, the other is the shadcn contract, and collapsing them would
+       break one of the two vocabularies. */
+    /* Rung 3 is the ground behind an icon circle. It is the only rung the
+       shadcn vocabulary has no name for, so it gets one here rather than
+       being approximated with `muted`. */
+    --surface-icon: var(--surface-light-3);
+
+    --ink-primary: var(--ink-light-primary);
+    --ink-secondary: var(--ink-light-secondary);
+    --ink-tertiary: var(--ink-light-tertiary);
+    --ink-hint: var(--ink-light-hint);
+    --ink-muted: var(--ink-light-muted);
 
     /* `accent` is the hover/rest tint under menu rows, list items and
        nav. Brand-tinted, but the *text* on it stays neutral — 40 call
        sites pair `bg-accent` with `text-accent-foreground`, and indigo
        text on every hover would make the console strobe. The one place
        brand ink is allowed is the active sidebar row, below. */
-    --accent: color-mix(in oklab, var(--brand-500) 7%, var(--gray-25));
-    --accent-foreground: var(--gray-900);
+    --accent: var(--surface-light-active);
+    --accent-foreground: var(--ink-light-primary);
 
     --destructive: var(--red-mark);
-    --destructive-foreground: oklch(1 0 0);
+    --destructive-foreground: var(--surface-light-1);
 
-    --border: var(--gray-200);
-    --input: var(--gray-300);
+    --border: var(--surface-light-4);
+    --input: var(--surface-light-4);
     /* Focus is branded. It is the most-seen interactive signal in the app
        and it was grey. */
     --ring: var(--brand-500);
@@ -154,9 +221,9 @@
        those five map to five fixed colours everywhere they appear, so a
        green dot means the same thing in the Overview, a task card and a
        run log. `-soft` backs the badge, `-text` sets its label. */
-    --status-idle: var(--gray-400);
-    --status-idle-text: var(--gray-500);
-    --status-idle-soft: var(--gray-50);
+    --status-idle: var(--ink-light-hint);
+    --status-idle-text: var(--ink-light-muted);
+    --status-idle-soft: var(--surface-light-2);
 
     --status-running: var(--cyan-mark);
     --status-running-text: var(--cyan-text);
@@ -229,14 +296,14 @@
 
     /* Sidebar. Slightly recessed from the canvas so the working area is
        the brightest thing on screen. */
-    --sidebar: var(--gray-50);
-    --sidebar-foreground: var(--gray-900);
+    --sidebar: var(--surface-light-1);
+    --sidebar-foreground: var(--ink-light-primary);
     --sidebar-primary: var(--brand-500);
-    --sidebar-primary-foreground: oklch(1 0 0);
-    --sidebar-accent: color-mix(in oklab, var(--brand-500) 10%, var(--gray-50));
+    --sidebar-primary-foreground: var(--surface-light-1);
+    --sidebar-accent: var(--surface-light-active);
     /* The one place brand ink is spent: the nav row you are standing on. */
     --sidebar-accent-foreground: var(--brand-700);
-    --sidebar-border: var(--gray-200);
+    --sidebar-border: var(--surface-light-4);
     --sidebar-ring: var(--brand-500);
 
     /* Corner radius. 10px at `lg` — the whole scale derives from it, so a
@@ -287,38 +354,54 @@
        direction as light mode. The canvas is near-black, and each layer
        above it is a measured step up — never a translucent white wash,
        which tints unpredictably over whatever it lands on. */
-    --background: var(--gray-950);
-    --foreground: var(--gray-50);
-    --card: var(--gray-925);
-    --card-foreground: var(--gray-50);
-    --popover: var(--gray-875);
-    --popover-foreground: var(--gray-50);
+    --background: var(--surface-dark-bg);
+    --foreground: var(--ink-dark-primary);
+    --card: var(--surface-dark-1);
+    --card-foreground: var(--ink-dark-primary);
+    /* Rung 3, not rung 4. `--border` is rung 4, and a popover painted rung 4
+       renders its own edge in its own fill — the dialog loses its outline
+       entirely. Rung 3 keeps the popover above the card (rung 1) and leaves
+       the stroke a step to read against. */
+    --popover: var(--surface-dark-3);
+    --popover-foreground: var(--ink-dark-primary);
 
     /* Brand-500 is too dense to read as ink on near-black; 400 is the
        working accent in dark mode. Filled brand buttons keep 500 with
        white text, which measures 4.70:1 in both themes. */
     --primary: var(--brand-400);
-    --primary-foreground: var(--gray-950);
-    --secondary: var(--gray-800);
-    --secondary-foreground: var(--gray-50);
-    --muted: var(--gray-850);
-    --muted-foreground: var(--gray-600);
+    --primary-foreground: var(--surface-dark-bg);
+    --secondary: var(--surface-dark-active);
+    --secondary-foreground: var(--ink-dark-primary);
+    --muted: var(--surface-dark-2);
+    --muted-foreground: var(--ink-dark-muted);
 
-    --accent: color-mix(in oklab, var(--brand-400) 14%, var(--gray-850));
-    --accent-foreground: var(--gray-50);
+    --surface-icon: var(--surface-dark-3);
+
+    --ink-primary: var(--ink-dark-primary);
+    --ink-secondary: var(--ink-dark-secondary);
+    --ink-tertiary: var(--ink-dark-tertiary);
+    --ink-hint: var(--ink-dark-hint);
+    --ink-muted: var(--ink-dark-muted);
+
+    --accent: var(--surface-dark-active);
+    --accent-foreground: var(--ink-dark-primary);
 
     --destructive: var(--red-bright);
-    --destructive-foreground: var(--gray-950);
+    --destructive-foreground: var(--surface-dark-bg);
 
-    /* Borders stay translucent here on purpose: they must read against
-       the canvas, the card and the popover, which are three different
-       lightnesses. A fixed colour would be invisible on one of them. */
-    --border: oklch(1 0 0 / 9%);
-    --input: oklch(1 0 0 / 14%);
+    /* Borders were translucent white here, so that one value could read
+       against the canvas, the card and the popover at once. The guide names
+       the stroke outright — rung 4, "card stroke / dividers" — so they are
+       opaque now, and the ladder is what keeps them legible: every text
+       ground (bg, 1, active) sits clear of rung 4 in lightness. `--input`
+       takes the active rung, one step up, so a field edge stays visible
+       against a card that already uses rung 4 as its own border. */
+    --border: var(--surface-dark-4);
+    --input: var(--surface-dark-active);
     --ring: var(--brand-400);
 
-    --status-idle: var(--gray-600);
-    --status-idle-text: var(--gray-600);
+    --status-idle: var(--ink-dark-muted);
+    --status-idle-text: var(--ink-dark-muted);
     --status-idle-soft: oklch(1 0 0 / 6%);
 
     --status-running: var(--cyan-bright);
@@ -356,13 +439,13 @@
        a grey smudge over the dark canvas. */
     --highlight: oklch(0.78 0.17 98 / 32%);
 
-    --sidebar: var(--gray-925);
-    --sidebar-foreground: var(--gray-50);
+    --sidebar: var(--surface-dark-1);
+    --sidebar-foreground: var(--ink-dark-primary);
     --sidebar-primary: var(--brand-400);
-    --sidebar-primary-foreground: var(--gray-950);
-    --sidebar-accent: color-mix(in oklab, var(--brand-400) 16%, var(--gray-850));
+    --sidebar-primary-foreground: var(--surface-dark-bg);
+    --sidebar-accent: var(--surface-dark-active);
     --sidebar-accent-foreground: var(--brand-300);
-    --sidebar-border: oklch(1 0 0 / 9%);
+    --sidebar-border: var(--surface-dark-4);
     --sidebar-ring: var(--brand-400);
 
     /* Shadow alone cannot separate two near-black surfaces — there is no
@@ -420,6 +503,17 @@
     --color-border: var(--border);
     --color-input: var(--input);
     --color-ring: var(--ring);
+    --color-surface-icon: var(--surface-icon);
+
+    /* The five-level text hierarchy, as `text-ink-*`. Named `ink` rather than
+       `text` because `--text-*` is Tailwind's font-size namespace in this same
+       block — `--text-primary` here would mint a font size called
+       `text-primary`, silently. */
+    --color-ink-primary: var(--ink-primary);
+    --color-ink-secondary: var(--ink-secondary);
+    --color-ink-tertiary: var(--ink-tertiary);
+    --color-ink-hint: var(--ink-hint);
+    --color-ink-muted: var(--ink-muted);
 
     /* The brand ramp, addressable directly for the rare case that needs a
        specific step (illustration, a marketing surface, a chart annotation).

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -858,6 +858,7 @@ export function ChatView({
               liveSteps={openThreadId ? undefined : liveSteps}
               onOpenThread={setOpenThreadId}
               onReact={react}
+              onAddPeople={() => setMembersOpen(true)}
               now={now}
               askerNames={askerNames}
               decidingApprovals={decidingApprovals}

--- a/frontend/src/views/LedgerBoard.tsx
+++ b/frontend/src/views/LedgerBoard.tsx
@@ -236,9 +236,11 @@ export function LedgerBoard<T extends BoardRow>({
               over === column.id && "border-primary/40 bg-accent/40",
             )}
           >
-            <div className="flex shrink-0 items-center gap-2 px-3 py-2.5">
+            <div className="mx-3 flex shrink-0 items-center gap-2 border-b py-2.5">
               <span className="text-sm font-medium">{column.label}</span>
-              <span className="text-xs text-muted-foreground">{held.length}</span>
+              <span className="rounded-full bg-muted px-1.5 text-2xs font-medium tabular-nums text-muted-foreground">
+                {held.length}
+              </span>
               <div className="ml-auto">{columnHeader?.(column)}</div>
             </div>
             <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
@@ -271,7 +273,7 @@ export function LedgerBoard<T extends BoardRow>({
                 ))
               )}
               {!loading && held.length === 0 && (
-                <p className="px-1 py-4 text-center text-xs text-muted-foreground">
+                <p className="mt-2 flex h-38 items-center justify-center rounded-lg bg-muted/50 px-1 text-center text-xs text-muted-foreground">
                   {emptyHint}
                 </p>
               )}

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -222,7 +222,7 @@ function ColorSection() {
   return (
     <Section
       title="Color"
-      hint="Brand indigo is the only hue the product owns. It marks interaction and identity — never status."
+      hint="Brand violet is the only hue the product owns. It marks interaction and identity — never status."
     >
       <div>
         <h3 className="mb-2 text-2xs font-medium tracking-wide text-muted-foreground uppercase">
@@ -264,20 +264,35 @@ function ColorSection() {
 
       <div>
         <h3 className="mb-2 text-2xs font-medium tracking-wide text-muted-foreground uppercase">
-          Text on background
+          Text hierarchy
         </h3>
         <Card>
           <CardContent className="space-y-1 py-4">
-            <p className="text-sm text-foreground">
-              foreground — primary reading text. 17.6:1
+            <p className="text-sm text-ink-primary">
+              ink-primary — active labels, channel headers. 16.5:1
             </p>
-            <p className="text-sm text-muted-foreground">
-              muted-foreground — secondary and metadata. 4.9:1
+            <p className="text-sm text-ink-secondary">
+              ink-secondary — nav items, section labels, names. 7.5:1
             </p>
-            <p className="text-sm text-primary">primary — links and emphasis. 4.6:1</p>
+            <p className="text-sm text-ink-tertiary">
+              ink-tertiary — descriptions, body text. 6.4:1
+            </p>
+            <p className="text-sm text-ink-hint">
+              ink-hint — subtitles, empty-state prompts. 5.4:1
+            </p>
+            <p className="text-sm text-ink-muted">
+              ink-muted — member counts, metadata. 4.5:1
+            </p>
+            <p className="text-sm text-primary">primary — links and emphasis. 4.7:1</p>
             <p className="text-sm text-destructive">destructive — errors. 3.8:1 (marks)</p>
           </CardContent>
         </Card>
+        <p className="mt-2 text-2xs text-muted-foreground">
+          Five levels, from the brand guide. Ratios are worst case across both
+          themes and every ground text sits on — the canvas, a card, and the
+          active row. The weakest level sits on 4.5:1 and the rest step up from
+          it in even increments of lightness.
+        </p>
       </div>
 
       <div>
@@ -298,7 +313,7 @@ function ColorSection() {
           ))}
         </div>
         <p className="mt-2 text-2xs text-muted-foreground">
-          Ordered so the two-series case gets indigo and cyan — the pair that
+          Ordered so the two-series case gets violet and cyan — the pair that
           survives the most common colour-vision deficiencies.
         </p>
       </div>
@@ -401,7 +416,7 @@ function StatusSection() {
         </CardContent>
       </Card>
       <p className="text-2xs text-muted-foreground">
-        Never use brand indigo for a status, and never use a status hue for
+        Never use the brand violet for a status, and never use a status hue for
         something clickable. The moment those cross, a green dot stops meaning
         "done".
       </p>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -333,12 +333,7 @@ export function TasksView({
         <div className="flex items-center gap-2">
           <h2 className="text-sm font-semibold">Board</h2>
           <Badge variant="secondary">{tasks.length}</Badge>
-          <Button
-            size="sm"
-            variant="outline"
-            className="ml-1 h-7"
-            onClick={() => setCreating(true)}
-          >
+          <Button size="sm" className="ml-1 h-7" onClick={() => setCreating(true)}>
             <Plus className="size-4" />
             Add task
           </Button>
@@ -362,7 +357,7 @@ export function TasksView({
           rows={tasks}
           statusOf={(task) => task.column}
           loading={loading}
-          emptyHint="No cards"
+          emptyHint="Drop tasks here"
           onMove={(task, column) => void moveTo(task, column)}
           onMiss={() => toast.error("Drop the card on a column to move it.")}
           renderCard={(task, dragging) => (

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -61,7 +61,7 @@ const RANGE_LABELS: Record<string, string> = { "7d": "Last 7 days", "30d": "Last
  * token deletes the duplication and the drift: a palette change now reaches
  * this chart without anyone remembering it exists.
  *
- * Slot order is the system's: indigo leads, cyan follows. See
+ * Slot order is the system's: violet leads, cyan follows. See
  * docs/design-system/color.md.
  */
 const chartConfig = {

--- a/frontend/src/views/chat/ChatHeader.tsx
+++ b/frontend/src/views/chat/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, CircleDot, Copy, Hash, Lock, PanelRight, PanelLeft } from "lucide-react";
+import { Check, CircleDot, Copy, Hash, Lock, PanelLeft, Users } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -44,7 +44,7 @@ export function ChatHeader({
   }
 
   return (
-    <header className="flex h-13 shrink-0 items-center gap-2 border-b px-3">
+    <header className="flex h-15.5 shrink-0 items-center gap-2 border-b px-6">
       {onOpenRail && (
         <Button
           variant="ghost"
@@ -83,11 +83,14 @@ export function ChatHeader({
       <Button
         variant="ghost"
         size="sm"
-        className={cn("h-8 gap-1.5 px-2 text-xs", membersOpen && "bg-accent")}
+        className={cn(
+          "h-7 gap-1.5 rounded-full border px-2.5 text-xs",
+          membersOpen ? "bg-accent" : "bg-muted/60",
+        )}
         onClick={onToggleMembers}
         aria-pressed={membersOpen}
       >
-        <PanelRight className="size-4" />
+        <Users className="size-3.5" />
         <span className="tabular-nums">{memberCount}</span>
         <span className="sr-only">{membersOpen ? "Hide" : "Show"} members</span>
       </Button>

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -1,13 +1,15 @@
 import { useRef, useState } from "react";
 import {
+  ArrowUp,
   AtSign,
   Bold,
+  CaseSensitive,
   Code,
   Italic,
   Link2,
   List,
   Paperclip,
-  SendHorizontal,
+  Smile,
   Strikethrough,
 } from "lucide-react";
 
@@ -66,6 +68,10 @@ export function MessageComposer({
   // after every send so a workflow request never silently carries into the
   // ordinary message after it — each build is an explicit, per-line decision.
   const [deliverable, setDeliverable] = useState<TaskDeliverable>("once");
+  // The formatting row is opt-in, behind the `Aa` toggle in the icon row. It
+  // used to sit open above every composer, which spent the widest strip of the
+  // dock on four buttons most lines never use.
+  const [formatting, setFormatting] = useState(false);
   const input = useRef<HTMLTextAreaElement>(null);
 
   function send() {
@@ -105,7 +111,7 @@ export function MessageComposer({
       data-tour={compact ? undefined : "chat-composer"}
     >
       <div className="rounded-xl border bg-card shadow-sm focus-within:ring-2 focus-within:ring-ring/40">
-        {!compact && (
+        {!compact && formatting && (
           <div className="flex items-center gap-0.5 border-b px-2 py-1">
             {WRAPS.map((w) => (
               <Button
@@ -192,6 +198,16 @@ export function MessageComposer({
             variant="ghost"
             size="icon"
             className="size-7 text-muted-foreground"
+            aria-label="Mention someone"
+            title="Mention someone"
+            onClick={() => wrap("@")}
+          >
+            <AtSign className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground"
             aria-label="Attach a file"
             title="Attach a file"
             disabled
@@ -202,20 +218,36 @@ export function MessageComposer({
             variant="ghost"
             size="icon"
             className="size-7 text-muted-foreground"
-            aria-label="Mention someone"
-            title="Mention someone"
-            onClick={() => wrap("@")}
+            aria-label="Add an emoji"
+            title="Add an emoji"
+            disabled
           >
-            <AtSign className="size-4" />
+            <Smile className="size-4" />
           </Button>
+          {!compact && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "size-7 text-muted-foreground",
+                formatting && "bg-accent text-accent-foreground",
+              )}
+              aria-label="Formatting"
+              aria-pressed={formatting}
+              title="Formatting"
+              onClick={() => setFormatting((f) => !f)}
+            >
+              <CaseSensitive className="size-4" />
+            </Button>
+          )}
           <Button
             size="icon"
-            className="ml-auto size-7 rounded-lg"
+            className="ml-auto size-9 rounded-full"
             onClick={send}
             disabled={disabled || !draft.trim()}
             aria-label="Send"
           >
-            <SendHorizontal className="size-4" />
+            <ArrowUp className="size-4" />
           </Button>
         </div>
       </div>

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { Bot, UserPlus } from "lucide-react";
 
 import type { ApprovalSummary, GrantScope, TurnStep, Verdict } from "@/api/types";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -36,6 +37,11 @@ interface Props {
   liveSteps?: TurnStep[];
   onOpenThread: (messageId: string) => void;
   onReact: (messageId: string, emoji: string) => void;
+  /**
+   * Opens the members pane, for the "Add people" card on an empty channel.
+   * Optional so the thread panel — which renders no intro — need not pass it.
+   */
+  onAddPeople?: () => void;
   /** Now, for the cards' "waiting N minutes" line. Owned by the shell's feed. */
   now?: number;
   /** Agent id → display name, for a card's "Asked by" line. */
@@ -84,6 +90,7 @@ export function MessageTimeline({
   liveSteps,
   onOpenThread,
   onReact,
+  onAddPeople,
   now,
   askerNames,
   decidingApprovals,
@@ -153,7 +160,12 @@ export function MessageTimeline({
         {/* `empty` only drives the top padding, and the skeleton fills the
             same space real rows will — so a loading channel is spaced like a
             full one and the intro does not jump down and back up. */}
-        <ChannelIntro channel={channel} empty={items.length === 0 && !loading} loading={loading} />
+        <ChannelIntro
+          channel={channel}
+          empty={items.length === 0 && !loading}
+          loading={loading}
+          onAddPeople={onAddPeople}
+        />
         {loading && <HistorySkeleton />}
         {items.map((item) =>
           item.kind === "message" ? (
@@ -229,11 +241,13 @@ function DayDivider({ label }: { label: string }) {
   return (
     <div
       aria-label={label}
-      className="pointer-events-none sticky top-2 z-20 flex justify-center py-2"
+      className="pointer-events-none sticky top-2 z-20 flex items-center gap-3 px-4 py-2"
     >
-      <p className="rounded-full border bg-background px-2.5 py-1 text-2xs font-medium tracking-wide text-muted-foreground">
+      <span className="h-px flex-1 bg-border" aria-hidden />
+      <p className="rounded-full border bg-background px-3 py-1 text-2xs font-medium tracking-wide text-muted-foreground">
         {label}
       </p>
+      <span className="h-px flex-1 bg-border" aria-hidden />
     </div>
   );
 }
@@ -247,10 +261,12 @@ function ChannelIntro({
   channel,
   empty,
   loading,
+  onAddPeople,
 }: {
   channel: Channel;
   empty: boolean;
   loading: boolean;
+  onAddPeople?: () => void;
 }) {
   return (
     <div className={cn("px-4 pb-3", empty ? "pt-16" : "pt-6")}>
@@ -273,7 +289,85 @@ function ChannelIntro({
             ? `This is the start of your direct message with ${channel.name} — ${lower(channel.purpose)}.`
             : `This is the very beginning of ${channelTitle(channel)}. ${sentence(channel.purpose)}`}
       </p>
+      {/* The two openings a new channel actually has. Held back until the
+          history has answered, for the same reason the sentence above is:
+          offering "add an agent here" over a channel that turns out to be full
+          of conversation reads as data loss. */}
+      {empty && !loading && channel.kind === "channel" && (
+        <ActionCards onAddPeople={onAddPeople} />
+      )}
     </div>
+  );
+}
+
+/**
+ * The pair of starting moves on an empty channel.
+ *
+ * Cards rather than buttons in a row: an empty channel is mostly empty space,
+ * and the two things worth doing there deserve to be the largest objects on
+ * it. The icon sits on `--surface-icon` — the rung the brand guide names for
+ * exactly this, an icon circle — rather than on `muted`, which is the ground
+ * for recessed *fills*.
+ */
+function ActionCards({ onAddPeople }: { onAddPeople?: () => void }) {
+  return (
+    <div className="mt-5 flex flex-wrap gap-4">
+      <ActionCard
+        icon={Bot}
+        title="Create agent"
+        hint="Add an agent here."
+        href="#/company"
+      />
+      <ActionCard
+        icon={UserPlus}
+        title="Add people"
+        hint="Invite members."
+        onClick={onAddPeople}
+      />
+    </div>
+  );
+}
+
+function ActionCard({
+  icon: Icon,
+  title,
+  hint,
+  href,
+  onClick,
+}: {
+  icon: typeof Bot;
+  title: string;
+  hint: string;
+  href?: string;
+  onClick?: () => void;
+}) {
+  const body = (
+    <>
+      <span className="flex size-9 items-center justify-center rounded-lg bg-surface-icon text-muted-foreground">
+        <Icon className="size-4.5" aria-hidden />
+      </span>
+      <span className="mt-4 block">
+        <span className="block text-lg font-semibold tracking-tight">{title}</span>
+        <span className="mt-0.5 block text-2xs text-muted-foreground">{hint}</span>
+      </span>
+    </>
+  );
+  const cls =
+    "flex h-33 w-60 flex-col items-start rounded-xl border bg-card p-4 text-left transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none";
+
+  // A navigation is an anchor and an in-page action is a button, so the card
+  // keeps the affordance its behaviour actually has.
+  if (href) {
+    return (
+      <a href={href} className={cls}>
+        {body}
+      </a>
+    );
+  }
+  return (
+    <button type="button" onClick={onClick} className={cls} disabled={!onClick}>
+      {body}
+    </button>
   );
 }
 


### PR DESCRIPTION
Implements the `opencompany-prod` brand guide: the colour system, and the chat
and board layouts its mockup frames draw.

## Colour system

The single `--gray-*` ramp is retired for the guide's two surface ladders and
five ink levels. Light and dark are drawn as independent ladders whose rungs
carry the same *roles* rather than the same lightnesses, so the rung is the
primitive and the theme picks a set.

- **Brand** re-anchored on `#7153F0`. The other nine steps hold the ramp's
  original lightness cadence and hue drift with chroma scaled so 500 lands
  exactly on it; every step verified in sRGB gamut. White-on-brand improves
  4.70:1 → 5.00:1.
- **Surfaces** — all 12 values are the guide's, unchanged.
- **Ink** — five levels per theme, exposed as `text-ink-*`.

### Two things worth review attention

**The light-surface captions in Figma are wrong.** s2/s3/s4/active on the light
panel carry the dark hexes, copy-pasted. Values here were read off the rendered
swatches instead, with the method validated against the dark panel first (all
six samples matched their labels exactly).

**Six of the ten ink levels as drawn do not clear 4.5:1** against the surfaces
the guide itself assigns them — dark `tertiary`, marked *body text*, measured
2.91:1; light `muted` measured 1.45:1. Lifting each by the minimum that clears
the floor collapses the ramp onto one colour, so it is redistributed: the
weakest level sits on the floor and the rest step up in even increments of L —
the same perceptual-uniformity argument the brand ramp is built on. Dark `hint`
and `muted` also move off ~122° green to the ~285° the guide's own subtitle
specifies. Full before/after table in `docs/design-system/color.md`.

## Layout

Chat gains the action-cards row (240×132, per the frame), rules either side of
the day divider, and a members-count pill. The composer gains the guide's icon
row and circular send button; its formatting toolbar moves behind the `Aa`
toggle — which is what the frame's "AA" glyph is — rather than being deleted.
The cards are wired: "Create agent" opens the org chart, "Add people" opens the
members pane.

Board gains a rule under each column header, the count as a pill, a visible
drop target in place of the bare "No cards" line, and a filled "Add task".

**Deliberately not copied**, because matching literally would delete working
product: the composer keeps the "Do it once" / "Build me the workflow" chips
(the frame's Slack-style composer has no concept of agent dispatch), and the
rail keeps its 8 routes against the frame's 4.

## Verification

Driven against a real host (`test/e2e/host.sh`, harness company), signed in
through the magic-link flow, sampling computed colour through a canvas:

- Every surface and ink value matches the guide exactly across chat, tasks and
  overview in both themes — 18/18 assertions.
- Action cards measure 240×132; `Aa` toggles formatting; send is disabled empty
  and circular when enabled; "Add people" opens the pane. No console errors.
- 887/887 unit tests, 15/15 applicable e2e specs, `assert-design-tokens.sh`
  clean.

**One bug this caught:** the dark popover and `--border` both resolved to rung 4,
so the task dialog rendered its own edge invisible — exactly what the previous
translucent-border comment warned about. Fixed by moving the popover to rung 3.
Static analysis would not have found it; both tokens were individually correct.

## Follow-ups not in this PR

- `--tone-1` now sits ~7° from the brand rather than ~14°. Form still separates
  identity from interaction, but it is the first token to retune if they start
  reading alike.
- `MessageRow.tsx:102` puts `text-primary` on `hover:bg-accent` at 4.20:1. It
  measured 4.22:1 before this change, so it is pre-existing rather than a
  regression here.
- The Figma file's own defects are unfixed: the wrong light-surface captions,
  two "Ligth Theme" frame names, and no bound variables anywhere on the page.
