### PR TITLE
workflows: run history as a left rail beside the canvas

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -101,6 +101,7 @@ import { classifyRunError } from "@/views/workflows/run-error";
 import { runFailureFrom, type RunFailure } from "@/views/workflows/run-failure";
 import { RunFailurePanel } from "@/views/workflows/RunFailurePanel";
 import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+import { CanvasShell } from "@/views/workflows/CanvasShell";
 import { approvalsForRun } from "@/views/workflows/run-approvals";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 import { type NodeOutputView, nodeOutputFor } from "@/views/workflows/run-output";
@@ -2133,7 +2134,30 @@ export function WorkflowsView({
         </div>
       )}
 
-      <div className="relative flex-1">
+      {/* Issue #1107: canvas and left rail side by side. `CanvasShell` owns the
+          view's column layout and documents which slot a new panel belongs in —
+          left rail, right overlay, or bottom strip. */}
+      <CanvasShell
+        rail={
+          historyOpen && historySupported ? (
+            <RunHistoryPanel
+              runs={historyRows}
+              graph={graph}
+              workflowName={selected?.name ?? selectedId ?? ""}
+              onClose={() => setHistoryOpen(false)}
+              selectedRunSeq={overlayRun?.seq ?? null}
+              onSelectRun={(picked) =>
+                // Clicking the row already shown clears it, so the control is a
+                // toggle rather than a one-way trip into overlay mode.
+                setOverlayRun((prev) => (prev?.seq === picked.seq ? null : picked))
+              }
+              onFixWithCopilot={handleFixWithCopilot}
+              fixingRunSeq={fixingRunSeq}
+              fixReason={fixReason}
+            />
+          ) : null
+        }
+      >
         {/* Issue #303: browsing REPLACES the canvas rather than squeezing in
             above it. A card grid needs the width, and the canvas is meaningless
             while the operator is deciding which workflow they want. Picking one
@@ -2257,7 +2281,7 @@ export function WorkflowsView({
             )}
           </>
         )}
-      </div>
+      </CanvasShell>
 
       {result && (
         <RunResultPanel
@@ -2286,24 +2310,6 @@ export function WorkflowsView({
         <RunFailurePanel
           failure={runFailure}
           onClose={() => setRunFailure(null)}
-        />
-      )}
-
-      {historyOpen && historySupported && (
-        <RunHistoryPanel
-          runs={historyRows}
-          graph={graph}
-          workflowName={selected?.name ?? selectedId ?? ""}
-          onClose={() => setHistoryOpen(false)}
-          selectedRunSeq={overlayRun?.seq ?? null}
-          onSelectRun={(picked) =>
-            // Clicking the row already shown clears it, so the control is a
-            // toggle rather than a one-way trip into overlay mode.
-            setOverlayRun((prev) => (prev?.seq === picked.seq ? null : picked))
-          }
-          onFixWithCopilot={handleFixWithCopilot}
-          fixingRunSeq={fixingRunSeq}
-          fixReason={fixReason}
         />
       )}
 

--- a/frontend/src/views/workflows/CanvasShell.tsx
+++ b/frontend/src/views/workflows/CanvasShell.tsx
@@ -1,0 +1,64 @@
+// The workflows view's column layout — and the convention for where a panel
+// mounts (issue #1107).
+//
+// Before this, every panel the view grew was appended to one vertical stack
+// under the canvas, and each one ate the dimension a workflow graph needs most.
+// Run history was the worst case: tall rows in a `max-h-72` horizontal strip,
+// showing two runs at a time while spending the full width of the screen.
+//
+// The view now has three slots, and each one is a decision about the panel's
+// LIFETIME, not about where there happens to be room:
+//
+//   left   — an in-flow rail. A browsing context the operator opened on
+//            purpose and keeps open while they work: it shrinks the canvas,
+//            because it is meant to be read alongside it. Run history is the
+//            only occupant today. Single occupancy — a second rail must
+//            replace this one rather than stack under it, the same way the
+//            right slot already arbitrates between its two panels.
+//
+//   right  — a floating overlay, mounted `absolute right-3 top-3 bottom-3
+//            z-10` INSIDE the canvas (see `CopilotPanel` and
+//            `NodeDetailPanel`). A transient focus that covers the graph and
+//            is dismissed: the canvas keeps its full width underneath, so
+//            closing the panel restores it instantly. Also single occupancy,
+//            and `WorkflowsView` arbitrates it with a ternary — opening the
+//            copilot clears the selected node.
+//
+//   bottom — a full-width strip below BOTH canvas and rail, mounted as a
+//            sibling of this component. The receipt for something that just
+//            happened and is dismissed when read: `RunResultPanel` and
+//            `RunFailurePanel`. Full width because it spans the whole view,
+//            and below the rail because the rail answers "what has run
+//            before" while the strip answers "what did the run I just started
+//            do" — two questions, two places.
+//
+// The arithmetic that fixes the breakpoint: the rail is in-flow, so it costs
+// the canvas real width, while the right overlays only cover it. A 320px rail
+// plus a 384px overlay is 704px of chrome, which is most of a laptop window
+// once the app's own nav sidebar is subtracted. So the rail is in-flow only at
+// `xl` (≥1280px viewport, ≥~1024px of view) — below that it falls back to the
+// bottom strip it has always been, which never competes with the right slot.
+
+import type { ReactNode } from "react";
+
+export function CanvasShell({
+  rail,
+  children,
+}: {
+  /**
+   * The left rail, or nothing. Rendered AFTER the canvas in the DOM and moved
+   * left with `order` at `xl`: keeping the canvas first means the narrow
+   * layout's reading order is unchanged, and the rail names itself as a
+   * landmark so assistive tech can reach it directly either way.
+   */
+  rail?: ReactNode;
+  /** The canvas. Positioned, because the right slot mounts inside it. */
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
+      <div className="relative min-h-0 flex-1">{children}</div>
+      {rail && <div className="shrink-0 xl:order-first xl:w-80">{rail}</div>}
+    </div>
+  );
+}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -202,22 +202,45 @@ export function RunHistoryPanel({
   // click did something, and it is only true if it moves.
   const now = useRunningClock(runs.some(isRunning));
   return (
-    <div className="border-t bg-card/60" data-testid="workflow-run-history">
-      <div className="flex items-center justify-between px-4 py-2">
-        <div className="flex items-center gap-2">
+    // Issue #1107: a left rail at `xl`, the bottom strip it has always been
+    // below that. `CanvasShell` owns the placement and the width; this owns
+    // the chrome, and the two readings differ only in which edge carries the
+    // border and whether the list is capped or grows.
+    //
+    // `aside` + `aria-label`: at `xl` the rail is painted left of a canvas it
+    // follows in the DOM, so it is reachable as a named complementary landmark
+    // rather than only by tabbing past the graph.
+    <aside
+      aria-label="Run history"
+      className="flex h-full flex-col border-t bg-card/60 xl:border-t-0 xl:border-r"
+      data-testid="workflow-run-history"
+    >
+      {/* `flex-wrap` rather than a breakpoint: at 320px the workflow name drops
+          to its own line on its own, and at full width it stays inline where
+          there is room for it. */}
+      <div className="flex items-start justify-between gap-2 border-b px-4 py-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
           <span className="text-sm font-medium">Run history</span>
+          <Badge variant="secondary">{runs.length}</Badge>
           {workflowName && (
-            <span className="truncate text-xs text-muted-foreground">
+            <span className="max-w-full truncate text-xs text-muted-foreground">
               {workflowName}
             </span>
           )}
-          <Badge variant="secondary">{runs.length}</Badge>
         </div>
-        <Button variant="ghost" size="sm" onClick={onClose}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-mr-2 shrink-0"
+          onClick={onClose}
+        >
           Dismiss
         </Button>
       </div>
-      <div className="max-h-72 overflow-auto px-4 pb-3">
+      {/* Capped as a strip, growing as a rail. `min-h-0` is what actually lets
+          it scroll inside the column — without it the flex item floors at its
+          content height and the rail overflows the view instead. */}
+      <div className="max-h-72 overflow-auto px-4 py-3 xl:min-h-0 xl:max-h-none xl:flex-1">
         {runs.length === 0 ? (
           <p className="text-xs text-muted-foreground">
             This workflow hasn't finished a run yet. Runs appear here once they
@@ -242,7 +265,7 @@ export function RunHistoryPanel({
           </div>
         )}
       </div>
-    </div>
+    </aside>
   );
 }
 
@@ -618,9 +641,9 @@ function RunNodeChip({ node }: { node: WorkflowRunNode }) {
  * A once-a-second clock, live only while something on screen is counting
  * against it (issue #1007).
  *
- * Gated rather than always-on: the history drawer sits under the canvas for as
- * long as the operator leaves it open, and a settled row's duration is a fixed
- * number that re-rendering every second cannot change.
+ * Gated rather than always-on: the history rail stays up for as long as the
+ * operator leaves it open, and a settled row's duration is a fixed number that
+ * re-rendering every second cannot change.
  */
 function useRunningClock(active: boolean): number {
   const [now, setNow] = useState(() => Date.now());

--- a/frontend/test/e2e/workflow-run-history-rail.spec.ts
+++ b/frontend/test/e2e/workflow-run-history-rail.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Issue #1107: run history is a LEFT RAIL beside the canvas on a wide viewport,
+ * and the bottom strip it has always been below `xl` (1280px).
+ *
+ * Pinned as geometry rather than as class names, because the thing that broke
+ * is the thing an operator sees: run rows are tall, so a horizontal strip shows
+ * two of them while spending the full width of the screen, and it eats the
+ * canvas height that a workflow graph needs most — the same canvas the selected
+ * run is overlaid onto (issue #371).
+ *
+ * The second assertion is the one that keeps the fix honest. A rail is only an
+ * improvement while the canvas beside it stays usable: the rail is in-flow, so
+ * every pixel it takes is a pixel the graph loses, and the right-hand overlays
+ * (`CopilotPanel`, `NodeDetailPanel`) then cover ~396px more of what is left.
+ * Below `xl` the rail is therefore not in-flow at all — hence the narrow case.
+ */
+
+/** Dismisses the first-run tour if it is up; see `workflow-run-history.spec.ts`. */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** Opens run history, skipping on a host that does not serve `…/workflows/runs`. */
+async function openHistory(page: Page) {
+  const toggle = page.getByTestId("workflow-history-toggle");
+  try {
+    await toggle.waitFor({ state: "visible", timeout: 30_000 });
+  } catch {
+    test.skip(true, "this host does not serve …/workflows/runs");
+  }
+  await toggle.click();
+  const panel = page.getByTestId("workflow-run-history");
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+/** The canvas ReactFlow paints into — the surface the rail is competing with. */
+function canvas(page: Page) {
+  return page.locator(".react-flow").first();
+}
+
+test("at xl the run history is a left rail, and the canvas keeps its width", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  const panel = await openHistory(page);
+  const flow = canvas(page);
+  await expect(flow).toBeVisible();
+
+  const rail = (await panel.boundingBox())!;
+  const graph = (await flow.boundingBox())!;
+
+  // Left of the canvas, not under it.
+  expect(rail.x + rail.width, "the rail must sit left of the canvas").toBeLessThanOrEqual(
+    graph.x + 1,
+  );
+  // Full height of the canvas region, which is what lets it show more than two
+  // runs. Compared with a tolerance because they are siblings in a flex row,
+  // not the same box.
+  expect(
+    Math.abs(rail.height - graph.height),
+    "the rail runs the full height of the canvas region",
+  ).toBeLessThan(4);
+  // A rail that costs the canvas more than it is worth is the failure mode this
+  // whole change has to avoid. 640px is a floor, not a target: the graph must
+  // stay a graph, not a keyhole.
+  expect(graph.width, "the canvas keeps a usable width beside the rail").toBeGreaterThan(
+    640,
+  );
+});
+
+test("below xl the run history falls back to a strip under the canvas", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 800 });
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  const panel = await openHistory(page);
+  const flow = canvas(page);
+  await expect(flow).toBeVisible();
+
+  const strip = (await panel.boundingBox())!;
+  const graph = (await flow.boundingBox())!;
+
+  // Under the canvas, full width — a fixed rail plus a canvas does not fit here,
+  // and squeezing the graph to a sliver would be worse than the strip.
+  expect(strip.y, "the strip must sit below the canvas").toBeGreaterThanOrEqual(
+    graph.y + graph.height - 1,
+  );
+  expect(
+    Math.abs(strip.width - graph.width),
+    "the strip spans the same width as the canvas",
+  ).toBeLessThan(4);
+});


### PR DESCRIPTION
Closes #1107

Run history opened as a horizontal strip under the canvas. Run rows are tall, so the strip showed **two runs at a time** while spending the full width of the screen — and it ate the canvas height a workflow graph needs most, including the very canvas a selected run is overlaid onto (#371).

It is now a **320px in-flow rail down the left**, full height of the canvas region, with the list growing to fill it instead of capping at `max-h-72`. At 1440×900 that is four runs visible instead of two, in the same screen.

## What changed

- `RunHistoryPanel` root: `border-t bg-card/60` → `flex h-full flex-col border-t bg-card/60 xl:border-t-0 xl:border-r`; list `max-h-72 overflow-auto` → `max-h-72 overflow-auto xl:min-h-0 xl:max-h-none xl:flex-1`.
- Header gained a `border-b` and `flex-wrap`, so the workflow name drops to its own line at 320px and stays inline where there is room. No breakpoint needed for it.
- The root is now an `<aside aria-label="Run history">`: at `xl` the rail is painted *left* of a canvas it *follows* in the DOM, so it is reachable as a named complementary landmark rather than only by tabbing past the graph. Keeping the canvas first in the DOM is what leaves the narrow reading order exactly as it was.
- New `frontend/src/views/workflows/CanvasShell.tsx` — see "the seam" below.
- New `frontend/test/e2e/workflow-run-history-rail.spec.ts` — pins the geometry, not the class names.

Behaviour is unchanged: row click toggles the canvas overlay (#371), Fix with copilot keeps its `anyFixInFlight` guard disabling *every* row's button while one fix is in flight, the header count badge and Dismiss are where they were.

## Judgement call 1 — narrow viewports: fall back to the strip, at `xl`

Below `xl` (1280px viewport) the rail renders exactly as it does today: a full-width strip under the canvas, capped at `max-h-72`. Nothing new to learn on a tablet, and no risk of the canvas being squeezed.

`xl` rather than `lg` because of the arithmetic below. The app's own nav sidebar is 216px, so a 1024px viewport leaves the view 808px — a 320px rail there would leave 488px of canvas *before* a right-hand overlay covers 396 more of it. At 1280 the numbers work; at 1024 they do not.

## Judgement call 2 — the arithmetic, measured on the real app

Measured on the running host, `history + copilot` both open:

| viewport | view width | rail | canvas | right overlay | canvas still visible |
|---|---|---|---|---|---|
| 1440×900 | 1224 | 320 | **904** | 384 @ x=1044 | **508px** |
| 1280×800 | 1064 | 320 | **744** | 384 @ x=884 | **348px** |
| 1024×800 | 808 | — (strip) | 808 | — | 808px |

The asymmetry is deliberate, and it is the reason those numbers are acceptable: **the left rail is in-flow and costs the canvas real width; the right panels float and only cover it.** That maps onto how they are used. History is a browsing context you open on purpose and keep open while you work, so it should sit *beside* the graph. `CopilotPanel` and `NodeDetailPanel` are a transient focus you dismiss, so the graph keeps its full width underneath and closing the panel restores it instantly — at 1280 the canvas is still 744px, it is just partly occluded.

**No new collapse control**, deliberately. The obvious third option was a collapsible rail, but the control already exists: the toolbar's `History` toggle, one click away, carrying the run count. Closing history does **not** clear `overlayRun` — the canvas overlay and its banner survive — so dismissing the rail is lossless. A second collapse affordance would be the same button twice.

## Judgement call 3 — `RunResultPanel` stays at the bottom

It answers a different question with a different lifetime. `RunResultPanel` (and `RunFailurePanel`, its mutually-exclusive sibling) is the receipt for **the run you just started**: it appears unbidden, you read it, you dismiss it. The rail is **what has run before**: you open it and keep it. Moving the result into the rail would put two panels in one column — the failure mode #1107 explicitly rules out — and would make the rail's meaning ambiguous. Full width under *both* canvas and rail keeps them separate.

## The seam for what comes next

`CanvasShell` is a ~20-line layout component whose header comment is the actual deliverable: it names three slots and says what decides which one a new panel belongs in — **lifetime, not where there happens to be room**.

- **left** — in-flow rail, single occupancy, `xl`+. Shrinks the canvas because it is meant to be read alongside it.
- **right** — floating overlay, `absolute right-3 top-3 bottom-3 z-10` inside the canvas. Single occupancy, arbitrated by `WorkflowsView`.
- **bottom** — full-width strip, a sibling of `CanvasShell`.

A new left rail passes `rail`; a new right panel mounts absolutely inside the canvas and inherits the anchoring for free (`CanvasShell` keeps `relative` on the canvas wrapper, so the overlays now anchor to the canvas's right edge, which has moved — verified at 1440 and 1280 above). Not a panel framework: one component and a documented convention.

**On the "right slot is double-booked" concern:** checked, and it is not. `WorkflowsView` renders them as a ternary — `copilotOpen && graph ? <CopilotPanel/> : selectedNode && <NodeDetailPanel/>` — and opening the copilot clears `selectedNodeId`. They are mutually exclusive by construction. Nothing here changes that, and the new layout does not depend on it.

## Verification

Run locally, real output:

- `npm run typecheck` — clean
- `npm run typecheck:unit` — clean
- `npm run typecheck:e2e` — clean
- `npm test` — **1044 passed, 105 files**
- `scripts/ci/assert-design-tokens.sh` — `✓ design tokens: no arbitrary sizes, no palette colours, no stray hex`
- Playwright, against a host built from this branch (`workflow-run-history-rail`, `workflow-run-history`, `workflow-selection-persists`, `workflow-run-result`, `workflow-toolbar-reachable`) — **9 passed, 2 skipped** (the two need a live brain)
- Playwright, the rest of the workflow specs (`workflow-canvas-live`, `workflow-create-affordance`, `workflow-dialog-feedback`, `workflow-edit-delete`, `workflow-live-list`, `workflow-node-config`, `workflow-inline-approval`) — **31 passed, 2 skipped**

Screenshotted at 1440×900 (light and dark, with and without the copilot), 1280×800 with the copilot, 1024×800 and 820×900. Dark mode is token-only, so `.dark` picks it up with no `dark:` pairs added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow details now open consistently when selecting or creating a workflow, with an “All workflows” control to return to the index.
  * Added Cards/List switching on the workflow index.
  * Invalid or missing workflow links now return safely to the index with a dismissible alert.
  * Workflow run history appears in a dedicated side rail on wide screens and below the canvas on smaller screens.
  * Blocked runs now display related approval information.

* **Tests**
  * Added end-to-end coverage for responsive history layouts and index/detail navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->