### PR TITLE
fix(metering): post inference spend as a negative amount (#1047)

### DIFF
--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -679,7 +679,7 @@ async fn e2e_reported_usage_lands_on_the_usage_meter() {
         record
             .ledger
             .iter()
-            .any(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND && e.amount_usd == 0.042)
+            .any(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND && e.amount_usd == -0.042)
     );
 }
 

--- a/src/harness/cost.rs
+++ b/src/harness/cost.rs
@@ -212,7 +212,8 @@ mod tests {
         let turn = turn_with(0.42);
         let entry = ledger_entry_for(&turn, "ceo").unwrap();
         assert_eq!(entry.kind, "inference.spend");
-        assert_eq!(entry.amount_usd, 0.42);
+        // Negative: an outflow, per the ledger convention (issue #1047).
+        assert_eq!(entry.amount_usd, -0.42);
         assert_eq!(entry.memo, "ceo");
     }
 
@@ -235,7 +236,8 @@ mod tests {
 
         let ledger = store.ledger.lock().unwrap();
         assert_eq!(ledger.len(), 1);
-        assert_eq!(ledger[0].amount_usd, 1.5);
+        // Negative: an outflow, per the ledger convention (issue #1047).
+        assert_eq!(ledger[0].amount_usd, -1.5);
         let samples = meter.samples.lock().unwrap();
         assert_eq!(samples.len(), 1);
         assert_eq!(samples[0].kind, SampleKind::Inference);
@@ -282,7 +284,7 @@ mod tests {
         // Attribution only — the spend itself is unchanged.
         let ledger = store.ledger.lock().unwrap();
         assert_eq!(ledger.len(), 2);
-        assert!(ledger.iter().all(|e| e.amount_usd == 0.5));
+        assert!(ledger.iter().all(|e| e.amount_usd == -0.5));
 
         // The field is additive on the wire: an unattributed sample serializes
         // exactly as it did before #242.

--- a/src/metering/inference.rs
+++ b/src/metering/inference.rs
@@ -65,6 +65,25 @@ pub const INFERENCE_SPEND_KIND: &str = "inference.spend";
 /// tokens but bills backend-side and echoes no USD, so a token-bearing
 /// zero-cost cycle must not post a meaningless `$0.00` spend line to Finances.
 /// Its tokens still land on the Usage surface through [`inference_sample`].
+///
+/// # Sign (issue #1047)
+///
+/// The amount is posted **negative**. Inference is an outflow, and the ledger's
+/// convention — stated in [`finances`](super::finances) and implemented by
+/// `finances_from` — is that outflows are negative and inflows positive. This
+/// posted `usage.cost_usd` unnegated, so the projection read every model charge
+/// as income: `revenueUsd` and `balanceUsd` grew with spending while `spentUsd`
+/// and the `byCategory` breakdown stayed empty.
+///
+/// Negated **here**, at the one constructor every writer goes through
+/// (`harness::cost`, `metering::planning`, `metering::triage`,
+/// `metering::workflow_build`), rather than at the reader — the x402 outflow in
+/// `economy::adapter` already posts negative, so inverting `finances_from`
+/// would have meant changing that and both server fixtures to match a
+/// convention the docs already state correctly.
+///
+/// `usage.cost_usd` is a non-zero cost, so the result is strictly negative; the
+/// zero case returned above and never reaches here.
 pub fn inference_ledger_entry(usage: &TokenUsage, agent: &str) -> Option<LedgerEntry> {
     if usage.cost_usd == 0.0 {
         return None;
@@ -72,7 +91,7 @@ pub fn inference_ledger_entry(usage: &TokenUsage, agent: &str) -> Option<LedgerE
     Some(LedgerEntry {
         at_millis: now_millis(),
         kind: INFERENCE_SPEND_KIND.to_string(),
-        amount_usd: usage.cost_usd,
+        amount_usd: -usage.cost_usd,
         memo: agent.to_string(),
     })
 }
@@ -151,6 +170,106 @@ pub async fn record_inference_usage(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// **Issue #1047, the test whose absence let this stand.** The writer and
+    /// the reader, together — because each was self-consistent and only their
+    /// pairing was wrong.
+    ///
+    /// A company that has only ever spent money must report that spending as
+    /// `spent_usd`. Before this, `inference_ledger_entry` posted the cost
+    /// unnegated and `finances_from` read a positive amount as income, so the
+    /// Finances surface showed growing **revenue** and a growing **balance**
+    /// while `spent_usd` and `by_category` stayed at zero.
+    ///
+    /// Asserts the **direction**, not the magnitude: `revenue_usd` must be
+    /// exactly zero and `balance_usd` must be negative. A test that only
+    /// checked `spent_usd.abs()` would pass with the sign flipped either way,
+    /// which is the failure mode that produced this bug.
+    #[test]
+    fn a_costed_cycle_is_spending_not_revenue() {
+        let usage = TokenUsage {
+            input: 1_000,
+            output: 200,
+            cached_input: 0,
+            cost_usd: 0.42,
+        };
+        let entry = inference_ledger_entry(&usage, "ceo").expect("a costed cycle posts");
+
+        // The writer's half: an outflow is negative.
+        assert!(
+            entry.amount_usd < 0.0,
+            "inference is an outflow, so the ledger amount is negative: {}",
+            entry.amount_usd
+        );
+        assert!((entry.amount_usd - -0.42).abs() < 1e-9);
+
+        // The reader's half, over the entry the writer actually produced.
+        let at_millis = entry.at_millis;
+        let finances = crate::metering::finances::finances_from(
+            std::slice::from_ref(&entry),
+            &crate::company::Budget { monthly_usd: None },
+            None,
+            at_millis,
+        );
+
+        assert!(
+            (finances.spent_usd - 0.42).abs() < 1e-9,
+            "the charge lands in spent_usd: {finances:?}"
+        );
+        assert_eq!(
+            finances.revenue_usd, 0.0,
+            "a company that only spent money has NO revenue: {finances:?}"
+        );
+        assert!(
+            finances.balance_usd < 0.0,
+            "and spending moves the balance down, not up: {}",
+            finances.balance_usd
+        );
+        assert_eq!(
+            finances.by_category.len(),
+            1,
+            "the spend is categorised rather than invisible: {finances:?}"
+        );
+        assert_eq!(finances.by_category[0].category, "Inference");
+        assert!((finances.by_category[0].amount - 0.42).abs() < 1e-9);
+    }
+
+    /// The operator-facing rendering, pinned because it is the half a sign
+    /// change could plausibly break: `Transaction` carries an **absolute**
+    /// amount plus a `Direction`, so negating the writer must flip the
+    /// direction to `Out` and must NOT start rendering a negative figure.
+    #[test]
+    fn a_charge_renders_as_an_outgoing_transaction_with_a_positive_amount() {
+        let usage = TokenUsage {
+            input: 10,
+            output: 5,
+            cached_input: 0,
+            cost_usd: 0.42,
+        };
+        let entry = inference_ledger_entry(&usage, "ceo").expect("a costed cycle posts");
+        let at_millis = entry.at_millis;
+        let finances = crate::metering::finances::finances_from(
+            std::slice::from_ref(&entry),
+            &crate::company::Budget { monthly_usd: None },
+            None,
+            at_millis,
+        );
+
+        assert_eq!(finances.transactions.len(), 1);
+        let tx = &finances.transactions[0];
+        assert!(
+            matches!(tx.direction, crate::metering::types::Direction::Out),
+            "a charge is money going out"
+        );
+        assert!(
+            tx.amount_usd > 0.0,
+            "the rendered amount stays a positive magnitude — the sign is the \
+             `direction` field's job, not the number's: {}",
+            tx.amount_usd
+        );
+        assert!((tx.amount_usd - 0.42).abs() < 1e-9);
+        assert_eq!(tx.category, "Inference");
+    }
 
     use std::sync::Mutex;
 
@@ -295,7 +414,8 @@ mod tests {
     fn spend_maps_to_the_inference_ledger_kind() {
         let entry = inference_ledger_entry(&usage_with(0.42), "ceo").unwrap();
         assert_eq!(entry.kind, INFERENCE_SPEND_KIND);
-        assert_eq!(entry.amount_usd, 0.42);
+        // Negative: an outflow, per the ledger convention (issue #1047).
+        assert_eq!(entry.amount_usd, -0.42);
         assert_eq!(entry.memo, "ceo");
     }
 
@@ -315,7 +435,8 @@ mod tests {
 
         let ledger = store.ledger.lock().unwrap();
         assert_eq!(ledger.len(), 1);
-        assert_eq!(ledger[0].amount_usd, 1.5);
+        // Negative: an outflow, per the ledger convention (issue #1047).
+        assert_eq!(ledger[0].amount_usd, -1.5);
         let samples = meter.samples.lock().unwrap();
         assert_eq!(samples.len(), 1);
         assert_eq!(samples[0].kind, SampleKind::Inference);

--- a/src/metering/planning.rs
+++ b/src/metering/planning.rs
@@ -219,7 +219,10 @@ mod test {
         let entry = inference_ledger_entry(&usage_with(0.25), UNATTRIBUTED_AGENT)
             .expect("a costed pass posts");
         assert_eq!(entry.kind, crate::metering::INFERENCE_SPEND_KIND);
-        assert_eq!(entry.amount_usd, 0.25);
+        assert_eq!(
+            entry.amount_usd, -0.25,
+            "an outflow is negative (issue #1047)"
+        );
         assert_eq!(entry.memo, "company");
         // A token-bearing but zero-cost pass (the managed passthrough) posts no
         // money — the sample still lands, the ledger stays honest.

--- a/src/metering/workflow_build.rs
+++ b/src/metering/workflow_build.rs
@@ -243,7 +243,10 @@ mod test {
     fn builder_spend_posts_to_the_inference_ledger_under_the_assignee() {
         let entry = inference_ledger_entry(&usage_with(0.25), "maya").expect("a costed pass posts");
         assert_eq!(entry.kind, crate::metering::INFERENCE_SPEND_KIND);
-        assert_eq!(entry.amount_usd, 0.25);
+        assert_eq!(
+            entry.amount_usd, -0.25,
+            "an outflow is negative (issue #1047)"
+        );
         assert_eq!(entry.memo, "maya");
         assert!(inference_ledger_entry(&usage_with(0.0), "maya").is_none());
     }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -4514,7 +4514,8 @@ mod test {
             .filter(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND)
             .collect();
         assert_eq!(spend.len(), 1);
-        assert_eq!(spend[0].amount_usd, 0.031);
+        // Negative: an outflow, per the ledger convention (issue #1047).
+        assert_eq!(spend[0].amount_usd, -0.031);
     }
 
     /// Tokens without USD (the managed passthrough bills backend-side) still


### PR DESCRIPTION
## Summary

The ledger's sign convention is stated in `src/metering/finances.rs:10-11` — outflows negative, inflows positive — and `finances_from` implements exactly that. The inference writer posted `usage.cost_usd` **unnegated**, so the projection read every model charge as income.

A company that has only ever spent money therefore reports **growing `revenueUsd` and a growing `balanceUsd`**, while `spentUsd` and the `byCategory` breakdown stay at zero.

Fixed at `inference_ledger_entry` — the single constructor all four writers go through (`harness::cost`, `metering::planning`, `metering::triage`, `metering::workflow_build`).

**The reader was deliberately not touched.** The x402 outflow in `economy::adapter:153` already posts negative, and both server fixtures (`server/ops/finances.rs:181`, `server/graphql/test.rs:1037`) already encode the negative convention. Inverting `finances_from` would have meant changing all three to match a convention the docs already state correctly.

## It is a one-character fix with a nine-site audit

Worth stating plainly, because the diff is larger than a reviewer expecting one line will predict:

**Grep found five assertions. The compiler found four more. Nine total.**

My initial sweep for `INFERENCE_SPEND_KIND` / `"inference.spend"` missed `cost.rs:239`, `cost.rs:286`, `inference.rs:417` and `inference.rs:437` — each asserts the amount inline without naming the kind, so no text search for the kind would surface them. That is the argument for auditing every consumer rather than negating and moving on.

Each site was decided on its own merits — signed ledger value, or absolute magnitude:

| Consumer | Wants | Outcome |
| --- | --- | --- |
| `finances_from` spent/revenue split | signed | the target of the fix — now correct |
| `bookkeeping_net` → `balance_usd` | signed | was inflating the balance; now decreases correctly |
| `Transaction.amount_usd` | **magnitude** | already `.abs()`, sign carried separately — see below |
| per-agent daily budget gate | — | **unaffected**: reads the usage meter, not this projection (verified, not assumed) |
| 9 test assertions | — | corrected to negative |

### The display half needs no change, and is now pinned

This is the part a sign fix could plausibly break, so it was checked rather than assumed.

`finances.rs:85-90` builds each `Transaction` with `amount_usd: e.amount_usd.abs()` and expresses the sign as a separate `direction: Direction::Out | In`. **The display never sees the sign.** After this change a charge flips `In` → `Out` carrying the same positive figure, which is the correct rendering — it does not start showing `-$0.42`.

`a_charge_renders_as_an_outgoing_transaction_with_a_positive_amount` pins both halves of that.

## Forward-only — and what that leaves behind

**There is no migration, deliberately.** An `inference.spend` ledger is an append-only financial record; rewriting historical rows to correct a sign is not a fix but a falsification — anyone who exported or reconciled against those figures would silently disagree with the system and have no way to tell why.

So every row already written keeps its positive amount and will keep reading as revenue. What that means for a company that has run costed cycles, stated precisely:

- **The revenue and category distortion ages out.** `finances_from` filters `spent_usd` / `revenue_usd` / `by_category` to the **current month**, so at the next month boundary those three surfaces become correct on their own.
- **The balance distortion is permanent.** `balance_usd` is `bookkeeping_net`, summed across **all time** with no month filter. Every pre-fix charge stays in it as a positive contribution, so the reported balance remains inflated by the total of all inference spend posted before this lands — indefinitely.

That distinction is the one someone reconciling a company's books needs, and it is why "it fixes itself next month" is only two-thirds true.

The accountancy-correct remedy for a wrong posting is not an edit but a **compensating entry** that names itself as a correction, leaving both the original and the adjustment visible. That is a product and finance decision rather than something to settle inside a sign fix, so it is filed as a follow-up rather than folded in here — see the linked issue.

*(A company with an economy wallet is unaffected on this axis: `economy_balance` overrides `bookkeeping_net` when present.)*

## API Or Behavior Changes

- `inference.spend` ledger entries are now written with a **negative** `amount_usd`. Same kind, same memo, same gating on non-zero cost.
- `GET /api/v1/company/finances` and the GraphQL equivalent now report inference spend under `spentUsd` and `byCategory` instead of `revenueUsd`; `balanceUsd` decreases with spending instead of increasing.
- The `[budget].monthly_usd` comparison, built on the same projection, becomes correct as a consequence.
- **Unchanged:** the per-agent daily budget gate (reads the usage meter), the Usage surface, the rendered `Transaction` figure, and every pre-existing ledger row.

## Tests

Gated lane — default features skip this code. No prettier run; this change is Rust only.

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --no-deps -p opencompany --features openhuman,tinycortex --all-targets -- -D warnings` — mirrors CI's `--no-deps`; no findings.
- [x] `cargo check -p opencompany --features openhuman,tinycortex --tests` — clean, via the test run below.
- [x] `cargo test -p opencompany --features openhuman,tinycortex` — **4303 passed, 0 failed, 3 ignored.**

### Both new tests fail with the fix reverted — on direction, not magnitude

A sign test that passes with the sign flipped either way is worthless, so both assert the **direction**. With `amount_usd: -usage.cost_usd` reverted to `usage.cost_usd`:

| Test | Fails with |
| --- | --- |
| `a_costed_cycle_is_spending_not_revenue` | `inference is an outflow, so the ledger amount is negative: 0.42` |
| `a_charge_renders_as_an_outgoing_transaction_with_a_positive_amount` | `a charge is money going out` |

Neither failure is a magnitude mismatch. The first also asserts `revenue_usd == 0.0` exactly and `balance_usd < 0.0` — a company that only spent money must have **no** revenue — and runs the reader over the entry the writer actually produced, so it pins the writer/reader pairing that was the whole defect. Each half was self-consistent; only their combination was wrong, which is why no existing test caught this.

### One flake, investigated rather than waved off

A full-suite run failed on `server::operator::test::a_failed_continuation_tells_the_operator`. It passed 3/3 in isolation, and the **same tree** then passed the full suite 4303/0 in **31s** against **154s** for the failing run. Same code, different result under machine contention — a load-sensitive flake in an async continuation test, unrelated to ledger amounts.

## Documentation

None needed. `metering::finances` already documents the convention correctly — this makes the writer obey it. The reasoning is recorded on `inference_ledger_entry` itself, including why the fix is at the writer rather than the reader.

Refs tinyhumansai/opencompany#1047
