### PR TITLE
fix(workflows): refuse an ungranted email destination at save, and stop the channel pre-flight passing on a timer (#981)

### DIFF
--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -147,6 +147,31 @@ rides the create body and the read shape under the same key, and the model
 type is reused verbatim in both directions (`kind` / `target` are single words,
 so there is no camelCase mirror to drift from).
 
+### Destinations that can never deliver are refused at save (issue #981)
+
+Two of delivery's refusals are decided by facts that hold for *every* run of the
+graph, so a save that names one is a graph guaranteed to drop its report. Both
+are refused with a `400` when the workflow is written, not only when it runs:
+
+| Destination | Refused when | Checked in |
+| --- | --- | --- |
+| `channel` | the target is not one this **running company** can deliver to — `CompanyRuntime::deliverable_channel_ids()`, which is also what `GET …/workflows/wired-channels` serves the console's picker, and which never includes `operator` | `reject_undeliverable_channel_destinations`, on both write routes (the deliverable set is a runtime fact, not a record one) |
+| `email` | this company's `[tools].allow` does not grant `email`, which delivery answers with `Denied` / `EmailNotGranted` before it even looks for a mailbox | `validate_draft_against_record` in `src/company/workflow_create.rs`, beside the `tool_call` grant gate — so the orchestrator's `create_workflow` tool is held to it too |
+
+Both are guards, not guarantees. Desks come and go and grants can be revoked, so
+a graph valid at save can be invalid at run, and delivery's own refusal stays the
+backstop — as it must for seed and legacy graphs, which never pass through the
+create path at all. Neither check runs at TOML parse time: a seed template is
+parsed with no runtime in hand, and checking there would refuse to boot it on a
+company whose desks are not resolved yet.
+
+Deliberately **not** refused at save: a wired mailbox and an established inbound
+thread with an `email` recipient. Those are per-run, per-recipient conditions an
+author-time check cannot see, and refusing on them would refuse graphs that work.
+Arming a *schedule* does check the mailbox lever (issue #1046) — see
+`UNDELIVERABLE_SCHEDULE_REFUSAL` — because a scheduled run has no reader to
+notice the dropped report.
+
 Delivery itself is **not** a route concern. It runs host-side in the shared
 `WorkflowRunner` path (`src/workflows/delivery.rs`) once the engine returns,
 because the orchestrator's `run_workflow` tool and the trigger scheduler drive

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -169,6 +169,34 @@ function scheduleProblem(schedule: string): string | null {
   return null;
 }
 
+/** What the console knows about the channels this company can deliver to
+ * (issue #981).
+ *
+ * Three states, deliberately not collapsed into `string[]`. They used to be:
+ * `[]` meant "loading", "the host has no such route", and "the host answered,
+ * this company has nowhere to deliver" all at once, and the pre-flight treated
+ * all three as "don't check". Only the last of those is knowledge, and it is
+ * the one the host refuses a channel target against — so the console skipped
+ * exactly the check the host applies, and skipped it on a timer.
+ *
+ * - `loading` — the request is in flight. We know nothing YET, and the answer
+ *   is coming: {@link destinationCheckDeferred} holds Save rather than passing.
+ * - `unavailable` — the request failed, or the host predates the route. We know
+ *   nothing and never will, so the channel target degrades to free text and the
+ *   host's save-time 400 is the only gate. Never blocks Save.
+ * - `ready` — the host answered. `ids` is the answer, **including `[]`**, which
+ *   means this company genuinely has nowhere to post a report.
+ */
+export type WiredChannels =
+  | { status: "loading" }
+  | { status: "unavailable" }
+  | { status: "ready"; ids: string[] };
+
+/** The `ids` a picker may offer: only a settled, non-empty answer has any. */
+function channelOptions(channels: WiredChannels): string[] {
+  return channels.status === "ready" ? channels.ids : [];
+}
+
 /** What is wrong with an output node's `destination.target` for `kind`, or
  * `null` when it is postable. Mirrors the host's per-kind target contract in
  * `src/company/workflow_file.rs`; `owner` and "no destination" carry no target
@@ -185,7 +213,7 @@ function scheduleProblem(schedule: string): string | null {
 export function destinationTargetProblem(
   kind: DraftNode["destinationKind"],
   target: string,
-  wiredChannels: string[],
+  channels: WiredChannels,
 ): string | null {
   const value = target.trim();
   if (kind === "email" && !value.includes("@")) {
@@ -197,22 +225,61 @@ export function destinationTargetProblem(
   // #813: when the host told us which channels it can deliver to, a target that
   // is not one of them is refused when the workflow is saved (#981) and, for a
   // graph saved before a desk went away, fails at delivery (`ChannelNotWired`) —
-  // catch it at author time instead. Skipped when the list is empty (host
-  // offered none), so a degraded free-text box is never wrongly rejected.
+  // catch it at author time instead.
   //
   // #981: the same sentence the host's save-time rejection carries, so an author
   // who trips the pre-flight and an author who trips the 400 are told the same
   // thing. `operator` is no longer in the list the host serves — it never was a
   // delivery target — so this is what now catches it.
+  //
+  // Gated on `status === "ready"`, NOT on the list being non-empty. Those were
+  // the same test until the host started answering `[]` for a company with no
+  // desks and no connected channels (#981): that list is knowledge, and the
+  // host refuses every channel target against it, so the pre-flight must too.
+  // While the answer is still in flight, or when the request failed, we know
+  // nothing — {@link destinationCheckDeferred} is what keeps that from reading
+  // as a pass.
   if (
     kind === "channel" &&
     value &&
-    wiredChannels.length > 0 &&
-    !wiredChannels.includes(value)
+    channels.status === "ready" &&
+    !channels.ids.includes(value)
   ) {
-    return `\`${value}\` is not a workflow delivery channel — this runtime has: ${wiredChannels.join(", ")}.`;
+    return `\`${value}\` is not a workflow delivery channel — this runtime has: ${
+      channels.ids.length > 0 ? channels.ids.join(", ") : "no durable channels"
+    }.`;
   }
   return null;
+}
+
+/** Why the channel pre-flight cannot answer yet, or `null` when it can (or when
+ * there is nothing for it to check).
+ *
+ * Issue #981: {@link destinationTargetProblem} has to return `null` while the
+ * wired-channel list is loading — it genuinely does not know — and `null` is
+ * indistinguishable from "checked and fine". That made the check a race: an
+ * author who hit Save before the fetch settled got no pre-flight at all, while a
+ * slower one got the full one. Same draft, different validation, decided by
+ * network timing.
+ *
+ * So `validate()` asks this FIRST and defers instead: Save is held for as long
+ * as the answer is genuinely in flight, and released the moment it lands. A
+ * failed or absent request settles as `unavailable`, never `loading`, so a host
+ * that cannot answer degrades to free text and the host's own 400 rather than
+ * blocking the save forever.
+ *
+ * Not wired into the blur handler: a field is blurred constantly, and "still
+ * checking" is not a mistake the author made.
+ */
+export function destinationCheckDeferred(
+  kind: DraftNode["destinationKind"],
+  target: string,
+  channels: WiredChannels,
+): string | null {
+  if (kind !== "channel" || !target.trim() || channels.status !== "loading") {
+    return null;
+  }
+  return "still checking which channels this company can deliver to — try Save again in a moment.";
 }
 
 /** How a validation message names a node.
@@ -416,8 +483,12 @@ export function WorkflowCreateDialog({
   const [roster, setRoster] = useState<TeamMemberDto[]>([]);
   /** The chat channels this company can actually deliver to (#813): the picker
    * options for an output node's `channel` destination. Degrades to a free-text
-   * box when the host offers no list, so authoring is never blocked. */
-  const [wiredChannels, setWiredChannels] = useState<string[]>([]);
+   * box when the host offers no list, so authoring is never blocked. Carries
+   * its own load status (#981) — see {@link WiredChannels} for why an empty
+   * list and an unanswered request must not be the same value. */
+  const [wiredChannels, setWiredChannels] = useState<WiredChannels>({
+    status: "loading",
+  });
   /** The company's workflows, for the `sub_workflow` config picker (#541). The
    * graph's own id is dropped at render time — a sub-workflow can't call
    * itself. Degrades to a free-text id field when the host offers no list. */
@@ -556,12 +627,19 @@ export function WorkflowCreateDialog({
     // Issue #813: the wired-channel picker's options. Same degrade-on-failure
     // shape — a host that can't list channels leaves the channel target a
     // free-text box rather than blocking authoring.
+    //
+    // #981: the two outcomes are recorded as DIFFERENT states. A settled answer
+    // is knowledge the pre-flight checks against (even when it is `[]`); a
+    // failure is not, and must never be mistaken for one. Reset to `loading` on
+    // every open so a reopened dialog re-asks rather than validating against the
+    // previous company's answer.
+    setWiredChannels({ status: "loading" });
     (async () => {
       try {
         const channels = await listWiredChannels(client, company);
-        if (live) setWiredChannels(channels);
+        if (live) setWiredChannels({ status: "ready", ids: channels });
       } catch {
-        if (live) setWiredChannels([]);
+        if (live) setWiredChannels({ status: "unavailable" });
       }
     })();
     return () => {
@@ -791,6 +869,17 @@ export function WorkflowCreateDialog({
       // "destination on a non-output node" check: `changeKind` makes that state
       // unreachable, and re-adding the check would only recreate the trap of an
       // error the author has no visible control to clear.
+      //
+      // #981: ask the deferral FIRST. While the wired-channel list is in
+      // flight the target check below cannot answer, and its `null` would read
+      // as a pass — which made the strength of the pre-flight depend on how
+      // fast the author clicked Save.
+      const deferred = destinationCheckDeferred(
+        n.destinationKind,
+        n.destinationTarget,
+        wiredChannels,
+      );
+      if (deferred) return `Node \`${nodeLabel(n)}\`: ${deferred}`;
       const destinationProblem = destinationTargetProblem(
         n.destinationKind,
         n.destinationTarget,
@@ -1536,8 +1625,9 @@ function NodeRow({
   company: string | null;
   roster: TeamMemberDto[];
   /** The company's wired chat channels (#813): the output-node channel-destination
-   * picker's options. Empty → the channel target degrades to a free-text box. */
-  wiredChannels: string[];
+   * picker's options. Anything but a settled, non-empty answer degrades the
+   * channel target to a free-text box (#981). */
+  wiredChannels: WiredChannels;
   /** The company's workflows, for a `sub_workflow` node's picker (issue #541). */
   workflows: WorkflowSummary[];
   /** True while creating a new workflow (not editing an existing one), so the
@@ -1554,6 +1644,10 @@ function NodeRow({
 }) {
   const rowId = useId();
   const targetErrorId = `${rowId}-target-error`;
+  // The channels there are to offer, which is none until the host has answered
+  // (#981). A picker with no options is worse than the free-text fallback, so
+  // this drives both which control renders and which explanation sits under it.
+  const channelIds = channelOptions(wiredChannels);
   return (
     <div className="grid gap-2 rounded-lg border p-2 sm:grid-cols-[1fr_1fr_1.4fr_auto] sm:items-start">
       <div className="grid gap-1">
@@ -1668,7 +1762,7 @@ function NodeRow({
                 ))}
               </SelectContent>
             </Select>
-            {node.destinationKind === "channel" && wiredChannels.length > 0 && (
+            {node.destinationKind === "channel" && channelIds.length > 0 && (
               <>
                 {/* #813: pick from the channels this company can actually
                     deliver to, instead of a free-text box that only fails at
@@ -1687,7 +1781,7 @@ function NodeRow({
                     <SelectValue placeholder="pick a wired channel" />
                   </SelectTrigger>
                   <SelectContent>
-                    {wiredChannels.map((channelId) => (
+                    {channelIds.map((channelId) => (
                       <SelectItem key={channelId} value={channelId}>
                         {channelId}
                       </SelectItem>
@@ -1698,7 +1792,7 @@ function NodeRow({
               </>
             )}
             {(node.destinationKind === "email" ||
-              (node.destinationKind === "channel" && wiredChannels.length === 0)) && (
+              (node.destinationKind === "channel" && channelIds.length === 0)) && (
               <>
                 <Input
                   value={node.destinationTarget}
@@ -1718,21 +1812,40 @@ function NodeRow({
             )}
             {node.destinationKind === "email" && (
               <p className="text-2xs leading-snug text-muted-foreground">
-                Only sends if this company grants email and the recipient has
-                already written in.
+                Needs this company to grant email — the save is refused
+                otherwise — and the recipient to have already written in.
               </p>
             )}
             {/* #981: an empty list is now a legitimate answer — a company with
                 no desks and no connected channels has nowhere to post a report,
                 so the free-text box above is the honest fallback rather than a
                 picker of one bad option. Say why it is empty; without this the
-                author sees a blank box and no reason. */}
-            {node.destinationKind === "channel" && wiredChannels.length === 0 && (
+                author sees a blank box and no reason.
+
+                Gated on `ready`: while the request is in flight, or when it
+                failed, the box is equally empty and this sentence would be a
+                claim we cannot make. Each of those states says its own thing
+                below instead. */}
+            {node.destinationKind === "channel" &&
+              wiredChannels.status === "ready" &&
+              wiredChannels.ids.length === 0 && (
+                <p className="text-2xs leading-snug text-muted-foreground">
+                  No delivery channels are wired for this company — add a desk,
+                  or connect a channel, before a report can be posted to one.
+                </p>
+              )}
+            {node.destinationKind === "channel" && wiredChannels.status === "loading" && (
               <p className="text-2xs leading-snug text-muted-foreground">
-                No delivery channels are wired for this company — add a desk, or
-                connect a channel, before a report can be posted to one.
+                Checking which channels this company can deliver to…
               </p>
             )}
+            {node.destinationKind === "channel" &&
+              wiredChannels.status === "unavailable" && (
+                <p className="text-2xs leading-snug text-muted-foreground">
+                  This host did not say which channels it can deliver to, so the
+                  target is checked when the workflow is saved.
+                </p>
+              )}
           </>
         )}
         {/* The five kinds that need config to run (issue #541). Rendered here,

--- a/frontend/test/unit/workflow-destination-target.test.ts
+++ b/frontend/test/unit/workflow-destination-target.test.ts
@@ -1,31 +1,90 @@
 import { describe, expect, it } from "vitest";
 
-import { destinationTargetProblem } from "@/views/WorkflowCreateDialog";
+import {
+  destinationCheckDeferred,
+  destinationTargetProblem,
+} from "@/views/WorkflowCreateDialog";
+import type { WiredChannels } from "@/views/WorkflowCreateDialog";
+
+const ready = (...ids: string[]): WiredChannels => ({ status: "ready", ids });
+const loading: WiredChannels = { status: "loading" };
+const unavailable: WiredChannels = { status: "unavailable" };
 
 // #813 defect 4: a channel destination pointing at a channel this deployment
 // never wired only failed at delivery (`ChannelNotWired`). The picker keeps a
 // create-mode author on the wired list, but the branch is still reachable — an
 // edit dialog can carry a persisted target for a channel since unwired, and a
-// free-text value can be entered during the async `listWiredChannels` load
-// before the list arrives. These pin the author-time refusal on that path.
+// free-text value can be entered when the host offered no list at all. These
+// pin the author-time refusal on that path.
 describe("destinationTargetProblem — unwired channel", () => {
-  const wired = ["operator", "email"];
+  // `operator` is deliberately NOT in this fixture: the host stopped serving it
+  // (#981) because delivery refuses it by name, so a wired set containing it is
+  // no longer a state the console can be in.
+  const wired = ready("engineering", "product_design");
 
   it("rejects a channel that is not in the wired set, naming what is", () => {
     const problem = destinationTargetProblem("channel", "ghost", wired);
     expect(problem).toBe(
-      "`ghost` is not a workflow delivery channel — this runtime has: operator, email.",
+      "`ghost` is not a workflow delivery channel — this runtime has: engineering, product_design.",
+    );
+  });
+
+  it("rejects `operator`, which the host never offers and delivery refuses", () => {
+    expect(destinationTargetProblem("channel", "operator", wired)).toContain(
+      "is not a workflow delivery channel",
     );
   });
 
   it("accepts a channel that is wired", () => {
-    expect(destinationTargetProblem("channel", "operator", wired)).toBeNull();
-    expect(destinationTargetProblem("channel", "email", wired)).toBeNull();
+    expect(destinationTargetProblem("channel", "engineering", wired)).toBeNull();
+    expect(destinationTargetProblem("channel", "product_design", wired)).toBeNull();
   });
 
-  it("does not reject free text when the host offered no wired list", () => {
-    // Degraded/loading state: an empty list means "we don't know", so a
-    // free-text box must not be wrongly refused.
-    expect(destinationTargetProblem("channel", "anything", [])).toBeNull();
+  // #981: a settled empty answer is knowledge, not ignorance — the company has
+  // no desks and no connected channels, and the host refuses every channel
+  // target against that same empty set. The pre-flight has to agree, in the
+  // host's own words for the empty case (`undeliverable_channel_message`).
+  it("rejects any channel when the host answered with an empty set", () => {
+    expect(destinationTargetProblem("channel", "engineering", ready())).toBe(
+      "`engineering` is not a workflow delivery channel — this runtime has: no durable channels.",
+    );
+  });
+
+  it("does not reject free text when the host could not answer", () => {
+    // A failed request / a host predating the route tells us nothing, so a
+    // free-text box must not be wrongly refused — the save-time 400 is the gate.
+    expect(destinationTargetProblem("channel", "anything", unavailable)).toBeNull();
+  });
+});
+
+// #981: the check used to be skipped while the list was loading, and a skip is
+// indistinguishable from a pass. An author who clicked Save before the fetch
+// settled got no channel pre-flight at all; a slower author got the full one.
+describe("destinationCheckDeferred — the loading-order trap", () => {
+  it("does not silently pass a channel target while the list is loading", () => {
+    // The pair is the point: the target check alone cannot answer (`null`), and
+    // the deferral is what stops that `null` from being read as "fine".
+    expect(destinationTargetProblem("channel", "ghost", loading)).toBeNull();
+    expect(destinationCheckDeferred("channel", "ghost", loading)).toBe(
+      "still checking which channels this company can deliver to — try Save again in a moment.",
+    );
+  });
+
+  it("stops deferring the moment the answer lands", () => {
+    expect(destinationCheckDeferred("channel", "ghost", ready("engineering"))).toBeNull();
+    expect(destinationCheckDeferred("channel", "ghost", ready())).toBeNull();
+  });
+
+  it("never defers when the host cannot answer at all", () => {
+    // Otherwise a host without the route would block Save forever.
+    expect(destinationCheckDeferred("channel", "ghost", unavailable)).toBeNull();
+  });
+
+  it("only defers what it is about: a channel target that exists", () => {
+    expect(destinationCheckDeferred("channel", "", loading)).toBeNull();
+    expect(destinationCheckDeferred("channel", "   ", loading)).toBeNull();
+    expect(destinationCheckDeferred("email", "ada@example.com", loading)).toBeNull();
+    expect(destinationCheckDeferred("owner", "", loading)).toBeNull();
+    expect(destinationCheckDeferred("", "", loading)).toBeNull();
   });
 });

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -728,6 +728,20 @@ fn validate_draft_against_record(draft: &RawWorkflow, record: &CompanyRecord) ->
                 }
             },
             "tool_call" => validate_tool_call_node(node, record)?,
+            // Issue #981: an `email` destination on a company that does not
+            // grant `email` is a graph every run denies. Checked here, beside
+            // the `tool_call` grant gate, because it is the same *kind* of fact
+            // — a record grant, not a live runtime one — and because this
+            // helper is the shared create/update gate, so the orchestrator's
+            // `create_workflow` tool is held to it too. Its sibling rule ("a
+            // `channel` target must be one this runtime can deliver to") cannot
+            // live here: the deliverable set is a property of the *running*
+            // company, not of its record, so that one stays on the write routes
+            // (`reject_undeliverable_channel_destinations`).
+            "output" => {
+                #[cfg(feature = "openhuman")]
+                validate_output_destination(node, record)?;
+            }
             // Per-kind required config (issue #661): reject a `condition` with no
             // `field`, an `http_request` missing `method`/`url`, or a `switch`
             // with no discriminant at author time — the same gate the on-disk
@@ -935,6 +949,59 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
     }
 
     Ok(())
+}
+
+/// Author-time `output` destination check: an `email` destination needs the
+/// company to grant the `email` namespace in `[tools].allow` (issue #981).
+///
+/// The mirror of delivery's FIRST email gate
+/// ([`deliver_outputs`](crate::workflows::delivery), which answers a missing
+/// grant with a `Denied` / [`EmailNotGranted`] row before it even looks at
+/// whether a mailbox is wired), surfaced at save so an author hears about it
+/// now instead of after a scheduled run nobody watched dropped its report. A
+/// missing grant is a deployment-wide fact, exactly like naming the operator
+/// channel: it denies *every* run of the graph, on every recipient, until
+/// somebody edits the manifest.
+///
+/// **Only the grant half.** Delivery's later gates — a wired mailbox, and an
+/// established inbound thread with the recipient (issue #170's reply-only
+/// rule) — are per-run, per-recipient conditions an author-time check cannot
+/// see, and refusing a save on them would refuse graphs that work. #1046 drew
+/// the same line for the arm-time check
+/// ([`destination_is_reachable`](crate::company::destination_is_reachable)),
+/// which stops at the mailbox lever for the same reason.
+///
+/// Like the `tool_call` grant gate this is an author-time convenience, not the
+/// enforcement point: a grant can be revoked after a graph is saved, and seed /
+/// legacy graphs never pass through this create path at all, so delivery's own
+/// refusal stays the backstop.
+///
+/// `cfg(feature = "openhuman")` because
+/// [`grants_cover`](crate::harness::build::grants_cover) — the namespace
+/// matcher delivery itself calls — lives behind that feature, as does the whole
+/// `workflows` module that would run the graph. The default build links no
+/// delivery path at all, so there is nothing there for this to guard.
+///
+/// [`EmailNotGranted`]: crate::ports::DeliveryReason::EmailNotGranted
+#[cfg(feature = "openhuman")]
+fn validate_output_destination(node: &RawNode, record: &CompanyRecord) -> Result<()> {
+    let Some(destination) = node.destination.as_ref() else {
+        return Ok(());
+    };
+    // Only `email`. A missing/unknown `kind`, and a `channel` with no target,
+    // are `parse_workflow`'s to report — it says something more specific about
+    // each, and reporting the wrong problem first is worse than second.
+    if destination.kind.trim() != "email" {
+        return Ok(());
+    }
+    if crate::harness::build::grants_cover(&record.manifest.tools.allow, "email") {
+        return Ok(());
+    }
+    Err(OpenCompanyError::InvalidRequest(format!(
+        "node `{}` delivers its report to an email address, which this company's `[tools].allow` \
+         does not grant — grant `email` in `[tools].allow`, or send the report to a wired channel.",
+        node.id
+    )))
 }
 
 /// Whether `[tools].allow` grants the namespace `info` belongs to — a catalogue
@@ -2804,17 +2871,8 @@ to = "done"
         dest_kind: &str,
         dest_target: Option<&str>,
     ) -> RawWorkflow {
-        let mut draft = valid_draft(id, name);
+        let mut draft = draft_with_destination(id, name, dest_kind, dest_target);
         draft.nodes[0].schedule = Some("0 9 * * *".to_string());
-        let output = draft
-            .nodes
-            .iter_mut()
-            .find(|node| node.kind == "output")
-            .expect("valid_draft carries an output node");
-        output.destination = Some(WorkflowDestinationDef {
-            kind: dest_kind.to_string(),
-            target: dest_target.map(str::to_string),
-        });
         draft
     }
 
@@ -4154,6 +4212,129 @@ to = "done"
             err.to_string().contains("not a wired workflow tool"),
             "{err}"
         );
+    }
+
+    // --- output destinations (issue #981) ------------------------------------
+
+    /// [`valid_draft`] with the `output` node routed to `kind` / `target`.
+    fn draft_with_destination(
+        id: &str,
+        name: &str,
+        kind: &str,
+        target: Option<&str>,
+    ) -> RawWorkflow {
+        let mut draft = valid_draft(id, name);
+        let output = draft
+            .nodes
+            .iter_mut()
+            .find(|node| node.kind == "output")
+            .expect("valid_draft has an output node");
+        output.destination = Some(WorkflowDestinationDef {
+            kind: kind.to_string(),
+            target: target.map(str::to_string),
+        });
+        draft
+    }
+
+    /// Issue #981: an `email` destination on a company whose `[tools].allow`
+    /// does not grant `email` is refused at SAVE, not silently accepted and then
+    /// denied on every run. Granting `email` lets the same graph through, which
+    /// is what proves the refusal is about the grant rather than about the kind.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn an_email_destination_needs_the_email_grant() {
+        let company = CompanyId::new("acme");
+        // `web.*` grants something, just not `email` — so a bare "no grants at
+        // all" is not what the refusal is keying off.
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["web.*"]),
+        )));
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "email", Some("ops@example.com")),
+        )
+        .await
+        .expect_err("email destination without the grant");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("does not grant"), "{err}");
+        assert!(err.to_string().contains("`done`"), "{err}");
+
+        // Positive control: grant `email` and the same graph saves.
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["email"]),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf2", "WF2", "email", Some("ops@example.com")),
+        )
+        .await
+        .expect("email is granted");
+    }
+
+    /// The grant gate is scoped to `email`. An `owner` destination resolves
+    /// through the company's own directory and never sends to a named address,
+    /// so it must not be caught by the `email` rule — otherwise the fix for
+    /// #981 would refuse graphs that deliver perfectly well.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn an_owner_destination_is_not_gated_on_the_email_grant() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["web.*"]),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "owner", None),
+        )
+        .await
+        .expect("owner delivery needs no `email` grant");
+    }
+
+    /// The shared helper gates BOTH surfaces: an update that introduces an
+    /// ungranted `email` destination is refused the same way a create is.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn update_gates_email_destinations_through_the_shared_helper() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["web.*"]),
+        )));
+        create_company_workflow(&company, None, &store, None, valid_draft("wf", "WF"))
+            .await
+            .expect("seed create");
+
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            draft_with_destination("wf", "WF", "email", Some("ops@example.com")),
+            None,
+        )
+        .await
+        .expect_err("update must gate email destinations too");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("does not grant"), "{err}");
     }
 
     /// A slug padded with leading/trailing whitespace is rejected outright rather

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -5764,7 +5764,8 @@ mod tests {
             fn subscribe(
                 &self,
                 id: &CompanyId,
-            ) -> futures::stream::BoxStream<'static, crate::ports::types::StoredEvent> {
+            ) -> futures::stream::BoxStream<'static, crate::ports::events::EventStreamItem>
+            {
                 self.inner.subscribe(id)
             }
         }


### PR DESCRIPTION
## Summary

Finishes **PR-1 of #981**. When I re-audited the chain against current `main`, most of it had already landed — #995 renamed `wired_channel_ids` → `deliverable_channel_ids` and filtered `operator` out of it, made the picker route serve that, and added `reject_undeliverable_channel_destinations` on both write routes; #1083 added the arm-time refusal. Two gaps the issue names were still open, and this closes both.

**1. An ungranted `email` destination still saved clean** (`src/company/workflow_create.rs`). `deliver_outputs`' *first* email gate — checked before it even looks for a mailbox — answers `Denied` / `EmailNotGranted` when `[tools].allow` does not cover `email`. That grant is a deployment-wide fact, the same shape as naming the operator channel: it denies *every* run of the graph, on every recipient, until somebody edits the manifest. So it is now refused at save.

It goes in `validate_draft_against_record`, not beside the channel guard on the write routes, because the two rules read different sources:

| rule | source | so it lives |
| --- | --- | --- |
| `channel` target must be deliverable | the **running company** (`deliverable_channel_ids()`) | on the write routes |
| `email` needs the `email` grant | the company **record** (`[tools].allow`) | in the shared create/update gate, beside the `tool_call` namespace gate that reads the same field |

Putting it there also means the orchestrator's `create_workflow` tool is held to it, not just the console.

Deliberately **only the grant half**. A wired mailbox and an established inbound thread with the recipient are per-run, per-recipient conditions an author-time check cannot see, and refusing on them would refuse graphs that work — the line #1046 already drew for the arm-time check.

**2. The console's channel pre-flight passed on a timer** (`frontend/src/views/WorkflowCreateDialog.tsx`). `destinationTargetProblem` skipped its check whenever `wiredChannels` was `[]`, and `[]` meant three unrelated things: the request is in flight, the request failed, and *the host answered — this company has nowhere to deliver*. Only the last is knowledge, and it is the one the host refuses every channel target against. So the console skipped exactly the check the host applies, and whether an author got a pre-flight at all depended on how fast they clicked Save.

`WiredChannels` splits the three apart:

- `ready` — checked against, **`[]` included**, in the host's own words for the empty case (`no durable channels`, matching `undeliverable_channel_message`).
- `unavailable` — a failed request, or a host predating the route. Degrades to free text and the save-time 400, exactly as before. Never blocks Save.
- `loading` — the one that cannot answer *yet*. `validate()` now asks `destinationCheckDeferred` **first** and holds Save while the answer is genuinely in flight, releasing the moment it lands, instead of letting a "don't know" read as a pass. Not wired into the blur handler: a field is blurred constantly, and "still checking" is not a mistake the author made.

Each state also says its own thing under the field. The "No delivery channels are wired for this company" sentence used to render *while the list was loading* — a claim the console could not make yet.

**3. Unrelated: `upstream/main` does not build its lib tests.** #1011 changed `EventLog::subscribe` to yield `EventStreamItem`; the `FinishOnRead` mock added alongside it by the `list_runs` race fix still returns `StoredEvent`. Two green PRs, a semantic conflict on merge, nothing that ran both. One-line signature fix in the mock, in its own commit — happy to split it out if you'd rather land it separately.

## On the operator filter, since it is the load-bearing decision

Filtering `operator` out of the accessor (rather than at the route or the picker) is right, and I re-checked it rather than inheriting it. All five callers on current `main` — `ops/workflows.rs:711` (save guard), `:999` (arm guard), `:2322` (picker route), and two in `builder.rs` tests — are delivery-target consumers. Nothing reads the accessor wanting "every adapter id", and `CompanyRuntime.channels` has no public accessor, so there is no other path to the raw list. The rename #995 did is what makes that checkable.

## Not in scope

**Part 2 of #981 is not fixed here** — the server-side `WorkflowRunVerdict`, so a dropped report stops reading as a green run. The issue asks for it as a separate PR, and @oxoxDev confirmed it still reproduces. **So this deliberately does not say `Closes #981`** — auto-closing would drop Part 2 on the floor. Please close the issue manually if you'd rather track Part 2 separately.

## Commands run locally

```
cargo fmt --all -- --check                                        # clean
cargo clippy --all-targets --features openhuman,tinycortex -- -D warnings   # clean
cargo clippy --all-targets -- -D warnings                         # clean (default features)
cargo check --all-features                                        # clean
cargo test --features openhuman,tinycortex                        # 4386 + 26 passed, 0 failed
scripts/ci/assert-feature-lanes.sh                                # 29 features, 0 owed a lane
cd frontend && npm ci && npm run typecheck && npm test            # 104 files, 1042 tests passed
```

## Behaviour changes

- `POST`/`PUT …/workflows` now answer `400` for an `output` node with an `email` destination when `[tools].allow` does not grant `email`. A company granting `*` is unaffected (`grants_cover` covers it). Existing graphs are untouched at run time — delivery's own refusal is unchanged and stays the backstop for seed/legacy graphs, which never pass through the create path.
- The console holds Save (with "still checking which channels this company can deliver to — try Save again in a moment") for as long as the wired-channel request is in flight and a channel target is set. A failed request never holds it.
- A channel target is now refused client-side when the host answered with an empty set, matching the host's existing save-time refusal instead of round-tripping for it.

Part of #981.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent saving workflows with unavailable channel destinations.
  * Added validation to ensure email destinations are supported by the company’s enabled tools.
  * Improved destination entry guidance based on channel availability and discovery status.

* **Bug Fixes**
  * Prevented premature rejection while channel availability is still loading.
  * Preserved support for valid workflows when no channels are currently available.

* **Documentation**
  * Documented destination validation rules for workflow creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->