### PR TITLE
console: theme the scrollbars and rest them at low weight

### DIFF
--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -168,8 +168,10 @@ Never nest a modal inside a modal.
 
 ## ScrollArea, Separator, Skeleton, Avatar, Sonner, Chart
 
-- **ScrollArea** — styled scrollbars for panels. The page itself uses native
-  scrolling.
+- **ScrollArea** — a JS-driven scrollbar for panels that need one they can
+  position. Native scrolling is themed globally (see **Scrollbars** below), so
+  reach for this only when a panel needs the overlay behaviour, not merely to
+  make the bar look right.
 - **Separator** — a single `--border` hairline. Two adjacent separators, or a
   separator against a border, is one too many.
 - **Skeleton** — `bg-muted` blocks matching the shape of what is loading.
@@ -184,6 +186,41 @@ Never nest a modal inside a modal.
 - **Chart** — Recharts wrapper. Series use `--chart-1…5` in order. Axis labels,
   gridlines and legends use `--muted-foreground` and `--border`, never a series
   colour.
+
+---
+
+## Scrollbars
+
+Native scrollbars are themed once, globally, in `index.css` — nothing opts in
+and nothing per-view is needed.
+
+| State | Thumb |
+| --- | --- |
+| Rest | `--scrollbar-thumb-rest` — ~22% `--muted-foreground` (30% in dark) |
+| Scrolling | `--scrollbar-thumb-active` — 48% (58% in dark) |
+| Thumb hover / drag | `--scrollbar-thumb-grab` — 70% (80% in dark) |
+
+The track is transparent, so the thumb composites onto whatever surface it sits
+on; the lane is 10px with a 6px pill inset inside it, matching the rail
+`ScrollArea` draws.
+
+Three things to know before touching it:
+
+- **The bar never disappears.** It fades in weight, not out of existence — it
+  is the only affordance saying there is more content, and a panel whose action
+  is below the fold must keep it. Never replace this with `width: 0`.
+- **"Scrolling" is a JS signal.** `src/lib/scroll-activity.ts` marks the
+  scrolled element with `data-scrolling` from one capturing document listener
+  and clears it after an idle beat. It is not `:hover`, which matches every
+  ancestor of the pointer up to `html` and so lights every nested scroller at
+  once.
+- **The engines are mutually exclusive.** Chromium ignores `::-webkit-scrollbar`
+  as soon as `scrollbar-width`/`scrollbar-color` are set, so the standard
+  properties live behind `@supports not selector(::-webkit-scrollbar)` — the
+  Firefox arm — and the pseudo-element block serves Chromium and WebKit.
+
+Under `prefers-reduced-motion: reduce` the bar holds the active weight
+permanently: no transition and no state change to notice.
 
 ---
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -772,3 +772,151 @@
         }
     }
 }
+
+/* ============================================================================
+ * Scrollbars (issue #1109)
+ *
+ * One rule set, at the document level, so every scroll container in the console
+ * — the 69 that exist and the next one somebody adds — is themed without opting
+ * in. The browser default is a wide, pale, permanently-on bar that belongs to
+ * the operating system rather than to this canvas; against `bg-card` in dark it
+ * reads as a light stripe down the side of the panel.
+ *
+ * Three decisions worth stating, because each had an obvious alternative:
+ *
+ * 1. THE BAR NEVER LEAVES. It rests at 22% of `--muted-foreground` (30% in
+ *    dark) instead of `width: 0`. A scrollbar is the only thing on screen that says "there is
+ *    more below", and hiding it until the reader scrolls means hiding it until
+ *    after they needed it — worst on exactly the panels where the thing they
+ *    are looking for is an action at the bottom of a list. So the fade is a
+ *    fade in weight, not in existence.
+ *
+ * 2. THE GEOMETRY IS CONSTANT. Only the thumb's colour changes between states;
+ *    the track keeps its width whether the thumb is bright or faint. That is
+ *    what makes `scrollbar-gutter: stable` unnecessary here: the gutter would
+ *    fix a reflow that this never causes, and applying it globally would carve
+ *    a permanent 10px notch out of every `overflow-auto` box that does not
+ *    overflow — including the tightly-sized panels (`RunHistoryPanel`,
+ *    `NodeDetailPanel`, `CopilotPanel`) and the small `<pre>` blocks inside
+ *    them, whose padding would go visibly lopsided.
+ *
+ * 3. THE ACTIVE STATE COMES FROM JS, NOT `:hover`. `:hover` matches every
+ *    ancestor of the pointer up to `html`, so a hover reveal lights every
+ *    nested scroller as soon as the pointer is anywhere in the window.
+ *    `src/lib/scroll-activity.ts` marks the element that actually scrolled with
+ *    `data-scrolling` and clears it after an idle beat; one capturing listener
+ *    covers the whole document. The thumb's own `:hover` still fires — that one
+ *    is the real scrollbar part under the cursor, and it is precise.
+ *
+ * The weights are `color-mix` over `--muted-foreground` with a transparent
+ * track, so the thumb composites onto whatever surface it happens to sit on and
+ * `.dark` retunes it for free. Dark carries slightly more alpha: the same
+ * percentage over `--surface-dark-1` reads fainter than it does over white.
+ * ========================================================================== */
+
+:root {
+    --scrollbar-size: 10px;
+    /* A transparent border plus `background-clip: padding-box` insets the pill
+       inside the track, so the thumb is a 6px capsule floating in a 10px lane
+       rather than a bar wedged against the edge. Matches the rail our own
+       `ScrollArea` component draws (`w-2.5`), so native and custom scrollbars
+       read as the same object. */
+    --scrollbar-inset: 2px;
+    --scrollbar-thumb-rest: color-mix(in oklab, var(--muted-foreground) 22%, transparent);
+    --scrollbar-thumb-active: color-mix(in oklab, var(--muted-foreground) 48%, transparent);
+    --scrollbar-thumb-grab: color-mix(in oklab, var(--muted-foreground) 70%, transparent);
+}
+
+.dark {
+    --scrollbar-thumb-rest: color-mix(in oklab, var(--muted-foreground) 30%, transparent);
+    --scrollbar-thumb-active: color-mix(in oklab, var(--muted-foreground) 58%, transparent);
+    --scrollbar-thumb-grab: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
+}
+
+@layer base {
+    /* ---- Chromium and WebKit -------------------------------------------
+     * These pseudo elements only exist on boxes that actually scroll, so no
+     * element selector is needed — or wanted.
+     *
+     * Chromium honours them ONLY while `scrollbar-width` and `scrollbar-color`
+     * are untouched: set either standard property and it drops the custom
+     * scrollbar entirely and paints its own thin one. That is why the two
+     * halves below are mutually exclusive rather than layered "one as a
+     * fallback for the other" — verified in a real browser, where declaring
+     * both gave Chromium a square 11px native bar and left this whole block
+     * dead. `@supports` splits them on the only thing that actually differs:
+     * Firefox does not know the pseudo element.
+     */
+    ::-webkit-scrollbar {
+        width: var(--scrollbar-size);
+        height: var(--scrollbar-size);
+    }
+    ::-webkit-scrollbar-track,
+    ::-webkit-scrollbar-corner {
+        background: transparent;
+    }
+    /* Windows and Linux draw stepper arrows on a default scrollbar. They are
+       not part of this vocabulary and there is nothing to theme them with. */
+    ::-webkit-scrollbar-button {
+        display: none;
+    }
+    ::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb-rest);
+        background-clip: padding-box;
+        border: var(--scrollbar-inset) solid transparent;
+        border-radius: 9999px;
+        transition: background-color var(--duration-base) var(--ease-standard);
+    }
+    [data-scrolling]::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb-active);
+    }
+    /* After the active rule, so a thumb under the cursor stays the strongest
+       weight while the content it controls is moving. */
+    ::-webkit-scrollbar-thumb:hover,
+    ::-webkit-scrollbar-thumb:active {
+        background-color: var(--scrollbar-thumb-grab);
+    }
+
+    /* ---- Firefox --------------------------------------------------------
+     * No pill and no inset — the standard properties offer a width keyword and
+     * two colours, and that is the whole surface. `thin` plus the same thumb
+     * weights still lands in the same visual family as the block above.
+     *
+     * `scrollbar-color` inherits, so the root declaration reaches every
+     * scroller under it and `[data-scrolling]` overrides it in the same
+     * cascade. `scrollbar-width` does NOT inherit — again, checked rather than
+     * assumed — so it has to be stated for every element; `:where()` keeps that
+     * at zero specificity so `.no-scrollbar` still wins on the one surface that
+     * deliberately trades its bar away (the sidebar nav).
+     */
+    @supports not selector(::-webkit-scrollbar) {
+        :where(*) {
+            scrollbar-width: thin;
+        }
+        html {
+            scrollbar-color: var(--scrollbar-thumb-rest) transparent;
+        }
+        [data-scrolling] {
+            scrollbar-color: var(--scrollbar-thumb-active) transparent;
+        }
+    }
+
+    /* The global reduced-motion block above cannot reach a scrollbar pseudo
+       element (`*` does not match one), and killing the transition alone would
+       leave the bar snapping between two weights — motion by another name. So
+       the fade is not shortened here, it is removed: the bar simply holds its
+       active weight all the time, which is the state the reader would otherwise
+       have to provoke. */
+    @media (prefers-reduced-motion: reduce) {
+        ::-webkit-scrollbar-thumb {
+            background-color: var(--scrollbar-thumb-active);
+            transition: none;
+        }
+        @supports not selector(::-webkit-scrollbar) {
+            html,
+            [data-scrolling] {
+                scrollbar-color: var(--scrollbar-thumb-active) transparent;
+            }
+        }
+    }
+}

--- a/frontend/src/lib/scroll-activity.ts
+++ b/frontend/src/lib/scroll-activity.ts
@@ -64,10 +64,14 @@ export function startScrollActivity(idleMs = 700): () => void {
           : null;
     if (!el) return;
 
+    // A pending timer and the attribute are set and cleared together, so the
+    // timer's presence is what says the element is already marked. Writing the
+    // attribute again on every frame of a scroll would invalidate style for the
+    // element dozens of times a second to set it to the value it already has.
     const running = pending.get(el);
-    if (running !== undefined) window.clearTimeout(running);
+    if (running === undefined) el.setAttribute("data-scrolling", "");
+    else window.clearTimeout(running);
 
-    el.setAttribute("data-scrolling", "");
     pending.set(
       el,
       window.setTimeout(() => clear(el), idleMs),

--- a/frontend/src/lib/scroll-activity.ts
+++ b/frontend/src/lib/scroll-activity.ts
@@ -1,0 +1,90 @@
+/**
+ * Marks the element the operator is currently scrolling (issue #1109).
+ *
+ * The console's scrollbars are themed in `index.css`, and they rest at a low
+ * weight so that a panel at rest is not fenced in by a bright grey bar. Lifting
+ * them while the content is actually moving is the other half of that, and CSS
+ * cannot do it: there is no `:scrolling` selector, and the two states CSS *can*
+ * see are both wrong for this.
+ *
+ * `:hover` is the usual substitute, and it matches every ancestor of the
+ * pointer — `html` included. A hover reveal is therefore really an "is the
+ * pointer inside the window" reveal, lighting every nested scroller at once,
+ * which is louder than the always-on bar it replaced. `:focus-within` has the
+ * same shape. So the signal comes from here instead: one listener, the element
+ * that actually emitted a `scroll` event, and an idle timer.
+ *
+ * ## One listener for the whole document
+ *
+ * `scroll` does not bubble from an element, but it still runs the capture phase
+ * down from the document, so a single capturing listener sees every scroller in
+ * the app — the ones that exist today and the ones added next month, with no
+ * per-view wiring and nothing for a new panel to forget. That is the entire
+ * reason this is a document-level utility and not a hook a view opts into.
+ *
+ * The element is marked with `data-scrolling`, an attribute React does not
+ * manage and therefore does not clobber on re-render, and it is cleared once
+ * the element has been still for `idleMs`. Each element carries its own timer:
+ * two panels can scroll at once (a chat thread under a copilot drawer), and a
+ * shared timer would clear the mark on whichever one stopped first.
+ *
+ * Deliberately framework-free, in the same spirit as `visible-poll.ts`: no React
+ * import, no hook rules, callable from `main.tsx` before anything mounts and
+ * from a plain test with fake timers.
+ *
+ * @param idleMs How long an element must be still before the mark is dropped.
+ *               The default is long enough to cover the pause between two flicks
+ *               of a trackpad, short enough that the bar is gone before the
+ *               reader has finished the line they scrolled to.
+ * @returns A disposer that removes the listener, cancels every pending timer and
+ *          clears every mark it left behind. The console calls this once for the
+ *          life of the document and never disposes; tests do.
+ */
+export function startScrollActivity(idleMs = 700): () => void {
+  // Strong refs, not a WeakMap: the disposer has to be able to find every mark
+  // it left in order to clear it, and an entry only lives for `idleMs` after its
+  // element last moved. An element ripped out of the DOM mid-scroll drops out of
+  // here on the next tick like any other.
+  const pending = new Map<Element, number>();
+
+  const clear = (el: Element) => {
+    pending.delete(el);
+    el.removeAttribute("data-scrolling");
+  };
+
+  const onScroll = (event: Event) => {
+    // The root scroller reports the document as its target, and the styling hook
+    // for it is the `html` element.
+    const target = event.target;
+    const el =
+      target instanceof Document
+        ? target.documentElement
+        : target instanceof Element
+          ? target
+          : null;
+    if (!el) return;
+
+    const running = pending.get(el);
+    if (running !== undefined) window.clearTimeout(running);
+
+    el.setAttribute("data-scrolling", "");
+    pending.set(
+      el,
+      window.setTimeout(() => clear(el), idleMs),
+    );
+  };
+
+  // `passive` because this handler never calls `preventDefault`, and telling the
+  // browser so up front keeps it off the critical path of the scroll it is
+  // watching. `capture` is what makes one listener enough — see above.
+  document.addEventListener("scroll", onScroll, { capture: true, passive: true });
+
+  return () => {
+    document.removeEventListener("scroll", onScroll, { capture: true });
+    for (const [el, timer] of pending) {
+      window.clearTimeout(timer);
+      el.removeAttribute("data-scrolling");
+    }
+    pending.clear();
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "next-themes";
 import { App } from "./App";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
+import { startScrollActivity } from "@/lib/scroll-activity";
 import "./index.css";
 
 /**
@@ -31,5 +32,12 @@ function mount(): void {
     </StrictMode>,
   );
 }
+
+// Started before the first render and never disposed: it is one capturing
+// listener for the life of the document, and every scroll container in the app
+// — including ones mounted much later — depends on it for the `data-scrolling`
+// mark the themed scrollbars in `index.css` lift on. Outside React on purpose,
+// so StrictMode's double-invoked effects cannot arm it twice.
+startScrollActivity();
 
 mount();

--- a/frontend/test/unit/scroll-activity.test.ts
+++ b/frontend/test/unit/scroll-activity.test.ts
@@ -63,9 +63,10 @@ describe("startScrollActivity", () => {
     expect(panel.hasAttribute("data-scrolling")).toBe(false);
   });
 
-  it("keeps the mark through a continuous scroll", () => {
+  it("keeps the mark through a continuous scroll, writing it once", () => {
     dispose = startScrollActivity(700);
     const panel = scroller();
+    const write = vi.spyOn(panel, "setAttribute");
 
     // A flick of a trackpad is a burst of events, not one: each has to push the
     // idle deadline out rather than queue its own expiry.
@@ -74,6 +75,10 @@ describe("startScrollActivity", () => {
       vi.advanceTimersByTime(400);
       expect(panel.hasAttribute("data-scrolling")).toBe(true);
     }
+
+    // Re-marking an already-marked element would invalidate its style on every
+    // frame of the scroll to set the attribute to what it already is.
+    expect(write).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(700);
     expect(panel.hasAttribute("data-scrolling")).toBe(false);

--- a/frontend/test/unit/scroll-activity.test.ts
+++ b/frontend/test/unit/scroll-activity.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startScrollActivity } from "@/lib/scroll-activity";
+
+/**
+ * The scroll-activity mark (issue #1109).
+ *
+ * What is worth asserting here is not "it sets an attribute" — it is the three
+ * properties the themed scrollbars actually rely on, each of which is invisible
+ * in a screenshot until it is wrong:
+ *
+ *   - one listener covers containers it was never told about, because `scroll`
+ *     is caught in the capture phase rather than by subscribing per view;
+ *   - two panels scrolling at once keep independent idle timers, so the one
+ *     that stopped first does not un-mark the one still moving;
+ *   - the disposer leaves nothing behind — no timer, no stuck mark.
+ */
+
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+/** A scroll container the utility was never handed a reference to. */
+function scroller(): HTMLElement {
+  const el = document.createElement("div");
+  document.body.append(el);
+  return el;
+}
+
+describe("startScrollActivity", () => {
+  it("marks whichever element scrolls, without being registered", () => {
+    dispose = startScrollActivity();
+
+    // Created *after* the listener was armed: the point of the capture-phase
+    // listener is that a panel mounted later needs no wiring of its own.
+    const panel = scroller();
+    expect(panel.hasAttribute("data-scrolling")).toBe(false);
+
+    panel.dispatchEvent(new Event("scroll"));
+    expect(panel.hasAttribute("data-scrolling")).toBe(true);
+  });
+
+  it("clears the mark once the element has been still for the idle beat", () => {
+    dispose = startScrollActivity(700);
+    const panel = scroller();
+
+    panel.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(699);
+    expect(panel.hasAttribute("data-scrolling")).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(panel.hasAttribute("data-scrolling")).toBe(false);
+  });
+
+  it("keeps the mark through a continuous scroll", () => {
+    dispose = startScrollActivity(700);
+    const panel = scroller();
+
+    // A flick of a trackpad is a burst of events, not one: each has to push the
+    // idle deadline out rather than queue its own expiry.
+    for (let i = 0; i < 10; i += 1) {
+      panel.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(400);
+      expect(panel.hasAttribute("data-scrolling")).toBe(true);
+    }
+
+    vi.advanceTimersByTime(700);
+    expect(panel.hasAttribute("data-scrolling")).toBe(false);
+  });
+
+  it("tracks two containers independently", () => {
+    dispose = startScrollActivity(700);
+    const thread = scroller();
+    const drawer = scroller();
+
+    thread.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(400);
+    drawer.dispatchEvent(new Event("scroll"));
+
+    // The thread's own deadline passes while the drawer is still moving.
+    vi.advanceTimersByTime(300);
+    expect(thread.hasAttribute("data-scrolling")).toBe(false);
+    expect(drawer.hasAttribute("data-scrolling")).toBe(true);
+
+    vi.advanceTimersByTime(400);
+    expect(drawer.hasAttribute("data-scrolling")).toBe(false);
+  });
+
+  it("marks the root element when the page itself scrolls", () => {
+    dispose = startScrollActivity();
+
+    // The document is the target for the root scroller, and `html` is the only
+    // thing a stylesheet can hang a scrollbar rule on.
+    document.dispatchEvent(new Event("scroll"));
+    expect(document.documentElement.hasAttribute("data-scrolling")).toBe(true);
+  });
+
+  it("stops listening and clears a live mark on dispose", () => {
+    const stop = startScrollActivity(700);
+    const panel = scroller();
+
+    panel.dispatchEvent(new Event("scroll"));
+    expect(panel.hasAttribute("data-scrolling")).toBe(true);
+
+    stop();
+    // Cleared immediately rather than left to expire: the timer is gone, so
+    // nothing would ever come back for it.
+    expect(panel.hasAttribute("data-scrolling")).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+
+    panel.dispatchEvent(new Event("scroll"));
+    expect(panel.hasAttribute("data-scrolling")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Scrollbars across the console were the browser default — a wide, pale, always-on
bar that belongs to the operating system rather than to this canvas. They are now
themed once, globally, in `frontend/src/index.css`, and they rest at a low weight
and lift while their container is actually scrolling.

- **Themed off existing tokens.** The thumb is `color-mix` over
  `--muted-foreground`; the track is transparent, so the thumb composites onto
  whatever surface it sits on (`bg-card`, `bg-background`, a popover) instead of
  painting its own. `.dark` re-declares `--muted-foreground`, so dark comes free;
  the dark arm additionally carries a little more alpha, because the same
  percentage over `--surface-dark-1` reads fainter than it does over white. No
  hex, no palette classes — `scripts/ci/assert-design-tokens.sh` passes.
- **Both engines.** `::-webkit-scrollbar` / `-thumb` / `-track` / `-corner`
  (`-button` too, so Windows and Linux get no stepper arrows), and
  `scrollbar-width: thin` + `scrollbar-color` for Firefox.
- **Applied once, at the document level.** No per-view class; every current and
  future scroll container inherits it.

Three states: rest 22% (30% dark) → scrolling 48% (58%) → thumb under the cursor
or being dragged 70% (80%).

## Judgement calls

**"Is scrolling" is a JS signal, not `:hover`.** CSS has no `:scrolling`, and its
two substitutes are both wrong here: `:hover` and `:focus-within` match every
*ancestor* of the pointer or the focus, up to `html`. A hover reveal is therefore
really an "is the pointer anywhere in the window" reveal, lighting every nested
scroller at once — louder than the always-on bar it replaced. So a small shared
utility, `frontend/src/lib/scroll-activity.ts`, marks the element that actually
emitted a `scroll` event with `data-scrolling` and clears it after a 700ms idle
beat. It is **one** listener for the whole document: `scroll` does not bubble but
does run the capture phase, so nothing opts in and no new panel can forget to.
Framework-free, in the same shape as the existing `lib/visible-poll.ts`, started
once in `main.tsx` outside React (StrictMode cannot arm it twice), and unit
tested. The thumb's own `::-webkit-scrollbar-thumb:hover` is kept — that pseudo
is the real scrollbar part under the cursor, and it is precise.

**The bar is never hidden.** It fades in weight, not out of existence — no
`width: 0`. It is the only affordance saying there is more content, and hiding it
until the reader scrolls means hiding it until after they needed it, worst on
exactly the panels whose action is below the fold. At rest it measures 216 on a
247 canvas in light and 46 on 8 in dark: quiet, but plainly there.

**Layout shift: nothing to fix, so `scrollbar-gutter` is deliberately not used.**
Only the thumb's *colour* changes between states; the lane keeps its width
whether the thumb is bright or faint, so the fade causes no reflow. Applying
`scrollbar-gutter: stable` globally would fix a jump that does not happen and
introduce a real cost: a permanent 10px notch in every `overflow-auto` box that
does not currently overflow — 69 of them, including the tightly-sized panels the
issue names (`RunHistoryPanel`'s `max-h-72`, `NodeDetailPanel`, `CopilotPanel`)
and the small `<pre>` blocks inside them, whose padding would go visibly
lopsided. Checked against those panels — see the screenshots below.

**`prefers-reduced-motion` removes the fade rather than shortening it.** The
global reduced-motion block in `index.css` cannot reach a scrollbar pseudo
element (`*` does not match one), and killing only the transition would leave the
bar snapping between two weights — motion by another name. Under `reduce` the
thumb simply holds the active weight all the time.

**The two engine paths are mutually exclusive, not layered.** Chromium drops
`::-webkit-scrollbar` entirely as soon as `scrollbar-width` or `scrollbar-color`
is set and paints its own square native bar instead. Declaring both — the obvious
first cut — left the whole `::-webkit-` block dead in Chromium and gave it an
11px square bar. The standard properties now sit behind
`@supports not selector(::-webkit-scrollbar)`, which is the Firefox arm only.
`scrollbar-width` also does not inherit (unlike `scrollbar-color`), so it is
stated with `:where(*)` — zero specificity, so `.no-scrollbar` still wins on the
one surface that deliberately trades its bar away.

## Verified

Real output, from `frontend/`:

- `npm run typecheck` — clean
- `npm run typecheck:unit` — clean
- `npm test` — 1056 tests passed, all green (6 new, in `test/unit/scroll-activity.test.ts`)
- `npm run build` — clean
- `scripts/ci/assert-design-tokens.sh` — ✓ no arbitrary sizes, no palette colours, no stray hex

## Screenshots

**macOS auto-hides overlay scrollbars, so I forced them on first:**
`defaults write -g AppleShowScrollBars -string Always` (equivalent to System
Settings → Appearance → Show scroll bars → Always), then restored the default
afterwards. Worth recording that *headless* Chromium on macOS ignores that
setting and draws overlay scrollbars regardless — a headless screenshot of this
change is worthless, and the first pass of mine was. Every shot below is from a
**headed** browser driving a real host on the `e2e_harness` company, in light and
dark, idle and mid-scroll (the container is genuinely scrolling while the shutter
is open, not faked with a class), on Chromium **and** Firefox:

- **Long chat thread** (`#/chat/dm:engineer`, 40 messages) — the pill sits inside
  the timeline's right edge, clear of the composer. Light: `216,216,222` at rest
  → `180,180,186` while scrolling on a `247,247,252` canvas. Dark: `46,46,51` →
  `80,81,88` on `8,9,11`. Thumb is 6px wide in a 10px lane, matching the rail our
  own `ScrollArea` draws.
- **Workflows run history** (`RunHistoryPanel`, `max-h-72`, 24 runs) — the panel
  keeps its tight height, rows are not reflowed, and the pill reads against
  `bg-card` in both themes.
- **Settings** (`#/settings`, General) — long form, page-level scroller: a soft
  capsule tucked against the right edge, no gutter carved out of the cards.
- **Firefox** — same thumb weights (light `215` → `180`), rendered as its native
  thin bar. Same visual family, no pill.
- **Reduced motion** — with `prefers-reduced-motion: reduce`, the idle thumb
  measures `80,81,88` (the active weight) instead of `46,46,51`, and identical
  geometry: the state simply does not change.
- **`NodeDetailPanel` and `CopilotPanel`** (both themes) — neither overflows at
  rest, so neither shows a bar and both keep symmetric padding. This is the
  `scrollbar-gutter` argument in one picture: a stable gutter would carve 10px
  out of the right edge of both for a scrollbar that is not there.

## Notes for review

- `docs/design-system/components.md` gains a **Scrollbars** section, and the
  `ScrollArea` bullet is corrected — it used to say "the page itself uses native
  scrolling" as though that meant unthemed.
- `.no-scrollbar` (used by the sidebar nav) still wins, deliberately.
- Aligning `ScrollArea`'s own thumb — `bg-border`, which is nearly invisible in
  dark — with these weights is a follow-up, not this change.

Closes #1109
