### PR TITLE
fix(policy): declare the six hosting tools instead of guessing at them

### DIFF
--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -282,6 +282,22 @@ const TOOL_LABELS: Readonly<Record<string, string>> = {
   // count is the whole difference between it and `edit` above.
   apply_patch: "Edit several files in its workspace at once",
   csv_export: "Save data as a spreadsheet file in its workspace",
+  // Hosting (issue #1079). Only the three that park need words here; the three
+  // read tools are `Reach::Nothing` and never reach an approval card.
+  //
+  // Each label names the thing an operator is actually consenting to, because
+  // these are the cards where a vague one costs the most: two of them change
+  // what the public sees at an address, and the third can write secrets at a
+  // third-party provider. "Use one of its tools" over a live deployment is the
+  // failure this issue is about.
+  hosting_launch_site: "Deploy a site to the public internet",
+  // "point at" rather than "add": the domain already exists and belongs to
+  // somebody — what this call does is aim it at a site.
+  hosting_add_domain: "Point a domain at one of its sites",
+  // Deliberately not worded as a deployment. The tool requires a redeploy
+  // afterwards for a build-time variable to take effect, so a label promising
+  // one would be describing an act that has not happened.
+  hosting_set_env: "Set environment variables on one of its sites",
   // `mcp_registry_tool_call` is deliberately absent: EFFECT_LABELS already
   // names it and is consulted first, so an entry here would be unreachable.
 };

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -735,6 +735,66 @@ const DECLARED: &[Declared] = &[
     // whenever" is exactly the grant the `Standing` field refuses to describe,
     // and every push already parks as its own approval regardless.
     d("repo_publish", EffectGroup::Publish, Reach::Nothing),
+    // ---- Hosting (issue #1079) ---------------------------------------------
+    //
+    // The six `hosting_*` tools openhuman ships in `src/openhuman/hosting/`.
+    // Declared here rather than left to `undeclared()`, which is what that
+    // fallback's own doc asks for: it is "a courtesy for an unregistered read,
+    // not a second classifier to trust with an unreviewed capability".
+    //
+    // **Why the fallback gets these wrong, and why it is not being taught to
+    // get them right.** `undeclared()` decides "is this a read?" with
+    // `READ_ONLY_PREFIXES` matched by `name.starts_with(p)`. Every name here
+    // begins with `hosting_`, so `list`/`get`/`read` can never match — the
+    // prefix test cannot see past the namespace, and all six come back
+    // `Consequence`. Widening that test to look inside a namespace is the
+    // tempting general fix and is the wrong one: the fallback runs ONLY for
+    // tools no belt registered (a registered one is caught by
+    // `every_registered_tool_is_declared`), so making it cleverer extends trust
+    // to exactly the population that has had no review. It would also trade a
+    // fail-CLOSED miss — a read that parks, which costs an approval — for a
+    // fail-OPEN one, an effect that reads as a read. Declaring is the fix the
+    // file already prescribes.
+    //
+    // Three reads, per openhuman's own `hosting/README.md`, which labels each
+    // of them "Read-only.". They ask the provider what exists and what it did;
+    // nothing leaves this company and nothing is spent.
+    d(
+        "hosting_deployment_status",
+        EffectGroup::Other,
+        Reach::Nothing,
+    ),
+    d("hosting_list_sites", EffectGroup::Other, Reach::Nothing),
+    d("hosting_analytics", EffectGroup::Other, Reach::Nothing),
+    // The public deployment itself: it spends money and changes what the world
+    // sees at an address. `Publish` is the label an operator's card needs, and
+    // the fallback gave it `Other` — its name contains no `deploy`, `publish` or
+    // `post`, while the *status read* contains `deploy` and was labelled
+    // `Publish`. The two were inverted, which is worse than both being vague.
+    d(
+        "hosting_launch_site",
+        EffectGroup::Publish,
+        Reach::Consequence,
+    ),
+    // Attaching a domain is the other half of "what the world sees at an
+    // address", so it carries the same label as the launch it points at.
+    d(
+        "hosting_add_domain",
+        EffectGroup::Publish,
+        Reach::Consequence,
+    ),
+    // `hosting_set_env` is the one the issue left open, and the tool's own
+    // description settles it: "The site must be redeployed afterwards for a
+    // build-time variable to take effect." It changes what the NEXT deployment
+    // serves; it does not itself deploy. `Publish` would tell an operator a
+    // deployment is happening when none is, which is the same misdescription
+    // this change exists to remove — so `Other`, and `Consequence` because it
+    // still writes provider state and can store secrets write-only there.
+    d("hosting_set_env", EffectGroup::Other, Reach::Consequence),
+    // NOTE: a `hosting_rollback` tool is in flight (issue #913). It will need a
+    // row here too — it is an outward effect on a live site, so `Publish` /
+    // `Consequence` is the shape to start from, but it is left to that change to
+    // declare rather than guessed at now.
 ];
 
 /// A per-call declaration — the default. `const fn` so [`DECLARED`] stays a
@@ -1656,6 +1716,130 @@ mod tests {
 
     fn c(tool: &str) -> Consequence {
         consequence_of(tool, &json!({}))
+    }
+
+    // ── hosting (issue #1079) ───────────────────────────────────────────────
+
+    /// The three tools openhuman's `hosting/README.md` labels "Read-only." ask
+    /// the provider what exists and what it did. Asking whether a build
+    /// finished must not cost an operator an approval.
+    #[test]
+    fn a_hosting_read_does_not_park() {
+        for tool in [
+            "hosting_deployment_status",
+            "hosting_list_sites",
+            "hosting_analytics",
+        ] {
+            let consequence = c(tool);
+            assert_eq!(
+                consequence.reach,
+                Reach::Nothing,
+                "`{tool}` only reads the provider"
+            );
+            assert!(
+                !consequence.parks_under_auto(),
+                "`{tool}` must not interrupt anybody"
+            );
+        }
+    }
+
+    /// The outward effects still park. Without this the downgrade above would
+    /// pass against a table that stopped gating the whole namespace.
+    #[test]
+    fn a_hosting_effect_still_parks() {
+        for tool in [
+            "hosting_launch_site",
+            "hosting_add_domain",
+            "hosting_set_env",
+        ] {
+            let consequence = c(tool);
+            assert_eq!(
+                consequence.reach,
+                Reach::Consequence,
+                "`{tool}` changes provider state"
+            );
+            assert!(
+                consequence.parks_under_auto(),
+                "`{tool}` must still park under auto"
+            );
+        }
+    }
+
+    /// **The label inversion this fixes.** Before declaring these, the fallback's
+    /// `undeclared_group` matched on substrings: `hosting_launch_site` — the
+    /// actual public deployment — contains no `deploy`/`publish`/`post` and fell
+    /// through to `Other`, while `hosting_deployment_status` — a read — contains
+    /// `deploy` and came back `Publish`. The operator's card described the
+    /// risky call as nothing in particular and the harmless one as a publish.
+    #[test]
+    fn the_deployment_is_labelled_publish_and_the_status_read_is_not() {
+        assert_eq!(c("hosting_launch_site").group, EffectGroup::Publish);
+        assert_eq!(c("hosting_add_domain").group, EffectGroup::Publish);
+        assert_ne!(
+            c("hosting_deployment_status").group,
+            EffectGroup::Publish,
+            "a status read must not announce itself as a deployment"
+        );
+    }
+
+    /// `hosting_set_env` is `Other`, not `Publish`, and the tool's own
+    /// description is why: "The site must be redeployed afterwards for a
+    /// build-time variable to take effect." It changes what the NEXT deployment
+    /// serves and does not itself deploy, so a `Publish` card would tell an
+    /// operator a deployment is happening when none is.
+    #[test]
+    fn setting_env_is_not_labelled_as_a_deployment() {
+        let consequence = c("hosting_set_env");
+        assert_eq!(consequence.group, EffectGroup::Other);
+        assert_eq!(consequence.reach, Reach::Consequence);
+    }
+
+    /// Every hosting tool answers from the table, not from `undeclared()`.
+    ///
+    /// This is the regression guard for the mechanism itself: the fallback's
+    /// `READ_ONLY_PREFIXES` are matched with `name.starts_with`, so a
+    /// `hosting_`-prefixed read can never match one and the fallback cannot
+    /// classify any of these correctly. If a row is dropped, the tool silently
+    /// returns to that fallback rather than erroring — so the coverage is
+    /// asserted directly.
+    #[test]
+    fn every_hosting_tool_is_declared() {
+        let declared: std::collections::BTreeSet<&str> = declared_tools().collect();
+        for tool in [
+            "hosting_deployment_status",
+            "hosting_list_sites",
+            "hosting_analytics",
+            "hosting_launch_site",
+            "hosting_add_domain",
+            "hosting_set_env",
+        ] {
+            assert!(
+                declared.contains(tool),
+                "`{tool}` fell back to `undeclared()`, where the `hosting_` prefix \
+                 defeats the read test — declare it in DECLARED"
+            );
+        }
+    }
+
+    /// The mechanism, pinned on a name that is *not* declared: a namespaced read
+    /// still cannot be seen by the prefix test.
+    ///
+    /// Kept as documentation of why declaring is the fix rather than teaching
+    /// the fallback to split on `_`. Widening that test would extend trust to
+    /// tools no belt registered and no reviewer saw, and would turn a
+    /// fail-closed miss into a fail-open one.
+    #[test]
+    fn the_fallback_cannot_see_a_read_verb_behind_a_namespace() {
+        assert_eq!(
+            c("hosting_list_something_undeclared").reach,
+            Reach::Consequence,
+            "an undeclared namespaced read gates — inconvenient, and the safe direction"
+        );
+        assert_eq!(
+            c("list_something_undeclared").reach,
+            Reach::Nothing,
+            "the same verb at the front is seen, which is what makes the namespace the problem"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#1079.

None of the six `hosting_*` tools was in `DECLARED`, so every one fell through to `undeclared()`.

## The mechanism

`undeclared()` decides "is this a read?" with `READ_ONLY_PREFIXES` matched by
**`name.starts_with(p)`**. Every name here begins with `hosting_`, so `list`, `get` and `read` **can
never match — the prefix test cannot see past the namespace.** Three tools openhuman's own
`hosting/README.md` labels *"Read-only."* parked for approval.

`undeclared_group()` matches **substrings**, and the two labels came out inverted:

| Tool | What it is | Fallback said |
| --- | --- | --- |
| `hosting_launch_site` | the public deployment — spends money, changes what the world sees | `Other` (no `deploy`/`publish`/`post` in the name) |
| `hosting_deployment_status` | a read | `Publish` (contains `deploy`) |

**This fails closed and is not a security hole** — everything gated. The cost is the other direction: a
live deployment described to the operator as nothing in particular, and a status check announcing
itself as a publish.

## The judgement: declare the six, do **not** widen the prefix test

Declaring six fixes today; a namespace-aware read test would fix the class. I argue for declaring, and
for leaving the prefix test exactly as it is.

**The class is already fixed — by a completeness guard, not by a classifier.**
`every_registered_tool_is_declared` (`harness/mod.rs`) walks the live belt and hard-fails on any
registered tool missing from `DECLARED`, telling the author to add it. So `undeclared()` runs **only**
for tools no belt registered — a population that has had no review by definition.

Teaching that fallback to look inside a namespace would therefore:

1. **Extend trust to exactly the unreviewed population** the fallback's own doc refuses it to — *"a
   courtesy for an unregistered read, not a second classifier to trust with an unreviewed
   capability."*
2. **Trade a fail-CLOSED miss for a fail-OPEN one.** Today's bug costs an approval on a read. A
   too-generous namespace test would classify an *effect* as a read — and any rule loose enough to
   see `hosting_list_sites` also sees a hypothetical `hosting_get_or_reset_key`.

`the_fallback_cannot_see_a_read_verb_behind_a_namespace` pins the mechanism on an *undeclared* name, so
the reason declaring is the fix stays documented in a test rather than only in prose.

## `hosting_set_env` — the open question in the issue

`Other`, not `Publish`, and the tool's own description settles it:

> "Set environment variables on a site, replacing any of the same name. **The site must be redeployed
> afterwards for a build-time variable to take effect.**"

It changes what the *next* deployment serves; it does not itself deploy. A `Publish` card would tell an
operator a deployment is happening when none is — the same misdescription this change removes.
`Consequence` because it still writes provider state and can store secrets write-only there.

## Console labels

The three gated tools also gain `TOOL_LABELS` entries in `frontend/src/lib/language.ts`. Not scope
creep — `every_consequence_tool_has_a_console_label` failed without them, and its point is exactly
this issue's: an approval card for a live deployment that reads *"Use one of its tools"* is the
operator being told nothing.

## Coordination

⚠️ **A `hosting_rollback` tool is in flight (issue #913) and will need a seventh row.** It is an
outward effect on a live site, so `Publish` / `Consequence` is the shape to start from — left to that
change to declare rather than guessed at here. A `NOTE:` in the table says so, so the next person adds
it rather than rediscovering the gap.

Also note #754 (catalogue-miss observability) touches this file; this change adds rows at the end of
`DECLARED` and one block of tests, so the two should not overlap.

## Reachability — read before assuming an operator is paying for this today

`UNVERIFIED` in the issue, and worth stating: **the six tool names appear nowhere in opencompany's
`src`.** The belt is explicitly enumerated (`shell_tools`, `code_tools`, `web_tools`, `media_tools`,
`subagent_tools`) with no generic pull of openhuman's registry, and `namespace_of` has no `hosting`
arm — so these tools are not wired onto an opencompany agent and cannot reach `consequence_of` today.
That is also why `every_registered_tool_is_declared` did not catch them.

So the issue's *mechanism* is exactly right, but its stated impact — "an operator pays an approval to
ask whether a build finished" — **is not observable in opencompany today**, and the acceptance
criterion phrased that way cannot be checked. What this PR buys is that the answers are correct and
reviewed **before** the tools are wired, which #913 is about to start doing.

## API Or Behavior Changes

Six new `DECLARED` rows and three `TOOL_LABELS` entries. No behaviour changes for any tool reachable
today; when the hosting tools are wired, reads will not park and effects will carry accurate groups.

## Tests

- [x] `cargo fmt --all -- --check` — clean, verified against the commit.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
      exit 0.
- [x] `cargo build --all-targets` — covered by the gated lane below.
- [x] `cargo test` — gated lane: `RUST_MIN_STACK=16777216 cargo test --locked --features
      openhuman,tinycortex --tests` → **4376 passed / 0 failed**. `RUST_MIN_STACK` matches `ci.yml:626`.
      `N/A` for a separate default-features run: this change is in a file compiled in every build and
      the gated lane is the superset; the frontend label map is covered by the Rust invariant that
      reads it.

Rebased onto `02743fda` for the `planning_attempts` break on `main`; this branch constructs no
`TaskRecord`, so the rebase alone cleared it.

### Revert proof — two

| Reverted | Result |
| --- | --- |
| the three read rows | **3 FAILED** — `a_hosting_read_does_not_park`, `every_hosting_tool_is_declared`, `the_deployment_is_labelled_publish_and_the_status_read_is_not` |
| re-inverted the labels (`launch_site` → `Other`, `set_env` → `Publish`) | **2 FAILED** — `setting_env_is_not_labelled_as_a_deployment`, `the_deployment_is_labelled_publish_and_the_status_read_is_not` |

The second reverts to the plausible-but-wrong call the issue left open, rather than to nonsense.

`a_hosting_effect_still_parks` and `the_fallback_cannot_see_a_read_verb_behind_a_namespace` survive
both — they guard against over-firing and document the mechanism, and I am not counting them as
coverage for the fix.

## Documentation

`N/A` — no module doc describes the consequence table; the reasoning lives in `DECLARED`'s own
comments, which is where this file already keeps it.
