### PR TITLE
fix(tenancy): record company ownership before the company exists (#1050)

### DIFF
--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -267,9 +267,63 @@ async fn provision(
     if let Some(overlay) = state.memory_overlay() {
         builder = builder.with_memory_overlay(overlay);
     }
+    // Issue #1050: the durable owner row is written BEFORE the company exists.
+    //
+    // It used to be written after, best-effort, and a failure was logged and
+    // swallowed — so a transient write failure returned `201 Created` for a
+    // company with no `owners` row. Boot hydration filters on exactly that row,
+    // so after a restart the company was unattributable to its tenant: not
+    // hydrated, addressable by nobody (`owner_of` → `None` → 403), and **missed
+    // by a tenant-scoped purge or export**. Data surviving a deletion someone
+    // believes they performed is the part that makes this more than untidiness.
+    //
+    // Ordering it first is what makes failing honest. Failing at the old site
+    // could not be atomic: by then the runtime is built and registered, so
+    // returning an error left exactly the orphan it meant to prevent, and there
+    // is no company-deletion path to roll back with (`archive` is a lifecycle
+    // transition plus registry removal, not a purge).
+    //
+    // This inverts the failure direction, deliberately: a crash between here
+    // and a successful build leaves an `owners` row naming a company that was
+    // never created. That is the strictly safer orphan — it hydrates a harmless
+    // in-memory entry and can be removed, whereas a company with no owner row
+    // hides data from a purge. Prefer the failure that leaves data visible over
+    // the one that hides it.
+    if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
+        && let Err(err) = persist_owner_with_retry(ownership.as_ref(), &id, &tenant).await
+    {
+        tracing::error!(
+            company = %id,
+            tenant = %tenant,
+            error = %err,
+            "refusing to provision: company ownership could not be persisted"
+        );
+        return envelope(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "ownership_not_persisted",
+            "could not record which tenant owns this company, so it was not created. \
+             Nothing was provisioned — retry the request.",
+        );
+    }
+
     let runtime = match builder.build().await {
         Ok(runtime) => runtime,
-        Err(err) => return ApiError(err).into_response(),
+        Err(err) => {
+            // The owner row above now names a company that does not exist.
+            // Best-effort removal keeps the reversed orphan from lingering; if
+            // it fails the row is still the benign direction.
+            if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
+                && let Err(cleanup) = ownership.remove_owner(&id).await
+            {
+                tracing::warn!(
+                    company = %id,
+                    error = %cleanup,
+                    "provision failed and its ownership row could not be rolled back; the row \
+                     names a company that was never created"
+                );
+            }
+            return ApiError(err).into_response();
+        }
     };
 
     // The same refusal boot applies to `serve --company`: a company with no
@@ -294,16 +348,51 @@ async fn provision(
     state
         .registry()
         .insert(id.clone(), std::sync::Arc::new(runtime));
+    // The durable row was written and verified above, before the build, so this
+    // is only the in-memory mirror the running process serves from (issue
+    // #1050).
     state.set_owner(id.clone(), tenant.clone());
-    // Persist ownership when the backend supports it, so the tenant map
-    // survives restarts (best-effort: the in-memory map already reflects it).
-    if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
-        && let Err(err) = ownership.set_owner(&id, &tenant).await
-    {
-        tracing::warn!(company = %id, error = %err, "failed to persist company ownership");
-    }
 
     (StatusCode::CREATED, Json(status)).into_response()
+}
+
+/// How many times [`persist_owner_with_retry`] attempts the durable write.
+///
+/// The failure this exists for is transient — a mongo blip, an election, a
+/// timeout — so a couple of extra attempts turn most would-be provision
+/// failures back into successes. Small on purpose: a caller is waiting on this
+/// request, and a backend that is genuinely down should be reported as down
+/// rather than held open.
+const OWNERSHIP_WRITE_ATTEMPTS: usize = 3;
+
+/// Writes the company → tenant row, retrying a transient failure (issue #1050).
+///
+/// Returns the last error if every attempt fails, which the caller turns into a
+/// refusal to provision. There is no sleep between attempts: the retry is here
+/// for a failed round-trip rather than a busy one, and a request-scoped backoff
+/// would hold the caller open for a backend that is not coming back inside this
+/// request anyway.
+async fn persist_owner_with_retry(
+    ownership: &dyn crate::store::select::OwnershipStore,
+    id: &CompanyId,
+    tenant: &str,
+) -> crate::Result<()> {
+    let mut last = None;
+    for attempt in 1..=OWNERSHIP_WRITE_ATTEMPTS {
+        match ownership.set_owner(id, tenant).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                tracing::warn!(
+                    company = %id,
+                    attempt,
+                    error = %err,
+                    "persisting company ownership failed; retrying"
+                );
+                last = Some(err);
+            }
+        }
+    }
+    Err(last.expect("at least one attempt ran"))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -1340,3 +1340,92 @@ async fn a_host_wide_auth_override_reaches_a_company_provisioned_after_it_is_set
          manifest's own mode, exactly as it does for a company built at boot"
     );
 }
+
+// ── issue #1050: the durable ownership write ────────────────────────────────
+
+/// An [`OwnershipStore`](crate::store::select::OwnershipStore) that fails its
+/// first `fail_first` `set_owner` calls, then succeeds — the transient blip
+/// (mongo election, timeout) issue #1050 names as the cause.
+struct FlakyOwnership {
+    fail_first: std::sync::Mutex<usize>,
+    attempts: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl FlakyOwnership {
+    fn new(fail_first: usize) -> (Self, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        (
+            Self {
+                fail_first: std::sync::Mutex::new(fail_first),
+                attempts: attempts.clone(),
+            },
+            attempts,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::store::select::OwnershipStore for FlakyOwnership {
+    async fn set_owner(&self, _id: &CompanyId, _tenant: &str) -> crate::Result<()> {
+        self.attempts
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let mut left = self.fail_first.lock().unwrap();
+        if *left > 0 {
+            *left -= 1;
+            return Err(crate::error::OpenCompanyError::Config(
+                "transient ownership write failure".into(),
+            ));
+        }
+        Ok(())
+    }
+    async fn remove_owner(&self, _id: &CompanyId) -> crate::Result<()> {
+        Ok(())
+    }
+    async fn owners(&self) -> crate::Result<Vec<(CompanyId, String)>> {
+        Ok(Vec::new())
+    }
+}
+
+/// A transient failure is retried and the write succeeds, so a mongo blip does
+/// not turn into a refused provision.
+#[tokio::test]
+async fn a_transient_ownership_failure_is_retried_and_succeeds() {
+    let (store, attempts) = FlakyOwnership::new(2);
+    let result = super::persist_owner_with_retry(&store, &CompanyId::new("acme"), "tenant-a").await;
+    assert!(result.is_ok(), "the third attempt succeeds: {result:?}");
+    assert_eq!(
+        attempts.load(std::sync::atomic::Ordering::SeqCst),
+        3,
+        "it retried rather than giving up on the first failure"
+    );
+}
+
+/// A backend that is genuinely down returns the error, which is what the route
+/// turns into a refusal. The bound matters: this must not retry forever with a
+/// caller waiting on the request.
+#[tokio::test]
+async fn a_persistent_ownership_failure_gives_up_and_reports_it() {
+    let (store, attempts) = FlakyOwnership::new(usize::MAX);
+    let result = super::persist_owner_with_retry(&store, &CompanyId::new("acme"), "tenant-a").await;
+    assert!(
+        result.is_err(),
+        "a write that never succeeds must be reported, not swallowed — swallowing it is \
+         issue #1050"
+    );
+    assert_eq!(
+        attempts.load(std::sync::atomic::Ordering::SeqCst),
+        super::OWNERSHIP_WRITE_ATTEMPTS,
+        "bounded: a caller is waiting on this request"
+    );
+}
+
+/// The happy path costs exactly one write — the retry must not multiply the
+/// normal case.
+#[tokio::test]
+async fn a_successful_ownership_write_is_attempted_once() {
+    let (store, attempts) = FlakyOwnership::new(0);
+    super::persist_owner_with_retry(&store, &CompanyId::new("acme"), "tenant-a")
+        .await
+        .expect("writes first time");
+    assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## An orphaned company is missed by a tenant-scoped purge or export

Its data survives a deletion someone believes they performed.

That is the consequence, and it is why this is more than a swallowed log line. `ownership.set_owner` failures were logged and discarded, so a transient write failure (a mongo blip, an election, a timeout) returned **`201 Created`** for a company with no `owners` row. Boot hydration filters on exactly that row (`bin/opencompany.rs:1242`), so after a restart the company is unattributable to its tenant.

Traced through, an orphan today is worse than "untidy":

- **Not hydrated** for its tenant at boot.
- **Addressable by nobody.** `owner_of` returns `None`, so `authorize_address` (`platform_auth.rs:489`) and the GraphQL twin answer **403** — the tenant is locked out of the company it paid for.
- **Missed by tenant-scoped operations**, including a purge. The data stays in the shared database, attributable to no one.

It fails *closed*, so this is not a cross-tenant leak — nobody else gains access. It is a tenancy and data-retention correctness problem, and the purge-invisibility is the part that matters.

Confined to shared-single-DB deployments using the provisioning route. The boot path already self-heals (`bin:249` re-runs `set_owner` every boot); provision-route companies never did.

## Which option, and why not the other three

Issue #1050 proposes failing the request. **At the site it names, that cannot be atomic** — and this is the crux of the change.

By `provision.rs:299` the runtime is already built and `registry().insert()` has already run: files and rows exist. Returning an error there leaves **exactly the orphan it means to prevent**, plus a caller who believes nothing happened. True atomicity would need a compensating delete, and there is no company-deletion path to roll back with — `archive` is a lifecycle transition plus registry removal, not a purge.

But `id` and `tenant` are both fully resolved at `provision.rs:210`, well before the build. So:

**The durable owner row is now written *before* the company is built, with a bounded retry, and the request is refused if it cannot be written.**

That makes failing honest, because at that point there is nothing to roll back. It also inverts the failure direction, deliberately:

> **An `owners` row with no company is harmless. A company with no `owners` row hides data from a purge.**

A stale row hydrates a benign in-memory entry and can be removed; a failed build also rolls it back best-effort. The residual failure is the one that leaves data **visible** rather than the one that hides it. That is the trade this change makes on purpose.

Self-healing (the other suggested option) does not work here: boot re-runs `set_owner` only for the company named on the command line, so a provision-route company never heals on any boot.

## What window remains

- **A refused provision creates nothing.** The caller gets `503 ownership_not_persisted` and can retry. No orphan.
- **A transient failure is retried** (3 attempts, no backoff — the retry is for a failed round-trip, not a busy one, and a caller is waiting on the request). Most would-be refusals stay successes.
- **A crash between the owner write and a successful build** leaves a row naming a company that was never created — benign, and rolled back on a clean build failure.
- **The boot path keeps its swallow, deliberately.** `bin:249` re-runs `set_owner` on every boot, so a boot-company failure self-heals on the next restart: its window is one boot cycle, not permanent. Changing it would trade a self-healing warning for a boot abort.
- **Companies already orphaned are not healed by this.** Nothing here repairs existing state — see the detection section below, which matters more to anyone who has one today.

What makes it observable in the meantime: the failed write is no longer silent at the point it happens. Each failed attempt logs at `warn` with the company and tenant, a final failure logs at `error`, and — the part that actually reaches a human — **the API call fails** instead of reporting success. The defect was never really the failed write; it was that nothing anywhere said it happened.

## Existing orphans *can* be found by a query — but nothing computes it

Established, not assumed:

- `MongoStore::list()` is `find(doc! {})` — **unfiltered across every tenant** in the shared database (`store/mongodb.rs:602`).
- `OwnershipStore::owners()` returns every row (`store/select.rs:260`).
- So the orphan set is exactly **`list()` ids − `owners()` ids**, computable from ports that exist today.

But `owners()` has **one caller in the entire tree** — boot hydration at `bin/opencompany.rs:1242` — and there is no orphan/unowned surface anywhere in `src/` or `docs/`. An operator cannot run that query without writing code.

**An operator with orphans today needs that detection more than this fix**, which only prevents new ones. It is filed separately rather than widened into here.

## API Or Behavior Changes

- `POST /api/v1/companies` now answers **`503 ownership_not_persisted`** when the company → tenant row cannot be written, and **creates nothing**. Previously it answered `201 Created` and left an orphan.
- Only reachable on a backend that persists ownership (MongoDB). Deployments with no ownership store are unaffected — the branch is skipped exactly as before.
- A failed build now also removes the ownership row it wrote, best-effort.
- **Unchanged:** the boot path, the in-memory owner map, hydration, `archive`, and every success path.

## Tests

Gated lane — default features skip this code.

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --no-deps -p opencompany --features openhuman,tinycortex --all-targets -- -D warnings` — mirrors CI's `--no-deps`; no findings.
- [x] `cargo check -p opencompany --features openhuman,tinycortex --tests` — clean, via the test run below.
- [x] `cargo test -p opencompany --features openhuman,tinycortex` — **4324 passed, 0 failed, 3 ignored.**

### Reverted-fix proof

Reverting `persist_owner_with_retry` to its pre-#1050 behaviour (one attempt, failure swallowed):

| Test | On revert |
| --- | --- |
| `a_transient_ownership_failure_is_retried_and_succeeds` | **FAILS** |
| `a_persistent_ownership_failure_gives_up_and_reports_it` | **FAILS** — the swallow returns `Ok`, which is the bug |
| `a_successful_ownership_write_is_attempted_once` | passes — see below |

The third passes either way **by design**: the happy path costs one write before and after. It is a guard that the retry does not multiply the normal case, not a regression test, and it is not counted as coverage of the fix.

### A coverage gap, stated rather than papered over

The **route-level** behaviour — that provisioning returns `503` and creates nothing — is not covered by a test. Reaching it requires `state.stores()` to be `Some`, which means constructing a `StorageHandles` with ~30 port implementations; **no test in this repository constructs one**, and the single-store backend that builds one (`sqlite`) is not in this lane.

What is covered is `persist_owner_with_retry`, where the new decision lives, through a fake `OwnershipStore` that fails a chosen number of times. The existing provision tests continue to pass unchanged because they run with no ownership store, which also pins that the new branch is inert on such a host.

## Documentation

None needed. The reasoning — why the write moved ahead of the build, why the inverted failure direction is the safer one, and why the boot path keeps its swallow — is recorded at the call site and on `persist_owner_with_retry`.

Refs tinyhumansai/opencompany#1050
