### PR TITLE
fix(workflows): require expectedVersion on every write, always serialize version (#1013)

### DIFF
--- a/frontend/src/api/workflow-proposal.ts
+++ b/frontend/src/api/workflow-proposal.ts
@@ -114,7 +114,13 @@ export function readProposal(reply: string, graph: WorkflowGraph): ReadProposal 
 
   const result = validateProposal(parsed, graph);
   if ("reason" in result) return { prose, problem: result };
-  return { prose, proposal: { ...result, basedOnVersion: graph.version } };
+  // `version` is now `string | null` (issue #1013); `basedOnVersion` is the
+  // token this proposal was based on, so a non-editable graph's `null` means "no
+  // base" — coerce it to `undefined`.
+  return {
+    prose,
+    proposal: { ...result, basedOnVersion: graph.version ?? undefined },
+  };
 }
 
 /** The known node fields an `updateNode` may set. */

--- a/frontend/src/api/workflow-proposal.ts
+++ b/frontend/src/api/workflow-proposal.ts
@@ -462,7 +462,10 @@ export function isEmptyDiff(diff: GraphDiff): boolean {
  * ours to know.
  */
 export function proposalIsStale(proposal: WorkflowProposal, graph: WorkflowGraph): boolean {
-  if (graph.version === undefined) return false;
+  // `null` (issue #1013, a current host's honest "no token" for a non-editable
+  // graph) and `undefined` (a host predating #259 entirely) both mean the same
+  // thing here: nothing to compare against, so nothing to call stale.
+  if (graph.version == null) return false;
   return proposal.basedOnVersion !== graph.version;
 }
 

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -143,16 +143,22 @@ export interface WorkflowGraph {
   /** See {@link WorkflowSummary.enabled}. Same "only `false` means off" rule. */
   enabled?: boolean;
   /**
-   * The opaque optimistic-concurrency token for this graph (issue #259),
-   * present only when `editable`.
+   * The opaque optimistic-concurrency token for this graph (issue #259). Always
+   * serialized by a current host (issue #1013): a `string` when the graph is
+   * `editable`, and `null` when it is not (a source-defined or body-less graph
+   * has nothing to version). It used to be omitted for a non-editable graph,
+   * which read back as `undefined` and let a caller send nothing — silently
+   * overwriting a concurrent save; an explicit `null` is the honest "no token".
    *
-   * **Echo it back, never parse it.** Pass it to {@link updateWorkflow} or
-   * {@link deleteWorkflow} and the host refuses the write with a 409 if the
-   * graph changed since this read — which is what stops one console silently
-   * overwriting another's edit. Absent from a host predating #259, in which case
-   * the write is unconditional and that protection simply does not exist.
+   * **Echo it back, never parse it.** Pass it to {@link updateWorkflow},
+   * {@link deleteWorkflow}, or {@link restoreWorkflowRevision} and the host
+   * refuses the write with a 409 if the graph changed since this read — which is
+   * what stops one console silently overwriting another's edit. A current host
+   * now also refuses the write with a 400 if you send no token at all. `null`
+   * from a non-editable graph is falsy and sends nothing, which the console never
+   * does — those graphs are not editable.
    */
-  version?: string;
+  version: string | null;
 }
 
 /**
@@ -870,14 +876,16 @@ export function fixWorkflowFromRun(
  * rename is a create plus a delete.
  *
  * Pass `expectedVersion` — the `version` from the {@link getWorkflow} this edit
- * was based on — to make the write conditional. If the graph moved in between,
- * the host answers `409` and **nothing is written**; surface that to the
- * operator with a reload rather than retrying without the token, which is the
- * silent-overwrite the guard exists to prevent.
+ * was based on — to make the write conditional. It is **required** (issue
+ * #1013): a `null`/absent token makes the host answer `400` rather than writing
+ * unconditionally, which is what stops a stale editor silently clobbering a
+ * concurrent save. If the graph moved in between, the host answers `409` and
+ * **nothing is written**; surface either as a reload rather than retrying, which
+ * is the silent-overwrite the guard exists to prevent.
  *
  * Other rejections carry the same prosumer-language `ApiError` a create does:
- * `400` for a bad graph, `404` for an unknown id, `409` for a source-defined
- * workflow or a display name already taken.
+ * `400` for a bad graph or a missing token, `404` for an unknown id, `409` for a
+ * source-defined workflow or a display name already taken.
  *
  * Returns the stored graph with a **fresh** `version`, so a second save needs no
  * intervening read.
@@ -887,7 +895,7 @@ export function updateWorkflow(
   company: string | null,
   wid: string,
   graph: WorkflowGraph,
-  expectedVersion?: string,
+  expectedVersion?: string | null,
 ): Promise<WorkflowGraph> {
   return client.put<WorkflowGraph>(
     `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}`,
@@ -903,9 +911,11 @@ export function updateWorkflow(
  * **Past runs are kept.** They record what the workflow did, which stays true
  * after it is gone; {@link listWorkflowRuns} keeps serving them.
  *
- * `expectedVersion` makes the delete conditional in exactly the sense the
- * operator means by clicking Delete on a graph they are looking at: if it
- * changed underneath them, the host answers `409` and removes nothing.
+ * `expectedVersion` is **required** (issue #1013) and makes the delete
+ * conditional in exactly the sense the operator means by clicking Delete on a
+ * graph they are looking at: a `null`/absent token is a `400` rather than an
+ * unconditional delete, and if the token changed underneath them the host
+ * answers `409` and removes nothing.
  *
  * Follows the same runtime-vs-source contract as `deleteDesk`: a workflow
  * defined by a file in the company source tree cannot be removed from the
@@ -915,7 +925,7 @@ export function deleteWorkflow(
   client: OpenCompanyClient,
   company: string | null,
   wid: string,
-  expectedVersion?: string,
+  expectedVersion?: string | null,
 ): Promise<void> {
   const query = expectedVersion
     ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
@@ -1016,18 +1026,20 @@ export async function listWorkflowRevisions(
  * review (issue #276) — read `enabled` on the result to reflect that.
  *
  * Pass `expectedVersion` — the `version` of the graph the operator was looking
- * at — to make the restore conditional. On a `409` the graph moved underneath
- * them: **reload and let them re-choose, do not retry** without the token, which
- * is the silent-overwrite the guard exists to prevent. Other rejections carry
- * the host's prosumer-language message: `404` for an unknown workflow or
- * revision, `409` for a source-defined / body-less workflow or a name collision.
+ * at — to make the restore conditional. It is **required** (issue #1013): a
+ * `null`/absent token is a `400` rather than an unconditional restore. On a `409`
+ * the graph moved underneath them: **reload and let them re-choose, do not
+ * retry** without the token, which is the silent-overwrite the guard exists to
+ * prevent. Other rejections carry the host's prosumer-language message: `400` for
+ * a missing token, `404` for an unknown workflow or revision, `409` for a
+ * source-defined / body-less workflow or a name collision.
  */
 export function restoreWorkflowRevision(
   client: OpenCompanyClient,
   company: string | null,
   wid: string,
   revisionId: string,
-  expectedVersion?: string,
+  expectedVersion?: string | null,
 ): Promise<WorkflowGraph> {
   return client.post<WorkflowGraph>(
     `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}/revisions/${encodeURIComponent(

--- a/frontend/src/lib/task-workflow-proposal.ts
+++ b/frontend/src/lib/task-workflow-proposal.ts
@@ -37,7 +37,14 @@ import {
 import type { WorkflowGraph } from "@/api/workflows";
 
 /** The graph a built proposal is diffed against: nothing, so all of it is new. */
-const EMPTY_GRAPH: WorkflowGraph = { id: "", name: "", nodes: [], edges: [] };
+const EMPTY_GRAPH: WorkflowGraph = {
+  id: "",
+  name: "",
+  nodes: [],
+  edges: [],
+  // No saved body, so no token (issue #1013 makes `version` explicit).
+  version: null,
+};
 
 /** Either the all-added diff, or the one sentence to show instead of Apply. */
 export type TaskProposalDiff = { diff: GraphDiff } | { reason: string };
@@ -79,6 +86,9 @@ export function taskProposalDiff(ops: unknown): TaskProposalDiff {
   const validated = validateProposal(candidate, EMPTY_GRAPH);
   if ("reason" in validated) return { reason: validated.reason };
 
-  const proposal = { ...validated, basedOnVersion: EMPTY_GRAPH.version };
+  const proposal = {
+    ...validated,
+    basedOnVersion: EMPTY_GRAPH.version ?? undefined,
+  };
   return { diff: diffGraphs(EMPTY_GRAPH, applyProposal(EMPTY_GRAPH, proposal)) };
 }

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -127,6 +127,8 @@ export function Overview({ client, company }: Props) {
               description: summary.description,
               nodes: [],
               edges: [],
+              // No saved graph to fetch, so no token (issue #1013).
+              version: null,
             }),
           ),
         ),

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -1012,6 +1012,9 @@ export function WorkflowCreateDialog({
       id: id.trim(),
       name: name.trim(),
       description: description.trim() || undefined,
+      // Locally-built body; the conditional-write token is passed separately as
+      // `expectedVersion`, so this carries none (issue #1013 makes it explicit).
+      version: null,
       nodes: nodes.map(
         (n): WorkflowNode => ({
           id: n.id.trim(),

--- a/frontend/test/e2e/workflow-canvas-live.spec.ts
+++ b/frontend/test/e2e/workflow-canvas-live.spec.ts
@@ -94,6 +94,20 @@ test.describe("workflow canvas during a live run", () => {
     expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
   }
 
+  /**
+   * Best-effort teardown so a failed spec does not poison the next run.
+   * `expectedVersion` is required (issue #1013), so this reads the workflow's
+   * current token first rather than sending a bare DELETE.
+   */
+  async function removeWorkflow(request: APIRequestContext, id: string) {
+    const version = await request
+      .get(`${COMPANY_SCOPE}/workflows/${id}`)
+      .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+      .catch(() => null);
+    const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+    await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
+  }
+
   /** The per-node run marks the canvas is painting right now. */
   async function painted(page: Page): Promise<Record<string, string>> {
     return page.evaluate(() =>
@@ -159,7 +173,7 @@ test.describe("workflow canvas during a live run", () => {
       expect(settled["Step 0"], JSON.stringify(settled)).toBe("ok");
       await run;
     } finally {
-      await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+      await removeWorkflow(request, id);
     }
   });
 
@@ -204,7 +218,7 @@ test.describe("workflow canvas during a live run", () => {
       expect(settled["Done"], JSON.stringify(settled)).toBe("ok");
       await run;
     } finally {
-      await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+      await removeWorkflow(request, id);
     }
   });
 });

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -100,9 +100,18 @@ async function createWorkflow(
   return body.version as string;
 }
 
-/** Best-effort teardown so a failed spec does not poison the next run. */
+/**
+ * Best-effort teardown so a failed spec does not poison the next run.
+ * `expectedVersion` is required (issue #1013), so this reads the workflow's
+ * current token first — a spec's own copy may be stale by teardown time.
+ */
 async function removeWorkflow(request: APIRequestContext, id: string) {
-  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+  const version = await request
+    .get(`${COMPANY_SCOPE}/workflows/${id}`)
+    .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+    .catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
 }
 
 /**
@@ -245,7 +254,7 @@ test("a version conflict surfaces distinctly with a way out, and deletes nothing
 }) => {
   const id = `e2e-conflict-${Date.now()}`;
   const name = `Conflict probe ${Date.now()}`;
-  await createWorkflow(request, id, name);
+  const createdVersion = await createWorkflow(request, id, name);
 
   try {
     await page.goto("/#/workflows");
@@ -253,9 +262,14 @@ test("a version conflict surfaces distinctly with a way out, and deletes nothing
     await selectWorkflow(page, name);
 
     // Force the race for real: someone else edits the graph while this console
-    // holds the token it loaded a moment ago.
+    // holds the token it loaded a moment ago. `expectedVersion` is required
+    // (issue #1013) even for this first out-of-band write, so it goes in as the
+    // token `createWorkflow` handed back.
     const edited = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, {
-      data: graphBody(id, name, "0 11 * * *", "Edited out-of-band, after the console loaded it."),
+      data: {
+        ...graphBody(id, name, "0 11 * * *", "Edited out-of-band, after the console loaded it."),
+        expectedVersion: createdVersion,
+      },
     });
     expect(edited.ok(), `out-of-band edit: ${edited.status()}`).toBeTruthy();
 
@@ -385,7 +399,7 @@ test("a stale save surfaces the conflict banner and writes nothing", async ({
 }) => {
   const id = `e2e-edit-conflict-${Date.now()}`;
   const name = `Edit conflict probe ${Date.now()}`;
-  await createWorkflow(request, id, name);
+  const createdVersion = await createWorkflow(request, id, name);
 
   try {
     await page.goto("/#/workflows");
@@ -395,9 +409,14 @@ test("a stale save surfaces the conflict banner and writes nothing", async ({
     const dialog = await openEditDialog(page);
 
     // Someone else saves while this dialog holds the token it loaded a moment
-    // ago. Forced for real, as with the delete conflict above.
+    // ago. Forced for real, as with the delete conflict above. `expectedVersion`
+    // is required (issue #1013), so this out-of-band write needs the token
+    // `createWorkflow` returned.
     const edited = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, {
-      data: graphBody(id, name, "0 11 * * *", "Edited out-of-band, mid-edit."),
+      data: {
+        ...graphBody(id, name, "0 11 * * *", "Edited out-of-band, mid-edit."),
+        expectedVersion: createdVersion,
+      },
     });
     expect(edited.ok(), `out-of-band edit: ${edited.status()}`).toBeTruthy();
 

--- a/frontend/test/e2e/workflow-inline-approval.spec.ts
+++ b/frontend/test/e2e/workflow-inline-approval.spec.ts
@@ -113,8 +113,15 @@ test.beforeEach(async ({ page, request }) => {
   expect(res.ok(), `create ${WORKFLOW.id}: ${res.status()} ${await res.text()}`).toBeTruthy();
 });
 
+// `expectedVersion` is required (issue #1013), so teardown reads the
+// workflow's current token first rather than sending a bare DELETE.
 test.afterEach(async ({ request }) => {
-  await request.delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW.id}`).catch(() => undefined);
+  const version = await request
+    .get(`${COMPANY_SCOPE}/workflows/${WORKFLOW.id}`)
+    .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+    .catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+  await request.delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW.id}${query}`).catch(() => undefined);
 });
 
 /**

--- a/frontend/test/e2e/workflow-live-list.spec.ts
+++ b/frontend/test/e2e/workflow-live-list.spec.ts
@@ -70,26 +70,55 @@ function graphBody(id: string, name: string) {
  * browser test can drive. The host journals `WorkflowCreated` on this path, so
  * the page under test can only learn about it through the SSE stream.
  */
-async function createWorkflow(request: APIRequestContext, id: string, name: string) {
+/** Creates a workflow over HTTP and returns its version token. */
+async function createWorkflow(
+  request: APIRequestContext,
+  id: string,
+  name: string,
+): Promise<string> {
   const res = await request.post(`${COMPANY_SCOPE}/workflows`, { data: graphBody(id, name) });
   expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  return body.version as string;
 }
 
 /**
  * Renames a saved workflow out-of-band. Journals `WorkflowUpdated`.
  *
  * The graph goes in flat — `UpdateWorkflowBody` flattens it and carries only
- * the optional `expectedVersion` alongside — and no token is sent, which is the
- * unconditional write an out-of-band caller makes.
+ * `expectedVersion` alongside. `expectedVersion` is required (issue #1013), so
+ * this needs the token the caller read the graph at — an out-of-band actor is
+ * not exempt from the same conditional-write contract the console follows.
  */
-async function renameWorkflow(request: APIRequestContext, id: string, name: string) {
-  const res = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, { data: graphBody(id, name) });
+async function renameWorkflow(
+  request: APIRequestContext,
+  id: string,
+  name: string,
+  expectedVersion: string,
+) {
+  const res = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, {
+    data: { ...graphBody(id, name), expectedVersion },
+  });
   expect(res.ok(), `rename ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
 }
 
-/** Best-effort teardown so a failed spec does not poison the next run. */
+/** Reads back a workflow's current version, or `null` if it is gone already. */
+async function currentVersion(request: APIRequestContext, id: string): Promise<string | null> {
+  const res = await request.get(`${COMPANY_SCOPE}/workflows/${id}`);
+  if (!res.ok()) return null;
+  const body = await res.json();
+  return (body.version as string | null) ?? null;
+}
+
+/**
+ * Best-effort teardown so a failed spec does not poison the next run.
+ * `expectedVersion` is required (issue #1013), so this reads the workflow's
+ * current token first — the caller's own copy may be stale by teardown time.
+ */
 async function removeWorkflow(request: APIRequestContext, id: string) {
-  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+  const version = await currentVersion(request, id).catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
 }
 
 /** The workflow picker's trigger. */
@@ -217,7 +246,7 @@ test("a workflow renamed elsewhere renames in the picker, with no reload", async
   const id = `e2e-live-rename-${stamp}`;
   const before = `Live rename probe ${stamp}`;
   const after = `Live renamed probe ${stamp}`;
-  await createWorkflow(request, id, before);
+  const createdVersion = await createWorkflow(request, id, before);
 
   try {
     await openWorkflows(page);
@@ -225,7 +254,7 @@ test("a workflow renamed elsewhere renames in the picker, with no reload", async
 
     // The graph on screen is renamed under the operator — the second-session
     // edit #259 made possible, and which nothing told this tab about.
-    await renameWorkflow(request, id, after);
+    await renameWorkflow(request, id, after, createdVersion);
 
     // Read off the trigger, which renders the *selected* workflow's name from
     // the same list the options come from: the rename has to land on the
@@ -247,7 +276,7 @@ test("deleting the workflow on screen elsewhere takes it out of the picker, not 
   const stamp = Date.now();
   const id = `e2e-live-delete-${stamp}`;
   const name = `Live delete probe ${stamp}`;
-  await createWorkflow(request, id, name);
+  const createdVersion = await createWorkflow(request, id, name);
 
   try {
     await openWorkflows(page);
@@ -256,8 +285,10 @@ test("deleting the workflow on screen elsewhere takes it out of the picker, not 
     // Deleted from another session while this tab has it selected and its graph
     // on the canvas. This is the worst symptom in the issue: the entry used to
     // stay put, and the next Run or Edit addressed a workflow the host had
-    // already dropped.
-    const deleted = await request.delete(`${COMPANY_SCOPE}/workflows/${id}`);
+    // already dropped. `expectedVersion` is required (issue #1013).
+    const deleted = await request.delete(
+      `${COMPANY_SCOPE}/workflows/${id}?expectedVersion=${encodeURIComponent(createdVersion)}`,
+    );
     expect(deleted.ok(), `delete ${id}: ${deleted.status()}`).toBeTruthy();
 
     // The selection moves off it, so the canvas stops showing a graph the host
@@ -295,7 +326,7 @@ test("a delete elsewhere corrects the URL in place, without pushing history", as
   const stamp = Date.now();
   const id = `e2e-live-history-${stamp}`;
   const name = `Live history probe ${stamp}`;
-  await createWorkflow(request, id, name);
+  const createdVersion = await createWorkflow(request, id, name);
 
   try {
     await openWorkflows(page);
@@ -306,7 +337,10 @@ test("a delete elsewhere corrects the URL in place, without pushing history", as
     await expect.poll(() => page.url(), { timeout: 20_000 }).toContain(id);
     const entriesBefore = await page.evaluate(() => window.history.length);
 
-    const deleted = await request.delete(`${COMPANY_SCOPE}/workflows/${id}`);
+    // `expectedVersion` is required (issue #1013).
+    const deleted = await request.delete(
+      `${COMPANY_SCOPE}/workflows/${id}?expectedVersion=${encodeURIComponent(createdVersion)}`,
+    );
     expect(deleted.ok(), `delete ${id}: ${deleted.status()}`).toBeTruthy();
 
     // The selection moves off the deleted workflow and the hash follows it.

--- a/frontend/test/e2e/workflow-node-config.spec.ts
+++ b/frontend/test/e2e/workflow-node-config.spec.ts
@@ -40,8 +40,18 @@ async function selectWorkflow(page: Page, name: string) {
 }
 
 /** Best-effort teardown so a failed spec does not poison the next run. */
+/**
+ * Best-effort teardown so a failed spec does not poison the next run.
+ * `expectedVersion` is required (issue #1013), so this reads the workflow's
+ * current token first.
+ */
 async function removeWorkflow(request: APIRequestContext, id: string) {
-  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+  const version = await request
+    .get(`${COMPANY_SCOPE}/workflows/${id}`)
+    .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+    .catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
 }
 
 const SUBMIT = "workflow-dialog-submit";

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -33,8 +33,18 @@ async function createWorkflow(request: APIRequestContext, id: string, name: stri
   expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
 }
 
+/**
+ * Best-effort teardown so a failed spec does not poison the next run.
+ * `expectedVersion` is required (issue #1013), so this reads the workflow's
+ * current token first rather than sending a bare DELETE.
+ */
 async function deleteWorkflow(request: APIRequestContext, id: string) {
-  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+  const version = await request
+    .get(`${COMPANY_SCOPE}/workflows/${id}`)
+    .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+    .catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
 }
 
 /** The workflow picker's trigger. */

--- a/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
+++ b/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
@@ -62,9 +62,19 @@ async function createWorkflow(request: APIRequestContext) {
   expect(res.ok(), `create: ${res.status()} ${await res.text()}`).toBeTruthy();
 }
 
+/**
+ * Best-effort teardown so a failed spec does not poison the next run.
+ * `expectedVersion` is required (issue #1013), so this reads the workflow's
+ * current token first.
+ */
 async function removeWorkflow(request: APIRequestContext) {
+  const version = await request
+    .get(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}`)
+    .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+    .catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
   await request
-    .delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}`)
+    .delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}${query}`)
     .catch(() => undefined);
 }
 

--- a/frontend/test/unit/overview-graph.test.ts
+++ b/frontend/test/unit/overview-graph.test.ts
@@ -40,7 +40,7 @@ function desk(id: string, name: string, members: string[] = []): DeskDto {
 }
 
 function flow(over: Partial<WorkflowGraph> & Pick<WorkflowGraph, "id" | "name">): WorkflowGraph {
-  return { nodes: [], edges: [], ...over };
+  return { version: null, nodes: [], edges: [], ...over };
 }
 
 function person(id: string, email: string, role: "admin" | "member"): HostPerson {

--- a/frontend/test/unit/overview-ring1.test.ts
+++ b/frontend/test/unit/overview-ring1.test.ts
@@ -213,6 +213,7 @@ describe("the workflow ring survives desks replacing the hardcoded departments",
         {
           id: "wf-nightly",
           name: "Nightly digest",
+          version: null,
           // `hedy` is seated on Engineering by the desk, not by her job title.
           nodes: [
             { id: "t", kind: "trigger", name: "22:00 UTC" },

--- a/frontend/test/unit/workflow-copilot-company-switch.test.ts
+++ b/frontend/test/unit/workflow-copilot-company-switch.test.ts
@@ -31,6 +31,7 @@ import { CopilotPanel } from "@/views/workflows/CopilotPanel";
 const graph: WorkflowGraph = {
   id: "weekly_report",
   name: "Weekly report",
+  version: null,
   description: "Assemble and send the Monday summary.",
   nodes: [
     {

--- a/frontend/test/unit/workflow-copilot.test.ts
+++ b/frontend/test/unit/workflow-copilot.test.ts
@@ -26,6 +26,7 @@ import type { WorkflowGraph } from "@/api/workflows";
 const graph: WorkflowGraph = {
   id: "weekly_report",
   name: "Weekly report",
+  version: null,
   description: "Assemble and send the Monday summary.",
   nodes: [
     {

--- a/frontend/test/unit/workflow-deeplink-reread.test.ts
+++ b/frontend/test/unit/workflow-deeplink-reread.test.ts
@@ -86,6 +86,7 @@ function graphFor(id: string): WorkflowGraph {
   return {
     id,
     name: id,
+    version: null,
     nodes: [{ id: "start", kind: "trigger", name: "Start" }],
     edges: [],
   };

--- a/frontend/test/unit/workflow-draft.test.ts
+++ b/frontend/test/unit/workflow-draft.test.ts
@@ -15,6 +15,7 @@ import { draftBanners } from "@/lib/workflow-draft";
 const GRAPH: WorkflowGraph = {
   id: "weekly-digest",
   name: "Weekly digest",
+  version: null,
   nodes: [],
   edges: [],
 };

--- a/frontend/test/unit/workflow-fix-from-run.test.ts
+++ b/frontend/test/unit/workflow-fix-from-run.test.ts
@@ -32,7 +32,13 @@ describe("fixWorkflowFromRun", () => {
     const answer: WorkflowFixFromRun = {
       automatable: true,
       summary: "dropped the unwired step",
-      workflow: { id: "weekly digest", name: "Weekly digest", nodes: [], edges: [] },
+      workflow: {
+        id: "weekly digest",
+        name: "Weekly digest",
+        version: null,
+        nodes: [],
+        edges: [],
+      },
       readiness: { ok: true },
     };
     const { client, calls } = fakeClient(answer);

--- a/frontend/test/unit/workflow-live-run.test.ts
+++ b/frontend/test/unit/workflow-live-run.test.ts
@@ -43,6 +43,7 @@ type Subs = import("@/hooks/use-events").Subscribers;
 const GRAPH: WorkflowGraph = {
   id: "greet",
   name: "Greet",
+  version: null,
   nodes: [
     { id: "start", kind: "trigger", name: "Start" },
     { id: "ceo", kind: "agent", name: "CEO", agent: "ceo" },

--- a/frontend/test/unit/workflow-proposal.test.ts
+++ b/frontend/test/unit/workflow-proposal.test.ts
@@ -511,10 +511,11 @@ describe("proposalIsStale", () => {
    * A host predating the version token (#259) has no concurrency protection at
    * all, for the canvas editor as much as for a proposal. Refusing every
    * proposal there would invent a protection that does not exist rather than
-   * report one.
+   * report one. A current host's `null` (issue #1013 — a non-editable graph's
+   * honest "no token") must be treated the same way.
    */
   it("does not invent staleness on a host that has no versions", () => {
-    const versionless = { ...graph(), version: undefined };
+    const versionless = { ...graph(), version: null };
     expect(proposalIsStale({ ...proposal, basedOnVersion: undefined }, versionless)).toBe(false);
   });
 });

--- a/frontend/test/unit/workflow-run-approvals.test.ts
+++ b/frontend/test/unit/workflow-run-approvals.test.ts
@@ -115,6 +115,7 @@ async function render(
         graph: {
           id: "feature_pipeline",
           name: "Feature pipeline",
+          version: null,
           nodes: [{ id: "spec", kind: "agent", name: "Draft the note", agent: "writer" }],
           edges: [],
         },

--- a/frontend/test/unit/workflow-run-blocked.test.ts
+++ b/frontend/test/unit/workflow-run-blocked.test.ts
@@ -153,6 +153,7 @@ describe("a blocked node on the canvas", () => {
     const graph: WorkflowGraph = {
       id: "feature_pipeline",
       name: "Feature pipeline",
+      version: null,
       nodes: [
         { id: "start", kind: "trigger", name: "Start" },
         { id: "spec", kind: "agent", name: "Spec", agent: "ceo" },

--- a/frontend/test/unit/workflow-run-error.test.ts
+++ b/frontend/test/unit/workflow-run-error.test.ts
@@ -78,6 +78,7 @@ describe("foldLiveRun scheduled", () => {
   const GRAPH: WorkflowGraph = {
     id: "wf1",
     name: "Nightly digest",
+    version: null,
     nodes: [
       { id: "t", kind: "trigger", name: "Trigger" },
       { id: "a", kind: "agent", name: "Agent" },

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -78,6 +78,7 @@ const { formatDuration, runDuration } = await import("@/views/workflows/run-heal
 const GRAPH: WorkflowGraph = {
   id: "digest",
   name: "Weekly digest",
+  version: null,
   nodes: [
     { id: "start", kind: "trigger", name: "Monday morning" },
     { id: "n_3", kind: "agent", name: "Draft the digest", agent: "writer" },

--- a/frontend/test/unit/workflow-tool-slugs.test.ts
+++ b/frontend/test/unit/workflow-tool-slugs.test.ts
@@ -8,6 +8,7 @@ import { listWorkflowToolSlugs, type WorkflowGraph } from "@/api/workflows";
 const graph: WorkflowGraph = {
   id: "weekly_report",
   name: "Weekly report",
+  version: null,
   nodes: [{ id: "collect", kind: "agent", name: "Collect", agent: "analyst" }],
   edges: [],
 };

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -890,6 +890,9 @@ async fn update_workflow(
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DeleteWorkflowQuery {
+    /// The token of the graph being removed. **Required** (issue #1013): an
+    /// absent `?expectedVersion=` is a `400`, not an unconditional delete, so a
+    /// stale editor can't drop a workflow that changed since they last looked.
     #[serde(default)]
     expected_version: Option<String>,
 }
@@ -904,8 +907,13 @@ struct DeleteWorkflowQuery {
 /// the workflow did, and that stays true after it is gone — `GET
 /// …/workflows/runs` keeps serving them. See the module doc.
 ///
-/// `204` on success. `404` for an unknown id; `409` for a source-defined or
-/// body-less id, or a stale `expectedVersion`.
+/// `expectedVersion` is **required** (issue #1013), for the same reason it is on
+/// `PUT`: an absent token used to mean an unconditional delete, so a console
+/// holding a stale graph could remove a workflow that changed underneath it. A
+/// missing `?expectedVersion=` is now a `400`.
+///
+/// `204` on success. `400` for a missing `expectedVersion`; `404` for an unknown
+/// id; `409` for a source-defined or body-less id, or a stale `expectedVersion`.
 async fn delete_workflow(
     company: ScopedCompany,
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
@@ -916,6 +924,17 @@ async fn delete_workflow(
             "workflow {wid}"
         ))));
     }
+    // `expectedVersion` is required (issue #1013) — a tokenless delete is refused
+    // rather than run unconditionally, so a stale editor can't drop a workflow
+    // that moved since they loaded it.
+    let Some(expected) = query.expected_version.as_deref() else {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "`expectedVersion` is required: read this workflow and pass its `version` as \
+             `?expectedVersion=`. Deleting without the version you read from could remove a \
+             workflow that changed since you last looked."
+                .to_string(),
+        )));
+    };
     delete_company_workflow(
         company.id(),
         company.runtime.source_dir(),
@@ -924,7 +943,7 @@ async fn delete_workflow(
         Some(company.runtime.schedule_fires()),
         Some(company.runtime.events()),
         &wid,
-        query.expected_version.as_deref(),
+        Some(expected),
     )
     .await
     .map_err(ApiError)?;
@@ -6097,7 +6116,7 @@ mod tests {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, id) = hosted_state(&home).await;
-            create_greeter(&state).await;
+            let version = create_greeter(&state).await;
             journal_run(
                 &state,
                 &id,
@@ -6109,7 +6128,11 @@ mod tests {
             .await;
 
             let response = router(state.clone())
-                .oneshot(request("DELETE", "/api/v1/company/workflows/greeter", None))
+                .oneshot(request(
+                    "DELETE",
+                    &format!("/api/v1/company/workflows/greeter?expectedVersion={version}"),
+                    None,
+                ))
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
@@ -6176,11 +6199,48 @@ mod tests {
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
 
+            // A token is required (issue #1013), so send one; the unknown id is
+            // resolved before the token is ever compared, so this stays a 404.
             let response = router(state)
-                .oneshot(request("DELETE", "/api/v1/company/workflows/ghost", None))
+                .oneshot(request(
+                    "DELETE",
+                    "/api/v1/company/workflows/ghost?expectedVersion=deadbeef",
+                    None,
+                ))
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        /// **The silent-clobber guard on delete (issue #1013).** A tokenless
+        /// `DELETE` used to remove unconditionally; a stale editor could drop a
+        /// workflow that changed underneath them. It is now a `400` that tells the
+        /// operator to re-read and pass the `version`, and removes nothing.
+        #[tokio::test]
+        async fn a_delete_without_a_token_is_rejected() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+
+            let response = router(state.clone())
+                .oneshot(request("DELETE", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = json_body(response).await;
+            let message = body["error"].as_str().unwrap_or_default().to_lowercase();
+            assert!(
+                message.contains("version") && message.contains("read"),
+                "the 400 must tell the operator to re-read and pass the version: {body}"
+            );
+
+            // The refusal removed nothing — the workflow is still there.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
         }
 
         /// The write verbs are reachable under the platform scope form too, not
@@ -6201,11 +6261,16 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
+            // The edit moved the token; delete with the one it just returned.
+            let next = json_body(response).await["version"]
+                .as_str()
+                .expect("edit returns a fresh token")
+                .to_string();
 
             let response = router(state)
                 .oneshot(request(
                     "DELETE",
-                    "/api/v1/companies/acme/workflows/greeter",
+                    &format!("/api/v1/companies/acme/workflows/greeter?expectedVersion={next}"),
                     None,
                 ))
                 .await
@@ -6269,9 +6334,15 @@ mod tests {
                 .expect("listed under its id");
             assert_eq!(legacy["editable"], false, "{items}");
 
-            // And the host agrees when actually asked to delete it.
+            // And the host agrees when actually asked to delete it. A token is
+            // required (issue #1013), so send one; the body-less id is a 409
+            // before the token is ever compared.
             let response = router(state)
-                .oneshot(request("DELETE", "/api/v1/company/workflows/legacy", None))
+                .oneshot(request(
+                    "DELETE",
+                    "/api/v1/company/workflows/legacy?expectedVersion=deadbeef",
+                    None,
+                ))
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::CONFLICT);

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -800,8 +800,11 @@ async fn graph_with_version(
 struct UpdateWorkflowBody {
     #[serde(flatten)]
     graph: CreateWorkflowBody,
-    /// The token from the `GET`/`PUT` this edit was based on. Omit for an
-    /// unconditional write (the `curl` path); the console always sends it.
+    /// The token from the `GET`/`PUT` this edit was based on. **Required** (issue
+    /// #1013): a missing token is a `400`, not an unconditional write, so a stale
+    /// editor can't silently clobber a concurrent save. Kept `Option` +
+    /// `serde(default)` so an omitted field is a clean handler-level `400` with a
+    /// recovery message, rather than an opaque serde `422`.
     #[serde(default)]
     expected_version: Option<String>,
 }
@@ -819,8 +822,17 @@ struct UpdateWorkflowBody {
 /// journalled run in the history — a rename would silently orphan all three. A
 /// rename is a create plus a delete, and the operator should say so.
 ///
-/// Statuses: `400` (bad graph, or `id` ≠ `wid`), `404` (unknown id), `409`
-/// (source-defined, body-less, name taken, or a stale `expectedVersion`).
+/// `expectedVersion` is **required** (issue #1013): omitting it used to mean an
+/// unconditional write, so a console holding a stale graph — or one that read
+/// `version` as `undefined` and sent nothing — silently clobbered a concurrent
+/// save. A missing token is now a `400`, matching the agent `update_workflow`
+/// tool, which has always demanded it. A caller re-reads the workflow and echoes
+/// back its `version`; the conditional write then refuses with a `409` if the
+/// graph moved in between.
+///
+/// Statuses: `400` (bad graph, `id` ≠ `wid`, or a missing `expectedVersion`),
+/// `404` (unknown id), `409` (source-defined, body-less, name taken, or a stale
+/// `expectedVersion`).
 async fn update_workflow(
     company: ScopedCompany,
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
@@ -840,7 +852,18 @@ async fn update_workflow(
         ))));
     }
 
-    let expected = body.expected_version.clone();
+    // `expectedVersion` is required (issue #1013). An absent token used to mean
+    // an unconditional write; that let a stale editor overwrite a concurrent save
+    // without ever seeing a 409. Refuse the write with a 400 instead, mirroring
+    // the agent `update_workflow` tool, and tell the caller how to recover.
+    let Some(expected) = body.expected_version.clone() else {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "`expectedVersion` is required: re-read this workflow and send back the `version` it \
+             returns. A `PUT` replaces the whole graph, so saving without the version you read \
+             from could silently overwrite a change made since."
+                .to_string(),
+        )));
+    };
     let draft = RawWorkflow::try_from(body.graph)?;
     reject_undeliverable_channel_destinations(&company, &draft)?;
     let file = update_company_workflow(
@@ -850,7 +873,7 @@ async fn update_workflow(
         company.runtime.workflow_revisions(),
         Some(company.runtime.events()),
         draft,
-        expected.as_deref(),
+        Some(expected.as_str()),
     )
     .await
     .map_err(ApiError)?;
@@ -3931,16 +3954,22 @@ mod tests {
             let home_dir = home();
             let state = desk_state(home_dir.path()).await;
 
-            assert_eq!(
-                post_create(state.clone(), create_body()).await.status(),
-                StatusCode::OK
-            );
+            let created = post_create(state.clone(), create_body()).await;
+            assert_eq!(created.status(), StatusCode::OK);
+            // Carry the created graph's token (required since #1013) so the 400
+            // comes from the destination guard, not the missing-token guard.
+            let version = json_body(created).await["version"]
+                .as_str()
+                .expect("create returns a version")
+                .to_string();
 
+            let mut body = body_with_destination("channel", Some("operator"));
+            body["expectedVersion"] = serde_json::json!(version);
             let response = router(state)
                 .oneshot(request(
                     "PUT",
                     "/api/v1/company/workflows/greeter",
-                    Some(body_with_destination("channel", Some("operator"))),
+                    Some(body),
                 ))
                 .await
                 .unwrap();
@@ -5892,15 +5921,19 @@ mod tests {
             assert_eq!(graph["description"], "Say hi, every morning.");
         }
 
-        /// Omitting the token is an unconditional write — the `curl` contract.
+        /// **The silent-clobber guard, at the front door (issue #1013).** Omitting
+        /// the token used to be an unconditional write; a stale editor could then
+        /// overwrite a concurrent save without ever seeing a `409`. A tokenless
+        /// `PUT` is now a `400` that tells the operator to re-read and resend the
+        /// `version`.
         #[tokio::test]
-        async fn an_edit_without_a_token_is_unconditional() {
+        async fn an_edit_without_a_token_is_rejected() {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
             create_greeter(&state).await;
 
-            let response = router(state)
+            let response = router(state.clone())
                 .oneshot(request(
                     "PUT",
                     "/api/v1/company/workflows/greeter",
@@ -5908,7 +5941,21 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = json_body(response).await;
+            let message = body["error"].as_str().unwrap_or_default().to_lowercase();
+            assert!(
+                message.contains("version") && message.contains("read"),
+                "the 400 must tell the operator to re-read and resend the version: {body}"
+            );
+
+            // The refusal changed nothing — the original description is intact.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            let graph = json_body(response).await;
+            assert_eq!(graph["description"], "Say hi.");
         }
 
         /// A `PUT` that would rename the id is a 400, not a silent create — the
@@ -5949,7 +5996,9 @@ mod tests {
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
 
-            let mut body = edited_body(None);
+            // A token is required (issue #1013), so send one; the unknown id is
+            // resolved before the token is ever compared, so this stays a 404.
+            let mut body = edited_body(Some("deadbeef"));
             body["id"] = serde_json::json!("ghost");
             let response = router(state)
                 .oneshot(request(
@@ -5969,14 +6018,16 @@ mod tests {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
-            create_greeter(&state).await;
+            let version = create_greeter(&state).await;
 
-            // No trigger node at all.
+            // No trigger node at all. Carries a valid token (required since #1013)
+            // so the 400 comes from structural validation, not the token guard.
             let body = serde_json::json!({
                 "id": "greeter",
                 "name": "Greeter",
                 "nodes": [ { "id": "done", "kind": "output", "name": "Report" } ],
-                "edges": []
+                "edges": [],
+                "expectedVersion": version
             });
             let response = router(state)
                 .oneshot(request(
@@ -6088,12 +6139,14 @@ mod tests {
             let (state, _store, _id) = hosted_state(&home).await;
             let stale = create_greeter(&state).await;
 
-            // Someone edits after the console loaded the graph.
+            // Someone edits after the console loaded the graph. This uses the
+            // then-current token (`stale`); the edit moves the version, so the
+            // delete below carries a now-stale one.
             let edited = router(state.clone())
                 .oneshot(request(
                     "PUT",
                     "/api/v1/company/workflows/greeter",
-                    Some(edited_body(None)),
+                    Some(edited_body(Some(&stale))),
                 ))
                 .await
                 .unwrap();
@@ -6137,13 +6190,13 @@ mod tests {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
-            create_greeter(&state).await;
+            let version = create_greeter(&state).await;
 
             let response = router(state.clone())
                 .oneshot(request(
                     "PUT",
                     "/api/v1/companies/acme/workflows/greeter",
-                    Some(edited_body(None)),
+                    Some(edited_body(Some(&version))),
                 ))
                 .await
                 .unwrap();

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -258,15 +258,18 @@ struct WorkflowGraph {
     /// Whether this graph can be replaced or removed through the API — see
     /// [`is_editable`].
     editable: bool,
-    /// The opaque optimistic-concurrency token for this graph (issue #259),
-    /// present only when `editable` (a source-defined graph has nothing to
-    /// version, and a token for an overlay body the read path does not even
-    /// serve would be actively misleading).
+    /// The opaque optimistic-concurrency token for this graph (issue #259).
+    /// Always serialized: a string when the graph is `editable`, and explicit
+    /// `null` when it is not (a source-defined or body-less graph has nothing to
+    /// version). It is deliberately NOT omitted — a client that read `version`
+    /// off a graph whose key was absent got `undefined` and sent nothing,
+    /// silently overwriting a concurrent save (issue #1013). An explicit `null`
+    /// says "no token here" instead of hiding the field.
     ///
     /// The contract is **echo it back**: hand it to `PUT` in the body or to
     /// `DELETE` as `?expectedVersion=`, and the write is refused with a `409` if
-    /// the graph moved in between. Never parse or derive it.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// the graph moved in between — and refused with a `400` if you omit it
+    /// entirely (issue #1013). Never parse or derive it.
     version: Option<String>,
     /// Whether this workflow's schedule is armed (issue #276) — see
     /// [`WorkflowSummary::enabled`]. Carried on the graph read as well as the
@@ -2856,6 +2859,27 @@ mod tests {
         assert!(done.get("agent").is_none());
         assert!(done.get("summary").is_none());
         assert_eq!(done["kind"], "output");
+    }
+
+    /// A non-editable graph serializes `version` as an explicit `null` rather
+    /// than omitting the key (issue #1013). Omitting it made a client read
+    /// `version` as `undefined` and send nothing, silently overwriting a
+    /// concurrent save; an explicit `null` is the honest "no token here".
+    #[test]
+    fn a_non_editable_graph_serializes_version_as_null() {
+        let dir = seed_demo();
+        let file = load_workflow_union(Some(dir.path()), &[], "demo")
+            .unwrap()
+            .unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None, false)).unwrap();
+        assert!(
+            json.get("version").is_some(),
+            "version key must be present, not omitted: {json}"
+        );
+        assert!(
+            json["version"].is_null(),
+            "no token serializes as null: {json}"
+        );
     }
 
     #[test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1094,8 +1094,10 @@ struct RevisionPath {
 #[serde(rename_all = "camelCase")]
 struct RestoreRevisionBody {
     /// The token from the `GET`/`PUT` the operator was looking at when they hit
-    /// Restore. Omit for an unconditional restore; the console always sends it,
-    /// and on a `409` should reload rather than retry — the graph moved under it.
+    /// Restore. **Required** (issue #1013): an absent token — or an absent body —
+    /// is a `400`, not an unconditional restore, so a stale editor can't overwrite
+    /// a concurrent save. On a `409` reload rather than retry — the graph moved
+    /// under it.
     #[serde(default)]
     expected_version: Option<String>,
 }
@@ -1111,10 +1113,15 @@ struct RestoreRevisionBody {
 /// itself undoable), the optimistic-concurrency token, and the #276 disarm of a
 /// restored schedule.
 ///
-/// Statuses: `200` (restored), `400` (the revision is invalid against the
-/// current record — e.g. it names a since-removed teammate), `404` (unknown
-/// `wid` or unknown `rev`), `409` (seed-backed / body-less `wid`, a stale
-/// `expectedVersion`, or a name collision).
+/// `expectedVersion` is **required** (issue #1013), aligning restore with `PUT`:
+/// an absent token — or an omitted body — used to mean an unconditional restore,
+/// so a stale editor could overwrite a concurrent save. A missing token is now a
+/// `400`.
+///
+/// Statuses: `200` (restored), `400` (a missing `expectedVersion`, or the
+/// revision is invalid against the current record — e.g. it names a since-removed
+/// teammate), `404` (unknown `wid` or unknown `rev`), `409` (seed-backed /
+/// body-less `wid`, a stale `expectedVersion`, or a name collision).
 async fn restore_workflow_revision(
     company: ScopedCompany,
     Path(RevisionPath { wid, rev }): Path<RevisionPath>,
@@ -1125,7 +1132,17 @@ async fn restore_workflow_revision(
             "workflow {wid}"
         ))));
     }
-    let expected = body.and_then(|Json(b)| b.expected_version);
+    // `expectedVersion` is required (issue #1013). Resolve it from the optional
+    // body; an absent token or an absent body alike is a 400, not an
+    // unconditional restore, so a stale editor can't clobber a concurrent save.
+    let Some(expected) = body.and_then(|Json(b)| b.expected_version) else {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "`expectedVersion` is required: read this workflow and send back its `version`. A \
+             restore replaces the current graph, so doing it without the version you read from \
+             could silently overwrite a change made since."
+                .to_string(),
+        )));
+    };
     let file = rollback_company_workflow(
         company.id(),
         company.runtime.source_dir(),
@@ -1134,7 +1151,7 @@ async fn restore_workflow_revision(
         Some(company.runtime.events()),
         &wid,
         &rev,
-        expected.as_deref(),
+        Some(expected.as_str()),
     )
     .await
     .map_err(ApiError)?;
@@ -5788,7 +5805,9 @@ mod tests {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
-            create_then_edit_greeter(&state).await;
+            // The token of the now-current (edited) graph — the one the restore
+            // replaces, and which it must carry (required since #1013).
+            let current = create_then_edit_greeter(&state).await;
 
             // Discover the revision id from the list.
             let list = json_body(
@@ -5804,12 +5823,12 @@ mod tests {
             .await;
             let rev_id = list["revisions"][0]["id"].as_str().unwrap().to_string();
 
-            // Restore it (unconditionally — no expectedVersion).
+            // Restore it, carrying the current graph's token.
             let response = router(state.clone())
                 .oneshot(request(
                     "POST",
                     &format!("/api/v1/company/workflows/greeter/revisions/{rev_id}/restore"),
-                    Some(serde_json::json!({})),
+                    Some(serde_json::json!({ "expectedVersion": current })),
                 ))
                 .await
                 .unwrap();
@@ -5860,17 +5879,62 @@ mod tests {
             let home_dir = home();
             let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
-            create_then_edit_greeter(&state).await;
+            // A token is required (issue #1013), so send one; the unknown revision
+            // is resolved before the token is ever compared, so this stays a 404.
+            let current = create_then_edit_greeter(&state).await;
 
             let response = router(state)
                 .oneshot(request(
                     "POST",
                     "/api/v1/company/workflows/greeter/revisions/no-such-rev/restore",
-                    Some(serde_json::json!({})),
+                    Some(serde_json::json!({ "expectedVersion": current })),
                 ))
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        /// **The silent-clobber guard on restore (issue #1013).** A restore with
+        /// no token — like an omitted body — used to overwrite unconditionally,
+        /// so a stale editor could clobber a concurrent save. It is now a `400`
+        /// that tells the operator to re-read and send the `version`.
+        #[tokio::test]
+        async fn a_restore_without_a_token_is_rejected() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_then_edit_greeter(&state).await;
+
+            // Discover a real revision id so the 400 is about the missing token,
+            // not the revision.
+            let list = json_body(
+                router(state.clone())
+                    .oneshot(request(
+                        "GET",
+                        "/api/v1/company/workflows/greeter/revisions",
+                        None,
+                    ))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            let rev_id = list["revisions"][0]["id"].as_str().unwrap().to_string();
+
+            let response = router(state)
+                .oneshot(request(
+                    "POST",
+                    &format!("/api/v1/company/workflows/greeter/revisions/{rev_id}/restore"),
+                    Some(serde_json::json!({})),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = json_body(response).await;
+            let message = body["error"].as_str().unwrap_or_default().to_lowercase();
+            assert!(
+                message.contains("version") && message.contains("read"),
+                "the 400 must tell the operator to re-read and send the version: {body}"
+            );
         }
 
         /// A workflow that was never edited has an empty history — `200 []`, not


### PR DESCRIPTION
## Summary

The optimistic-concurrency guard for workflow edits was correct but **skippable**, which made it decorative. `check_expected_version` returns `Ok(())` when the token is `None`, and the HTTP handlers made the token optional on PUT, DELETE and restore. Worse, `WorkflowGraph.version` was `skip_serializing_if = "Option::is_none"`, so a graph without a token serialized with the field **omitted** — a client reading `body.version` got `undefined`, sent nothing, and overwrote unconditionally. Two operators, or one operator and the copilot, could silently clobber each other.

This makes the token mandatory on every HTTP write surface and always serializes `version`:

- `expectedVersion` is now **required** on PUT, DELETE and restore — a tokenless call gets `400` with a read-first message mirroring the agent path (which already hard-required it).
- `WorkflowGraph.version` always serializes, emitting explicit `null` for a non-editable graph, so a client can never read `undefined` and send nothing.
- `check_expected_version` is left as the pure conditional-write primitive (the agent path, rollback reuse, and bundle import keep passing `None` legitimately) — required-ness lives in the handlers, where it is an API-contract concern.

## API Or Behavior Changes

- **PUT / DELETE / restore now 400 without `expectedVersion`.** This is intended: every legitimate editing caller (console PUT/DELETE/restore, copilot, agent path) already supplies the token. Curl/scripts that relied on tokenless writes must now read-then-write.
- `WorkflowGraph.version` is always present on the wire; it is `null` for a non-editable graph (previously the key was omitted). The console type is now `version: string | null`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` **and** `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --lib server::ops::workflows` — 94 passed; gated (`--features openhuman,tinycortex`) — 97 passed
- [x] `npm run typecheck` + `npm run build`

Red-first (each fails on pre-fix code, passes after):
- `a_non_editable_graph_serializes_version_as_null` — re-adding `skip_serializing_if` makes it fail.
- `an_edit_without_a_token_is_rejected` (inverted from the old `…_is_unconditional`) — reverting the guard makes it fail.
- `a_delete_without_a_token_is_rejected` — likewise.
- `a_restore_without_a_token_is_rejected` — likewise.
- `a_stale_expected_version_is_a_conflict` (409) stays green.

## Documentation

No doc pages — the required-token contract and the always-serialized `version` are documented in the handler/field docstrings and pinned by the tests.

## Related

Out of scope, needs a follow-up: `src/store/export.rs` `import_bundle` replaces `overlay_workflows` with no per-workflow version check. It is a cold bundle DR/migration restore with no live editor holding a token, so a per-workflow `expectedVersion` has no meaning there; guarding bundle restore (occupancy/revision capture) is a separate feature and was intentionally **not** folded into this change.

Note: the `version: string | null` type change ripples mechanically to a few frontend graph literals (empty/placeholder graphs now carry `version: null`) and two `basedOnVersion` assignments (`?? undefined`) — no behavior change, just the type-honest value for graphs that never had a token.

Closes #1013
