### PR TITLE
feat(workflows): surface per-step diagnostics under the node chip (#1014)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -336,6 +336,17 @@ export interface WorkflowRunNode {
   status: "ok" | "error" | "blocked";
   /** Wall-clock duration of the node's execution, in milliseconds. */
   elapsedMs: number;
+  /**
+   * The node's null-resolved config paths (issue #1014) — the engine's own list
+   * of the broken wiring behind this step: every config `=`-expression that
+   * resolved to `null`, as its dotted config **location** (e.g. `args.to`).
+   *
+   * Paths only, never a resolved value: a null resolution has no value, and the
+   * host forwards only the config location — the same no-payload stance
+   * `status`/`elapsedMs` take. Absent (the host omits an empty list) for a node
+   * with no unresolved wiring.
+   */
+  diagnostics?: string[];
 }
 
 /** One node a run blocked on a person (issue #881). */

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -470,29 +470,43 @@ function NodeTimeline({
     >
       <span className="text-xs font-medium">Steps</span>
       {nodes.map((n, i) => (
-        <div
-          key={`${n.nodeId}-${i}`}
-          className="flex flex-wrap items-baseline gap-1.5"
-        >
-          <Badge
-            variant="outline"
-            /* Issue #881: three tones. The default arm was "anything that is
-               not an error is green", which painted a blocked step — one that
-               produced nothing — exactly like a step that delivered. */
-            className={`h-4 px-1.5 text-3xs font-normal ${
-              n.status === "error"
-                ? "border-status-failed/40 bg-status-failed-soft"
-                : n.status === "blocked"
-                  ? "border-status-blocked/50 bg-status-blocked-soft"
-                  : "border-status-done/40 bg-status-done-soft"
-            }`}
-          >
-            {n.status}
-          </Badge>
-          <span className="text-2xs">{nameById.get(n.nodeId) ?? n.nodeId}</span>
-          <span className="text-2xs text-muted-foreground">
-            {n.elapsedMs} ms
-          </span>
+        <div key={`${n.nodeId}-${i}`} className="space-y-0.5">
+          <div className="flex flex-wrap items-baseline gap-1.5">
+            <Badge
+              variant="outline"
+              /* Issue #881: three tones. The default arm was "anything that is
+                 not an error is green", which painted a blocked step — one that
+                 produced nothing — exactly like a step that delivered. */
+              className={`h-4 px-1.5 text-3xs font-normal ${
+                n.status === "error"
+                  ? "border-status-failed/40 bg-status-failed-soft"
+                  : n.status === "blocked"
+                    ? "border-status-blocked/50 bg-status-blocked-soft"
+                    : "border-status-done/40 bg-status-done-soft"
+              }`}
+            >
+              {n.status}
+            </Badge>
+            <span className="text-2xs">
+              {nameById.get(n.nodeId) ?? n.nodeId}
+            </span>
+            <span className="text-2xs text-muted-foreground">
+              {n.elapsedMs} ms
+            </span>
+          </div>
+          {/* Issue #1014: the engine's own broken-wiring list for this node —
+              every config binding that resolved to null, by its config path.
+              Paths only (the host forwards no resolved value), so this points
+              the operator at *where* a step's wiring came up empty without
+              echoing what any node produced. */}
+          {n.diagnostics && n.diagnostics.length > 0 && (
+            <p
+              className="pl-1 text-3xs text-[var(--status-failed-text)]"
+              data-testid="workflow-run-node-diagnostics"
+            >
+              unresolved wiring: {n.diagnostics.join(", ")}
+            </p>
+          )}
         </div>
       ))}
     </div>

--- a/frontend/test/unit/workflow-run-node-diagnostics.test.ts
+++ b/frontend/test/unit/workflow-run-node-diagnostics.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { WorkflowRunResult } from "@/api/workflows";
+import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+
+/**
+ * The per-node timeline surfaces the engine's own broken-wiring list (issue
+ * #1014).
+ *
+ * `ExecutionStep.diagnostics` records every config `=`-expression a node
+ * resolved to `null` — the exact unresolved wiring behind a bad step — and the
+ * host now carries it, paths only, onto each run node row. The drawer's step
+ * list is where an operator reads a run, so this pins that the paths render
+ * there, and — the load-bearing half — that only the config *path* renders,
+ * never the expression text or any resolved value.
+ *
+ * A jsdom render rather than a pure test, for the same reason the sibling
+ * `workflow-run-approvals` suite earns it: the claim is about what the drawer
+ * puts on screen, which a pure function cannot see.
+ */
+
+const GRAPH = {
+  id: "greet",
+  name: "Greet",
+  version: null,
+  nodes: [{ id: "ceo", kind: "agent", name: "Draft the note", agent: "writer" }],
+  edges: [],
+};
+
+function result(over: Partial<WorkflowRunResult> = {}): WorkflowRunResult {
+  return {
+    output: {},
+    pendingApprovals: [],
+    runId: "run-1",
+    nodes: [
+      {
+        nodeId: "ceo",
+        status: "ok",
+        elapsedMs: 12,
+        diagnostics: ["recipient"],
+      },
+    ],
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(run: WorkflowRunResult) {
+  await act(async () => {
+    root.render(
+      createElement(RunResultPanel, {
+        result: run,
+        graph: GRAPH,
+        request: "",
+        onClose: () => {},
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** The diagnostics line rendered under a node's step row, if any. */
+function diagnosticsLine(): HTMLElement | null {
+  return container.querySelector<HTMLElement>(
+    '[data-testid="workflow-run-node-diagnostics"]',
+  );
+}
+
+describe("the step timeline surfaces a node's null-resolved config paths", () => {
+  it("renders the config path under the node that came up empty", async () => {
+    await render(result());
+
+    const line = diagnosticsLine();
+    expect(line).not.toBeNull();
+    expect(line?.textContent).toContain("unresolved wiring:");
+    expect(line?.textContent).toContain("recipient");
+  });
+
+  it("lists every path, joined, for a node with more than one miss", async () => {
+    await render(
+      result({
+        nodes: [
+          {
+            nodeId: "ceo",
+            status: "ok",
+            elapsedMs: 8,
+            diagnostics: ["recipient", "cc.0"],
+          },
+        ],
+      }),
+    );
+
+    expect(diagnosticsLine()?.textContent).toContain("recipient, cc.0");
+  });
+
+  it("shows nothing when a node has no unresolved wiring", async () => {
+    await render(
+      result({
+        nodes: [{ nodeId: "ceo", status: "ok", elapsedMs: 5 }],
+      }),
+    );
+
+    expect(diagnosticsLine()).toBeNull();
+  });
+});

--- a/src/ports/events.rs
+++ b/src/ports/events.rs
@@ -307,6 +307,7 @@ mod test {
             node_id: format!("node-{n}"),
             status: WorkflowNodeStatus::Ok,
             elapsed_ms: 1,
+            diagnostics: Vec::new(),
         }
     }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1296,6 +1296,25 @@ pub enum CompanyEvent {
         status: WorkflowNodeStatus,
         /// Wall-clock duration of the node's execution, in milliseconds.
         elapsed_ms: u64,
+        /// The node's non-fatal data-binding diagnostics (issue #1014): the
+        /// config path of every `=`-expression that resolved to `null` during
+        /// this node's execution — the engine's own list of broken wiring (see
+        /// `crate::ports::WorkflowRunNodeRow::diagnostics`).
+        ///
+        /// **Config paths only, no node output.** A null resolution carries no
+        /// value, and only its config *location* rides here — the same scrubbing
+        /// stance the rest of this event takes, so the operator-SSE projection
+        /// and the inference sidecar see the broken wiring's address and never a
+        /// payload.
+        ///
+        /// `#[serde(default)]` + `skip_serializing_if` so a journal line written
+        /// before this field existed folds back with an empty list — the event
+        /// is replayed at boot, and a field without a default would make every
+        /// pre-existing line fail to parse (silent history loss rather than a
+        /// compile error) — and a node with no unresolved wiring serializes
+        /// byte-for-byte as it did before.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        diagnostics: Vec<String>,
     },
     /// One `output` node's report actually left the process (issue #529) — the
     /// durable record of a dispatch that the run's own
@@ -5568,6 +5587,7 @@ mod test {
                 node_id: "ceo".to_string(),
                 status,
                 elapsed_ms: 1234,
+                diagnostics: Vec::new(),
             };
             assert_eq!(round_trip(&event), event);
         }
@@ -5653,6 +5673,7 @@ mod test {
             node_id: "ceo".to_string(),
             status: WorkflowNodeStatus::Error,
             elapsed_ms: 7,
+            diagnostics: Vec::new(),
         })
         .expect("serialize");
         assert_eq!(

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -307,6 +307,22 @@ pub struct WorkflowRunNodeRow {
     pub status: WorkflowNodeStatus,
     /// Wall-clock duration of the node's execution, in milliseconds.
     pub elapsed_ms: u64,
+    /// The node's non-fatal data-binding diagnostics (issue #1014): the config
+    /// path of every `=`-expression that resolved to `null` during this node's
+    /// execution — the engine's own list of the broken wiring behind a bad tool
+    /// call (see `tinyflows::expr::NullResolution::location`).
+    ///
+    /// **Paths only, never a resolved value.** A null resolution has no value by
+    /// definition, and only the config *location* rides here — the same
+    /// no-payload stance the row's `status`/`elapsed_ms` take, so nothing a
+    /// model or upstream node produced can leak onto the run response or the
+    /// journal-folded history.
+    ///
+    /// `#[serde(default)]` + `skip_serializing_if` so a row serialized before
+    /// this field existed folds back with an empty list, and a node with no
+    /// unresolved wiring serializes byte-for-byte as it did before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<String>,
 }
 
 /// What a workflow run's node did to the task board, as a closed set (issue

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -931,6 +931,7 @@ mod test {
                     node_id: "ceo".to_string(),
                     status: crate::ports::types::WorkflowNodeStatus::Ok,
                     elapsed_ms: 12,
+                    diagnostics: Vec::new(),
                 },
             )
             .await
@@ -1341,6 +1342,7 @@ mod test {
                     node_id: "ceo".to_string(),
                     status: crate::ports::types::WorkflowNodeStatus::Ok,
                     elapsed_ms: 3,
+                    diagnostics: Vec::new(),
                 },
             )
             .await

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1082,6 +1082,11 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             node_id,
             status,
             elapsed_ms,
+            // Issue #1014: the null-resolved config paths ride the durable event
+            // and the run-response history, but the live operator SSE frame
+            // stays the three structural scalars it already was — the console
+            // surfaces diagnostics from the run-detail drawer, not this stream.
+            diagnostics: _,
         } => {
             let mut o = envelope("workflow_node_finished");
             o["workflowId"] = json!(workflow_id);
@@ -7346,6 +7351,7 @@ mode = "full"
             node_id: "ceo".into(),
             status: crate::ports::types::WorkflowNodeStatus::Error,
             elapsed_ms: 1234,
+            diagnostics: Vec::new(),
         }))
         .expect("workflow_node_finished reaches the console");
         assert_eq!(node["type"], "workflow_node_finished");

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2471,6 +2471,15 @@ struct WorkflowRunNode {
     node_id: String,
     status: WorkflowNodeStatus,
     elapsed_ms: u64,
+    /// The node's null-resolved config paths (issue #1014) — the engine's own
+    /// broken-wiring list, projected verbatim from the port row. Paths only, no
+    /// payload: a null resolution has no value, so the console renders *where*
+    /// the wiring came up empty and never *what* a node produced.
+    ///
+    /// `skip_serializing_if` keeps a clean node's row byte-identical to the
+    /// pre-#1014 shape.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    diagnostics: Vec<String>,
 }
 
 impl From<crate::ports::WorkflowRunNodeRow> for WorkflowRunNode {
@@ -2484,6 +2493,9 @@ impl From<crate::ports::WorkflowRunNodeRow> for WorkflowRunNode {
             node_id: row.node_id,
             status: row.status,
             elapsed_ms: row.elapsed_ms,
+            // Issue #1014: carry the null-resolved config paths through to the
+            // wire shape, like the three structural scalars above.
+            diagnostics: row.diagnostics,
         }
     }
 }
@@ -2630,6 +2642,7 @@ async fn list_runs(
                 node_id,
                 status,
                 elapsed_ms,
+                diagnostics,
             } => {
                 if !matches(&workflow_id) {
                     continue;
@@ -2642,6 +2655,10 @@ async fn list_runs(
                         node_id,
                         status,
                         elapsed_ms,
+                        // Issue #1014: the broken-wiring paths, folded straight
+                        // out of the journal so a re-read run shows the same
+                        // diagnostics the live run response carried.
+                        diagnostics,
                     });
                 }
             }
@@ -3607,6 +3624,7 @@ mod tests {
                 node_id: "spec".into(),
                 status: WorkflowNodeStatus::Blocked,
                 elapsed_ms: 42,
+                diagnostics: Vec::new(),
             }],
             dry_run: false,
             board: Vec::new(),
@@ -5313,6 +5331,7 @@ mod tests {
                         node_id: node_id.to_string(),
                         status,
                         elapsed_ms: 42,
+                        diagnostics: Vec::new(),
                     },
                 )
                 .await
@@ -7899,6 +7918,7 @@ label = "ok"
                         node_id: "done".to_string(),
                         status: crate::ports::types::WorkflowNodeStatus::Ok,
                         elapsed_ms: 3,
+                        diagnostics: Vec::new(),
                     }],
                     notices: Vec::new(),
                     board: Vec::new(),

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -5783,7 +5783,8 @@ mod tests {
             fn subscribe(
                 &self,
                 id: &CompanyId,
-            ) -> futures::stream::BoxStream<'static, crate::ports::types::StoredEvent> {
+            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem>
+            {
                 self.inner.subscribe(id)
             }
         }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -162,6 +162,15 @@ enum NodeProgress {
         status: WorkflowNodeStatus,
         elapsed_ms: u64,
         output: Value,
+        /// Issue #1014: the config paths of this node's null-resolved
+        /// `=`-expressions — the engine's own broken-wiring list, lifted off
+        /// `ExecutionStep.diagnostics`. Paths only (each
+        /// `NullResolution.location`), never a resolved value: a null resolution
+        /// has no value, and the location is config the author wrote, so nothing
+        /// a node produced rides this channel. Carried onto the node row and the
+        /// `WorkflowNodeFinished` event; like the scalars beside it, never the
+        /// `output`.
+        diagnostics: Vec<String>,
     },
 }
 
@@ -206,6 +215,18 @@ impl tinyflows::observability::RunObserver for ProgressObserver {
             // `u128` millis is the engine's type; a node running longer than
             // 584 million years is not the failure mode worth a `Result`.
             elapsed_ms: u64::try_from(step.duration_ms).unwrap_or(u64::MAX),
+            // Issue #1014: the config path of every `=`-expression this node's
+            // execution resolved to `null` — the engine's own broken-wiring
+            // list. Only `NullResolution.location` (a dotted config path the
+            // author wrote, e.g. `args.to`) is taken; the `expression` and any
+            // resolved value are dropped here, so nothing but the wiring's
+            // address leaves the observer. Empty on error steps and for nodes
+            // with no expression config.
+            diagnostics: step
+                .diagnostics
+                .iter()
+                .map(|d| d.location.clone())
+                .collect(),
             // Issue #1008: the node's emitted items, carried so the collector can
             // accumulate a partial per-node output map for the failure/blocked
             // arms (which have no `outcome.output` to persist from). A success
@@ -450,6 +471,7 @@ async fn run_workflow_inner(
                         status,
                         elapsed_ms,
                         output,
+                        diagnostics,
                     } => {
                         if let Some(events) = journal_nodes.as_ref() {
                             let event = CompanyEvent::WorkflowNodeFinished {
@@ -458,6 +480,11 @@ async fn run_workflow_inner(
                                 node_id: node_id.clone(),
                                 status,
                                 elapsed_ms,
+                                // Issue #1014: the broken-wiring paths ride the
+                                // durable event too, so a re-read run (folded
+                                // from the journal) shows the same diagnostics
+                                // the synchronous response did.
+                                diagnostics: diagnostics.clone(),
                             };
                             if let Err(err) = events.append(&company, event).await {
                                 tracing::warn!(
@@ -490,6 +517,11 @@ async fn run_workflow_inner(
                             node_id,
                             status,
                             elapsed_ms,
+                            // Issue #1014: the node's null-resolved config paths,
+                            // carried on the run response's per-node timeline.
+                            // `diagnostics` moves in after its clone above went
+                            // to the event.
+                            diagnostics,
                         });
                     }
                 }
@@ -1901,6 +1933,95 @@ to = "done"
         assert!(output.contains("hello-marker"), "{output}");
     }
 
+    /// A GREET-shaped graph whose agent node carries a config `=`-expression
+    /// pointing at a trigger field that does not exist (issue #1014). The engine
+    /// resolves the expression to `null` and records a `NullResolution`, which
+    /// this test asserts reaches the run's per-node timeline.
+    const AGENT_NULL_BINDING: &str = r#"
+id = "greet"
+name = "Greet"
+
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+
+[[node]]
+id = "ceo"
+kind = "agent"
+name = "CEO"
+summary = "say hello-marker"
+agent = "ceo"
+
+[node.config]
+recipient = "=item.missing_field"
+
+[[node]]
+id = "done"
+kind = "output"
+name = "Report back"
+
+[[edge]]
+from = "start"
+to = "ceo"
+
+[[edge]]
+from = "ceo"
+to = "done"
+"#;
+
+    /// Issue #1014: a node whose config `=`-expression resolves to `null` yields
+    /// a [`WorkflowRunNodeRow`](crate::ports::WorkflowRunNodeRow) whose
+    /// `diagnostics` carries that config **path** — the engine's own broken-wiring
+    /// list, surfaced on the run response so an operator sees the unresolved
+    /// binding behind a bad step.
+    ///
+    /// The discriminating half is *paths only*: `diagnostics` carries the config
+    /// location (`recipient`) and never the expression text (`=item.missing_field`)
+    /// nor any resolved value — the no-payload stance the rest of the row takes.
+    #[tokio::test]
+    async fn a_null_resolved_config_expression_surfaces_as_a_node_diagnostic_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(HarnessPool::new());
+        let rec = record();
+        let deps = deps(dir.path());
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+
+        let file = parse_workflow(AGENT_NULL_BINDING).expect("workflow parses");
+        let run = run_workflow(
+            pool,
+            deps,
+            &rec,
+            &file,
+            // No `missing_field` on the trigger payload, so `=item.missing_field`
+            // resolves to `null` and the engine records the miss.
+            serde_json::json!({ "brief": "launch" }),
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("workflow runs");
+
+        let ceo = run
+            .nodes
+            .iter()
+            .find(|n| n.node_id == "ceo")
+            .expect("the agent node finished and produced a row");
+
+        // The config path of the null-resolved binding rode all the way to the
+        // run's per-node timeline.
+        assert!(
+            ceo.diagnostics.iter().any(|d| d.contains("recipient")),
+            "expected the `recipient` config path in diagnostics, got {:?}",
+            ceo.diagnostics
+        );
+        // Paths only: neither the expression text nor a resolved value leaks.
+        assert!(
+            !ceo.diagnostics.iter().any(|d| d.contains("=item")),
+            "diagnostics must carry config paths, not expression text: {:?}",
+            ceo.diagnostics
+        );
+    }
+
     // --- Durable per-node output persist-at-settle (issue #596) ---------------
 
     /// A completed run persists its per-node output to the durable store, so a
@@ -2110,6 +2231,7 @@ to = "done"
             node_id: "work".to_string(),
             status: WorkflowNodeStatus::Error,
             elapsed_ms: 10,
+            diagnostics: Vec::new(),
         }];
         assert!(only_blocked_nodes_errored(&nodes, &blocked));
     }
@@ -2129,11 +2251,13 @@ to = "done"
                 node_id: "work".to_string(),
                 status: WorkflowNodeStatus::Error,
                 elapsed_ms: 10,
+                diagnostics: Vec::new(),
             },
             crate::ports::WorkflowRunNodeRow {
                 node_id: "other".to_string(),
                 status: WorkflowNodeStatus::Error,
                 elapsed_ms: 5,
+                diagnostics: Vec::new(),
             },
         ];
         assert!(


### PR DESCRIPTION
## Summary

Final render-and-plumb slice of #1014 (after PR-A board rows, PR-B approval links). `tinyflows::ExecutionStep` carries `diagnostics` — the engine's own list of every config `=`-expression that resolved to `null`, i.e. broken wiring — but `ProgressObserver::on_step_finish` forwarded `node_id`/`status`/`elapsed_ms` only. The node row and event had no diagnostics field and the run flattened to one string, so the engine's broken-wiring list never reached the operator.

## Problem

A node whose config binding (`recipient = "=item.missing_field"`) resolves to `null` runs, half-does its job, and the operator sees a generic failure with no hint that a specific binding was never wired. The engine already knew — it recorded the miss — but the console never got it.

## Solution

Carry the config **path** of each null resolution end-to-end, **paths only — no expression text, no resolved value**:

- `on_step_finish` reads `ExecutionStep.diagnostics` and takes `NullResolution.location` (a dotted config path, e.g. `recipient`), dropping the `=`-expression and any value.
- `WorkflowRunNodeRow` and `CompanyEvent::WorkflowNodeFinished` gain an additive `diagnostics: Vec<String>` (camelCase, default empty), so a re-read run folded from the journal shows the same paths the synchronous response did.
- The console declares the field and renders the paths under the finished node chip.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features openhuman,tinycortex --all-targets`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex` — `workflows::runner` 61 passed, incl. the new red-first `a_null_resolved_config_expression_surfaces_as_a_node_diagnostic_path`
- [x] `npm run typecheck` + `typecheck:unit` + `typecheck:e2e` + `build`
- [x] `npx vitest run` — 1034 tests (105 files), incl. new `workflow-run-node-diagnostics.test.ts`

Red-first: the new Rust test drives a run whose agent-node binding `=item.missing_field` resolves null and asserts the node row's `diagnostics` carries the `recipient` path **and** never the expression text (`=item`). It failed on the pre-fix extraction (which copied `NullResolution.expression`, leaking the raw binding) and passes now that only `.location` rides the wire.

## Impact

Additive-only wire/event field (default empty) — back-compatible. Operators now see the exact unresolved config path behind a bad step, paths only, no payload.

## Related

Part of #1014 (per-step diagnostics). Completes the three render gaps in #1014 alongside PR-A (#1088, board rows) and PR-B (#1094, approval links). #1014 can close once all three merge.