### PR TITLE
workflows: carry a failed run's partial rows, and fix a blocked-node regression from #1041 (#1008)

### DIFF
--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -219,7 +219,7 @@ step waiting on a person is not a failure — and says so structurally:
 
 ```jsonc
 {
-  "output": null,
+  "output": { "nodes": { "draft": { "items": [ { "json": { "text": "…" } } ] } } },
   "pendingApprovals": ["spec"],
   "deliveries": [],
   "nodes": [ { "nodeId": "spec", "status": "blocked", "elapsedMs": 42000 } ],
@@ -232,6 +232,17 @@ step waiting on a person is not a failure — and says so structurally:
   ]
 }
 ```
+
+`output` carries what the nodes **upstream** of the block produced (issue
+#1008). It used to be `null`, so the run drawer showed nothing for a step that
+had just written a draft.
+
+The **blocked node itself has no entry**, here or in the durable snapshot behind
+`GET …/workflows/runs/{runId}/output`. A node refused inside its model's tool
+loop ends its turn by writing prose about being blocked, and filing that prose
+as the node's product would re-open, one surface over, exactly the confusion
+issue #881 fixed by stopping it reaching the next node. The node's `blocked`
+chip and the run's notice are what say what happened.
 
 `blockedNodes` and `approvals` are omitted entirely when empty, so a run that
 blocked on nobody is byte-unchanged. Both also ride the `WorkflowRunFinished`

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,36 @@ pub enum OpenCompanyError {
         limit: usize,
     },
 
+    /// A workflow run failed after some of its nodes had already done durable
+    /// work (issue #1008).
+    ///
+    /// # Why an error variant, rather than a message
+    ///
+    /// A run's outcome is journaled by the **caller**, off what
+    /// [`WorkflowRunner::run`](crate::ports::WorkflowRunner::run) returned — and
+    /// the error arm returned nothing but a string. So a run that opened two
+    /// board cards, parked an approval and then broke at a later node journaled
+    /// a `WorkflowRunFinished` with every one of those lists empty: the cards and
+    /// the approval were sitting in front of the operator while no run admitted
+    /// to opening them.
+    ///
+    /// This carries the partial run so the caller can list what did happen. It
+    /// **wraps** the underlying failure rather than replacing it, so
+    /// [`Display`](std::fmt::Display), [`code`](Self::code) and the HTTP status
+    /// are exactly what they were — a caller that never asks for the partial
+    /// cannot tell this variant apart from the error inside it, which is the
+    /// property that keeps it additive.
+    #[error("{source}")]
+    WorkflowRunFailed {
+        /// The failure as it would have been reported before this wrapper.
+        #[source]
+        source: Box<OpenCompanyError>,
+        /// What the run had done by the time it broke: its per-node rows and
+        /// output, and the durable board / approval / notice rows its nodes
+        /// already produced.
+        partial: Box<crate::ports::WorkflowRun>,
+    },
+
     /// An operation conflicts with the company's lifecycle state (e.g. the
     /// company is paused or archived).
     #[error("company is {0}")]
@@ -286,6 +316,32 @@ impl OpenCompanyError {
         }
     }
 
+    /// The partial run a [`WorkflowRunFailed`](Self::WorkflowRunFailed) carries,
+    /// if this is one (issue #1008).
+    ///
+    /// `None` for every other error, including a workflow failure raised before
+    /// the engine ran — there is no partial run in that case, and an empty one
+    /// would be a claim rather than an absence.
+    pub fn partial_run(&self) -> Option<&crate::ports::WorkflowRun> {
+        match self {
+            Self::WorkflowRunFailed { partial, .. } => Some(partial),
+            _ => None,
+        }
+    }
+
+    /// The failure underneath a [`WorkflowRunFailed`](Self::WorkflowRunFailed)
+    /// wrapper, or `self` when there is none (issue #1008).
+    ///
+    /// The wrapper is additive by design, so anything that classifies an error —
+    /// HTTP status, [`code`](Self::code) — asks for this first and is otherwise
+    /// unchanged.
+    pub fn unwrapped(&self) -> &Self {
+        match self {
+            Self::WorkflowRunFailed { source, .. } => source.unwrapped(),
+            other => other,
+        }
+    }
+
     /// A stable, machine-readable code for this error.
     ///
     /// Surfaced in the HTTP error envelope (`{ "error", "code" }`) so clients
@@ -317,6 +373,10 @@ impl OpenCompanyError {
             Self::BudgetExceeded(_) => "budget_exceeded".to_string(),
             Self::WorkspaceQuota(_) => "workspace_quota_exceeded".to_string(),
             Self::WorkflowRunLimit { .. } => "workflow_run_limit".to_string(),
+            // Issue #1008: delegated, not its own code. The wrapper adds a
+            // payload for the journal, never a new failure a client should
+            // branch on differently.
+            Self::WorkflowRunFailed { source, .. } => source.code(),
             Self::LifecycleConflict(_) => "lifecycle_conflict".to_string(),
             Self::EmergencyStop(_) => "emergency_stop".to_string(),
             Self::Conflict(_) => "conflict".to_string(),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -3671,13 +3671,21 @@ impl Tool for RunWorkflowTool {
             Err(err) => {
                 tracing::debug!(company = %self.company, workflow = %wid, error = %err, "run_workflow: run failed");
                 if let Some(events) = self.events.as_ref() {
+                    let message = err.to_string();
                     crate::runtime::record_run_finished(
                         events,
                         &self.company,
                         &wid,
                         false,
                         &ctx.run_id,
-                        Err(err.to_string().as_str()),
+                        // Issue #1008: an agent-started run journals what it did
+                        // before it broke on exactly the same terms as a console
+                        // or scheduled one — the three entry points share this
+                        // helper so their history cannot drift.
+                        Err(crate::runtime::FailedRun {
+                            error: message.as_str(),
+                            partial: err.partial_run(),
+                        }),
                     )
                     .await;
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -156,7 +156,7 @@ pub use tools::StubToolProvider;
 pub use turn_sweep::{TURN_INTERRUPTED_BY_RESTART, sweep_interrupted_turns};
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
 pub use workflow_outcome::{
-    delivered_by_unsettled_runs, record_run_finished, sweep_interrupted_runs,
+    FailedRun, delivered_by_unsettled_runs, record_run_finished, sweep_interrupted_runs,
 };
 pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -92,25 +92,71 @@ struct Settled {
     approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
 }
 
-impl From<Result<&WorkflowRun, &str>> for Settled {
-    /// # Why four of the six ride the `Ok` arm only
+/// A run that ended in an error, as [`record_run_finished`] takes it (issue
+/// #1008).
+///
+/// # Why this is not just a `&str`
+///
+/// It was, and that was the bug. A failed run's journal row listed no
+/// deliveries, no board rows, no blocked nodes and no approvals — not because
+/// the run had none, but because the *error arm had nowhere to read them from*.
+/// A run that mailed two owner summaries and then broke at a later node showed
+/// zero delivery rows, which reads as "it sent nothing" and is the opposite of
+/// true; a run that opened a card and then failed left the card on the board
+/// with no run admitting to it.
+///
+/// `partial` is what the run had done by the time it broke, threaded up from
+/// the runner on
+/// [`OpenCompanyError::WorkflowRunFailed`](crate::OpenCompanyError::WorkflowRunFailed).
+/// `None` is still correct and still common: the boot sweep's synthetic finish
+/// describes a run this process never saw, and a run refused before the engine
+/// started has genuinely done nothing.
+///
+/// The `From<&str>` conversion keeps every call site that has only a message
+/// reading as it did.
+pub struct FailedRun<'a> {
+    /// The failure, as the journal's `error` string.
+    pub error: &'a str,
+    /// What the run had already done, when the caller can say.
+    pub partial: Option<&'a WorkflowRun>,
+}
+
+impl<'a> From<&'a str> for FailedRun<'a> {
+    /// A failure with nothing known about what the run had done.
+    fn from(error: &'a str) -> Self {
+        Self {
+            error,
+            partial: None,
+        }
+    }
+}
+
+impl From<Result<&WorkflowRun, FailedRun<'_>>> for Settled {
+    /// # Which fields ride which arm
     ///
-    /// Issue #383: `cancelled` does, and that is not an oversight. A run the
-    /// runner never returned from cannot have been *stopped by an operator* — the
-    /// stop signal resolves into an `Ok(cancelled)`, never into an `Err` — so the
-    /// error arm is unambiguously a failure or the boot sweep's synthetic one.
+    /// Issue #383: `cancelled` rides the `Ok` arm only, and that is not an
+    /// oversight. A run the runner never returned from cannot have been *stopped
+    /// by an operator* — the stop signal resolves into an `Ok(cancelled)`, never
+    /// into an `Err` — so the error arm is unambiguously a failure or the boot
+    /// sweep's synthetic one.
     ///
-    /// Issue #638: `notices` does, for the same reason — a run that never
-    /// returned produced none, and an `Err` is already fully described by
-    /// `error`.
+    /// # The other five ride both arms now (issue #1008)
     ///
-    /// Issue #661 (M5): `board` does too, and here the limitation is worth
-    /// stating rather than inheriting. A card is durable the moment the drain
-    /// writes it, so a run that opened two cards and then failed at a later node
-    /// leaves **both cards on the board** — but returns no `WorkflowRun`, so this
-    /// event lists neither. The work survives; the listing does not, and the board
-    /// itself is the record in that case. Same trade `notices` already makes.
-    fn from(outcome: Result<&WorkflowRun, &str>) -> Self {
+    /// `deliveries`, `notices`, `board`, `blocked_nodes` and `approvals` used to
+    /// be hard-coded empty on the `Err` arm, on the argument that a failure
+    /// "returns no `WorkflowRun` to read rows off". That was true of the
+    /// signature, not of the world: every one of those rows records something
+    /// the run **already did** — a report that was mailed, a card that is on the
+    /// board, an approval sitting on the operator's Approvals page — and all of
+    /// them are durable by the time the run breaks. Zeroing them made the
+    /// journal disagree with what the operator could see in front of them.
+    ///
+    /// So the failure arm now carries a [`FailedRun::partial`] when the caller
+    /// has one, and reads exactly the same fields off it that the `Ok` arm
+    /// reads. `pending_approvals` is the one deliberate exception: it describes
+    /// what the run is *still waiting on*, and a run that failed is waiting on
+    /// nothing.
+    fn from(outcome: Result<&WorkflowRun, FailedRun<'_>>) -> Self {
         match outcome {
             Ok(run) => Self {
                 deliveries: run.deliveries.clone(),
@@ -122,24 +168,24 @@ impl From<Result<&WorkflowRun, &str>> for Settled {
                 blocked_nodes: run.blocked_nodes.clone(),
                 approvals: run.approvals.clone(),
             },
-            Err(err) => Self {
-                deliveries: Vec::new(),
-                pending_approvals: Vec::new(),
-                error: Some(err.to_string()),
-                cancelled: false,
-                notices: Vec::new(),
-                board: Vec::new(),
-                // Issues #881 / #880: the `Ok` arm only, same trade as `board`
-                // above and worth naming for the same reason. A run whose node
-                // blocked settles `Ok` by design — a blocked node is not a
-                // failed one — so this arm is genuinely a failure, and a
-                // failure returns no `WorkflowRun` to read rows off. Any
-                // approval such a run parked is still on the operator's
-                // Approvals page; what is lost is this event's *listing* of
-                // it, not the card.
-                blocked_nodes: Vec::new(),
-                approvals: Vec::new(),
-            },
+            Err(failed) => {
+                let partial = failed.partial;
+                Self {
+                    deliveries: partial.map(|p| p.deliveries.clone()).unwrap_or_default(),
+                    // The exception, and it is a claim: a failed run is not
+                    // waiting on anybody. Any gate it parked before it broke is
+                    // still decidable from the Approvals page — `approvals`
+                    // below is the receipt for that — but listing it here would
+                    // say this run intends to continue, which it does not.
+                    pending_approvals: Vec::new(),
+                    error: Some(failed.error.to_string()),
+                    cancelled: false,
+                    notices: partial.map(|p| p.notices.clone()).unwrap_or_default(),
+                    board: partial.map(|p| p.board.clone()).unwrap_or_default(),
+                    blocked_nodes: partial.map(|p| p.blocked_nodes.clone()).unwrap_or_default(),
+                    approvals: partial.map(|p| p.approvals.clone()).unwrap_or_default(),
+                }
+            }
         }
     }
 }
@@ -156,7 +202,7 @@ pub async fn record_run_finished(
     workflow_id: &str,
     scheduled: bool,
     run_id: &str,
-    outcome: Result<&WorkflowRun, &str>,
+    outcome: Result<&WorkflowRun, FailedRun<'_>>,
 ) -> bool {
     // Which fields ride which arm, and why, is documented on `Settled::from`.
     let settled = Settled::from(outcome);
@@ -294,7 +340,7 @@ pub async fn sweep_interrupted_runs(events: &Arc<dyn EventLog>, company: &Compan
             &workflow_id,
             scheduled,
             &run_id,
-            Err(INTERRUPTED_BY_RESTART),
+            Err(INTERRUPTED_BY_RESTART.into()),
         )
         .await;
     }
@@ -478,16 +524,30 @@ mod test {
     }
 
     /// The other direction, and the one that keeps the field honest: a run with
-    /// nothing to say carries an empty list, and a *failed* run carries none at
-    /// all rather than inheriting whatever the Ok arm would have had.
+    /// nothing to say carries an empty list, and a failure the caller knows
+    /// nothing else about carries none either — rather than inheriting whatever
+    /// the Ok arm would have had.
+    ///
+    /// Since issue #1008 that second clause is conditional on the *caller*: a
+    /// failure that arrives with a partial run does carry its notices, which
+    /// `a_run_that_delivered_and_then_failed_keeps_its_rows` pins. This one pins
+    /// the arm where there is genuinely nothing to read.
     #[tokio::test]
-    async fn an_ordinary_run_and_a_failed_run_carry_no_notices() {
+    async fn an_ordinary_run_and_a_failure_with_nothing_known_carry_no_notices() {
         let (_dir, events) = log();
         let company = CompanyId::new("acme");
 
         let ok = run_with(Vec::new(), Vec::new());
         record_run_finished(&events, &company, "wf", false, "run-ok", Ok(&ok)).await;
-        record_run_finished(&events, &company, "wf", false, "run-bad", Err("boom")).await;
+        record_run_finished(
+            &events,
+            &company,
+            "wf",
+            false,
+            "run-bad",
+            Err("boom".into()),
+        )
+        .await;
 
         for event in journaled(&events, &company).await {
             let CompanyEvent::WorkflowRunFinished { notices, .. } = event else {
@@ -495,6 +555,136 @@ mod test {
             };
             assert!(notices.is_empty(), "nothing to say means an empty list");
         }
+    }
+
+    /// Issue #1008's second half: a run that **delivered two reports and then
+    /// failed** still lists those deliveries.
+    ///
+    /// This is the arm that was hard-coded empty. The reports were already in
+    /// the recipients' inboxes by the time the later node broke, so journaling
+    /// zero delivery rows did not describe a run that sent nothing — it
+    /// described a run whose record disagreed with the world. The same holds for
+    /// the board card it opened, the approval it parked and the notice it
+    /// raised, so all four ride the failure arm together.
+    #[tokio::test]
+    async fn a_run_that_delivered_and_then_failed_keeps_its_rows() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+
+        let partial = WorkflowRun {
+            notices: vec!["a call was refused".to_string()],
+            board: vec![crate::ports::WorkflowRunBoardRow {
+                action: crate::ports::WorkflowBoardAction::Spawned,
+                task_id: Some("task-7".to_string()),
+                title: Some("Draft the summary".to_string()),
+                assignee: None,
+            }],
+            approvals: vec![crate::ports::WorkflowRunApprovalRow {
+                node_id: Some("work".to_string()),
+                tool: Some("shell".to_string()),
+                outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+                approval_id: Some("appr-1".to_string()),
+            }],
+            ..run_with(
+                vec![
+                    report("owner-summary", DeliveryStatus::Sent),
+                    report("board-summary", DeliveryStatus::Sent),
+                ],
+                Vec::new(),
+            )
+        };
+
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            false,
+            "run-bad",
+            Err(FailedRun {
+                error: "the third node died",
+                partial: Some(&partial),
+            }),
+        )
+        .await;
+
+        let CompanyEvent::WorkflowRunFinished {
+            deliveries,
+            error,
+            board,
+            approvals,
+            notices,
+            pending_approvals,
+            ..
+        } = journaled(&events, &company)
+            .await
+            .into_iter()
+            .find(|e| matches!(e, CompanyEvent::WorkflowRunFinished { .. }))
+            .expect("the failure was journaled")
+        else {
+            unreachable!("matched above")
+        };
+
+        assert_eq!(
+            deliveries.len(),
+            2,
+            "two reports were sent before the run broke; zeroing them tells the operator \
+             nothing went out: {deliveries:?}"
+        );
+        assert_eq!(
+            error.as_deref(),
+            Some("the third node died"),
+            "carrying the rows must not stop this reading as a failure"
+        );
+        assert_eq!(board.len(), 1, "the card is on the board: {board:?}");
+        assert_eq!(
+            approvals.len(),
+            1,
+            "the card is on the Approvals page: {approvals:?}"
+        );
+        assert_eq!(notices, vec!["a call was refused".to_string()]);
+        assert!(
+            pending_approvals.is_empty(),
+            "the one deliberate exception: a failed run is not waiting on anybody, however \
+             many gates it parked on the way down"
+        );
+    }
+
+    /// The other half of the same claim: a failure with **nothing known** about
+    /// what the run did still journals honestly empty rows rather than inventing
+    /// any. The boot sweep's synthetic finish is exactly this shape.
+    #[tokio::test]
+    async fn a_failure_with_no_partial_run_journals_empty_rows() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            false,
+            "run-bad",
+            Err("boom".into()),
+        )
+        .await;
+
+        let CompanyEvent::WorkflowRunFinished {
+            deliveries,
+            board,
+            approvals,
+            blocked_nodes,
+            ..
+        } = journaled(&events, &company)
+            .await
+            .into_iter()
+            .find(|e| matches!(e, CompanyEvent::WorkflowRunFinished { .. }))
+            .expect("the failure was journaled")
+        else {
+            unreachable!("matched above")
+        };
+        assert!(deliveries.is_empty());
+        assert!(board.is_empty());
+        assert!(approvals.is_empty());
+        assert!(blocked_nodes.is_empty());
     }
 
     fn report(node: &str, status: DeliveryStatus) -> DeliveryReport {
@@ -571,7 +761,7 @@ mod test {
             "digest",
             true,
             "run-1",
-            Err("agent node `worker` had no inference source"),
+            Err("agent node `worker` had no inference source".into()),
         )
         .await;
 
@@ -680,7 +870,7 @@ mod test {
             "digest",
             false,
             "run-bad",
-            Err("it broke"),
+            Err("it broke".into()),
         )
         .await;
         start(&events, &company, "run-dead", false).await;
@@ -961,7 +1151,15 @@ mod test {
             "owner",
         )
         .await;
-        record_run_finished(&events, &company, "digest", true, "run-1", Err("it broke")).await;
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            true,
+            "run-1",
+            Err("it broke".into()),
+        )
+        .await;
 
         assert_eq!(
             stranded(&events, &company, "digest").await,
@@ -1034,12 +1232,28 @@ mod test {
         let company = CompanyId::new("acme");
         start(&events, &company, "run-1", true).await;
         deliver(&events, &company, "digest", "run-1", "a", "owner").await;
-        record_run_finished(&events, &company, "digest", true, "run-1", Err("crash 1")).await;
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            true,
+            "run-1",
+            Err("crash 1".into()),
+        )
+        .await;
 
         start(&events, &company, "run-2", true).await;
         // run 2 skipped A (its own already_delivered saw it) and sent B.
         deliver(&events, &company, "digest", "run-2", "b", "owner").await;
-        record_run_finished(&events, &company, "digest", true, "run-2", Err("crash 2")).await;
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            true,
+            "run-2",
+            Err("crash 2".into()),
+        )
+        .await;
 
         assert_eq!(
             stranded(&events, &company, "digest").await,

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -56,7 +56,7 @@ use crate::company::WorkflowFile;
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::CompanyId;
 use crate::ports::{EventLog, WorkflowRun, WorkflowRunContext, WorkflowRunner};
-use crate::runtime::workflow_outcome::record_run_finished;
+use crate::runtime::workflow_outcome::{FailedRun, record_run_finished};
 use crate::runtime::{RunGuard, RunSupervisor};
 
 /// The error stamped on a run whose task **panicked** before it could journal a
@@ -231,7 +231,7 @@ impl WorkflowSpawn {
                             &workflow.id,
                             scheduled,
                             &ctx.run_id,
-                            Err(PANICKED_BEFORE_FINISH),
+                            Err(PANICKED_BEFORE_FINISH.into()),
                         )
                         .await;
                         // Issue #1009 (path B, surfaced): if even this finish
@@ -263,7 +263,11 @@ impl WorkflowSpawn {
                 // closed the tab; the record is what is still there tomorrow.
                 let outcome = match result.as_ref() {
                     Ok(run) => Ok(run),
-                    Err(err) => Err(err.to_string()),
+                    // Issue #1008: the message AND whatever the run had already
+                    // done. `partial_run` is `Some` only when the engine broke
+                    // after nodes had run, so a run refused before it started
+                    // still journals an honestly empty row.
+                    Err(err) => Err((err.to_string(), err.partial_run())),
                 };
                 let journaled = match outcome {
                     Ok(run) => {
@@ -277,14 +281,17 @@ impl WorkflowSpawn {
                         )
                         .await
                     }
-                    Err(err) => {
+                    Err((err, partial)) => {
                         record_run_finished(
                             &self.events,
                             &self.company,
                             &workflow.id,
                             scheduled,
                             &ctx.run_id,
-                            Err(err.as_str()),
+                            Err(FailedRun {
+                                error: err.as_str(),
+                                partial,
+                            }),
                         )
                         .await
                     }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -32,7 +32,11 @@ impl From<serde_json::Error> for ApiError {
 impl ApiError {
     /// The HTTP status this error maps to.
     pub fn status(&self) -> StatusCode {
-        match &self.0 {
+        // Issue #1008: a failed workflow run wraps its cause so it can carry the
+        // partial run back for the journal. Classify the cause — a graph that
+        // failed validation is still a 400 whether or not partial rows rode home
+        // with it.
+        match self.0.unwrapped() {
             OpenCompanyError::CompanyNotFound(_) | OpenCompanyError::NotFound(_) => {
                 StatusCode::NOT_FOUND
             }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2649,7 +2649,7 @@ async fn list_runs(
             &entry.workflow_id,
             entry.scheduled,
             &run_id,
-            Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART),
+            Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.into()),
         )
         .await;
         // In-memory half: flip the row this response returns, so the console does

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -591,6 +591,33 @@ async fn a_blocked_run_persists_the_partial_output_it_reached() {
         "the node that succeeded before the block must be in the partial snapshot: {}",
         stored.nodes
     );
+
+    // Issue #881's invariant, one surface over: the blocked node produced
+    // nothing, so it has no entry. Its turn ended by writing prose about being
+    // refused, and filing that prose as the node's output would re-open in the
+    // inspector exactly the confusion #881 fixed by stopping it reaching the
+    // next node.
+    assert!(
+        stored.nodes.get("work").is_none(),
+        "a blocked node's refusal prose must not be filed as its output: {}",
+        stored.nodes
+    );
+
+    // And the settled body carries the same capture, so the live run drawer and
+    // a run reopened from History cannot disagree about what the run produced.
+    assert!(
+        run.output.to_string().contains("BLOCK-MARKER-42"),
+        "the blocked run must report the output it reached, not `null`: {}",
+        run.output
+    );
+    assert!(
+        run.output
+            .get("nodes")
+            .and_then(|n| n.get("work"))
+            .is_none(),
+        "and must exclude the blocked node there too: {}",
+        run.output
+    );
 }
 
 #[cfg(test)]

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -646,10 +646,8 @@ async fn run_workflow_inner(
             let partial_output = Value::Object(partial_nodes);
             if blocked.is_empty() || !only_blocked_nodes_errored(&nodes, &blocked) {
                 // A genuine failure. Persist the partial capture so the inspector
-                // shows what the nodes that ran produced. Log-only on a write
-                // error (Part 3): this branch returns `Err`, so there is no
-                // `WorkflowRun` to hang a notice on.
-                let _ = persist_run_output(
+                // shows what the nodes that ran produced.
+                if !persist_run_output(
                     run_output_store.as_deref(),
                     &record.id,
                     &workflow.id,
@@ -657,8 +655,37 @@ async fn run_workflow_inner(
                     &partial_output,
                     true,
                 )
-                .await;
-                return Err(map_engine_error(err));
+                .await
+                {
+                    // This branch used to be log-only, because it returns `Err`
+                    // and an `Err` had no `WorkflowRun` to hang a notice on. It
+                    // has one now (below), so the operator hears about a lost
+                    // snapshot on the failure arm exactly as on the blocked one.
+                    notices.push(run_output_persist_failed_notice());
+                }
+                // Issue #1008 (second half): the failure carries the partial run
+                // rather than only a message. The nodes that ran before the break
+                // really did open board cards, park approvals and raise notices,
+                // and those are durable facts by now — so the caller's
+                // `record_run_finished` can list them instead of journaling a
+                // failed run as an empty one. See `OpenCompanyError::partial_run`.
+                return Err(OpenCompanyError::WorkflowRunFailed {
+                    source: Box::new(map_engine_error(err)),
+                    partial: Box::new(WorkflowRun {
+                        output: partial_output,
+                        pending_approvals: Vec::new(),
+                        deliveries: Vec::new(),
+                        cancelled: false,
+                        nodes,
+                        notices: notices.take(),
+                        board: board.take(),
+                        // Non-empty exactly when a real failure and a block
+                        // happened together — the case the containment check
+                        // above refuses to relabel as a plain block.
+                        blocked_nodes: blocked,
+                        approvals: approvals.take(),
+                    }),
+                });
             }
             tracing::info!(
                 company = %record.id,
@@ -668,6 +695,15 @@ async fn run_workflow_inner(
                 "workflow: the run stopped because a node is waiting on an operator, not because \
                  it failed"
             );
+            // Issue #1008: minus the blocked nodes' own entries, and that
+            // subtraction is issue #881's invariant rather than tidiness. A node
+            // refused inside its model's tool loop ends its turn by writing
+            // *prose about being blocked*, and the engine records that prose as
+            // the step's output. #881 stopped that apology travelling to the next
+            // node; letting it ride the run inspector as the node's product would
+            // re-open the same lie one surface over. The node's `blocked` chip and
+            // the run's notice already say what happened.
+            let partial_output = without_nodes(partial_output, &blocked);
             // A blocked run DOES return a `WorkflowRun`, so a failed persist adds
             // an operator-facing notice rather than only a log line (Part 6).
             if !persist_run_output(
@@ -688,6 +724,13 @@ async fn run_workflow_inner(
                 notices,
                 board: board.take(),
                 approvals: approvals.take(),
+                // Issue #1008: the same capture the durable snapshot took, so a
+                // live run drawer and a run reopened from History show one thing
+                // rather than disagreeing about what the run produced. Wrapped
+                // under `nodes` because that is the shape every reader of
+                // `WorkflowRun.output` already parses — the durable record stores
+                // the bare map, the run body carries the engine's envelope.
+                output: serde_json::json!({ "nodes": partial_output }),
             }));
         }
         None => {
@@ -1035,6 +1078,10 @@ struct BlockedRun {
     notices: super::caps::RunNotices,
     board: Vec<crate::ports::WorkflowRunBoardRow>,
     approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
+    /// Issue #1008: what the nodes upstream of the block produced, in the
+    /// engine's `{ "nodes": { "<id>": { "items": [ … ] } } }` envelope, with the
+    /// blocked nodes' own entries already removed by the caller.
+    output: Value,
 }
 
 /// Settles a run that stopped because a node is waiting on an operator (issue
@@ -1051,14 +1098,22 @@ struct BlockedRun {
 ///
 /// Each emptiness below is a claim rather than a shrug:
 ///
-/// * **no `output`** — the engine returned an error, not a final state. There is
-///   no partial state to report, and the per-node output snapshot the console
-///   inspector reads is likewise not written: nothing settled to persist. The
-///   blocked node in particular produced nothing, which is the entire point;
 /// * **no `deliveries`** — `deliver_outputs` runs off the settled output, which
 ///   does not exist here. An absent row already means "not reached" everywhere
 ///   else, and a run that stopped short must not mail anybody a report of work
 ///   it did not finish.
+///
+/// # `output` is threaded in, not emptied (issue #1008)
+///
+/// It used to be `Value::Null`, on the argument that "the engine returned an
+/// error, not a final state". That holds for the engine's *merged* state and not
+/// for the nodes: everything upstream of the block ran to completion and
+/// produced real items, which the progress observer collected on the way past.
+/// Reporting none of it made the run inspector say "no output for this node"
+/// about a node that had just written a draft. The caller threads its collected
+/// capture in — the same value it persisted — having first removed the blocked
+/// nodes' own entries, so "the blocked node produced nothing" stays literally
+/// true here.
 ///
 /// `notices` carries the operator-facing sentence, composed from the structural
 /// blocked rows so the wording lives in one place and no model prose or store
@@ -1070,6 +1125,7 @@ fn blocked_run(settled: BlockedRun) -> WorkflowRun {
         notices,
         board,
         approvals,
+        output,
     } = settled;
     for b in &blocked {
         notices.push(blocked_notice(b));
@@ -1077,7 +1133,7 @@ fn blocked_run(settled: BlockedRun) -> WorkflowRun {
     let mut pending_approvals = Vec::new();
     reclassify_blocked(&mut nodes, &mut pending_approvals, &blocked);
     WorkflowRun {
-        output: Value::Null,
+        output,
         pending_approvals,
         deliveries: Vec::new(),
         cancelled: false,
@@ -1087,6 +1143,25 @@ fn blocked_run(settled: BlockedRun) -> WorkflowRun {
         blocked_nodes: blocked,
         approvals,
     }
+}
+
+/// Drops `blocked`'s nodes from a collected `{ "<id>": { "items": [ … ] } }`
+/// capture (issue #1008).
+///
+/// A blocked node produced nothing, so it must have no entry — see the call site
+/// for why that is issue #881's invariant and not a cosmetic choice. A value of
+/// another shape is returned untouched: this narrows a map it recognises and
+/// never invents one.
+fn without_nodes(mut output: Value, blocked: &[crate::ports::WorkflowBlockedNode]) -> Value {
+    if blocked.is_empty() {
+        return output;
+    }
+    if let Value::Object(nodes) = &mut output {
+        for b in blocked {
+            nodes.remove(&b.node_id);
+        }
+    }
+    output
 }
 
 /// The operator's sentence for one blocked node (issue #881).
@@ -2132,6 +2207,70 @@ to = "boom"
                 .is_some(),
             "the node that succeeded before the failure must be in the partial snapshot: {}",
             stored.nodes
+        );
+
+        // Issue #1008 (second half): the failure also carries the partial run up
+        // to the caller, so `record_run_finished` can journal what the run did
+        // before it broke instead of an all-empty row.
+        let partial = err
+            .partial_run()
+            .expect("a run that broke mid-graph reports what it had already done");
+        assert!(
+            partial.nodes.iter().any(|n| n.node_id == "export"),
+            "{:?}",
+            partial.nodes
+        );
+        assert!(
+            !partial.cancelled,
+            "a failure is not an operator stop, whatever else it carries"
+        );
+        assert!(
+            partial.output.get("export").is_some(),
+            "the partial run reports the same capture that was persisted: {}",
+            partial.output
+        );
+    }
+
+    /// Issue #1008: `without_nodes` removes exactly the blocked nodes' entries
+    /// and leaves everything else — including a capture of another shape —
+    /// untouched.
+    ///
+    /// Unit-level beside the end-to-end proof in `blocked_node_test`, because
+    /// the "leaves a value it does not recognise alone" half has no reachable
+    /// path through a real run and would otherwise be an untested branch.
+    #[test]
+    fn without_nodes_removes_only_the_blocked_entries() {
+        let blocked = |id: &str| crate::ports::WorkflowBlockedNode {
+            node_id: id.to_string(),
+            tools: vec!["shell".to_string()],
+            approval_ids: Vec::new(),
+            unparkable: 0,
+        };
+
+        let capture = serde_json::json!({
+            "writer": { "items": ["draft"] },
+            "publish": { "items": ["apology prose"] },
+        });
+        let narrowed = without_nodes(capture, &[blocked("publish")]);
+        assert!(narrowed.get("writer").is_some(), "{narrowed}");
+        assert!(
+            narrowed.get("publish").is_none(),
+            "the blocked node produced nothing, so it must have no entry: {narrowed}"
+        );
+
+        // Nothing blocked: returned verbatim rather than rebuilt.
+        let untouched = serde_json::json!({ "writer": { "items": ["draft"] } });
+        assert_eq!(
+            without_nodes(untouched.clone(), &[]),
+            untouched,
+            "a run that blocked on nobody is byte-unchanged"
+        );
+
+        // A value of another shape is not a map to narrow — returned as-is
+        // rather than replaced with an invented one.
+        assert_eq!(
+            without_nodes(Value::Null, &[blocked("publish")]),
+            Value::Null
         );
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **This is not only a follow-up — it fixes a regression in #1041, which merged today.**
>
> A node refused inside its model's tool loop ends its turn by writing *prose about being blocked*, and the engine records that prose as the step's `output`. #1041's collector inserts **every** finished step's output into the capture unfiltered, so on `main` right now that apology is filed under the **blocked node's own id** and the run inspector renders it as that node's product.
>
> Issue #881 exists precisely because that apology used to travel to the *next* node as if it were the artifact. This is the same failure one surface over. This PR excludes blocked nodes' entries from the capture, on both the durable snapshot and the run body.
>
> Related, same area: `blocked_run` still returns `output: Value::Null` (`runner.rs:1080`), so the **live run drawer shows nothing** for a blocked run even though the durable snapshot now holds the data. This PR carries the same capture there too.

## What changed since this PR opened

This PR opened at 14:24 against issue #1008. **PR #1041 merged at 14:49** with an independent fix for the same issue, covering the persist-on-failed/blocked arms, the `partial` flag on `WorkflowRunOutputRecord`, the persist-failure notice, and the console badge.

Rather than leave a duplicate open, this branch has been **rebuilt from scratch on top of #1041** and narrowed to what #1041 did not do. #1041's implementation is taken wholesale — nothing already on `main` is re-landed — and its two tests are *extended* rather than duplicated. Everything below is additive to what is already on `main`.

## Summary

### 1. The issue's second bullet, still unfixed on `main`

From #1008:

> `Settled::from`'s Err arm zeroes `deliveries`, `board`, `blocked_nodes` and `approvals`. A run that delivered two reports and *then* failed shows zero delivery rows.

`Settled::from` on `main` still hard-codes all five empty on the failure arm; #1041 never opened that file. The argument in its doc — that a failure "returns no `WorkflowRun` to read rows off" — was true of the signature, not of the world: every one of those rows records something the run **already did**, and all of them are durable by the time it breaks. A run that mailed two owner summaries and then died at a later node journals `deliveries: []`, which reads as "it sent nothing" while the reports sit in people's inboxes. A run that opened a board card and then failed leaves the card on the board with no run admitting to opening it.

- `record_run_finished` now takes `FailedRun { error, partial }` (with `From<&str>`, so every call site that only has a message reads as it did).
- The runner threads the partial run up on a new `OpenCompanyError::WorkflowRunFailed`, which **wraps** its cause: `Display`, `code()` and the HTTP status are byte-identical, so a caller that never asks for the partial cannot tell the wrapper apart from the error inside it. `ApiError::status` classifies `self.0.unwrapped()`.
- `pending_approvals` stays empty on purpose — a failed run is not waiting on anybody. Any gate it parked is still decidable from the Approvals page, and `approvals` is the receipt for that.

### 2. The failure arm's persist notice, which #1041 had to leave log-only

#1041's own comment says it plainly:

> Log-only on a write error (Part 3): this branch returns `Err`, so there is no `WorkflowRun` to hang a notice on.

It has one now, so a lost snapshot reaches the operator on the failure arm exactly as it does on the blocked arm.

### 3. The blocked arm — the regression fix in the callout above

See the note at the top. Both halves: the blocked node's refusal prose is excluded from the capture, and `WorkflowRun.output` carries the capture instead of `null`.

## Commands run locally

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --features openhuman,tinycortex -- -D warnings` | clean |
| `cargo test --features openhuman,tinycortex --tests` | `4324 passed; 0 failed; 3 ignored` (lib) + `10` / `1` / `11` / `2` across the four integration targets, all `0 failed` |
| `cargo check --all-targets` (default features) | clean |

The full gated suite, not a filtered subset.

## Tests

- `runtime::workflow_outcome::test::a_run_that_delivered_and_then_failed_keeps_its_rows` — the headline: two deliveries, a board card, a parked approval and a notice all survive the failure arm; `pending_approvals` stays empty.
- `runtime::workflow_outcome::test::a_failure_with_no_partial_run_journals_empty_rows` — the other half: a failure with nothing known still journals honestly empty rows (the boot-sweep shape).
- `workflows::runner::tests::a_failed_run_persists_the_partial_output_it_reached` — **extends #1041's test**: the error also carries the partial run, with the reached node's rows and the same capture that was persisted.
- `workflows::runner::tests::without_nodes_removes_only_the_blocked_entries` — unit-level, including the "leaves a value it does not recognise alone" branch that no real run reaches.
- `workflows::blocked_node_test::a_blocked_run_persists_the_partial_output_it_reached` — **extends #1041's test**: the blocked node has no entry in the snapshot, and the settled body carries the same capture rather than `null`. Both assertions fail against `main`.

`an_ordinary_run_and_a_failed_run_carry_no_notices` is renamed to `…_and_a_failure_with_nothing_known_…`, because its second claim is now conditional on the caller.

## API / behavior changes

- New `OpenCompanyError::WorkflowRunFailed { source, partial }`, plus `partial_run()` and `unwrapped()`. Additive by construction — see above.
- `record_run_finished`'s error arm takes `FailedRun` instead of `&str`.
- A blocked run's `output` is no longer `null` on the HTTP response, and excludes blocked nodes. `docs/modules/server/workflow-routes.md` is updated, since it documented the old value.

## Not in scope

The console rendering of `partial` shipped with #1041. The other issues on this surface (#1009–#1017) are their own.

Refs #1008 — the persist half is already closed by #1041; this closes the `Settled::from` half and fixes the blocked-node capture.
