### PR TITLE
fix(copilot): make each create-time draft turn stateless, and keep raw JSON out of decline reasons (#1042)

### DIFF
--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -1953,7 +1953,23 @@ async fn run_copilot(
     let accepted: tools::AcceptedCell = Arc::new(StdMutex::new(None));
     let diag: tools::DiagCell = Arc::new(StdMutex::new(Vec::new()));
 
-    let mut copilot = agent::build_copilot_agent(deps, ctx, accepted.clone(), diag.clone())?;
+    // A UNIQUE PER-TURN workspace so the vendored turn's session-transcript
+    // persistence cannot bleed into the next turn's fresh, empty-history agent
+    // (issue #1042). Each create/fix is an independent turn; a fresh dir is always
+    // empty, so the turn's resume scan finds nothing to replay — statelessness by
+    // construction. The dir is reclaimed after the turn (below).
+    let turn_workspace = deps
+        .workspace_root
+        .join("workflow-copilot")
+        .join(generate_id());
+
+    let mut copilot = agent::build_copilot_agent(
+        deps,
+        ctx,
+        accepted.clone(),
+        diag.clone(),
+        turn_workspace.clone(),
+    )?;
 
     // A synchronous request (or a dead run's fix) mints no attempt row, but its
     // spend is still metered against a FRESH id under the copilot sentinel — the
@@ -1963,6 +1979,12 @@ async fn run_copilot(
     // ONE turn, under the same hard ceiling a card pass keeps. `run_single` drives
     // the bounded tool loop; the timeout bounds the whole turn.
     let outcome = tokio::time::timeout(BUILD_TIMEOUT, copilot.run_single(&user)).await;
+
+    // Reclaim the per-turn workspace now the turn is done — its transcript writes
+    // are synchronous within the turn, so nothing else needs it. Pure disk hygiene:
+    // correctness does NOT depend on this (a leftover dir is only ever scanned
+    // within its own already-empty scope, never by a later turn).
+    let _ = std::fs::remove_dir_all(&turn_workspace);
 
     // Meter the turn regardless of how it ended — the agent's own usage carries
     // backend-charged USD, so a charged turn records a non-zero cost even when the

--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -2141,9 +2141,24 @@ fn not_automatable_reason(end: &TurnEnd, diag: &[String]) -> String {
                 )
             } else {
                 // The agent finished cleanly without proposing — it judged the work
-                // a one-off; take its own words as the reason.
+                // a one-off; take its own words as the reason. But a model that
+                // closes with the raw answer envelope ({"automatable": false,
+                // "reason": "…"}) instead of prose must NOT leak that JSON to the
+                // operator (issue #1042): pull out only the typed `reason` field.
+                let extracted = parse_draft(text)
+                    .map(|draft| draft.reason.trim().to_string())
+                    .filter(|reason| !reason.is_empty());
+                if let Some(reason) = extracted {
+                    return cap(&reason, MAX_REASON_CHARS);
+                }
+                // No parseable typed reason — fall back to the prose text, unless
+                // that itself still carries a JSON-object fragment (an envelope with
+                // no usable `reason`, or partial JSON), in which case a raw brace
+                // must never reach the operator: use a generic one-off message.
                 let stated = cap(text, MAX_REASON_CHARS);
-                if stated.is_empty() {
+                let looks_like_json = stated.contains("\"automatable\"")
+                    || (stated.contains('{') && stated.contains('}'));
+                if stated.is_empty() || looks_like_json {
                     "this is better done once than built into a reusable workflow".to_string()
                 } else {
                     stated

--- a/src/harness/workflow_build/agent.rs
+++ b/src/harness/workflow_build/agent.rs
@@ -17,6 +17,7 @@
 //! advertised capability, native when supported — REQUIRED, or the model narrates
 //! prose and the tools never fire.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -75,6 +76,7 @@ pub(super) fn build_copilot_agent(
     ctx: Arc<CopilotContext>,
     accepted: AcceptedCell,
     diag: DiagCell,
+    workspace: PathBuf,
 ) -> crate::Result<Agent> {
     let memory: Arc<dyn Memory> = Arc::new(EphemeralMemory);
 
@@ -101,13 +103,18 @@ pub(super) fn build_copilot_agent(
         .unwrap_or_else(|| model_for_tier(None));
 
     // Scope the agent's harness bookkeeping (session/transcript/store subdirs) to
-    // a stable subdir of the company's own workspace root, NOT the process CWD.
-    // Without a `workspace_dir` the builder defaults to `"."`, which — in a tenant
-    // container — would litter the read-mostly working directory with `sessions/`
-    // / `session_raw/` / `tinyagents_store/`. `auto_save(false)` already turns off
-    // transcript persistence; this makes the location tenant-scoped either way.
-    // Best-effort create: a failure just leaves the harness to no-op its writes.
-    let workspace = deps.workspace_root.join("workflow-copilot");
+    // a UNIQUE PER-TURN subdir of the company's own workspace root, NOT the process
+    // CWD and NOT a stable per-company dir (issue #1042). The vendored turn ALWAYS
+    // persists a JSONL session transcript keyed by `agent_definition_name` into this
+    // workspace — `auto_save(false)` gates only the durable memory-store writes, not
+    // that transcript. A stable dir therefore let the fresh, empty-history agent of
+    // the NEXT turn discover the PREVIOUS turn's transcript and replay it, so the
+    // model saw its own prior draft and refused ("I already drafted this"). A fresh
+    // unique dir is always empty, so the resume scan finds nothing — statelessness
+    // by construction, not dedupe. The caller mints the path and reclaims it after
+    // the turn; without a `workspace_dir` the builder would default to `"."` and
+    // litter the read-mostly working directory. Best-effort create: a failure just
+    // leaves the harness to no-op its writes.
     let _ = std::fs::create_dir_all(&workspace);
 
     let mut agent = AgentBuilder::default()

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -175,6 +175,10 @@ pub(crate) struct NativeCopilotModel {
     usage: Option<Usage>,
     charged_usd: f64,
     profile: ModelProfile,
+    /// The `request.messages` seen on each `invoke`, in call order — so a test can
+    /// assert whether a later turn's first invoke replayed an earlier turn's
+    /// transcript (issue #1042).
+    seen_messages: StdMutex<Vec<Vec<Message>>>,
 }
 
 impl NativeCopilotModel {
@@ -201,6 +205,7 @@ impl NativeCopilotModel {
                 tool_calling: true,
                 ..ModelProfile::default()
             },
+            seen_messages: StdMutex::new(Vec::new()),
         })
     }
 
@@ -220,6 +225,11 @@ impl NativeCopilotModel {
 
     fn calls(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
+    }
+
+    /// The `request.messages` recorded for each invoke so far, in call order.
+    fn seen_messages(&self) -> Vec<Vec<Message>> {
+        self.seen_messages.lock().unwrap().clone()
     }
 
     fn next_step(&self) -> NativeStep {
@@ -242,8 +252,9 @@ impl ChatModel<()> for NativeCopilotModel {
         Some(&self.profile)
     }
 
-    async fn invoke(&self, _state: &(), _request: ModelRequest) -> TaResult<ModelResponse> {
+    async fn invoke(&self, _state: &(), request: ModelRequest) -> TaResult<ModelResponse> {
         self.calls.fetch_add(1, Ordering::SeqCst);
+        self.seen_messages.lock().unwrap().push(request.messages);
         let step = self.next_step();
         let tool_calls: Vec<ToolCall> = step
             .calls
@@ -556,6 +567,71 @@ fn the_not_automatable_reason_covers_every_turn_ending() {
         &[],
     );
     assert!(silent.contains("better done once"), "{silent}");
+}
+
+/// Issue #1042: a clean finish whose closing reply is the raw answer envelope
+/// ({"automatable": false, "reason": "…"}) must surface only the typed `reason` to
+/// the operator — never the raw JSON. Genuine prose still passes through verbatim,
+/// and an envelope with no usable reason falls back to a generic one-off message
+/// rather than leaking a brace.
+#[test]
+fn a_clean_finish_extracts_the_reason_and_never_leaks_json() {
+    // The model closed with the answer envelope instead of prose: the typed reason
+    // is surfaced, and no JSON punctuation survives.
+    let enveloped = not_automatable_reason(
+        &TurnEnd::Replied {
+            text: r#"{"automatable": false, "reason": "this is a one-off"}"#.to_string(),
+            hit_cap: false,
+        },
+        &[],
+    );
+    assert_eq!(enveloped, "this is a one-off");
+    assert!(!enveloped.contains('{'), "no raw brace leaks: {enveloped}");
+    assert!(
+        !enveloped.contains("\"automatable\""),
+        "no envelope key leaks: {enveloped}"
+    );
+
+    // A fenced envelope is handled the same way (parse_draft tolerates a fence).
+    let fenced = not_automatable_reason(
+        &TurnEnd::Replied {
+            text: "```json\n{\"automatable\": false, \"reason\": \"just once\"}\n```".to_string(),
+            hit_cap: false,
+        },
+        &[],
+    );
+    assert_eq!(fenced, "just once");
+
+    // Genuine prose is untouched — the model spoke plainly, so its words stand.
+    let prose = not_automatable_reason(
+        &TurnEnd::Replied {
+            text: "This only ever runs once, so it is not worth a reusable workflow.".to_string(),
+            hit_cap: false,
+        },
+        &[],
+    );
+    assert_eq!(
+        prose,
+        "This only ever runs once, so it is not worth a reusable workflow."
+    );
+
+    // An envelope with no usable reason must not leak its braces either — it falls
+    // back to the generic one-off line.
+    let reasonless = not_automatable_reason(
+        &TurnEnd::Replied {
+            text: r#"{"automatable": false}"#.to_string(),
+            hit_cap: false,
+        },
+        &[],
+    );
+    assert!(
+        !reasonless.contains('{'),
+        "no raw brace leaks: {reasonless}"
+    );
+    assert!(
+        reasonless.contains("better done once"),
+        "falls back to the generic line: {reasonless}"
+    );
 }
 
 /// The host assigns a safe, unique id — slugged from the name, deduped, and
@@ -1611,6 +1687,79 @@ async fn a_description_drafts_a_graph_via_the_agent() {
     assert!(spec.nodes.iter().all(|n| n.requires_approval.is_none()));
     assert_eq!(spec.nodes[0].schedule.as_deref(), Some("0 9 * * 1"));
     assert!(model.calls() >= 1, "the model ran at least once");
+}
+
+/// Issue #1042 regression: drafting the SAME description twice must draft a graph
+/// BOTH times, and the second turn must NOT replay the first turn's session
+/// transcript. Before the per-turn workspace fix, the copilot agent's stable
+/// per-company `workspace_dir` let the second turn's fresh, empty-history agent
+/// discover the first turn's persisted transcript and resume it — so the model saw
+/// its own prior draft and refused ("I already drafted this last turn"), leaving
+/// the dialog empty. The fix mints a unique workspace per turn, so each turn's
+/// resume scan finds nothing. This asserts both the OUTCOME (both are `Graph`) and
+/// the MECHANISM (the second turn's first invoke carries only system + user, no
+/// replayed assistant/tool turn).
+#[tokio::test]
+async fn repeating_a_description_does_not_replay_the_prior_turn() {
+    // Each turn is one propose (accepted) then a closing reply. Scripting both
+    // turns' steps explicitly — rather than relying on the exhausted-script repeat
+    // — so the SECOND turn genuinely proposes a graph too, isolating the transcript
+    // replay as the only thing that could make it refuse.
+    let model = NativeCopilotModel::scripting(vec![
+        propose_step("email the weekly digest", good_workflow()),
+        NativeStep::done("Proposed the weekly digest workflow for your review."),
+        propose_step("email the weekly digest", good_workflow()),
+        NativeStep::done("Proposed the weekly digest workflow for your review."),
+    ]);
+    let (_home, runtime) = runtime_with_agent(model.clone(), None).await;
+    seed_workflow(&runtime, "weekly-digest", "Weekly digest").await;
+
+    const DESC: &str = "email the weekly digest every Monday";
+
+    let first = draft_workflow_from_description(&runtime, DESC)
+        .await
+        .expect("the first draft runs");
+    if let DescriptionDraftOutcome::NotAutomatable(reason) = &first {
+        panic!("the first draft must be a graph, got not-automatable: {reason}");
+    }
+
+    // The number of invokes the first turn consumed — the next recorded invoke is
+    // the SECOND turn's first invoke.
+    let invokes_before_second = model.calls();
+
+    let second = draft_workflow_from_description(&runtime, DESC)
+        .await
+        .expect("the second draft runs");
+    if let DescriptionDraftOutcome::NotAutomatable(reason) = &second {
+        panic!(
+            "the repeated draft must ALSO be a graph, not a replay-driven refusal, got \
+             not-automatable: {reason}"
+        );
+    }
+
+    // The mechanism: the second turn opened on a FRESH conversation — only the
+    // system prompt and this turn's user message. A replayed prior transcript would
+    // inject the first turn's assistant (propose) + tool-result messages here.
+    let seen = model.seen_messages();
+    let second_turn_first_invoke = &seen[invokes_before_second];
+    let replayed_prior_turn = second_turn_first_invoke
+        .iter()
+        .any(|m| matches!(m, Message::Assistant(_) | Message::Tool(_)));
+    assert!(
+        !replayed_prior_turn,
+        "the second turn's first invoke must not replay the prior turn's transcript; saw \
+         {} messages: {:?}",
+        second_turn_first_invoke.len(),
+        second_turn_first_invoke
+            .iter()
+            .map(|m| match m {
+                Message::System(_) => "system",
+                Message::User(_) => "user",
+                Message::Assistant(_) => "assistant",
+                Message::Tool(_) => "tool",
+            })
+            .collect::<Vec<_>>()
+    );
 }
 
 /// The agent finishes without proposing — it judged the work a one-off — so the


### PR DESCRIPTION
## Summary

The create-time workflow copilot (`POST …/workflows/draft-from-description`, the New-workflow dialog's **Draft it**) carried state across HTTP requests. Sending the same description twice, the second call came back `automatable: false` with the model claiming it had already drafted and proposed that workflow *in a previous turn* — leaving the operator a refusal box and an empty form. Nothing had been accepted; no workflow existed.

Root cause is the harness **session transcript store**, a different subsystem from memory. `build_copilot_agent` set a **stable per-company** `workspace_dir` (`<workspace_root>/workflow-copilot`) with a fixed agent name, and the vendored turn **unconditionally persists a JSONL transcript** keyed by agent name into that dir. `EphemeralMemory` + `auto_save(false)` only gate durable *memory* writes — not that transcript. So the next turn's fresh agent, finding empty history, loaded the *previous* call's transcript from the shared dir and replayed it; the model saw its own prior turn and refused. It only misfired on a repeated description because a different description replays a prior turn about a different workflow.

Fixed by giving each turn a **unique per-turn workspace dir** (`workflow-copilot/<turn-id>`): an empty per-turn scope means the transcript loader finds nothing, so no prior turn can ever be replayed — statelessness by construction, not a dedupe. A second, related leak — the model's raw `{"automatable": …}` JSON echoed inside operator-facing prose — is fixed by extracting the typed `reason` and refusing to pass raw JSON through.

## API Or Behavior Changes

- Every `draft-from-description` (and the fix-from-failure seed) is now an independent turn: re-sending a description drafts a graph again instead of refusing about a "previous turn".
- A decline reason is now prose only — the typed `reason` is extracted; a raw JSON envelope never reaches the operator.
- No wire/route change. No console change (the route already maps outcomes; once repeats draft a graph the form populates). The empty-form-on-refusal for a *genuine* `automatable:false` is correct rendering; a UI guard to preserve form state is an optional follow-up (sibling to #1005/#1006).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` **and** `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib harness::workflow_build` — 54 passed / 0 failed (incl. the two new tests)

Red-first (both fail on pre-fix code, pass now):
- `repeating_a_description_does_not_replay_the_prior_turn` — drafts the same description twice; asserts both outcomes are `Graph` and the second turn's first invoke carries **no** replayed assistant/tool messages. Pre-fix it saw 6 messages `["system","user","assistant","tool","assistant","user"]`.
- `a_clean_finish_extracts_the_reason_and_never_leaks_json` — envelope → typed reason; fenced envelope; genuine prose passthrough; reasonless envelope → generic line; no braces leak. Pre-fix returned the raw `{"automatable": false, …}` string.

## Documentation

No doc pages needed — the per-turn-workspace contract and the transcript-vs-memory distinction are documented in-code on `build_copilot_agent` and `run_copilot`, and pinned by the tests.

Closes #1042
