### PR TITLE
fix(workflows): take the draft-overwrite consent when the draft lands, not when it is requested

### DIFF
--- a/frontend/src/lib/workflow-draft.ts
+++ b/frontend/src/lib/workflow-draft.ts
@@ -43,3 +43,49 @@ export function draftBanners(drafted: WorkflowDraftFromDescription): DraftBanner
     reason: drafted.reason ?? "This is better done once than built into a workflow.",
   };
 }
+
+/**
+ * What a landed copilot draft may do to the form it came back to (issue #1052).
+ *
+ * - `drop` — the dialog moved on (closed, reopened, re-hydrated) while the
+ *   request was in flight. The answer is about a form that no longer exists, so
+ *   it is discarded silently: nothing was asked, so nothing needs explaining.
+ * - `confirm` — the form holds work the operator did, so replacing it is a
+ *   question, not a side effect.
+ * - `apply` — nothing would be lost; hydrate.
+ */
+export type DraftLanding = "drop" | "confirm" | "apply";
+
+/**
+ * Decides what a draft response is allowed to do **at the moment it lands**.
+ *
+ * The bug this exists for: `runDraft` used to take its `window.confirm` *before*
+ * the request. A model call takes seconds, and the operator is invited to keep
+ * typing while it runs — so the consent was granted over a form that no longer
+ * existed by the time the answer arrived, and a draft could replace work the
+ * operator started *after* agreeing. Consent has to be taken against the state
+ * being replaced, which means after the await, which means here.
+ *
+ * `epoch` is the identity of the dialog's contents. The reset effect bumps it on
+ * every open, so a draft abandoned by cancelling cannot hydrate the *next* open —
+ * the failure mode where reopening the dialog filled itself in with a draft the
+ * operator had walked away from.
+ *
+ * Staleness is checked **before** dirtiness on purpose: a response for a form
+ * that is gone must not raise a confirm about a form the operator is no longer
+ * looking at. Asking a question nobody can place is worse than silence.
+ *
+ * Pure so the three outcomes can be proved without a slow request and a rendered
+ * dialog — the same reason `draftBanners` above lives here rather than inline.
+ */
+export function draftLanding(args: {
+  /** The dialog's epoch when the request was issued. */
+  requestedEpoch: number;
+  /** The dialog's epoch now that the response has landed. */
+  currentEpoch: number;
+  /** Whether the form holds operator work **right now**, not at request time. */
+  dirtyNow: boolean;
+}): DraftLanding {
+  if (args.requestedEpoch !== args.currentEpoch) return "drop";
+  return args.dirtyNow ? "confirm" : "apply";
+}

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -46,7 +46,7 @@ import {
   configFromDraft,
   hasConfigForm,
 } from "@/lib/workflow-node-config";
-import { draftBanners } from "@/lib/workflow-draft";
+import { draftBanners, draftLanding } from "@/lib/workflow-draft";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import { CronPreviewLine } from "@/views/CronPreviewLine";
@@ -427,6 +427,25 @@ export function WorkflowCreateDialog({
   /** The submit-time error banner, so a failed submit can scroll it into view
    * and focus it rather than leave the message off-screen (#813 defect 6). */
   const errorRef = useRef<HTMLDivElement>(null);
+  /**
+   * Identity of the dialog's current contents (issue #1052).
+   *
+   * Bumped by the reset effect below, i.e. on every open and every re-hydrate.
+   * `runDraft` captures it before its request and compares after, so a draft the
+   * operator walked away from cannot hydrate whatever is on screen later. The
+   * file's other async paths use an effect-scoped `live` flag; an event handler
+   * has no cleanup to flip, so the same idea is carried on a ref.
+   */
+  const draftEpochRef = useRef(0);
+  /**
+   * Whether the form holds operator work, readable **after** an await.
+   *
+   * `isDraftDirty()` closes over its render's state, so calling it again when a
+   * response lands re-reads the values captured when the request was issued —
+   * it would look like a re-check and answer the old question. This ref is
+   * refreshed on every render, so the post-await read sees what is on screen now.
+   */
+  const draftDirtyRef = useRef(false);
   /** Per-field problems raised on blur (issue #261), keyed by
    * {@link errorKey}. Separate from `error`, the submit-time banner: this one
    * is inline, scoped to the control that caused it, and never blocks Save on
@@ -478,6 +497,14 @@ export function WorkflowCreateDialog({
   // and keeping the edit would keep the stale token with it.
   useEffect(() => {
     if (!open) return;
+    // Issue #1052: a draft still in flight belongs to the contents being
+    // replaced right now, not to these. Bumping first is what makes its
+    // response land as `drop` instead of overwriting a freshly-reset form.
+    draftEpochRef.current += 1;
+    // …and the button it disabled belongs to that abandoned request too, or a
+    // reopened dialog starts with Draft it inert until a request nobody is
+    // waiting for settles.
+    setDrafting(false);
     setId(workflow?.id ?? "");
     setName(workflow?.name ?? "");
     setDescription(workflow?.description ?? "");
@@ -853,6 +880,13 @@ export function WorkflowCreateDialog({
     );
   }
 
+  // Issue #1052: refresh the post-await view of dirtiness on every render. See
+  // `draftDirtyRef` for why re-calling `isDraftDirty()` after an await cannot
+  // work on its own.
+  useEffect(() => {
+    draftDirtyRef.current = isDraftDirty();
+  });
+
   /** Draft a graph from the description and hydrate the form with it (issue
    * #753). The hydrated, editable form IS the review surface — there is no
    * read-only diff — so on success the operator lands in the ordinary create
@@ -860,16 +894,14 @@ export function WorkflowCreateDialog({
   async function runDraft() {
     const description = copilotPrompt.trim();
     if (!description || drafting || echoing) return;
-    // Overwriting work the operator has already started is a confirm, not a
-    // silent clobber — the same courtesy the History restore extends.
-    if (
-      isDraftDirty() &&
-      !window.confirm(
-        "Replace what you've started with the drafted workflow? You can still edit it before creating.",
-      )
-    ) {
-      return;
-    }
+    // Issue #1052: the consent for overwriting the operator's work is taken
+    // AFTER the await, not here. A model call takes seconds and the operator is
+    // invited to keep typing through it, so a confirm asked now would be
+    // answered about a form that no longer exists when the draft lands — and
+    // the answer would then authorise replacing work started after it was
+    // given. It also asked at all for a draft that turns out not automatable,
+    // which leaves the form untouched and needed no permission.
+    const requestedEpoch = draftEpochRef.current;
     setDrafting(true);
     setDraftError(null);
     setDraftSummary(null);
@@ -877,8 +909,30 @@ export function WorkflowCreateDialog({
     setDraftNotes([]);
     try {
       const drafted = await draftWorkflowFromDescription(client, company, description);
+      // Issue #1052: what this response is allowed to do to the form it came
+      // back to, decided against the form as it is NOW.
+      const landing = draftLanding({
+        requestedEpoch,
+        currentEpoch: draftEpochRef.current,
+        dirtyNow: draftDirtyRef.current,
+      });
+      // The dialog moved on — closed, reopened, re-hydrated. Drop it silently:
+      // nothing was asked of the operator, so nothing needs explaining, and the
+      // banners below belong to a form that is gone.
+      if (landing === "drop") return;
       const banners = draftBanners(drafted);
       if (drafted.automatable && drafted.workflow) {
+        // Only a draft that will actually replace something asks. `confirm`
+        // means the form holds work right now; declining leaves it exactly as
+        // the operator left it, prompt and all, so they can draft again.
+        if (
+          landing === "confirm" &&
+          !window.confirm(
+            "Replace what you've started with the drafted workflow? You can still edit it before creating.",
+          )
+        ) {
+          return;
+        }
         const graph = drafted.workflow;
         // Hydrate via the same helpers edit mode uses, so a drafted graph and a
         // saved one populate the form identically.
@@ -904,7 +958,10 @@ export function WorkflowCreateDialog({
       // operator can still author by hand.
       setDraftError(e instanceof Error ? e.message : "could not draft a workflow");
     } finally {
-      setDrafting(false);
+      // Issue #1052: only the request that owns the current contents may clear
+      // the spinner — a stale one would switch off a draft the operator is
+      // actually waiting on.
+      if (draftEpochRef.current === requestedEpoch) setDrafting(false);
     }
   }
 

--- a/frontend/test/unit/workflow-draft.test.ts
+++ b/frontend/test/unit/workflow-draft.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { WorkflowDraftFromDescription, WorkflowGraph } from "@/api/workflows";
-import { draftBanners } from "@/lib/workflow-draft";
+import { draftBanners, draftLanding } from "@/lib/workflow-draft";
 
 /**
  * The create-time copilot's banner reducer (issue #813).
@@ -63,5 +63,54 @@ describe("draftBanners", () => {
 
     const noReason = draftBanners({ automatable: false });
     expect(noReason.reason).toBe("This is better done once than built into a workflow.");
+  });
+});
+
+/**
+ * What a landed copilot draft may do to the form it came back to (issue #1052).
+ *
+ * The defect was a consent problem, not a missing guard: `runDraft` took its
+ * `window.confirm` *before* a request that takes seconds, while the operator is
+ * invited to keep typing through it. The answer therefore authorised replacing a
+ * form that no longer existed by the time it arrived — and a draft abandoned by
+ * cancelling could hydrate the *next* open.
+ *
+ * These pin the decision itself. Proving it through the dialog would need a slow
+ * request, a rendered form and a stubbed `window.confirm`; the branch that
+ * matters is three lines of reasoning about two epochs and a dirty flag.
+ */
+describe("draftLanding", () => {
+  it("applies when nothing would be lost", () => {
+    expect(draftLanding({ requestedEpoch: 3, currentEpoch: 3, dirtyNow: false })).toBe("apply");
+  });
+
+  /**
+   * The bug's core case: the form was clean when the request went out and the
+   * operator typed while it ran. Dirtiness is read at landing, so this asks.
+   */
+  it("asks when the operator has made the form dirty since the request", () => {
+    expect(draftLanding({ requestedEpoch: 3, currentEpoch: 3, dirtyNow: true })).toBe("confirm");
+  });
+
+  /**
+   * Cancel mid-draft, reopen: the reset effect bumped the epoch, so the
+   * abandoned response must not fill in the fresh form.
+   */
+  it("drops a response whose dialog has moved on", () => {
+    expect(draftLanding({ requestedEpoch: 3, currentEpoch: 4, dirtyNow: false })).toBe("drop");
+  });
+
+  /**
+   * Staleness outranks dirtiness. A response for a form that is gone must not
+   * raise a confirm about a form the operator is no longer looking at — a
+   * question nobody can place is worse than silence.
+   */
+  it("drops rather than asking when the dialog moved on AND the form is dirty", () => {
+    expect(draftLanding({ requestedEpoch: 3, currentEpoch: 4, dirtyNow: true })).toBe("drop");
+  });
+
+  /** Epochs only ever move forward, but the rule is inequality, not ordering. */
+  it("treats any epoch change as stale, in either direction", () => {
+    expect(draftLanding({ requestedEpoch: 4, currentEpoch: 3, dirtyNow: false })).toBe("drop");
   });
 });


### PR DESCRIPTION
## Summary

Click **Draft it**, keep filling the form in while it thinks, and the draft replaced your work
with no warning. Or cancel mid-draft, reopen, and the dialog filled itself in with the draft
you walked away from.

`runDraft` took its `window.confirm` **before** the request. A copilot draft takes seconds and
the operator is explicitly invited to keep working through it — so the consent was granted over
a form that no longer existed when the answer arrived, and it authorised replacing work started
*after* it was given.

**That is the bug: a permission question asked too early, not a missing guard.** A guard added
around the same early confirm would still be asking about the wrong state.

## Why the early confirm is *removed*, not kept alongside a late one

The obvious shape is "confirm before, then re-check after". It is worse, and a reviewer's
instinct to restore the early confirm as a belt-and-braces safety would reintroduce this bug in
a politer form — so, explicitly:

Two confirms ask about **two different forms**. The first is about the form as it was when the
request went out; the second about the form as it is when the draft lands. Only the second one
is about the thing actually being replaced. Keeping both means interrupting the operator twice
to answer one question, and the first answer is meaningless by the time it matters.

So the confirm moved. It is taken once, against the state being overwritten.

**A side effect worth stating, because it looks like a dropped prompt and is not:** the dialog
no longer asks at all when the draft comes back **not automatable**. That branch leaves the
form completely untouched — the old code asked permission to replace work it then didn't
replace. A confirm that appears only when something is genuinely about to be overwritten is the
correct behaviour.

## Why Cancel stays enabled

Disabling Cancel while `drafting` is the one-line fix and a worse product: it traps the
operator in a dialog until a slow model call returns, to prevent a problem they are trying to
walk away from.

**The draft becomes irrelevant instead of un-cancellable.** `draftEpochRef` identifies the
dialog's current contents; the reset effect bumps it on every open and re-hydrate. `runDraft`
captures it before the request and compares after, so a response whose dialog has moved on is
**dropped silently** — nothing was asked of the operator, so nothing needs explaining, and its
banners belong to a form that is gone.

## The detail that decides whether this fix is real

**`isDraftDirty()` closes over its render's state.** Re-calling it after the `await` — the
literal shape the issue proposes — re-reads the values captured *when the request was issued*.
It looks like a re-check, passes review, and does nothing: the operator's new typing is
invisible to it and the draft still clobbers.

Dirtiness therefore rides `draftDirtyRef`, refreshed by an effect on every render, so the
post-await read sees what is on screen now. This is the load-bearing line of the change; the
rest is plumbing around it.

## Reusing the file's convention rather than adding a second one

Every other async path here uses an effect-scoped `let live = true` flipped by the effect's
cleanup. `runDraft` is an **event handler** — there is no cleanup to flip — so the same idea is
carried on a ref instead. That is recorded at `draftEpochRef` so it reads as the existing
convention adapted, not a rival one.

Two smaller consequences of the same ownership rule:

* the `finally` clears `drafting` only when the epoch still matches — a stale request switching
  off the spinner would kill the indicator for a newer draft the operator *is* waiting on;
* the reset effect clears `drafting`, because cancelling mid-draft previously left **Draft it**
  inert on reopen until an abandoned promise settled.

## API Or Behavior Changes

**No API change.** Console-only; no route, no wire type, no host code.

**Behaviour.**
1. The overwrite confirm is asked when the draft lands, against the form being replaced.
2. It is not asked when nothing will be overwritten (clean form, or a non-automatable result).
3. A draft whose dialog was closed, reopened or re-hydrated is discarded instead of applied.
4. Cancel remains enabled throughout — unchanged.

## Tests

- [x] `cargo fmt --all -- --check` — N/A: no Rust file is touched. The diff is three paths, all
      under `frontend/`.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust file is touched, so neither the
      default nor the `openhuman,tinycortex` lane has anything to lint here.
- [x] `cargo build --all-targets` — N/A as above; `git diff --stat Cargo.lock` is empty.
- [x] `cargo test` — N/A as above. **Ran instead, as the console's CI lane does:**
  - `npm run typecheck`, `typecheck:unit`, `typecheck:e2e` — all clean
  - `npm run build` — clean
  - `npx vitest run` — **960 passed, 98 files, 0 failed** (5 of them new)

  Not run: `prettier`. CI does not run it, and files untouched by this change already fail
  `prettier --check` on `main`, so running it would produce reformatting noise unrelated to this.

### Every new test was proven to fail with its fix reverted — 3 reverts, 5 tests

| reverted | tests that failed |
|---|---|
| the staleness check is removed | `drops a response whose dialog has moved on`, `drops rather than asking when the dialog moved on AND the form is dirty`, `treats any epoch change as stale, in either direction` |
| dirtiness is ignored (the silent-clobber bug itself) | `asks when the operator has made the form dirty since the request` |
| staleness is checked *after* dirtiness | `drops rather than asking when the dialog moved on AND the form is dirty` |

That third revert is the one worth keeping: checking dirtiness first still passes four of the
five tests, and produces a confirm about a form the operator is no longer looking at. A question
nobody can place is worse than silence.

The decision lives in `@/lib/workflow-draft` beside `draftBanners`, which is where this file
already puts logic it wants proved without a render.

### What is NOT proven, stated rather than claimed as coverage

**The wiring is untested.** The tests pin the `draftLanding` decision; that `runDraft` calls it,
that the epoch is bumped on open, and — most importantly — that dirtiness comes from the **ref**
rather than a direct `isDraftDirty()` call are guarded by the compiler and by reading, not by a
test. If someone simplifies that ref away, every test here still passes and the bug returns.

Proving it needs a render harness with a stubbed slow request and a stubbed `window.confirm`;
this repo has no component-test harness for this dialog, and its e2e lane needs a live host.
Recorded as a real gap rather than papered over — it is the same gap `#1005` touches on the same
surface.

**Not reproduced on a live tenant.** The cause is precisely located in source and the fix is
reasoned from it; no staging observation was made.

## Documentation

No spec doc changes. The reasoning lives at the code it governs: `draftLanding` carries why
consent must be taken at landing, `draftEpochRef` carries why an event handler cannot use the
file's effect-scoped `live` flag, and `draftDirtyRef` carries why re-calling `isDraftDirty()`
after an await cannot work.

Refs tinyhumansai/opencompany#1052
