### PR TITLE
fix(workflows): surface silent disarm, purge stale pause on delete, 4xx an unparseable graph (#1017)

### DIFF
--- a/frontend/src/lib/workflow-saved-toast.ts
+++ b/frontend/src/lib/workflow-saved-toast.ts
@@ -1,0 +1,31 @@
+/**
+ * Which acknowledgement an edit-save of a workflow should raise (issue #1017).
+ *
+ * A save can silently *disarm* a workflow: adding or changing a schedule makes
+ * the host return the graph with `enabled: false`, and the plain "Workflow
+ * saved." toast never told the operator their workflow will no longer run on its
+ * schedule. This pure reducer names the one transition that earns the paused,
+ * Resume-carrying toast — armed → disarmed — so the branch is unit-testable
+ * without rendering `WorkflowsView`. The view maps the result to the toast; the
+ * decision lives here.
+ */
+export type WorkflowSavedToast = "saved" | "disarmed";
+
+/**
+ * Classifies an edit-save from the `enabled` state before the save and the
+ * state the host returned.
+ *
+ * Only an *explicit* `false` is off (mirrors `WorkflowSummary.enabled`), so an
+ * `undefined` prev counts as armed. A workflow that was armed and comes back
+ * disarmed is the schedule-edit path that pauses it — that, and only that, is
+ * `"disarmed"`. Every other save (unchanged, re-armed, or a re-save of an
+ * already-paused workflow) is a plain `"saved"`, because nothing the operator
+ * needs to act on just changed.
+ */
+export function workflowSavedToast(
+  prevEnabled: boolean | undefined,
+  savedEnabled: boolean | undefined,
+): WorkflowSavedToast {
+  const justDisarmed = prevEnabled !== false && savedEnabled === false;
+  return justDisarmed ? "disarmed" : "saved";
+}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -82,6 +82,7 @@ import type { DecidedApproval } from "@/views/chat/model";
 import { cn } from "@/lib/utils";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import type { NodeRunState } from "@/lib/workflow-sample";
+import { workflowSavedToast } from "@/lib/workflow-saved-toast";
 // Issue #303: the canvas arithmetic, the run-state folds and the three drawers
 // moved out when this file passed 1800 lines and was about to grow an index and
 // a copilot. See `workflows/graph.ts` for why the fold is pure.
@@ -1188,6 +1189,10 @@ export function WorkflowsView({
   // save again without a re-read — dropping it and re-fetching would be a round
   // trip that can only return the same thing.
   const handleSaved = useCallback((saved: WorkflowGraph) => {
+    // Issue #1017: read the armed state BEFORE overwriting `graph`, so a save
+    // that silently disarmed the workflow (a schedule edit comes back
+    // `enabled: false`) can be told apart from an ordinary one below.
+    const wasEnabled = graph?.enabled;
     // Newer than any list request already in flight — see `localWriteRef`.
     localWriteRef.current += 1;
     setGraph(saved);
@@ -1214,8 +1219,44 @@ export function WorkflowsView({
     // The write landed, so whatever we hold is current — the same reasoning as
     // the graph-load effect's clear.
     setConflict(null);
-    toast.success("Workflow saved.");
-  }, []);
+    // Issue #1017: a save that just disarmed the workflow gets a paused toast
+    // with a one-click Resume, instead of a "saved" that hid that its schedule
+    // was switched off. Every other save keeps the plain acknowledgement.
+    if (workflowSavedToast(wasEnabled, saved.enabled) === "disarmed") {
+      toast.warning(
+        `Saved, and paused “${saved.name}”. Its schedule is off — it won't run on its own until you resume it.`,
+        {
+          action: {
+            label: "Resume",
+            onClick: () => {
+              void (async () => {
+                try {
+                  const updated = await setWorkflowEnabled(client, company, saved.id, true);
+                  // Newer than any list request already in flight.
+                  localWriteRef.current += 1;
+                  setGraph(updated);
+                  setWorkflows((prev) =>
+                    prev.map((w) =>
+                      w.id === updated.id ? { ...w, enabled: updated.enabled } : w,
+                    ),
+                  );
+                  toast.success(
+                    `Resumed “${updated.name}”. It will run on its schedule again.`,
+                  );
+                } catch (e) {
+                  toast.error(
+                    e instanceof Error ? e.message : "could not change the workflow",
+                  );
+                }
+              })();
+            },
+          },
+        },
+      );
+    } else {
+      toast.success("Workflow saved.");
+    }
+  }, [client, company, graph]);
 
   // The creator posts the full graph back, so the new entry can be spliced
   // straight into the list and selected — no extra round trip to re-list.

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -293,6 +293,10 @@ export function WorkflowsView({
   // a stale `selectedId` (issue #840 PR-3: guards the copilot-fix race).
   const selectedIdRef = useRef<string | null>(null);
   selectedIdRef.current = selectedId;
+  // Issue #1089: guards the company-switch race in the Resume handler — the same
+  // pattern as selectedIdRef: captured in the toast closure, checked after await.
+  const companyRef = useRef<string | null>(company);
+  companyRef.current = company;
   const [graph, setGraph] = useState<WorkflowGraph | null>(null);
   const [loadingList, setLoadingList] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1387,7 +1387,13 @@ export function WorkflowsView({
             onClick: () => {
               void (async () => {
                 try {
+                  const resumeCompany = company;
                   const updated = await setWorkflowEnabled(client, company, saved.id, true);
+                  // The operator may have switched companies while this Resume
+                  // was in flight. Discard the response — the new company's list
+                  // is what matters, and mutating state keyed to the old one
+                  // would overwrite it.
+                  if (companyRef.current !== resumeCompany) return;
                   // Newer than any list request already in flight.
                   localWriteRef.current += 1;
                   // The operator may have selected a different workflow while

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1234,7 +1234,15 @@ export function WorkflowsView({
                   const updated = await setWorkflowEnabled(client, company, saved.id, true);
                   // Newer than any list request already in flight.
                   localWriteRef.current += 1;
-                  setGraph(updated);
+                  // The operator may have selected a different workflow while
+                  // this Resume was in flight. Only replace the displayed graph
+                  // when it still belongs to the selection — otherwise the
+                  // picker would identify the new workflow while the canvas
+                  // showed (and a later edit would mutate) the old one. The list
+                  // update below is safe unconditionally: it keys by id.
+                  if (selectedIdRef.current === updated.id) {
+                    setGraph(updated);
+                  }
                   setWorkflows((prev) =>
                     prev.map((w) =>
                       w.id === updated.id ? { ...w, enabled: updated.enabled } : w,

--- a/frontend/test/unit/workflow-saved-toast.test.ts
+++ b/frontend/test/unit/workflow-saved-toast.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { workflowSavedToast } from "@/lib/workflow-saved-toast";
+
+/**
+ * The edit-save acknowledgement reducer (issue #1017).
+ *
+ * `WorkflowsView.handleSaved` wires exactly one of two toasts off this result —
+ * a paused, Resume-carrying toast for a save that just disarmed the workflow, or
+ * the plain "saved" one — so the branch is proved here rather than through a
+ * render.
+ */
+describe("workflowSavedToast", () => {
+  it("flags a save that disarmed an armed workflow", () => {
+    // The schedule-edit path: armed (true) → host returns disarmed (false).
+    expect(workflowSavedToast(true, false)).toBe("disarmed");
+  });
+
+  it("treats an unknown prev state as armed", () => {
+    // Only an explicit `false` is off, so `undefined` → `false` is a disarm.
+    expect(workflowSavedToast(undefined, false)).toBe("disarmed");
+  });
+
+  it("stays a plain save when the workflow is still armed", () => {
+    expect(workflowSavedToast(true, true)).toBe("saved");
+  });
+
+  it("does not re-flag a re-save of an already-paused workflow", () => {
+    // false → false changed nothing the operator must act on.
+    expect(workflowSavedToast(false, false)).toBe("saved");
+  });
+
+  it("is a plain save when an edit re-armed a paused workflow", () => {
+    expect(workflowSavedToast(false, true)).toBe("saved");
+  });
+});

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -654,7 +654,22 @@ impl AppState {
         if let Some(cached) = self.skill_registry.get() {
             return Ok(cached.clone());
         }
-        let registry: Arc<[SkillDoc]> = load_dir_skills(dir)?.into();
+        // `load_dir_skills` reports a parse/validation failure via the same
+        // `DataParse`/`DataInvalid` variants a per-company workflow file uses,
+        // where the HTTP mapping (issue #1017) treats them as the *caller's*
+        // bad input (400/422). Here the "file" is the operator-provisioned
+        // shared library, not anything a caller submitted, so that mapping
+        // would misreport a host misconfiguration as a client error. Recast
+        // as `Config` — already the crate's "runtime setup is broken" variant
+        // (see `app/config.rs`) — so it renders the 500 documented above.
+        let registry: Arc<[SkillDoc]> = load_dir_skills(dir)
+            .map_err(|error| {
+                crate::OpenCompanyError::Config(format!(
+                    "shared skill library at {} failed to load: {error}",
+                    dir.display()
+                ))
+            })?
+            .into();
         // A concurrent caller may have set it first; keep whichever won.
         let _ = self.skill_registry.set(registry.clone());
         Ok(self.skill_registry.get().cloned().unwrap_or(registry))

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -654,6 +654,18 @@ impl AppState {
         if let Some(cached) = self.skill_registry.get() {
             return Ok(cached.clone());
         }
+        // A *configured* library that is missing or not a directory is a host
+        // misconfiguration, not a parse failure `load_dir_skills` would flag —
+        // it returns `Ok(empty)` for a nonexistent `dir`, which would silently
+        // downgrade a server-authoritative install to a client-authored one
+        // (the exact invariant `shared_skill_registry`'s doc forbids). Reject it
+        // as `Config` (a 500 / failed boot) before the load can flatten it away.
+        if !dir.is_dir() {
+            return Err(crate::OpenCompanyError::Config(format!(
+                "shared skill library at {} is not a directory",
+                dir.display()
+            )));
+        }
         // `load_dir_skills` reports a parse/validation failure via the same
         // `DataParse`/`DataInvalid` variants a per-company workflow file uses,
         // where the HTTP mapping (issue #1017) treats them as the *caller's*
@@ -1428,6 +1440,23 @@ mod tests {
             .skill_registry(std::path::Path::new("/nonexistent"))
             .expect("cached registry");
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn skill_registry_rejects_a_configured_but_missing_library() {
+        // A configured `skills_root` that does not exist is a host
+        // misconfiguration. `load_dir_skills` returns `Ok(empty)` for a missing
+        // dir, so without the `is_dir` guard the registry would silently flatten
+        // to empty — downgrading a server-authoritative install to a
+        // client-authored one, the invariant `shared_skill_registry` forbids.
+        let state = AppState::new(AppConfig::default());
+        let err = state
+            .skill_registry(std::path::Path::new("/nonexistent"))
+            .expect_err("a missing configured library must fail, not load empty");
+        assert!(
+            matches!(err, crate::OpenCompanyError::Config(_)),
+            "expected a Config error for a missing library, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1793,6 +1793,13 @@ pub(crate) async fn delete_company_workflow(
     // across a restart.
     record.overlay_workflows.remove(index);
     record.manifest.workflows.enabled.retain(|id| id != wid);
+    // Issue #1017: purge the pause flag too. `disabled_workflows` is keyed by id,
+    // so a workflow re-created under this id later would otherwise inherit the
+    // deleted one's pause and stay silently off its schedule. `retain` is a purge,
+    // NOT a re-arm: the "enabled == true" state is only ever reached through the
+    // explicit enable route (see `CompanyRecord::set_workflow_enabled`), and this
+    // id has no body left to run regardless.
+    record.disabled_workflows.retain(|id| id != wid);
     store.save(&record).await?;
 
     drop(_lock);
@@ -3592,6 +3599,60 @@ to = "done"
             }
             other => panic!("expected WorkflowDeleted, got {other:?}"),
         }
+    }
+
+    /// Issue #1017: deleting a paused workflow must purge its pause flag, so a
+    /// workflow later re-created under the same id starts armed instead of
+    /// inheriting a stale pause the operator never asked for. `disabled_workflows`
+    /// is keyed by id, and a re-created id reuses it, so a leftover entry would
+    /// silently keep the fresh workflow off its schedule.
+    #[tokio::test]
+    async fn deleting_a_paused_workflow_purges_the_stale_pause_for_a_re_create() {
+        let company = CompanyId::new("acme");
+        let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        // Pause it — the id lands in `disabled_workflows`.
+        set_company_workflow_enabled(&company, None, &store, None, "greeter", false)
+            .await
+            .expect("pausing must never be refused");
+        let paused = store.load(&company).await.unwrap().unwrap();
+        assert!(
+            !paused.workflow_enabled("greeter"),
+            "precondition: the workflow is paused"
+        );
+
+        // Delete it, then re-create the same id from scratch.
+        delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            None,
+            "greeter",
+            Some(&version),
+        )
+        .await
+        .expect("deletes");
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("greeter", "Greeter"),
+        )
+        .await
+        .expect("re-create");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(
+            !record.disabled_workflows.iter().any(|id| id == "greeter"),
+            "the delete must purge the stale pause flag"
+        );
+        assert!(
+            record.workflow_enabled("greeter"),
+            "a re-created workflow must start armed, not inherit the deleted one's pause"
+        );
     }
 
     /// Issue #1045: the REST create/delete persist path puts

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -3612,7 +3612,7 @@ to = "done"
         let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
 
         // Pause it — the id lands in `disabled_workflows`.
-        set_company_workflow_enabled(&company, None, &store, None, "greeter", false)
+        set_company_workflow_enabled(&company, None, &store, None, "greeter", false, true, &[])
             .await
             .expect("pausing must never be refused");
         let paused = store.load(&company).await.unwrap().unwrap();

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -47,6 +47,16 @@ impl ApiError {
             | OpenCompanyError::MissingManifest(_)
             | OpenCompanyError::InvalidRequest(_)
             | OpenCompanyError::WorkflowInvalid { .. } => StatusCode::BAD_REQUEST,
+            // Issue #1017: a stored company data file that no longer parses is
+            // the caller's bad input, not a server fault — 400, so a route like
+            // get_workflow (and the render `?` in update_company_workflow)
+            // surfaces the parse message instead of a blank 500. One central
+            // mapping covers every current and future caller that lets a
+            // DataParse escape as an ApiError.
+            OpenCompanyError::DataParse { .. } => StatusCode::BAD_REQUEST,
+            // A file that parses but fails validation is a semantically bad
+            // payload the caller can correct — 422.
+            OpenCompanyError::DataInvalid { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             OpenCompanyError::LifecycleConflict(_) | OpenCompanyError::Conflict(_) => {
                 StatusCode::CONFLICT
             }
@@ -142,6 +152,30 @@ mod test {
 
         let other = ApiError(OpenCompanyError::Store("disk full".into()));
         assert_eq!(other.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn maps_company_data_errors_to_400_and_422() {
+        // Issue #1017: an unparseable company data file (e.g. a workflow whose
+        // stored body is no longer valid TOML) is the caller's bad input, not a
+        // server fault — 400 with the stable `data_parse` code, so a route like
+        // get_workflow surfaces the parse message instead of a blank 500.
+        let parse = ApiError(OpenCompanyError::DataParse {
+            path: PathBuf::from("workflows/weekly-digest.toml"),
+            message: "expected `=` after key".into(),
+        });
+        assert_eq!(parse.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(parse.0.code(), "data_parse");
+
+        // A file that parses but fails validation is a semantically bad payload —
+        // 422, matching how the render `?` in update_company_workflow should
+        // report a graph the caller can fix.
+        let invalid = ApiError(OpenCompanyError::DataInvalid {
+            path: PathBuf::from("workflows/weekly-digest.toml"),
+            problems: vec!["missing a trigger".into()],
+        });
+        assert_eq!(invalid.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(invalid.0.code(), "data_invalid");
     }
 
     #[test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -5764,7 +5764,8 @@ mod tests {
             fn subscribe(
                 &self,
                 id: &CompanyId,
-            ) -> futures::stream::BoxStream<'static, crate::ports::types::StoredEvent> {
+            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem>
+            {
                 self.inner.subscribe(id)
             }
         }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -5764,7 +5764,8 @@ mod tests {
             fn subscribe(
                 &self,
                 id: &CompanyId,
-            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem> {
+            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem>
+            {
                 self.inner.subscribe(id)
             }
         }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -5764,8 +5764,7 @@ mod tests {
             fn subscribe(
                 &self,
                 id: &CompanyId,
-            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem>
-            {
+            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem> {
                 self.inner.subscribe(id)
             }
         }


### PR DESCRIPTION
## Summary

Three edit-path defects that share a theme — the host changes state and the console can't tell:

- **C — an unparseable stored graph 500s on open, so it can't be repaired.** `ApiError::status` had no arm for `DataParse`/`DataInvalid`, so both fell to a 500. The list route skips a malformed body silently, so the workflow shows in the picker but can't be opened. Now `DataParse → 400` and `DataInvalid → 422`; the parse message and stable `code` were already in the body, so the editor can show what's wrong.
- **B — a stale pause survives delete + re-create.** `delete_company_workflow` cleared the overlay and the `[workflows].enabled` id but never `disabled_workflows`, so a workflow re-created under a previously-paused id landed disabled and never fired (durable across restart). Now the delete purges the id from `disabled_workflows` — a purge, not a re-arm, preserving the "enable only via the explicit route" invariant.
- **A — adding a schedule silently pauses the workflow.** `update_company_workflow` correctly disarms a newly-scheduled workflow, but the console toasted only "Workflow saved." Now, when a save flips `enabled` true→false, the toast says the schedule was paused and offers a one-click **Resume**.

## API Or Behavior Changes

- `GET …/workflows/{id}` (and the render path) return **400/422** with the parse problem instead of a dead-end 500 for a malformed graph.
- Deleting a paused workflow no longer leaves a stale pause that disables a same-id re-creation.
- Console: a save that disarms a workflow shows a paused toast with a Resume action instead of a plain success toast. No wire/schema change (the existing `enabled` field carries the signal).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` + `--no-deps --features openhuman,tinycortex --all-targets`
- [x] `cargo build --features openhuman,mcp,telegram --all-targets`
- [x] `cargo test --lib server::error` (3/3), `company::workflow_create` (67/67)
- [x] frontend `typecheck` + `typecheck:unit` + `typecheck:e2e` + `npm test` (vitest 1036) + `build`

Red-first (each fails pre-fix, passes after):
- **C** — `DataParse.status()==400` / `DataInvalid==422` (both 500 today).
- **B** — pause → delete → re-create → `disabled_workflows` no longer contains the id (it lingers today).
- **A** — the disarm-toast decision helper returns `"disarmed"` on a true→false save and `"saved"` otherwise (5 cases). The disarm branch is extracted into a pure `workflowSavedToast` helper because this repo's vitest is node-env/pure-functions-only (no React render harness — following the existing `workflow-draft` `draftBanners` precedent); the view wires the copy/Resume action from that decision.

## Documentation

No doc pages — behavior is captured in the handler/delete-path comments and pinned by the tests.

Closes #1017


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Saving a workflow that becomes paused now displays a warning with a one-click **Resume** action.
  - Resuming a workflow provides success or error feedback.
  - Workflow validation now identifies invalid nodes, fields, connections, and sub-workflow references.

- **Bug Fixes**
  - Recreated workflows no longer inherit a previous paused state.
  - Invalid requests return clearer, more appropriate error responses.
  - Skill-library configuration failures include clearer context.

- **Tests**
  - Added coverage for workflow notifications, validation, recreation, configuration errors, and API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->