### PR TITLE
feat(workflows): render blocked-node approval links in run drawer (#1014)

### DIFF
--- a/frontend/src/views/workflows/BlockedNodeApprovals.tsx
+++ b/frontend/src/views/workflows/BlockedNodeApprovals.tsx
@@ -1,0 +1,96 @@
+// The gated tool names and per-approval links a blocked run leaves behind
+// (issues #881 / #1002, render half of #1014).
+//
+// The run drawer already NAMES the nodes a run blocked on (#881) and COUNTS the
+// cards it parked (#880), but said nothing about *which* tools were gated and
+// gave no way to reach the cards from here — the operator read "decide it in
+// Approvals" with no link. This renders both, from data already on the wire:
+// `WorkflowBlockedNode.tools` (the gated tool names — names only, never
+// arguments) and `WorkflowBlockedNode.approvalIds` (the cards those calls
+// opened).
+//
+// The link target is the whole Approvals queue (`#/approvals`), not a
+// per-approval route: an approval id is deliberately never put in a URL — the
+// console joins a run to its cards by `workflow_run_id` equality, not through a
+// route (see `ApprovalSummary.workflow_run_id`), and the only id the queue
+// route narrows on is a *board task* id (`#/approvals/<taskId>`, #883), which a
+// blocked node does not carry. So each parked call links to the same queue the
+// Approvals page and the sidebar badge already read — exactly the href that
+// page's own "back to the whole queue" control uses (`ApprovalsView`).
+
+import type {
+  WorkflowBlockedNode,
+  WorkflowRunApprovalRow,
+} from "@/api/workflows";
+
+/** The canonical Approvals queue route — the whole queue, no narrowing. */
+const APPROVALS_ROUTE = "#/approvals";
+
+/** approvalId → the tool whose gated call opened it, from the run's receipt (#880). */
+function toolByApprovalId(
+  rows: readonly WorkflowRunApprovalRow[] | undefined,
+): Map<string, string> {
+  const byId = new Map<string, string>();
+  for (const row of rows ?? []) {
+    if (row.approvalId && row.tool) byId.set(row.approvalId, row.tool);
+  }
+  return byId;
+}
+
+/**
+ * Under a blocked run's sentence: one line per blocked node, naming the tools it
+ * gated and linking each parked card to the Approvals queue.
+ *
+ * Renders nothing when no blocked node carries tools or approval ids — a host
+ * predating #881 sends neither, and the sentence above already stands on its
+ * own. Each `approvalId` becomes its own link, labelled with the tool that
+ * opened it when the run's receipt names one and with a neutral fallback when it
+ * does not (an old host that sent approval ids but no per-call rows).
+ */
+export function BlockedNodeApprovals({
+  blockedNodes,
+  approvalRows,
+}: {
+  blockedNodes: readonly WorkflowBlockedNode[];
+  /** The run's per-call receipt (#880), used only to LABEL each link with its tool. */
+  approvalRows?: readonly WorkflowRunApprovalRow[];
+}) {
+  const shown = blockedNodes.filter(
+    (b) => b.tools.length > 0 || (b.approvalIds?.length ?? 0) > 0,
+  );
+  if (shown.length === 0) return null;
+  const toolFor = toolByApprovalId(approvalRows);
+  return (
+    <ul
+      className="mt-1 space-y-0.5 text-2xs text-[var(--status-blocked-text)]"
+      data-testid="workflow-blocked-node-tools"
+    >
+      {shown.map((b) => {
+        const approvalIds = b.approvalIds ?? [];
+        return (
+          <li key={b.nodeId}>
+            <span className="font-medium">“{b.nodeId}”</span>
+            {b.tools.length > 0 && <> gated {b.tools.join(", ")}</>}
+            {approvalIds.length > 0 && (
+              <>
+                {" — decide in Approvals: "}
+                {approvalIds.map((id, i) => (
+                  <span key={id}>
+                    {i > 0 && ", "}
+                    <a
+                      href={APPROVALS_ROUTE}
+                      className="underline underline-offset-2 hover:text-foreground"
+                      data-testid="workflow-blocked-approval-link"
+                    >
+                      {toolFor.get(id) ?? "this call"}
+                    </a>
+                  </span>
+                ))}
+              </>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -18,6 +18,7 @@ import type {
   WorkflowRunOutcome,
 } from "@/api/workflows";
 
+import { BlockedNodeApprovals } from "./BlockedNodeApprovals";
 import { failedNodeOf, nodeName } from "./graph";
 import {
   awaitingCount,
@@ -470,6 +471,7 @@ function RunHistoryRow({
         // that, with the honest caveat that the continuation re-runs the agent's
         // turn and may ask again if it diverges. The unparkable-only case still
         // cannot continue and says so.
+        <>
         <p
           className="text-2xs text-[var(--status-blocked-text)]"
           data-testid="workflow-run-blocked"
@@ -495,6 +497,14 @@ function RunHistoryRow({
             ? `Approve ${parked === 1 ? "it" : "them"} in Approvals and this run continues on its own — approving re-runs the step, so a changed decision may ask again.`
             : "Nothing here can be approved; change the policy and run the workflow again."}
         </p>
+        {/* Issue #1014 (PR-B): the gated tool names per blocked node and a link
+            per parked card to the Approvals queue — the sentence above says
+            "decide it in Approvals" and, until this, pointed nowhere. */}
+        <BlockedNodeApprovals
+          blockedNodes={blocked}
+          approvalRows={run.approvals}
+        />
+        </>
       ) : run.running ? (
         // Same root cause as the tone bug: a run still walking its graph has no
         // error, no cancellation and no deliveries yet, so it fell through to

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { ApprovalRow } from "@/views/chat/ApprovalRow";
 import type { DecidedApproval } from "@/views/chat/model";
 
+import { BlockedNodeApprovals } from "./BlockedNodeApprovals";
 import { DeliveryRows } from "./RunHistoryPanel";
 // Issue #596: the per-node parse is now shared with the durable run inspector
 // and the pre-publish approvals card, so it lives in `run-output.ts`.
@@ -246,6 +247,17 @@ export function RunResultPanel({
                 } and this run continues on its own — approving re-runs the step, so a changed decision may ask again.`
               : "Nothing here can be approved; change the policy and run the workflow again."}
           </p>
+        )}
+        {/* Issue #1014 (PR-B): the gated tool names per blocked node, and a link
+            per parked card to the Approvals queue. Kept consistent with the run
+            history drawer — the section below can also decide them inline when
+            this console can join the live queue (#1002), but the tool names and
+            a pointer to the page stand even when it cannot. */}
+        {blockedNodes.length > 0 && (
+          <BlockedNodeApprovals
+            blockedNodes={blockedNodes}
+            approvalRows={result.approvals}
+          />
         )}
         {blockedNodes.length === 0 && result.pendingApprovals.length > 0 && (
           <p className="mb-2 text-xs text-muted-foreground">

--- a/frontend/test/unit/workflow-run-approval-links.test.ts
+++ b/frontend/test/unit/workflow-run-approval-links.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { GrantScope, Verdict, ApprovalSummary } from "@/api/types";
+import type {
+  WorkflowGraph,
+  WorkflowRunOutcome,
+  WorkflowRunResult,
+} from "@/api/workflows";
+import type { DecidedApproval } from "@/views/chat/model";
+import { RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
+import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+
+/**
+ * The render half of issue #1014 (PR-B): a blocked run names the tools it gated
+ * and links each parked card to the Approvals queue.
+ *
+ * Before this the run drawer said "decide it in Approvals" and pointed nowhere —
+ * `WorkflowBlockedNode.tools` and `.approvalIds` rode the wire and were only
+ * COUNTED, never rendered. Each test below fails on that code: there is no
+ * gated-tool line and no link at all.
+ *
+ * A jsdom render rather than a pure test, because the claim is about what the
+ * drawer paints — the tool text and an anchor per approval id — which a pure
+ * test of the data cannot see.
+ */
+
+const GRAPH: WorkflowGraph = {
+  id: "feature_pipeline",
+  name: "Feature pipeline",
+  version: null,
+  nodes: [{ id: "spec", kind: "agent", name: "Draft the spec", agent: "writer" }],
+  edges: [],
+};
+
+/** A settled run whose "spec" node blocked on two gated `publish_artifact` calls. */
+function blockedOutcome(
+  over: Partial<WorkflowRunOutcome> = {},
+): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    workflowId: "feature_pipeline",
+    scheduled: false,
+    runId: "run-1",
+    deliveries: [],
+    pendingApprovals: ["spec"],
+    nodes: [{ nodeId: "spec", status: "blocked", elapsedMs: 42_000 }],
+    blockedNodes: [
+      {
+        nodeId: "spec",
+        tools: ["publish_artifact", "web_search"],
+        approvalIds: ["appr-1", "appr-2"],
+      },
+    ],
+    approvals: [
+      { nodeId: "spec", tool: "publish_artifact", outcome: "parked", approvalId: "appr-1" },
+      { nodeId: "spec", tool: "web_search", outcome: "parked", approvalId: "appr-2" },
+    ],
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderHistory(run: WorkflowRunOutcome) {
+  await act(async () => {
+    root.render(
+      createElement(RunHistoryPanel, {
+        runs: [run],
+        graph: GRAPH,
+        workflowName: "Feature pipeline",
+        onClose: () => {},
+        selectedRunSeq: null,
+        onSelectRun: () => {},
+      }),
+    );
+  });
+}
+
+function resultFrom(run: WorkflowRunOutcome): WorkflowRunResult {
+  return {
+    output: {},
+    pendingApprovals: run.pendingApprovals,
+    runId: run.runId,
+    deliveries: run.deliveries,
+    nodes: run.nodes,
+    blockedNodes: run.blockedNodes,
+    approvals: run.approvals,
+  };
+}
+
+async function renderResult(run: WorkflowRunOutcome) {
+  await act(async () => {
+    root.render(
+      createElement(RunResultPanel, {
+        result: resultFrom(run),
+        graph: GRAPH,
+        request: "",
+        onClose: () => {},
+        // Empty live queue: the inline decidable section (#1002) does not render,
+        // so this isolates PR-B's tool-name line + links.
+        approvals: [] as ApprovalSummary[],
+        now: 1_700_000_060_000,
+        askerNames: new Map<string, string>(),
+        deciding: new Map<string, Verdict>(),
+        decided: {} as Record<string, DecidedApproval>,
+        failed: {} as Record<string, string>,
+        onDecide: (_a: ApprovalSummary, _v: Verdict, _s: GrantScope) => {},
+      }),
+    );
+  });
+}
+
+function toolLine(): HTMLElement | null {
+  return container.querySelector<HTMLElement>(
+    '[data-testid="workflow-blocked-node-tools"]',
+  );
+}
+
+function approvalLinks(): HTMLAnchorElement[] {
+  return [
+    ...container.querySelectorAll<HTMLAnchorElement>(
+      '[data-testid="workflow-blocked-approval-link"]',
+    ),
+  ];
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the run history drawer's blocked node", () => {
+  it("names the tools the blocked node gated", async () => {
+    await renderHistory(blockedOutcome());
+    const line = toolLine();
+    expect(line).not.toBeNull();
+    expect(line?.textContent).toContain("publish_artifact");
+    expect(line?.textContent).toContain("web_search");
+  });
+
+  it("turns each approval id into a link to the Approvals queue", async () => {
+    await renderHistory(blockedOutcome());
+    const links = approvalLinks();
+    // Two parked cards → two links, each to the canonical queue route.
+    expect(links).toHaveLength(2);
+    for (const a of links) {
+      expect(a.getAttribute("href")).toBe("#/approvals");
+    }
+    // Labelled by the tool that opened each card, from the run's receipt (#880).
+    expect(links.map((a) => a.textContent)).toEqual(["publish_artifact", "web_search"]);
+  });
+
+  it("still links every approval id when an old host sent no per-call rows", async () => {
+    // A host predating the receipt sends `approvalIds` but no `approvals` rows.
+    // The links must still appear — one per id — with a neutral label.
+    await renderHistory(
+      blockedOutcome({
+        approvals: undefined,
+        blockedNodes: [
+          { nodeId: "spec", tools: ["publish_artifact"], approvalIds: ["appr-1", "appr-2"] },
+        ],
+      }),
+    );
+    const links = approvalLinks();
+    expect(links).toHaveLength(2);
+    for (const a of links) expect(a.getAttribute("href")).toBe("#/approvals");
+  });
+
+  it("renders no blocked-node line for an ordinary run", async () => {
+    await renderHistory(
+      blockedOutcome({
+        pendingApprovals: [],
+        nodes: [{ nodeId: "spec", status: "ok", elapsedMs: 10 }],
+        blockedNodes: undefined,
+        approvals: undefined,
+      }),
+    );
+    expect(toolLine()).toBeNull();
+    expect(approvalLinks()).toHaveLength(0);
+  });
+});
+
+describe("the synchronous run result panel", () => {
+  it("renders the same tool names and approval links, for consistency", async () => {
+    await renderResult(blockedOutcome());
+    const line = toolLine();
+    expect(line).not.toBeNull();
+    expect(line?.textContent).toContain("publish_artifact");
+    const links = approvalLinks();
+    expect(links).toHaveLength(2);
+    for (const a of links) expect(a.getAttribute("href")).toBe("#/approvals");
+  });
+});


### PR DESCRIPTION
## Summary

Second render-only slice of #1014 (after PR-A board rows). `WorkflowBlockedNode.tools`, `WorkflowBlockedNode.approvalIds`, and `WorkflowRunApprovalRow.{nodeId,tool,approvalId}` are all on the wire and were only *counted* — the run drawer said "decide it in Approvals" with no link and never named the gated tools. This draws them.

## API Or Behavior Changes

Console only. For each blocked node the run drawer now lists the gated tool names and one link per `approvalId` to the Approvals queue (`#/approvals` — the exact route `ApprovalsView` uses; the tool that opened each id labels its link, joined from the run's approval receipts). No wire/schema change — the fields were already serialised; backend reverse-link (`ApprovalSummary.workflow_run_id`) already merged.

Approval ids are deliberately never placed in a URL (per the `workflow_run_id` contract); the only id the queue route narrows on is a board task id, which a blocked node does not carry — so each link targets the whole queue.

## Tests

- [x] `npm run typecheck` + `typecheck:unit` + `typecheck:e2e`
- [x] `npm run build`
- [x] `npx vitest run` — 1036 tests (105 files), incl. new `workflow-run-approval-links.test.ts` (5)

Red-first: a run with a blocked node carrying tools + approvalIds renders the tool names and one link per id; 4/5 new tests fail on pre-fix code (links absent), the 5th asserts absence for an ordinary run.

## Documentation

No doc pages — the render is self-evident in the drawer; the wire fields are documented on the Rust structs.

## Related

Part of #1014. Renders the #1002 approval half in the run drawer. PR-C (per-step diagnostics) follows. #1014 stays open until PR-C lands.