### PR TITLE
test(operator): wait for the continuation's replies, not for 400ms

### DIFF
--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -7977,8 +7977,32 @@ mode = "full"
         resolve_request(id, serde_json::json!({"verdict":"approve","detach":true}))
     }
 
-    /// Waits for the follow-up work a detached resolve spawned to settle.
-    async fn settle(runtime: &Arc<CompanyRuntime>) {
+    /// Waits for the follow-up work a detached resolve spawned to settle:
+    /// first for the turn to unblock, then for its continuation to have
+    /// journaled `expected_replies` `AgentReply` rows.
+    ///
+    /// # Condition, not clock (issue #1071)
+    ///
+    /// The second half used to be `sleep(400ms)` with a comment admitting what
+    /// it was — "the continuation itself runs on a spawned task; let it finish".
+    /// `ContinuationQueue::waiting()` drops to zero when the turn is
+    /// **unblocked**, which is strictly earlier than when the continuation's
+    /// replies are **written**, so the gap had to be covered by something. A
+    /// fixed sleep covers it only on a machine fast enough that day: on a loaded
+    /// CI runner the assertions read the event log first and came back short —
+    /// `3` replies instead of `4`, or `[]` instead of `["ceo"]` — on branches
+    /// with nothing to do with this code.
+    ///
+    /// Raising the sleep is the tempting fix and only moves the threshold. This
+    /// waits for the thing the caller is about to assert, the same way the first
+    /// half already waits for `waiting()`, under the same 10-second cap. A test
+    /// that is going to check for N replies has no reason to proceed before N
+    /// replies exist, and every reason not to.
+    ///
+    /// The count is the caller's because only the caller knows it. Passing a
+    /// number smaller than the assertion would reintroduce the race quietly, so
+    /// pass exactly what is asserted.
+    async fn settle(runtime: &Arc<CompanyRuntime>, expected_replies: usize) {
         tokio::time::timeout(std::time::Duration::from_secs(10), async {
             while runtime.continuations.waiting() > 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -7986,8 +8010,13 @@ mode = "full"
         })
         .await
         .expect("the turn never unblocked");
-        // The continuation itself runs on a spawned task; let it finish.
-        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while agent_replies(runtime).await.len() < expected_replies {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("the continuation never journaled {expected_replies} replies"));
     }
 
     /// **The keystone (issue #469).** A turn that parks four sign-offs, all
@@ -8018,7 +8047,7 @@ mode = "full"
         for handle in handles {
             assert_eq!(handle.await.unwrap().status(), StatusCode::OK);
         }
-        settle(&c.runtime).await;
+        settle(&c.runtime, 4).await;
 
         assert_eq!(
             c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before,
@@ -8070,7 +8099,7 @@ mode = "full"
                 );
             }
         }
-        settle(&c.runtime).await;
+        settle(&c.runtime, 4).await;
 
         assert_eq!(
             c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before,
@@ -8097,7 +8126,7 @@ mode = "full"
             let response = c.app.clone().oneshot(approve_detached(id)).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
         }
-        settle(&c.runtime).await;
+        settle(&c.runtime, 2).await;
 
         let replies = agent_replies(&c.runtime).await;
         assert_eq!(replies.len(), 2, "both re-issues answered");
@@ -8132,7 +8161,7 @@ mode = "full"
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            settle(&c.runtime).await;
+            settle(&c.runtime, 1).await;
             agent_replies(&c.runtime)
                 .await
                 .into_iter()
@@ -8172,7 +8201,7 @@ mode = "full"
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        settle(&c.runtime).await;
+        settle(&c.runtime, 1).await;
 
         assert_eq!(
             c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before,
@@ -8202,7 +8231,7 @@ mode = "full"
                 "the verdict is durable regardless of what the turn then does"
             );
         }
-        settle(&c.runtime).await;
+        settle(&c.runtime, 1).await;
 
         let replies = agent_replies(&c.runtime).await;
         assert_eq!(


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#1071.

`settle()` in `server::operator::test` polls a **condition** for its first half — waiting for
`ContinuationQueue::waiting()` to drop to zero — and then waits a **fixed 400 ms** for the spawned
continuation task to journal its replies:

```rust
.expect("the turn never unblocked");
// The continuation itself runs on a spawned task; let it finish.
tokio::time::sleep(Duration::from_millis(400)).await;
```

The comment admits what it is. `waiting()` reaching zero means the turn is **unblocked**, which is
strictly earlier than its replies being **written**, so something had to cover that gap — and a fixed
sleep covers it only on a machine fast enough that day.

On a loaded CI runner it is not enough: the assertions read the event log first and come back short.

## Condition, not clock

That phrase is the whole change, and it is worth stating because **raising the sleep is the fix
somebody will reach for next** — and it only moves the threshold. 400 ms failed today; 800 ms fails on
a busier runner, and the test is green until it is not.

This waits for the thing the caller is about to assert, the same way the first half already waits for
`waiting()`, under the same 10-second cap:

```rust
tokio::time::timeout(Duration::from_secs(10), async {
    while agent_replies(runtime).await.len() < expected_replies {
        tokio::time::sleep(Duration::from_millis(10)).await;
    }
})
```

A test that is going to check for N replies has no reason to proceed before N replies exist, and every
reason not to. The count is the caller's parameter because only the caller knows it — each of the six
call sites passes exactly the number it goes on to assert. Passing a smaller number would reintroduce
the race quietly, and the doc comment says so.

There is no longer a timing constant to tune, which is the property that matters: the new version
cannot be made to fail by making the machine slower.

## Evidence this is a shared flake, not one branch's change

The same two tests failed in the same window on two unrelated branches:

| Run | Branch | SHA | Event |
| --- | --- | --- | --- |
| [32147221462](https://github.com/tinyhumansai/opencompany/actions/runs/32147221462) | `fix/877-git-ops-consequence` | `68a568d3` | push |
| [32147243251](https://github.com/tinyhumansai/opencompany/actions/runs/32147243251) | `feat/figma-brand-system` | `90c1bdc0` | pull_request |

```
four_sign_offs_from_one_turn_produce_one_continuation       left: 3    right: 4
a_continuation_resumes_in_the_thread_it_was_raised_in…      left: []   right: ["ceo"]
```

Both are **missing async writes, not wrong counts.** In the first test the assertions *above* the
failing one — `c.decisions.len() == 4` and `pending_approvals().is_empty()` — both pass, so the parking
and the decisions were right and only the journaled rows were short.

⚠️ **Distinct from #969**, which is the frontend Playwright `toast-dismissal.spec.ts` flake. Different
suite, different lane, different cause.

⚠️ **Reproduce on the default-features `Rust` lane (2828 tests)**, not
`Rust (openhuman, tinycortex)` (4300+). On the gated lane you will not see it.

## API Or Behavior Changes

`N/A` — test-only. `settle()` is a private test helper; it gains an `expected_replies` parameter and
all six call sites pass their asserted count. No production code is touched.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
      exit 0.
- [x] `cargo build --all-targets` — covered by the two test lanes below.
- [x] `cargo test` — both lanes. Default features (the lane that failed): **2853 passed / 0 failed**.
      Gated: `RUST_MIN_STACK=16777216 cargo test --locked --features openhuman,tinycortex --tests` →
      **4332 passed / 0 failed**.

### Revert proof — and it needed thought, because the old code passes locally

The flake does not reproduce on this machine: the old `settle()` passes here, which is exactly why it
survived long enough to bite CI. **You cannot race a flake into failing on demand — but you can
simulate the condition it fails under.**

So the proof shortens the constant rather than raising it. Restoring the old fixed-sleep body and
setting `400ms` → `0ms` models a runner on which 400 ms is not enough, without needing that runner.
Raising it instead would prove nothing: any sleep long enough to pass here is also long enough to hide
the defect here.

> **To be unambiguous, because a bare `0` invites a "fix":** that `0` exists **only inside this revert
> experiment**, and is not in the shipped diff. **The merged code contains no sleep at all** — that is
> the point of the change. Nobody should "restore" a 400 ms sleep on the strength of seeing a `0` in
> this section; there is no constant in `settle()` any more to restore it to.

With the old body at `0ms`:

```
a_continuation_resumes_in_the_thread_it_was_raised_in_and_no_other ... FAILED
a_continuation_answers_in_the_thread_the_sign_off_was_raised_in    ... FAILED
four_sign_offs_from_one_turn_produce_one_continuation              ... FAILED
test result: FAILED. 98 passed; 3 failed
```

Both tests that failed in CI are in that set, plus a third in the same family that CI has not hit yet —
so the fix covers more than the two that happened to go red.

**Said plainly: that demonstrates the old implementation's correctness depends on a timing constant,
and that the new one has no such constant. It does not reproduce the CI runner's load**, which I cannot
do here. The new version passing is not evidence it is immune; the absence of a tunable sleep is.

## Documentation

`N/A` — test-only change. The reasoning lives on `settle()`'s own doc comment, which is where the
previous behaviour's justification lived too.
