### PR TITLE
feat(workflows): render board rows in the run drawer (#1014 PR-A)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -262,6 +262,12 @@ export interface WorkflowRunResult {
    * never a count of what is still outstanding.
    */
   approvals?: WorkflowRunApprovalRow[];
+  /**
+   * The board writes this run's agent nodes performed (issue #661 / M5) — the
+   * cards it opened or re-owned. Absent when it touched no card, which is
+   * nearly every run. Rendered by the run drawer since issue #1014.
+   */
+  board?: WorkflowRunBoardRow[];
 }
 
 /**
@@ -376,6 +382,52 @@ export interface WorkflowRunApprovalRow {
 }
 
 /**
+ * What a run's node did to the task board, as a closed set (issue #661 / M5).
+ *
+ * The two spawn arms opened (or tried to open) a card; the two assign arms set
+ * (or tried to set) an owner. The `*Failed` arms are NOT run failures — they
+ * record that the store refused a write the node's turn was already told would
+ * happen, the same honesty {@link DeliveryStatus} `failed` gives a report that
+ * did not send. Mirrors the Rust `WorkflowBoardAction` camelCase serde.
+ */
+export type WorkflowBoardAction =
+  | "spawned"
+  | "assigned"
+  | "spawnFailed"
+  | "assignFailed";
+
+/**
+ * One board write a run's agent node performed (issue #661 / M5) — "this run
+ * opened card X", the half the run drawer never rendered (issue #1014).
+ *
+ * Structural only: the action, the ids involved, nothing a model wrote. The
+ * same shape rides all three surfaces — the synchronous run response, the run
+ * history, and the `WorkflowRunFinished` event — so a console reads a run's
+ * board effects identically wherever it finds them. Mirrors the Rust
+ * `WorkflowRunBoardRow` camelCase serde.
+ */
+export interface WorkflowRunBoardRow {
+  /** What was attempted, and whether it landed. */
+  action: WorkflowBoardAction;
+  /**
+   * The card the row is about, so a console can link straight to it. Absent on
+   * a `spawnFailed` row — no card was written, so there is no id to point at.
+   */
+  taskId?: string;
+  /**
+   * The title the node asked for, on the two spawn arms — including
+   * `spawnFailed`, where it is the only thing that explains the failure. Absent
+   * on the assign arms, which name a card by id and carry no title.
+   */
+  title?: string;
+  /**
+   * The owner the node asked for, as it wrote it — the requested name rather
+   * than a resolved roster id. `None` when the node named nobody.
+   */
+  assignee?: string;
+}
+
+/**
  * One finished workflow run, read back from the company's journal (issue #228).
  *
  * Before this, a run's outcome existed only in the moment: a manual run's
@@ -479,6 +531,12 @@ export interface WorkflowRunOutcome {
    * A receipt of what the run opened, never a count of what is outstanding.
    */
   approvals?: WorkflowRunApprovalRow[];
+  /**
+   * The board writes this run's agent nodes performed (issue #661 / M5) — the
+   * same rows a manual run's response carries, durable in the history. Absent
+   * on a run that touched no card.
+   */
+  board?: WorkflowRunBoardRow[];
 }
 
 export function listWorkflows(

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -4,6 +4,7 @@
 //
 // Extracted verbatim from `WorkflowsView.tsx` (issue #303).
 
+import { SquareKanban } from "lucide-react";
 import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -11,6 +12,7 @@ import remarkGfm from "remark-gfm";
 import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
 import type {
   WorkflowGraph,
+  WorkflowRunBoardRow,
   WorkflowRunNode,
   WorkflowRunResult,
 } from "@/api/workflows";
@@ -134,6 +136,9 @@ export function RunResultPanel({
   // cannot disagree about whether this run stopped for a person.
   const blockedNodes = result.blockedNodes ?? [];
   const parkedCount = result.approvals?.length ?? 0;
+  // Issue #1014: the board writes this run performed — shipped on the wire
+  // since #661 but never rendered, so "this run opened card X" was invisible.
+  const board = result.board ?? [];
   // Issue #1002. Derived from the LIVE queue, never from `result.approvals` —
   // that is a receipt of what this run opened (#880) and nothing ever comes back
   // to flip a row on it, so a panel grounded there would go on calling a step
@@ -272,6 +277,11 @@ export function RunResultPanel({
 
         {deliveries.length > 0 && <DeliveryRows deliveries={deliveries} />}
 
+        {/* Issue #1014: the cards this run opened or re-owned. Shipped on the
+            wire since #661, but the drawer never rendered them — so a run that
+            opened a card in To-do read as if it touched nothing. */}
+        {board.length > 0 && <BoardRows board={board} />}
+
         {/* Issue #542: the per-node timeline, carried on every synchronous run's
             body. It is most load-bearing for a dry run, which journals nothing —
             this is the only place a test run's step-by-step trail appears, since
@@ -305,6 +315,93 @@ export function RunResultPanel({
           </pre>
         </details>
       </div>
+    </div>
+  );
+}
+
+/** The label and badge tone for one board action. The two `*Failed` arms get a
+ * failed hue — a write the node was told would happen and did not — while the
+ * two success arms stay neutral, since the card itself is the loud thing. */
+const BOARD_ACTION: Record<
+  WorkflowRunBoardRow["action"],
+  { label: string; tone: string; failed: boolean }
+> = {
+  spawned: { label: "Opened", tone: "border-border bg-muted/60", failed: false },
+  assigned: { label: "Assigned", tone: "border-border bg-muted/60", failed: false },
+  spawnFailed: {
+    label: "Open failed",
+    tone: "border-status-failed/40 bg-status-failed-soft",
+    failed: true,
+  },
+  assignFailed: {
+    label: "Assign failed",
+    tone: "border-status-failed/40 bg-status-failed-soft",
+    failed: true,
+  },
+};
+
+/**
+ * The board writes a run performed (issue #1014) — one row per card it opened
+ * or re-owned, shipped on the wire since #661 but never rendered until now.
+ *
+ * A row with a `taskId` links straight to its card through the same
+ * `#/tasks/:id` hash route the Approvals footer and the whole console use. A
+ * `spawnFailed` row has no card to point at — no write landed — so it renders
+ * the attempted title as plain text, which is the only thing that explains the
+ * failure.
+ */
+function BoardRows({ board }: { board: WorkflowRunBoardRow[] }) {
+  const failed = board.filter((r) => BOARD_ACTION[r.action].failed).length;
+  return (
+    <div
+      className="mb-3 space-y-1.5 rounded-lg border bg-background/40 p-2"
+      data-testid="workflow-run-board"
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium">Board</span>
+        {failed > 0 && (
+          <Badge
+            variant="outline"
+            className="h-4 px-1.5 text-3xs font-normal border-status-failed/40 bg-status-failed-soft"
+          >
+            {failed} not written
+          </Badge>
+        )}
+      </div>
+      {board.map((row, i) => {
+        const meta = BOARD_ACTION[row.action];
+        // The card link — every arm but `spawnFailed` names a card by id.
+        const label = row.title ?? "the card";
+        return (
+          <div
+            key={`${row.action}-${row.taskId ?? ""}-${i}`}
+            className="flex flex-wrap items-baseline gap-1.5"
+          >
+            <Badge
+              variant="outline"
+              className={`h-4 px-1.5 text-3xs font-normal ${meta.tone}`}
+            >
+              {meta.label}
+            </Badge>
+            {row.taskId ? (
+              <a
+                href={`#/tasks/${encodeURIComponent(row.taskId)}`}
+                className="flex w-fit items-center gap-1 text-2xs font-medium text-accent-foreground underline-offset-2 hover:underline"
+              >
+                <SquareKanban className="size-3 shrink-0" />
+                {label}
+              </a>
+            ) : (
+              <span className="text-2xs">{label}</span>
+            )}
+            {row.assignee && (
+              <span className="text-2xs text-muted-foreground">
+                → {row.assignee}
+              </span>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/test/unit/workflow-run-board.test.ts
+++ b/frontend/test/unit/workflow-run-board.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { WorkflowRunResult } from "@/api/workflows";
+import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+
+/**
+ * The board block on the run drawer (issue #1014 PR-A).
+ *
+ * A run's `board` rows are shipped on the wire — on the synchronous run
+ * response and on every history row — but the drawer never rendered them, so
+ * "this run opened card X" was invisible. This suite is the one exception the
+ * unit runner earns the same way `provider-detail-render` does: the thing under
+ * test IS what reaches the operator's eye, and a spawned card's link to its
+ * board card cannot be asserted anywhere but a render.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderPanel(result: WorkflowRunResult): void {
+  act(() => {
+    root.render(
+      createElement(RunResultPanel, {
+        result,
+        graph: null,
+        request: "",
+        onClose: () => {},
+      }),
+    );
+  });
+}
+
+const BASE: WorkflowRunResult = {
+  output: {},
+  pendingApprovals: [],
+};
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("run drawer — board rows", () => {
+  it("renders a spawned row and links its taskId to the card", () => {
+    renderPanel({
+      ...BASE,
+      board: [{ action: "spawned", taskId: "t_1", title: "Draft" }],
+    });
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Draft");
+    // The card link is the canonical hash route the whole console uses.
+    const link = document.querySelector('a[href="#/tasks/t_1"]');
+    expect(link).not.toBeNull();
+    expect(link?.textContent ?? "").toContain("Draft");
+  });
+
+  it("renders a spawnFailed row's attempted title with no card link", () => {
+    renderPanel({
+      ...BASE,
+      board: [{ action: "spawnFailed", title: "Broken Draft" }],
+    });
+    const text = document.body.textContent ?? "";
+    // The attempted title is the only thing that explains the failure — a
+    // spawnFailed row carries no taskId, so there is no card to point at.
+    expect(text).toContain("Broken Draft");
+    expect(document.querySelector('a[href^="#/tasks/"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The run drawer already receives `board: WorkflowRunBoardRow[]` on both the synchronous run response and every history row — the backend computes and serialises it — but the console declared no `board` field and rendered nothing. "This run opened card X" was invisible to the operator.

This is **PR-A of #1014** (board rows only): declare the wire shape and render a Board block in the run drawer, each `taskId` linking to the card. Backend was already done; this is frontend-only.

Wire shape confirmed against the Rust source (`src/ports/workflow_runner.rs`): `WorkflowBoardAction` (`#[serde(rename_all="camelCase")]`) = `spawned | assigned | spawnFailed | assignFailed`; `WorkflowRunBoardRow { action, taskId?, title?, assignee? }`. A `spawnFailed`/`assignFailed` row carries no `taskId` — rendered as the attempted title with no link and a failed-hue badge.

## API Or Behavior Changes

- Console only. The run drawer now shows a Board block listing the cards a run opened/assigned, each spawned/assigned row linking to its task via the canonical `#/tasks/<id>` route. No wire/schema change (the fields were already serialised).

## Tests

- [x] `npm run typecheck` + `typecheck:unit` + `typecheck:e2e`
- [x] `npm run build`
- [x] `npx vitest run` — 1033 tests (105 files), incl. the new `workflow-run-board.test.ts`
- [x] `cargo fmt --all -- --check` (no Rust changed)

Red-first: a `WorkflowRunResult` fixture with a board row renders the Board block and links the `taskId`; a `spawnFailed` row shows the attempted title with no link. Both failed on pre-fix code (board block absent), pass now.

## Documentation

No doc pages — the board render is self-evident in the drawer; the wire fields are documented on the Rust structs.

## Related

Part of #1014. The other two parts are filed as follow-ups, both sequenced after #899 (PR #1085) merges because they land in its files:
- **PR-B** — list the gated tool names per blocked node and link each `approvalId` (backend reverse-link already merged via #880/#900; #1002's inline approvals already shipped via #1003 — render-only).
- **PR-C** — per-step diagnostics (paths only) under the node chip.

Closes part of #1014 (board rows). #1014 stays open until PR-B/PR-C land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow run results now show task-board activity, including opened cards, assignments, and failed actions.
  * Linked board entries can be opened directly to view the associated task.
  * Failed actions display clear status indicators and relevant task details.

* **Tests**
  * Added coverage for successful task creation and failed task-board actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->