### PR TITLE
fix(workflows): validate node config at save and return structured problems (#1016 backend)

### DIFF
--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -211,6 +211,32 @@ curl -X POST "$HOST/api/v1/company/workflows/weekly_digest/run" \
 }
 ```
 
+### Structured validation errors (issue #1016)
+
+A `POST`/`PUT …/workflows` whose graph fails author-time validation answers
+`400 { "code": "workflow_invalid" }` with an **additive** `problems` array — one
+entry per fault, each naming the node and config field so the console can
+highlight the exact spot. The `error` string stays the joined human sentence, so
+older string-only clients are unaffected; only this one code carries `problems`.
+
+```jsonc
+{
+  "error": "node `greet` has a `config.url` of `not-a-url` that is not a valid URL — …",
+  "code": "workflow_invalid",
+  "problems": [
+    { "node_id": "greet", "field": "config.url", "message": "node `greet` has a `config.url` …" }
+  ]
+}
+```
+
+The author-time config gate (issue #661, extended #1016) now also requires a
+`transform` to carry a non-empty `config.set` (a table of expression strings), a
+`split_out` to carry `config.path`, and an `http_request` `config.url` to be a
+real `http(s)` URL with a host (a bare `not-a-url` / `ftp://…` is refused at save
+instead of failing at run). An `output_parser` stays schema-optional (a bare
+identity parser is valid) and `merge` stays config-free; a `sub_workflow` whose
+`workflow_id` names no saved workflow this company can resolve is refused too.
+
 ### A run that stopped for a person (issues #881, #880)
 
 When a tool call inside an agent node's turn is parked for approval, the node

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -157,7 +157,7 @@ use crate::company::{
     list_workflows_union, parse_workflow, raw_workflow_from_toml, render_workflow,
     required_config_problems,
 };
-use crate::error::{OpenCompanyError, Result};
+use crate::error::{OpenCompanyError, Result, WorkflowProblem};
 use crate::ports::events::EventLog;
 use crate::ports::now_millis;
 use crate::ports::store::company_write_lock;
@@ -224,7 +224,7 @@ pub(crate) async fn create_company_workflow(
     // every `tool_call` node against the company's wired+granted tools.
     // `parse_workflow` checks the graph's own shape but has no record to validate
     // names against — the same helper gates create and update identically.
-    validate_draft_against_record(&draft, &record)?;
+    validate_draft_against_record(&draft, &record, source_dir)?;
 
     // Id uniqueness against every id this company already answers for: the seed
     // files, the record's overlay bodies, and the manifest-enabled ids. The
@@ -275,9 +275,14 @@ pub(crate) async fn create_company_workflow(
         )));
     }
     let file = parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            OpenCompanyError::InvalidRequest(problems.join(" "))
-        }
+        // A structural validation failure of the rendered draft becomes a
+        // structured `WorkflowInvalid` 400 (issue #1016). These graph-level
+        // problems (an inescapable cycle, an unreachable node) name no single
+        // node, so they carry `node_id: None` — the per-node/field problems come
+        // from `validate_draft_against_record`, which runs first.
+        OpenCompanyError::DataInvalid { problems, .. } => OpenCompanyError::WorkflowInvalid {
+            problems: problems.into_iter().map(WorkflowProblem::from).collect(),
+        },
         OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
         other => other,
     })?;
@@ -561,13 +566,22 @@ pub(crate) fn courtesy_validate_draft(draft: &RawWorkflow, record: &CompanyRecor
         )));
     }
     parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            OpenCompanyError::InvalidRequest(problems.join(" "))
-        }
+        // A structural validation failure of the rendered draft becomes a
+        // structured `WorkflowInvalid` 400 (issue #1016). These graph-level
+        // problems (an inescapable cycle, an unreachable node) name no single
+        // node, so they carry `node_id: None` — the per-node/field problems come
+        // from `validate_draft_against_record`, which runs first.
+        OpenCompanyError::DataInvalid { problems, .. } => OpenCompanyError::WorkflowInvalid {
+            problems: problems.into_iter().map(WorkflowProblem::from).collect(),
+        },
         OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
         other => other,
     })?;
-    validate_draft_against_record(draft, record)?;
+    // The courtesy pre-check has no source directory to hand; a sub_workflow's
+    // existence is still checked against the record's overlays + enabled ids +
+    // globals, only seed-file ids are out of reach here (the run-time cycle guard
+    // stays the backstop).
+    validate_draft_against_record(draft, record, None)?;
     Ok(())
 }
 
@@ -594,9 +608,14 @@ pub(crate) fn workflow_graph_from_spec(
     let raw = raw_workflow_from_spec(spec)?;
     let toml_src = render_workflow(&raw)?;
     let file = parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            OpenCompanyError::InvalidRequest(problems.join(" "))
-        }
+        // A structural validation failure of the rendered draft becomes a
+        // structured `WorkflowInvalid` 400 (issue #1016). These graph-level
+        // problems (an inescapable cycle, an unreachable node) name no single
+        // node, so they carry `node_id: None` — the per-node/field problems come
+        // from `validate_draft_against_record`, which runs first.
+        OpenCompanyError::DataInvalid { problems, .. } => OpenCompanyError::WorkflowInvalid {
+            problems: problems.into_iter().map(WorkflowProblem::from).collect(),
+        },
         OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
         other => other,
     })?;
@@ -701,7 +720,11 @@ fn validate_draft_shape(draft: &RawWorkflow) -> Result<()> {
 /// seed / legacy graphs never pass through this create path at all — so passing
 /// here means the draft was coherent when written, not that a run is forever
 /// permitted.
-fn validate_draft_against_record(draft: &RawWorkflow, record: &CompanyRecord) -> Result<()> {
+fn validate_draft_against_record(
+    draft: &RawWorkflow,
+    record: &CompanyRecord,
+    source_dir: Option<&Path>,
+) -> Result<()> {
     let roster: HashSet<&str> = record
         .manifest
         .agents
@@ -709,6 +732,14 @@ fn validate_draft_against_record(draft: &RawWorkflow, record: &CompanyRecord) ->
         .map(|a| a.id.as_str())
         .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
         .collect();
+
+    // Structured problems (issue #1016): the config gate, the sub_workflow
+    // existence check, and dangling edge endpoints each carry the node id and
+    // config field at fault, so the console can highlight the exact node + field.
+    // They accumulate and are raised together as a `WorkflowInvalid` 400. The
+    // roster/tool checks below keep their own early `InvalidRequest` (a bad
+    // teammate/tool name is not a node-config problem the highlighter consumes).
+    let mut problems: Vec<WorkflowProblem> = Vec::new();
 
     for node in &draft.nodes {
         match node.kind.as_str() {
@@ -728,33 +759,105 @@ fn validate_draft_against_record(draft: &RawWorkflow, record: &CompanyRecord) ->
                 }
             },
             "tool_call" => validate_tool_call_node(node, record)?,
-            // Per-kind required config (issue #661): reject a `condition` with no
-            // `field`, an `http_request` missing `method`/`url`, or a `switch`
-            // with no discriminant at author time — the same gate the on-disk
-            // `validate` applies, surfaced here as a 400 so the console/builder
-            // draft path never persists a graph whose runtime behaviour is
-            // silently wrong. `tool_call` keeps its richer `validate_tool_call_node`
-            // (slug + namespace/grant); the structural kinds share the helper.
-            "condition" | "http_request" | "switch" => {
+            // Per-kind required config (issue #661, extended #1016): reject a
+            // `condition` with no `field`, an `http_request` missing `method` or a
+            // real `url`, a `switch` with no discriminant, a `transform` with no
+            // `config.set`, a `split_out` with no `config.path`, or an
+            // `output_parser` whose present keys are mistyped — the same gate the
+            // on-disk `validate` applies, surfaced here as a structured 400 so the
+            // console/builder draft path never persists a graph whose runtime
+            // behaviour is silently wrong. `tool_call` keeps its richer
+            // `validate_tool_call_node` (slug + namespace/grant); the structural
+            // kinds share the helper.
+            "condition" | "http_request" | "switch" | "transform" | "split_out"
+            | "output_parser" => {
                 let kind = match node.kind.as_str() {
                     "condition" => WorkflowNodeKind::Condition,
                     "http_request" => WorkflowNodeKind::HttpRequest,
-                    _ => WorkflowNodeKind::Switch,
+                    "switch" => WorkflowNodeKind::Switch,
+                    "transform" => WorkflowNodeKind::Transform,
+                    "split_out" => WorkflowNodeKind::SplitOut,
+                    _ => WorkflowNodeKind::OutputParser,
                 };
                 // Report EVERY missing-config problem for the node, not just the
                 // first: an `http_request` missing both `method` AND `url` should
                 // name both, since the draft path is where a human/model iterates.
-                let problems = required_config_problems(
+                problems.extend(required_config_problems(
                     kind,
+                    &node.id,
                     &format!("node `{}`", node.id),
                     node.config.as_ref(),
-                );
-                if !problems.is_empty() {
-                    return Err(OpenCompanyError::InvalidRequest(problems.join(" ")));
+                ));
+            }
+            // A `sub_workflow` node names a saved workflow to run (issue #1016).
+            // `parse_workflow` already rejects a missing/empty/inline/self `workflow_id`
+            // structurally; here — where the record is available — reject a
+            // `workflow_id` that names NO saved workflow this company can resolve,
+            // so a rename or a typo is caught at author time instead of failing at
+            // run. A self-reference is left to the structural check (it names a
+            // clearer problem) rather than reported as "not saved".
+            "sub_workflow" => {
+                if let Some(wid) = node
+                    .config
+                    .as_ref()
+                    .and_then(toml::Value::as_table)
+                    .and_then(|table| table.get("workflow_id"))
+                    .and_then(toml::Value::as_str)
+                    && !wid.trim().is_empty()
+                    && wid != draft.id
+                    && !workflow_id_exists(source_dir, record, wid)
+                {
+                    problems.push(WorkflowProblem::node_field(
+                        &node.id,
+                        "workflow_id",
+                        format!(
+                            "node `{}` runs sub-workflow `{wid}`, which is not a saved workflow in \
+                             this company — check the id or create the workflow first.",
+                            node.id
+                        ),
+                    ));
                 }
             }
             _ => {}
         }
+    }
+
+    // Dangling edge endpoints (issue #1016): an edge whose `from`/`to` names no
+    // node is reported naming the ENDPOINT and the field, so the console can
+    // highlight the id the author actually wrote. `parse_workflow` catches these
+    // too, but only as flat `edge #N` strings — reporting them here first keeps
+    // the structured node/field detail the flat pass would drop.
+    let node_ids: HashSet<&str> = draft
+        .nodes
+        .iter()
+        .filter(|n| !n.id.trim().is_empty())
+        .map(|n| n.id.as_str())
+        .collect();
+    for edge in &draft.edges {
+        if !edge.from.trim().is_empty() && !node_ids.contains(edge.from.as_str()) {
+            problems.push(WorkflowProblem::node_field(
+                &edge.from,
+                "from",
+                format!(
+                    "an edge starts at `{}`, which is not a node in this workflow.",
+                    edge.from
+                ),
+            ));
+        }
+        if !edge.to.trim().is_empty() && !node_ids.contains(edge.to.as_str()) {
+            problems.push(WorkflowProblem::node_field(
+                &edge.to,
+                "to",
+                format!(
+                    "an edge points to `{}`, which is not a node in this workflow.",
+                    edge.to
+                ),
+            ));
+        }
+    }
+
+    if !problems.is_empty() {
+        return Err(OpenCompanyError::WorkflowInvalid { problems });
     }
 
     // Condition branch labels must read `yes`/`no` at author time (issue #661).
@@ -1072,6 +1175,20 @@ pub(crate) fn seed_file_exists(source_dir: Option<&Path>, wid: &str) -> bool {
     source_dir.is_some_and(|dir| dir.join("workflows").join(format!("{wid}.toml")).is_file())
 }
 
+/// Whether `wid` names a workflow this company can actually resolve and run as a
+/// sub-workflow (issue #1016): a seed file, a saved overlay body, a
+/// manifest-`enabled` id, or a global baseline workflow. Deliberately lenient —
+/// it errs toward "exists" (globals are counted whether or not the company
+/// disabled them) so a real reference is never rejected; the run-time resolver
+/// stays the backstop for anything this author-time probe can't see. Used to
+/// reject a `sub_workflow` node whose `workflow_id` names nothing at all.
+fn workflow_id_exists(source_dir: Option<&Path>, record: &CompanyRecord, wid: &str) -> bool {
+    seed_file_exists(source_dir, wid)
+        || record.overlay_workflows.iter().any(|w| w.id == wid)
+        || record.manifest.workflows.enabled.iter().any(|id| id == wid)
+        || crate::globals::workflows().iter().any(|w| w.id == wid)
+}
+
 /// Resolves `wid` to the record's overlay body, or explains why it can't be
 /// written to. Shared by update and delete so the two answer identically.
 ///
@@ -1185,7 +1302,7 @@ pub(crate) async fn update_company_workflow(
     // Same record cross-check as create (roster + tool_call grants):
     // `parse_workflow` validates the graph's own shape but has no record to check
     // `agent`/`tool_call` node names against.
-    validate_draft_against_record(&draft, &record)?;
+    validate_draft_against_record(&draft, &record, source_dir)?;
 
     // Display-name uniqueness, MINUS this workflow's own current name — a
     // re-save that doesn't rename must not collide with itself. Every other
@@ -1218,9 +1335,14 @@ pub(crate) async fn update_company_workflow(
         )));
     }
     let file = parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            OpenCompanyError::InvalidRequest(problems.join(" "))
-        }
+        // A structural validation failure of the rendered draft becomes a
+        // structured `WorkflowInvalid` 400 (issue #1016). These graph-level
+        // problems (an inescapable cycle, an unreachable node) name no single
+        // node, so they carry `node_id: None` — the per-node/field problems come
+        // from `validate_draft_against_record`, which runs first.
+        OpenCompanyError::DataInvalid { problems, .. } => OpenCompanyError::WorkflowInvalid {
+            problems: problems.into_iter().map(WorkflowProblem::from).collect(),
+        },
         OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
         other => other,
     })?;
@@ -4108,10 +4230,13 @@ to = "done"
         )
         .await
         .expect_err("condition with no field");
-        assert!(
-            matches!(err, OpenCompanyError::InvalidRequest(_)),
-            "{err:?}"
-        );
+        // Issue #1016: the config gate now raises a structured `WorkflowInvalid`.
+        let problems = match &err {
+            OpenCompanyError::WorkflowInvalid { problems } => problems,
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(problems[0].node_id.as_deref(), Some("gate"));
+        assert_eq!(problems[0].field.as_deref(), Some("config.field"));
         assert!(err.to_string().contains("config.field"), "{err}");
     }
 
@@ -4211,10 +4336,21 @@ to = "done"
         let err = create_company_workflow(&company, None, &store, None, draft)
             .await
             .expect_err("http_request with no method or url");
+        // Issue #1016: structured `WorkflowInvalid`, one problem per field, both
+        // pinned to the offending node.
+        let problems = match &err {
+            OpenCompanyError::WorkflowInvalid { problems } => problems,
+            other => panic!("{other:?}"),
+        };
         assert!(
-            matches!(err, OpenCompanyError::InvalidRequest(_)),
-            "{err:?}"
+            problems
+                .iter()
+                .all(|p| p.node_id.as_deref() == Some("fetch")),
+            "{problems:?}"
         );
+        let fields: Vec<&str> = problems.iter().filter_map(|p| p.field.as_deref()).collect();
+        assert!(fields.contains(&"config.method"), "{fields:?}");
+        assert!(fields.contains(&"config.url"), "{fields:?}");
         let message = err.to_string();
         assert!(message.contains("config.method"), "{message}");
         assert!(message.contains("config.url"), "{message}");
@@ -5084,5 +5220,275 @@ to = "done"
             matches!(err, OpenCompanyError::CompanyNotFound(_)),
             "{err:?}"
         );
+    }
+
+    // --- issue #1016: structured, per-node/field workflow problems -----------
+
+    /// A bare node with an optional config table.
+    fn oc_node(id: &str, kind: &str, config: Option<toml::Value>) -> RawNode {
+        RawNode {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            name: id.to_string(),
+            summary: None,
+            agent: None,
+            schedule: None,
+            config,
+            on_error: None,
+            retry: None,
+            requires_approval: None,
+            destination: None,
+        }
+    }
+
+    /// A `trigger → <node>` two-node draft, so the node under test sits on a
+    /// reachable, single-trigger graph the shape check accepts.
+    fn one_node_draft(node: RawNode) -> RawWorkflow {
+        let to = node.id.clone();
+        RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![oc_node("start", "trigger", None), node],
+            edges: vec![RawEdge {
+                from: "start".to_string(),
+                to,
+                label: None,
+            }],
+        }
+    }
+
+    fn problems_of(err: &OpenCompanyError) -> &[WorkflowProblem] {
+        match err {
+            OpenCompanyError::WorkflowInvalid { problems } => problems,
+            other => panic!("expected WorkflowInvalid, got {other:?}"),
+        }
+    }
+
+    /// RED-FIRST #1 (headline): a `transform` with no `config.set` is now rejected
+    /// at save, naming the node and `config.set`. Accepted on unpatched code.
+    #[tokio::test]
+    async fn draft_transform_without_set_is_rejected() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            one_node_draft(oc_node("tf", "transform", None)),
+        )
+        .await
+        .expect_err("transform with no config.set");
+        let problems = problems_of(&err);
+        assert_eq!(problems[0].node_id.as_deref(), Some("tf"));
+        assert_eq!(problems[0].field.as_deref(), Some("config.set"));
+    }
+
+    /// RED-FIRST #1 (split_out half): a `split_out` with no `config.path` is
+    /// rejected, naming `config.path`.
+    #[tokio::test]
+    async fn draft_split_out_without_path_is_rejected() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            one_node_draft(oc_node("so", "split_out", None)),
+        )
+        .await
+        .expect_err("split_out with no config.path");
+        let problems = problems_of(&err);
+        assert_eq!(problems[0].node_id.as_deref(), Some("so"));
+        assert_eq!(problems[0].field.as_deref(), Some("config.path"));
+    }
+
+    fn http_bad_url_draft() -> RawWorkflow {
+        let mut config = toml::map::Map::new();
+        config.insert("method".to_string(), toml::Value::String("GET".to_string()));
+        config.insert(
+            "url".to_string(),
+            toml::Value::String("not-a-url".to_string()),
+        );
+        one_node_draft(oc_node(
+            "greet",
+            "http_request",
+            Some(toml::Value::Table(config)),
+        ))
+    }
+
+    /// RED-FIRST #2 (create): a create with an http_request `url` of `not-a-url`
+    /// yields a `WorkflowInvalid` whose first problem is pinned to `greet` /
+    /// `config.url`. Asserted on the STRUCT, not the joined message.
+    #[tokio::test]
+    async fn draft_http_request_bad_url_is_rejected_on_create() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(&company, None, &store, None, http_bad_url_draft())
+            .await
+            .expect_err("http_request url = not-a-url");
+        let problems = problems_of(&err);
+        assert_eq!(problems[0].node_id.as_deref(), Some("greet"));
+        assert_eq!(problems[0].field.as_deref(), Some("config.url"));
+    }
+
+    /// RED-FIRST #2 (update): the same structured rejection on the update path.
+    #[tokio::test]
+    async fn draft_http_request_bad_url_is_rejected_on_update() {
+        let company = CompanyId::new("acme");
+        let (store, version) = with_one_workflow(&company, "wf", "WF").await;
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            http_bad_url_draft(),
+            Some(&version),
+        )
+        .await
+        .expect_err("update to a bad url");
+        let problems = problems_of(&err);
+        assert_eq!(problems[0].node_id.as_deref(), Some("greet"));
+        assert_eq!(problems[0].field.as_deref(), Some("config.url"));
+    }
+
+    /// RED-FIRST #3: a create whose edge has a dangling `from` yields a structured
+    /// problem naming the endpoint (`old-id`) and the `from` field, and the
+    /// message no longer leads with `edge #N`.
+    #[tokio::test]
+    async fn draft_dangling_from_edge_is_structured() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let draft = RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![oc_node("start", "trigger", None)],
+            edges: vec![RawEdge {
+                from: "old-id".to_string(),
+                to: "start".to_string(),
+                label: None,
+            }],
+        };
+        let err = create_company_workflow(&company, None, &store, None, draft)
+            .await
+            .expect_err("dangling from");
+        let problems = problems_of(&err);
+        assert_eq!(problems[0].node_id.as_deref(), Some("old-id"));
+        assert_eq!(problems[0].field.as_deref(), Some("from"));
+        assert!(!err.to_string().contains("edge #"), "{err}");
+    }
+
+    fn sub_workflow_draft(workflow_id: &str) -> RawWorkflow {
+        let mut config = toml::map::Map::new();
+        config.insert(
+            "workflow_id".to_string(),
+            toml::Value::String(workflow_id.to_string()),
+        );
+        one_node_draft(oc_node(
+            "child",
+            "sub_workflow",
+            Some(toml::Value::Table(config)),
+        ))
+    }
+
+    /// A `sub_workflow` naming a workflow id that this company cannot resolve is
+    /// rejected, pinned to the node and `workflow_id`.
+    #[tokio::test]
+    async fn draft_sub_workflow_with_unknown_id_is_rejected() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = sub_workflow_draft("nope");
+        draft.id = "parent".to_string();
+        let err = create_company_workflow(&company, None, &store, None, draft)
+            .await
+            .expect_err("unknown sub-workflow id");
+        let problems = problems_of(&err);
+        assert_eq!(problems[0].node_id.as_deref(), Some("child"));
+        assert_eq!(problems[0].field.as_deref(), Some("workflow_id"));
+    }
+
+    /// A `sub_workflow` referencing an existing saved workflow passes the record
+    /// cross-check.
+    #[tokio::test]
+    async fn draft_sub_workflow_with_existing_id_is_accepted() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let mut draft = sub_workflow_draft("greeter");
+        draft.id = "parent".to_string();
+        draft.name = "Parent".to_string();
+        create_company_workflow(&company, None, &store, None, draft)
+            .await
+            .expect("sub_workflow referencing a saved workflow is accepted");
+    }
+
+    /// A `sub_workflow` referencing its own id is still rejected (regression): the
+    /// structural self-reference check owns that message.
+    #[tokio::test]
+    async fn draft_sub_workflow_self_reference_is_rejected() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        // draft.id defaults to "wf" — a self reference to the same id.
+        let draft = sub_workflow_draft("wf");
+        let err = create_company_workflow(&company, None, &store, None, draft)
+            .await
+            .expect_err("self-referencing sub_workflow");
+        assert!(err.to_string().contains("run itself"), "{err}");
+    }
+
+    /// An `output_parser` with no schema (a pass-through identity parser) is
+    /// accepted; a `merge` with no config is accepted — the gate does not
+    /// over-reject the config-optional kinds.
+    #[tokio::test]
+    async fn draft_output_parser_and_merge_are_config_optional() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            one_node_draft(oc_node("op", "output_parser", None)),
+        )
+        .await
+        .expect("schema-less output_parser is accepted");
+
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            one_node_draft(oc_node("mg", "merge", None)),
+        )
+        .await
+        .expect("config-less merge is accepted");
     }
 }

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::{OpenCompanyError, Result};
+use crate::error::{OpenCompanyError, Result, WorkflowProblem};
 
 /// The node kinds a workflow graph may use — the OpenCompany authoring
 /// contract. The first six are the original set; the trailing six (P2) add the
@@ -1024,7 +1024,15 @@ pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
         // silently stop a scheduled run. The console-draft path applies the same
         // helper strictly, so the two AUTHOR surfaces reject the same shapes.
         if strict && let Some(kind) = kind {
-            problems.extend(required_config_problems(kind, &label, node.config.as_ref()));
+            // The on-disk/strict pass keeps its flat `Vec<String>` shape; the
+            // structured node/field detail (issue #1016) is consumed on the
+            // author-time draft path, which calls `required_config_problems`
+            // directly.
+            problems.extend(
+                required_config_problems(kind, &node.id, &label, node.config.as_ref())
+                    .into_iter()
+                    .map(|problem| problem.message),
+            );
         }
 
         // `schedule` says *when* the workflow starts, so it is trigger-only —
@@ -1228,30 +1236,32 @@ pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
     // Edges: endpoints must reference existing nodes; no self-loops. An
     // "error"-labeled edge and an `on_error = "route"` node imply each other.
     let mut route_nodes_with_error_edge = std::collections::HashSet::new();
-    for (index, edge) in raw.edges.iter().enumerate() {
-        let label = format!("edge #{}", index + 1);
-
+    for edge in &raw.edges {
+        // Edge problems name the ENDPOINT at fault (`old-id`), not a positional
+        // `edge #N` (issue #1016): the author sees a node id they wrote, and the
+        // console can highlight it. The `to → from` label describes the edge only
+        // when neither endpoint has a usable id to name.
         if edge.from.trim().is_empty() {
-            problems.push(format!("{label} is missing a `from` node."));
+            problems.push("an edge is missing a `from` node.".to_string());
         } else if !seen.contains(edge.from.as_str()) {
             problems.push(format!(
-                "{label} starts at `{}`, which is not a node in this workflow.",
+                "an edge starts at `{}`, which is not a node in this workflow.",
                 edge.from
             ));
         }
 
         if edge.to.trim().is_empty() {
-            problems.push(format!("{label} is missing a `to` node."));
+            problems.push("an edge is missing a `to` node.".to_string());
         } else if !seen.contains(edge.to.as_str()) {
             problems.push(format!(
-                "{label} points to `{}`, which is not a node in this workflow.",
+                "an edge points to `{}`, which is not a node in this workflow.",
                 edge.to
             ));
         }
 
         if !edge.from.trim().is_empty() && edge.from == edge.to {
             problems.push(format!(
-                "{label} loops `{}` back to itself — an edge must connect two different nodes.",
+                "an edge loops `{}` back to itself — an edge must connect two different nodes.",
                 edge.from
             ));
         }
@@ -1266,7 +1276,7 @@ pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
                 && !switch_nodes.contains(edge.from.as_str())
             {
                 problems.push(format!(
-                    "{label} is labeled `error` but its source `{}` is not `on_error = \"route\"` — only a routing node emits an error edge.",
+                    "the edge leaving `{}` is labeled `error` but its source is not `on_error = \"route\"` — only a routing node emits an error edge.",
                     edge.from
                 ));
             }
@@ -1308,7 +1318,7 @@ pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
                     .map(|l| format!("`{l}`"))
                     .unwrap_or_else(|| "no label".to_string());
                 problems.push(format!(
-                    "{label} leaves condition node `{}` with {shown} — a condition's branches must be labeled `yes` or `no`.",
+                    "an edge leaves condition node `{}` with {shown} — a condition's branches must be labeled `yes` or `no`.",
                     edge.from
                 ));
             }
@@ -1502,9 +1512,10 @@ pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
 /// tool would run) — so surfacing it at load/author time is the point.
 pub(crate) fn required_config_problems(
     kind: WorkflowNodeKind,
+    node_id: &str,
     label: &str,
     config: Option<&toml::Value>,
-) -> Vec<String> {
+) -> Vec<WorkflowProblem> {
     let table = config.and_then(toml::Value::as_table);
     // A config key set to a non-empty, non-whitespace string.
     let non_empty = |key: &str| -> bool {
@@ -1513,26 +1524,54 @@ pub(crate) fn required_config_problems(
             .and_then(toml::Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
     };
+    // Enriches a message with the node + config field at fault (issue #1016).
+    let problem =
+        |field: &str, message: String| WorkflowProblem::node_field(node_id, field, message);
     let mut problems = Vec::new();
     match kind {
         WorkflowNodeKind::Condition if !non_empty("field") => {
-            problems.push(format!(
-                "{label} is a condition node but sets no `config.field` — give it the boolean \
-                 expression the branch tests (e.g. `field = \"=item.approved\"`)."
+            problems.push(problem(
+                "config.field",
+                format!(
+                    "{label} is a condition node but sets no `config.field` — give it the boolean \
+                     expression the branch tests (e.g. `field = \"=item.approved\"`)."
+                ),
             ));
         }
         WorkflowNodeKind::HttpRequest => {
             if !non_empty("method") {
-                problems.push(format!(
-                    "{label} is an http_request node but sets no `config.method` — name the HTTP \
-                     method (e.g. `method = \"GET\"`)."
+                problems.push(problem(
+                    "config.method",
+                    format!(
+                        "{label} is an http_request node but sets no `config.method` — name the \
+                         HTTP method (e.g. `method = \"GET\"`)."
+                    ),
                 ));
             }
-            if !non_empty("url") {
-                problems.push(format!(
-                    "{label} is an http_request node but sets no `config.url` — give the request \
-                     URL (e.g. `url = \"https://…\"`)."
-                ));
+            // `url` is upgraded from a mere non-empty check to a real URL check
+            // (issue #1016): a value like `not-a-url` was accepted at save then
+            // failed at run. Require a full http(s) URL with a host so the node
+            // can actually reach an endpoint.
+            match table
+                .and_then(|t| t.get("url"))
+                .and_then(toml::Value::as_str)
+            {
+                Some(url) if is_valid_http_url(url) => {}
+                Some(url) if !url.trim().is_empty() => problems.push(problem(
+                    "config.url",
+                    format!(
+                        "{label} has a `config.url` of `{}` that is not a valid URL — give a full \
+                         http:// or https:// URL with a host (e.g. `url = \"https://…\"`).",
+                        url.trim()
+                    ),
+                )),
+                _ => problems.push(problem(
+                    "config.url",
+                    format!(
+                        "{label} is an http_request node but sets no `config.url` — give the \
+                         request URL (e.g. `url = \"https://…\"`)."
+                    ),
+                )),
             }
         }
         // `field` OR `expression` both satisfy a switch — the tinyflows engine
@@ -1541,20 +1580,134 @@ pub(crate) fn required_config_problems(
         // honoured downstream and requiring only that ONE is present matches the
         // runtime.
         WorkflowNodeKind::Switch if !non_empty("field") && !non_empty("expression") => {
-            problems.push(format!(
-                "{label} is a switch node but names no discriminant — set `config.field` or \
-                 `config.expression` to the value that selects the branch."
+            problems.push(problem(
+                "config.field",
+                format!(
+                    "{label} is a switch node but names no discriminant — set `config.field` or \
+                     `config.expression` to the value that selects the branch."
+                ),
             ));
         }
         WorkflowNodeKind::ToolCall if !non_empty("slug") => {
-            problems.push(format!(
-                "{label} is a tool_call but sets no `config.slug` — set `config.slug` to the \
-                 tool to run."
+            problems.push(problem(
+                "config.slug",
+                format!(
+                    "{label} is a tool_call but sets no `config.slug` — set `config.slug` to the \
+                     tool to run."
+                ),
             ));
+        }
+        // A `transform` maps upstream items through a `config.set` table of
+        // expression strings (issue #1016). An author writing `kind = \"transform\"`
+        // with no `set` produced a node that silently passed items through — the
+        // pass-through role is what a `kind = \"output\"` node is for, so require a
+        // real, non-empty mapping here. Every value in the table must be a string
+        // expression.
+        WorkflowNodeKind::Transform => match table.and_then(|t| t.get("set")) {
+            Some(toml::Value::Table(set)) if !set.is_empty() => {
+                for (key, value) in set {
+                    if value.as_str().is_none() {
+                        problems.push(problem(
+                            "config.set",
+                            format!(
+                                "{label} has a `config.set` entry `{key}` that is not a string — \
+                                 each set value is an expression string (e.g. `name = \
+                                 \"=item.name\"`)."
+                            ),
+                        ));
+                    }
+                }
+            }
+            Some(toml::Value::Table(_)) => problems.push(problem(
+                "config.set",
+                format!(
+                    "{label} is a transform node but its `config.set` is empty — map at least one \
+                     output field to an expression (e.g. under `[node.config.set]`, \
+                     `name = \"=item.name\"`)."
+                ),
+            )),
+            Some(_) => problems.push(problem(
+                "config.set",
+                format!(
+                    "{label} has a `config.set` that is not a table — it must map output fields to \
+                     expression strings (e.g. under `[node.config.set]`, `name = \"=item.name\"`)."
+                ),
+            )),
+            None => problems.push(problem(
+                "config.set",
+                format!(
+                    "{label} is a transform node but sets no `config.set` — map at least one \
+                     output field to an expression (e.g. under `[node.config.set]`, \
+                     `name = \"=item.name\"`)."
+                ),
+            )),
+        },
+        // A `split_out` fans one upstream item into many by reading an array at
+        // `config.path` (issue #1016). With no path it has nothing to split on.
+        WorkflowNodeKind::SplitOut if !non_empty("path") => {
+            problems.push(problem(
+                "config.path",
+                format!(
+                    "{label} is a split_out node but sets no `config.path` — name the field \
+                     holding the list to split into separate items (e.g. `path = \"items\"`)."
+                ),
+            ));
+        }
+        // An `output_parser` is legitimately schema-LESS — a bare identity parser
+        // that passes items through — so schema is NOT required (issue #1016).
+        // Only type-check the keys that ARE present: `schema` must be a table,
+        // `auto_fix` a bool, `connection_ref` a string.
+        WorkflowNodeKind::OutputParser => {
+            if let Some(t) = table {
+                if let Some(schema) = t.get("schema")
+                    && !schema.is_table()
+                {
+                    problems.push(problem(
+                        "config.schema",
+                        format!(
+                            "{label} has a `config.schema` that is not a table — a parser schema is \
+                             a table of fields, or leave it out for a pass-through parser."
+                        ),
+                    ));
+                }
+                if let Some(auto_fix) = t.get("auto_fix")
+                    && auto_fix.as_bool().is_none()
+                {
+                    problems.push(problem(
+                        "config.auto_fix",
+                        format!(
+                            "{label} has a `config.auto_fix` that is not a boolean — set it to \
+                             `true` or `false`."
+                        ),
+                    ));
+                }
+                if let Some(connection_ref) = t.get("connection_ref")
+                    && connection_ref.as_str().is_none()
+                {
+                    problems.push(problem(
+                        "config.connection_ref",
+                        format!(
+                            "{label} has a `config.connection_ref` that is not a string — it names \
+                             a saved connection."
+                        ),
+                    ));
+                }
+            }
         }
         _ => {}
     }
     problems
+}
+
+/// Whether `value` is a full http(s) URL with a host (issue #1016). A workflow
+/// `http_request` node needs a real endpoint, so a scheme-less or hostless
+/// string (`not-a-url`, `ftp://x`, `https://`) is refused at author time rather
+/// than accepted at save and failed at run.
+fn is_valid_http_url(value: &str) -> bool {
+    match url::Url::parse(value.trim()) {
+        Ok(url) => matches!(url.scheme(), "http" | "https") && url.has_host(),
+        Err(_) => false,
+    }
 }
 
 /// Whether a TOML config contains a float JSON cannot represent.
@@ -3579,5 +3732,112 @@ to = "done"
             "{CONSOLE_DIALOG_PATH} no longer defines `looksLikeCron` — this test \
              exists to pin the arity that helper assumes"
         );
+    }
+
+    // --- issue #1016: per-kind config gate (transform / split_out / http url /
+    //     output_parser) --------------------------------------------------------
+
+    /// Parses a bare TOML config table for a node.
+    fn cfg(src: &str) -> toml::Value {
+        toml::from_str::<toml::Value>(src).expect("valid config table")
+    }
+
+    fn problems(kind: WorkflowNodeKind, config: Option<&toml::Value>) -> Vec<WorkflowProblem> {
+        required_config_problems(kind, "n", "node `n`", config)
+    }
+
+    #[test]
+    fn transform_without_set_is_rejected_naming_the_field() {
+        let out = problems(WorkflowNodeKind::Transform, None);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].node_id.as_deref(), Some("n"));
+        assert_eq!(out[0].field.as_deref(), Some("config.set"));
+    }
+
+    #[test]
+    fn transform_with_empty_set_is_rejected() {
+        let config = cfg("[set]\n");
+        assert_eq!(
+            problems(WorkflowNodeKind::Transform, Some(&config))[0]
+                .field
+                .as_deref(),
+            Some("config.set")
+        );
+    }
+
+    #[test]
+    fn transform_with_non_string_set_value_is_rejected() {
+        let config = cfg("[set]\ncount = 3\n");
+        let out = problems(WorkflowNodeKind::Transform, Some(&config));
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].field.as_deref(), Some("config.set"));
+    }
+
+    #[test]
+    fn transform_with_string_expressions_is_accepted() {
+        let config = cfg("[set]\nname = \"=item.name\"\n");
+        assert!(problems(WorkflowNodeKind::Transform, Some(&config)).is_empty());
+    }
+
+    #[test]
+    fn split_out_without_path_is_rejected_naming_the_field() {
+        let out = problems(WorkflowNodeKind::SplitOut, None);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].field.as_deref(), Some("config.path"));
+    }
+
+    #[test]
+    fn split_out_with_path_is_accepted() {
+        let config = cfg("path = \"items\"\n");
+        assert!(problems(WorkflowNodeKind::SplitOut, Some(&config)).is_empty());
+    }
+
+    #[test]
+    fn http_request_url_must_be_a_real_url() {
+        let good = cfg("method = \"GET\"\nurl = \"https://example.com/x\"\n");
+        assert!(problems(WorkflowNodeKind::HttpRequest, Some(&good)).is_empty());
+
+        // "" is rejected as before (regression guard) …
+        let empty = cfg("method = \"GET\"\nurl = \"\"\n");
+        assert_eq!(
+            problems(WorkflowNodeKind::HttpRequest, Some(&empty))[0]
+                .field
+                .as_deref(),
+            Some("config.url")
+        );
+
+        // … and now `ftp://x` and bare `garbage` are rejected too (new).
+        for bad in ["ftp://x", "garbage", "https://"] {
+            let config = cfg(&format!("method = \"GET\"\nurl = \"{bad}\"\n"));
+            let out = problems(WorkflowNodeKind::HttpRequest, Some(&config));
+            assert_eq!(out.len(), 1, "{bad}: {out:?}");
+            assert_eq!(out[0].field.as_deref(), Some("config.url"), "{bad}");
+        }
+    }
+
+    #[test]
+    fn output_parser_is_schema_less_by_default() {
+        // A bare identity parser (no config at all) is accepted.
+        assert!(problems(WorkflowNodeKind::OutputParser, None).is_empty());
+        // A present but mistyped key is rejected, each naming its field.
+        let config = cfg("auto_fix = \"yes\"\nconnection_ref = 5\n");
+        let out = problems(WorkflowNodeKind::OutputParser, Some(&config));
+        let fields: Vec<&str> = out.iter().filter_map(|p| p.field.as_deref()).collect();
+        assert!(fields.contains(&"config.auto_fix"), "{fields:?}");
+        assert!(fields.contains(&"config.connection_ref"), "{fields:?}");
+    }
+
+    #[test]
+    fn output_parser_with_well_typed_keys_is_accepted() {
+        let config =
+            cfg("auto_fix = true\nconnection_ref = \"conn\"\n[schema]\nname = \"string\"\n");
+        assert!(problems(WorkflowNodeKind::OutputParser, Some(&config)).is_empty());
+    }
+
+    #[test]
+    fn merge_stays_config_free() {
+        assert!(problems(WorkflowNodeKind::Merge, None).is_empty());
+        let config = cfg("anything = \"goes\"\n");
+        assert!(problems(WorkflowNodeKind::Merge, Some(&config)).is_empty());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,65 @@ use std::path::PathBuf;
 /// Crate-wide result type.
 pub type Result<T> = std::result::Result<T, OpenCompanyError>;
 
+/// One structured problem with a workflow graph draft (issue #1016).
+///
+/// Unlike the flat `Vec<String>` an [`OpenCompanyError::DataInvalid`] carries,
+/// each problem names the node it belongs to and the config field at fault, so
+/// the console can highlight the exact node + field instead of parsing a joined
+/// sentence. `node_id` is the offending node's id — or, for an edge problem, the
+/// dangling endpoint's id — and is `None` for a graph-level problem with no
+/// single owner (an inescapable cycle names several nodes at once). `field` is
+/// the config path at fault (`config.url`, `config.set`, `workflow_id`, `from`).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct WorkflowProblem {
+    /// The node id this problem belongs to (or the dangling endpoint id for an
+    /// edge problem); `None` for a graph-level problem with no single owner.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    /// The config field at fault (`config.url`, `config.set`, `workflow_id`,
+    /// `from`/`to`); `None` when the problem is not about a single field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// The human-readable problem, in the same prosumer language the flat
+    /// validation messages use.
+    pub message: String,
+}
+
+impl WorkflowProblem {
+    /// A problem pinned to a specific node and config field.
+    pub fn node_field(
+        node_id: impl Into<String>,
+        field: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        let node_id = node_id.into();
+        Self {
+            node_id: (!node_id.trim().is_empty()).then_some(node_id),
+            field: Some(field.into()),
+            message: message.into(),
+        }
+    }
+}
+
+/// A graph-level problem with no single owner keeps its message and leaves both
+/// `node_id` and `field` empty — the fallback for every validation string that
+/// is not enriched with a node/field.
+impl From<String> for WorkflowProblem {
+    fn from(message: String) -> Self {
+        Self {
+            node_id: None,
+            field: None,
+            message,
+        }
+    }
+}
+
+impl From<&str> for WorkflowProblem {
+    fn from(message: &str) -> Self {
+        Self::from(message.to_string())
+    }
+}
+
 /// Errors returned by OpenCompany.
 #[derive(Debug, thiserror::Error)]
 pub enum OpenCompanyError {
@@ -179,6 +238,20 @@ pub enum OpenCompanyError {
     #[error("invalid request: {0}")]
     InvalidRequest(String),
 
+    /// A workflow graph draft was rejected at author time with one or more
+    /// structured problems (issue #1016). Distinct from [`Self::DataInvalid`]:
+    /// each [`WorkflowProblem`] carries the node id and config field at fault so
+    /// the console can highlight the exact node + field, while `Display` still
+    /// joins every message so the human `error` string stays populated and every
+    /// string-only reader keeps working. Renders as `400 Bad Request`; the HTTP
+    /// envelope additionally carries a `problems` array (see `server::error`).
+    #[error("{}", format_workflow_problems(.problems))]
+    WorkflowInvalid {
+        /// Every problem found, each naming its node and config field where one
+        /// applies.
+        problems: Vec<WorkflowProblem>,
+    },
+
     /// Runtime configuration could not be resolved (bad value, unreadable or
     /// malformed `config.toml`).
     #[error("configuration error: {0}")]
@@ -322,6 +395,7 @@ impl OpenCompanyError {
             Self::Conflict(_) => "conflict".to_string(),
             Self::Quiescing(_) => "quiescing".to_string(),
             Self::InvalidRequest(_) => "invalid_request".to_string(),
+            Self::WorkflowInvalid { .. } => "workflow_invalid".to_string(),
             Self::Config(_) => "config_error".to_string(),
             Self::Orchestration { code, .. } => code.clone(),
             Self::Tinyplace { code, .. } => format!("tinyplace_{code}"),
@@ -334,6 +408,19 @@ impl OpenCompanyError {
             Self::Harness(_) => "harness_error".to_string(),
         }
     }
+}
+
+/// Joins every workflow problem's message into one human-readable string, so a
+/// [`OpenCompanyError::WorkflowInvalid`] renders the same flat sentence a
+/// string-only caller expects even though it carries structured problems. The
+/// per-node/field detail rides in the `problems` vec, surfaced by the HTTP
+/// envelope; `Display` stays a plain join for logs and legacy readers.
+fn format_workflow_problems(problems: &[WorkflowProblem]) -> String {
+    problems
+        .iter()
+        .map(|problem| problem.message.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn format_manifest_problems(path: &std::path::Path, problems: &[String]) -> String {

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -4506,6 +4506,9 @@ impl Tool for CreateWorkflowTool {
                 let detail = match &err {
                     OpenCompanyError::InvalidRequest(message)
                     | OpenCompanyError::Conflict(message) => message.clone(),
+                    // A structured workflow rejection (issue #1016) carries the
+                    // joined problem text via `Display`, so the agent reads why.
+                    OpenCompanyError::WorkflowInvalid { .. } => err.to_string(),
                     _ => "the company couldn't save it right now; try again.".to_string(),
                 };
                 Ok(ToolResult::error(format!(

--- a/src/harness/workflow_admin.rs
+++ b/src/harness/workflow_admin.rs
@@ -291,6 +291,10 @@ fn detail_of(err: &OpenCompanyError) -> String {
         OpenCompanyError::InvalidRequest(message) | OpenCompanyError::Conflict(message) => {
             message.clone()
         }
+        // A structured workflow rejection (issue #1016) also carries prosumer
+        // text — its `Display` joins every problem's message — so the agent reads
+        // the same actionable sentence the flat #682 path gave it.
+        OpenCompanyError::WorkflowInvalid { .. } => err.to_string(),
         OpenCompanyError::CompanyNotFound(what) => {
             format!("no {what} exists — check the workflows list for valid ids.")
         }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -41,7 +41,8 @@ impl ApiError {
             OpenCompanyError::ManifestInvalid { .. }
             | OpenCompanyError::ManifestParse(_, _)
             | OpenCompanyError::MissingManifest(_)
-            | OpenCompanyError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+            | OpenCompanyError::InvalidRequest(_)
+            | OpenCompanyError::WorkflowInvalid { .. } => StatusCode::BAD_REQUEST,
             OpenCompanyError::LifecycleConflict(_) | OpenCompanyError::Conflict(_) => {
                 StatusCode::CONFLICT
             }
@@ -86,10 +87,22 @@ impl ApiError {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let status = self.status();
-        let body = Json(json!({
-            "error": self.0.to_string(),
-            "code": self.0.code(),
-        }));
+        // Every error renders the api.md envelope `{ "error", "code" }`. A
+        // `WorkflowInvalid` additively carries a `problems` array (issue #1016)
+        // so the console can highlight the exact node + field; the key is present
+        // ONLY for that variant, so every other error stays byte-for-byte as
+        // before and no existing client sees a new field.
+        let body = match &self.0 {
+            OpenCompanyError::WorkflowInvalid { problems } => Json(json!({
+                "error": self.0.to_string(),
+                "code": self.0.code(),
+                "problems": problems,
+            })),
+            _ => Json(json!({
+                "error": self.0.to_string(),
+                "code": self.0.code(),
+            })),
+        };
         (status, body).into_response()
     }
 }
@@ -135,5 +148,48 @@ mod test {
 
         let upstream = ApiError(OpenCompanyError::tinyplace("http_500", "boom"));
         assert_eq!(upstream.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// Issue #1016: a `WorkflowInvalid` renders a `400` whose envelope additively
+    /// carries a `problems` array, each entry naming its node + field.
+    #[tokio::test]
+    async fn workflow_invalid_envelope_carries_problems() {
+        use crate::error::WorkflowProblem;
+        use axum::body::to_bytes;
+
+        let err = ApiError(OpenCompanyError::WorkflowInvalid {
+            problems: vec![WorkflowProblem::node_field(
+                "greet",
+                "config.url",
+                "greet has a bad url.",
+            )],
+        });
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.0.code(), "workflow_invalid");
+
+        let body = err.into_response().into_body();
+        let bytes = to_bytes(body, usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["code"], "workflow_invalid");
+        assert_eq!(json["problems"][0]["node_id"], "greet");
+        assert_eq!(json["problems"][0]["field"], "config.url");
+        assert!(
+            json["error"].as_str().unwrap().contains("bad url"),
+            "{json}"
+        );
+    }
+
+    /// Every other error keeps the plain `{ error, code }` envelope with NO
+    /// `problems` key — the new field is additive and scoped to `WorkflowInvalid`.
+    #[tokio::test]
+    async fn non_workflow_error_has_no_problems_key() {
+        use axum::body::to_bytes;
+
+        let err = ApiError(OpenCompanyError::CompanyNotFound("acme".into()));
+        let body = err.into_response().into_body();
+        let bytes = to_bytes(body, usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["code"], "company_not_found");
+        assert!(json.get("problems").is_none(), "{json}");
     }
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3939,7 +3939,12 @@ async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert_eq!(body["code"], "invalid_request");
+    // Issue #1016: a dangling edge is now a structured `workflow_invalid` whose
+    // `problems` array names the endpoint and the field, so the console can
+    // highlight the id the author wrote.
+    assert_eq!(body["code"], "workflow_invalid");
+    assert_eq!(body["problems"][0]["node_id"], "ghost");
+    assert_eq!(body["problems"][0]["field"], "to");
 
     // An agent node naming a teammate not on the roster.
     let (status, body) = send(


### PR DESCRIPTION
## Summary

Two backend defects in the workflow editor stack, both about a save that looks fine but isn't:

- **Config accepted at save, fails at run.** The per-kind config gate had arms only for `condition`/`http_request`/`switch`/`tool_call`, then `_ => {}` — so a `transform` with no `config.set`, a `split_out` with no `config.path`, a bad-typed `output_parser`, a non-URL `http_request.url`, or a `sub_workflow.workflow_id` that names no saved workflow all saved clean and were silent no-ops (or hard failures) at run. Now every kind is validated at save.
- **Errors were an unstructured blob.** Every 400 flattened problems with `join(" ")` into one string with no field paths, and the edge validator named the edge by *index* (`edge #N starts at \`old-id\``) not by the node. Now a new `WorkflowInvalid { problems: [{node_id, field, message}] }` variant carries structured problems; the HTTP envelope emits an additive `problems` array (only for this variant); the edge message names the endpoint.

**This is the backend half of #1016.** The frontend half (cascade a node-id rename into edges, prune by row key, consume `problems` to highlight the offending node) is **deferred** — it lives entirely in `WorkflowCreateDialog.tsx`, which graycyrus's open PR #1020 is rewriting; doing it now would guarantee a hard conflict. It will land as a follow-up rebased on merged #1020. The backend ships first: the additive envelope keeps today's frontend working, and the failure is now a fixable 400 with the node/field named.

## API Or Behavior Changes

- Saving a workflow with an unschema'd/invalid node config now returns **400** at save (previously accepted, failed at run). New kinds gated: `transform` (`config.set`), `split_out` (`config.path`), `output_parser` (type-checks present keys; a schema-less identity parser is still accepted), `http_request.url` (now a real http/https URL check), `sub_workflow.workflow_id` (must name an existing workflow).
- 400 responses for workflow validation now carry an additive `problems: [{nodeId, field, message}]` array (new `code: "workflow_invalid"`); every other error is unchanged (no `problems` key) — backward compatible.
- The dangling-edge error names the endpoint node instead of `edge #N`.
- `merge` stays schema-free by design.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` + `--no-deps --features openhuman,tinycortex --all-targets`
- [x] `cargo build --locked --features openhuman,mcp,telegram --all-targets` + `cargo check --locked --all-features --all-targets`
- [x] `cargo test --lib` — `company::workflow_create` (81), `company::workflow_file` (81), `server::error` (4)

Red-first (fail pre-fix, pass after): a `transform` with no `config.set` (and `split_out` with no `config.path`) is now rejected naming the node + field; an `http_request` with `url="not-a-url"` yields `WorkflowInvalid` whose first problem is `{node_id:"greet", field:"config.url"}`; a dangling edge `from` yields a structured problem naming the endpoint, message no longer leading with `edge #N`. Regression guards: schema-less `output_parser` and no-config `merge` still accepted; `sub_workflow` self-ref still rejected.

## Documentation

`docs/modules/server/workflow-routes.md` documents the structured `workflow_invalid` envelope.

## Related

Part of #1016. Follow-up (deferred, blocked on graycyrus #1020 rewriting `WorkflowCreateDialog.tsx`): the frontend rename-cascade + prune-by-key + consume `problems` to highlight the node. #1016 stays open until that lands.

Note: `src/server/error.rs` here adds a `WorkflowInvalid` arm; PR #1089 (#1017) adds `DataParse`/`DataInvalid` arms to the same match — different arms, trivial rebase for whichever merges second.

Closes part of #1016 (backend).
