### PR TITLE
fix(approvals): answer a workflow park's continuation on its run, not in a DM (#1092)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1817,11 +1817,17 @@ impl CompanyRuntime {
             .approval_conversation(approval_id)
             .unwrap_or_default();
         let thread = conversation.thread;
+        // Where the reply goes when the approval was raised in no conversation
+        // at all — a workflow node's parked tool call, a scheduler tick. Read
+        // once for the whole report: every response of one continuation answers
+        // the same approval, so they cannot land in two places.
+        let nowhere =
+            continuation_fallback_chat_id(self.journal.approval_origin(approval_id).as_ref());
         for response in &mut report.responses {
-            let chat_id = thread.clone().unwrap_or_else(|| response.channel.clone());
+            let chat_id = thread.clone().unwrap_or_else(|| nowhere.clone());
             // Checked against the channel actually being answered into, not
             // against the recorded thread: when `thread` is absent the reply
-            // goes to the responding agent's own channel, and a root belonging
+            // goes to the run or card the work belongs to, and a root belonging
             // to some other channel must not follow it there.
             let parent = self.resolvable_parent(conversation.parent, &chat_id).await;
             match self
@@ -2623,6 +2629,58 @@ fn workflow_run_of(parked: &crate::runtime::journal::PendingApproval) -> Option<
     .flatten()
 }
 
+/// Where a continuation's reply is journaled when the approval it resumes was
+/// raised in **no conversation** (issue #1092), read off the park's own origin.
+///
+/// `publish_continuation` answers in the thread the approval came from. When
+/// there is none it used to fall back to the answering agent's own id — which
+/// `chat_history::owns` resolves as that teammate's DM, so a workflow node's
+/// parked `web_fetch`, once approved, posted the re-issued turn's narration
+/// into the operator's direct messages as though the teammate had written to
+/// them unprompted. `GrantedCall::origin_thread` documents that fallback as
+/// "right for a DM and never right for a desk channel"; a workflow run is a
+/// third case, and it is the one that reaches here.
+///
+/// Every arm below names something that **matches no desk**, so the reply stays
+/// on the event stream and inside the run or card timeline it belongs to
+/// instead of appearing in a chat nobody opened. That is the same device — and
+/// the same reasoning — `HarnessBrain::journal_task_outcome` already uses when
+/// it journals a dispatch reply under the card id.
+///
+/// The order is by specificity, and the workflow arm reuses
+/// [`workflow_run_of`]'s discrimination rather than restating it:
+/// `Effect::run_id` carries two id spaces, and only an explicitly `Unlinked`
+/// park with a run id on it is a workflow run. A park with neither a card nor a
+/// run came from an unaddressed conversation, so it answers in General — the
+/// same reading `chat_history::owns` gives a message journaled with no chat.
+fn continuation_fallback_chat_id(
+    origin: Option<&crate::runtime::journal::ApprovalOrigin>,
+) -> String {
+    // An unaddressed operator message is journaled with no chat on it, and
+    // `chat_history::owns` reads that absence as the General desk — so a park
+    // that carries no run and no card came from a conversation after all, and
+    // General is where its answer is read. It is the destination for the
+    // unknown case too (a pre-#333 line with no recorded link): a reply in the
+    // operator's own line is recoverable, while one in a teammate's DM reads as
+    // a message that teammate never sent.
+    let general = || crate::server::ops::language::DEFAULT_DESK.to_string();
+    let Some(origin) = origin else {
+        return general();
+    };
+    match &origin.task {
+        // A board task's dispatch cycle parked this: the card owns the work,
+        // and its timeline is where the answer is already read.
+        Some(crate::runtime::journal::TaskLink::Task { id }) => id.clone(),
+        // Explicitly unlinked *and* carrying a run id is a workflow park — the
+        // case this issue exists for. The run id matches no desk, so the answer
+        // stays on the run rather than arriving as a teammate's DM.
+        Some(crate::runtime::journal::TaskLink::Unlinked) => {
+            origin.run_id.clone().unwrap_or_else(general)
+        }
+        None => general(),
+    }
+}
+
 impl std::fmt::Debug for CompanyRuntime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CompanyRuntime")
@@ -2694,6 +2752,119 @@ mod tests {
         // A pre-#333 line records no link at all, so the park site is unknown.
         // Conservative rather than guessing — the same fallback rule #333 set.
         assert_eq!(super::workflow_run_of(&parked(None, Some("run-1"))), None);
+    }
+
+    /// Issue #1092: a continuation whose approval was raised in no conversation
+    /// must never be journaled into the answering teammate's DM.
+    ///
+    /// The fallback is the whole content of the fix, so it is asserted per park
+    /// site rather than through one happy path: the id it returns is what
+    /// `chat_history::owns` will (or will not) resolve to a chat thread.
+    #[test]
+    fn a_continuation_with_no_conversation_answers_outside_every_chat() {
+        use crate::runtime::journal::{ApprovalOrigin, TaskLink};
+
+        let origin = |task: Option<TaskLink>, run_id: Option<&str>| ApprovalOrigin {
+            at_millis: 1,
+            kind: "web_fetch".to_string(),
+            task,
+            run_id: run_id.map(str::to_string),
+            thread: None,
+            parent: None,
+            cycle: None,
+        };
+
+        // A workflow node's parked call: unlinked, with the run stamped on it.
+        // The run id is the destination — the timeline the operator was already
+        // watching, and a value no desk answers to.
+        assert_eq!(
+            super::continuation_fallback_chat_id(Some(&origin(
+                Some(TaskLink::Unlinked),
+                Some("run-9")
+            ))),
+            "run-9",
+        );
+        // A board card's dispatch: the card owns the work, exactly as
+        // `journal_task_outcome` already records it.
+        assert_eq!(
+            super::continuation_fallback_chat_id(Some(&origin(
+                Some(TaskLink::Task {
+                    id: "card-3".to_string()
+                }),
+                Some("attempt-4"),
+            ))),
+            "card-3",
+        );
+        // Unlinked with nothing stamped is an unaddressed operator turn, and a
+        // pre-#333 line with no link at all is unknown. Both answer in General
+        // — visible to the person who approved, and never a teammate's DM.
+        assert_eq!(
+            super::continuation_fallback_chat_id(Some(&origin(Some(TaskLink::Unlinked), None))),
+            "General",
+        );
+        assert_eq!(
+            super::continuation_fallback_chat_id(Some(&origin(None, Some("run-9")))),
+            "General",
+        );
+        assert_eq!(super::continuation_fallback_chat_id(None), "General");
+    }
+
+    /// Issue #1092, the property that actually matters: a workflow park's
+    /// continuation must not resolve to a teammate's DM or to a desk.
+    ///
+    /// Asserted through `chat_history::owns` itself rather than by eyeballing
+    /// the string, so a change on either side fails here instead of silently
+    /// re-opening the leak. The General arm is asserted the other way round in
+    /// the same breath — it is *supposed* to be readable — because a fallback
+    /// that hid every continuation would pass a one-directional test and lose
+    /// the operator's answer.
+    #[test]
+    fn a_workflow_parks_continuation_owns_no_desk_and_no_dm() {
+        use crate::ports::types::CompanyEvent;
+        use crate::runtime::journal::{ApprovalOrigin, TaskLink};
+        use crate::server::chat_history::owns;
+
+        let reply = |chat_id: String| CompanyEvent::AgentReply {
+            parent: None,
+            chat_id,
+            agent_id: "copywriter".to_string(),
+            text: "re-issued".to_string(),
+            steps: Vec::new(),
+            task_id: None,
+        };
+        let origin = |task: Option<TaskLink>, run_id: Option<&str>| ApprovalOrigin {
+            at_millis: 1,
+            kind: "web_fetch".to_string(),
+            task,
+            run_id: run_id.map(str::to_string),
+            thread: None,
+            parent: None,
+            cycle: None,
+        };
+
+        // The leak: a workflow node's park, answered into the copywriter's DM.
+        let workflow = super::continuation_fallback_chat_id(Some(&origin(
+            Some(TaskLink::Unlinked),
+            Some("run-9"),
+        )));
+        for (desk_id, desk_name) in [
+            ("copywriter", "Copywriter"),
+            ("creative", "Creative studio"),
+        ] {
+            assert!(
+                !owns(desk_id, desk_name, &reply(workflow.clone())),
+                "`{workflow}` must not be read as the `{desk_id}` conversation",
+            );
+        }
+
+        // And the other direction: an unaddressed operator turn still answers
+        // somewhere the person who approved is looking.
+        let unaddressed =
+            super::continuation_fallback_chat_id(Some(&origin(Some(TaskLink::Unlinked), None)));
+        assert!(
+            owns("main", "General", &reply(unaddressed.clone())),
+            "`{unaddressed}` must still be read as the operator's General line",
+        );
     }
 
     #[cfg(feature = "openhuman")]

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -7820,6 +7820,10 @@ mode = "full"
         rt: Arc<std::sync::OnceLock<Arc<CompanyRuntime>>>,
         /// Fail the continuation cycle, to exercise defect 4.
         fail_continuation: bool,
+        /// Stamp a workflow run id onto every parked effect (issue #1092), so
+        /// the park records the shape a workflow node's gated tool call has:
+        /// explicitly unlinked from any card, and carrying a run.
+        run_id: Option<String>,
     }
 
     #[async_trait::async_trait]
@@ -7845,6 +7849,7 @@ mode = "full"
                             let mut effect = gated_tool_call();
                             effect.payload =
                                 crate::policy::test_support::composio_unclassified_args_numbered(i);
+                            effect.run_id = self.run_id.clone();
                             host.park_effect(effect).await?;
                         }
                     }
@@ -7900,6 +7905,18 @@ mode = "full"
         chat: Option<&str>,
         fail_continuation: bool,
     ) -> MultiParkCompany {
+        multi_park_company_run(home, parks, chat, fail_continuation, None).await
+    }
+
+    /// [`multi_park_company`], with the parked effects stamped as a workflow
+    /// run (issue #1092).
+    async fn multi_park_company_run(
+        home: &std::path::Path,
+        parks: usize,
+        chat: Option<&str>,
+        fail_continuation: bool,
+        run_id: Option<&str>,
+    ) -> MultiParkCompany {
         let decisions = Arc::new(std::sync::Mutex::new(Vec::new()));
         let cycles = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let rt_slot: Arc<std::sync::OnceLock<Arc<CompanyRuntime>>> =
@@ -7914,6 +7931,7 @@ mode = "full"
                 cycles: cycles.clone(),
                 rt: rt_slot.clone(),
                 fail_continuation,
+                run_id: run_id.map(str::to_string),
             })),
         )
         .await;
@@ -8133,6 +8151,47 @@ mode = "full"
         assert!(
             replies.iter().all(|r| r.starts_with("sales|")),
             "the continuation must land in the channel the approval was raised in, got {replies:?}"
+        );
+    }
+
+    /// **Issue #1092.** A workflow node's parked call, once approved, answers
+    /// on its run — never as a direct message from the teammate that ran it.
+    ///
+    /// This is the wiring test for `continuation_fallback_chat_id`: the unit
+    /// tests pin what the fallback *returns*, and this pins that
+    /// `publish_continuation` actually uses it, through a real park, a real
+    /// resolve and the journal the console reads back.
+    ///
+    /// The assertion is written against the agent id rather than only for the
+    /// run id, because that is the regression: the leak put the re-issued
+    /// turn's narration into `chat/history?desk=<teammate>`, where it rendered
+    /// as an unprompted DM.
+    #[tokio::test]
+    async fn a_workflow_parks_continuation_answers_on_the_run_not_in_a_dm() {
+        let home_dir = home();
+        let c = multi_park_company_run(home_dir.path(), 1, None, false, Some("run-1092")).await;
+
+        let response = c
+            .app
+            .clone()
+            .oneshot(approve_detached(&c.approvals[0]))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        settle(&c.runtime, 1).await;
+
+        let replies = agent_replies(&c.runtime).await;
+        assert_eq!(replies.len(), 1, "the re-issue answered once");
+        let (chat_id, _) = replies[0].split_once('|').expect("chat_id|text");
+        assert_eq!(
+            chat_id, "run-1092",
+            "a workflow park's continuation belongs to its run, got {replies:?}"
+        );
+        // The regression, stated as itself: before this fix the fallback was
+        // the answering teammate's own id, so this is what the leaked row held.
+        assert_ne!(
+            chat_id, "ceo",
+            "the re-issue must not be journaled as a DM from the teammate that ran it"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #1092.

Approve a tool call that a **workflow agent node** parked, and the re-dispatched turn's reply arrived as a direct message *from that teammate* — in a thread the operator never opened, with no question above it.

`publish_continuation` answers in the conversation the approval was raised in, and fell back to the answering agent's own id when there was none:

```rust
let chat_id = thread.clone().unwrap_or_else(|| response.channel.clone());
```

`chat_history::owns` resolves a reply into a desk's history by matching `chat_id` against a desk id/name, and reads an unmatched selector as an ad-hoc thread id — so `chat_id = "copywriter"` **is** the copywriter's DM to the console and to `chat/history`. `GrantedCall::origin_thread` documents that fallback as *"right for a DM and never right for a desk channel"*; a workflow run is a third case, and the same doc says `origin_thread` is `None` exactly for "a workflow delivery, a scheduler tick".

The fix reads the destination off the park's own origin, which already carries what is needed (`ApprovalOrigin.task`, `ApprovalOrigin.run_id`):

| Park site | Answers on | Why |
|---|---|---|
| `Task { id }` | the card id | its timeline already reads the reply — the device `journal_task_outcome` uses deliberately ("a card id matches no desk") |
| `Unlinked` + run id | the run id | the workflow case; matches no desk, so no phantom DM |
| `Unlinked`, no run | `General` | an unaddressed operator turn — `owns` reads a missing chat as General, and that is where the approver is looking |
| no origin recorded | `General` | unknown; a recoverable reply beats a message a teammate never sent |

The agent id is never a destination. The workflow arm reuses `workflow_run_of`'s discrimination rather than restating it: `Effect::run_id` carries two id spaces, and only an explicitly `Unlinked` park with a run id is a workflow run.

**A note on the `General` arm**, because the first cut of this got it wrong: sending *every* no-conversation park to an opaque `approval:{id}` also swallowed the unaddressed-chat case, where the operator is genuinely waiting for the answer. Fixing a leak by losing the reply is not a fix, so the property test asserts both directions.

## API Or Behavior Changes

Behaviour only, on one path: a continuation whose approval carried no thread. It used to be journaled under the answering agent's id; it is now journaled under the card, the run, or `General`. No wire shape, route or type changes. A continuation whose approval *did* carry a thread is untouched — `a_continuation_answers_in_the_thread_the_sign_off_was_raised_in` and `a_continuation_resumes_in_the_thread_it_was_raised_in_and_no_other` still pass unchanged.

`announce_continuation_failure`, just below, has a sibling fallback to the `operator` channel. **Deliberately left alone**: that message is addressed to the operator ("Your approval was recorded, but the agent could not pick the work back up"), so routing it by this rule would hide the one message a person is actively waiting on. It wants its own decision, not a silent ride-along.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [ ] `cargo build --all-targets` — not run; `clippy --all-targets` compiled the same graph
- [ ] `cargo test` — not run in full (long on this workspace). Ran scoped: `cargo test --lib company::runtime` (13 passed) and `cargo test --lib server::operator::test::a_workflow_parks` (1 passed)

`--no-deps` on clippy per this repo's vendored-lint setup.

**The wiring test was verified to fail on the pre-fix code**, not merely to pass on the new:

```
assertion `left == right` failed: a workflow park's continuation belongs to its run,
got ["ceo|re-issued 01a018af4cb6-000000000013"]
  left: "ceo"
 right: "run-1092"
```

`ceo|…` — the agent id as `chat_id` — is the exact shape of the rows found in production DMs.

Three tests:
- `a_continuation_with_no_conversation_answers_outside_every_chat` — the id per park site.
- `a_workflow_parks_continuation_owns_no_desk_and_no_dm` — asserted through `chat_history::owns` itself rather than by comparing strings, so a change on either side fails here instead of quietly re-opening the leak; and the `General` arm asserted the other way round, since a fallback that hid every continuation would pass a one-directional test.
- `a_workflow_parks_continuation_answers_on_the_run_not_in_a_dm` — end to end: real park, real `POST /approvals/{id}`, journal read back. The park fixture gained a `run_id` so it can produce the workflow shape (`CycleHostImpl::park` records `Unlinked` with no task, and the origin's `run_id` comes off the effect); `multi_park_company` delegates to it, so existing call sites are untouched.

## Documentation

No docs change. The rule lives on `continuation_fallback_chat_id`'s own doc comment, next to `workflow_run_of` whose discrimination it reuses.

## Related

Found while investigating unsolicited agent DMs on a staging tenant. Adjacent, not fixed here: a `workflow.approve` gate carries `agent: None`, so a workflow park can never be granted standing (`scope: "tool"`) and re-parks on every run — which is what made this arrive in volume rather than once.