### PR TITLE
fix(approvals): say what a parked payload's age is an age of

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -298,6 +298,10 @@ export interface ApprovalSummary {
   /** The parked effect's dotted kind, e.g. "payment.send". */
   kind: string;
   amount_usd: number | null;
+  /**
+   * Epoch-millis the effect was parked — stamped in the same turn that composed
+   * its arguments, so it dates the **payload**, not the queue (#1024).
+   */
   at_millis: number;
   /**
    * Epoch-millis this approval default-denies if nobody decides it (#971) —
@@ -314,6 +318,19 @@ export interface ApprovalSummary {
    * than guessing one.
    */
   expires_at_millis?: number | null;
+  /**
+   * The host's consequence group for the parked effect (#1024).
+   *
+   * Derived server-side from the tool **and its arguments**, so a
+   * `composio_execute` carrying `GMAIL_SEND_EMAIL` arrives as `"send"` rather
+   * than as the catch-all its tool name alone implies. It cannot be computed
+   * here: for a harness tool call `kind` is the tool name, so a console keying
+   * on `kind` would miss exactly the outbound sends this marks.
+   *
+   * Optional, and that is how an old host degrades: no field, no age label,
+   * exactly the pre-#1024 card.
+   */
+  group?: "spend" | "send" | "sign" | "publish" | "hire" | "identity" | "other";
   /**
    * Which board task this approval was parked for (#333). Mirrors `TaskLink` in
    * `src/runtime/journal.rs`.

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -38,7 +38,7 @@ import {
 
 import type { OpenCompanyClient } from "@/api/client";
 import { GRANT_DURATIONS, type ApprovalSummary, type GrantScope } from "@/api/types";
-import { approvalAction, money, payloadLines, timeAgo, untilLabel } from "@/lib/language";
+import { approvalAction, money, payloadAge, payloadLines, untilLabel } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
 const KIND_ICONS: Record<string, LucideIcon> = {
@@ -126,6 +126,8 @@ export function ApprovalMeta({
   // An id the roster does not know still beats no attribution at all — the
   // operator can at least tell two askers apart.
   const asker = a.agent ? (askerNames.get(a.agent) ?? a.agent) : null;
+  // #1024, computed once: the age, and whether this card should say it loudly.
+  const age = payloadAge(a, now);
 
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
@@ -149,9 +151,25 @@ export function ApprovalMeta({
           <span aria-hidden>·</span>
         </>
       )}
-      <span>{timeAgo(a.at_millis, now)}</span>
-      {/* The deadline (#971), beside how long it has already waited — the two
-          halves of "is this still worth deciding?".
+      {/*
+       * #1024. The same integer means two different things depending on where it
+       * sits. In this footer, between "Asked by Maya" and "Open the card", a bare
+       * "5d ago" reads as QUEUE LATENCY — how long the operator's backlog has held
+       * this — a fact about the queue. What decides an outbound send is that the
+       * PAYLOAD is five days old, a fact about the content. A digest built from
+       * 13 Aug mailed as "Weekly Digest — 18 Aug" the moment a backlog was cleared,
+       * and the report says why nobody caught it: "from the operator's side it
+       * looked like a routine send." The signal was not missing — it was
+       * unlabelled, and dressed as routing metadata.
+       *
+       * Wording and emphasis both come from `payloadAge`, so they are testable as
+       * a string rather than only as rendered output.
+       */}
+      <span className={age.emphasise ? "font-medium text-foreground" : undefined}>
+        {age.text}
+      </span>
+      {/* The deadline (#971), beside how old the payload is — the two halves of
+          "is this still worth deciding?".
 
           Rendered only when the host reports one. An absent
           `expires_at_millis` means the host does not have deadlines, NOT that

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -591,6 +591,44 @@ export const FEEDBACK_CATEGORIES: { value: FeedbackCategory; label: string }[] =
 ];
 
 /** A short relative time like "2m ago", "3h ago", "just now". */
+/**
+ * Does approving this put something outside the company (#1024)?
+ *
+ * Reads the host's own `group`, never the effect `kind`. For a harness tool call
+ * `kind` IS the tool name — `composio_execute`, not `email.send` — so a predicate
+ * keyed on `kind` would match the native effects the icon table knows and miss
+ * the composio `GMAIL_SEND_EMAIL` send this was reported for. `group` is derived
+ * host-side from the tool *and its arguments*, the only place that is known.
+ *
+ * `other` is the catch-all internal bucket — the same line the host draws for
+ * `broadly_grantable`. An absent `group` is an older host and reads as internal,
+ * so the card renders exactly as it did before rather than labelling something
+ * this console cannot classify.
+ */
+export function leavesTheCompany(a: ApprovalSummary): boolean {
+  return a.group != null && a.group !== "other";
+}
+
+/**
+ * How old the parked payload is, and whether to say so loudly (#1024).
+ *
+ * `at_millis` is stamped when the effect is parked, in the same turn that
+ * composed its arguments — so it dates the payload, not the queue, and
+ * "Composed" is the honest word. "Parked" would be closer to the field name and
+ * would reintroduce the exact reading this fixes: parking is a queue event, and
+ * a queue reading is what let a five-day-old digest look routine.
+ *
+ * Labelled only for effects that leave the company. Elsewhere the age genuinely
+ * IS queue latency, and labelling it everywhere would spend the emphasis where
+ * it does not matter and dilute it where it does.
+ */
+export function payloadAge(a: ApprovalSummary, now: number): { text: string; emphasise: boolean } {
+  const age = timeAgo(a.at_millis, now);
+  return leavesTheCompany(a)
+    ? { text: `Composed ${age}`, emphasise: true }
+    : { text: age, emphasise: false };
+}
+
 export function timeAgo(atMillis: number, now: number): string {
   const secs = Math.max(0, Math.floor((now - atMillis) / 1000));
   if (secs < 45) return "just now";

--- a/frontend/test/unit/approval-payload-age.test.ts
+++ b/frontend/test/unit/approval-payload-age.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { ApprovalSummary } from "@/api/types";
+import { leavesTheCompany, payloadAge } from "@/lib/language";
+
+/**
+ * Issue #1024: a `GMAIL_SEND_EMAIL` gate sat parked for days, and the moment an
+ * operator cleared a backlog it mailed a digest built from 13 Aug under the
+ * heading "Weekly Digest — 18 Aug 2026".
+ *
+ * The age was already on the card. It rendered as a bare "5d ago" in the footer
+ * between "Asked by Maya" and "Open the card" — routing metadata — where it
+ * reads as how long the QUEUE has held the item. What decides an outbound send
+ * is that the PAYLOAD is five days old. Same integer, different fact, and only
+ * the second one should stop a send. Hence the report's "from the operator's
+ * side it looked like a routine send".
+ *
+ * These pin the label, not the number: asserting a time string alone would pass
+ * against the pre-fix card too.
+ */
+const NOW = 1_755_500_000_000;
+const FIVE_DAYS = 5 * 24 * 60 * 60 * 1000;
+
+function approval(over: Partial<ApprovalSummary> = {}): ApprovalSummary {
+  return {
+    id: "a-1",
+    kind: "composio_execute",
+    amount_usd: null,
+    at_millis: NOW - FIVE_DAYS,
+    ...over,
+  } as ApprovalSummary;
+}
+
+describe("how old the parked payload is", () => {
+  it("says what the age is OF on an effect that leaves the company", () => {
+    // The #1024 case exactly: a composio send, five days parked.
+    const age = payloadAge(approval({ group: "send" }), NOW);
+    expect(age.text).toBe("Composed 5d ago");
+    expect(age.emphasise).toBe(true);
+  });
+
+  it("leaves an internal effect's age unlabelled", () => {
+    // On a card that sends nothing outward the age genuinely IS queue latency,
+    // and labelling it "Composed" everywhere would spend the emphasis where it
+    // does not matter.
+    const age = payloadAge(approval({ group: "other" }), NOW);
+    expect(age.text).toBe("5d ago");
+    expect(age.emphasise).toBe(false);
+  });
+
+  it("labels every outward group, not just sends", () => {
+    for (const group of [
+      "spend",
+      "send",
+      "sign",
+      "publish",
+      "hire",
+      "identity",
+    ] as const) {
+      expect(payloadAge(approval({ group }), NOW).text).toBe("Composed 5d ago");
+    }
+  });
+
+  it("claims nothing when the host does not classify the effect", () => {
+    // An older host omits `group`. Silence is honest: the card renders exactly
+    // as it did before #1024 rather than labelling something this console
+    // cannot actually classify.
+    const age = payloadAge(approval(), NOW);
+    expect(age.text).toBe("5d ago");
+    expect(age.emphasise).toBe(false);
+  });
+
+  it("reads outbound-ness from the host's group, never from the effect kind", () => {
+    // The trap this exists to stop. For a harness tool call `kind` is the TOOL
+    // NAME, so a predicate keyed on `kind` would miss the composio send that
+    // #1024 was reported for while matching native effects like "email.send".
+    expect(
+      leavesTheCompany(approval({ kind: "composio_execute", group: "send" })),
+    ).toBe(true);
+    expect(
+      leavesTheCompany(approval({ kind: "email.send", group: "other" })),
+    ).toBe(false);
+  });
+});

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2159,6 +2159,11 @@ impl CompanyRuntime {
                 expires_at_millis: Some(
                     p.at_millis.saturating_add(self.approval_gate.ttl_millis()),
                 ),
+                // Issue #1024: the host's own classification, not the console's
+                // guess. `kind` is the tool name for a harness call, so this is
+                // the only field that distinguishes an outbound send from an
+                // internal effect.
+                group: p.effect.group,
                 task: p.task,
                 agent: p.effect.agent.clone(),
                 payload: crate::runtime::approval_display::display_payload(&p.effect),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -3772,6 +3772,52 @@ mod test {
 
     // --- What the card says (issue #372) ------------------------------------
 
+    /// **Issue #1024.** The parked effect's consequence group reaches the card.
+    ///
+    /// A `GMAIL_SEND_EMAIL` gate sat parked for days and mailed a five-day-old
+    /// digest the moment an operator cleared a backlog. The age was already on
+    /// the card — as a bare "5d ago" in the footer, where it reads as how long
+    /// the QUEUE has held the item rather than how old the PAYLOAD is. The
+    /// console can only tell those apart for an effect that leaves the company,
+    /// and it cannot work out which those are on its own: for a harness tool
+    /// call `kind` is the TOOL NAME (`composio_execute`), not `email.send`, so
+    /// a console keying on `kind` would miss exactly this send.
+    ///
+    /// So the host's own classification has to ride on the summary. This pins
+    /// that it is the PARKED EFFECT's group and not a constant: a summary that
+    /// hard-coded `Other` would render every outbound send as internal and put
+    /// the bug straight back.
+    #[tokio::test]
+    async fn a_parked_effect_carries_its_group_to_the_card() {
+        let home_dir = tmp_home();
+        let mut effect = harness_effect(
+            "devrel",
+            "composio_execute",
+            serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" }),
+        );
+        // The group a real `composio_execute` of a send resolves to.
+        effect.group = EffectGroup::Send;
+        let (rt, _id) = park_one(home_dir.path().to_path_buf(), effect).await;
+
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].group,
+            EffectGroup::Send,
+            "the card must carry the parked effect's own group; anything constant \
+             renders an outbound send as internal"
+        );
+        // And the tool name is NOT the discriminator — the reason the group has
+        // to be sent at all.
+        assert_eq!(pending[0].kind, "composio_execute");
+
+        // It survives the wire: the console reads this field, so a summary that
+        // classified correctly and serialized nothing would be no fix.
+        let wire: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&pending[0]).unwrap()).unwrap();
+        assert_eq!(wire["group"], "send");
+    }
+
     /// A harness-projected park reaches the operator naming its asker and what
     /// it will actually do — the whole point of #372, where the card used to say
     /// only "Shell".

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ports::types::{
-    ApprovalId, CompanyId, Effect, EventSeq, OutboundMessage, TemplateProvenance,
+    ApprovalId, CompanyId, Effect, EffectGroup, EventSeq, OutboundMessage, TemplateProvenance,
 };
 
 /// Which board task an approval was parked for (issue #333).
@@ -120,6 +120,13 @@ pub struct ApprovalSummary {
     /// The USD amount involved, if any.
     pub amount_usd: Option<f64>,
     /// Epoch-millis the effect was parked.
+    ///
+    /// Stamped by `CycleRunner::park` in the same turn that composed the
+    /// effect's arguments, so it dates the PAYLOAD, not the queue: it is read
+    /// back off the journal record on replay rather than re-stamped, so a host
+    /// restart does not reset it to boot time. That is what lets the console
+    /// say how old the content is rather than how long the card has sat
+    /// (issue #1024).
     pub at_millis: u64,
     /// Epoch-millis this approval default-denies if nobody decides it
     /// (issue #971) — `at_millis` plus the gate's TTL.
@@ -141,6 +148,19 @@ pub struct ApprovalSummary {
     /// host does not report deadlines" and renders the card exactly as before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at_millis: Option<u64>,
+    /// The consequence group of the parked effect (issue #1024).
+    ///
+    /// Copied off [`Effect::group`], which the harness derives from the tool
+    /// AND its arguments — so a `composio_execute` carrying `GMAIL_SEND_EMAIL`
+    /// arrives here as [`EffectGroup::Send`], not as the catch-all its tool
+    /// name alone would suggest.
+    ///
+    /// The console needs it to tell an effect that leaves the company from one
+    /// that does not, and it cannot be derived client-side: for a harness tool
+    /// call `kind` is the TOOL NAME, so a console keying on `kind` would miss
+    /// exactly the outbound sends this exists to mark. Sending the host's own
+    /// classification keeps that judgement in one place.
+    pub group: EffectGroup,
     /// Which board task this approval was parked for (issue #333).
     ///
     /// Three states, and the Task Detail read depends on telling them apart:

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -152,6 +152,7 @@ mod tests {
         ApprovalSummary {
             id: ApprovalId::new("appr-1"),
             kind: "email.send".to_string(),
+            group: crate::ports::types::EffectGroup::Send,
             amount_usd: Some(2400.0),
             at_millis: 1_000,
             expires_at_millis: Some(87_400_000),


### PR DESCRIPTION
## Summary

A `GMAIL_SEND_EMAIL` gate sat parked for days. The moment an operator cleared an approvals backlog it
sent — mailing a digest built from **13 Aug** data under the heading **"Weekly Digest — 18 Aug 2026"**,
to a real recipient, over the company's name.

**The age was already on the card.** That is the finding, and it is why "add the age" would have been a
no-op with a comment claiming to fix a live bug.

It rendered as a bare `5d ago`, in muted 12px footer text, between *"Asked by Maya"* and *"Open the
card"* — routing metadata. In that position the number reads as **queue latency**: how long the
operator's backlog has held this item. What decides an outbound send is that the **payload** is five
days old. Same integer, two different facts, and only the second should stop a send.

That is exactly what the report describes: *"From the operator's side it looked like a routine send."*
The signal was not missing. It was **unlabelled**, and dressed as metadata.

So this says what the age is **of**, and gives it a weight the surrounding metadata does not have:

> Asked by Maya · Open the card · **Composed 5d ago** · declined in 3h

## Why not re-validate the payload instead

The obvious question a reviewer asks — *"why not just re-run it and recompose?"* — has an answer in the
code, and it is a decision rather than an omission.

Per #243 approving does not resume a suspended call: it refuses the gated call, mints a **single-use
grant**, and re-dispatches. The payload is frozen in `GrantedCall.args`, and `redispatch_granted_call`
(`src/harness/brain.rs`) builds the re-dispatch instruction from the **stored** arguments:

```rust
let args = serde_json::to_string(&grant.args)…;
instruction: format!(
    "Operator approved your `{tool}` call. Re-issue it now with EXACTLY these \
     arguments: {args}. Do not modify them.", …)
```

with the code's own note: *"Re-issue verbatim. The grant admits ONE call matching these arguments
exactly, so any drift the model introduces will simply re-park."*

**Two independent locks, both deliberate.** The instruction tells the model not to recompose, and
`GrantSet::consume` matches `(agent, tool, args)` by whole-value equality — so a recomposed payload
would not match the grant and would **re-park rather than send**.

Recomposing on approval would therefore authorise content the operator never saw. That is a worse
defect than staleness: a stale send is at least the thing the human read. **Showing the age is the fix
here, not a consolation prize.**

## What the age actually measures

`at_millis` is stamped by `CycleRunner::park` in the **same turn that composed the arguments**, and both
journal fold sites read it back off the record rather than re-stamping — so it survives replay instead
of resetting to boot time. It dates the payload, not the queue.

Strictly the field is *park* time; compose and park differ by the remainder of one turn, i.e. seconds.
**"Composed" is the deliberate word.** "Parked" would be closer to the field name and would reintroduce
the precise reading this fixes — parking is a queue event, and the queue reading is what let a
five-day-old digest look routine.

## Outbound only, and why the host has to say so

Labelled only for effects that leave the company. Elsewhere the age genuinely *is* queue latency, and
labelling everything would spend the emphasis where it does not matter.

**The console cannot work out which those are.** `effect_for` sets `kind` to the **tool name** and
`group` from `classify_group(tool, args)`, so the reported send arrives as
`kind: "composio_execute"` — not `email.send`. A console rule keyed on `kind` (or on the icon table)
would match native effects and **miss exactly the send this was reported for**. A classifier that misses
the reported case is worse than none.

So `ApprovalSummary` now carries the parked effect's `group`, read straight off `Effect::group` at the
single projection point. Outbound is `group != "other"` — the same line the host already draws for
`broadly_grantable`. The judgement stays in one place.

## API Or Behavior Changes

**Additive.** `ApprovalSummary` gains `group`; the console DTO types it optional, so an older host
omitting it renders exactly the pre-#1024 card rather than labelling something the console cannot
classify.

The label lands on **both** approval surfaces, because it is in the shared `ApprovalMeta` — the
Approvals page and the chat approval row.

**No TTL, deliberately.** An outbound send that silently expires is a *new* failure mode: the operator
approves, nothing happens, nobody is told. A stale send is at least visible to its recipient; a silent
non-send is visible to nobody. Refusing loudly needs a synchronous channel back to the operator who just
clicked approve, and the resolve path answers before the follow-up completes — that surface is its own
change, and half of it is worse than none.

**Rebased onto #971 (#1028), not around it.** That sibling landed mid-work and touches the same struct,
the same projection map and the same footer line. `ApprovalSummary` now carries both `expires_at_millis`
(#971) and `group` (#1024); the footer composes as `Composed 5d ago · declined in 3h` — how old the
payload is, and how long is left to decide. Worth stating because a payload-age diff adjacent to that
code should be read as a deliberate merge rather than a collision.

**Not in scope:** #971 itself (the internal-facing sibling — a stale internal approval wastes attention;
this one leaves the company), and whether a report that declares itself partial should be sendable at
all — the digest advertised *"PARTIAL: 17 of 32 issues enumerated"* and shipped anyway. That is filed
separately rather than folded in here.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs it:
  `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`.
- [x] `cargo build --all-targets` — `--locked --features openhuman,tinycortex --all-targets`.
- [x] `cargo test` — `cargo test --locked --features openhuman,tinycortex --tests`:
  **4302 passed, 0 failed, 3 ignored**. Default features are not sufficient here; they skip roughly a
  third of the code.

Plus the console's own lane, since that is where this change lives: `npm run typecheck` (exit 0),
`vitest` — **944 passed across 95 files** — and `npm run build` (exit 0).

Every number above was measured on **this** tree: after dropping an unrelated commit that had landed
underneath this branch, and after rebasing onto current `main`. An earlier green on the contaminated
stack is not evidence about this one, so it is not quoted.

### Both halves verified to gate

A rendering test that asserts only the presence of a time string passes against the pre-fix card too, so
the wording is extracted into a pure `payloadAge()` and the test asserts the **string**:

* **Console** — reverting to the bare age fails with
  `expected '5d ago' to be 'Composed 5d ago'` (2 failed / 3 passed).
* **Rust** — hard-coding the summary's group to `Other` fails
  `a_parked_effect_carries_its_group_to_the_card` with `left: Other, right: Send`:
  *"the card must carry the parked effect's own group; anything constant renders an outbound send as
  internal."*

Six tests total, including one pinning that outbound-ness comes from `group` and **never** from `kind`,
and one asserting an absent `group` claims nothing.

## Documentation

No spec doc changes. The reasoning lives where the decisions do: why "Composed" and not "Parked", and
why `group` cannot be derived console-side, are recorded on `payloadAge`/`leavesTheCompany` and on the
`ApprovalSummary` field itself.

Part of tinyhumansai/opencompany#1024 — the card now shows the payload's age. The threshold behaviour
that issue also asks for is deliberately not built here; see the TTL note above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval cards now distinguish externally directed effects with “Composed” age labels and visual emphasis.
  * Approval summaries now include consequence classifications such as spending, sending, signing, publishing, hiring, and identity-related actions.
  * Effect timestamps are clearly identified as payload composition times.

* **Bug Fixes**
  * Preserved consequence classifications for parked approvals, including approvals triggered by external integrations.

* **Tests**
  * Added coverage for payload-age labels and classification handling across supported effect types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->