### PR TITLE
fix: stop a workflow run hanging in running forever

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -71,6 +71,11 @@ with `{ "runId": "…", "detached": true }` before the engine walks a node; the
 run is then followed through the `workflow_run_started` / `workflow_node_finished`
 / `workflow_run_finished` frames it already keys by that `runId`, and read back
 from `GET …/workflows/runs`, whose fold reports `running: true` until it settles.
+That reading is cross-checked against the company's live run supervisor before it
+is served (issue #1009): a run the supervisor no longer holds and whose finish is
+nowhere in the journal is settled on the spot with the synthetic "interrupted by
+a host restart" outcome, so a run whose task died cannot spin forever. See
+`workflow-events.md`.
 
 **Clients must discriminate on the response shape, not on what they sent.** A
 host predating this ignores the unknown `detach` field and answers the full

--- a/docs/spec/runtime/workflow-events.md
+++ b/docs/spec/runtime/workflow-events.md
@@ -107,7 +107,42 @@ the nodes that did complete still group under it.
 
 This is what keeps the read side honest: `GET …/workflows/runs` folds a start
 without a finish as `running: true`, and that claim is only true because runs
-that will never finish are settled at the next boot.
+that will never finish are settled.
+
+### A boot sweep alone is not enough (#1009)
+
+The boot sweep repairs a host that *died*. It does nothing for a run that dies
+inside a host that stays up — a run task that panics unwinds past its own
+`record_run_finished`, and a finish append that fails is swallowed by design. In
+both cases the start stands alone in a journal nobody will sweep until the next
+restart, so the console shows a node pulsing, a header reading "running" and a
+Stop button, indefinitely. Two things close that:
+
+- **A watchdog on the run task.** `WorkflowSpawn::spawn_admitted` spawns the run
+  on an inner task and returns an outer task that awaits it. A `JoinError` —
+  panic or abort — means the run never ran its own journal write, so the
+  watchdog writes one carrying `RUN_TASK_LOST`. The `RunGuard` is held by the
+  watchdog rather than the run task, so the supervisor entry outlives *whichever*
+  path journaled. A panic is re-raised afterwards, so every caller's existing
+  `Err(JoinError)` arm behaves exactly as before.
+- **A liveness cross-check on the read.** `GET …/workflows/runs` checks each
+  still-running row against the company's `RunSupervisor::live()`. A run the
+  supervisor does not hold, whose finish is nowhere in the journal, is settled
+  there and then with the same synthetic "interrupted by a host restart" finish
+  the boot sweep writes — durably, so the next reader folds it without repeating
+  the work.
+
+The cross-check cannot mistake a live run for a dead one. `begin` registers a run
+*before* its task is spawned and therefore before the runner journals the start,
+so a start visible in the journal implies the run was already registered; and a
+run that settles between the journal read and the liveness check is caught by
+re-reading the journal tail before anything is written. A journal that cannot be
+re-read settles nothing — an unprovable claim is left alone.
+
+The one case it gets wrong is the pre-existing rebuild gap: a live runtime swap
+hands the successor a fresh supervisor, so a run started before the swap is
+settled early. Its real finish still lands, after the synthetic one, and the fold
+takes the last finish it sees — the reading is wrong in between, not the record.
 
 **It must not run on a rebuild.** The argument above holds at boot and is false
 once a company has been serving: a scheduler-spawned run survives a live runtime

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -75,6 +75,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
 import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
 import { cn } from "@/lib/utils";
+import { startVisiblePolling } from "@/lib/visible-poll";
 import type { NodeRunState } from "@/lib/workflow-sample";
 // Issue #303: the canvas arithmetic, the run-state folds and the three drawers
 // moved out when this file passed 1800 lines and was about to grow an index and
@@ -1210,11 +1211,18 @@ export function WorkflowsView({
   // Same self-limiting shape as before: `settledRunIds` clears `liveRun.active`
   // on the first settled row, which unmounts this interval. With a working
   // stream the finish frame gets there first and this costs at most one fetch.
+  //
+  // Issue #1009: through `startVisiblePolling`, like every other poll in the
+  // console. "Self-limiting" was only ever true while a run really does settle,
+  // and this is the fastest poll here at 2s — so a run that hangs turns a
+  // background tab into a permanent 30-requests-a-minute conversation with the
+  // host about a company nobody is looking at. Stopping while hidden bounds the
+  // damage; the hidden → visible edge re-reads, so returning to the tab shows
+  // the current history rather than a stale snapshot plus a 2s wait.
   const watchingRun = Boolean(activeRunId) || Boolean(liveRun?.active);
   useEffect(() => {
     if (!watchingRun || !historySupported) return;
-    const timer = window.setInterval(() => setRunsTick((n) => n + 1), 2_000);
-    return () => window.clearInterval(timer);
+    return startVisiblePolling(() => setRunsTick((n) => n + 1), 2_000);
   }, [watchingRun, historySupported]);
 
   // Switching workflow (or company) clears the canvas: another graph's node ids

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -152,7 +152,7 @@ pub use workflow_outcome::{
 pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;
 pub(crate) use workflow_scheduler::workflow_schedule_id;
-pub use workflow_spawn::WorkflowSpawn;
+pub use workflow_spawn::{RUN_TASK_LOST, WorkflowSpawn};
 pub use workspace_events::WorkspaceAnnouncer;
 pub use workspace_quota::{
     DEFAULT_MAX_BLOB_BYTES, QuotaEnforcedWorkspace, UPLOAD_BODY_LIMIT_BYTES, WorkspaceQuota,

--- a/src/runtime/run_supervisor.rs
+++ b/src/runtime/run_supervisor.rs
@@ -38,14 +38,19 @@
 //! and [`RunGuard`] are what make that inference sound, and both have to survive
 //! any future change here:
 //!
-//! * `begin` registers **before** the run's task is spawned, and therefore
-//!   before the runner journals the run's `WorkflowRunStarted`. So a start in
-//!   the journal implies the run *was* registered — there is no window in which
-//!   a run is visibly started but not yet addressable.
+//! * `begin` runs **before** the runner journals the run's
+//!   `WorkflowRunStarted`, at every entry point — before the `tokio::spawn` in
+//!   [`WorkflowSpawn`](super::WorkflowSpawn), before the cron scheduler's
+//!   minute-claim, and immediately above the orchestrator tool's inline
+//!   `runner.run`. So a start in the journal implies the run *was* registered:
+//!   there is no window in which a run is visibly started but not yet
+//!   addressable.
 //! * the guard is dropped **after** the outcome is journaled — by the watchdog
-//!   in [`WorkflowSpawn::spawn_admitted`](crate::runtime::WorkflowSpawn), which holds it
-//!   across the normal and the abnormal path alike. So a run that has left this
-//!   map has already written its finish, if it was ever going to write one.
+//!   in [`WorkflowSpawn::spawn_admitted`](crate::runtime::WorkflowSpawn), which
+//!   holds it across the normal and the abnormal path alike, and by the
+//!   orchestrator tool holding `_run_guard` across both of its
+//!   `record_run_finished` arms. So a run that has left this map has already
+//!   written its finish, if it was ever going to write one.
 //!
 //! That second property is also what closed this module's other long-standing
 //! gap: a **panicking** run task used to unwind past its own journal write, so

--- a/src/runtime/run_supervisor.rs
+++ b/src/runtime/run_supervisor.rs
@@ -27,19 +27,39 @@
 //! help from an in-memory map (and could not get any — the map dies with the
 //! process). This module adds no sweep of its own.
 //!
-//! ## Two known gaps, both inherited rather than introduced
+//! ## The map is also the read side's liveness proof (issue #1009)
 //!
-//! * A **panicking** run task unwinds, so its guard drops and the entry goes —
-//!   but nothing journals a `WorkflowRunFinished`, so the run reads
-//!   `running: true` in `GET …/workflows/runs` until the next restart sweeps it.
-//!   That is the same exposure #371 accepted for a run whose journal append
-//!   failed, and the same remedy settles both.
-//! * A live runtime swap ([`rebuild_company`](super::rebuild_company)) gives the
-//!   successor runtime a fresh supervisor, so a run registered on the old one
-//!   can no longer be cancelled (it still finishes and still journals). This
-//!   matches how the steer registry behaves across a rebuild — see
-//!   [`RuntimeHandover`](super::RuntimeHandover) — and cancelling is a
-//!   best-effort operator convenience, not a correctness guarantee.
+//! [`live`](RunSupervisor::live) started life as a diagnostic. It is now load
+//! bearing. `GET …/workflows/runs` folds a start with no finish as
+//! `running: true`, and cross-checks that claim against this map: a run the map
+//! does not hold, whose finish is nowhere in the journal, is one that died
+//! without journaling, and the read settles it rather than serving a spinner
+//! that would otherwise last until the next restart. Two properties of `begin`
+//! and [`RunGuard`] are what make that inference sound, and both have to survive
+//! any future change here:
+//!
+//! * `begin` registers **before** the run's task is spawned, and therefore
+//!   before the runner journals the run's `WorkflowRunStarted`. So a start in
+//!   the journal implies the run *was* registered — there is no window in which
+//!   a run is visibly started but not yet addressable.
+//! * the guard is dropped **after** the outcome is journaled — by the watchdog
+//!   in [`WorkflowSpawn::spawn_admitted`](super::WorkflowSpawn), which holds it
+//!   across the normal and the abnormal path alike. So a run that has left this
+//!   map has already written its finish, if it was ever going to write one.
+//!
+//! That second property is also what closed this module's other long-standing
+//! gap: a **panicking** run task used to unwind past its own journal write, so
+//! its guard dropped and nothing recorded the run at all. The watchdog now
+//! journals [`RUN_TASK_LOST`](super::RUN_TASK_LOST) for it.
+//!
+//! ## One known gap, inherited rather than introduced
+//!
+//! A live runtime swap ([`rebuild_company`](super::rebuild_company)) gives the
+//! successor runtime a fresh supervisor, so a run registered on the old one can
+//! no longer be cancelled (it still finishes and still journals). This matches
+//! how the steer registry behaves across a rebuild — see
+//! [`RuntimeHandover`](super::RuntimeHandover) — and cancelling is a
+//! best-effort operator convenience, not a correctness guarantee.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/src/runtime/run_supervisor.rs
+++ b/src/runtime/run_supervisor.rs
@@ -43,14 +43,14 @@
 //!   the journal implies the run *was* registered — there is no window in which
 //!   a run is visibly started but not yet addressable.
 //! * the guard is dropped **after** the outcome is journaled — by the watchdog
-//!   in [`WorkflowSpawn::spawn_admitted`](super::WorkflowSpawn), which holds it
+//!   in [`WorkflowSpawn::spawn_admitted`](crate::runtime::WorkflowSpawn), which holds it
 //!   across the normal and the abnormal path alike. So a run that has left this
 //!   map has already written its finish, if it was ever going to write one.
 //!
 //! That second property is also what closed this module's other long-standing
 //! gap: a **panicking** run task used to unwind past its own journal write, so
 //! its guard dropped and nothing recorded the run at all. The watchdog now
-//! journals [`RUN_TASK_LOST`](super::RUN_TASK_LOST) for it.
+//! journals [`RUN_TASK_LOST`](crate::runtime::RUN_TASK_LOST) for it.
 //!
 //! ## One known gap, inherited rather than introduced
 //!

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -53,10 +53,26 @@ use tokio::task::JoinHandle;
 use crate::Result;
 use crate::company::WorkflowFile;
 use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
 use crate::ports::types::CompanyId;
 use crate::ports::{EventLog, WorkflowRun, WorkflowRunContext, WorkflowRunner};
 use crate::runtime::workflow_outcome::record_run_finished;
 use crate::runtime::{RunGuard, RunSupervisor};
+
+/// The error stamped on a run whose **task** ended without recording its own
+/// outcome (issue #1009).
+///
+/// Phrased as a host fact, like
+/// [`INTERRUPTED_BY_RESTART`](crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART),
+/// and deliberately distinct from it: "interrupted by a host restart" sends an
+/// operator to the deployment, and this one did not happen at a restart. The
+/// process is still up; one run's task unwound or was dropped, which is a
+/// different thing to go looking at.
+pub const RUN_TASK_LOST: &str = concat!(
+    "this run's task ended without finishing — it panicked, or it was aborted — ",
+    "so it never recorded its own outcome; the nodes recorded against it are the ",
+    "ones that completed before it stopped"
+);
 
 /// Everything starting a supervised workflow run needs, and nothing else.
 #[derive(Clone)]
@@ -98,9 +114,10 @@ impl WorkflowSpawn {
     /// mode, and the cron scheduler, which has to hold its overlap claim for
     /// the length of the run) or dropped (the console's detached mode, and the
     /// resume arm). Dropping it abandons the *waiting*, never the work: the
-    /// task holds its own guard, journals its own outcome, and deregisters
-    /// itself on every exit path including an unwind. Awaiting it therefore
-    /// resolves only once the outcome is already durable.
+    /// run holds its guard, journals its outcome, and deregisters itself on
+    /// every exit path including an unwind. Awaiting it therefore resolves only
+    /// once the outcome is already durable — including the abnormal exits the
+    /// watchdog in [`spawn_admitted`](Self::spawn_admitted) covers.
     ///
     /// `dry_run` (issue #542) makes this a **test run**: the flag is stamped
     /// onto the run's [`WorkflowRunContext`] (the supervisor still registers it,
@@ -160,6 +177,35 @@ impl WorkflowSpawn {
     /// `dry_run` (issue #542) is stamped on the admitted context here rather than
     /// at `begin`, so the supervisor is untouched — a dry run registers and
     /// cancels exactly like a real one.
+    ///
+    /// # The watchdog (issue #1009)
+    ///
+    /// Two tasks, not one. The inner task runs the graph and journals its own
+    /// outcome exactly as before; the returned handle belongs to an **outer
+    /// watchdog** that awaits it and covers the one exit the inner task cannot
+    /// cover for itself — the one where it never gets to run its own code.
+    ///
+    /// A panicking run task unwinds past its `record_run_finished`, so it
+    /// journals nothing; an aborted one is dropped at its next await point, so
+    /// it journals nothing either. Either way the run's
+    /// `WorkflowRunStarted` stands alone in the journal forever, which
+    /// `GET …/workflows/runs` folds as `running: true` until the *next process*
+    /// sweeps it — a hang that outlives the run by however long the host stays
+    /// up. `run_supervisor`'s module docs called this out as a known gap; the
+    /// watchdog is what closes it, by journaling [`RUN_TASK_LOST`] for a run
+    /// whose task did not come back.
+    ///
+    /// The [`RunGuard`] moves into the **watchdog**, not the run task. It has to:
+    /// the supervisor entry is what proves the run is still alive to the read
+    /// side's liveness cross-check, and dropping it while the finish is still
+    /// unwritten would open a window in which the run reads dead and its finish
+    /// has not landed — two writers racing to settle one run. Held out here, the
+    /// entry disappears only after *whichever* of the two paths journaled.
+    ///
+    /// A panic is **re-raised** rather than absorbed, so every existing
+    /// `Err(JoinError)` arm (the console's synchronous run route, the cron
+    /// scheduler) fires exactly as it did before — the watchdog adds a durable
+    /// record, it does not change what a caller sees.
     pub(crate) fn spawn_admitted(
         self,
         mut ctx: WorkflowRunContext,
@@ -171,12 +217,15 @@ impl WorkflowSpawn {
         let scheduled = ctx.scheduled;
         ctx.dry_run = dry_run;
         let run_id = ctx.run_id.clone();
-        let handle = tokio::spawn(async move {
-            // Held for the whole run INCLUDING the journal write below, so the
-            // window in which a cancel is accepted matches the window in which
-            // it can still do anything. Dropping on every exit path, unwind
-            // included, is why this is a guard rather than a call at the end.
-            let _guard = guard;
+        // The watchdog's own copies of what journaling a finish needs. Taken
+        // before `self` and `workflow` move into the run task below, and
+        // deliberately no more than these: the watchdog never runs a graph, so
+        // it has no use for the runner.
+        let events = self.events.clone();
+        let company = self.company.clone();
+        let workflow_id = workflow.id.clone();
+        let watched_run_id = run_id.clone();
+        let run = tokio::spawn(async move {
             let result = self.runner.run(&self.company, &workflow, input, &ctx).await;
             // Issue #542: a dry run journals NOTHING. The runner already skipped
             // the started + per-node rows; skipping the finish here keeps the
@@ -216,6 +265,57 @@ impl WorkflowSpawn {
                 }
             }
             result
+        });
+
+        // Issue #1009: the watchdog. It owns the run task's handle, so nothing
+        // else can be waiting on it, and it is the only thing that can tell the
+        // difference between "the run returned" and "the run's task went away".
+        let handle = tokio::spawn(async move {
+            // Held here rather than inside the run task, and across the journal
+            // write below: the supervisor entry is the read side's proof that
+            // this run is still alive, so it must not vanish while the run's
+            // finish is still unwritten. The window in which a cancel is
+            // accepted still matches the window in which it can do anything —
+            // it now simply extends past the abnormal exits too.
+            let _guard = guard;
+            match run.await {
+                // The run task ran its own code to completion, which means it
+                // already journaled its own outcome (or deliberately did not,
+                // for a dry run). Nothing owed.
+                Ok(result) => result,
+                Err(join) => {
+                    // Issue #542 again: a dry run journals NOTHING, and that
+                    // holds when it blows up too. There is no started row for a
+                    // finish to pair with.
+                    if !dry_run {
+                        record_run_finished(
+                            &events,
+                            &company,
+                            &workflow_id,
+                            scheduled,
+                            &watched_run_id,
+                            Err(RUN_TASK_LOST),
+                        )
+                        .await;
+                    }
+                    if join.is_panic() {
+                        // Re-raised, not absorbed: the callers that await this
+                        // handle already have an `Err(JoinError)` arm and it is
+                        // the right one — the run's outcome is unknown, not
+                        // failed. The only thing that changed is that the
+                        // journal now says so as well.
+                        std::panic::resume_unwind(join.into_panic());
+                    }
+                    // Cancelled rather than panicked. Nothing in this crate
+                    // aborts a run task — only the watchdog holds the handle —
+                    // so this is the runtime shutting the task down. Reported
+                    // as the same "outcome unknown" the run route's own
+                    // `JoinError` arm reports, so the two agree.
+                    Err(OpenCompanyError::BackgroundTask(format!(
+                        "the workflow run task for {watched_run_id} was cancelled before it finished"
+                    )))
+                }
+            }
         });
         (run_id, handle)
     }

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -307,9 +307,29 @@ impl WorkflowSpawn {
                         std::panic::resume_unwind(join.into_panic());
                     }
                     // Cancelled rather than panicked. Nothing in this crate
-                    // aborts a run task — only the watchdog holds the handle —
-                    // so this is the runtime shutting the task down. Reported
-                    // as the same "outcome unknown" the run route's own
+                    // aborts a run task — the watchdog is the only holder of the
+                    // handle, and an operator's Stop goes through
+                    // [`RunSupervisor::cancel`](super::RunSupervisor::cancel),
+                    // which fires the run's own signal and lets it wind down and
+                    // journal normally. So this is the runtime shutting the task
+                    // down.
+                    //
+                    // Logged HERE, at `error`, because the arm it now lands in
+                    // downstream is quieter than the one it used to. Before the
+                    // watchdog a cancelled task surfaced to the run route as
+                    // `Err(JoinError)`, which logs; it now surfaces as
+                    // `Ok(Err(..))`, which the route turns straight into a
+                    // response without a line. Same severity as the arm it
+                    // replaced, so moving the log rather than dropping it keeps
+                    // "a run task vanished" as loud as it was.
+                    tracing::error!(
+                        company = %company,
+                        workflow = %workflow_id,
+                        run_id = %watched_run_id,
+                        scheduled,
+                        "workflow run task was cancelled before it finished; its outcome is unknown"
+                    );
+                    // Reported as the same "outcome unknown" the run route's own
                     // `JoinError` arm reports, so the two agree.
                     Err(OpenCompanyError::BackgroundTask(format!(
                         "the workflow run task for {watched_run_id} was cancelled before it finished"

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2496,12 +2496,18 @@ async fn list_runs(
 /// that is walking its graph perfectly well. Three windows could produce it, and
 /// each is closed:
 ///
-/// * **Between spawn and registration.** There is none, in that order.
-///   [`RunSupervisor::begin`](crate::runtime::RunSupervisor::begin) registers the
-///   run *before* `WorkflowSpawn` spawns its task, and the task journals the
-///   `WorkflowRunStarted` later still. So a start visible in the journal implies
-///   the run was already registered — a just-started run is addressable before
-///   it is ever visible here, never the other way round.
+/// * **Between starting and registration.** There is none, in that order, and
+///   all four entry points order it the same way:
+///   [`RunSupervisor::begin`](crate::runtime::RunSupervisor::begin) runs first
+///   and the runner journals the `WorkflowRunStarted` afterwards. `WorkflowSpawn`
+///   calls `begin` before it spawns the run's task (the console's run route and
+///   the approved-gate resume); the cron scheduler calls `begin` on its tick
+///   thread, earlier still, so it can hold the guard across its minute-claim;
+///   and the orchestrator's `run_workflow` tool, which deliberately runs inline
+///   rather than on a task, calls `begin` immediately above its `runner.run`.
+///   So a start visible in the journal implies the run was already registered —
+///   a just-started run is addressable before it is ever visible here, never the
+///   other way round.
 /// * **Between the journal read and the liveness check.** A run that settled in
 ///   that gap has left the supervisor *and* has a finish this snapshot is too
 ///   old to have seen — it would look exactly like a dead one. So the journal is

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2612,8 +2612,8 @@ async fn settle_dead_runs(
     dead.retain(|(_, run_id)| !settled_since.contains(run_id));
 
     let events = company.runtime.events();
-    for (index, run_id) in dead {
-        let entry = &mut runs[index];
+    for (index, run_id) in &dead {
+        let entry = &mut runs[*index];
         tracing::info!(
             company = %company.id(),
             workflow = %entry.workflow_id,
@@ -2626,17 +2626,74 @@ async fn settle_dead_runs(
             company.id(),
             &entry.workflow_id,
             entry.scheduled,
-            &run_id,
+            run_id,
             Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART),
         )
         .await;
         // Applied to the row being served as well, not just to the journal: this
         // response is the one that has to stop the console's spinner. Only the
-        // two fields the synthetic finish actually carries — it delivered
-        // nothing, blocked on nobody, and was not cancelled, all of which the
-        // row already says.
+        // fields the synthetic finish actually carries — it delivered nothing,
+        // blocked on nobody, and was not cancelled, all of which the row already
+        // says. `seq` and `at_millis` come from the appended rows below.
         entry.running = false;
         entry.error = Some(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.to_string());
+    }
+
+    // # Serve the row the NEXT read will fold, identically
+    //
+    // The fold keys a settled entry on its **finish**: it overwrites `seq` and
+    // `at_millis` from the finish row (see the settle arm above). So a response
+    // that flipped `running` but left the start's `seq` in place would be
+    // followed, one 2s poll later, by the same run carrying a different `seq`
+    // and a different time — and the console keys its history rows on exactly
+    // that field (`RunHistoryPanel`: `key={run.seq}`, and `selectedRunSeq` /
+    // `fixingRunSeq` compare against it). The row would remount and any
+    // selection on it would be dropped, in the one window where an operator is
+    // most likely to be looking at it: while the run they were watching gets
+    // repaired.
+    //
+    // So the appended rows are read back and their real `seq` / `at_millis`
+    // stamped on. Reading is what makes them the *durable* values rather than a
+    // second guess at them — `record_run_finished` is the one place that writes
+    // this event and it returns nothing, and teaching it to return a sequence is
+    // issue #1008's file, not this one.
+    match events
+        .read_from(
+            company.id(),
+            EventSeq::new(read_through.saturating_add(1)),
+            usize::MAX,
+        )
+        .await
+    {
+        Ok(appended) => {
+            let stamped: std::collections::HashMap<String, (u64, u64)> = appended
+                .into_iter()
+                .filter_map(|stored| match stored.event {
+                    CompanyEvent::WorkflowRunFinished {
+                        run_id: Some(run_id),
+                        ..
+                    } => Some((run_id, (stored.seq.value(), stored.at_millis))),
+                    _ => None,
+                })
+                .collect();
+            for (index, run_id) in &dead {
+                if let Some((seq, at_millis)) = stamped.get(run_id) {
+                    let entry = &mut runs[*index];
+                    entry.seq = *seq;
+                    entry.at_millis = *at_millis;
+                }
+            }
+        }
+        Err(err) => {
+            // The settle itself stands — it is already durable. Only the row's
+            // identity is left at the start's, which the next read corrects.
+            tracing::warn!(
+                company = %company.id(),
+                %err,
+                "settled a dead workflow run but could not read back its finish row; \
+                 this response carries the start's seq and time"
+            );
+        }
     }
 }
 
@@ -4861,6 +4918,63 @@ mod tests {
             let body = json_body(response).await;
             assert_eq!(body.as_array().unwrap().len(), 1, "still one run: {body}");
             assert!(body[0].get("running").is_none(), "{body}");
+        }
+
+        /// **The settled row keeps one identity across reads.** The response
+        /// that performs the settle and every response after it carry the same
+        /// `seq` and `atMillis` — the appended finish's, not the start's.
+        ///
+        /// This is not cosmetic. `RunHistoryPanel` keys its rows on `run.seq`
+        /// (`key={run.seq}`) and compares it against `selectedRunSeq` and
+        /// `fixingRunSeq`, so a row whose `seq` changed between two polls would
+        /// remount and lose its selection — in the one window where that is most
+        /// likely to be noticed, since the 2s recovery poll is running precisely
+        /// because someone is watching this run.
+        #[tokio::test]
+        async fn a_settled_dead_run_keeps_its_seq_and_time_across_reads() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "digest", "run-dead", false).await;
+
+            let first = json_body(
+                router(state.clone())
+                    .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            let second = json_body(
+                router(state)
+                    .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+
+            assert!(first[0].get("running").is_none(), "{first}");
+            assert_eq!(
+                first[0]["seq"], second[0]["seq"],
+                "the settling read and the one after it must agree on the row's \
+                 identity: {first} then {second}"
+            );
+            assert_eq!(
+                first[0]["atMillis"], second[0]["atMillis"],
+                "…and on when it settled: {first} then {second}"
+            );
+            // Specifically the FINISH's position, not the start's — which is
+            // what the next fold will use, and the only value the two reads can
+            // both hold.
+            assert_ne!(
+                first[0]["seq"], first[0]["startedAtMillis"],
+                "sanity: the start and the finish are different rows"
+            );
+            assert!(
+                first[0]["atMillis"].as_u64().unwrap()
+                    >= first[0]["startedAtMillis"].as_u64().unwrap(),
+                "the settle cannot predate the start: {first}"
+            );
         }
 
         /// **The false positive that would matter most, pinned.** A run the

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2156,10 +2156,13 @@ struct WorkflowRunOutcome {
     started_at_millis: Option<u64>,
     /// `true` for a run that has started and not yet settled.
     ///
-    /// Honest rather than optimistic, and only because of the boot sweep: a run
-    /// whose host died is settled with an "interrupted" outcome at the next
-    /// start, so nothing sits here spinning forever. Omitted when false, which
-    /// keeps every settled row's wire shape as short as it was.
+    /// Honest rather than optimistic, and issue #1009 is what keeps it that
+    /// way: the fold can only see that a finish is *missing*, so before this is
+    /// served it is cross-checked against the live supervisor and a run that is
+    /// no longer there is settled (see [`settle_dead_runs`]). The boot sweep
+    /// used to be the only thing that ever repaired one, which meant a
+    /// long-lived host never did. Omitted when false, which keeps every settled
+    /// row's wire shape as short as it was.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     running: bool,
     /// `true` for a run an operator stopped (issue #383).
@@ -2296,10 +2299,15 @@ async fn list_runs(
     // not "whichever of the last N happen to match".
     let wanted = query.workflow.as_deref();
     let matches = |workflow_id: &str| wanted.is_none_or(|w| w == workflow_id);
+    // The high-water mark of this read, kept over EVERY row rather than only the
+    // matched ones — it is where `settle_dead_runs` resumes to close the race
+    // between this snapshot and the liveness check that follows it.
+    let mut read_through = 0u64;
 
     for stored in stored {
         let seq = stored.seq.value();
         let at_millis = stored.at_millis;
+        read_through = read_through.max(seq);
         match stored.event {
             CompanyEvent::WorkflowRunStarted {
                 workflow_id,
@@ -2443,12 +2451,168 @@ async fn list_runs(
         }
     }
 
+    // Issue #1009: `running: true` above is a claim about *now*, and the fold
+    // has no way to check it. Cross-check it against the live supervisor before
+    // serving it, and settle the rows that turn out to be dead.
+    settle_dead_runs(&company, &mut runs, read_through).await;
+
     // Newest first: a history panel leads with the run that just happened. The
     // `limit` now cuts *runs* rather than journal rows, which is the number the
     // caller was asking about all along.
     runs.reverse();
     runs.truncate(limit);
     Ok(Json(runs))
+}
+
+/// Settles the folded rows that claim to be running but whose run is gone
+/// (issue #1009).
+///
+/// # The hang this closes
+///
+/// A run journals a `WorkflowRunStarted` before the engine call and a
+/// `WorkflowRunFinished` after it, and [`list_runs`] folds a start with no
+/// finish as `running: true`. That reading is only honest while *something*
+/// guarantees the missing finish is still coming. Two things can take that
+/// guarantee away without anyone noticing: the finish's append can fail (it is
+/// best-effort by construction), and the run's task can die before it writes one
+/// at all. Either way the row stays `running: true` **forever** — nothing but
+/// the boot-time [`sweep_interrupted_runs`](crate::runtime::sweep_interrupted_runs)
+/// ever repairs it, so a long-lived host never recovers. The console reads that
+/// as a run still walking: a node pulses, the Stop button stays, and the
+/// recovery poll never stops.
+///
+/// So the read checks. The company's [`RunSupervisor`](crate::runtime::RunSupervisor)
+/// holds every run this process has admitted and not yet let go of; a run it
+/// does not hold, whose finish is nowhere in the journal, is one that will never
+/// write one. This appends the same synthetic
+/// [`INTERRUPTED_BY_RESTART`](crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART)
+/// finish the boot sweep would have appended eventually — durably, so the next
+/// reader folds it without repeating this work, and so the console's
+/// `settledRunIds` backstop finally sees the run settle.
+///
+/// # Why a live run cannot be mistaken for a dead one
+///
+/// The dangerous mistake is the opposite one: stamping "interrupted" on a run
+/// that is walking its graph perfectly well. Three windows could produce it, and
+/// each is closed:
+///
+/// * **Between spawn and registration.** There is none, in that order.
+///   [`RunSupervisor::begin`](crate::runtime::RunSupervisor::begin) registers the
+///   run *before* `WorkflowSpawn` spawns its task, and the task journals the
+///   `WorkflowRunStarted` later still. So a start visible in the journal implies
+///   the run was already registered — a just-started run is addressable before
+///   it is ever visible here, never the other way round.
+/// * **Between the journal read and the liveness check.** A run that settled in
+///   that gap has left the supervisor *and* has a finish this snapshot is too
+///   old to have seen — it would look exactly like a dead one. So the journal is
+///   re-read from where the snapshot stopped, and a candidate whose finish turns
+///   up in that tail is dropped. The tail read costs a query only when there are
+///   candidates at all, which after the first settle is nothing.
+/// * **A journal that cannot be re-read.** Then nothing is settled. An
+///   unprovable claim is left alone rather than guessed at, and the row keeps
+///   reporting `running` until a later poll can prove otherwise.
+///
+/// One window is deliberately left open, because it is the pre-existing rebuild
+/// gap documented on [`RunSupervisor`](crate::runtime::run_supervisor): a live
+/// runtime swap hands the successor a *fresh* supervisor, so a run started
+/// before the swap is invisible to it and is settled early here. That run still
+/// finishes and still journals, and its real finish lands after this synthetic
+/// one — so the fold, which settles an entry from the last finish it sees, ends
+/// up with the truth. The reading is wrong in between, not the record.
+async fn settle_dead_runs(
+    company: &ScopedCompany,
+    runs: &mut [WorkflowRunOutcome],
+    read_through: u64,
+) {
+    // The rows the fold left open. A pre-#371 row carries no run id and so
+    // cannot be cross-checked against anything — it also folds `running: false`,
+    // so it is never in here.
+    let open: Vec<(usize, String)> = runs
+        .iter()
+        .enumerate()
+        .filter(|(_, run)| run.running)
+        .filter_map(|(index, run)| run.run_id.clone().map(|run_id| (index, run_id)))
+        .collect();
+    if open.is_empty() {
+        return;
+    }
+
+    let live: HashSet<String> = company
+        .runtime
+        .run_supervisor()
+        .live()
+        .into_iter()
+        .map(|(run_id, _)| run_id)
+        .collect();
+    let mut dead: Vec<(usize, String)> = open
+        .into_iter()
+        .filter(|(_, run_id)| !live.contains(run_id))
+        .collect();
+    if dead.is_empty() {
+        return;
+    }
+
+    // The tail re-read described above: everything appended since the snapshot,
+    // which is normally nothing at all.
+    let tail = match company
+        .runtime
+        .events()
+        .read_from(
+            company.id(),
+            EventSeq::new(read_through.saturating_add(1)),
+            usize::MAX,
+        )
+        .await
+    {
+        Ok(tail) => tail,
+        Err(err) => {
+            tracing::warn!(
+                company = %company.id(),
+                %err,
+                "could not re-read the journal to confirm a workflow run is dead; leaving it as running"
+            );
+            return;
+        }
+    };
+    let settled_since: HashSet<String> = tail
+        .into_iter()
+        .filter_map(|stored| match stored.event {
+            CompanyEvent::WorkflowRunFinished {
+                run_id: Some(run_id),
+                ..
+            } => Some(run_id),
+            _ => None,
+        })
+        .collect();
+    dead.retain(|(_, run_id)| !settled_since.contains(run_id));
+
+    let events = company.runtime.events();
+    for (index, run_id) in dead {
+        let entry = &mut runs[index];
+        tracing::info!(
+            company = %company.id(),
+            workflow = %entry.workflow_id,
+            %run_id,
+            scheduled = entry.scheduled,
+            "settling a workflow run whose task went away without recording an outcome"
+        );
+        crate::runtime::record_run_finished(
+            events,
+            company.id(),
+            &entry.workflow_id,
+            entry.scheduled,
+            &run_id,
+            Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART),
+        )
+        .await;
+        // Applied to the row being served as well, not just to the journal: this
+        // response is the one that has to stop the console's spinner. Only the
+        // two fields the synthetic finish actually carries — it delivered
+        // nothing, blocked on nobody, and was not cancelled, all of which the
+        // row already says.
+        entry.running = false;
+        entry.error = Some(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.to_string());
+    }
 }
 
 /// Relabels a run's node rows for the nodes it blocked on a human (issue #881).
@@ -4605,34 +4769,138 @@ mod tests {
             );
         }
 
-        /// A run whose host died leaves a start with no finish, and it folds as
-        /// `running: true` with the nodes it did complete. Honest only because
-        /// the boot sweep settles such runs — see `sweep_interrupted_runs`.
+        /// **Issue #1009, at the HTTP boundary.** A run whose start stands alone
+        /// in the journal and whose supervisor entry is gone is a run that died
+        /// without recording an outcome — and the read settles it rather than
+        /// reporting a spinner that would last until the next restart.
+        ///
+        /// Nothing registered `run-dead` with this company's supervisor, which
+        /// is exactly the state a panicking task or a failed finish-append
+        /// leaves behind. Before #1009 this folded `running: true` forever: only
+        /// the boot-time `sweep_interrupted_runs` ever repaired it, so a
+        /// long-lived host never recovered.
+        ///
+        /// The nodes it *did* complete are still there. Settling a run is not
+        /// forgetting it — the trail is the only thing that says how far it got.
         #[tokio::test]
-        async fn run_history_reports_an_unsettled_run_as_running() {
+        async fn run_history_settles_a_run_whose_supervisor_entry_is_gone() {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, id) = hosted_state(&home).await;
 
-            journal_start(&state, &id, "digest", "run-live", false).await;
+            journal_start(&state, &id, "digest", "run-dead", false).await;
             journal_node(
                 &state,
                 &id,
                 "digest",
-                "run-live",
+                "run-dead",
                 "ceo",
                 WorkflowNodeStatus::Ok,
             )
             .await;
+
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            // `running` is omitted when false, so its ABSENCE is the settled
+            // reading — the same wire shape every finished run has always had.
+            assert!(body[0].get("running").is_none(), "{body}");
+            assert_eq!(
+                body[0]["error"],
+                crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART,
+                "{body}"
+            );
+            assert_eq!(body[0]["nodes"].as_array().unwrap().len(), 1, "{body}");
+
+            // Durable, not just cosmetic: the synthetic finish is appended, so
+            // the *next* reader folds it without repeating the cross-check —
+            // and the console's `settledRunIds` backstop finally sees this run
+            // settle.
+            let runtime = state.registry().get(&id).expect("registered");
+            let finishes = runtime
+                .events()
+                .read_from(&id, crate::ports::types::EventSeq::new(0), usize::MAX)
+                .await
+                .expect("read")
+                .into_iter()
+                .filter(|stored| matches!(stored.event, CompanyEvent::WorkflowRunFinished { .. }))
+                .count();
+            assert_eq!(finishes, 1, "the settle must be journaled exactly once");
 
             let response = router(state)
                 .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            assert_eq!(body[0]["running"], true, "{body}");
-            assert_eq!(body[0]["nodes"].as_array().unwrap().len(), 1);
+            assert_eq!(body.as_array().unwrap().len(), 1, "still one run: {body}");
+            assert!(body[0].get("running").is_none(), "{body}");
+        }
+
+        /// **The false positive that would matter most, pinned.** A run the
+        /// supervisor still holds is a run that is still going, and #1009's
+        /// cross-check must leave it alone — stamping "interrupted" on a healthy
+        /// run would tell an operator to re-run work that is still in flight,
+        /// which for a delivering workflow means mailing real people twice.
+        ///
+        /// The registration is real: `begin` is the same call every entry point
+        /// makes, and its guard is what the read consults. Dropping the guard —
+        /// which is what a run task's death does, and all it does — flips the
+        /// same journal from "running" to "interrupted" with nothing else
+        /// changed, so the two halves of the claim are asserted against one
+        /// fixture.
+        #[tokio::test]
+        async fn run_history_does_not_settle_a_run_the_supervisor_still_holds() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            let runtime = state.registry().get(&id).expect("registered");
+            let (ctx, guard) = runtime
+                .run_supervisor()
+                .begin("digest", false)
+                .expect("the first run is under any cap");
+            journal_start(&state, &id, "digest", &ctx.run_id, false).await;
+
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(
+                body[0]["running"], true,
+                "a registered run is alive and must read that way: {body}"
+            );
             assert!(body[0].get("error").is_none(), "{body}");
+
+            // …and nothing was written behind its back. A settle that journaled
+            // a finish for a live run would be discovered later, by the run's
+            // own finish landing second and contradicting it.
+            let finishes = runtime
+                .events()
+                .read_from(&id, crate::ports::types::EventSeq::new(0), usize::MAX)
+                .await
+                .expect("read")
+                .into_iter()
+                .filter(|stored| matches!(stored.event, CompanyEvent::WorkflowRunFinished { .. }))
+                .count();
+            assert_eq!(finishes, 0, "a live run must not be settled");
+
+            // The only thing a dying run task changes.
+            drop(guard);
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert!(body[0].get("running").is_none(), "{body}");
+            assert_eq!(
+                body[0]["error"],
+                crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART,
+                "{body}"
+            );
         }
 
         /// **The compatibility claim, pinned.** A journal written before #371
@@ -5736,8 +6004,14 @@ label = "ok"
                 .expect("tempdir")
         }
 
-        /// A hosted company with one overlay workflow and a runner that stalls.
-        async fn stalled_company(home: &std::path::Path) -> Stalled {
+        /// Saves the hosted company these tests drive, and hands back what
+        /// building a runtime over it needs.
+        ///
+        /// Split out of [`stalled_company`] (issue #1009), which now has a
+        /// sibling: a fixture whose runner **panics** rather than parks, driven
+        /// through the identical route, supervisor, spawn and journal. One copy
+        /// of the company, two runners.
+        async fn saved_company(home: &std::path::Path) -> (CompanyId, CompanyManifest) {
             let manifest: CompanyManifest =
                 toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
             let id = CompanyId::new("acme");
@@ -5763,28 +6037,52 @@ label = "ok"
                 })
                 .await
                 .unwrap();
+            (id, manifest)
+        }
 
-            let entered = Arc::new(tokio::sync::Notify::new());
-            let release = Arc::new(tokio::sync::Notify::new());
-            let completed = Arc::new(AtomicBool::new(false));
+        /// A hosted company serving the graph above, driven by `runner`.
+        ///
+        /// Everything above the runner is production code — the route, the
+        /// supervisor registration, `WorkflowSpawn`'s task and its watchdog, the
+        /// journal write — which is what lets these tests be about the entry
+        /// point rather than about the engine.
+        async fn company_with_runner(
+            home: &std::path::Path,
+            runner: Arc<dyn WorkflowRunner>,
+        ) -> (axum::Router, Arc<crate::company::runtime::CompanyRuntime>) {
+            let (id, manifest) = saved_company(home).await;
             let mut runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
                 .with_id(id.clone())
                 .build()
                 .await
                 .unwrap();
-            runtime.set_workflow_runner(Arc::new(StalledRunner {
-                entered: entered.clone(),
-                release: release.clone(),
-                completed: completed.clone(),
-            }));
+            runtime.set_workflow_runner(runner);
             let runtime = Arc::new(runtime);
 
             let state = AppState::new(AppConfig::default());
             state.registry().insert(id.clone(), runtime.clone());
             crate::server::test_support::seed_fixed_admin(&state, "acme").await;
 
+            (router(state), runtime)
+        }
+
+        /// A hosted company with one overlay workflow and a runner that stalls.
+        async fn stalled_company(home: &std::path::Path) -> Stalled {
+            let entered = Arc::new(tokio::sync::Notify::new());
+            let release = Arc::new(tokio::sync::Notify::new());
+            let completed = Arc::new(AtomicBool::new(false));
+            let (app, runtime) = company_with_runner(
+                home,
+                Arc::new(StalledRunner {
+                    entered: entered.clone(),
+                    release: release.clone(),
+                    completed: completed.clone(),
+                }),
+            )
+            .await;
+
             Stalled {
-                app: router(state),
+                app,
                 runtime,
                 entered,
                 release,
@@ -5845,6 +6143,124 @@ label = "ok"
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
             None
+        }
+
+        /// A runner that journals the run's start and then **panics**, which is
+        /// what an unhandled fault inside the engine looks like from out here.
+        ///
+        /// It writes the `WorkflowRunStarted` the real runner writes, because
+        /// that row is the whole problem: without it a lost run leaves nothing
+        /// behind, and with it the history folds `running: true` for a run that
+        /// will never finish.
+        ///
+        /// The log arrives through a [`OnceLock`](std::sync::OnceLock) because
+        /// of the order the fixture builds in — the runtime that owns the
+        /// journal is built first and the runner is set on it afterwards, so
+        /// there is no journal to hand the runner at construction time.
+        struct PanickingRunner {
+            events: std::sync::OnceLock<Arc<dyn crate::ports::EventLog>>,
+        }
+
+        #[async_trait::async_trait]
+        impl WorkflowRunner for PanickingRunner {
+            async fn run(
+                &self,
+                company: &CompanyId,
+                workflow: &crate::company::WorkflowFile,
+                _input: serde_json::Value,
+                ctx: &WorkflowRunContext,
+            ) -> crate::Result<WorkflowRun> {
+                self.events
+                    .get()
+                    .expect("the journal is set before any run starts")
+                    .append(
+                        company,
+                        CompanyEvent::WorkflowRunStarted {
+                            workflow_id: workflow.id.clone(),
+                            run_id: ctx.run_id.clone(),
+                            scheduled: ctx.scheduled,
+                        },
+                    )
+                    .await
+                    .expect("append");
+                panic!("the run blew up mid-graph");
+            }
+        }
+
+        fn runs_request() -> Request<Body> {
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/workflows/runs")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap()
+        }
+
+        /// **Issue #1009's write half.** A run task that panics still ends with
+        /// a journaled finish, and the history reads settled rather than
+        /// running.
+        ///
+        /// Before the watchdog, a panicking task unwound straight past its own
+        /// `record_run_finished`: the guard dropped, the supervisor entry went,
+        /// and the `WorkflowRunStarted` stood alone in the journal for the life
+        /// of the process — `sweep_interrupted_runs` is boot-only, so nothing
+        /// short of a restart ever settled it. `run_supervisor`'s module docs
+        /// named this as a known gap; this is that gap, closed.
+        ///
+        /// Detached mode on purpose. The synchronous arm re-raises the panic
+        /// into the request, which is behaviour that must NOT change; what is
+        /// asserted here is what the run leaves behind when nobody is waiting on
+        /// it at all, which is the case that used to leave nothing.
+        #[tokio::test]
+        async fn a_panicking_run_task_still_journals_a_finish() {
+            let home_dir = home();
+            let runner = Arc::new(PanickingRunner {
+                events: std::sync::OnceLock::new(),
+            });
+            let (app, runtime) = company_with_runner(home_dir.path(), runner.clone()).await;
+            runner
+                .events
+                .set(runtime.events().clone())
+                .ok()
+                .expect("set once");
+
+            let response = app
+                .clone()
+                .oneshot(run_request(
+                    serde_json::json!({ "detach": true, "input": {} }),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::ACCEPTED);
+            let accepted = json_body(response).await;
+            let run_id = accepted["runId"].as_str().expect("a run id").to_string();
+
+            let finished = await_finished(&runtime)
+                .await
+                .expect("the run task panicked and journaled nothing at all");
+            let CompanyEvent::WorkflowRunFinished {
+                run_id: settled,
+                error,
+                cancelled,
+                ..
+            } = finished
+            else {
+                unreachable!()
+            };
+            assert_eq!(
+                settled.as_deref(),
+                Some(run_id.as_str()),
+                "the finish must correlate with the run that died"
+            );
+            assert_eq!(error.as_deref(), Some(crate::runtime::RUN_TASK_LOST));
+            assert!(!cancelled, "a panic is not an operator pressing Stop");
+
+            // And the whole point of journaling it: the history stops claiming
+            // this run is walking.
+            let body = json_body(app.oneshot(runs_request()).await.unwrap()).await;
+            assert_eq!(body[0]["runId"], run_id, "{body}");
+            assert!(body[0].get("running").is_none(), "{body}");
+            assert_eq!(body[0]["error"], crate::runtime::RUN_TASK_LOST, "{body}");
         }
 
         /// **The keystone.** A client that walks away mid-run must not take the

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2519,6 +2519,25 @@ async fn list_runs(
 /// finishes and still journals, and its real finish lands after this synthetic
 /// one — so the fold, which settles an entry from the last finish it sees, ends
 /// up with the truth. The reading is wrong in between, not the record.
+///
+/// # Yes, a read writes
+///
+/// Two consequences, both accepted deliberately:
+///
+/// * **Two concurrent readers can append the same finish twice.** Both would see
+///   the run open, absent, and unsettled in the tail, and both would write. The
+///   rows are byte-identical, and every consumer of the journal is indifferent
+///   to the repeat — the fold settles one entry from the last finish it sees,
+///   `sweep_interrupted_runs` removes an already-removed key, and
+///   `delivered_by_unsettled_runs` reads the same error either way. Serialising
+///   the write to avoid a duplicate that changes no answer would cost a lock on
+///   the read path for nothing.
+/// * **It settles every open row, not just the page.** `limit` cuts the response
+///   *after* this runs, on purpose: a dead run that happens to fall off the
+///   requested page is still dead, and skipping it would leave it hanging for
+///   exactly as long as it stays off the page. The work is bounded in practice
+///   — the boot sweep clears the backlog at start, and each run is settled once,
+///   after which its finish is durable and it is no longer a candidate.
 async fn settle_dead_runs(
     company: &ScopedCompany,
     runs: &mut [WorkflowRunOutcome],


### PR DESCRIPTION
## Summary

A workflow run could sit at `running` forever. A run journals a `WorkflowRunStarted` before the engine call and a `WorkflowRunFinished` after it, and `list_runs` folds a start with no finish as `running: true`. Two things take the missing finish away without anyone noticing — a run task that panics unwinds past its own `record_run_finished`, and a finish append that fails is swallowed by design — and the only repair was the boot-time `sweep_interrupted_runs`. A long-lived host therefore never recovered: a node pulsed, the header read "running", the Stop button stayed, and the console's 2s recovery poll never stopped.

Three parts, matching the issue's proposal:

**1. A watchdog on the run task** (`src/runtime/workflow_spawn.rs`). `spawn_admitted` now spawns the run on an inner task and returns an outer watchdog that awaits it. A `JoinError` — panic or abort — means the run never ran its own journal write, so the watchdog writes one carrying the new `RUN_TASK_LOST` constant. The `RunGuard` moves into the watchdog rather than the run task, so the supervisor entry outlives *whichever* path journaled. A panic is re-raised with `resume_unwind`, so the console's synchronous run route and the cron scheduler see the same `Err(JoinError)` they always did — the watchdog adds a durable record, it does not change what a caller sees. Implemented in `WorkflowSpawn` rather than in `spawn_workflow_run` because that is where the spawn actually happens, so all four entry points get it (`run_workflow`, the cron scheduler, the approved-gate continuation, and the resume arm) instead of one.

**2. A liveness cross-check on the read** (`src/server/ops/workflows.rs`). After the fold, `settle_dead_runs` checks each still-running row against `RunSupervisor::live()` and settles the rows the supervisor no longer holds with the same synthetic `INTERRUPTED_BY_RESTART` finish the boot sweep writes — durably, so the next reader folds it without repeating the work and the console's `settledRunIds` backstop finally sees the run settle.

A genuinely live run cannot be mistaken for a dead one:

- **Between spawn and registration** there is no window, in that order: `RunSupervisor::begin` registers *before* `WorkflowSpawn` spawns the task, and the task journals the `WorkflowRunStarted` later still. A start visible in the journal implies the run was already registered.
- **Between the journal read and the liveness check** a run can settle, leaving it absent from `live()` with a finish this snapshot is too old to have seen. So the journal is re-read from where the snapshot stopped, and a candidate whose finish turns up in that tail is dropped. The tail read costs a query only when there are candidates at all.
- **A journal that cannot be re-read** settles nothing. An unprovable claim is left alone rather than guessed at.

One window is deliberately left open and documented: the pre-existing rebuild gap (a live runtime swap hands the successor a fresh supervisor, so a run started before the swap is settled early). Its real finish still lands, after the synthetic one, and the fold takes the last finish it sees — the reading is wrong in between, not the record.

**3. The recovery poll** (`frontend/src/views/WorkflowsView.tsx`) goes through `startVisiblePolling`, like every other poll in the console, so it stops in a hidden tab and re-reads on the hidden → visible edge.

**Not in this PR:** `record_run_finished` swallowing a failed append (`src/runtime/workflow_outcome.rs:174-183`) is #1008 and is being implemented in parallel — that file is untouched here.

## Tests

- `run_history_settles_a_run_whose_supervisor_entry_is_gone` — a start with no finish and no supervisor entry folds as interrupted, keeps its node trail, and the synthetic finish is journaled exactly once. (Replaces `run_history_reports_an_unsettled_run_as_running`, whose premise was the bug.)
- `run_history_does_not_settle_a_run_the_supervisor_still_holds` — the false positive that would matter most. A run registered through the real `begin` reads `running: true` and nothing is written behind its back; dropping the guard — the only thing a dying run task changes — flips the same journal to interrupted.
- `a_panicking_run_task_still_journals_a_finish` — a run driven through the real route with a runner that journals a start and then panics ends with a `WorkflowRunFinished` correlated to its run id and carrying `RUN_TASK_LOST`, and the history reads settled.

`stalled_company` was split into `saved_company` + `company_with_runner` so the panicking runner reuses the existing fixture rather than copying it.

## Commands run

```
cargo fmt --all -- --check
```
Clean.

```
cargo clippy --all-targets --features openhuman,tinycortex -- -D warnings
```
`Finished dev profile ... in 33.79s` — no warnings.

```
cargo test --features openhuman,tinycortex --lib -- \
  runtime::workflow runtime::run_supervisor server::ops::workflows workflows::runner
```
`test result: ok. 255 passed; 0 failed; 0 ignored; 0 measured; 4004 filtered out`

```
cd frontend && npm ci && npm run typecheck && npm test
```
typecheck clean; `Test Files 87 passed (87) / Tests 891 passed (891)`.

## Docs

`docs/spec/runtime/workflow-events.md` gains "A boot sweep alone is not enough (#1009)" covering the watchdog, the cross-check and each window it closes; `docs/spec/runtime/api.md` notes the cross-check on `GET …/workflows/runs`. Both stay under 500 lines.

Closes #1009


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow history now detects and settles orphaned or unexpectedly interrupted runs.
  * Aborted or panicking workflow tasks are recorded with a clear “task lost” outcome.
  * Run history polling pauses when the browser tab is hidden and refreshes immediately when it becomes visible.

* **Documentation**
  * Updated runtime and workflow event documentation to explain interruption handling, task monitoring, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->