### PR TITLE
test(e2e): hold the hover and poll, instead of sleeping past the ceiling

### DIFF
--- a/frontend/test/e2e/toast-dismissal.spec.ts
+++ b/frontend/test/e2e/toast-dismissal.spec.ts
@@ -24,6 +24,19 @@ type Page = import("@playwright/test").Page;
 const TOAST = "[data-sonner-toast]";
 
 /**
+ * The one toast a test is about (issue #969).
+ *
+ * `TOAST` is unqualified and matches *every* toast on screen. These tests raise
+ * one, so it resolves — but a second arriving mid-test would silently change
+ * what is being hovered and asserted, and `toBeVisible()` on a two-match
+ * locator fails as a strict-mode violation rather than as the thing under test.
+ * Naming the first match makes the subject explicit instead of incidental.
+ */
+function firstToast(page: Page) {
+  return page.locator(TOAST).first();
+}
+
+/**
  * Land on Settings with no tour running, and no welcome dialog in the way.
  *
  * The dialog is not cosmetic here: it is a Radix dialog, so while it is open
@@ -41,7 +54,10 @@ async function settings(page: Page): Promise<void> {
 /** Raise the toast the issue is about, and park the pointer far from it. */
 async function replayTour(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Replay tour" }).click();
-  await expect(page.locator(TOAST)).toBeVisible();
+  // Scoped for the same reason as `firstToast` (#969): a `toBeVisible()` on the
+  // unqualified locator would fail as a strict-mode violation, not as the
+  // assertion it looks like, the moment a second toast is up.
+  await expect(firstToast(page)).toBeVisible();
   await page.mouse.move(20, 20);
 }
 
@@ -83,16 +99,37 @@ test("a toast does not follow the operator across views", async ({ page }) => {
 test("hovering a toast still holds it open to be read", async ({ page }) => {
   await settings(page);
   await page.getByRole("button", { name: "Replay tour" }).click();
-  const toast = page.locator(TOAST);
+  const toast = firstToast(page);
   await expect(toast).toBeVisible();
 
   // The pause the fix must not take away: a toast under the pointer is one
   // somebody is reading.
-  await toast.hover();
-  await page.waitForTimeout(9_000);
-  await expect(toast).toBeVisible();
+  //
+  // Held and re-asserted rather than slept through (issue #969). The guard
+  // re-reads the live `:hover` state every 500ms and suppresses only the
+  // VERDICT while hovered — `visibleMs` keeps accumulating underneath. So by
+  // the time this window is over the toast is already well past
+  // `duration + grace`, and a single tick that reads `:hover` false dismisses
+  // it instantly with no grace left. `await page.waitForTimeout(9_000)` then
+  // one assertion made the test pass only if all ~18 consecutive reads came
+  // back true, with a stationary synthetic pointer, on a loaded CI runner.
+  //
+  // Re-hovering each round is the point: it keeps the pointer's position true
+  // against a stack that may reflow underneath it, so the test measures
+  // "hovering holds the toast" rather than "the pointer never once lost the
+  // element". The total held time still exceeds the ~6s ceiling this is about.
+  const HOLD_ROUNDS = 12;
+  const HOLD_STEP_MS = 750;
+  for (let round = 0; round < HOLD_ROUNDS; round++) {
+    await toast.hover();
+    await page.waitForTimeout(HOLD_STEP_MS);
+    await expect(
+      toast,
+      `the hovered toast was dismissed after ~${(round + 1) * HOLD_STEP_MS}ms of hold`,
+    ).toBeVisible();
+  }
 
   // ...and it goes as soon as they look away, without a click.
   await page.mouse.move(20, 20);
-  await expect(toast).toHaveCount(0, { timeout: 10_000 });
+  await expect(page.locator(TOAST)).toHaveCount(0, { timeout: 10_000 });
 });


### PR DESCRIPTION
## Summary

`toast-dismissal.spec.ts` — *"hovering a toast still holds it open to be read"* — has reddened **six**
unrelated PRs (#962, #954, #967, #1036, #1038 and one more), every one cleared by a re-run with no code
change. That is roughly 40 minutes of CI, and a more expensive half: a human reading each red and
deciding it is not real. A test that cries wolf trains people to re-run without looking, which is how a
genuine failure gets waved through.

## First: is the test right and the product wrong?

Asked and answered before touching anything, because "fixing" the test would otherwise bury a hole in
#953's fix.

**It cannot be the backstop.** `sweepToasts` (`frontend/src/lib/toast-lifetime.ts`) returns
unconditionally before any overdue computation:

```ts
if (env.hovered) return { next, overdue: [] };
```

and `hovered` is not sonner's belief about the pointer — it is the browser's own state, re-read on every
500 ms tick (`toasterHovered()` in `components/ui/sonner.tsx`):

```ts
el.matches(":hover")   // on [data-sonner-toaster]
```

So the ceiling can only dismiss a hovered toast when the pointer is **genuinely not over the toaster** —
which, for a real operator, means they moved away, and dismissing is exactly what should happen.
**Editing this test buries no defect.**

## What actually made it knife-edge

Not the wall clock racing the backstop, which is what the issue supposed. `visibleMs` accumulates
**during** the hover — `next` is computed before the hover check and returned by it, so only the
*verdict* is suppressed, never the accumulation.

By the end of a nine-second hold the toast is already at `visibleMs ≈ 9000`, well past
`duration + grace = 4000 + 2000 = 6000`. From that point a **single tick that reads `:hover` false
dismisses it instantly, with no grace left**.

So `await page.waitForTimeout(9_000)` followed by one assertion passed only if **~18 consecutive reads of
a live CSS state came back true**, with a stationary synthetic pointer, on a loaded CI runner. That is
fragile by construction, whatever the individual transient turns out to be.

## The change

**Hold the hover in rounds and assert between them** — 12 × 750 ms, re-hovering each round — so a stack
that reflows underneath a stationary synthetic pointer cannot silently end the run.

**The total held time still exceeds the ~6 s ceiling**, so the behaviour under test is unchanged: this
weakens the *flakiness*, not the *assertion*. A toast that genuinely stopped being held would still fail
this test, and would fail it sooner.

**The failure message names the round.** A future red now reads

> the hovered toast was dismissed after ~3000ms of hold

instead of a bare `element(s) not found`. That turns the next occurrence into evidence about *when* the
hold broke, rather than another re-run — which is worth as much as the change itself.

**Scoped the locator.** `const TOAST = "[data-sonner-toast]"` matched every toast with no `.first()`, so
a second toast arriving mid-test would change what is being hovered and asserted — and `toBeVisible()` on
a two-match locator fails as a *strict-mode violation*, not as the thing under test. A `firstToast()`
helper names the subject; the same hazard in the `replayTour` helper is fixed too. The `toHaveCount(0)`
assertions stay **unqualified on purpose** — they mean *every* toast, and scoping them would have
silently weakened them.

## What this does NOT claim

**It was not reproduced locally**, and this PR is not a red-to-green demonstration:

| Run | Result |
| --- | --- |
| **Before**, `--repeat-each=10`, 1 worker | 10 passed — no failure |
| **Before**, `--repeat-each=12`, 4 workers under CPU load | 12 passed — no failure |
| **After**, whole spec file, `--repeat-each=8` | **32 passed** |
| **After**, this test, `--repeat-each=20`, 4 workers under CPU load | **20 passed** |

52 green runs after the change is **not** proof that the flake is gone — the failure was never observed
here, so nothing can be shown to have stopped. The justification is the mechanism above: an assertion
depending on 18 consecutive true reads of a live CSS state is fragile whether or not this machine can
lose the race. An instrumented probe (sampling `matches(":hover")` and `elementFromPoint` every 250 ms
through the window) held true for all 36 samples, so the react-joyride overlay theory was tested and
**discarded** rather than shipped as a premise.

## API Or Behavior Changes

None. One test file; no product code is touched.

## Related product question, deliberately not fixed here

Filed as **#1064** (assigned @oxoxDev): because hovering defers the verdict without pausing the clock, an
operator who reads a toast for nine seconds and then glances away loses it **within 500 ms, with none of
the grace they would have had if they had never hovered it**. That may be intended — it is a real
trade-off against #933's ceiling, since pausing the clock lets a toast latched under a stationary pointer
age forever — so it is a question for the owner rather than a change smuggled into a test fix.

## Tests

- [x] `cargo fmt --all -- --check` — N/A: no Rust file is touched. `Cargo.lock` and submodule pins
  unchanged.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust file is touched.
- [x] `cargo build --all-targets` — N/A: no Rust file is touched.
- [x] `cargo test` — N/A for Rust. The console lane is what exercises this: `npm run typecheck:e2e`
  (exit 0), and the spec itself run 52 times as tabled above, including 20 iterations across 4 workers
  under deliberate CPU contention.

No prettier was run: this repo has no prettier config and no prettier CI gate, so it would reformat
untouched code and bury the change.

## Documentation

No doc changes. The reasoning — why the old shape was knife-edge, why the rounds still exceed the
ceiling, and why `toHaveCount(0)` stays unqualified — is recorded in the test's own comments, next to the
assertions it explains.

Refs tinyhumansai/opencompany#969
