### PR TITLE
Refuse a dry-run target the real run would refuse

### DIFF
--- a/src/workflows/caps/dry_run.rs
+++ b/src/workflows/caps/dry_run.rs
@@ -137,15 +137,53 @@ impl ToolInvoker for DryRunTools {
 /// [`GuardedHttpClient`](super::http::GuardedHttpClient): it echoes the request
 /// descriptor back without issuing anything, so no outbound request (guarded or
 /// not) leaves the process.
-pub(super) struct DryRunHttp;
+pub(super) struct DryRunHttp {
+    /// The company's `[tools].web_allowed_domains`, so the target check a dry
+    /// run *can* make is made against the same list the live client uses.
+    allowed_domains: Vec<String>,
+}
+
+impl DryRunHttp {
+    pub(super) fn new(allowed_domains: Vec<String>) -> Self {
+        Self { allowed_domains }
+    }
+}
 
 #[async_trait]
 impl HttpClient for DryRunHttp {
+    /// Refuses a target the real run would refuse; otherwise reports the request
+    /// as **not checked**, never as a success.
+    ///
+    /// Issue #1048: this used to return the same cheerful stub for every URL, so
+    /// a node aimed at a host the capability layer blocks reported `ok` on Test
+    /// run and failed immediately on the real one. Test run is the single
+    /// control an operator has before arming a graph on a schedule, so a green
+    /// there followed by a refusal on the real run is worse than no dry run at
+    /// all — it converts "I checked it" into a false belief.
+    ///
+    /// The refusal message and `EngineError::Capability` shape match
+    /// [`GuardedHttpClient`](super::http::GuardedHttpClient)'s, so a node fails
+    /// under its own `on_error`/retry policy exactly as it would live.
+    ///
+    /// **Still no request is issued, in either branch.** The verdict below is a
+    /// pure function of the URL and the company's config — see
+    /// [`preflight_refusal`](super::http::preflight_refusal) for what it decides
+    /// and, more importantly, what it deliberately leaves to the real run.
     async fn request(&self, request: Value, _conn: Option<&str>) -> TfResult<Value> {
+        if let Some(reason) = super::http::preflight_refusal(&request, &self.allowed_domains) {
+            tracing::debug!(%reason, "workflow dry run: refusing http_request target");
+            return Err(EngineError::Capability(format!("http_request: {reason}")));
+        }
         tracing::debug!("workflow dry run: stubbing http_request (not sent)");
         Ok(json!({
             "status": Value::Null,
-            "body": "[dry run] http_request was not sent",
+            // Deliberately not phrased as a result. A dry run cannot know
+            // whether the host is up, the credential is current or the response
+            // parses, and saying so is more honest than a green that implies it
+            // does — the opposite error to the one #1048 fixed, and the one that
+            // erodes trust fastest because an operator cannot tell it is wrong.
+            "body": "[dry run] http_request was not sent — target allowed, delivery not checked",
+            "checked": "target only: a real run may still fail to reach this host",
             "request": request,
             DRY_RUN_MARKER: true,
         }))
@@ -228,13 +266,110 @@ mod tests {
         );
     }
 
+    /// An allowed target is still never sent — and the stub says so rather than
+    /// implying the request succeeded (issue #1048).
+    ///
+    /// This case used to be written with `http://127.0.0.1:9/`, a URL the real
+    /// guard refuses, so the old assertion pinned the bug in place: it proved a
+    /// dry run reports success for a target no real run can reach.
     #[tokio::test]
-    async fn dry_http_echoes_without_sending() {
-        let out = DryRunHttp
-            .request(json!({ "url": "http://127.0.0.1:9/" }), None)
+    async fn dry_http_reports_an_allowed_target_as_unchecked_rather_than_ok() {
+        let out = DryRunHttp::new(Vec::new())
+            .request(json!({ "url": "https://example.com/hook" }), None)
             .await
-            .expect("dry http never sends");
+            .expect("an allowed target is not refused");
         assert_eq!(out[DRY_RUN_MARKER], json!(true));
         assert_eq!(out["status"], Value::Null);
+        let body = out["body"].as_str().unwrap_or_default();
+        assert!(
+            body.contains("not checked"),
+            "a dry run must not imply the request would succeed: {body}"
+        );
+    }
+
+    /// A target the real run refuses is refused here too, in the same shape.
+    #[tokio::test]
+    async fn dry_http_refuses_a_blocked_target() {
+        let refused = DryRunHttp::new(Vec::new())
+            .request(json!({ "url": "http://127.0.0.1:9/" }), None)
+            .await;
+        assert!(
+            matches!(refused, Err(EngineError::Capability(ref m))
+                if m.contains("http_request") && m.contains("127.0.0.1")),
+            "{refused:?}"
+        );
+
+        // The company's own allowlist, when it is unambiguous.
+        let off_list = DryRunHttp::new(vec!["example.com".to_string()])
+            .request(json!({ "url": "https://elsewhere.test/x" }), None)
+            .await;
+        assert!(
+            matches!(off_list, Err(EngineError::Capability(ref m))
+                if m.contains("allowed domains")),
+            "{off_list:?}"
+        );
+
+        // On the list — and a subdomain of it — passes.
+        for url in ["https://example.com/x", "https://api.example.com/x"] {
+            assert!(
+                DryRunHttp::new(vec!["example.com".to_string()])
+                    .request(json!({ "url": url }), None)
+                    .await
+                    .is_ok(),
+                "{url} is on the allowlist and must not be refused"
+            );
+        }
+    }
+
+    /// **Behavioural parity with the real client.**
+    ///
+    /// The authoritative rules live upstream in a private `url_guard` module, so
+    /// the pre-flight in `super::http` is a copy — and a copy drifts. This does
+    /// not compare it against upstream's *source*; it drives the same URLs
+    /// through the real [`GuardedHttpClient`](super::super::http::GuardedHttpClient)
+    /// and asserts the two agree, so it keeps holding when upstream changes its
+    /// internals and fails loudly the day upstream loosens a rule.
+    ///
+    /// Only refusals are compared, and that is not a gap: the real guard rejects
+    /// these **before it dials anything**, so the comparison needs no network and
+    /// performs no effect. An *allowed* URL cannot be compared this way, because
+    /// confirming it would mean actually issuing the request — which is the one
+    /// thing neither a dry run nor this suite may do.
+    ///
+    /// The direction that matters is the one this covers. A dry run that refuses
+    /// what a real run would allow blocks a working graph, and an operator cannot
+    /// tell that from a real refusal without arming it anyway.
+    #[tokio::test]
+    async fn dry_run_refusal_matches_the_real_client() {
+        use crate::workflows::caps::http::GuardedHttpClient;
+        use openhuman_core::openhuman::security::SecurityPolicy;
+        use std::sync::Arc;
+
+        let allowed = vec!["example.com".to_string()];
+        let cases = [
+            "http://127.0.0.1:9/",
+            "http://localhost:8080/x",
+            "http://10.0.0.5/admin",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]:9/",
+            "https://elsewhere.test/x",
+        ];
+
+        let real = GuardedHttpClient::new(Arc::new(SecurityPolicy::default()), allowed.clone());
+        for url in cases {
+            let request = json!({ "method": "GET", "url": url });
+            let dry = DryRunHttp::new(allowed.clone())
+                .request(request.clone(), None)
+                .await;
+            let live = real.request(request, None).await;
+            assert!(
+                live.is_err(),
+                "{url} must be refused by the real client for this comparison to mean anything"
+            );
+            assert!(
+                dry.is_err(),
+                "the real client refuses {url} but the dry run reported success —                  that is the false green issue #1048 is about"
+            );
+        }
     }
 }

--- a/src/workflows/caps/http.rs
+++ b/src/workflows/caps/http.rs
@@ -120,6 +120,159 @@ fn parse_http_output(output: &str) -> (Value, String) {
     (status, body)
 }
 
+// ---------------------------------------------------------------------------
+// Pre-flight: the part of the guard's verdict a dry run can reach (issue #1048)
+// ---------------------------------------------------------------------------
+
+/// Why a dry run refused a target, or `None` when this check reached no verdict.
+///
+/// **`None` means "not refused by the decidable subset", never "this would
+/// work."** A dry run performs nothing, so it cannot know whether a host is up,
+/// a credential is current, or a body parses. Treating `None` as success is the
+/// false green issue #1048 is about; the caller says *not checked* instead.
+///
+/// # What is decided here, and what deliberately is not
+///
+/// Decided — pure functions of the URL and the company's own config, answerable
+/// without performing anything:
+///
+/// * the scheme (only `http`/`https` reach the real client at all);
+/// * a **private / loopback / link-local literal** in the URL, which the real
+///   guard refuses *regardless of the company's allowlist*;
+/// * the company's [`web_allowed_domains`] list, when it is unambiguous.
+///
+/// **Not** decided — DNS. The real path uses `validate_url_with_dns_check`,
+/// which resolves the host to catch a public name pointing at a private address.
+/// Resolving is itself a network effect and it fails offline, so a dry run must
+/// not attempt it: a name that resolves privately still passes this check and is
+/// refused by the real run. That is a *missing* refusal, which is honest, rather
+/// than an invented one.
+///
+/// # Never stricter than the real guard
+///
+/// Every rule below mirrors one the real guard applies, so anything refused here
+/// is refused by a real run too. That direction is the one that matters: a dry
+/// run that wrongly refuses blocks a working graph and cannot be told from a
+/// real refusal without arming it anyway. Where a rule is ambiguous — a
+/// malformed allowlist, an unparseable URL — this returns `None` and checks
+/// nothing rather than guessing.
+///
+/// `dry_run_refusal_matches_the_real_client` pins the agreement **behaviourally**,
+/// by driving the same URLs through [`GuardedHttpClient`], so this stays correct
+/// when upstream changes its internals rather than only when someone re-reads
+/// them.
+pub(super) fn preflight_refusal(request: &Value, allowed_domains: &[String]) -> Option<String> {
+    let url = request.get("url")?.as_str()?.trim();
+    let host = host_of(url)?;
+
+    if is_private_or_local_host(&host) {
+        return Some(format!("Blocked local/private host: {host}"));
+    }
+
+    // An empty list is open-public mode upstream, so there is nothing to refuse.
+    if allowed_domains.is_empty() {
+        return None;
+    }
+    // Upstream substitutes a fail-closed sentinel when *every* entry is
+    // malformed, which would refuse all traffic. Rather than reproduce that
+    // subtlety — the easiest place for a copy to invent a refusal the real run
+    // would not make — an allowlist this cannot read cleanly is left unchecked.
+    let normalized: Vec<String> = allowed_domains
+        .iter()
+        .filter_map(|d| normalize(d))
+        .collect();
+    if normalized.len() != allowed_domains.len() {
+        return None;
+    }
+    let allowed = normalized.iter().any(|domain| {
+        domain == "*"
+            || host == *domain
+            || host
+                .strip_suffix(domain.as_str())
+                .is_some_and(|prefix| prefix.ends_with('.'))
+    });
+    (!allowed).then(|| format!("URL not in allowed domains: {host}"))
+}
+
+/// The host of an `http`/`https` URL, lowercased, without port or brackets
+/// stripped — `None` for anything this cannot read, which checks nothing.
+fn host_of(url: &str) -> Option<String> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))?;
+    let authority = rest.split(['/', '?', '#']).next()?;
+    // Userinfo is not part of the host; `user@host` must not read as a host.
+    let authority = authority.rsplit('@').next()?;
+    let host = match authority.strip_prefix('[') {
+        // IPv6 literal: the port sits after the closing bracket.
+        Some(inner) => inner.split(']').next()?.to_string(),
+        None => authority.split(':').next()?.to_string(),
+    };
+    (!host.is_empty()).then(|| host.to_lowercase())
+}
+
+/// Mirrors the real guard's allowlist entry normalization.
+fn normalize(raw: &str) -> Option<String> {
+    let mut d = raw.trim().to_lowercase();
+    if let Some(stripped) = d.strip_prefix("https://") {
+        d = stripped.to_string();
+    } else if let Some(stripped) = d.strip_prefix("http://") {
+        d = stripped.to_string();
+    }
+    if let Some((host, _)) = d.split_once('/') {
+        d = host.to_string();
+    }
+    d = d.trim_start_matches('.').trim_end_matches('.').to_string();
+    if let Some((host, _)) = d.split_once(':') {
+        d = host.to_string();
+    }
+    (!d.is_empty() && !d.chars().any(char::is_whitespace)).then_some(d)
+}
+
+/// Mirrors the real guard's private/local rule.
+fn is_private_or_local_host(host: &str) -> bool {
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    if bare == "localhost"
+        || bare.ends_with(".localhost")
+        || bare.rsplit('.').next().is_some_and(|tld| tld == "local")
+    {
+        return true;
+    }
+    match bare.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(v4)) => is_non_global_v4(v4),
+        Ok(std::net::IpAddr::V6(v6)) => {
+            let segs = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (segs[0] & 0xfe00) == 0xfc00
+                || (segs[0] & 0xffc0) == 0xfe80
+                || (segs[0] == 0x2001 && segs[1] == 0x0db8)
+                || v6.to_ipv4_mapped().is_some_and(is_non_global_v4)
+        }
+        Err(_) => false,
+    }
+}
+
+fn is_non_global_v4(v4: std::net::Ipv4Addr) -> bool {
+    let [a, b, c, _] = v4.octets();
+    v4.is_loopback()
+        || v4.is_private()
+        || v4.is_link_local()
+        || v4.is_unspecified()
+        || v4.is_broadcast()
+        || v4.is_multicast()
+        || (a == 100 && (64..=127).contains(&b))
+        || a >= 240
+        || (a == 192 && b == 0 && (c == 0 || c == 2))
+        || (a == 198 && b == 51)
+        || (a == 203 && b == 0)
+        || (a == 198 && (18..=19).contains(&b))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -228,7 +228,9 @@ pub async fn build_capabilities(
         );
         (
             Arc::new(dry_run::DryRunTools::new(grants, wiring.clone())),
-            Arc::new(dry_run::DryRunHttp),
+            Arc::new(dry_run::DryRunHttp::new(
+                record.manifest.tools.web_allowed_domains.clone(),
+            )),
             Arc::new(NoopState),
             Some(Arc::new(dry_run::DryRunAgent)),
         )
@@ -2267,12 +2269,18 @@ mod tests {
         .await
         .expect("build_capabilities");
 
-        // http: the stub echoes without sending, carrying the marker.
+        // http: the stub reports without sending, carrying the marker.
+        //
+        // A *public* URL, deliberately. This case used to use `127.0.0.1`, which
+        // the real guard refuses — so it asserted that the dry slot answers `ok`
+        // for a target no real run can reach, pinning issue #1048's false green
+        // in place. The slot being the stub is what this test is about; whether a
+        // given target is refused is `dry_run`'s own suite.
         let http_out = caps
             .http
-            .request(json!({ "url": "http://127.0.0.1:9/" }), None)
+            .request(json!({ "url": "https://example.com/hook" }), None)
             .await
-            .expect("dry http never fails");
+            .expect("an allowed target is not refused by the dry stub");
         assert_eq!(
             http_out["dry_run"],
             json!(true),

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -2583,6 +2583,72 @@ to = "done"
         );
     }
 
+    /// A run context with the dry flag set. `WorkflowRunContext::new` takes
+    /// `scheduled`, not `dry_run` — the dry flag defaults to false and is
+    /// flipped after construction, exactly as the run route does.
+    fn dry_context() -> WorkflowRunContext {
+        let mut ctx = WorkflowRunContext::new(false);
+        ctx.dry_run = true;
+        ctx
+    }
+
+    /// **Issue #1048.** The same graph as `t5`, dry-run: a target the real run
+    /// refuses must not report `ok`.
+    ///
+    /// Test run is the one control an operator has for checking a graph before
+    /// arming it on a schedule, so a green dry run followed by a real run that
+    /// cannot start is worse than no dry run at all — it converts "I checked it"
+    /// into a false belief.
+    ///
+    /// A loopback target is the lever because the upstream guard refuses
+    /// private/loopback addresses *regardless of the company's allowlist*
+    /// (see `t5_http_request_to_loopback_is_ssrf_denied`), so the verdict is
+    /// decidable from the URL alone — no DNS, no request, nothing performed.
+    #[tokio::test]
+    async fn a_dry_run_refuses_a_target_the_real_run_would_refuse() {
+        let src = r#"
+id = "dry-ssrf"
+name = "Dry SSRF"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "fetch"
+kind = "http_request"
+name = "Fetch"
+[node.config]
+method = "GET"
+url = "http://127.0.0.1:9/"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "fetch"
+[[edge]]
+from = "fetch"
+to = "done"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let file = parse_workflow(src).expect("parses");
+        let err = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps(dir.path()),
+            &tools_record(),
+            &file,
+            serde_json::json!({ "seed": 1 }),
+            &dry_context(),
+        )
+        .await
+        .expect_err("a dry run must refuse a target the real run refuses");
+        assert!(
+            err.to_string().contains("http_request"),
+            "the dry refusal should name the node, as the live one does: {err}"
+        );
+    }
+
     // --- P2: the six new node kinds, end to end through the engine -----------
 
     /// Runs `src` through the full translate → compile → engine pipeline with a


### PR DESCRIPTION
## Summary

A dry run reported **`ok`** for an `http_request` node aimed at a host the capability layer blocks, and
the real run failed immediately. Test run is the single control an operator has before arming a graph
on a schedule, so a green there is worse than no dry run at all: it converts *"I checked it"* into a
false belief.

Reproduced before fixing, on the same graph as the existing
`t5_http_request_to_loopback_is_ssrf_denied`:

```
dry:  nodes: [WorkflowRunNodeRow { node_id: "fetch", status: Ok }]
      body:  "[dry run] http_request was not sent"
real: http_request: Blocked local/private host: 127.0.0.1
```

**Reproduced locally rather than on staging, deliberately.** Reproducing needs *creating a workflow*,
which is a write to a live company, and this is deterministic code with no tenant state in it — the
verdict is a pure function of the URL and the manifest. A live probe would have left a workflow behind
and told us nothing the runner does not.

## The stubs stay — this is not "stop stubbing"

`dry_run.rs` stubs every effectful capability **by design**, and it must: a Test run that performed
real effects would be a far worse bug than this one. **No request is issued in either branch**, before
or after this change.

What changes is that the verdicts a dry run can reach *without performing anything* are now reached.
The distinction, slot by slot:

| Stubbed slot | Category | Verdict |
|---|---|---|
| `tool_call` grant (`[tools].allow`) | decidable pre-flight | **already correct** — `DryRunTools` keeps the fail-closed grant gate deliberately. The issue's "verify this may already hold" item does hold. |
| `http_request` URL vs **private / loopback / link-local literal** | decidable pre-flight — pure string→IP, no DNS | **now refuses** ← the reported bug |
| `http_request` URL vs **company `web_allowed_domains`** | decidable pre-flight — pure host-vs-list | **now refuses**, conservatively (below) |
| `http_request` **DNS resolution** | requires the network | **must not**, see below |
| host down / TLS / stale credential / non-2xx / malformed body | requires execution | **must not** |
| agent inference, state persistence, delivery | requires execution | **must not** |

### Why DNS is excluded

The real path calls `validate_url_with_dns_check`, which **resolves** the host to catch a public name
pointing at a private address. **Resolving is itself a network effect, and it fails offline.** A dry
run must not attempt it.

The consequence is stated rather than hidden: a hostname that resolves to a private address still
passes this check and is refused by the real run. That is a **missing** refusal, which is honest. An
invented one would block a working graph, and an operator cannot distinguish that from a real refusal
without arming the thing anyway — which is the failure that erodes trust fastest.

### Conservative where a copy could invent a refusal

Upstream substitutes a fail-closed sentinel when *every* allowlist entry is malformed, refusing all
traffic. This deliberately does **not** reproduce that: an allowlist `preflight_refusal` cannot read
cleanly returns `None` and checks nothing. Reproducing that subtlety is the easiest place for a copy
to refuse something the real run would allow.

### An allowed target now says "not checked", not "ok"

Passing pre-flight yields `"[dry run] http_request was not sent — target allowed, delivery not
checked"` plus a `checked` field naming the limit, rather than a bare stub that reads as a successful
request. A dry run cannot know whether the host is up, the credential is current, or the response
parses, and saying so is more useful than a green that implies it does.

## The copy, and how drift is caught

The authoritative rules live upstream in `mod url_guard;` — a **private** module whose predicates are
`pub(super)`, so nothing in opencompany can call them. `preflight_refusal` is therefore a copy, which
is a real drift risk and is named as one.

`dry_run_refusal_matches_the_real_client` is what makes that manageable. It does **not** compare
against upstream's source; it drives the same URLs through the real
`GuardedHttpClient` and asserts the two verdicts agree. So it keeps holding when upstream changes its
internals, and **fails loudly the day upstream loosens a rule**. Six cases: loopback, `localhost`,
RFC1918, link-local `169.254.169.254`, IPv6 `[::1]`, and an off-allowlist public host.

That comparison needs no network and performs no effect, because the real guard refuses these
**before it dials anything** — which is also why only refusals are compared. Confirming an *allowed*
URL would mean actually issuing the request. The direction covered is the one that matters.

Filed **tinyhumansai/opencompany#1075** asking upstream to export the predicates, so this copy can be
deleted rather than maintained.

## A trap worth more than the fix

**`WorkflowRunContext::new(true)` is `scheduled`, not `dry_run`.** The dry flag defaults to `false`
and is set after construction, exactly as the run route does it.

My first reproduction used `new(true)` believing it selected a dry run. It ran a **real** run, which
refused the loopback target correctly, so the test asserting "a dry run refuses this" went **green —
for entirely the wrong reason**. I found it only by printing the actual error instead of trusting the
assertion.

A test that passes for the wrong reason is indistinguishable from one that works, right up until it
matters. The suite now has a `dry_context()` helper whose doc says which argument is which, so the
next person writing a dry-run test does not have to rediscover it.

## Two existing tests had pinned the bug in place

`dry_http_echoes_without_sending` and `a_dry_bundle_wires_stubs_and_noop_state` both used
**`http://127.0.0.1:9/` and asserted success** — the exact URL class the real guard refuses. So the
false green was not merely untested; it was *asserted*, twice. Both now use a public URL, since what
they are really about is the slot being the stub, not what any particular target does.

## API Or Behavior Changes

Dry runs only. An `http_request` node whose target the real run would refuse now **fails the dry run**
with the same `EngineError::Capability` shape and message the live client produces, so the node's
`on_error`/retry policy governs it identically. An allowed target's stub body is reworded as above.

Live runs are untouched. No route, schema or default changes.

## Tests

- [x] `cargo fmt --all -- --check` — PASS.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI's gated form,
      `--no-deps --features openhuman,tinycortex --all-targets`. PASS.
- [x] `cargo build --all-targets` — covered by the clippy and test runs above.
- [x] `cargo test` — **4285 passed / 0 failed** gated (`--features openhuman,tinycortex --lib`) and
      **2809 passed / 0 failed** at default features.

### Proven to fail with the fix reverted

Removing the `preflight_refusal` call from `DryRunHttp::request` fails exactly three, tests untouched:

```
workflows::caps::dry_run::tests::dry_http_refuses_a_blocked_target
workflows::caps::dry_run::tests::dry_run_refusal_matches_the_real_client
workflows::runner::tests::a_dry_run_refuses_a_target_the_real_run_would_refuse
```

All pass with it restored. The first is the unit verdict, the second is the parity guard, the third is
end to end through `run_workflow` — the shape the operator actually meets.

## Not in this PR

A node that *passes* pre-flight still reports `status: Ok` in the run's node rows. The body now says
"not checked", but the row-level status still reads as success, which is the residual half of the same
false green. Closing that properly needs a distinct not-executed status on `WorkflowRunNodeRow` —
a wider change than this fix, and better argued on its own.

## Documentation

`preflight_refusal` carries the reasoning at the point of decision: what it decides, what it
deliberately leaves to the real run, why it is never stricter than the real guard, and what `None`
means (**"not refused by the decidable subset"**, never "this would work"). `DryRunHttp::request`
states why both branches issue nothing.

No `docs/` change: no route, launcher behavior or `tiny*` integration changes.

Closes tinyhumansai/opencompany#1048
