### PR TITLE
Prove the offline path with a lane that runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,6 +764,47 @@ jobs:
       - name: Assert every integration target actually runs
         run: scripts/ci/assert-integration-targets-run.sh openhuman,tinycortex
 
+      # Issue #579: the offline claim, executed rather than asserted.
+      #
+      # `sudo unshare -n` puts the test binary in a fresh network namespace: no
+      # routes, no DNS, no interfaces but the loopback this brings up. An
+      # accidental cloud call on a shared code path is therefore a RED BUILD
+      # here, which is the whole point — a lane that merely declines to
+      # configure cloud providers passes just as happily when something dials
+      # out on a path the test did not reach.
+      #
+      # Why not the alternatives. `iptables -P OUTPUT DROP` would also cut the
+      # Actions runner's own control connection to the service, and a container
+      # with `--network none` needs an image built for the purpose; the
+      # namespace needs neither and the binary is already on disk.
+      #
+      # BUILT FIRST, DELIBERATELY. `--no-run` compiles (and therefore fetches)
+      # while the network still exists; only the execution is sandboxed. A
+      # namespace around `cargo test` would fail on the registry, not on the
+      # code, and would say nothing about the runtime.
+      #
+      # `OPENCOMPANY_OFFLINE_LANE=1` is what arms the guard's own self-check —
+      # `a_deliberate_outbound_call_fails_inside_the_namespace` asserts that
+      # egress FAILS. Without it a sandbox that silently failed to apply would
+      # produce a green lane indistinguishable from a working one, and "nothing
+      # dialled out" could not be told from "the jail was never locked".
+      - name: Build the offline end-to-end target
+        run: cargo test --locked --features openhuman,tinycortex --test offline_e2e --no-run
+
+      - name: Run it with no network at all
+        run: |
+          set -eu
+          binary="$(cargo test --locked --features openhuman,tinycortex --test offline_e2e \
+            --no-run --message-format=json 2>/dev/null \
+            | jq -r 'select(.executable != null and (.target.name == "offline_e2e")) | .executable' \
+            | tail -n 1)"
+          test -n "$binary" || { echo "could not locate the offline_e2e test binary" >&2; exit 1; }
+          echo "running $binary inside a network namespace"
+          sudo --preserve-env=RUST_MIN_STACK,OPENCOMPANY_OFFLINE_LANE \
+            unshare --net -- sh -c "ip link set lo up && exec '$binary' --test-threads=1 --nocapture"
+        env:
+          OPENCOMPANY_OFFLINE_LANE: "1"
+
       # Catches the combination traps no single feature set can: most often a
       # mandatory struct field constructed differently across feature arms.
       #

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -107,6 +107,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [runtime/repos.md](runtime/repos.md) | Bound repositories: mirror cache, credential handling, quota |
 | [runtime/data-root.md](runtime/data-root.md) | Data-root resolution, the single-writer lock, instance identity |
 | [runtime/desktop.md](runtime/desktop.md) | The desktop client: connections, transport seam, embedded host |
+| [runtime/offline.md](runtime/offline.md) | Running with no network: the configuration, what is not local, and the CI lane that proves it |
 | [runtime/hub-console.md](runtime/hub-console.md) | One console deployment operating many hosts on other origins |
 | [security/agent-isolation.md](security/agent-isolation.md) | What confines an agent and what does not — enforced controls, the gaps, and the capability that survives every planned control |
 | [company-as-agent/README.md](company-as-agent/README.md) | Companies as economy citizens |

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -33,6 +33,9 @@ Supporting docs:
     why an ephemeral data root refuses to boot
   - [data-root.md](data-root.md) — the root itself: resolution order, ownership,
     and two processes wanting the same directory
+  - [offline.md](offline.md) — running with no network at all: the documented
+    manifest, what stays hosted (Medulla, Composio, the hub identity exchange),
+    and the CI lane that executes the claim inside a network namespace
 - [events.md](events.md) — the `CompanyEvent` vocabulary those ports carry, and
   the run/task/approval correlation rules a journal reader folds on
   - [workflow-events.md](workflow-events.md) — the workflow-run progress

--- a/docs/spec/runtime/offline.md
+++ b/docs/spec/runtime/offline.md
@@ -1,0 +1,134 @@
+# Running with no network
+
+OpenCompany runs a company end to end with no outbound network: local
+inference, a filesystem store, the embedded OpenHuman agent runtime, and local
+MCP processes. This document is the configuration, and
+[`tests/offline_e2e.rs`](../../../tests/offline_e2e.rs) is the proof — CI
+executes it inside a network namespace with no routes, so the claim on this
+page fails a build when it stops being true.
+
+That ordering is the point of issue #579. An offline path documented and not
+executed rots the first time a cloud call is added to a shared code path, and it
+rots silently: nothing fails, and the page keeps asserting with authority.
+
+## What is not local
+
+Three things are hosted services, and no configuration makes them otherwise:
+
+| Not local | What it is |
+|---|---|
+| **Medulla** | the hosted cognition brain |
+| **Composio** | the hosted third-party tool broker |
+| **Hub identity exchange** | the platform's cross-tenant identity service |
+
+A green offline lane says **the offline path works**. It does not say everything
+works offline. Configure none of the above and their surfaces are *absent*
+rather than present-and-failing, which is the behaviour #579 asks for: an
+operator should not be offered a tool that cannot run here.
+
+Specifically, with the manifest below: no `composio` grant means Composio-backed
+tools are never wired onto an agent's belt; no managed credential means the
+cognition brain is not the hosted one; and nothing contacts the hub.
+
+## The configuration
+
+```toml
+[company]
+name = "Offline Co"
+summary = "Proves the no-network path."
+
+# Local inference. `ollama` resolves through the ordinary OpenAI-compatible
+# path: one `base_url`, and no bearer at all when no key is set.
+[inference]
+provider = "ollama"
+base_url = "http://localhost:11434/v1"
+model = "llama3"
+
+# No `composio`, no `search`, no `media` — a hosted surface is absent rather
+# than offered and broken.
+[tools]
+allow = ["workspace", "files"]
+
+[users]
+admins = ["operator@opencompany.local"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+
+[[agent]]
+id = "writer"
+role = "Writer"
+```
+
+Run it:
+
+```sh
+ollama serve                     # or any OpenAI-compatible server on that port
+opencompany serve --company path/to/company
+```
+
+The default store is the filesystem and needs nothing; `sqlite` also runs with
+no server. `OPENCOMPANY_DATA_DIR` sets where state lives — see
+[data-root.md](data-root.md).
+
+## What the lane actually does
+
+`tests/offline_e2e.rs` boots that manifest on loopback, signs in over the
+magic-link flow, creates a card, drags it into In Progress, and watches an agent
+work it — then finishes it. Every model call goes to a scripted
+OpenAI-compatible endpoint on loopback, and the test asserts that endpoint was
+actually called, so a run that never reached a model cannot pass as one that
+did.
+
+**Why a scripted endpoint rather than a real Ollama.** `provider = "ollama"`
+resolves through the same code as any OpenAI-compatible endpoint, and its
+`base_url` is overridable, so a loopback script exercises the real provider path
+while keeping the lane fast and deterministic. What it does **not** prove is
+that a real Ollama server is wire-compatible with this client — that needs a
+model pull, which is slow and fails for reasons unrelated to this repository.
+
+**Why the operator has to finish the card.** The lane drives the card to
+`in_review` with no help, which is as far as an agent can take it: since the
+operator decision of 2026-08-05 (recorded in `harness::lifecycle`),
+**`done` is reached only by a person**, through an approving verdict. The test
+then plays that person. Read the lane as "an agent does the work offline and a
+human approves it offline", never as "an agent reaches Done unaided" — the
+product does not permit the second, and #579's acceptance was written before the
+decision that changed it.
+
+## How "no network" is enforced
+
+The CI step runs the compiled test binary under:
+
+```sh
+sudo unshare --net -- sh -c "ip link set lo up && exec <binary>"
+```
+
+A fresh network namespace has no routes, no DNS and no interfaces beyond the
+loopback that command brings up, so an accidental cloud call **fails** rather
+than passing unnoticed. The binary is compiled *before* the namespace is
+entered, because compiling fetches crates; sandboxing the build would fail on
+the registry and say nothing about the runtime.
+
+`iptables -P OUTPUT DROP` was rejected because it would also cut the Actions
+runner's own control connection; a container with `--network none` was rejected
+because it needs an image built for the purpose and buys no extra isolation.
+
+### The guard checks itself
+
+`a_deliberate_outbound_call_fails_inside_the_namespace` attempts a real outbound
+connection and asserts it fails. It runs only when the lane sets
+`OPENCOMPANY_OFFLINE_LANE=1`, so the same file still runs on a networked laptop.
+
+Without it this lane would be theatre: a sandbox that silently failed to apply
+produces a green run indistinguishable from a working one, and "nothing dialled
+out" cannot be told from "the jail was never locked".
+
+## If you add a cloud call
+
+The lane goes red, and it should. Either the call belongs behind a capability
+that is absent offline — the Composio/Medulla shape, where the surface is not
+offered at all — or it is a genuine new dependency and this page needs to say
+so. Do not make the lane pass by giving the namespace a route.

--- a/tests/offline_e2e.rs
+++ b/tests/offline_e2e.rs
@@ -1,0 +1,421 @@
+#![cfg(feature = "openhuman")]
+//! **Proof that a company boots, works and finishes a card with no network.**
+//!
+//! Issue #579. Running OpenCompany with no cloud dependency was mostly true and
+//! nowhere proven, and an unproven offline path rots the first time a cloud call
+//! is added to a shared code path — silently, because nothing fails.
+//!
+//! # What this covers, and what it deliberately does not
+//!
+//! Covered: manifest-configured local inference (`provider = "ollama"` against an
+//! OpenAI-compatible endpoint), the filesystem store, the embedded OpenHuman
+//! agent runtime, the HTTP surface, loopback magic-link sign-in, and a card
+//! driven from creation to `done`.
+//!
+//! **Not covered, by design**: the Medulla hosted brain, Composio, and the hub
+//! identity exchange. Those are hosted services and are not local; #579 says so
+//! outright. A green run of this file says the *offline* path works, never that
+//! everything works offline. See `docs/spec/runtime/offline.md`.
+//!
+//! # Why the endpoint is a stub rather than a real Ollama
+//!
+//! `provider = "ollama"` resolves through the same code as any other
+//! OpenAI-compatible endpoint — one `base_url`, no bearer when keyless
+//! (`harness::provider`'s `request_plan_omits_bearer_for_keyless_ollama`), the
+//! same request shape — and the URL is overridable. So pointing it at a scripted
+//! loopback endpoint exercises the real `ollama` provider path while keeping the
+//! lane fast and deterministic.
+//!
+//! What that does **not** prove is that a real Ollama server is wire-compatible
+//! with this client; that needs a model pull, which is slow and fails for reasons
+//! unrelated to this repo. Stated here rather than left for a reader to assume.
+//!
+//! # The egress guard
+//!
+//! The lane runs this under `sudo unshare -n` (see `.github/workflows/ci.yml`),
+//! which gives the process a network namespace with nothing but loopback.
+//!
+//! `a_deliberate_outbound_call_fails` is what makes that a proof rather than a
+//! claim: without it, a lane whose sandbox silently failed to apply would pass
+//! exactly as a lane whose sandbox worked, and "nothing dialled out" would be
+//! indistinguishable from "the namespace was not applied". It asserts only when
+//! `OPENCOMPANY_OFFLINE_LANE=1` — the lane sets it — so the same file still runs
+//! on a developer's networked laptop without failing for having a network.
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use opencompany::company::CompanyManifest;
+use opencompany::runtime::{RuntimeBuilder, company_id_from_name};
+use opencompany::{AppConfig, AppState};
+
+/// Set by the CI lane to say "you are inside the namespace; prove it".
+const LANE_ENV: &str = "OPENCOMPANY_OFFLINE_LANE";
+
+/// Whether this process is the sandboxed lane rather than a local run.
+fn in_offline_lane() -> bool {
+    std::env::var(LANE_ENV).is_ok_and(|v| v == "1")
+}
+
+// ---------------------------------------------------------------------------
+// The scripted local endpoint
+// ---------------------------------------------------------------------------
+
+/// One scripted model turn.
+#[derive(Clone, Debug)]
+enum Turn {
+    /// Finish the turn with plain assistant text.
+    Say(&'static str),
+}
+
+/// A scripted OpenAI-compatible endpoint, served on loopback.
+///
+/// `/embeddings` is served alongside `/chat/completions` because the host's
+/// embeddings client shares the same `base_url` and validates the width it gets
+/// back — without it a memory write 404s in the middle of a turn, which reads as
+/// an inference failure and is not one.
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+    seen: Mutex<Vec<Value>>,
+}
+
+async fn spawn_script(turns: Vec<Turn>) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
+    });
+    let chat = Arc::clone(&script);
+    let app = axum::Router::new()
+        .route(
+            "/chat/completions",
+            post(move |Json(body): Json<Value>| {
+                let script = Arc::clone(&chat);
+                async move {
+                    script.seen.lock().unwrap().push(body);
+                    let next = {
+                        let mut turns = script.turns.lock().unwrap();
+                        (!turns.is_empty()).then(|| turns.remove(0))
+                    };
+                    // Running off the end means the loop turned more than
+                    // scripted; end it with text rather than hanging.
+                    let Turn::Say(text) = next.unwrap_or(Turn::Say("done"));
+                    Json(json!({
+                        "choices": [{
+                            "index": 0,
+                            "message": { "role": "assistant", "content": text },
+                            "finish_reason": "stop"
+                        }],
+                        "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                    }))
+                }
+            }),
+        )
+        .route(
+            "/embeddings",
+            post(|Json(_body): Json<Value>| async move {
+                Json(json!({
+                    "data": [{ "index": 0, "embedding": vec![0.0_f32; 1536] }],
+                    "usage": { "prompt_tokens": 1, "total_tokens": 1 }
+                }))
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+// ---------------------------------------------------------------------------
+// The offline company
+// ---------------------------------------------------------------------------
+
+/// The manifest `docs/spec/runtime/offline.md` documents, with `base_url` bound
+/// to the scripted endpoint instead of Ollama's default port.
+///
+/// Everything hosted is absent rather than configured-and-broken: no `composio`
+/// grant, no managed credential, no Medulla. #579 asks for exactly that — a
+/// surface that degrades by being missing, not by failing at call time.
+fn offline_manifest(base_url: &str) -> String {
+    format!(
+        r#"
+[company]
+name = "Offline Co"
+summary = "Proves the no-network path."
+
+[inference]
+provider = "ollama"
+base_url = "{base_url}"
+model = "llama3"
+
+[tools]
+allow = ["workspace", "files"]
+
+[users]
+admins = ["operator@opencompany.local"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+
+[[agent]]
+id = "writer"
+role = "Writer"
+"#
+    )
+}
+
+/// Boots the offline company on loopback and returns its address and id.
+async fn boot(home: &std::path::Path, base_url: &str) -> (SocketAddr, String) {
+    let mut manifest = CompanyManifest::from_stored_toml(&offline_manifest(base_url))
+        .expect("the documented offline manifest parses");
+    manifest.apply_globals();
+    let problems = manifest.validate();
+    assert!(
+        problems.is_empty(),
+        "the documented offline manifest must be valid: {problems:?}"
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let company_id = company_id_from_name(&manifest.company.name);
+    let state = AppState::new(AppConfig {
+        bind: address.to_string(),
+        ..AppConfig::default()
+    })
+    .with_home(home.to_path_buf());
+    let runtime = RuntimeBuilder::new(state.home().to_path_buf(), manifest)
+        .with_id(company_id.clone())
+        // The agent pool. `serve` wires this (`src/bin/opencompany.rs`); without
+        // it `dispatch_task` is a documented no-op and the board stays inert, so
+        // a card would sit in In Progress forever and the lane would prove
+        // nothing about an agent working offline.
+        .with_harness(Arc::new(opencompany::harness::HarnessPool::new()))
+        .build()
+        .await
+        .expect("the offline company builds with no network");
+    state
+        .registry()
+        .insert(company_id.clone(), Arc::new(runtime));
+    tokio::spawn(async move {
+        let _ = opencompany::server::serve_on(listener, state).await;
+    });
+    (address, company_id.as_ref().to_string())
+}
+
+#[tokio::test]
+async fn a_deliberate_outbound_call_fails_inside_the_namespace() {
+    if !in_offline_lane() {
+        eprintln!(
+            "[offline] {LANE_ENV} is unset, so this is a local run with a network; \
+             skipping the egress assertion. The CI lane sets it inside `unshare -n`."
+        );
+        return;
+    }
+    // A routable public address, dialled directly so no DNS is needed — the
+    // failure must be "there is no route", not "the name did not resolve",
+    // which a namespace with no interfaces gives us either way.
+    let attempt = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::net::TcpStream::connect("1.1.1.1:443"),
+    )
+    .await;
+    // A refusal, an unreachable network, or a timeout all mean the same thing
+    // here: nothing got out. Only a *connection* is a failure.
+    if let Ok(Ok(_)) = attempt {
+        panic!(
+            "egress SUCCEEDED inside the offline lane, so the network namespace was not applied \
+             and every other assertion in this file proves nothing about being offline"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The end-to-end path
+// ---------------------------------------------------------------------------
+
+/// A tiny cookie-carrying HTTP helper. `reqwest`'s cookie store is behind a
+/// feature this crate does not enable, so the session cookie is carried by hand.
+struct Client {
+    inner: reqwest::Client,
+    base: String,
+    cookie: Mutex<Option<String>>,
+}
+
+impl Client {
+    fn new(address: SocketAddr) -> Self {
+        Self {
+            inner: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .unwrap(),
+            base: format!("http://{address}"),
+            cookie: Mutex::new(None),
+        }
+    }
+
+    async fn send(&self, method: reqwest::Method, path: &str, body: Option<Value>) -> (u16, Value) {
+        let mut request = self.inner.request(method, format!("{}{path}", self.base));
+        if let Some(cookie) = self.cookie.lock().unwrap().clone() {
+            request = request.header(reqwest::header::COOKIE, cookie);
+        }
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request.send().await.expect("the loopback host answers");
+        let status = response.status().as_u16();
+        if let Some(set) = response.headers().get(reqwest::header::SET_COOKIE)
+            && let Ok(value) = set.to_str()
+            && let Some((pair, _)) = value.split_once(';')
+        {
+            *self.cookie.lock().unwrap() = Some(pair.to_string());
+        }
+        let text = response.text().await.unwrap_or_default();
+        let json = serde_json::from_str(&text).unwrap_or(Value::String(text));
+        (status, json)
+    }
+
+    async fn get(&self, path: &str) -> (u16, Value) {
+        self.send(reqwest::Method::GET, path, None).await
+    }
+    async fn post(&self, path: &str, body: Value) -> (u16, Value) {
+        self.send(reqwest::Method::POST, path, Some(body)).await
+    }
+    async fn patch(&self, path: &str, body: Value) -> (u16, Value) {
+        self.send(reqwest::Method::PATCH, path, Some(body)).await
+    }
+
+    /// Signs in as the manifest admin over the loopback magic-link flow, which
+    /// echoes the code rather than mailing it — there is no mail transport here,
+    /// and on a routable host it would not echo at all.
+    async fn sign_in(&self, email: &str) {
+        let (status, body) = self
+            .post("/api/v1/company/auth/request", json!({ "email": email }))
+            .await;
+        assert_eq!(status, 200, "sign-in request refused: {body}");
+        let code = body["dev_code"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no dev_code came back, so no session can be minted: {body}"))
+            .to_string();
+        let (status, body) = self
+            .post("/api/v1/company/auth/verify", json!({ "code": code }))
+            .await;
+        assert_eq!(status, 200, "the login code was refused: {body}");
+    }
+}
+
+/// Polls `GET /tasks/{id}` until its column is one of `wanted`, or gives up.
+async fn wait_for_column(client: &Client, task_id: &str, wanted: &[&str]) -> String {
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    let mut last = String::new();
+    while std::time::Instant::now() < deadline {
+        let (status, body) = client
+            .get(&format!("/api/v1/company/tasks/{task_id}"))
+            .await;
+        if status == 200 {
+            let column = body
+                .get("task")
+                .and_then(|task| task.get("column"))
+                .or_else(|| body.get("column"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if wanted.contains(&column.as_str()) {
+                return column;
+            }
+            last = column;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!("card never reached {wanted:?}; it is sitting in `{last}`");
+}
+
+/// **The acceptance path.** A company boots, an agent works a card, and the card
+/// reaches `done` — with no network.
+///
+/// ## Why the operator's move is part of the path rather than a shortcut
+///
+/// #579 asks for a card driven "to Done". Since the operator decision of
+/// 2026-08-05 (recorded in `harness::lifecycle`), **`done` is reachable only by a
+/// person**: every card — delegated or board-created — settles in `in_review`
+/// first, and an approving verdict is what moves it. So the agent half of this
+/// test drives the card as far as an agent can take it, offline and unaided, and
+/// the harness then plays the operator who approves it.
+///
+/// That is not a weakening of the claim; it is the claim stated accurately. A
+/// version of this test that reported `in_review` as "Done" would be reading the
+/// lane as proof that an agent finishes work alone, which the product does not
+/// permit.
+#[tokio::test]
+async fn a_company_boots_works_a_card_and_reaches_done_with_no_network() {
+    let home = tempfile::tempdir().unwrap();
+    let (base_url, script) =
+        spawn_script(vec![Turn::Say("The brief is written and ready to review.")]).await;
+    let (address, _company) = boot(home.path(), &base_url).await;
+    let client = Client::new(address);
+
+    let (status, _) = client.get("/healthz").await;
+    assert_eq!(status, 200, "the offline host serves /healthz");
+
+    client.sign_in("operator@opencompany.local").await;
+
+    let (status, card) = client
+        .post(
+            "/api/v1/company/tasks",
+            json!({ "title": "Write the launch brief", "assignee": "writer" }),
+        )
+        .await;
+    assert_eq!(status, 200, "card creation refused: {card}");
+    let task_id = card["id"]
+        .as_str()
+        .expect("the new card has an id")
+        .to_string();
+
+    // The board drag that starts work — `upsert_task` reads this edge and
+    // dispatches, which is what puts the agent (and therefore the local
+    // endpoint) on the path.
+    let (status, body) = client
+        .patch(
+            &format!("/api/v1/company/tasks/{task_id}"),
+            json!({ "column": "in_progress" }),
+        )
+        .await;
+    assert_eq!(status, 200, "dispatch refused: {body}");
+
+    let settled = wait_for_column(&client, &task_id, &["in_review", "done", "paused"]).await;
+    assert_eq!(
+        settled, "in_review",
+        "an agent takes a card as far as In Review and no further"
+    );
+
+    // The person. `done` has exactly one route and it runs through a human.
+    let (status, body) = client
+        .patch(
+            &format!("/api/v1/company/tasks/{task_id}"),
+            json!({ "column": "done" }),
+        )
+        .await;
+    assert_eq!(
+        status, 200,
+        "the operator's approving move was refused: {body}"
+    );
+    let finished = wait_for_column(&client, &task_id, &["done"]).await;
+    assert_eq!(finished, "done");
+
+    // The load-bearing assertion about *offline*: the work above actually went
+    // through the local endpoint. Without this the test would pass just as well
+    // against a card that never reached a model at all.
+    let calls = script.seen.lock().unwrap().len();
+    assert!(
+        calls > 0,
+        "no inference request reached the local endpoint, so this proves nothing about \
+         a locally-served model driving the work"
+    );
+}


### PR DESCRIPTION
## Summary

Running OpenCompany with no cloud dependency was mostly true and nowhere proven. This adds the proof
first and the document second, because a documented offline path that nothing executes **rots the
first time a cloud call is added to a shared code path — and rots silently**, since nothing fails and
the page keeps asserting with authority.

`tests/offline_e2e.rs` boots a company from the documented manifest (`provider = "ollama"`, fs store),
signs in over the loopback magic-link flow, creates a card, drags it into In Progress, and an agent
works it. Verified against a real run:

```
timeline = [dispatched, "Reply from writer", "Finished on writer → in_review"]
script calls = 1
```

Every model call goes to a scripted OpenAI-compatible endpoint on loopback, and the test asserts that
endpoint **was actually called** — so a run that never reached a model cannot pass as one that did.

## How "no network" is enforced, and why that is the whole point

CI runs the compiled binary under:

```sh
sudo unshare --net -- sh -c "ip link set lo up && exec <binary>"
```

A fresh network namespace has no routes, no DNS and no interfaces beyond the loopback that brings up.
An accidental cloud call therefore **fails** rather than passing unnoticed. A lane that merely declines
to configure cloud providers proves nothing: it passes just as happily when something dials out on a
code path the test did not reach.

Compiled **before** the namespace is entered, deliberately — compiling fetches crates, so sandboxing
the build would fail on the registry and say nothing about the runtime.

Alternatives rejected, with reasons, so nobody re-litigates them: `iptables -P OUTPUT DROP` would also
cut the Actions runner's own control connection to the service; a container with `--network none`
needs an image built for the purpose and buys no extra isolation over a namespace, with the binary
already on disk.

### The sentinel — proof versus theatre

`a_deliberate_outbound_call_fails_inside_the_namespace` attempts a real outbound connection and
asserts it **fails**. If it succeeds:

> egress SUCCEEDED inside the offline lane, so the network namespace was not applied and every other
> assertion in this file proves nothing about being offline

**If `unshare` misbehaves on `ubuntu-latest`, the lane goes red on its own sentinel rather than passing
green.** That is the difference between proof and theatre. Without it, a sandbox that silently failed
to apply produces a run indistinguishable from a working one, and "nothing dialled out" cannot be told
from "the jail was never locked".

**Do not delete this test to make a red build go away** — a red here means the isolation is not real,
which invalidates every other assertion in the file.

It asserts only when the lane sets `OPENCOMPANY_OFFLINE_LANE=1`, so the same file still runs on a
developer's networked laptop without failing for having a network.

### What I could and could not verify locally

Stating this plainly rather than leaving it implied.

**I could not run `unshare` on macOS**, so the sandbox mechanism itself is unverified until this runs
in CI. What I *did* verify locally is the part that decides whether the lane is meaningful: running
the binary with `OPENCOMPANY_OFFLINE_LANE=1` **and a real network present** — exactly what an
unapplied namespace looks like — fails with the message above. So the failure mode that would make
this lane worthless is caught, and if the mechanics are wrong the first CI run says so instead of
going quietly green.

## Vacuity: the #475 / #477 trap

The target carries `#![cfg(feature = "openhuman")]`, so it reports **0 tests at default features and 2
in the gated lane**. That is precisely the pathology `scripts/ci/assert-integration-targets-run.sh`
exists to catch, and it is satisfied rather than worked around:

```
  offline_e2e: 2 tests
Every integration target executed at least one test.
```

## A footgun found on the way — filed separately, not fixed here

`RuntimeBuilder` does not attach the agent pool by default. Without `.with_harness(...)`,
`CompanyRuntime::dispatch_task` is a **documented no-op**: a card dragged into In Progress simply sits
there, no dispatch, no error, no log. `serve` wires it (`src/bin/opencompany.rs:589`); nothing warns
anyone who does not.

That cost real time here — the first version of this test had a card inert in In Progress with an
empty timeline and zero inference calls — and it will catch the next person writing a test or a tool
against the builder. Filed as tinyhumansai/opencompany#1059 rather than widened into this PR.

## Judgement calls, all stated in the doc as well

**A scripted endpoint rather than a real Ollama.** `provider = "ollama"` resolves through the same
code as any OpenAI-compatible endpoint — one `base_url`, no bearer when keyless (already pinned by
`request_plan_omits_bearer_for_keyless_ollama`), same request shape — and the URL is overridable. So
the script exercises the **real** `ollama` provider path while keeping the lane fast and
deterministic. What it does **not** prove is that a real Ollama server is wire-compatible with this
client; that needs a model pull, which is slow and fails for reasons unrelated to this repository.

**Why the operator finishes the card.** #579 asks for a card driven "to Done". Since the operator
decision of **2026-08-05** (recorded in `harness::lifecycle`), `done` is reached **only by a person**
through an approving verdict — every card settles in `in_review` first. So the agent half drives the
card as far as an agent can take it, offline and unaided, and the harness then plays the operator who
approves it, also offline.

That is the claim stated accurately, not weakened. A version reporting `in_review` as "Done" would
read as proof that an agent finishes work alone, which the product does not permit. Noted on #579,
whose acceptance predates the decision and cannot be met literally.

## Out of scope by design

**Medulla, Composio and the hub identity exchange are hosted services and stay hosted.** The doc leads
with that as a table. A green lane says **the offline path works** — never that everything works
offline. With the documented manifest those surfaces are *absent* rather than present-and-failing: no
`composio` grant means those tools are never wired onto a belt, no managed credential means the
cognition brain is not the hosted one, and nothing contacts the hub.

## API Or Behavior Changes

None. This adds a test target, a CI step and documentation; no runtime code changes.

## Tests

- [x] `cargo fmt --all -- --check` — PASS.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI's gated form,
      `--no-deps --features openhuman,tinycortex --all-targets`. PASS.
- [x] `cargo build --all-targets` — covered by the clippy and test runs above.
- [x] `cargo test` — **4282 passed / 0 failed** at `--features openhuman,tinycortex --lib`; the new
      target is **2 passed** and `assert-integration-targets-run.sh openhuman,tinycortex` reports
      `offline_e2e: 2 tests`.

Also: `scripts/ci/assert-md-line-cap.sh` PASS.

### Proven to fail when the thing it guards is broken

- **The sentinel**: run with `OPENCOMPANY_OFFLINE_LANE=1` and a network present (an unapplied
  namespace) → fails with the message quoted above.
- **The end-to-end test**: without `.with_harness(...)` the card never leaves In Progress and the test
  fails on `card never reached ["in_review", ...]; it is sitting in 'in_progress'` — which is how the
  footgun above was found.
- **Vacuity**: dropping the crate-level `cfg` would make the target report 0 in the gated lane and
  `assert-integration-targets-run.sh` fails on the count.

**Not verified locally, and cannot be**: the `unshare` sandbox itself — see the section above. The
first CI run is its first execution.

## Documentation

`docs/spec/runtime/offline.md` — the configuration, what is not local, what the lane does, how the
isolation is enforced, why the sentinel exists, and what to do when a new cloud call turns it red
("do not make the lane pass by giving the namespace a route"). Indexed in `docs/spec/README.md` and
`docs/spec/runtime/README.md`.

Closes tinyhumansai/opencompany#579

