### PR TITLE
Confirm an added teammate, and say a failure the same way everywhere (#1099)

### DIFF
--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -294,6 +294,17 @@ feature-gated off.
   dismisses one whose duration plus a grace period is spent. Hovering to read, a
   backgrounded tab, and an explicit `duration: Infinity` are all still honoured,
   so callers keep raising plain `toast.*` calls and need not think about it.
+- **How a write answers:** a toast, everywhere. The inline `role="alert"` banner
+  is reserved for a surface that could not *load* — it is a state of the page and
+  it sits with the Retry that clears it, whereas the answer to an action the
+  operator just took has to survive the dialog closing over it. Issue #1099 is
+  the case that fixed the split: adding a teammate said nothing on success from
+  any of its three surfaces (Team, Company, the chat empty state) and reported
+  failure two different ways. `src/lib/member-feedback.ts` now owns that one
+  answer — the views decide *what happened*, it decides what that is called and
+  how loudly. Half-landed writes stay distinguishable from clean ones
+  (`toast.warning`, as `PeopleView`'s invite already did), because a teammate
+  whose inbox never came up is not a clean add.
 
 ## Implementation order (delivered)
 

--- a/frontend/src/lib/member-feedback.ts
+++ b/frontend/src/lib/member-feedback.ts
@@ -1,0 +1,121 @@
+/**
+ * What adding a teammate actually did, and how the console says so (issue #1099).
+ *
+ * A teammate can be created from three surfaces — the Team roster, the Company
+ * org chart, and the chat empty state — and every one of them ended by closing
+ * its dialog and refetching, with nothing said. The operator was left inferring
+ * success from a list that repaints a moment later, on the one write that
+ * creates a *person*, while the budget writes on the same screen have confirmed
+ * themselves for months ("Daily cap set to $5.00.").
+ *
+ * The failure half was worse than absent: it was inconsistent. The roster
+ * toasted, the org chart pushed the same conditions into an inline banner with
+ * its own wording, and the chat empty state said nothing at all for a host that
+ * cannot persist teammates. Three implementations of one answer, which is
+ * exactly the shape that drifts.
+ *
+ * So the answer lives here instead. The views still decide *what happened* —
+ * only they know whether an inbox or a desk was part of the ask — and this
+ * module decides what that is called and how loudly it is said. Two of the
+ * outcomes are deliberately not `success`: a teammate whose inbox never came up,
+ * and a teammate who exists only in this browser tab, are not clean adds, and
+ * flattening either into "Added Ada." would be the console claiming a write it
+ * did not get.
+ */
+
+import { toast } from "sonner";
+
+/** The outcome of one add, as the surface that ran it saw it. */
+export type AddMemberOutcome =
+  /** Created on the host, and every follow-up step the operator asked for landed. */
+  | { kind: "added"; name: string }
+  /**
+   * Created on the host, but a step that was part of the same ask did not
+   * land — the inbox toggle, or the desk placement. `missed` completes the
+   * sentence "Added Ada, but …"; `fix` is what the operator can do about it.
+   */
+  | { kind: "partial"; name: string; missed: string; fix?: string }
+  /**
+   * The host has no team write plane, so the row exists in this console and
+   * nowhere else. `note` carries anything the missing host record cost — an
+   * inbox that could not be created, say.
+   */
+  | { kind: "console-only"; name: string; note?: string }
+  /** Nothing was created. `message` is the host's refusal where there is one. */
+  | { kind: "failed"; message: string };
+
+/** A toast, decided but not yet raised — the testable half of the answer. */
+export interface AddMemberMessage {
+  level: "success" | "warning" | "error";
+  title: string;
+  description?: string;
+}
+
+/**
+ * The words for an outcome.
+ *
+ * The person is named in every arm that has a name. "Teammate added" is a
+ * status; "Added Ada." is a receipt, and a receipt is what an operator who has
+ * just typed a name into a dialog is looking for.
+ */
+export function addMemberMessage(outcome: AddMemberOutcome): AddMemberMessage {
+  switch (outcome.kind) {
+    case "added":
+      return { level: "success", title: `Added ${outcome.name}.` };
+    case "partial":
+      return {
+        level: "warning",
+        title: `Added ${outcome.name}, but ${outcome.missed}`,
+        description: outcome.fix,
+      };
+    case "console-only":
+      return {
+        level: "warning",
+        title: `Added ${outcome.name} to this console only.`,
+        description: [
+          "This host can't save teammates, so they'll be gone when the console reloads.",
+          outcome.note,
+        ]
+          .filter(Boolean)
+          .join(" "),
+      };
+    case "failed":
+      return { level: "error", title: outcome.message };
+  }
+}
+
+/**
+ * Raise it.
+ *
+ * A toast on every surface, including the org chart, which used to route these
+ * into a banner above the chart. The banner is still right for a chart that
+ * could not be *loaded* — that is a state of the page, and it sits with the
+ * Retry button that clears it — but an add is an action the operator just took,
+ * and its answer belongs where every other action's answer on that screen
+ * already is. It also has to survive the dialog closing over it, which a banner
+ * behind a modal does not.
+ */
+export function reportAddMember(outcome: AddMemberOutcome): void {
+  const { level, title, description } = addMemberMessage(outcome);
+  toast[level](title, description ? { description } : undefined);
+}
+
+/**
+ * The wording for a host that refuses to create teammates at all (404 on the
+ * team write plane).
+ *
+ * The org chart cannot fall back to a console-only row the way the roster and
+ * the chat empty state do: a local teammate has no id to place on a desk and
+ * would vanish from the chart on the next read, so that surface refuses and
+ * says why. Shared so the two answers to one host condition stay recognisably
+ * the same answer.
+ */
+export const NO_TEAM_WRITE_PLANE = "This host can't create teammates.";
+
+/** The host's own words where it gave any, else a caller-chosen fallback. */
+export function addMemberFailure(
+  error: unknown,
+  fallback = "Couldn't add teammate.",
+): AddMemberOutcome {
+  return { kind: "failed", message: error instanceof Error ? error.message : fallback };
+}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -33,6 +33,11 @@ import {
 } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { readLastChannel } from "@/lib/last-channel";
+import {
+  addMemberFailure,
+  reportAddMember,
+  type AddMemberOutcome,
+} from "@/lib/member-feedback";
 import { fromDto, newMember, starterTeam, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import { useAskerNames } from "@/components/approval-card";
@@ -751,10 +756,11 @@ export function ChatView({
         // No team write plane on this host — keep the add local-only.
         setMembers((m) => [...m, newMember(fields)]);
       } else {
-        toast.error(error instanceof Error ? error.message : "Couldn't add teammate.");
+        reportAddMember(addMemberFailure(error));
         return;
       }
     }
+    let outcome: AddMemberOutcome;
     if (created) {
       const member = fromDto(created);
       setMembers((m) => [...m, member]);
@@ -763,6 +769,7 @@ export function ChatView({
       // `boot`) — flip it so this and later actions (inbox, budget) target
       // the host instead of refusing on a now-stale local-only guard.
       setFromHost(true);
+      outcome = { kind: "added", name: fields.name };
       // A host-backed add has a real agent id, so the inbox request can go
       // straight through rather than waiting for a second save.
       if (fields.inbox) {
@@ -770,15 +777,27 @@ export function ChatView({
           await setInboxEnabled(client, company, member.id, true);
           setMembers((ms) => ms.map((m) => (m.id === member.id ? { ...m, inboxEnabled: true } : m)));
         } catch {
-          toast.error("Couldn't enable the inbox — add it from the member's actions menu.");
+          outcome = {
+            kind: "partial",
+            name: fields.name,
+            missed: "their inbox couldn't be switched on.",
+            fix: "Add it from the member's actions menu.",
+          };
         }
       }
-    } else if (fields.inbox) {
+    } else {
       // A locally-added teammate has no host record yet, so there is no agent
       // id to hang an inbox off — say so rather than silently dropping it.
-      toast.error("Save this teammate on the host before giving them an inbox.");
+      outcome = {
+        kind: "console-only",
+        name: fields.name,
+        note: fields.inbox
+          ? "Save them on the host before giving them an inbox."
+          : undefined,
+      };
     }
     setAddOpen(false);
+    reportAddMember(outcome);
   }
 
   /**

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -29,6 +29,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { emptyDraft, type AgentDraft, type AgentFieldKey } from "@/lib/agent";
+import { addMemberFailure, reportAddMember } from "@/lib/member-feedback";
 import {
   fromDto,
   initials,
@@ -237,27 +238,45 @@ export function TeamView({ client, company, sub, onOpenAgent }: Props) {
         // No team write plane on this host — keep the edit local-only. An inbox
         // needs a persisted teammate to hang off, so it can't be enabled here.
         setMembers((m) => [...m, newMember(fields)]);
-        if (fields.inbox) toast.error("This host can't persist teammates, so no inbox was created.");
+        reportAddMember({
+          kind: "console-only",
+          name: fields.name,
+          note: fields.inbox ? "No inbox was created." : undefined,
+        });
         setAddOpen(false);
         return;
       }
-      toast.error(error instanceof Error ? error.message : "Couldn't add teammate.");
+      reportAddMember(addMemberFailure(error));
       return;
     }
 
     // Enable the inbox against the host's real agent id *before* refetching, so
     // the reloaded roster already reports the toggle as on.
+    let inboxMissed = false;
     if (fields.inbox) {
       try {
         await setInboxEnabled(client, company, created.id, true);
       } catch {
-        toast.error("Teammate added, but their inbox couldn't be switched on.");
+        inboxMissed = true;
       }
     }
     // Persisted on the host — refetch so the card reflects the real record
     // (id, merge order, inbox state) rather than a locally-guessed one.
     await boot();
     setAddOpen(false);
+    // Announced after the refetch, not on the response: the roster the operator
+    // is looking at is the one being claimed about, so a read that contradicted
+    // the write would contradict the toast too rather than follow it.
+    reportAddMember(
+      inboxMissed
+        ? {
+            kind: "partial",
+            name: fields.name,
+            missed: "their inbox couldn't be switched on.",
+            fix: "Turn it on from their actions menu.",
+          }
+        : { kind: "added", name: fields.name },
+    );
   }
 
   async function removeMember(member: TeamMember) {

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -30,6 +30,7 @@ import {
   Users,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import { listPeople } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
@@ -43,6 +44,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  addMemberFailure,
+  NO_TEAM_WRITE_PLANE,
+  reportAddMember,
+  type AddMemberOutcome,
+} from "@/lib/member-feedback";
 import {
   addableTo,
   buildOrgTree,
@@ -124,6 +131,10 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
         client.status(company).catch(() => null),
       ]);
       if (mine !== gen.current) return;
+      // Cleared here rather than at the top of the write that triggered this
+      // read: since #1099 the banner belongs to the load alone, so a chart that
+      // loads is the only thing that can retire the message saying it did not.
+      setError(null);
       setTree(
         buildOrgTree(
           status?.name || company || "This company",
@@ -232,12 +243,16 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
    */
   async function mutate(key: string, run: () => Promise<unknown>) {
     setBusy(key);
-    setError(null);
     try {
       await run();
       await boot();
     } catch (e) {
-      setError(
+      // Toasted, not banked in the banner above the chart (issue #1099). The
+      // banner is the page's own state — it belongs to a chart that could not
+      // be *loaded*, and it sits with the Retry button that clears it. A write
+      // the operator just attempted is an action, and every other action in
+      // this console answers in a toast.
+      toast.error(
         e instanceof Error ? e.message : "Something went wrong. Try again.",
       );
     } finally {
@@ -254,13 +269,16 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
   async function addMember(fields: NewMemberFields) {
     const deskId = addMemberDeskId;
     setBusy("add-member");
-    setError(null);
     // Whether the host has the teammate, which decides whether the chart needs
     // re-reading on the way out. A desk add that fails after the teammate is
     // created leaves the two disagreeing: the roster has someone the chart has
     // never heard of, so the message telling the operator to place them by hand
     // would point at a dropdown that does not list them yet.
     let createdOnHost = false;
+    // What to say once the chart has been re-read — decided here, raised after
+    // `boot()`, so a refetch that contradicts the write contradicts the message
+    // too rather than arriving a beat behind it.
+    let outcome: AddMemberOutcome;
     try {
       let created: TeamMemberDto;
       try {
@@ -275,32 +293,43 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
         createdOnHost = true;
       } catch (e) {
         if (e instanceof ApiError && e.status === 404) {
+          // No local-only fallback here, unlike the roster and the chat empty
+          // state: a console-only teammate has no host id to place on a desk
+          // and would vanish on the next chart read.
           throw new Error(
-            "This host does not support creating teammates from the Company page.",
+            `${NO_TEAM_WRITE_PLANE} They can't be created from the Company page.`,
           );
         }
         throw e;
       }
+      outcome = { kind: "added", name: fields.name };
       if (deskId) {
         try {
           await client.addDeskMember(deskId, created.id, company);
         } catch (e) {
-          throw new Error(
-            `Teammate ${fields.name} was created, but could not be added to the selected desk: ${e instanceof Error ? e.message : "unknown error"}`,
-          );
+          // Created but unplaced — a real half-landing, and the operator has
+          // to know which half, because the fix is on the chart in front of
+          // them rather than in the dialog they just closed.
+          outcome = {
+            kind: "partial",
+            name: fields.name,
+            missed: `they couldn't be added to that desk: ${e instanceof Error ? e.message : "unknown error"}`,
+            fix: "They're on the roster — drag them onto the desk from here.",
+          };
         }
       }
       await boot();
       setAddMemberOpen(false);
     } catch (e) {
       setAddMemberOpen(false);
-      setError(e instanceof Error ? e.message : "Could not create teammate.");
+      outcome = addMemberFailure(e, "Could not create teammate.");
       if (createdOnHost) {
         await boot();
       }
     } finally {
       setBusy(null);
     }
+    reportAddMember(outcome);
   }
 
   return (

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -55,6 +55,16 @@ const ROSTER = [
   { id: "turing", name: "Turing", role: "Researcher" },
 ];
 
+/**
+ * The toast layer (issue #1099).
+ *
+ * Since #1099 an *action* on this page answers in a toast; the `role="alert"`
+ * banner is left to a chart that could not be loaded. Located by sonner's own
+ * attribute, like `toast-dismissal.spec.ts` — the toast carries `role="status"`,
+ * which several live regions on this page share.
+ */
+const toasts = (page: Page) => page.locator("[data-sonner-toast]");
+
 /** Every write the console made, so the request shape can be asserted on. */
 let writes: { method: string; path: string; body?: unknown }[] = [];
 let roster = [...ROSTER];
@@ -513,10 +523,29 @@ test("#839 refuses a company-page teammate add when the host has no team write p
   await dialog.getByLabel("Role").fill("Unavailable");
   await dialog.getByRole("button", { name: "Add member" }).click();
 
-  await expect(page.getByRole("alert")).toContainText(
-    "does not support creating teammates",
-  );
-  await expect(page.locator("text=Not Saved")).toHaveCount(0);
+  await expect(toasts(page)).toContainText("can't create teammates");
+  await expect(chart(page).locator("text=Not Saved")).toHaveCount(0);
+});
+
+test("#1099 a teammate added from the company page is confirmed by name", async ({
+  page,
+}) => {
+  await mockApi(page);
+  await openChart(page);
+
+  await page.getByRole("button", { name: "New teammate" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name").fill("Katherine");
+  await dialog.getByLabel("Role").fill("Navigator");
+  await dialog.getByRole("button", { name: "Add member" }).click();
+
+  // The whole of #1099 on this surface: the operator is told, by name, rather
+  // than left to infer the add from a chart that repaints a moment later.
+  await expect(toasts(page)).toContainText("Added Katherine.");
+  // And it is a *success*, not the warning a half-landed add gets — asserted
+  // through sonner's own type attribute so the two cannot be confused by
+  // wording alone.
+  await expect(toasts(page).first()).toHaveAttribute("data-type", "success");
 });
 
 test("#311 the lead can be changed from the chart and survives a reload", async ({
@@ -573,10 +602,12 @@ test("#839 a teammate created but not placed is still on the chart to place by h
   await dialog.getByLabel("Role").fill("Compiler");
   await dialog.getByRole("button", { name: "Add member" }).click();
 
-  await expect(page.getByRole("alert")).toContainText(
-    "could not be added to the selected desk",
-  );
-  await expect(page.getByRole("alert")).toContainText("Hopper");
+  const halfLanded = toasts(page).first();
+  await expect(halfLanded).toContainText("couldn't be added to that desk");
+  await expect(halfLanded).toContainText("Hopper");
+  // Not dressed as a success (#1099): a teammate the host took but could not
+  // place is exactly the outcome "Added Hopper." would have lied about.
+  await expect(halfLanded).toHaveAttribute("data-type", "warning");
   // Created on the host, so it must be on the chart's unplaced list — the one
   // place a teammate with no desk belongs, and where the operator picks them
   // up to place by hand. Asserted against that list rather than the page: the

--- a/frontend/test/unit/member-feedback.test.ts
+++ b/frontend/test/unit/member-feedback.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { addMemberFailure, addMemberMessage, reportAddMember } = await import(
+  "@/lib/member-feedback"
+);
+
+/**
+ * Issue #1099: adding a teammate said nothing at all, and the three surfaces
+ * that can add one disagreed about how a failure was said.
+ *
+ * These pin the two halves the issue names. The first is that a clean add is
+ * confirmed, by name. The second is that the two ways an add can *half* land —
+ * a teammate whose inbox never came up, a teammate who exists only in this
+ * browser tab — stay distinguishable from a clean one, because the operator
+ * owes a follow-up in both and owes nothing in the first.
+ */
+describe("addMemberMessage", () => {
+  it("confirms a clean add by name", () => {
+    expect(addMemberMessage({ kind: "added", name: "Ada" })).toEqual({
+      level: "success",
+      title: "Added Ada.",
+    });
+  });
+
+  it("does not call a half-landed add a success", () => {
+    const msg = addMemberMessage({
+      kind: "partial",
+      name: "Ada",
+      missed: "their inbox couldn't be switched on.",
+      fix: "Turn it on from their actions menu.",
+    });
+    expect(msg.level).toBe("warning");
+    expect(msg.title).toBe("Added Ada, but their inbox couldn't be switched on.");
+    expect(msg.description).toBe("Turn it on from their actions menu.");
+  });
+
+  it("says a console-only row is console-only, and what that cost", () => {
+    const msg = addMemberMessage({
+      kind: "console-only",
+      name: "Ada",
+      note: "No inbox was created.",
+    });
+    expect(msg.level).toBe("warning");
+    expect(msg.title).toBe("Added Ada to this console only.");
+    // Both halves: the row is not durable, *and* the thing that needed a
+    // durable row did not happen.
+    expect(msg.description).toContain("gone when the console reloads");
+    expect(msg.description).toContain("No inbox was created.");
+  });
+
+  it("omits the follow-up clause when nothing was owed", () => {
+    const msg = addMemberMessage({ kind: "console-only", name: "Ada" });
+    expect(msg.description).toBe(
+      "This host can't save teammates, so they'll be gone when the console reloads.",
+    );
+  });
+
+  it("carries a refusal through as an error", () => {
+    expect(addMemberMessage({ kind: "failed", message: "Name already taken." })).toEqual({
+      level: "error",
+      title: "Name already taken.",
+    });
+  });
+});
+
+describe("addMemberFailure", () => {
+  it("prefers the host's own words", () => {
+    expect(addMemberFailure(new Error("Name already taken."))).toEqual({
+      kind: "failed",
+      message: "Name already taken.",
+    });
+  });
+
+  it("falls back when the failure carried no message", () => {
+    expect(addMemberFailure("boom")).toEqual({
+      kind: "failed",
+      message: "Couldn't add teammate.",
+    });
+    expect(addMemberFailure(null, "Could not create teammate.")).toEqual({
+      kind: "failed",
+      message: "Could not create teammate.",
+    });
+  });
+});
+
+describe("reportAddMember", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(toasts)) fn.mockClear();
+  });
+
+  it("raises a success toast for a clean add", () => {
+    reportAddMember({ kind: "added", name: "Ada" });
+    expect(toasts.success).toHaveBeenCalledWith("Added Ada.", undefined);
+    expect(toasts.error).not.toHaveBeenCalled();
+    expect(toasts.warning).not.toHaveBeenCalled();
+  });
+
+  it("raises a warning, with the follow-up, for a half-landed add", () => {
+    reportAddMember({
+      kind: "partial",
+      name: "Ada",
+      missed: "they couldn't be added to that desk: 500",
+      fix: "They're on the roster.",
+    });
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(toasts.warning).toHaveBeenCalledWith(
+      "Added Ada, but they couldn't be added to that desk: 500",
+      { description: "They're on the roster." },
+    );
+  });
+
+  it("raises an error, and only an error, for a refusal", () => {
+    reportAddMember({ kind: "failed", message: "Nope." });
+    expect(toasts.error).toHaveBeenCalledWith("Nope.", undefined);
+    expect(toasts.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #1099.

## RCA

Three surfaces create a teammate — `TeamView` (roster), `OrgChartView`
(Company page) and `ChatView` (the empty-state "Add a teammate") — and all
three ended the same way: `await boot(); setAddOpen(false);`. Nothing was said.
The operator inferred success from a list that repaints a moment later, on the
one write that creates a *person*, while `applyBudget`/`resetBudget` on the
same screen have confirmed themselves for months.

The failure half was not absent so much as forked. Each surface had written its
own answer to the same host conditions:

| condition | `TeamView` | `OrgChartView` | `ChatView` |
| --- | --- | --- | --- |
| refusal | `toast.error` | inline `role="alert"` banner | `toast.error` |
| host has no team write plane (404) | silent local row, `toast.error` only if an inbox was asked for | refuses: "This host does not support creating teammates from the Company page." | silent local row, `toast.error` only if an inbox was asked for |
| created, follow-up step failed | "Teammate added, but their inbox couldn't be switched on." | "Teammate X was created, but could not be added to the selected desk: …" (banner) | "Couldn't enable the inbox — …" |

So the root cause is not a missing `toast.success` call; it is that there was
no single owner of *what an add outcome is called*, and three copies of an
answer drift exactly like this. Adding a fourth copy of the toast would have
left the banner/toast split in place.

## The fix

`frontend/src/lib/member-feedback.ts` owns the answer, following the
`lib/approval-wording.ts` precedent. The views decide **what happened** — only
they know whether an inbox or a desk was part of the ask — and the module
decides what that is called and how loudly:

- `added` → `toast.success` — `Added Ada.`, named, so it reads as a receipt.
- `partial` → `toast.warning` — `Added Ada, but their inbox couldn't be switched on.` plus the follow-up the operator now owes. Deliberately not a success: the issue's point 3, and the same treatment `PeopleView`'s invite already gives a grant that landed without an email.
- `console-only` → `toast.warning` — the 404 path in `TeamView`/`ChatView` used to add a row silently and let it vanish on the next read. It now says so.
- `failed` → `toast.error`, carrying the host's own words.

**One failure convention.** `OrgChartView`'s action errors — the add *and* the
desk writes in `mutate` — move to toasts. The `role="alert"` banner is left to
a chart that could not be *loaded*: that is a state of the page and it sits
with the Retry button that clears it, whereas the answer to an action the
operator just took has to survive the dialog closing over it. `boot()` now
clears the banner on a successful read, which `mutate` used to do.

**When it fires.** After `boot()` resolves, per the issue's last note, so a
refetch that contradicted the write would contradict the toast too rather than
arrive a beat behind it. Same order `PeopleView.inviteAndReport` already uses.

## Beyond the issue text

The issue names two surfaces; `ChatView` is a third with the identical gap, so
it is included — otherwise the "one convention" holds for two thirds of the
places a teammate can be created.

## Tests

- `frontend/test/unit/member-feedback.test.ts` (new, 10 cases) — the wording and the toast *level* for each outcome, with sonner mocked. The teeth are the negative assertions: a partial or console-only add must not reach `toast.success`.
- `frontend/test/e2e/org-tree.spec.ts` — new `#1099` case asserting `Added Katherine.` with `data-type="success"`; **verified red on `upstream/main`** (no toast at all) and green here. The two existing `#839` cases that asserted the banner now assert the toast, and the half-landed one additionally pins `data-type="warning"` so it cannot silently become a success.

## Commands run

- `npx pnpm@10 install --frozen-lockfile`
- `tsc -b --noEmit`, `tsc -p tsconfig.unit.json`, `tsc -p tsconfig.e2e.json` — clean
- `vitest run` — 106 files, 1054 tests, all pass
- `playwright test test/e2e/org-tree.spec.ts test/e2e/chat-channel-membership.spec.ts test/e2e/workflow-selection-persists.spec.ts` against a dev-server `PW_BASE_URL` — 30 passed, 1 failed: `workflow-selection-persists.spec.ts:126` (#864), which **also fails on `upstream/main` unchanged**, so it is pre-existing and unrelated.

Console-only change; no Rust, no API surface. `frontend/ARCHITECTURE.md` gains
the banner-vs-toast rule beside the existing toast-lifetime note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent toast notifications for teammate additions across chat, team, and company views.
  - Success, partial completion, local-only, and failed additions now receive distinct feedback.
  - Partial results identify missed inbox or desk placement details.
  - Unsupported environments show a clear explanation when teammate creation is unavailable.

- **Bug Fixes**
  - Action results remain visible after dialogs close.
  - Loading errors continue using retryable page banners, while action failures use toasts.

- **Documentation**
  - Documented the updated feedback behavior and notification guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->