### PR TITLE
fix(workflows): resolve a deep link by re-reading before the no-workflow toast (#1045)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -491,6 +491,15 @@ export function WorkflowsView({
   const appliedWorkflowRef = useRef<string | null>(null);
   const appliedRunRef = useRef<string | null>(null);
 
+  // Issue #1045: the deep-link id whose absent-path re-read is in flight, so
+  // that read is started at most once per id even though the follow effect
+  // reruns on every fresh `workflows` array. Deliberately SEPARATE from
+  // `appliedWorkflowRef`: an id is "applied" only once it has RESOLVED — got
+  // selected, or was confirmed missing after a fresh read — whereas an id whose
+  // re-read is still outstanding must stay unapplied, so a refresh that finally
+  // carries a graph authored elsewhere can still select it.
+  const resolvingWorkflowRef = useRef<string | null>(null);
+
   // How many local writes have landed. Compared across the list effect's await
   // so a `GET …/workflows` that was already in flight when a create, save or
   // delete completed cannot paint the picker with rows that predate it — the
@@ -613,27 +622,87 @@ export function WorkflowsView({
   // clicks a second task card's link without ever leaving this tab, so the
   // first-load resolution above never runs again.
   //
-  // Guarded to once per distinct id: this also reruns whenever `workflows` gets
+  // Guarded to once per RESOLVED id: this also reruns whenever `workflows` gets
   // a new array (a create, a rename, a company switch), and re-applying the URL
   // then would yank the selection back from wherever the operator had moved it.
   // A no-longer-current `sub` — the operator picked something else, so the hash
   // no longer matches — is left alone precisely because it was already applied.
+  //
+  // Issue #1045: an id is recorded in `appliedWorkflowRef` ONLY once it has
+  // resolved — selected, or confirmed missing after a fresh read. An id that is
+  // merely absent from the list on screen right now must NOT be frozen there:
+  // a graph the orchestrator (or another session) authored lands in the picker
+  // a beat after its link is followed, and that later refresh has to be allowed
+  // to select it. And an absent id no longer toasts on sight — it toasts only
+  // after a fresh re-read still cannot find it, which is what tells "renamed or
+  // deleted" apart from "authored elsewhere and not pulled into this tab yet".
   useEffect(() => {
     if (!requestedWorkflowId || workflows.length === 0) return;
     if (appliedWorkflowRef.current === requestedWorkflowId) return;
-    appliedWorkflowRef.current = requestedWorkflowId;
+    // Present in the list already on screen: select it, done. Marking it applied
+    // HERE, inside the present branch, is half the #1045 fix — an absent id must
+    // never reach the ref, or a later refresh carrying it would early-return
+    // above instead of selecting it.
     if (workflows.some((w) => w.id === requestedWorkflowId)) {
+      appliedWorkflowRef.current = requestedWorkflowId;
       setSelectedId(requestedWorkflowId);
       return;
     }
-    // Say so rather than silently showing a different graph: the operator
-    // followed a link expecting one specific workflow, and a canvas quietly
-    // painting another one is worse than no canvas at all.
-    toast.error(`This company has no workflow “${requestedWorkflowId}”.`, {
-      description:
-        "It may have been renamed or deleted since the link was made. Showing the current selection instead.",
-    });
-  }, [requestedWorkflowId, workflows]);
+    // Absent from the list on screen. Before #1045 this toasted straight away,
+    // against whatever the picker happened to hold the instant the id was first
+    // seen — on a link followed to a just-authored graph, a list that predates
+    // it — so the operator got a false "no workflow" and the canvas never
+    // resolved. Re-read the list first, and decide on the fresh answer. At most
+    // one read per requested id (the effect reruns on every `workflows` array).
+    if (resolvingWorkflowRef.current === requestedWorkflowId) return;
+    resolvingWorkflowRef.current = requestedWorkflowId;
+    let live = true;
+    const target = requestedWorkflowId;
+    const writesBefore = localWriteRef.current;
+    (async () => {
+      try {
+        const rows = await listWorkflows(client, company);
+        // Same liveness discipline as the list effect above: bail if the view
+        // unmounted or a dependency changed under us (both flip `live` via this
+        // effect's cleanup), and drop the rows if a local write landed while the
+        // read was in flight — that write holds newer truth than a read which
+        // predates it.
+        if (!live) return;
+        if (localWriteRef.current !== writesBefore) return;
+        if (appliedWorkflowRef.current === target) return;
+        appliedWorkflowRef.current = target;
+        if (rows.some((r) => r.id === target)) {
+          // The graph exists after all — authored elsewhere and not yet pulled
+          // into this tab. Adopt the fresh list so the picker shows it too, and
+          // select it. No toast: nothing was wrong.
+          setWorkflows(rows);
+          setSelectedId(target);
+          return;
+        }
+        // Still absent after a fresh read: the link genuinely names a workflow
+        // this company no longer has. Say so, once.
+        toast.error(`This company has no workflow “${target}”.`, {
+          description:
+            "It may have been renamed or deleted since the link was made. Showing the current selection instead.",
+        });
+      } catch {
+        // A failed re-read is not proof the workflow is missing. Leave the id
+        // unresolved so a later refresh can still land it, rather than toasting
+        // a false "no workflow" off a transient network error.
+        if (live) resolvingWorkflowRef.current = null;
+      }
+    })();
+    return () => {
+      live = false;
+      // Let a rerun retry the re-read: this cleanup fires when a dependency
+      // changed the read out from under us (an unrelated list refresh, a company
+      // switch), and the abandoned read above will not clear the guard itself.
+      resolvingWorkflowRef.current = null;
+    };
+    // `requestedWorkflowId` and `workflows` drive the resolution; `client` and
+    // `company` scope the re-read. `listWorkflows`, `localWriteRef`,
+    // `setWorkflows`, `setSelectedId` are stable.
+  }, [requestedWorkflowId, workflows, client, company]);
 
   // Issue #339: mirror the selection back into the hash, so whatever is on the
   // canvas can be copied out of the address bar and shared.

--- a/frontend/test/unit/workflow-deeplink-reread.test.ts
+++ b/frontend/test/unit/workflow-deeplink-reread.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph, WorkflowSummary } from "@/api/workflows";
+
+/**
+ * A deep link to a workflow authored elsewhere resolves, and stops toasting a
+ * false "no workflow" (issue #1045).
+ *
+ * The reported symptom is an absence and a wrong toast — neither of which the
+ * pure helpers can pin — so this file renders the view, the way
+ * `workflow-run-failure.test.ts` earns its exception to the pure-function rule.
+ *
+ * The deep-link resolver had two coupled defects:
+ *
+ *  (a) it fired the "no workflow" toast against whatever the picker happened to
+ *      hold the instant the id was first seen, without re-reading the list — so
+ *      a link followed to a just-authored graph, whose create frame had not yet
+ *      reached this tab, got a false toast; and
+ *  (b) it recorded the id as "applied" BEFORE the presence check, so an absent
+ *      id was frozen — a later refresh that finally carried the graph re-ran the
+ *      effect and early-returned instead of selecting it, so the false toast
+ *      stood forever and the canvas never resolved.
+ *
+ * The fix re-reads the list before deciding, and marks an id applied only once
+ * it has resolved (selected, or confirmed missing after the fresh read).
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount; jsdom has no layout and no
+// `ResizeObserver`, so these stubs are what let the view render at all. None is
+// under test. (Same three as `workflow-run-failure.test.ts`.)
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+const PROBE = "qa_probe_wf3";
+const NO_WORKFLOW = "This company has no workflow";
+
+/** Seven ordinary workflows — the list a link's target is NOT yet part of. */
+const STALE: WorkflowSummary[] = Array.from({ length: 7 }, (_, i) => ({
+  id: `wf${i + 1}`,
+  name: `Workflow ${i + 1}`,
+}));
+/** The same list once the graph authored elsewhere has landed in it. */
+const FULL: WorkflowSummary[] = [...STALE, { id: PROBE, name: "QA probe" }];
+
+function graphFor(id: string): WorkflowGraph {
+  return {
+    id,
+    name: id,
+    nodes: [{ id: "start", kind: "trigger", name: "Start" }],
+    edges: [],
+  };
+}
+
+/**
+ * A client whose `GET …/workflows` answer is supplied by the test, and which
+ * records every `getWorkflow` id so a test can assert a selection actually
+ * landed (the selection drives the graph fetch).
+ */
+function makeClient(
+  listFor: () => Promise<WorkflowSummary[]>,
+): { client: OpenCompanyClient; graphGets: string[] } {
+  const graphGets: string[] = [];
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return listFor();
+      if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
+      if (path.includes("/workflows/wired-channels")) return { channels: [] };
+      if (path.includes("/workflows/runs")) return [];
+      const m = path.match(/\/workflows\/([^/?]+)$/);
+      if (m) {
+        const id = decodeURIComponent(m[1]);
+        graphGets.push(id);
+        return graphFor(id);
+      }
+      return null;
+    },
+    post: async () => ({}),
+  } as unknown as OpenCompanyClient;
+  return { client, graphGets };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function toastedNoWorkflow(): boolean {
+  return toasts.error.mock.calls.some((args) =>
+    String(args[0] ?? "").includes(NO_WORKFLOW),
+  );
+}
+
+describe("a deep link to a workflow authored elsewhere resolves", () => {
+  it(
+    "re-reads the list and selects the id instead of toasting (decisive)",
+    async () => {
+      // First read (the picker's own load) predates the graph; the re-read the
+      // resolver now does before deciding carries it. On main the resolver never
+      // re-reads: it toasts against the stale list and freezes the id.
+      let call = 0;
+      const lists = [STALE, FULL];
+      const { client, graphGets } = makeClient(() =>
+        Promise.resolve(lists[Math.min(call++, lists.length - 1)]),
+      );
+
+      await act(async () => {
+        root.render(
+          createElement(WorkflowsView, { client, company: "acme", sub: PROBE }),
+        );
+      });
+
+      // The selection landed on the requested graph — the fetch that only fires
+      // for the selected workflow was asked for it.
+      expect(graphGets).toContain(PROBE);
+      // …and no false "no workflow" toast was raised.
+      expect(toastedNoWorkflow()).toBe(false);
+    },
+  );
+
+  it(
+    "does not freeze an absent id: a later list refresh still selects it (defect b)",
+    async () => {
+      // The re-read is held pending, so resolution can only come from the tick
+      // that refreshes the picker into carrying the id. That path is exactly the
+      // one defect (b) broke: on main the id is marked applied on the absent
+      // pass, so this refresh re-runs the effect and early-returns.
+      let phase: "mount" | "live" = "mount";
+      let mountCall = 0;
+      let tail: WorkflowSummary[] = STALE;
+      const { client, graphGets } = makeClient(() => {
+        if (phase === "mount") {
+          if (mountCall++ === 0) return Promise.resolve(STALE);
+          // Hang the resolver's re-read so only the tick can resolve the id.
+          return new Promise<WorkflowSummary[]>(() => {});
+        }
+        return Promise.resolve(tail);
+      });
+
+      await act(async () => {
+        root.render(
+          createElement(WorkflowsView, {
+            client,
+            company: "acme",
+            sub: PROBE,
+            listEventTick: 0,
+          }),
+        );
+      });
+      // Not selected yet: the picker still holds the stale list.
+      expect(graphGets).not.toContain(PROBE);
+
+      // The host's create frame lands: the shell bumps the tick and the picker
+      // re-reads into a list that now carries the graph.
+      phase = "live";
+      tail = FULL;
+      await act(async () => {
+        root.render(
+          createElement(WorkflowsView, {
+            client,
+            company: "acme",
+            sub: PROBE,
+            listEventTick: 1,
+          }),
+        );
+      });
+
+      expect(graphGets).toContain(PROBE);
+      expect(toastedNoWorkflow()).toBe(false);
+    },
+  );
+
+  it(
+    "still toasts exactly once for an id absent from both reads (no over-suppression)",
+    async () => {
+      // The genuinely-missing case: the link names a workflow this company does
+      // not have and never gets. Re-reading must not swallow the report — the
+      // operator followed a dead link and has to be told, once.
+      const { client, graphGets } = makeClient(() => Promise.resolve(STALE));
+
+      await act(async () => {
+        root.render(
+          createElement(WorkflowsView, { client, company: "acme", sub: PROBE }),
+        );
+      });
+
+      expect(graphGets).not.toContain(PROBE);
+      const noWorkflowToasts = toasts.error.mock.calls.filter((args) =>
+        String(args[0] ?? "").includes(NO_WORKFLOW),
+      );
+      expect(noWorkflowToasts).toHaveLength(1);
+    },
+  );
+});

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1831,6 +1831,68 @@ mod tests {
         }
     }
 
+    /// An in-memory [`EventLog`] whose [`subscribe`](EventLog::subscribe) stream
+    /// actually delivers what [`append`](EventLog::append) writes — the property
+    /// [`MemLog`] above deliberately lacks (its `subscribe` is empty). This is
+    /// what lets a test stand in for the live SSE fan-out: the console's picker
+    /// re-reads off exactly this broadcast (issue #1045), so a create/delete
+    /// that reaches a live subscriber here is evidence that in-process delivery
+    /// is intact and a stale picker is a console-side defect, not a lost frame.
+    struct BroadcastMemLog {
+        tx: tokio::sync::broadcast::Sender<StoredEvent>,
+        next_seq: StdMutex<u64>,
+    }
+
+    impl BroadcastMemLog {
+        fn new() -> Self {
+            Self {
+                tx: tokio::sync::broadcast::channel(64).0,
+                next_seq: StdMutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl EventLog for BroadcastMemLog {
+        async fn append(&self, id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+            let seq = {
+                let mut n = self.next_seq.lock().unwrap();
+                *n += 1;
+                *n
+            };
+            let stored = StoredEvent {
+                seq: EventSeq::new(seq),
+                company: id.clone(),
+                event,
+                at_millis: now_millis(),
+            };
+            // No live subscriber is not an error — a send with zero receivers
+            // just means nobody is watching yet.
+            let _ = self.tx.send(stored);
+            Ok(EventSeq::new(seq))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            let rx = self.tx.subscribe();
+            Box::pin(stream::unfold(rx, |mut rx| async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(event) => return Some((event, rx)),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                    }
+                }
+            }))
+        }
+    }
+
     /// An in-memory [`WorkflowRevisionStore`] so the capture, prune, cascade and
     /// rollback behaviour can be asserted without a real backend. Pruning to the
     /// cap is applied on push, mirroring the durable backends.
@@ -3083,6 +3145,88 @@ to = "done"
                 assert_eq!(name, "Greeter");
             }
             other => panic!("expected WorkflowDeleted, got {other:?}"),
+        }
+    }
+
+    /// Issue #1045: the REST create/delete persist path puts
+    /// `WorkflowCreated` / `WorkflowDeleted` on a stream a **live subscriber**
+    /// actually receives — the in-process delivery the console's SSE picker
+    /// depends on. A green characterization: it locates the reported "graph
+    /// authored elsewhere stays invisible" defect on the console side, not in a
+    /// dropped host frame.
+    ///
+    /// The projection of these variants onto the `{type, workflowId, name}` wire
+    /// frame the console keys on is asserted next to `project_event` itself
+    /// (`server::operator` — `projects_workflow_created_without_the_actor`,
+    /// `projects_workflow_updated_and_deleted_without_the_actor`). This test
+    /// closes the remaining link: that the persist path emits those variants,
+    /// carrying the same id and name, onto a stream `subscribe` delivers.
+    #[tokio::test]
+    async fn create_and_delete_reach_a_live_subscriber() {
+        use futures::StreamExt;
+
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let log = Arc::new(BroadcastMemLog::new());
+        let log_dyn: Arc<dyn EventLog> = log.clone();
+        // Subscribe before the writes, exactly as the SSE handler does.
+        let mut stream = log_dyn.subscribe(&company);
+
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            Some(&log_dyn),
+            valid_draft("greeter", "Greeter"),
+        )
+        .await
+        .expect("creates");
+
+        let created = stream
+            .next()
+            .await
+            .expect("workflow_created delivered live");
+        match &created.event {
+            CompanyEvent::WorkflowCreated {
+                workflow_id, name, ..
+            } => {
+                assert_eq!(workflow_id, "greeter");
+                assert_eq!(name, "Greeter");
+            }
+            other => panic!("expected WorkflowCreated on the wire, got {other:?}"),
+        }
+
+        // Delete the same graph over the same persist path. `None` expected
+        // version skips the optimistic-concurrency check — this test is about
+        // the emitted frame, not the token.
+        delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires()),
+            Some(&log_dyn),
+            "greeter",
+            None,
+        )
+        .await
+        .expect("deletes");
+
+        let deleted = stream
+            .next()
+            .await
+            .expect("workflow_deleted delivered live");
+        match &deleted.event {
+            CompanyEvent::WorkflowDeleted {
+                workflow_id, name, ..
+            } => {
+                assert_eq!(workflow_id, "greeter");
+                assert_eq!(name, "Greeter");
+            }
+            other => panic!("expected WorkflowDeleted on the wire, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Following a deep link to a workflow that exists on the host raised a **false** "This company has no workflow …" toast and never selected the workflow, until a hard reload. The break is console-side, in the deep-link resolver in `WorkflowsView.tsx`, and has two coupled defects:

- **(a)** it fired the "no workflow" toast against whatever the client list happened to hold the instant the id was first seen — without ever re-reading, contradicting the #384 contract that the toast should only fire after the list has actually been re-read.
- **(b)** `appliedWorkflowRef` was set to the requested id *before* the presence check, so an **absent** id was marked "applied". When the list later refreshed to include the workflow, the effect early-returned and never selected it — the false toast stood permanently. Hard reload only worked because the initial fetch already contained the id.

The resolver now sets "applied" only on a successful select (or a confirmed-missing terminal after a fresh read), and an absent id triggers a fresh `listWorkflows` re-read before deciding: found → select, no toast; still absent → toast once. The re-read is guarded against the local-write race and unmount/company-switch, reusing the view's existing `live`/`localWriteRef` discipline.

Root-cause narrowing (host vs console): the reporter's two hypotheses were **falsified** — the host emits `workflow_created`/`updated`/`deleted` and the console matches those exact strings; the REST routes journal; in-process delivery broadcasts on a shared per-company `EventLog`. The tick→re-read *picker* path is correct in committed main. A test-only backend characterization pins that, locating the deep-link break console-side.

## API Or Behavior Changes

- Console only. A deep link to a host-present workflow now resolves (re-reads the list before deciding) instead of false-toasting against a stale client list; a genuinely-missing id still toasts exactly once, after the re-read. No wire/route/schema change.

## Tests

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run` — 947 passed / 96 files (includes the new suite)
- [x] `cargo fmt --all -- --check` · `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` host characterization (`…create_and_delete_reach_a_live_subscriber`)

Red-first (console, fail on main → pass with fix):
- **decisive** — list returns `[wf1..wf7]` then `[…7, qa_probe_wf3]`; asserts the workflow is eventually selected and the "no workflow" toast never fires. Pre-fix: selection frozen at default.
- **defect-b isolation** — with the stale list, bumping the list tick to include the id moves selection to it, no toast. Pre-fix: frozen.
- **no over-suppression** — an id absent from both reads toasts exactly once.
- **host characterization (green)** — REST create/delete emit `WorkflowCreated`/`WorkflowDeleted` (right id+name) onto a stream a live `subscribe()` receives.

## Documentation

No doc pages — behavior and the host-vs-console narrowing are captured in the resolver comments and the characterization test.

## Scope limit (follow-up)

This fully fixes the deep-link false-toast + non-resolution and hardens it against a missing SSE frame. It does **not** close the *live-picker staleness with no deep link* on a multi-replica tenant (a REST write landing on one pod while the `EventSource` is pinned to another loses the live frame though the journal row persists) — that is a cross-process pub/sub infra gap, outside committed logic. Recommend a separate follow-up and capturing the tenant `/events` stream on `smoke1` to confirm the frame does not cross replicas.

Closes #1045
