### PR TITLE
fix(workflows): refuse to arm a schedule whose report has nowhere to land (#1046)

### DIFF
--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -131,11 +131,11 @@ pub use types::{
     grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
 };
 pub use workflow_file::{
-    STAGELESS_SCHEDULE_REFUSAL, STAGELESS_WORKFLOW_NOTICE, WORKFLOW_DESTINATION_KINDS,
-    WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
-    WorkflowNodeKind, WorkflowRetryDef, list_source_workflows, list_workflows_union,
-    list_workflows_with_globals, load_company_workflows, load_workflow_union,
-    load_workflow_with_globals, parse_workflow,
+    STAGELESS_SCHEDULE_REFUSAL, STAGELESS_WORKFLOW_NOTICE, UNDELIVERABLE_SCHEDULE_REFUSAL,
+    WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,
+    WorkflowFile, WorkflowNodeDef, WorkflowNodeKind, WorkflowRetryDef, destination_is_reachable,
+    list_source_workflows, list_workflows_union, list_workflows_with_globals,
+    load_company_workflows, load_workflow_union, load_workflow_with_globals, parse_workflow,
 };
 // Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`
 // from its request body, renders it to TOML, and re-parses it through

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1429,6 +1429,12 @@ pub(crate) async fn rollback_company_workflow(
 /// last-write-wins is what a light switch already means. Requiring a token would
 /// also make a seed-backed workflow untoggleable, since only overlay bodies have
 /// one.
+///
+/// `mail_configured` and `wired_channels` are the deployment's delivery
+/// capability (issue #1046) — whether a mailbox is wired and which channels are
+/// deliverable — which the arm-time undeliverable-schedule check needs and the
+/// caller reads off the runtime.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn set_company_workflow_enabled(
     company: &CompanyId,
     source_dir: Option<&Path>,
@@ -1436,6 +1442,8 @@ pub(crate) async fn set_company_workflow_enabled(
     events: Option<&Arc<dyn EventLog>>,
     wid: &str,
     enabled: bool,
+    mail_configured: bool,
+    wired_channels: &[String],
 ) -> Result<bool> {
     if !is_safe_workflow_id(wid) {
         return Err(OpenCompanyError::InvalidRequest(
@@ -1531,6 +1539,38 @@ pub(crate) async fn set_company_workflow_enabled(
     {
         return Err(OpenCompanyError::InvalidRequest(
             crate::company::STAGELESS_SCHEDULE_REFUSAL.to_string(),
+        ));
+    }
+
+    // Issue #1046: the delivery-side sibling of the stage-less refusal above. A
+    // scheduled graph that runs a stage but can only deliver its report to a
+    // place this deployment cannot reach — `owner` with no mailbox (which falls
+    // back to the operator channel and is discarded), or a channel that isn't
+    // wired — fires on time, runs, and drops the report unseen every time. So
+    // arming, where the delivery promise is made, is where it is checked.
+    //
+    // Reuses the `file` already parsed for the stage-less check and the journal
+    // name — zero extra load. `mail_configured` and `wired_channels` are the
+    // deployment's delivery capability, computed by the caller from
+    // `runtime.mail()` and `runtime.deliverable_channel_ids()` (the console
+    // picker's own source of truth, #813) — the arm path cannot see them
+    // otherwise.
+    //
+    // None-vs-any, matching the stage-less guard's minimalism: refuse only when
+    // the graph *asks* to deliver somewhere (`has_output_destination`) and
+    // **nothing** it asks for can land (`!has_deliverable_output`). A
+    // drawer-only graph (outputs with no destination) promises no delivery and
+    // is left alone; a partially-deliverable graph still arms. Switching such a
+    // workflow OFF stays allowed, and a manual (unscheduled) graph is untouched
+    // — same reasoning as the guard above.
+    if enabled
+        && let Some(file) = file.as_ref()
+        && file.trigger_schedule().is_some()
+        && file.has_output_destination()
+        && !file.has_deliverable_output(mail_configured, wired_channels)
+    {
+        return Err(OpenCompanyError::InvalidRequest(
+            crate::company::UNDELIVERABLE_SCHEDULE_REFUSAL.to_string(),
         ));
     }
 
@@ -2597,6 +2637,8 @@ to = "done"
             None,
             "campaign",
             true,
+            true,
+            &[],
         )
         .await
         .expect_err("a schedule that cannot run must not be armed");
@@ -2635,9 +2677,18 @@ to = "done"
         .await
         .expect("saves");
 
-        set_company_workflow_enabled(&company, Some(dir.path()), &store, None, "campaign", false)
-            .await
-            .expect("pausing must never be refused");
+        set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "campaign",
+            false,
+            true,
+            &[],
+        )
+        .await
+        .expect("pausing must never be refused");
     }
 
     /// A graph with a real stage arms normally. Without this the refusal above
@@ -2657,9 +2708,273 @@ to = "done"
             .await
             .expect("saves");
 
-        set_company_workflow_enabled(&company, Some(dir.path()), &store, None, "greeter", true)
+        set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "greeter",
+            true,
+            true,
+            &[],
+        )
+        .await
+        .expect("a graph that can actually run may be armed");
+    }
+
+    // --- Undeliverable-schedule refusal (issue #1046) ------------------------
+
+    /// A scheduled `trigger → agent → output` draft whose output delivers to
+    /// `(dest_kind, dest_target)`. The shape #1046 guards: a graph that runs a
+    /// stage but whose only report may land nowhere.
+    fn scheduled_output_draft(
+        id: &str,
+        name: &str,
+        dest_kind: &str,
+        dest_target: Option<&str>,
+    ) -> RawWorkflow {
+        let mut draft = valid_draft(id, name);
+        draft.nodes[0].schedule = Some("0 9 * * *".to_string());
+        let output = draft
+            .nodes
+            .iter_mut()
+            .find(|node| node.kind == "output")
+            .expect("valid_draft carries an output node");
+        output.destination = Some(WorkflowDestinationDef {
+            kind: dest_kind.to_string(),
+            target: dest_target.map(str::to_string),
+        });
+        draft
+    }
+
+    /// The core of #1046: a scheduled graph whose only report goes to the owner
+    /// on a company with no mailbox is refused at arm time. `owner` with no
+    /// mailbox falls back to the operator channel, which delivery discards, so a
+    /// schedule would fire and drop the report unseen every time.
+    #[tokio::test]
+    async fn arming_a_scheduled_owner_output_with_no_mailbox_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            scheduled_output_draft("digest", "Digest", "owner", None),
+        )
+        .await
+        .expect("saving a stub is legitimate and must succeed");
+
+        let err = set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "digest",
+            true,
+            // No mailbox, no wired channels: nowhere for an owner report to land.
+            false,
+            &[],
+        )
+        .await
+        .expect_err("a schedule whose report cannot be delivered must not arm");
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("nowhere to land"),
+            "the operator is told WHAT is wrong: {rendered}"
+        );
+        assert!(
+            rendered.contains("mailbox") && rendered.contains("wired channel"),
+            "...and the two things they can do about it: {rendered}"
+        );
+    }
+
+    /// The manual half of the fix: the same undeliverable graph, but with **no**
+    /// schedule on its trigger, enables freely. Running a stub by hand — knowing
+    /// its report only reaches the run drawer — is the operator's own business;
+    /// only a *schedule* makes a delivery promise nobody is watching.
+    #[tokio::test]
+    async fn a_manual_undeliverable_graph_is_not_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        // owner output, no mailbox — but drop the schedule so it is manual.
+        let mut draft = scheduled_output_draft("digest", "Digest", "owner", None);
+        draft.nodes[0].schedule = None;
+        create_company_workflow(&company, Some(dir.path()), &store, None, draft)
             .await
-            .expect("a graph that can actually run may be armed");
+            .expect("saves");
+
+        set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "digest",
+            true,
+            false,
+            &[],
+        )
+        .await
+        .expect("a manual graph is never refused for undeliverable output");
+    }
+
+    /// The refusal is delivery-capability-specific, not a blanket ban on
+    /// owner outputs: the identical scheduled owner graph arms once a mailbox is
+    /// configured, because owner delivery can then email the company's admins.
+    #[tokio::test]
+    async fn arming_a_scheduled_owner_output_with_a_mailbox_arms() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            scheduled_output_draft("digest", "Digest", "owner", None),
+        )
+        .await
+        .expect("saves");
+
+        set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "digest",
+            true,
+            // A mailbox is configured: owner reports can be emailed.
+            true,
+            &[],
+        )
+        .await
+        .expect("an owner report can land once a mailbox exists");
+    }
+
+    /// A scheduled output to a wired channel arms even with no mailbox — the
+    /// channel is a real write path.
+    #[tokio::test]
+    async fn arming_a_scheduled_channel_output_to_a_wired_channel_arms() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            scheduled_output_draft("digest", "Digest", "channel", Some("engineering")),
+        )
+        .await
+        .expect("saves");
+
+        set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "digest",
+            true,
+            false,
+            &["engineering".to_string()],
+        )
+        .await
+        .expect("a report to a wired channel can land");
+    }
+
+    /// A scheduled output to the operator channel is refused: the operator
+    /// channel is an in-memory spy with no durable reader, so a report posted
+    /// there reaches nobody. `deliverable_channel_ids` never lists it, and the
+    /// predicate excludes it by name for good measure.
+    #[tokio::test]
+    async fn arming_a_scheduled_channel_output_to_operator_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            scheduled_output_draft("digest", "Digest", "channel", Some("operator")),
+        )
+        .await
+        .expect("saves");
+
+        let err = set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "digest",
+            true,
+            false,
+            // Even if a caller passed a rawer list carrying `operator`, it is refused.
+            &["operator".to_string()],
+        )
+        .await
+        .expect_err("the operator channel is not a delivery surface");
+
+        assert!(err.to_string().contains("nowhere to land"), "{err}");
+    }
+
+    /// Switching an undeliverable scheduled graph **off** is always allowed — an
+    /// operator must be able to stop a thing, the same rule the stage-less guard
+    /// keeps.
+    #[tokio::test]
+    async fn an_undeliverable_scheduled_graph_can_still_be_switched_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            scheduled_output_draft("digest", "Digest", "owner", None),
+        )
+        .await
+        .expect("saves");
+
+        set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "digest",
+            false,
+            false,
+            &[],
+        )
+        .await
+        .expect("pausing must never be refused");
     }
 
     /// A manifest-`enabled` id with no body in either source is shown by the
@@ -4282,6 +4597,8 @@ to = "done"
             Some(&log_dyn),
             "digest",
             true,
+            true,
+            &[],
         )
         .await
         .expect("arms");
@@ -4388,6 +4705,8 @@ to = "done"
             Some(&log_dyn),
             "greeter",
             false,
+            true,
+            &[],
         )
         .await
         .expect("pauses");
@@ -4410,6 +4729,8 @@ to = "done"
             Some(&log_dyn),
             "greeter",
             false,
+            true,
+            &[],
         )
         .await
         .expect("no-ops");
@@ -4429,6 +4750,8 @@ to = "done"
                 Some(&log_dyn),
                 "greeter",
                 true,
+                true,
+                &[],
             )
             .await
             .expect("arms")
@@ -4462,6 +4785,8 @@ to = "done"
             None,
             "nowhere",
             false,
+            true,
+            &[],
         )
         .await
         .expect_err("unknown id");
@@ -4470,10 +4795,18 @@ to = "done"
             "{err:?}"
         );
 
-        let err =
-            set_company_workflow_enabled(&company, Some(dir.path()), &store, None, "ghost", false)
-                .await
-                .expect_err("bodiless id");
+        let err = set_company_workflow_enabled(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            "ghost",
+            false,
+            true,
+            &[],
+        )
+        .await
+        .expect_err("bodiless id");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
     }
 
@@ -4507,6 +4840,8 @@ to = "done"
                 Some(&log_dyn),
                 "broken",
                 false,
+                true,
+                &[],
             )
             .await
             .expect("an unreadable graph is still pausable")
@@ -4571,6 +4906,8 @@ to = "done"
                 None,
                 "seeded",
                 false,
+                true,
+                &[],
             )
             .await
             .expect("pauses a seed-defined workflow")
@@ -4853,7 +5190,7 @@ to = "done"
         create_company_workflow(&company, None, &store, None, scheduled)
             .await
             .expect("create scheduled");
-        set_company_workflow_enabled(&company, None, &store, None, "greeter", true)
+        set_company_workflow_enabled(&company, None, &store, None, "greeter", true, true, &[])
             .await
             .expect("arm it");
 

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -194,6 +194,87 @@ impl WorkflowFile {
             .iter()
             .any(|node| node.kind != WorkflowNodeKind::Trigger)
     }
+
+    /// Whether this graph carries any `output` node that names a delivery
+    /// destination at all (issue #1046).
+    ///
+    /// The half of the arming check that says "this graph is *trying* to
+    /// deliver". An `output` node with `destination = None` keeps the legacy
+    /// pre-#170 behaviour — its value surfaces in the run-result drawer and goes
+    /// nowhere else — so it is not a delivery promise and a schedule that only
+    /// produces those is not undeliverable, just drawer-only. Paired with
+    /// [`has_deliverable_output`](Self::has_deliverable_output) it draws the
+    /// none-vs-any line: refuse to arm only when the graph asks to deliver
+    /// somewhere **and** nowhere it asks for can land.
+    pub fn has_output_destination(&self) -> bool {
+        self.nodes
+            .iter()
+            .any(|node| node.kind == WorkflowNodeKind::Output && node.destination.is_some())
+    }
+
+    /// Whether any `output` node in this graph names a destination the running
+    /// deployment can actually reach (issue #1046).
+    ///
+    /// `mail_configured` is `company.runtime.mail().is_some()` and
+    /// `wired_channels` is `company.runtime.deliverable_channel_ids()` — the same
+    /// two the console's destination picker (#813) and delivery
+    /// ([`deliver_one`](crate::workflows::delivery)) read, so a destination this
+    /// calls reachable is one delivery would not drop and one the author was
+    /// offered. Per-destination reachability is
+    /// [`destination_is_reachable`]; this is the "any of them lands" reduction
+    /// over the graph's outputs.
+    pub fn has_deliverable_output(&self, mail_configured: bool, wired_channels: &[String]) -> bool {
+        self.nodes.iter().any(|node| {
+            node.kind == WorkflowNodeKind::Output
+                && node.destination.as_ref().is_some_and(|destination| {
+                    destination_is_reachable(destination, mail_configured, wired_channels)
+                })
+        })
+    }
+}
+
+/// Whether an `output` node's `destination` can be delivered on a deployment
+/// with this delivery capability (issue #1046).
+///
+/// A pure mirror of the per-kind outcome
+/// [`deliver_one`](crate::workflows::delivery) produces, evaluated at author
+/// time so a schedule whose only report would be dropped is refused before it
+/// arms rather than firing on time and landing nowhere:
+///
+/// - `owner` needs a mailbox: with none, owner delivery falls back to the
+///   operator channel, which [`post_to_channel`](crate::workflows::delivery)
+///   refuses by name (an in-memory spy with no durable reader), so the report is
+///   discarded. So `owner` is reachable exactly when `mail_configured`.
+/// - `email` sends from the company mailbox, so it too needs `mail_configured`.
+///   (Delivery further gates on the `email` grant and an established thread;
+///   those are per-recipient runtime conditions an author-time check cannot see,
+///   so this stays at the coarser mailbox lever — the same one that decides
+///   whether there is anything to send *from* at all.)
+/// - `channel` is reachable when its target is a currently wired, deliverable
+///   channel — `wired_channels` already excludes the operator channel via
+///   [`deliverable_channel_ids`](crate::company::CompanyRuntime::deliverable_channel_ids),
+///   and the explicit `!= OPERATOR_CHANNEL` keeps the rule honest even if a
+///   caller passes a rawer list.
+/// - any other (or empty) kind never delivers.
+///
+/// Reuses [`is_deliverable_channel`](crate::runtime::channel)'s constant rather
+/// than editing `delivery.rs` (issue #981 owns it): the reachability rule is
+/// stated once there and read here.
+pub fn destination_is_reachable(
+    destination: &WorkflowDestinationDef,
+    mail_configured: bool,
+    wired_channels: &[String],
+) -> bool {
+    match destination.kind.trim() {
+        "owner" => mail_configured,
+        "email" => mail_configured,
+        "channel" => {
+            let target = destination.target.as_deref().map(str::trim).unwrap_or("");
+            target != crate::runtime::channel::OPERATOR_CHANNEL
+                && wired_channels.iter().any(|id| id == target)
+        }
+        _ => false,
+    }
 }
 
 /// What a run of a stage-less graph records (issue #976).
@@ -220,6 +301,24 @@ pub const STAGELESS_WORKFLOW_NOTICE: &str = "This workflow has no stage to run �
 pub const STAGELESS_SCHEDULE_REFUSAL: &str = "This workflow has no stage to run — its only node is the trigger that starts it — so a \
      schedule would fire on time and do nothing. Add at least one node after the trigger, then \
      switch it on.";
+
+/// Why arming a scheduled workflow whose report can reach nobody is refused
+/// (issue #1046).
+///
+/// The delivery-side sibling of [`STAGELESS_SCHEDULE_REFUSAL`]: that one guards
+/// a graph with nothing to *execute*, this one a graph with nowhere to
+/// *deliver*. Its only `output` destinations name places this deployment cannot
+/// reach — `owner` with no mailbox (which falls back to the operator channel and
+/// is discarded), or a channel that is not wired — so a schedule would fire on
+/// time, run, and drop its report unseen every time.
+///
+/// A literal, like [`STAGELESS_SCHEDULE_REFUSAL`] and every other notice:
+/// nothing runtime-supplied reaches an operator surface through it. Says what is
+/// wrong, why it matters, and the two things the operator can do.
+pub const UNDELIVERABLE_SCHEDULE_REFUSAL: &str = "This workflow's report has nowhere to land — its output goes to the owner, but no \
+     mailbox is configured, or to a channel that isn't wired — so a schedule would fire on \
+     time and drop the report unseen. Configure a mailbox, or point the output at a wired \
+     channel, then switch it on.";
 
 /// A single node in a workflow graph.
 #[derive(Clone, Debug, PartialEq)]
@@ -2778,6 +2877,91 @@ to = "done"
         let dest = channel.nodes[1].destination.as_ref().expect("present");
         assert_eq!(dest.kind, "channel");
         assert_eq!(dest.target.as_deref(), Some("operator"));
+    }
+
+    /// The reachability predicate mirrors delivery's per-kind outcome (issue
+    /// #1046): `owner`/`email` need a mailbox, `channel` needs a wired,
+    /// non-operator target, anything else never lands.
+    #[test]
+    fn destination_reachability_matches_delivery() {
+        let owner = WorkflowDestinationDef {
+            kind: "owner".to_string(),
+            target: None,
+        };
+        assert!(destination_is_reachable(&owner, true, &[]));
+        assert!(!destination_is_reachable(&owner, false, &[]));
+
+        let email = WorkflowDestinationDef {
+            kind: "email".to_string(),
+            target: Some("ada@example.com".to_string()),
+        };
+        assert!(destination_is_reachable(&email, true, &[]));
+        assert!(!destination_is_reachable(&email, false, &[]));
+
+        let eng = vec!["engineering".to_string()];
+        let channel = WorkflowDestinationDef {
+            kind: "channel".to_string(),
+            target: Some("engineering".to_string()),
+        };
+        assert!(destination_is_reachable(&channel, false, &eng));
+        // Unwired channel and the operator channel never land, mailbox or not.
+        let unwired = WorkflowDestinationDef {
+            kind: "channel".to_string(),
+            target: Some("marketing".to_string()),
+        };
+        assert!(!destination_is_reachable(&unwired, true, &eng));
+        let operator = WorkflowDestinationDef {
+            kind: "channel".to_string(),
+            target: Some(crate::runtime::channel::OPERATOR_CHANNEL.to_string()),
+        };
+        assert!(!destination_is_reachable(
+            &operator,
+            true,
+            &[crate::runtime::channel::OPERATOR_CHANNEL.to_string()],
+        ));
+    }
+
+    /// The none-vs-any line the arm gate rides on. A graph with one unreachable
+    /// owner output and one reachable channel output is deliverable — a
+    /// partially-deliverable schedule still arms; only a graph where **nothing**
+    /// can land is refused.
+    #[test]
+    fn mixed_graph_is_deliverable_when_any_output_lands() {
+        let src = r#"
+id = "wf"
+name = "WF"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+schedule = "0 9 * * *"
+[[node]]
+id = "to_owner"
+kind = "output"
+name = "Owner"
+[node.destination]
+kind = "owner"
+[[node]]
+id = "to_channel"
+kind = "output"
+name = "Channel"
+[node.destination]
+kind = "channel"
+target = "engineering"
+[[edge]]
+from = "start"
+to = "to_owner"
+[[edge]]
+from = "start"
+to = "to_channel"
+"#;
+        let file = parse_workflow(src).expect("parses");
+        assert!(file.has_output_destination());
+        let eng = vec!["engineering".to_string()];
+        // No mailbox: the owner output is dead, but the channel output lands.
+        assert!(file.has_deliverable_output(false, &eng));
+        // Strip the channel to its unwired name: now nothing lands.
+        assert!(!file.has_deliverable_output(false, &[]));
     }
 
     #[test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -944,6 +944,14 @@ async fn set_workflow_enabled(
             "workflow {wid}"
         ))));
     }
+    // Issue #1046: the arm-time delivery check needs the deployment's delivery
+    // capability, which lives on the runtime and the arm path cannot otherwise
+    // see: whether a mailbox is wired (so `owner`/`email` outputs can land) and
+    // which channels are deliverable (`deliverable_channel_ids` already excludes
+    // the operator channel, and is the console destination picker's own source
+    // of truth, #813).
+    let mail_configured = company.runtime.mail().is_some();
+    let wired_channels = company.runtime.deliverable_channel_ids();
     set_company_workflow_enabled(
         company.id(),
         company.runtime.source_dir(),
@@ -951,6 +959,8 @@ async fn set_workflow_enabled(
         Some(company.runtime.events()),
         &wid,
         body.enabled,
+        mail_configured,
+        &wired_channels,
     )
     .await
     .map_err(ApiError)?;


### PR DESCRIPTION
## Summary

Saving a scheduled graph validated the cron, node kinds, teammate names and (per #981) a named `channel` target — but never checked that the terminal `output` node could **deliver**. A workflow whose only destination is `owner` on a company with no mailbox saved clean, armed clean, and then dropped its report on every fire: `owner` with no mailbox falls back to `operator`, and `operator` is refused by name. On a schedule nobody watches the run banner, so it burned a metered agent turn every N minutes and produced nothing anyone received.

This is the delivery twin of #976 / PR #1028 ("refuse to arm a schedule the graph cannot keep") — that covered a graph with nothing to *execute*; this covers a graph with nowhere to *deliver*. It mirrors #1028 exactly: the refusal lives in the enable path (`set_company_workflow_enabled`), returns `400 InvalidRequest` with the reason, and leaves saving a stub, switching off, and manual runs all untouched.

## API Or Behavior Changes

- Enabling a **scheduled** graph that asks to deliver somewhere but whose every output destination is unreachable now returns **400** with a message naming the mailbox/channel gap and the fix. "Reachable" = `owner`/`email` need a configured mailbox; `channel` must be wired and not the operator channel.
- Unchanged: saving such a graph (stub stays legal), switching a workflow **off**, and **manual** (unscheduled) runs — a hand-run's result is on screen, a real reader.
- **none-vs-any:** a graph with at least one deliverable output still arms (matches #1028's minimalism); the per-run "not delivered" row remains the backstop for the partially-broken case.
- No change to `delivery.rs` — the reachability predicate reuses the existing channel list and operator-channel constant rather than duplicating or altering delivery logic.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` **and** `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib company::workflow_create` (80) + `company::workflow_file` (73) — 0 failed
- [x] `cargo build --locked --features openhuman,mcp,telegram` (full-feature combo — guards the known OC full-feature gap)

New tests (mirroring #1028's set): red-first `arming_a_scheduled_owner_output_with_no_mailbox_is_refused` (today returns `Ok(true)`); `a_manual_undeliverable_graph_is_not_refused`; owner-with-mailbox arms; channel-to-wired arms; channel-to-operator refused; undeliverable graph can still be switched off; predicate unit test documenting none-vs-any.

## Documentation

No doc pages — the reachability rule and the refusal are documented in-code on the predicates and the refusal const, beside #1028's stageless equivalents, and pinned by the tests.

## Related

- #976 / PR #1028 — the stageless-schedule refusal this mirrors.
- #981 — the destination picker offers a target delivery refuses; the channel-kind reachability here is intentional belt-and-suspenders with #981's save-time gate (different lifecycle point, no file overlap).
- Static limits (documented, unchanged): `owner`-with-mailbox-but-no-admin-address is data-dependent and not statically refused; `wired_channels` is boot-time truth — arm-time green is not a forever guarantee. The per-run "not delivered" row stays the backstop for both.

Closes #1046


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows now verify that scheduled outputs have at least one reachable delivery destination before activation.
  * Delivery checks support owners, email, and wired channels.
  * Workflows with partially reachable destinations can still run.
  * Manual workflows and disabling workflows retain their previous behavior.
* **Bug Fixes**
  * Prevented scheduled workflows from being enabled when they have no runnable stages or entirely undeliverable outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->