### PR TITLE
policy(composio): name a catalogue miss instead of silently sending it

### DIFF
--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -886,7 +886,36 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
             return send;
         }
     };
-    if composio_action_is_read(slug) {
+    let lookup = composio_catalog_lookup(slug);
+    // Issue #754: a catalogue miss is recorded, not silent. It changes no
+    // verdict — everything below still parks exactly as it did — but a drifted
+    // read and a correct refusal are the same `send` at the approval card, so
+    // without this nobody learns the curated names and Composio's live names
+    // have moved apart. The slug and toolkit are the dataset any future alias
+    // mapping would be designed from.
+    //
+    // Deliberately NOT emitted for a curated write: that is the gate working,
+    // and logging it would bury the real signal under every `GMAIL_SEND_EMAIL`.
+    match &lookup {
+        CatalogLookup::UncuratedAction { toolkit } => tracing::warn!(
+            composio_slug = %slug,
+            composio_toolkit = %toolkit,
+            catalogue_miss = true,
+            "[policy] '{slug}' is not in the '{toolkit}' curated catalogue; classifying it as a \
+             send. That is the cautious answer, and it is the right one for an action nobody has \
+             classified — but it is also what a catalogued read looks like once its live slug has \
+             drifted from the curated one (issue #754)."
+        ),
+        CatalogLookup::UnknownToolkit { toolkit } => tracing::warn!(
+            composio_slug = %slug,
+            composio_toolkit = toolkit.as_deref().unwrap_or("<unrecognised>"),
+            catalogue_miss = true,
+            "[policy] no curated catalogue to classify '{slug}' against; classifying it as a send \
+             (issue #754)."
+        ),
+        CatalogLookup::Curated { .. } => {}
+    }
+    if lookup.is_read() {
         // A read reaches a third-party account, so `readonly` denies it — but
         // it changes nothing and is billed for nothing, so `supervised` lets it
         // through (issue #559).
@@ -920,6 +949,39 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
         }
     } else {
         send
+    }
+}
+
+/// What the curated catalogue knows about one action slug (issue #754).
+///
+/// The classification is unchanged by this type — everything that is not a
+/// curated read is still a send. It exists so a **catalogue miss** stops being
+/// silent: today a drifted read and a genuine send are the same `false`, so a
+/// stale catalogue is indistinguishable from a correct refusal and nobody ever
+/// learns the names have moved.
+///
+/// The distinction that matters is [`Curated`](Self::Curated) `{ read: false }`
+/// versus [`UncuratedAction`](Self::UncuratedAction). A curated write is the
+/// gate working; an uncurated slug is the gate guessing. Logging both would
+/// bury the second in the first — every `GMAIL_SEND_EMAIL` would look like
+/// drift.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CatalogLookup {
+    /// The slug is in its toolkit's catalogue, with a hand-assigned scope.
+    Curated { read: bool },
+    /// The toolkit has a catalogue and this slug is not in it — the drift case
+    /// #754 is about, and the one worth recording.
+    UncuratedAction { toolkit: String },
+    /// No catalogue to consult: the slug named no toolkit this build knows, or
+    /// the toolkit has no curated surface at all. `None` also covers the
+    /// non-`openhuman` build, where the catalogue is not linked in.
+    UnknownToolkit { toolkit: Option<String> },
+}
+
+impl CatalogLookup {
+    /// The verdict this feeds — byte-identical to the boolean it replaced.
+    fn is_read(&self) -> bool {
+        matches!(self, Self::Curated { read: true })
     }
 }
 
@@ -1553,7 +1615,7 @@ fn composio_toolkit_of(slug: &str) -> Option<String> {
 }
 
 /// Without the harness feature the curated catalogue is not linked in — the same
-/// seam `composio_action_is_read` straddles, answered the same cautious way.
+/// seam `composio_catalog_lookup` straddles, answered the same cautious way.
 #[cfg(not(feature = "openhuman"))]
 fn composio_toolkit_of(_slug: &str) -> Option<String> {
     None
@@ -1562,28 +1624,31 @@ fn composio_toolkit_of(_slug: &str) -> Option<String> {
 /// Is this Composio action slug a read, according to the provider's own
 /// curated catalogue? Unknown is **not** a read.
 #[cfg(feature = "openhuman")]
-fn composio_action_is_read(slug: &str) -> bool {
+fn composio_catalog_lookup(slug: &str) -> CatalogLookup {
     use openhuman_core::openhuman::memory::sync::composio::providers::{
         ToolScope, catalog_for_toolkit, find_curated, toolkit_from_slug,
     };
     let Some(toolkit) = toolkit_from_slug(slug) else {
-        return false;
+        return CatalogLookup::UnknownToolkit { toolkit: None };
     };
     let Some(catalog) = catalog_for_toolkit(&toolkit) else {
-        return false;
+        return CatalogLookup::UnknownToolkit {
+            toolkit: Some(toolkit),
+        };
     };
-    matches!(
-        find_curated(catalog, slug).map(|entry| entry.scope),
-        Some(ToolScope::Read)
-    )
+    match find_curated(catalog, slug).map(|entry| entry.scope) {
+        Some(ToolScope::Read) => CatalogLookup::Curated { read: true },
+        Some(_) => CatalogLookup::Curated { read: false },
+        None => CatalogLookup::UncuratedAction { toolkit },
+    }
 }
 
 /// Without the harness feature the curated catalogue is not linked in, and no
 /// `composio_execute` call can be made either — only replayed from a journal
 /// line an openhuman build wrote. Cautious is the only honest answer.
 #[cfg(not(feature = "openhuman"))]
-fn composio_action_is_read(_slug: &str) -> bool {
-    false
+fn composio_catalog_lookup(_slug: &str) -> CatalogLookup {
+    CatalogLookup::UnknownToolkit { toolkit: None }
 }
 
 /// A tool with no declaration.
@@ -2275,7 +2340,72 @@ mod tests {
             "upstream's fallback still defaults to read; if this changes the \
              comment above is stale, not the behaviour"
         );
-        assert!(!composio_action_is_read("GITHUB_INVENT_A_NEW_VERB"));
+        assert!(!composio_catalog_lookup("GITHUB_INVENT_A_NEW_VERB").is_read());
+    }
+
+    /// **Issue #754.** The catalogue miss the whole issue is about, pinned from
+    /// both sides of the pair it was reported with.
+    ///
+    /// `GITHUB_ISSUES_LIST_FOR_REPO` and `GITHUB_LIST_REPOSITORY_ISSUES` are the
+    /// same GitHub operation under two naming conventions — Composio's live
+    /// `operationId`-derived slug and the curated descriptive one. The second is
+    /// classified as a read and runs; the first misses the catalogue and parks.
+    ///
+    /// The verdict for the drifted slug is deliberately UNCHANGED by this
+    /// commit — it still parks, because a slug nobody has classified should.
+    /// What changes is that the miss is now *distinguishable* from a correct
+    /// refusal, which is the thing that was silent.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn a_drifted_read_is_a_miss_and_its_curated_twin_is_not() {
+        assert_eq!(
+            composio_catalog_lookup("GITHUB_LIST_REPOSITORY_ISSUES"),
+            CatalogLookup::Curated { read: true },
+            "the curated spelling is a read"
+        );
+        assert_eq!(
+            composio_catalog_lookup("GITHUB_ISSUES_LIST_FOR_REPO"),
+            CatalogLookup::UncuratedAction {
+                toolkit: "github".to_string()
+            },
+            "the live spelling of the same operation is a catalogue MISS, and \
+             naming it as such is the whole of #754"
+        );
+        // …and the verdict is untouched: still a send, still per-call.
+        let verdict = consequence_of(
+            COMPOSIO_EXECUTE,
+            &json!({ "tool": "GITHUB_ISSUES_LIST_FOR_REPO" }),
+        );
+        assert_eq!(verdict.group, EffectGroup::Send);
+        assert_eq!(verdict.standing, Standing::PerCall);
+    }
+
+    /// A curated **write** is not a miss, and telling them apart is what keeps
+    /// the signal readable (issue #754).
+    ///
+    /// Both classify as a send, so a boolean cannot separate them — which is
+    /// exactly why the drift was invisible. If every send were reported as a
+    /// catalogue miss, `GMAIL_SEND_EMAIL` would drown the handful of slugs that
+    /// have actually drifted.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn a_curated_write_is_not_reported_as_drift() {
+        assert_eq!(
+            composio_catalog_lookup("GMAIL_SEND_EMAIL"),
+            CatalogLookup::Curated { read: false },
+            "a curated send is the gate working, not the catalogue rotting"
+        );
+    }
+
+    /// A slug whose toolkit has no curated surface is a *different* miss from a
+    /// slug its toolkit has never heard of, and the record says which.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn an_unrecognised_toolkit_is_its_own_kind_of_miss() {
+        assert!(matches!(
+            composio_catalog_lookup("NOTAREALTOOLKIT_LIST_THINGS"),
+            CatalogLookup::UnknownToolkit { .. }
+        ));
     }
 
     /// Issue #443: the agent persona instructs every agent to call these rather

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -965,7 +965,25 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
 /// gate working; an uncurated slug is the gate guessing. Logging both would
 /// bury the second in the first — every `GMAIL_SEND_EMAIL` would look like
 /// drift.
+///
+/// Both miss arms are constructed only by the `openhuman` build of
+/// [`composio_catalog_lookup`]; without that feature the curated catalogue is
+/// not linked in, so the only reachable answer is [`UnknownToolkit`](Self::UnknownToolkit)
+/// and the other two are dead there. The type stays whole across both builds
+/// on purpose — the call site matches one shape, and `is_read` keeps one
+/// definition, so the feature cannot change what classifies as a read. The
+/// expectation is `expect` rather than `allow` and is scoped to the build that
+/// earns it: if a non-`openhuman` build ever does construct these, the
+/// unfulfilled expectation says so instead of staying quietly stale.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    not(feature = "openhuman"),
+    expect(
+        dead_code,
+        reason = "without the harness feature there is no catalogue to hit, so only \
+                  UnknownToolkit is constructible; see the note above"
+    )
+)]
 pub(crate) enum CatalogLookup {
     /// The slug is in its toolkit's catalogue, with a hand-assigned scope.
     Curated { read: bool },


### PR DESCRIPTION
## Summary

A Composio call is classified by looking its action slug up in the curated catalogue. A **hit** marked
`ToolScope::Read` becomes `Reach::ExternalRead` — it does not park under `supervised` and runs
unattended under `auto`. A **miss** falls through to `EffectGroup::Send` / `Reach::Consequence` /
`Standing::PerCall`: it parks, per call, forever, and cannot take a standing grant.

The miss branch is the right default for a slug nobody has classified. The defect is that a **catalogued
read whose live name has drifted** takes the same branch — and today it is indistinguishable from a
correct refusal, at the approval card and in the logs alike. So a stale catalogue looks exactly like a
working gate, and nobody ever learns the names have moved.

**This PR makes the miss observable. It does not change what parks.**

## No behaviour change — stated, not left to be inferred

`composio_action_is_read(slug) -> bool` becomes `composio_catalog_lookup(slug) -> CatalogLookup`, and
the verdict is read off it with

```rust
fn is_read(&self) -> bool { matches!(self, Self::Curated { read: true }) }
```

which is byte-identical to the boolean it replaces. Every miss still classifies as `Send` / `PerCall`;
the fail-closed default is untouched.

**How this fails when it is wrong: it cannot fail open.** It changes no classification, so the worst
case is a misfiled log line. That asymmetry is the reason this is the half being shipped first.

## Why an enum rather than a log line at the existing call site

A curated **write** also fails the read test. A boolean therefore cannot separate *the gate working*
from *the catalogue rotting* — which is precisely why the drift was invisible — and logging every
`false` would bury the handful of genuinely drifted slugs under every `GMAIL_SEND_EMAIL`.

| Arm | Meaning | Recorded? |
| --- | --- | --- |
| `Curated { read }` | in its toolkit's catalogue, hand-assigned scope | no — the gate working |
| `UncuratedAction { toolkit }` | toolkit has a catalogue, slug is not in it | **yes** — the #754 case |
| `UnknownToolkit { toolkit }` | no catalogue to consult, incl. the non-`openhuman` build | **yes** |

The two miss arms emit a structured `tracing::warn!` carrying `composio_slug`, `composio_toolkit` and
`catalogue_miss = true` — the slug, the toolkit, and that it missed, which is the dataset any future
alias mapping would be designed from.

## What is deliberately NOT built, and why

The alias layer that would *resolve* the drift. Designing a mapping now means fitting it to a
distribution nobody has observed: there is no endpoint that lists Composio's live slugs — the tenant API
answers `401`, and `frontend/src/api/composio.ts` exposes status, token, authorize and connections, none
of which serve a tool list. So the size and shape of the real miss set is unknown.

Shipping observability first is what makes that decision informed — whether the miss set is three stale
names that should simply be curated, or a long tail that needs machinery.

**The design and its measurements are recorded on #754**, not here: the finding that upstream's
`classify_unknown` is unsafe as a *classifier* but sound as a *veto* (its failure mode is false-`Read`,
not false-`Write`), scored against the curated catalogue as a labelled set — **86 of 430 curated
Write/Admin slugs classify as `Read`, 20%**, against **5 of 269 curated Reads vetoed, 1%**. That belongs
with the issue, where the next person will look.

## Also corrected on the issue

Two things a reader of #754 would otherwise inherit as fact, both posted there:

* **Only one of its two reported slugs is drift.** `GITHUB_ISSUES_LIST_FOR_REPO` has a curated twin
  (`GITHUB_LIST_REPOSITORY_ISSUES`, `Read`). `GITHUB_LIST_ORGANIZATIONS_FOR_THE_AUTHENTICATED_USER` has
  **no** organizations entry anywhere in the 46 — that one parks because nobody has curated the action,
  which is the fail-closed default working correctly, and no alias table would or should resolve it.
* Both file paths cited in the issue are stale — the catalogue moved to the extracted crate at
  `vendor/openhuman/vendor/tinymemory/core/src/sync/composio/providers/`.

## API Or Behavior Changes

None. No wire change, no verdict change, no new dependency. `CatalogLookup` is `pub(crate)`.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs it:
  `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, exit 0.
- [x] `cargo build --all-targets` — `--locked --features openhuman,tinycortex --all-targets`, exit 0.
- [x] `cargo test` — **both** configurations, see below.

### The default-features run is load-bearing here

`cargo test --locked --features openhuman,tinycortex --tests` → **4348 passed, 0 failed, 3 ignored**.

That green proves nothing on its own. The `#[cfg(not(feature = "openhuman"))]` stub changed shape too —
from returning `bool` to returning `CatalogLookup` — and that is the configuration where the curated
catalogue is not linked in at all, which almost nobody runs locally. So:

`cargo test --locked --lib` (default features) → **2842 passed, 0 failed**, and specifically
`without_the_catalogue_every_composio_action_is_a_send` still holds: with no catalogue, every
`composio_execute` is still a send with `Standing::PerCall`.

### Verified to gate

Three new tests, all `#[cfg(feature = "openhuman")]`:

* `a_drifted_read_is_a_miss_and_its_curated_twin_is_not` — pins the reported GitHub pair from both sides,
  **and** asserts the drifted slug's verdict is still `Send`/`PerCall`, i.e. that this commit changed the
  visibility and not the gate.
* `a_curated_write_is_not_reported_as_drift` — `GMAIL_SEND_EMAIL` is `Curated { read: false }`, so the
  signal is not drowned.
* `an_unrecognised_toolkit_is_its_own_kind_of_miss`.

Reverting the distinction — collapsing `UncuratedAction` back into an anonymous miss — fails the first:

```
assertion `left == right` failed: the live spelling of the same operation is a catalogue MISS,
and naming it as such is the whole of #754
  left: UnknownToolkit { toolkit: None }
 right: UncuratedAction { toolkit: "github" }
```

The pre-existing `we_do_not_fall_back_to_the_upstream_read_default` guard is kept and updated to the new
lookup. Worth noting it already existed: somebody had spotted the `classify_unknown` trap and pinned it;
what was missing was the number, which is now on the issue.

## Documentation

No spec doc changes. The reasoning — why a curated write must not be reported as drift, and why the
alias layer waits for data — is recorded on `CatalogLookup` and at the call site.

Part of tinyhumansai/opencompany#754 — this makes the drift observable. The classification half is
deliberately not addressed; the issue stays open for it.
