### PR TITLE
feat(workflows): auto-continue a blocked agent node when its approval lands (#899, Stage 1)

### DIFF
--- a/frontend/src/lib/approval-wording.ts
+++ b/frontend/src/lib/approval-wording.ts
@@ -1,9 +1,12 @@
 /**
  * What an approve actually promises (issue #561).
  *
- * Approving does not resume a suspended call — the host refuses a gated call,
- * mints a single-use grant and re-dispatches the agent (issue #243). Since
- * issue #469 it does that **once per turn, when the last decision that turn was
+ * Approving does not resume a suspended call in place — the host refuses a
+ * gated call, mints a single-use grant and re-dispatches (issue #243): a chat
+ * turn re-dispatches the agent, and since issue #899 (Stage 1) a blocked
+ * workflow run re-dispatches the run itself, so approving now continues that run
+ * automatically rather than leaving it for a manual re-run. Since issue #469 the
+ * re-dispatch happens **once per turn, when the last decision that turn was
  * blocked on lands**. So on a turn that parked four calls, three of the
  * operator's four clicks release nothing at all, and the console said "the
  * agent is completing the action" for every one of them. Measured on staging:

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -465,10 +465,11 @@ function RunHistoryRow({
         // Wording is the review item here. "Parked N approvals", never "waiting
         // on N": nothing refreshes this row when the operator approves one, so
         // an outstanding count is stale on arrival, while a record of what the
-        // run parked stays true. And it says plainly that approving does not
-        // continue THIS run — an agent step is not resumable, so the operator
-        // has to run the workflow again or they will sit waiting for a
-        // continuation that never comes.
+        // run parked stays true. Since issue #899 (Stage 1), approving a parked
+        // call CONTINUES this run automatically — so the closing sentence says
+        // that, with the honest caveat that the continuation re-runs the agent's
+        // turn and may ask again if it diverges. The unparkable-only case still
+        // cannot continue and says so.
         <p
           className="text-2xs text-[var(--status-blocked-text)]"
           data-testid="workflow-run-blocked"
@@ -491,7 +492,7 @@ function RunHistoryRow({
           {unparkable > 0 &&
             `${unparkable} call${unparkable === 1 ? "" : "s"} could not be queued for approval at all, so you will not be asked about ${unparkable === 1 ? "it" : "them"}. `}
           {parked > 0
-            ? `Decide ${parked === 1 ? "it" : "them"} in Approvals, then run the workflow again — approving does not continue this run.`
+            ? `Approve ${parked === 1 ? "it" : "them"} in Approvals and this run continues on its own — approving re-runs the step, so a changed decision may ask again.`
             : "Nothing here can be approved; change the policy and run the workflow again."}
         </p>
       ) : run.running ? (

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -221,8 +221,9 @@ export function RunResultPanel({
         {/* Issue #881: the sentence the drawer never had. A blocked run comes
             back with no error, nothing delivered and — before this — eight
             green node cards, so the operator's only reading was "it worked".
-            It says plainly that approving does not continue THIS run: an agent
-            step is not resumable, so they must run the workflow again. */}
+            Since issue #899 (Stage 1) it says approving CONTINUES this run
+            automatically, with the honest caveat that the continuation re-runs
+            the agent's turn and may ask again if it diverges. */}
         {blockedNodes.length > 0 && (
           <p
             className="mb-2 text-xs text-[var(--status-blocked-text)]"
@@ -242,7 +243,7 @@ export function RunResultPanel({
                   // still gets the original sentence rather than a pointer to
                   // something that is not there.
                   canDecideHere ? "below or in Approvals" : "in Approvals"
-                }, then run the workflow again — approving does not continue this run.`
+                } and this run continues on its own — approving re-runs the step, so a changed decision may ask again.`
               : "Nothing here can be approved; change the policy and run the workflow again."}
           </p>
         )}
@@ -374,11 +375,11 @@ function RunApprovalsSection({
       <p className="text-xs font-medium">
         {stillWaiting > 0
           ? `Waiting on you — ${stillWaiting} of ${rows.length} still to decide`
-          : // Every card answered. It must NOT say the run is continuing: an
-            // agent node is not re-enterable, so approving never resumes this
-            // run — the same thing the blocked sentence above says, said again
-            // at the moment the operator has just finished deciding.
-            `All ${rows.length} decided — run the workflow again to continue`}
+          : // Every card answered. Since issue #899 (Stage 1) the last decision
+            // continues the run automatically, so this says the run is picking
+            // back up — with the caveat, carried by the blocked sentence above,
+            // that the re-run may ask again if the agent's turn diverges.
+            `All ${rows.length} decided — this run is continuing`}
       </p>
       <div className="mt-1 space-y-1">
         {rows.map((row) => {

--- a/frontend/test/unit/workflow-run-approvals.test.ts
+++ b/frontend/test/unit/workflow-run-approvals.test.ts
@@ -291,9 +291,11 @@ describe("the staleness guard", () => {
     expect(control(MINE.id, "Approve")).toBeNull();
     expect(control(MINE.id, "Decline")).toBeNull();
     // The row does not vanish — the operator has to be able to see the decision
-    // land — but it states the verdict instead of asking again.
+    // land — but it states the verdict instead of asking again. Since #899 a
+    // decided blocked run continues on its own, so the section says so rather
+    // than telling the operator to re-run.
     expect(card(MINE.id)?.textContent).toContain("Approved");
-    expect(section()?.textContent).toContain("run the workflow again");
+    expect(section()?.textContent).toContain("this run is continuing");
   });
 
   it("is not fooled by the run's own frozen receipt", async () => {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -109,6 +109,7 @@ pub(crate) async fn join_follow_up(
     }
 }
 use crate::runtime::CycleRunner;
+use crate::runtime::blocked_nodes::BlockedNodeQueue;
 use crate::runtime::continuation::ContinuationQueue;
 use crate::runtime::cycle::ResolveReceipt;
 use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantId, GrantScope, GrantSet, StandingGrant};
@@ -301,6 +302,19 @@ pub struct CompanyRuntime {
     /// a swap mid-decision that forgot a run's parked gates would re-ask about
     /// every one of them.
     pub(crate) workflow_gates: WorkflowGateQueue,
+    /// Issue #899 (Stage 1): the workflow id and trigger input each **blocked
+    /// agent node** needs to re-dispatch its run when the operator approves the
+    /// gated call parked inside its tool loop.
+    ///
+    /// The agent-node companion to [`workflow_gates`](Self::workflow_gates): both
+    /// hold the facts a released [`continuations`](Self::continuations) batch
+    /// cannot carry, but for the two structurally different ways a run blocks —
+    /// a `requires_approval` gate node (there) versus a policy-gated call inside
+    /// an agent node's own tool loop (here). Live per-instance state; unlike its
+    /// neighbours it is **not** rebuilt from the journal on a swap, because the
+    /// parked tool-call effect carries no workflow lineage to rebuild it from —
+    /// see [`BlockedNodeQueue`](crate::runtime::blocked_nodes::BlockedNodeQueue).
+    pub(crate) blocked_nodes: BlockedNodeQueue,
     /// Held for the duration of a cycle so cycles never interleave per company.
     ///
     /// `Arc`-shared rather than owned so a rebuilt runtime can inherit the *same*
@@ -418,6 +432,7 @@ impl CompanyRuntime {
             grants,
             continuations: ContinuationQueue::default(),
             workflow_gates: WorkflowGateQueue::default(),
+            blocked_nodes: BlockedNodeQueue::default(),
             serial: Arc::new(TokioMutex::new(())),
             task_writes: Arc::new(TokioMutex::new(())),
             quiesced: Arc::new(AtomicBool::new(false)),
@@ -1177,6 +1192,24 @@ impl CompanyRuntime {
         self.workflow_gates = gates;
     }
 
+    /// Installs the blocked-agent-node stash the builder prepared (issue #899,
+    /// Stage 1) — inherited live on a rebuild, and empty on a boot (the parked
+    /// tool-call effect carries nothing to rehydrate it from).
+    ///
+    /// Set through the builder for [`adopt_continuations`](Self::adopt_continuations)'
+    /// reason, and shared with the workflow runner's `DeliveryParking` so the
+    /// runner that arms a stash at block-settle and the `continue_turn` that
+    /// releases it see one set.
+    pub fn adopt_blocked_nodes(&mut self, blocked_nodes: BlockedNodeQueue) {
+        self.blocked_nodes = blocked_nodes;
+    }
+
+    /// The blocked-agent-node stash, for the workflow-node continuation fork in
+    /// [`continue_turn`](Self::continue_turn) (issue #899, Stage 1).
+    pub fn blocked_nodes(&self) -> &BlockedNodeQueue {
+        &self.blocked_nodes
+    }
+
     /// Rejects a cycle on a runtime that is being replaced.
     ///
     /// Separate from [`ensure_running`](Self::ensure_running): that one reads a
@@ -1453,6 +1486,18 @@ impl CompanyRuntime {
         {
             return self.resume_workflow_run(&approval_id, turn, batch).await;
         }
+        // Issue #899 (Stage 1): a blocked agent node, likewise not a brain turn.
+        // Its gated calls parked under a `workflow-node:` key (disjoint from the
+        // `workflow-run:` gate key above), so the same batch counting releases
+        // them together, and this re-dispatches the run once — the auto-continue
+        // that used to be missing. Deny/expire-only spawns nothing.
+        if let Some(turn) = turn.as_deref()
+            && crate::runtime::workflow_resume::is_node_turn(turn)
+        {
+            return self
+                .resume_blocked_agent_node(&approval_id, turn, batch)
+                .await;
+        }
         if batch.is_empty() {
             // Every approval the turn raised expired rather than being decided.
             // The sweep already appended each `ApprovalResolved` itself, so
@@ -1510,6 +1555,108 @@ impl CompanyRuntime {
                 "Every sign-off on that workflow step is in, but the run could not be \
                  restarted: {error}. Nothing else is waiting on you — re-run the workflow to \
                  pick it back up."
+            ))
+            .await;
+            return Err(error);
+        }
+        Ok(CycleRunner::new(self).already_resolved_report())
+    }
+
+    /// Re-dispatches the run a **blocked agent node** belonged to — once, when
+    /// its gated calls are all decided and at least one was approved (issue #899,
+    /// Stage 1).
+    ///
+    /// The agent-node counterpart to
+    /// [`resume_workflow_run`](Self::resume_workflow_run). The difference is what
+    /// a continuation needs: a gate threads its node id into the trigger's
+    /// `approvals` array, but a call gated *inside* an agent node's tool loop is
+    /// not a graph node — the re-run just runs the graph again, and the grant the
+    /// approve minted (a shared [`GrantSet`](crate::runtime::grants::GrantSet))
+    /// lets the identical call pass. So this spawns from the stashed workflow id
+    /// and trigger input, unchanged.
+    ///
+    /// Three outcomes, all ending with the decisions appended to the timeline:
+    ///
+    /// * **at least one approved** — spawn one continuation run. A diverging
+    ///   re-run may re-ask (Stage 2 closes that); a failed spawn is announced,
+    ///   not swallowed, on [`resume_workflow_run`](Self::resume_workflow_run)'s
+    ///   reasoning — the cards are already consumed.
+    /// * **all denied or expired** — spawn nothing. The block is final; there is
+    ///   nothing to continue, exactly as `resume_run` starts no run for a wholly
+    ///   refused batch.
+    /// * **approved but the stash is gone** — a restart lost it (the parked
+    ///   tool-call card carries no lineage to rehydrate from), so the run cannot
+    ///   be located. The operator is told to re-run rather than left waiting.
+    async fn resume_blocked_agent_node(
+        &self,
+        approval_id: &ApprovalId,
+        turn: &str,
+        batch: Vec<CompanyEvent>,
+    ) -> Result<CycleReport> {
+        let approved = batch.iter().any(|event| {
+            matches!(
+                event,
+                CompanyEvent::ApprovalResolved {
+                    verdict: Verdict::Approve,
+                    ..
+                }
+            )
+        });
+        for event in batch {
+            if let Err(error) = self.events.append(&self.id, event).await {
+                tracing::warn!(
+                    company = %self.id,
+                    %approval_id,
+                    %error,
+                    "[approval] a blocked node's resolution could not be appended to the event \
+                     log; the journal remains the binding record"
+                );
+            }
+        }
+        // Drop the stash whatever the verdict — a refused block has nothing to
+        // continue, and a spawned one has consumed it.
+        let stashed = self.blocked_nodes.release(turn);
+        if !approved {
+            tracing::info!(
+                company = %self.id,
+                %turn,
+                "[approval] every gated call on this blocked node was refused or expired, so no \
+                 continuation runs"
+            );
+            return Ok(CycleRunner::new(self).already_resolved_report());
+        }
+        let Some(stashed) = stashed else {
+            tracing::error!(
+                company = %self.id,
+                %turn,
+                "[approval] a blocked node's calls were approved, but this host no longer holds \
+                 the run's stash (a restart drops it), so there is nothing to continue"
+            );
+            self.announce_to_operator(
+                "That workflow step's approval is in, but this host no longer has the run to \
+                 continue — re-run the workflow to pick it back up.",
+            )
+            .await;
+            return Ok(CycleRunner::new(self).already_resolved_report());
+        };
+        if let Err(error) = crate::runtime::workflow_resume::spawn_blocked_node_continuation(
+            self,
+            &stashed.workflow_id,
+            stashed.input,
+        )
+        .await
+        {
+            tracing::error!(
+                company = %self.id,
+                %turn,
+                %error,
+                "[approval] the workflow run released by a blocked node's approval could not be \
+                 continued"
+            );
+            self.announce_to_operator(&format!(
+                "That workflow step's approval is in, but the run could not be restarted: \
+                 {error}. Nothing else is waiting on you — re-run the workflow to pick it back \
+                 up."
             ))
             .await;
             return Err(error);

--- a/src/runtime/blocked_nodes.rs
+++ b/src/runtime/blocked_nodes.rs
@@ -1,0 +1,182 @@
+//! One blocked agent node, one continuation (issue #899, Stage 1).
+//!
+//! # What this stashes, and why the [`ContinuationQueue`] cannot
+//!
+//! A policy-gated call inside an agent node's own tool loop parks a
+//! tool-call-shaped effect (`agent: Some`). Approving it mints a grant, but
+//! nothing re-dispatches the workflow run — the hole issue #899 closes. The fix
+//! reuses the [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue)
+//! to count a node's parked calls as one batch (armed at park time under a
+//! [`workflow_node_turn_key`](crate::runtime::workflow_resume::workflow_node_turn_key)),
+//! and releases once when the last decision lands. But to *spawn* the
+//! continuation the host needs two facts that batch cannot carry — the
+//! **workflow id** and the paused run's **trigger input** — for the same reason
+//! [`WorkflowGateQueue`](crate::runtime::workflow_gates::WorkflowGateQueue)
+//! exists beside that queue for gates: the released batch is only
+//! `ApprovalResolved` events, and the parked tool-call effect carries no
+//! workflow lineage of its own (it is minted by `ApprovalPolicy::effect_for`,
+//! which knows nothing of the run).
+//!
+//! # Why armed at block-settle, not at park time
+//!
+//! The calls are parked mid-turn from `HarnessAgentRunner`, which does **not**
+//! carry the trigger input (only the run request). The runner's block-settle
+//! *does* — it is the one place with the workflow id and the trigger input
+//! beside the list of blocked nodes — so the stash is populated there, exactly
+//! as `park_pending_gates` populates the gate queue from the runner.
+//!
+//! # Durability, stated plainly
+//!
+//! In-memory, and — unlike [`WorkflowGateQueue`] — **not** rehydrated from the
+//! journal at recovery, because the parked tool-call effect carries no
+//! workflow id or trigger input to rebuild it from (widening the effect payload
+//! to carry them is a larger change than Stage 1 takes on). A restart in the
+//! middle of a blocked node therefore comes back with the
+//! [`ContinuationQueue`] counter re-armed (from `parked_turns`) but the stash
+//! empty: the batch releases and finds nothing to spawn, and the operator is
+//! told to re-run the workflow. That is a strictly worse restart story than the
+//! gate path's, and it is the Stage-1 boundary — the durable-card version is
+//! Stage 2 territory.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+
+/// The two facts a blocked agent node's continuation needs, stashed at
+/// block-settle and handed back on release.
+#[derive(Clone, Debug)]
+pub struct StashedBlock {
+    /// The workflow whose run blocked, to load the graph for the re-run.
+    pub workflow_id: String,
+    /// The paused run's own trigger input, replayed unchanged — the minted grant
+    /// is what lets the identical gated call pass on the re-run.
+    pub input: Value,
+}
+
+/// Per-(run, node) continuation state for a blocked agent node: the workflow id
+/// and trigger input its re-run needs (issue #899, Stage 1).
+///
+/// Cheap to [`Clone`] — a shared handle like every other queue in the runtime —
+/// so the arming side (the workflow runner, through `DeliveryParking`) and the
+/// releasing side (the runtime's `continue_turn`) see one set of stashes.
+#[derive(Clone, Default)]
+pub struct BlockedNodeQueue {
+    inner: Arc<Mutex<HashMap<String, StashedBlock>>>,
+}
+
+impl BlockedNodeQueue {
+    /// Stashes the facts a blocked node's continuation needs, keyed by its
+    /// per-(run, node) turn key.
+    ///
+    /// **First write wins.** Every gated call one node parked shares one turn
+    /// key and one trigger input, so a second arm for the same key would carry
+    /// identical facts; keeping the first is simplest and cannot disagree.
+    pub fn arm(&self, turn: &str, workflow_id: &str, input: &Value) {
+        self.inner
+            .lock()
+            .expect("blocked node queue poisoned")
+            .entry(turn.to_string())
+            .or_insert_with(|| StashedBlock {
+                workflow_id: workflow_id.to_string(),
+                input: input.clone(),
+            });
+    }
+
+    /// Takes `turn`'s stash, dropping it from the queue.
+    ///
+    /// Called once, by whichever caller the [`ContinuationQueue`] handed the
+    /// release to — that queue's counting decides who, under one lock, so this
+    /// cannot be entered twice for one blocked node. `None` for a turn this
+    /// queue is not holding: a card parked before this issue, or a stash lost to
+    /// a restart, which the caller reports as "re-run the workflow".
+    pub fn release(&self, turn: &str) -> Option<StashedBlock> {
+        self.inner
+            .lock()
+            .expect("blocked node queue poisoned")
+            .remove(turn)
+    }
+
+    /// Whether `turn` is a blocked node this queue is holding a stash for.
+    pub fn is_armed(&self, turn: &str) -> bool {
+        self.inner
+            .lock()
+            .expect("blocked node queue poisoned")
+            .contains_key(turn)
+    }
+
+    /// How many blocked nodes are stashed. For tests and diagnostics.
+    pub fn waiting(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("blocked node queue poisoned")
+            .len()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn arm_then_release_hands_back_the_stashed_facts() {
+        let q = BlockedNodeQueue::default();
+        q.arm(
+            "workflow-node:run-1:draft",
+            "digest",
+            &json!({ "topic": "x" }),
+        );
+        assert!(q.is_armed("workflow-node:run-1:draft"));
+
+        let block = q.release("workflow-node:run-1:draft").expect("armed");
+        assert_eq!(block.workflow_id, "digest");
+        assert_eq!(block.input, json!({ "topic": "x" }));
+        assert_eq!(q.waiting(), 0, "release drops the stash");
+        assert!(!q.is_armed("workflow-node:run-1:draft"));
+    }
+
+    #[test]
+    fn release_of_an_unheld_turn_is_none() {
+        let q = BlockedNodeQueue::default();
+        assert!(q.release("workflow-node:run-9:ghost").is_none());
+    }
+
+    #[test]
+    fn first_arm_wins_for_a_repeated_key() {
+        let q = BlockedNodeQueue::default();
+        q.arm(
+            "workflow-node:run-1:draft",
+            "digest",
+            &json!({ "topic": "first" }),
+        );
+        q.arm(
+            "workflow-node:run-1:draft",
+            "digest",
+            &json!({ "topic": "second" }),
+        );
+        let block = q.release("workflow-node:run-1:draft").expect("armed");
+        assert_eq!(block.input, json!({ "topic": "first" }));
+    }
+
+    /// Two blocked nodes of two runs are independent stashes — a release of one
+    /// leaves the other untouched (the scope-disjointness a cross-continuation
+    /// would violate).
+    #[test]
+    fn two_blocked_nodes_do_not_share_a_stash() {
+        let q = BlockedNodeQueue::default();
+        q.arm("workflow-node:run-1:draft", "digest", &json!({ "n": 1 }));
+        q.arm("workflow-node:run-2:draft", "digest", &json!({ "n": 2 }));
+
+        let first = q.release("workflow-node:run-1:draft").expect("armed");
+        assert_eq!(first.input, json!({ "n": 1 }));
+        assert!(
+            q.is_armed("workflow-node:run-2:draft"),
+            "the other run stays"
+        );
+        assert_eq!(
+            q.release("workflow-node:run-2:draft").unwrap().input,
+            json!({ "n": 2 })
+        );
+    }
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1768,6 +1768,20 @@ impl RuntimeBuilder {
             }
         };
 
+        // Issue #899 (Stage 1): the blocked-agent-node stash, shared between the
+        // workflow runner (which arms it at block-settle through `DeliveryParking`)
+        // and the runtime (whose `continue_turn` releases it). Inherited live on a
+        // rebuild, and a plain `default()` on a boot — unlike its two neighbours
+        // it is NOT rehydrated from the journal, because the parked tool-call
+        // effect carries no workflow id or trigger input to rebuild a stash from.
+        // A boot mid-block therefore re-arms the `continuations` counter but not
+        // this, and the released batch reports "re-run the workflow" instead of
+        // spawning. See `BlockedNodeQueue`.
+        let blocked_nodes = match handover.as_ref() {
+            Some(h) => h.blocked_nodes.clone(),
+            None => crate::runtime::blocked_nodes::BlockedNodeQueue::default(),
+        };
+
         // Brain selection, in precedence order:
         //   1. an explicit brain (test injection) always wins;
         //   2. under the `openhuman` feature, an attached harness pool + a
@@ -2531,6 +2545,11 @@ impl RuntimeBuilder {
                                         // never continued at all.
                                         continuations: continuations.clone(),
                                         gates: workflow_gates.clone(),
+                                        // Issue #899 (Stage 1): the SAME stash the
+                                        // runtime gets below, armed at block-settle
+                                        // for a blocked agent node so the resolve
+                                        // path can find the run to re-dispatch.
+                                        blocked_nodes: blocked_nodes.clone(),
                                     }),
                                     // Issue #529: the same journal the runner
                                     // writes its start/per-node trail to, so a
@@ -2789,6 +2808,7 @@ impl RuntimeBuilder {
         }
         runtime.adopt_continuations(continuations);
         runtime.adopt_workflow_gates(workflow_gates);
+        runtime.adopt_blocked_nodes(blocked_nodes);
 
         // MCP uses OpenHuman's process-global live connection registry. Keep a
         // runtime-owned config for this OpenCompany home so REST and agents see

--- a/src/runtime/handover.rs
+++ b/src/runtime/handover.rs
@@ -54,6 +54,7 @@ use crate::feedback::service::FeedbackFiler;
 use crate::feedback::store::FeedbackStore;
 use crate::policy::ManifestApprovalGate;
 use crate::ports::{CompanyStore, ContextStore, EventLog, InboxStore, MemoryStore, SecretStore};
+use crate::runtime::blocked_nodes::BlockedNodeQueue;
 use crate::runtime::continuation::ContinuationQueue;
 use crate::runtime::grants::GrantSet;
 use crate::runtime::journal::RuntimeJournal;
@@ -92,6 +93,12 @@ pub struct RuntimeHandover {
     /// exactly — a successor that forgot them would re-ask about every gate of a
     /// partly-decided run.
     pub(crate) workflow_gates: WorkflowGateQueue,
+    /// Issue #899 (Stage 1): the blocked-agent-node stashes still awaiting a
+    /// decision. Inherited live for [`continuations`](Self::continuations)'
+    /// reason — a successor that forgot them would release a blocked node's
+    /// batch with nothing to spawn and tell the operator to re-run a workflow
+    /// that is in fact ready to continue.
+    pub(crate) blocked_nodes: BlockedNodeQueue,
     pub(crate) serial: Arc<TokioMutex<()>>,
     pub(crate) task_writes: Arc<TokioMutex<()>>,
     #[cfg(feature = "openhuman")]
@@ -128,6 +135,7 @@ impl CompanyRuntime {
             grants: self.grants.clone(),
             continuations: self.continuations.clone(),
             workflow_gates: self.workflow_gates.clone(),
+            blocked_nodes: self.blocked_nodes.clone(),
             serial: self.serial.clone(),
             task_writes: self.task_writes.clone(),
             #[cfg(feature = "openhuman")]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -27,6 +27,11 @@ pub mod approval_display;
 /// harness dispatch path and the REST write boundary so the board's assignee
 /// means one thing. See [`assignee`].
 pub mod assignee;
+/// Issue #899 (Stage 1): the workflow id and trigger input each **blocked agent
+/// node** needs to re-dispatch its run when the operator approves a call gated
+/// inside its tool loop — the agent-node companion to [`workflow_gates`]. See
+/// [`blocked_nodes`].
+pub mod blocked_nodes;
 /// Issue #464: [`BoardAnnouncer`] — the [`TaskStore`](crate::ports::tasks::TaskStore)
 /// decorator that announces a board write on the company event log, so a card
 /// opened by *anything* reaches a watching console without a reload. Emitted at

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -175,6 +175,60 @@ pub fn run_id_from_turn(turn: &str) -> Option<&str> {
         .filter(|run_id| !run_id.is_empty())
 }
 
+/// The prefix a **blocked agent node's** continuation turn key carries
+/// (issue #899, Stage 1).
+///
+/// # Why a third turn-key namespace, distinct from `workflow-run:`
+///
+/// A `requires_approval` **gate** and a policy-gated call *inside an agent
+/// node's own tool loop* block a run in two structurally different ways, and
+/// they must not share a batch:
+///
+/// * A gate parks a `WORKFLOW_APPROVE_KIND` effect (`agent: None`), and
+///   approving it re-runs the graph with the gate's node id in the trigger's
+///   `approvals` array. That is the `workflow-run:` batch ([`workflow_turn_key`]).
+/// * An agent node's gated call parks a **tool-call-shaped** effect
+///   (`agent: Some`, minted by `ApprovalPolicy::effect_for`), and approving it
+///   mints a grant. Nothing re-dispatches the run — the whole hole this issue
+///   closes. The re-run needs no `approvals` array (the call is not a graph
+///   node); it re-runs from the top and the minted grant lets the identical call
+///   pass ([`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue)-armed
+///   at park time, stashed by
+///   [`BlockedNodeQueue`](crate::runtime::blocked_nodes::BlockedNodeQueue)).
+///
+/// Keying per **(run, node)** rather than per run is deliberate: one agent node
+/// blocking on several gated calls is one batch owed one continuation (the #469
+/// property), but two agent nodes of one run that each block are two independent
+/// blocks — a continuation of one is not a continuation of the other.
+pub const WORKFLOW_NODE_TURN_PREFIX: &str = "workflow-node:";
+
+/// The continuation turn key **every gated call one blocked agent node parked**
+/// shares (issue #899, Stage 1).
+///
+/// Per (run, node): all of a node's parked calls carry this one key, so the
+/// [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue) counts
+/// them as one batch and releases once, when the last decision lands. `node_id`
+/// is the block's resolved node id — the graph node id when the engine gave the
+/// turn one, else the agent ref — so the runner's stash and the parker agree on
+/// the key by construction.
+pub fn workflow_node_turn_key(run_id: &str, node_id: &str) -> String {
+    format!("{WORKFLOW_NODE_TURN_PREFIX}{run_id}:{node_id}")
+}
+
+/// Whether `turn` names a blocked agent node minted by [`workflow_node_turn_key`]
+/// (issue #899, Stage 1).
+///
+/// What `continue_turn` forks on to route a released batch to a workflow-run
+/// continuation rather than a brain cycle. The full key is the
+/// [`BlockedNodeQueue`](crate::runtime::blocked_nodes::BlockedNodeQueue) stash
+/// key, so nothing here parses the run/node back out — the prefix test is the
+/// whole question, and it is disjoint from `workflow-run:` so the gate fork
+/// ([`run_id_from_turn`]) never misfires on it.
+pub fn is_node_turn(turn: &str) -> bool {
+    turn.strip_prefix(WORKFLOW_NODE_TURN_PREFIX)
+        .is_some_and(|rest| !rest.is_empty())
+}
+
 /// The payload key holding the workflow whose run paused.
 pub const PAYLOAD_WORKFLOW_ID: &str = "workflow_id";
 /// The payload key holding the gate node awaiting sign-off.
@@ -914,6 +968,74 @@ async fn spawn_continuation(
         denied = ?denied,
         %run_id,
         "workflow: an approved gate started a continuation run; upstream nodes re-execute"
+    );
+    Ok(())
+}
+
+/// Re-dispatches the workflow run a **blocked agent node** belonged to, by
+/// starting a fresh supervised run with the paused run's own trigger input
+/// (issue #899, Stage 1).
+///
+/// # Why this is simpler than [`spawn_continuation`]
+///
+/// A `requires_approval` gate is a graph node, so approving it threads the
+/// node id into the trigger's `approvals` array and the re-run proceeds past it.
+/// A gated call *inside an agent node's tool loop* is not a graph node — there
+/// is nothing to add to `approvals`. The re-run simply runs the graph again from
+/// the top; the grant minted when the operator approved (a shared
+/// [`GrantSet`](crate::runtime::grants::GrantSet), redeemed at the top of the
+/// policy's `check`) lets the identical call through without re-parking. So this
+/// spawns with the input **unchanged** — no ledger transform, no approvals set.
+///
+/// # The honest Stage-1 limit
+///
+/// If the model **diverges** on the re-run (different arguments, or an extra
+/// call), the grant does not match and the new call parks a fresh card. That is
+/// a genuinely new decision rather than a loop, but it is a re-ask — Stage 2's
+/// at-most-once grant capture is what closes it. Re-delivery of any report an
+/// earlier partial run already sent is guarded independently by the durable
+/// #529 delivery ledger the runner folds in, so it is not re-threaded here.
+///
+/// # Errors
+///
+/// Propagated, on [`spawn_continuation`]'s terms: the approval is already
+/// committed, so a graph that has since been deleted or a build with no workflow
+/// execution has to reach the operator at click time, not vanish.
+pub async fn spawn_blocked_node_continuation(
+    runtime: &CompanyRuntime,
+    workflow_id: &str,
+    input: Value,
+) -> Result<()> {
+    let Some(runner) = runtime.workflow_runner().cloned() else {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "approved a blocked step on workflow `{workflow_id}`, but this runtime has no \
+             workflow execution wired, so there is nothing to continue"
+        )));
+    };
+    let overlays = runtime
+        .store()
+        .load(runtime.id())
+        .await?
+        .map(|record| record.overlay_workflows)
+        .unwrap_or_default();
+    let workflow =
+        load_workflow_union(runtime.source_dir(), &overlays, workflow_id)?.ok_or_else(|| {
+            OpenCompanyError::CompanyNotFound(format!(
+                "workflow {workflow_id} (a blocked step was approved, but the graph no longer \
+                 exists)"
+            ))
+        })?;
+    // Issue #542: a resumed run is always real (`false`). Issue #401: `spawn`
+    // refuses at the concurrency ceiling; propagate it so the caller surfaces
+    // the same refusal rather than losing the run silently.
+    let (run_id, _handle) =
+        WorkflowSpawn::new(runtime, runner).spawn(workflow, input, false, false)?;
+    tracing::info!(
+        company = %runtime.id(),
+        workflow = %workflow_id,
+        %run_id,
+        "workflow: an approved agent-node call started a continuation run; the whole graph \
+         re-executes and the minted grant lets the identical call pass"
     );
     Ok(())
 }

--- a/src/workflows/blocked_node_continuation_test.rs
+++ b/src/workflows/blocked_node_continuation_test.rs
@@ -1,0 +1,433 @@
+//! Issue #899 (Stage 1) — approving a call gated **inside an agent node's own
+//! tool loop** auto-continues the blocked run.
+//!
+//! # The hole this proves closed, and why the suite was blind to it
+//!
+//! A workflow agent node runs openhuman's tool loop. A policy-gated call mid-turn
+//! is refused inside that loop, `park_gated_calls` opens a decidable card, and
+//! the node returns `Err` so `WorkflowRun` reclassifies it Blocked (#881). Every
+//! part worked — and approving the card still did **nothing to the run**. The
+//! parked effect is tool-call-shaped (`agent: Some`), so approving it minted a
+//! grant and the resolution ran a brain cycle; nothing re-dispatched the
+//! settled run. The operator's only recourse was to re-run the whole workflow by
+//! hand. `blocked_node_test` proves the block; `gated_tool_turn_test` proves the
+//! card; neither drives the **resolve → continue** seam, because before this
+//! there was nothing on the other side of it.
+//!
+//! # What this drives
+//!
+//! The real path, end to end: a real graph, the real engine through
+//! [`HarnessWorkflowRunner`](super::runner::HarnessWorkflowRunner), the real
+//! `ApprovalPolicy` gate, a real on-disk journal, and a real [`CompanyRuntime`]
+//! resolving through `resolve_approval` — the same call the console's Approvals
+//! route makes. The one thing scripted is the model's choices, over a loopback
+//! OpenAI-compatible endpoint, exactly as its two ancestors script it. The grant
+//! set is **shared** between the runtime that mints and the workflow policy that
+//! redeems (the production wiring), so a continuation whose agent re-issues the
+//! identical call passes rather than re-parking — the Stage-1 loop-safety.
+//!
+//! # Reading the count
+//!
+//! One number carries the issue, asserted as an **equality**: `runs_started`.
+//! The cold run is 1. On `main` an approval adds nothing (the resolution is a
+//! brain cycle, not a re-dispatch), so it stays 1 — this is the red. With the
+//! fix an approval adds exactly one continuation, so it is 2; a refusal still
+//! adds none; and a node blocked on two calls adds one, only after the second
+//! decision. Two blocked runs never continue each other.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::harness::HarnessPool;
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyId, CompanyRecord, Verdict};
+use crate::ports::{WorkflowRun, WorkflowRunContext, WorkflowRunner};
+use crate::runtime::RuntimeBuilder;
+use crate::runtime::workflow_resume::workflow_node_turn_key;
+
+use super::gated_tool_turn_test::{Turn, deps, spawn_script_recording};
+
+/// `start -> work(agent, gates a shell call) -> done`. The minimal shape of the
+/// reported case: one agent node whose turn is stopped by a policy gate.
+const SOLO_TOML: &str = r#"
+id = "solo"
+name = "Solo"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Do the gated thing."
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "done"
+"#;
+
+/// The agent node id every card in these tests is keyed under.
+const NODE: &str = "work";
+
+/// A company that gates `shell` under **full** autonomy — the strongest tier, so
+/// the stop is the policy's explicit gate rather than a supervised classifier.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+always_approve = ["shell"]
+
+[tools]
+allow = ["shell"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        manifest: manifest(),
+        ..super::gated_tool_turn_test::record()
+    }
+}
+
+fn operator() -> Actor {
+    Actor {
+        kind: ActorKind::Operator,
+        id: "owner".into(),
+    }
+}
+
+/// What the host actually asked the engine to run.
+#[derive(Clone, Debug)]
+struct StartedRun {
+    #[allow(dead_code)]
+    input: Value,
+}
+
+/// The real runner, wrapped so the test can count dispatches — the reported
+/// symptom (approving started zero continuations) is a count the run history
+/// cannot give back.
+struct RecordingRunner {
+    inner: super::runner::HarnessWorkflowRunner,
+    started: Mutex<Vec<StartedRun>>,
+}
+
+impl RecordingRunner {
+    fn started(&self) -> usize {
+        self.started.lock().expect("recording runner").len()
+    }
+}
+
+#[async_trait]
+impl WorkflowRunner for RecordingRunner {
+    async fn run(
+        &self,
+        company: &CompanyId,
+        workflow: &crate::company::WorkflowFile,
+        input: Value,
+        ctx: &WorkflowRunContext,
+    ) -> crate::Result<WorkflowRun> {
+        self.started
+            .lock()
+            .expect("recording runner")
+            .push(StartedRun {
+                input: input.clone(),
+            });
+        self.inner.run(company, workflow, input, ctx).await
+    }
+}
+
+/// A home whose `workflows/` directory holds the graph, so a continuation's
+/// loader finds it by id exactly as the console run route would.
+fn seed_home() -> tempfile::TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("opencompany-blocked-cont-")
+        .tempdir()
+        .expect("tempdir");
+    let workflows = dir.path().join("workflows");
+    std::fs::create_dir_all(&workflows).expect("workflows dir");
+    std::fs::write(workflows.join("solo.toml"), SOLO_TOML).expect("seed graph");
+    dir
+}
+
+/// A runtime wired to the **real** workflow runner, parking into the runtime's
+/// own gate/journal/continuation/blocked-node queues, with the grant set
+/// **shared** so a continuation redeems what the resolve minted.
+///
+/// The model is served by `turns` on loopback. Everything the resolve path
+/// touches is the runtime's own handle, or every assertion here would be vacuous.
+async fn runtime(
+    home: &std::path::Path,
+    turns: Vec<Turn>,
+) -> (
+    Arc<crate::company::runtime::CompanyRuntime>,
+    Arc<RecordingRunner>,
+) {
+    let mut rt = RuntimeBuilder::new(home.to_path_buf(), manifest())
+        .with_seed_dir(home.to_path_buf())
+        .build()
+        .await
+        .expect("runtime builds");
+
+    let (base_url, _script) = spawn_script_recording(turns).await;
+    let (mut deps, _unused) = deps(base_url, home);
+    // Production wiring: the workflow policy redeems from the SAME grant set the
+    // runtime mints into, so an approved continuation's identical call passes.
+    deps.approval_requests = ApprovalRequestQueue::with_grants(rt.grants.clone());
+    let delivery = deps.delivery.as_mut().expect("the fixture wires delivery");
+    delivery.parking = Some(super::delivery::DeliveryParking {
+        approvals: rt.approvals.clone(),
+        journal: rt.journal().clone(),
+        continuations: rt.continuations.clone(),
+        gates: rt.workflow_gates().clone(),
+        blocked_nodes: rt.blocked_nodes().clone(),
+    });
+
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record(), &deps).await.expect("roster builds");
+    let runner = Arc::new(RecordingRunner {
+        inner: super::runner::HarnessWorkflowRunner::new(pool, deps, record()),
+        started: Mutex::new(Vec::new()),
+    });
+    rt.set_workflow_runner(runner.clone());
+    (Arc::new(rt), runner)
+}
+
+/// Starts the graph through the runtime's own runner — the console run path — and
+/// returns the run id. The agent node parks its gated call and the run settles
+/// Blocked rather than erroring.
+async fn cold_run(rt: &Arc<crate::company::runtime::CompanyRuntime>) -> String {
+    let file = parse_workflow(SOLO_TOML).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+    let runner = rt.workflow_runner().cloned().expect("a runner is wired");
+    runner
+        .run(rt.id(), &file, json!({ "request": "the thing" }), &ctx)
+        .await
+        .expect("a blocked run settles rather than failing");
+    run_id
+}
+
+/// The agent-internal cards a given run parked, oldest first — the ones keyed
+/// under this issue's `workflow-node:` turn key.
+fn cards_for(rt: &Arc<crate::company::runtime::CompanyRuntime>, run_id: &str) -> Vec<ApprovalId> {
+    let turn = workflow_node_turn_key(run_id, NODE);
+    rt.journal()
+        .pending()
+        .into_iter()
+        .filter(|entry| entry.batch.as_deref() == Some(turn.as_str()))
+        .map(|entry| entry.id)
+        .collect()
+}
+
+/// Every agent-internal card still parked, across all runs.
+fn all_blocked_cards(rt: &Arc<crate::company::runtime::CompanyRuntime>) -> usize {
+    rt.journal()
+        .pending()
+        .into_iter()
+        .filter(|entry| {
+            entry
+                .batch
+                .as_deref()
+                .is_some_and(|b| b.starts_with("workflow-node:"))
+        })
+        .count()
+}
+
+/// A resolve, plus the settling window the detached continuation needs — the
+/// continuation is spawned rather than awaited (issue #380's drop safety), so an
+/// immediate assertion would race it. Bounded, so a genuine failure fails.
+async fn resolve_and_settle(
+    rt: &Arc<crate::company::runtime::CompanyRuntime>,
+    id: &ApprovalId,
+    verdict: Verdict,
+) {
+    rt.resolve_approval(id, verdict, operator())
+        .await
+        .expect("the verdict is recorded");
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+}
+
+/// The headline. On `main` this is red: approving an agent-internal card starts
+/// no run, so `runs_started` stays 1. With the fix it is 2 — one continuation.
+#[tokio::test]
+async fn approving_a_blocked_agent_node_call_continues_the_run() {
+    let home = seed_home();
+    // Cold turn gates one call; the continuation redeems the grant and finishes.
+    let (rt, runner) = runtime(
+        home.path(),
+        vec![
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "echo hi" }),
+            },
+            Turn::Say("I was refused, so I stopped."),
+            Turn::Say("Done."),
+        ],
+    )
+    .await;
+
+    let run_id = cold_run(&rt).await;
+    let cards = cards_for(&rt, &run_id);
+    assert_eq!(cards.len(), 1, "the cold run parks exactly one card");
+    assert_eq!(runner.started(), 1, "only the cold run has started");
+
+    resolve_and_settle(&rt, &cards[0], Verdict::Approve).await;
+
+    assert_eq!(
+        runner.started(),
+        2,
+        "approving the card auto-continues the run — exactly one continuation"
+    );
+    assert_eq!(
+        all_blocked_cards(&rt),
+        0,
+        "the continuation redeemed the grant and did not re-park (loop-safety)"
+    );
+}
+
+/// A refused block starts no continuation — the run stays stopped, which is the
+/// correct outcome for a denial.
+#[tokio::test]
+async fn a_denied_blocked_call_starts_no_continuation() {
+    let home = seed_home();
+    let (rt, runner) = runtime(
+        home.path(),
+        vec![
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "echo hi" }),
+            },
+            Turn::Say("I was refused, so I stopped."),
+        ],
+    )
+    .await;
+
+    let run_id = cold_run(&rt).await;
+    let cards = cards_for(&rt, &run_id);
+    assert_eq!(cards.len(), 1);
+
+    resolve_and_settle(&rt, &cards[0], Verdict::Deny).await;
+
+    assert_eq!(
+        runner.started(),
+        1,
+        "a denied block starts nothing — no continuation run"
+    );
+}
+
+/// A node blocked on **two** calls owes ONE continuation, after the LAST
+/// decision — the #469 batch property, on the agent-node key. Approving the
+/// first releases nothing.
+#[tokio::test]
+async fn two_calls_on_one_node_continue_once_after_the_last_decision() {
+    let home = seed_home();
+    let (rt, runner) = runtime(
+        home.path(),
+        vec![
+            // Cold turn: two gated calls, then the model stops.
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "echo one" }),
+            },
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "echo two" }),
+            },
+            Turn::Say("Both were refused, so I stopped."),
+            // Continuation: both grants redeem, then it finishes.
+            Turn::Say("Done."),
+        ],
+    )
+    .await;
+
+    let run_id = cold_run(&rt).await;
+    let cards = cards_for(&rt, &run_id);
+    assert_eq!(cards.len(), 2, "the node parked two cards under one batch");
+    assert_eq!(runner.started(), 1);
+
+    resolve_and_settle(&rt, &cards[0], Verdict::Approve).await;
+    assert_eq!(
+        runner.started(),
+        1,
+        "the first of two decisions releases nothing"
+    );
+
+    resolve_and_settle(&rt, &cards[1], Verdict::Approve).await;
+    assert_eq!(
+        runner.started(),
+        2,
+        "the last decision releases exactly one continuation for the node"
+    );
+}
+
+/// Two runs blocked at once do not continue each other — the stash is per
+/// (run, node), so approving one run's card leaves the other's untouched and
+/// starts a continuation for the approved run only.
+#[tokio::test]
+async fn two_blocked_runs_do_not_cross_continue() {
+    let home = seed_home();
+    let (rt, runner) = runtime(
+        home.path(),
+        vec![
+            // Run A cold turn.
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "echo a" }),
+            },
+            Turn::Say("A refused."),
+            // Run B cold turn.
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "echo b" }),
+            },
+            Turn::Say("B refused."),
+            // A's continuation.
+            Turn::Say("A done."),
+        ],
+    )
+    .await;
+
+    // Sequential cold runs, so the shared script is consumed deterministically.
+    let run_a = cold_run(&rt).await;
+    let run_b = cold_run(&rt).await;
+    let cards_a = cards_for(&rt, &run_a);
+    let cards_b = cards_for(&rt, &run_b);
+    assert_eq!(cards_a.len(), 1, "run A parked its own card");
+    assert_eq!(cards_b.len(), 1, "run B parked its own card");
+    assert_eq!(runner.started(), 2, "two cold runs, no continuations yet");
+
+    resolve_and_settle(&rt, &cards_a[0], Verdict::Approve).await;
+
+    assert_eq!(
+        runner.started(),
+        3,
+        "approving A starts exactly one continuation (A's)"
+    );
+    assert_eq!(
+        cards_for(&rt, &run_b).len(),
+        1,
+        "run B's card is untouched — no cross-continuation"
+    );
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -881,7 +881,7 @@ impl HarnessAgentRunner {
     /// No differencing is needed to know which requests are "ours": the bucket
     /// is already run-scoped ([`ApprovalScope::Run`], issue #439), so everything
     /// the drain returns was queued by this run's own turn.
-    async fn park_gated_calls(&self, node_id: Option<&str>) -> ParkedCalls {
+    async fn park_gated_calls(&self, node_id: Option<&str>, node_turn: &str) -> ParkedCalls {
         let mut summary = ParkedCalls::default();
         let mut rows: Vec<crate::ports::WorkflowRunApprovalRow> = Vec::new();
         let row = |tool: Option<String>,
@@ -1002,13 +1002,18 @@ impl HarnessAgentRunner {
                     request.effect,
                     crate::runtime::journal::TaskLink::Unlinked,
                     None,
-                    // Issue #978: no run turn key, deliberately. These cards are
-                    // tool-call-shaped — `ApprovalPolicy::effect_for` stamps an
-                    // `agent` on them — so approving mints a grant and
-                    // re-dispatches the agent; it never re-dispatches the run.
-                    // Batching them under the run would owe a continuation
-                    // nothing performs.
-                    None,
+                    // Issue #899 (Stage 1): the per-(run, node) continuation turn
+                    // key. Issue #978 deliberately passed `None` here because a
+                    // tool-call-shaped card (`ApprovalPolicy::effect_for` stamps
+                    // an `agent`) only ever minted a grant on approve and nothing
+                    // re-dispatched the run — the run settled Blocked and stayed
+                    // there. Keying the node's calls as one batch is what lets the
+                    // resolve path re-dispatch the run once, when the last of them
+                    // is decided (the runner's stash carries the workflow id and
+                    // trigger input the spawn needs). The grant is still minted, so
+                    // the identical call passes on the re-run; a diverging re-run
+                    // re-asks, which Stage 2 closes.
+                    Some(node_turn.to_string()),
                 )
                 .await
             {
@@ -1118,6 +1123,17 @@ impl AgentRunner for HarnessAgentRunner {
             .and_then(Value::as_str)
             .filter(|id| !id.is_empty())
             .map(str::to_string);
+        // Issue #899 (Stage 1): the continuation turn key every gated call this
+        // node parks will share, so approving them re-dispatches the run once —
+        // the whole hole this closes. Keyed on the block's RESOLVED node id (the
+        // graph node when there is one, else the agent ref), which is exactly the
+        // id the runner's block-settle stashes under, so the two agree by
+        // construction. `park_gated_calls` arms `ContinuationQueue` with it via
+        // `park_and_journal`; the runner arms the sibling stash that carries the
+        // workflow id and trigger input the release needs.
+        let lineage_node = node_id.clone().unwrap_or_else(|| agent_ref.to_string());
+        let node_turn =
+            crate::runtime::workflow_resume::workflow_node_turn_key(&self.run_id, &lineage_node);
         tracing::debug!(
             company = %self.company,
             agent = agent_ref,
@@ -1171,7 +1187,9 @@ impl AgentRunner for HarnessAgentRunner {
             // reclassifying it as "blocked" would hide one behind an approval
             // nobody has answered.
             let parked = claim
-                .scoped(Box::pin(self.park_gated_calls(node_id.as_deref())))
+                .scoped(Box::pin(
+                    self.park_gated_calls(node_id.as_deref(), &node_turn),
+                ))
                 .await;
             // Issue #661 (M5): likewise on both arms, and for the same reason. A
             // turn that failed after calling `spawn_task` had already been told the
@@ -1286,8 +1304,9 @@ fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCall
     }
     format!(
         "workflow node '{node}' is blocked: {tools} needed approval before {agent_ref} could \
-         finish, so the node produced no deliverable and nothing after it ran. {}. Approving \
-         does not continue this run — decide the card, then run the workflow again.",
+         finish, so the node produced no deliverable and nothing after it ran. {}. Approving the \
+         card continues this run automatically; because approving re-runs the agent's turn, a \
+         changed decision may ask again.",
         what.join("; ")
     )
 }
@@ -1697,7 +1716,11 @@ mod tests {
                 }
             })
             .await;
-        claim.scoped(runner.park_gated_calls(Some("work"))).await;
+        let node_turn =
+            crate::runtime::workflow_resume::workflow_node_turn_key(&runner.run_id, "work");
+        claim
+            .scoped(runner.park_gated_calls(Some("work"), &node_turn))
+            .await;
         (notices.take(), queue)
     }
 

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -267,6 +267,14 @@ pub struct DeliveryParking {
     /// decisions are counted but whose gates are not recorded releases a batch
     /// the host cannot re-dispatch.
     pub gates: crate::runtime::workflow_gates::WorkflowGateQueue,
+    /// The workflow id and trigger input each blocked agent node needs to
+    /// re-dispatch its run (issue #899, Stage 1).
+    ///
+    /// Armed by the runner at block-settle (not here, and not in
+    /// [`park_and_journal`](DeliveryParking::park_and_journal) — the parker has
+    /// no trigger input), and released by the runtime's `continue_turn`. The same
+    /// handle both sides share, for [`gates`](Self::gates)' reason.
+    pub blocked_nodes: crate::runtime::blocked_nodes::BlockedNodeQueue,
 }
 
 impl std::fmt::Debug for WorkflowDeliveryDeps {
@@ -1735,6 +1743,7 @@ admins = [{list}]
                 // path releases.
                 continuations: Default::default(),
                 gates: Default::default(),
+                blocked_nodes: Default::default(),
             });
             self.gate = Some(gate);
             self.journal = Some(journal);
@@ -1765,6 +1774,7 @@ admins = [{list}]
                 // path releases.
                 continuations: Default::default(),
                 gates: Default::default(),
+                blocked_nodes: Default::default(),
             });
             self.gate = Some(gate);
             self.journal = Some(journal);

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -263,6 +263,7 @@ pub(super) fn deps(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc
                 // path releases.
                 continuations: Default::default(),
                 gates: Default::default(),
+                blocked_nodes: Default::default(),
             }),
             events: Arc::new(crate::store::FsEventLog::new(dir)),
         }),

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -19,6 +19,11 @@
 /// downstream agent node's turn (an `agent -> agent` pipeline passes data).
 #[cfg(test)]
 mod agent_upstream_input_test;
+/// Issue #899 (Stage 1): end-to-end proof that approving a call gated inside an
+/// agent node's own tool loop AUTO-CONTINUES the blocked run — one continuation,
+/// after the last decision, and none for a wholly refused block.
+#[cfg(test)]
+mod blocked_node_continuation_test;
 /// Issues #881 / #880: end-to-end proof that a node whose deliverable was
 /// parked for approval reports `blocked`, stops its branch instead of handing
 /// its apology downstream, and that the run says what it parked.

--- a/src/workflows/parallel_gate_fanout_test.rs
+++ b/src/workflows/parallel_gate_fanout_test.rs
@@ -255,6 +255,7 @@ async fn runtime(
         journal: rt.journal().clone(),
         continuations: rt.continuations.clone(),
         gates: rt.workflow_gates().clone(),
+        blocked_nodes: rt.blocked_nodes().clone(),
     });
 
     let pool = Arc::new(crate::harness::HarnessPool::new());

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -682,6 +682,19 @@ async fn run_workflow_inner(
             {
                 notices.push(run_output_persist_failed_notice());
             }
+            // Issue #899 (Stage 1): this is the block-settle arm the DEFAULT
+            // `on_error = "stop"` takes — a blocked agent node reaches here as an
+            // `Err` the containment check reclassifies. Stash each blocked node's
+            // continuation facts so approving its parked calls re-dispatches the
+            // run. (The `on_error = "continue"/"route"` case settles on the main
+            // arm below, which arms the same stash there.)
+            stash_blocked_agent_nodes(
+                delivery.as_ref(),
+                &workflow.id,
+                &run_id,
+                &trigger_input,
+                &blocked,
+            );
             return Ok(blocked_run(BlockedRun {
                 nodes,
                 blocked,
@@ -933,6 +946,17 @@ async fn run_workflow_inner(
     let mut pending_approvals = outcome.pending_approvals;
     let blocked_nodes = blocks.take();
     reclassify_blocked(&mut nodes, &mut pending_approvals, &blocked_nodes);
+    // Issue #899 (Stage 1): stash the workflow id and trigger input each blocked
+    // agent node's continuation needs, keyed by the same per-(run, node) turn key
+    // its parked calls armed `ContinuationQueue` under. The resolve path releases
+    // both together and re-dispatches the run once the last call is decided.
+    stash_blocked_agent_nodes(
+        delivery.as_ref(),
+        &workflow.id,
+        &run_id,
+        &trigger_input,
+        &blocked_nodes,
+    );
     // Issue #900: `blocked_run` (the halt arm) tells the operator what blocked
     // via a `notices` sentence, not only via the node's own status — the
     // per-node chip is easy to miss on a run that otherwise looks fine, and a
@@ -1112,7 +1136,9 @@ pub(super) fn blocked_notice(blocked: &crate::ports::WorkflowBlockedNode) -> Str
     let mut tail = String::new();
     if parked > 0 {
         tail.push_str(&format!(
-            " It parked {parked} approval{}; decide {} in Approvals and run the workflow again.",
+            " It parked {parked} approval{}; approve {} in Approvals and this run continues on \
+             its own. Approving re-runs the step, so if the agent's next turn differs it may ask \
+             again.",
             if parked == 1 { "" } else { "s" },
             if parked == 1 { "it" } else { "them" }
         ));
@@ -1272,6 +1298,40 @@ struct PausedGates<'a> {
 /// continuation an approval starts knows what has already left the process.
 /// Without it, approving a gate re-mails every report upstream of it — the
 /// re-run semantics above applied to a side effect that reaches a real person.
+/// Stashes the facts each blocked agent node's continuation needs — the workflow
+/// id and this run's trigger input — keyed by the per-(run, node) turn key its
+/// gated calls armed `ContinuationQueue` under at park time (issue #899, Stage 1).
+///
+/// # Why here, and not where the calls are parked
+///
+/// The calls are parked mid-turn from `HarnessAgentRunner`, which carries no
+/// trigger input. This is the one place with the workflow id, the trigger input
+/// and the list of blocked nodes together — exactly as `park_pending_gates` is
+/// the one place a gate's facts come together. A node with no parked approval id
+/// is skipped: nothing can be decided, so nothing will ever release a stash.
+///
+/// A build with no approvals queue wired stashes nothing and is silent — the
+/// same node already logged its own "could not be parked" line, and there is no
+/// resolve path to release a stash to.
+fn stash_blocked_agent_nodes(
+    delivery: Option<&super::delivery::WorkflowDeliveryDeps>,
+    workflow_id: &str,
+    run_id: &str,
+    trigger_input: &serde_json::Value,
+    blocked: &[crate::ports::WorkflowBlockedNode],
+) {
+    let Some(parking) = delivery.and_then(|delivery| delivery.parking.as_ref()) else {
+        return;
+    };
+    for node in blocked {
+        if node.approval_ids.is_empty() {
+            continue;
+        }
+        let turn = crate::runtime::workflow_resume::workflow_node_turn_key(run_id, &node.node_id);
+        parking.blocked_nodes.arm(&turn, workflow_id, trigger_input);
+    }
+}
+
 async fn park_pending_gates(
     delivery: Option<&super::delivery::WorkflowDeliveryDeps>,
     record: &CompanyRecord,
@@ -3455,6 +3515,7 @@ to = "done"
                 // path releases.
                 continuations: Default::default(),
                 gates: Default::default(),
+                blocked_nodes: Default::default(),
             }),
             events: Arc::new(crate::store::FsEventLog::new(dir)),
         });
@@ -3754,6 +3815,7 @@ to = "gate"
                 // path releases.
                 continuations: Default::default(),
                 gates: Default::default(),
+                blocked_nodes: Default::default(),
             }),
             events: Arc::new(crate::store::FsEventLog::new(dir)),
         });


### PR DESCRIPTION
## Summary

When a workflow **agent node**'s internal, policy-gated tool call was parked for approval, approving it minted the grant but **nothing re-dispatched the run** — the run had already settled `Blocked`, and the operator's only move was a manual re-run, which re-chose tools from scratch rather than continuing the approved call. This is the agent-node sibling of #846's `tool_call`-node replay, and the missing continuation behind #881's honest "blocked" reporting.

**Stage 1** makes approving **auto-continue the run**. The parked thing is a normal tool-call approval (`agent: Some`), not a `WORKFLOW_APPROVE_KIND`, so it never reached the gate-node resume path. Rather than force it there, Stage 1 routes through the **existing `continue_turn` / `ContinuationQueue` fork** (the same mechanism gate runs use):

- `park_gated_calls` stamps a `workflow-node:{run_id}:{node_id}` turn key on the parked approval (durable, restart-rearmed).
- the runner stashes `{workflow_id, trigger_input}` in a new `BlockedNodeQueue` at block-settle (the runner is the only place with the trigger input); the queue lives beside the gate queue in `DeliveryParking` and is inherited across handover.
- `continue_turn` spawns **exactly one** continuation run when that key's decision batch carries an approval; a wholly denied/expired batch spawns nothing.

**Loop-safety already holds** without a new ledger: the agent node's `ApprovalRequestQueue` shares the runtime `GrantSet`, so when the continuation re-run re-issues the *identical* call the minted grant is consumed and it passes — no re-park. Only a **diverging** re-run (different args / extra call) re-parks, which is a genuine new human decision, not a loop. The blocked-node copy (backend + 4 console spots) is reworded to say approving continues the run, with the honest caveat that a diverging re-run may re-ask.

### Deviation from the filed plan (worth a look)

The plan's routing seam (an arm in `perform_effect`) is **unreachable** for these effects: an approved `agent: Some` effect forks at `settle_approved_effect` into `mint_grant` and never reaches `perform_effect`. The `continue_turn`/`ContinuationQueue` seam above is the corrected route — it stays entirely in Stage-1 scope (no vendored change), and inherits last-decision batching, deny/expire handling, concurrency-safety and restart-rearm from the existing queue.

## API Or Behavior Changes

- Approving (the last undecided) parked approval on a blocked agent node now **spawns a continuation run** automatically; before, it did nothing and required a manual re-run. Denied/expired decisions spawn nothing.
- New `BlockedNodeQueue` on `DeliveryParking`, inherited via `RuntimeHandover` (restart-durable). No wire/schema change.
- Console copy: the "approving does not continue this run" text (4 spots) now states the opposite, matching the new behavior.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` **and** `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — `blocked_node_continuation_test` (4), `workflows::caps` (85), `workflows::runner` (57), `gated_tool_turn_test` (4), `parallel_gate_fanout_test` (9), `runtime::workflow_resume` (33), `runtime::blocked_nodes` (4), `company::runtime` (19) — 0 failed
- [x] frontend `npm run typecheck` + `npm run build`

Red-first (`blocked_node_continuation_test`): a blocked agent node whose parked approval is granted spawns one continuation run for its lineage — fails on main (nothing re-dispatched), passes now. Negatives: first run arms none; denied/expired spawns none; several parked calls continue once after the last decision; overlapping blocked runs don't cross-continue.

## Documentation

Behavior + the continue_turn-vs-perform_effect routing are documented in-code on the new queue, the park/stash sites, and the `continue_turn` fork.

## Related — follow-ups (out of scope here)

- **Stage 2** — grant capture + consume for a guaranteed at-most-once replay of the *exact* approved call. Not needed for Stage-1 correctness (the shared-`GrantSet` consume already makes auto-continue work); closes the diverging-re-run re-ask.
- **OPT-1a** — an upstream openhuman-harness grant-ledger consulted by `ApprovalPolicy` (cross-repo, `vendor/openhuman`). The only path that fully closes the re-run non-determinism gap; its strongest form also needs tinyflows agent-node checkpointing.

Note: `src/workflows/runner.rs` block-settle here is adjacent to PR #1041's failure-arm persist region — this branch cut from `main` and will rebase cleanly onto #1041.

Closes #899
