### PR TITLE
feat(console): the Workflows tab opens on the list, and a workflow only when you pick one (#1110)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -14,6 +14,8 @@ import {
   Bot,
   FlaskConical,
   History,
+  LayoutGrid,
+  List as ListIcon,
   Loader2,
   Pause,
   Pencil,
@@ -2198,6 +2200,43 @@ export function WorkflowsView({
           </span>
             </>
           )}
+          {/* Issue #1110: the index's Cards/List toggle, in the tab's one
+              toolbar. It used to sit in a header the index drew for itself,
+              which was fine while the index was a panel over the canvas and
+              wrong the moment it became the page — "Workflows 7" and "All
+              workflows 7" one above the other, with the toggle stranded under
+              the duplicate.
+
+              Segmented rather than two loose buttons, because the pair is one
+              question with two answers and reads as a switch. Shown only on the
+              index: it decides how the list is drawn, and there is no list to
+              draw inside a workflow. */}
+          {!detailOpen && workflows.length > 0 && (
+            <div className="flex items-center gap-1 rounded-lg border p-0.5">
+              {(
+                [
+                  { value: "cards", label: "Cards", Icon: LayoutGrid },
+                  { value: "list", label: "List", Icon: ListIcon },
+                ] as const
+              ).map(({ value, label, Icon }) => (
+                <Button
+                  key={value}
+                  size="sm"
+                  variant={indexMode === value ? "secondary" : "ghost"}
+                  className="h-7 px-2"
+                  onClick={() => {
+                    setIndexMode(value);
+                    writeIndexMode(value);
+                  }}
+                  aria-pressed={indexMode === value}
+                  data-testid={`workflow-index-${value}`}
+                >
+                  <Icon className="mr-1.5 size-3.5" />
+                  {label}
+                </Button>
+              ))}
+            </div>
+          )}
           {/* Issue #341: THE control named "New workflow". It is in the
               toolbar in every state, so it is the one an operator — or a
               screen reader, or a spec — should find under that name. The
@@ -2397,10 +2436,6 @@ export function WorkflowsView({
               selectedId={null}
               onSelect={(id) => setSelectedId(id)}
               mode={indexMode}
-              onModeChange={(mode) => {
-                setIndexMode(mode);
-                writeIndexMode(mode);
-              }}
               loading={loadingList}
               runsLoaded={indexRunsLoaded}
             />

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1391,10 +1391,9 @@ export function WorkflowsView({
   // place the operator chose to go. Pushing keeps browser Back and this button
   // exact inverses of each other, which is what makes the pair learnable.
   //
-  // The two body-level drawers are closed on the way out because they are
-  // per-workflow surfaces: an operator who left one open, went back to the
-  // index and opened a second workflow would otherwise find it already up,
-  // showing the second workflow's runs under a panel they never asked for.
+  // Closing the per-workflow drawers is NOT done here — the effect that watches
+  // the selection does it, so that every route back to the index closes them and
+  // not just this one.
   const backToIndex = useCallback(() => {
     setSelectedId(null);
     setHistoryOpen(false);
@@ -2428,12 +2427,6 @@ export function WorkflowsView({
             <WorkflowIndex
               workflows={workflows}
               runsByWorkflow={runsByWorkflow}
-              // Issue #1110: nothing is ever "the selected one" while the index
-              // is what you are looking at — selecting IS leaving the index. It
-              // is passed as null rather than dropped so the component keeps one
-              // shape, and so a future surface that lists workflows beside an
-              // open one can still say which.
-              selectedId={null}
               onSelect={(id) => setSelectedId(id)}
               mode={indexMode}
               loading={loadingList}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -849,11 +849,29 @@ export function WorkflowsView({
     else window.location.hash = next.slice(1);
   }, [selectedId]);
 
-  // Issue #1110: the dead-link explanation belongs to the arrival that raised
-  // it, and to nothing after. Opening any workflow answers it, and a company
-  // switch makes it a statement about a company nobody is looking at.
+  // Issue #1110: what leaving a workflow — by any route — settles.
+  //
+  // The dead-link explanation belongs to the arrival that raised it and to
+  // nothing after, so opening any workflow answers it. (A company switch does
+  // too, below: it makes the banner a statement about a company nobody is
+  // looking at.)
+  //
+  // The two body-level drawers are per-workflow surfaces, and going back to the
+  // index is the one selection change that must close them. A workflow-to-
+  // workflow switch deliberately does NOT: an operator comparing two histories
+  // opened that panel and still wants it. But left open across a return to the
+  // index — from the back button, from a delete here, from a delete somewhere
+  // else — the NEXT workflow opened comes up wearing a drawer nobody asked it
+  // for, showing that workflow's runs. One rule here rather than one per route,
+  // because the routes to the index that are not the back button are exactly
+  // the ones nobody remembers to update.
   useEffect(() => {
-    if (selectedId !== null) setMissingWorkflowId(null);
+    if (selectedId !== null) {
+      setMissingWorkflowId(null);
+      return;
+    }
+    setHistoryOpen(false);
+    setCopilotOpen(false);
   }, [selectedId]);
   useEffect(() => {
     setMissingWorkflowId(null);
@@ -1396,8 +1414,6 @@ export function WorkflowsView({
   // not just this one.
   const backToIndex = useCallback(() => {
     setSelectedId(null);
-    setHistoryOpen(false);
-    setCopilotOpen(false);
     const { onWorkflows, workflowId } = readWorkflowHash();
     if (onWorkflows && workflowId !== null) window.location.hash = "/workflows";
   }, []);

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -10,10 +10,10 @@ import {
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
 import {
+  ArrowLeft,
   Bot,
   FlaskConical,
   History,
-  LayoutGrid,
   Loader2,
   Pause,
   Pencil,
@@ -160,6 +160,25 @@ function readWorkflowHash(): {
     workflowId: id ? safeDecode(id) : null,
     runId: query ? new URLSearchParams(query).get("run") : null,
   };
+}
+
+/**
+ * Rewrite `#/workflows/<id>` back to `#/workflows`, in place (issue #1110).
+ *
+ * `replaceState`, never a push, and that is the whole reason this is a function
+ * rather than an assignment at each call site: every caller is the view
+ * *correcting* the URL — a workflow the operator deleted, one another session
+ * deleted, one a link named that this company does not have. Pushing any of
+ * those would offer Back as a route to a workflow that is gone.
+ *
+ * Silent when the hash does not name a workflow, so a call made while another
+ * view owns the hash (a company switch mid-navigation) cannot drag the operator
+ * back here.
+ */
+function clearWorkflowFromHash(): void {
+  const { onWorkflows, workflowId } = readWorkflowHash();
+  if (!onWorkflows || workflowId === null) return;
+  window.history.replaceState(null, "", "#/workflows");
 }
 
 /**
@@ -447,14 +466,25 @@ export function WorkflowsView({
   // already over.
   const [cancelUnsupportedFor, setCancelUnsupportedFor] = useState<string | null>(null);
   const [cancelling, setCancelling] = useState(false);
-  // Issue #303: the browse index (cards or list) is up instead of the canvas.
+  // Issue #1110: the index (cards or list) is no longer a panel that opens over
+  // the canvas — it is what `#/workflows` *is*. There is exactly one piece of
+  // state behind that, `selectedId`, and it is the URL's second segment: null
+  // means the index, an id means that workflow's detail view.
   //
-  // Closed by default, and that is deliberate rather than timid: the toolbar
-  // picker, the Run button and the Edit/Delete affordances are what this tab
-  // opens onto today, and moving the canvas behind a landing screen would
-  // change the first thing every operator sees for the sake of a browse
-  // surface most of them reach for occasionally.
-  const [indexOpen, setIndexOpen] = useState(false);
+  // Introduced as a name rather than inlined because a dozen places read it and
+  // "is a workflow open" is the question they are all asking. It is deliberately
+  // NOT separate state — a second flag could disagree with the selection, and
+  // the disagreement would be a canvas with no graph or an index with a
+  // per-workflow toolbar over it.
+  const detailOpen = selectedId !== null;
+  // Issue #1110: a deep link whose workflow this company does not have.
+  //
+  // Set only after the resolver's fresh re-read has confirmed the absence (see
+  // the follow effect), and rendered on the index rather than raised as a toast:
+  // the operator arrived from somebody else's link and the useful reading —
+  // "that link is dead, here is what this company does have" — has to still be
+  // on screen while they scan the list for the workflow that replaced it.
+  const [missingWorkflowId, setMissingWorkflowId] = useState<string | null>(null);
   // Which rendering the index uses, remembered across sessions — an operator
   // who prefers one has no reason to re-pick it every visit.
   const [indexMode, setIndexMode] = useState<IndexMode>(readIndexMode);
@@ -551,9 +581,20 @@ export function WorkflowsView({
   // Holds the id rather than a bare flag so a marker that outlives its render
   // cannot suppress an unrelated push later — it counts only when it names the
   // very selection the mirror is about to write.
-  const reconciledSelectionRef = useRef<string | null>(null);
+  //
+  // Issue #1110: BOXED, because the selection it names can now be `null` — the
+  // list effect no longer falls back to the first remaining row, it falls back
+  // to the index. A bare `string | null` cannot tell "reconciled to nothing"
+  // from "no marker set", and reading the second as the first would leave a
+  // deleted workflow's id in the address bar over an index.
+  const reconciledSelectionRef = useRef<{ id: string | null } | null>(null);
 
-  // Load the workflow list, and auto-select the first entry.
+  // Load the workflow list.
+  //
+  // Issue #1110: it does NOT select anything on the operator's behalf. A list
+  // that lands with nothing selected renders the index, which is the whole
+  // point of the tab — "what workflows do I have?" — and a workflow is opened
+  // only by a click or by a URL that names one.
   //
   // Re-runs on `listEventTick` (issue #384), i.e. whenever the host says a
   // workflow was created, edited or deleted anywhere — the orchestrator's
@@ -609,19 +650,26 @@ export function WorkflowsView({
           if (requestedWorkflowId && rows.some((r) => r.id === requestedWorkflowId)) {
             return requestedWorkflowId;
           }
-          // Nothing valid to keep: fall to the first remaining entry, exactly
-          // as the local Delete button does — so a workflow deleted from
-          // another session and one deleted from this button leave the view in
-          // the same place. A company whose last workflow just went away
-          // selects nothing, and the canvas empties.
+          // Issue #1110: nothing valid to keep, so the view goes back to the
+          // INDEX. It used to fall to `rows[0]`, which is the behaviour the
+          // issue is about seen from its other side — on first load that is the
+          // auto-select that drops the operator inside a workflow they did not
+          // choose, and after a delete elsewhere it is a neighbouring graph
+          // appearing on the canvas as though they had opened it.
+          //
+          // Exactly the same rule the local Delete button now follows, so a
+          // workflow deleted from another session and one deleted from this
+          // console leave the view in the same place.
           //
           // Marked as a reconciliation so the hash mirror replaces rather than
           // pushes: nobody navigated here, the workflow they were on stopped
-          // existing. Writing the same id twice (React re-invokes an updater in
-          // StrictMode) says the same thing twice.
-          const fallback = rows[0]?.id ?? null;
-          reconciledSelectionRef.current = fallback;
-          return fallback;
+          // existing. The marker is only worth setting when there was something
+          // to leave — a `prev` of null that stays null never re-renders, so a
+          // marker set there would sit unconsumed. (React re-invokes an updater
+          // in StrictMode; writing the same marker twice says the same thing
+          // twice.)
+          if (prev !== null) reconciledSelectionRef.current = { id: null };
+          return null;
         });
         setError(null);
       } catch (e) {
@@ -701,10 +749,24 @@ export function WorkflowsView({
           return;
         }
         // Still absent after a fresh read: the link genuinely names a workflow
-        // this company no longer has. Say so, once.
+        // this company no longer has.
+        //
+        // Issue #1110: land on the INDEX and say so there, rather than leaving
+        // a detail view addressed to nothing. Before this the view kept
+        // whatever was auto-selected and toasted "showing the current selection
+        // instead", which was the wrong offer twice over — the operator never
+        // chose that workflow, and four seconds later the only trace that the
+        // link was dead had gone.
+        //
+        // The toast stays as well, because the banner alone is silent for an
+        // operator who is already looking at the index when a second card's
+        // link is followed into it: nothing on screen would move.
+        setMissingWorkflowId(target);
+        setSelectedId(null);
+        clearWorkflowFromHash();
         toast.error(`This company has no workflow “${target}”.`, {
           description:
-            "It may have been renamed or deleted since the link was made. Showing the current selection instead.",
+            "It may have been renamed or deleted since the link was made. Showing every workflow this company has instead.",
         });
       } catch {
         // A failed re-read is not proof the workflow is missing. Leave the id
@@ -738,35 +800,62 @@ export function WorkflowsView({
   // to a different workflow the query is dropped, which is correct — that run
   // belongs to the graph being left behind.
   //
-  // Replace vs push is decided by whether the hash already names a workflow,
-  // and by whether the operator moved the selection at all.
+  // Replace vs push is decided by whether the view moved the selection on the
+  // operator's behalf.
   //
-  // Filling in a bare `#/workflows` is this view resolving its own default, not
-  // a place the operator has been — pushing it would put an entry in the
-  // history stack that looks identical to the one before it, so their first
-  // Back press out of the tab would appear to do nothing. Moving from one named
-  // workflow to another IS a navigation they took, and Back should undo it.
+  // Issue #1110 changed this rule, and the change is the whole of "Back must
+  // move index ↔ detail". Filling in a bare `#/workflows` used to be the view
+  // resolving its own default — nobody had navigated, so pushing it would have
+  // left a duplicate-looking history entry — and it was written with `replace`.
+  // There is no default to resolve any more: a bare `#/workflows` IS the index,
+  // and the only thing that fills it in is an operator opening a workflow from
+  // the index (or the picker, or a create). That is a navigation, it pushes,
+  // and Back returns to the list they came from.
   //
-  // A reconciliation is neither: the workflow they were on stopped existing and
-  // the list effect moved them off it (issue #384). Pushing that would offer
-  // Back as a route to a workflow that is gone — see `reconciledSelectionRef`
-  // for why the view does not even correct itself once it is there.
+  // A reconciliation is still not a navigation: the workflow they were on
+  // stopped existing and the list effect moved them off it (issue #384).
+  // Pushing that would offer Back as a route to a workflow that is gone — see
+  // `reconciledSelectionRef` for why the view does not even correct itself once
+  // it is there.
+  //
+  // A selection of `null` writes nothing HERE. It is also what an unresolved
+  // deep link looks like for the render or two before the list lands, and
+  // clearing the hash on sight would destroy the link before it could be
+  // followed. Everything that genuinely leaves a workflow behind calls
+  // {@link clearWorkflowFromHash} for itself, at the point where it knows.
   useEffect(() => {
     // Consumed on every run, whichever branch is taken below: a marker left
     // over from a reconciliation that did not end up writing the URL must not
     // decide a later, genuine navigation.
-    const reconciled = reconciledSelectionRef.current === selectedId;
+    const marker = reconciledSelectionRef.current;
     reconciledSelectionRef.current = null;
-    if (!selectedId) return;
+    const reconciled = marker !== null && marker.id === selectedId;
+    if (!selectedId) {
+      // A reconciliation onto the index (issue #1110): the list came back
+      // without the workflow on screen. Take its id out of the address bar so
+      // the URL names the index the operator is now looking at.
+      if (reconciled) clearWorkflowFromHash();
+      return;
+    }
     const { onWorkflows, workflowId } = readWorkflowHash();
     // Another view owns the hash (a company switch mid-navigation, a stale
     // effect): rewriting it would drag the operator back here.
     if (!onWorkflows) return;
     if (workflowId === selectedId) return;
     const next = `#/workflows/${encodeURIComponent(selectedId)}`;
-    if (workflowId === null || reconciled) window.history.replaceState(null, "", next);
+    if (reconciled) window.history.replaceState(null, "", next);
     else window.location.hash = next.slice(1);
   }, [selectedId]);
+
+  // Issue #1110: the dead-link explanation belongs to the arrival that raised
+  // it, and to nothing after. Opening any workflow answers it, and a company
+  // switch makes it a statement about a company nobody is looking at.
+  useEffect(() => {
+    if (selectedId !== null) setMissingWorkflowId(null);
+  }, [selectedId]);
+  useEffect(() => {
+    setMissingWorkflowId(null);
+  }, [company]);
 
   // Fetch the selected workflow's full graph.
   useEffect(() => {
@@ -889,18 +978,22 @@ export function WorkflowsView({
 
   // Issue #303: the run page the index's health readings are folded from.
   //
-  // Fetched only while the index is open — every card reads from one request,
-  // and a company that never opens the browse panel should not pay for it. It
-  // refreshes on `runEventTick` so a run finishing with the index up updates
+  // Fetched only while the index is on screen — every card reads from one
+  // request, and a workflow's own detail view reads the scoped history instead.
+  // It refreshes on `runEventTick` so a run finishing with the index up updates
   // the card that owns it, and on `runsTick` so a run started from here shows
   // as running.
+  //
+  // Issue #1110: the gate used to be "the Browse panel is open" and is now "no
+  // workflow is open", which is the same question asked of the one piece of
+  // state that decides what the tab renders.
   //
   // UNSCOPED, unlike the selected workflow's history above: `?workflow=` covers
   // exactly one graph, and the index needs every graph. The cost of that is a
   // page cut by `limit` across all workflows, which is precisely why the cards
   // are worded "No recent runs" — see `WorkflowIndex`'s `HealthLine`.
   useEffect(() => {
-    if (!indexOpen) return;
+    if (detailOpen) return;
     let live = true;
     (async () => {
       try {
@@ -920,7 +1013,7 @@ export function WorkflowsView({
     return () => {
       live = false;
     };
-  }, [client, company, indexOpen, runsTick, runEventTick]);
+  }, [client, company, detailOpen, runsTick, runEventTick]);
 
   // A company switch invalidates the whole page — another company's runs must
   // never be folded onto this one's cards, and `indexRunsLoaded` has to go back
@@ -1158,7 +1251,19 @@ export function WorkflowsView({
       localWriteRef.current += 1;
       const remaining = workflows.filter((w) => w.id !== selectedId);
       setWorkflows(remaining);
-      setSelectedId(remaining[0]?.id ?? null);
+      // Issue #1110: back to the INDEX, never to a neighbour. Selecting
+      // `remaining[0]` put a workflow the operator had not asked for onto the
+      // canvas under a toolbar addressed to it — the same wrong answer the tab
+      // used to give on arrival, arriving a second way.
+      //
+      // The id is marked applied and taken out of the address bar here rather
+      // than through the hash mirror: the mirror only ever hears about the
+      // selection, and this is the one path that also has to stop the URL-follow
+      // effect treating the id still sitting in the router's `sub` as a fresh
+      // request to re-open the graph that was just deleted.
+      appliedWorkflowRef.current = selectedId;
+      setSelectedId(null);
+      clearWorkflowFromHash();
       setGraph(null);
       setResult(null);
       setSelectedNodeId(null);
@@ -1268,8 +1373,32 @@ export function WorkflowsView({
         },
       ].sort((a, b) => a.name.localeCompare(b.name));
     });
+    // Issue #1110: a create lands on the new workflow's DETAIL view, not back
+    // on the index. Nobody authors a workflow in order to look at a list of
+    // workflows — the next thing they want is its canvas, to run it or to keep
+    // editing it. The hash mirror pushes that as a navigation, so Back returns
+    // to the index they created it from.
     setSelectedId(created.id);
     toast.success("Workflow created.");
+  }, []);
+
+  // Issue #1110: leave the workflow on screen and go back to the index.
+  //
+  // A push, unlike every other route to the index in this file: those are the
+  // view correcting itself off a workflow that stopped existing, this is a
+  // place the operator chose to go. Pushing keeps browser Back and this button
+  // exact inverses of each other, which is what makes the pair learnable.
+  //
+  // The two body-level drawers are closed on the way out because they are
+  // per-workflow surfaces: an operator who left one open, went back to the
+  // index and opened a second workflow would otherwise find it already up,
+  // showing the second workflow's runs under a panel they never asked for.
+  const backToIndex = useCallback(() => {
+    setSelectedId(null);
+    setHistoryOpen(false);
+    setCopilotOpen(false);
+    const { onWorkflows, workflowId } = readWorkflowHash();
+    if (onWorkflows && workflowId !== null) window.location.hash = "/workflows";
   }, []);
 
   // Issue #840 (PR-3): correct a failed run's workflow with the copilot. The
@@ -1755,26 +1884,59 @@ export function WorkflowsView({
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3">
+        {/* Issue #1110: the heading says where you are. On the index that is
+            the tab — "Workflows", and how many there are. In a workflow it is
+            that workflow's name, behind the control that goes back to the list,
+            which is the ordinary shape of a list → detail pair and is what
+            makes the two states tell themselves apart at a glance. */}
         <div className="flex min-w-0 items-center gap-2">
-          <h2 className="text-sm font-semibold">Workflows</h2>
-          <Badge variant="secondary">{workflows.length}</Badge>
-          {/* Issue #228: the last run's outcome at a glance — including for a
-              scheduled run nobody watched, which is the case the issue is
-              about. Absent until this workflow has run at least once. */}
-          {lastRun && <LastRunChip run={lastRun} />}
-          {/* Issue #276: state an operator must not have to hover to learn. A
-              paused workflow looks exactly like a live one otherwise, and the
-              case that matters most — a schedule the disarm rule switched off on
-              create — has never run, so there is no LastRunChip to hint at it. */}
-          {paused && (
-            <Badge variant="outline" data-testid="workflow-paused-badge">
-              Schedule paused
-            </Badge>
-          )}
-          {selected?.description && (
-            <p className="hidden truncate text-xs text-muted-foreground sm:block">
-              {selected.description}
-            </p>
+          {detailOpen ? (
+            <>
+              {/* Issue #1110: what "Browse" became. It used to toggle a panel
+                  over the canvas; the panel is the tab's front door now, so the
+                  button that pointed at it is the way back out. Named for the
+                  destination rather than the gesture — "Back" alone would be
+                  ambiguous next to the browser's own Back, which lands in the
+                  same place from here on purpose. */}
+              <Button
+                size="sm"
+                variant="ghost"
+                className="-ml-2 h-8 shrink-0 px-2 text-muted-foreground hover:text-foreground"
+                onClick={backToIndex}
+                data-testid="workflow-back-to-index"
+                title="Back to every workflow in this company."
+              >
+                <ArrowLeft className="mr-1.5 size-4" />
+                All workflows
+              </Button>
+              <h2 className="min-w-0 truncate text-sm font-semibold" data-testid="workflow-detail-name">
+                {selected?.name ?? graph?.name ?? selectedId}
+              </h2>
+              {/* Issue #228: the last run's outcome at a glance — including for
+                  a scheduled run nobody watched, which is the case the issue is
+                  about. Absent until this workflow has run at least once. */}
+              {lastRun && <LastRunChip run={lastRun} />}
+              {/* Issue #276: state an operator must not have to hover to learn.
+                  A paused workflow looks exactly like a live one otherwise, and
+                  the case that matters most — a schedule the disarm rule
+                  switched off on create — has never run, so there is no
+                  LastRunChip to hint at it. */}
+              {paused && (
+                <Badge variant="outline" data-testid="workflow-paused-badge">
+                  Schedule paused
+                </Badge>
+              )}
+              {selected?.description && (
+                <p className="hidden truncate text-xs text-muted-foreground sm:block">
+                  {selected.description}
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              <h2 className="text-sm font-semibold">Workflows</h2>
+              <Badge variant="secondary">{workflows.length}</Badge>
+            </>
           )}
         </div>
         {/* Issue #824. `flex-wrap` on the ACTION ROW, not just on the header
@@ -1791,6 +1953,17 @@ export function WorkflowsView({
             budget. `justify-end` keeps the wrapped line aligned to the right
             edge it belongs to instead of drifting left under the title. */}
         <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+          {/* Issue #1110: every control from here to `New workflow` acts on ONE
+              workflow, so none of them is on screen until one is open. That is
+              the issue in a line: an index with a Run button has no subject to
+              run, and a toolbar that keeps its subject by picking one for you is
+              how the tab came to open inside a workflow nobody chose.
+
+              `New workflow` stays outside this branch and is rendered in both
+              states, exactly as issue #341 requires of the control that answers
+              to that name. */}
+          {detailOpen && (
+            <>
           <Select
             // Issue #406, half one. NOT `selectedId ?? undefined`: Base UI
             // decides controlled-vs-uncontrolled ONCE, on the first render,
@@ -1884,21 +2057,12 @@ export function WorkflowsView({
               Stop
             </Button>
           )}
-          {/* Issue #303. Deliberately placed AFTER the picker and Run: this
-              toggles what fills the body, and grouping it with the other
-              body-level toggle (History) reads better than sitting beside the
-              selection controls it does not change. */}
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setIndexOpen((open) => !open)}
-            aria-pressed={indexOpen}
-            data-testid="workflow-browse-toggle"
-            title="Browse every workflow as cards or as a list."
-          >
-            <LayoutGrid className="mr-1.5 size-4" />
-            Browse
-          </Button>
+          {/* Issue #1110: the Browse toggle that used to sit here is gone. It
+              opened the index over the canvas, and the index is what the tab
+              opens on now — a button that toggles the surface you arrived
+              through is one control for two states with one name. Its job as a
+              way back is done by "All workflows" at the head of this bar, where
+              a back affordance belongs. */}
           {/* Issue #303. Needs a loaded graph, not just a selection: the
               copilot's whole grounding IS the graph, and opening it against a
               workflow that failed to load would give it nothing to answer
@@ -2032,6 +2196,8 @@ export function WorkflowsView({
               </AlertDialogContent>
             </AlertDialog>
           </span>
+            </>
+          )}
           {/* Issue #341: THE control named "New workflow". It is in the
               toolbar in every state, so it is the one an operator — or a
               screen reader, or a spec — should find under that name. The
@@ -2053,7 +2219,7 @@ export function WorkflowsView({
       {/* Issue #259: a write refused because the graph moved under us. Distinct
           from `error` on purpose — this one is recoverable, and the recovery is
           right here, so it must not be mistaken for a generic load failure. */}
-      {conflict && (
+      {detailOpen && conflict && (
         <div className="px-4 pt-3">
           <Alert variant="destructive" data-testid="workflow-conflict">
             <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
@@ -2076,7 +2242,7 @@ export function WorkflowsView({
           can clear from Settings. Persistent (not a toast) and mirroring the
           conflict banner's layout, with the fix one click away. Keyed on the
           structured `code`, never the prose. */}
-      {runRefusal && (
+      {detailOpen && runRefusal && (
         <div className="px-4 pt-3">
           <Alert variant="destructive" data-testid="workflow-run-inference-alert">
             <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
@@ -2108,10 +2274,40 @@ export function WorkflowsView({
         </div>
       )}
 
+      {/* Issue #1110: a link named a workflow this company does not have.
+          Rendered on the index, over the list of what it does have, because
+          that list is the answer to the question a dead link raises. Not a
+          detail shell addressed to nothing, and not only a toast — the operator
+          arrived here from somebody else's link and may take a while to work
+          out which workflow replaced it.
+
+          Dismissible rather than timed: it is a statement about how they got
+          here, and it stops being true the moment they open something. */}
+      {missingWorkflowId && !detailOpen && (
+        <div className="px-4 pt-3">
+          <Alert data-testid="workflow-missing-link">
+            <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-xs">
+                This company has no workflow “{missingWorkflowId}”. It may have been renamed
+                or deleted since that link was made. Everything it does have is below.
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setMissingWorkflowId(null)}
+                data-testid="workflow-missing-link-dismiss"
+              >
+                Dismiss
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
       {/* Issue #371: the canvas is showing a PAST run, not the live one. Said
           plainly, with the way out attached — an unexplained ring on a node
           would otherwise read as the current state of the workflow. */}
-      {overlayRun && (
+      {detailOpen && overlayRun && (
         <div className="px-4 pt-3">
           <Alert data-testid="workflow-overlay-banner">
             <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
@@ -2134,70 +2330,84 @@ export function WorkflowsView({
       )}
 
       <div className="relative flex-1">
-        {/* Issue #303: browsing REPLACES the canvas rather than squeezing in
-            above it. A card grid needs the width, and the canvas is meaningless
-            while the operator is deciding which workflow they want. Picking one
-            drops straight back to that workflow's canvas. */}
-        {indexOpen ? (
-          <WorkflowIndex
-            workflows={workflows}
-            runsByWorkflow={runsByWorkflow}
-            selectedId={selectedId}
-            onSelect={(id) => {
-              setSelectedId(id);
-              setIndexOpen(false);
-            }}
-            mode={indexMode}
-            onModeChange={(mode) => {
-              setIndexMode(mode);
-              writeIndexMode(mode);
-            }}
-            loading={loadingList}
-            runsLoaded={indexRunsLoaded}
-          />
+        {/* Issue #1110: ONE branch, on the one piece of state that says where
+            the operator is. No workflow open ⇒ the index fills the body; a
+            workflow open ⇒ its canvas does.
+
+            The index REPLACES the canvas rather than squeezing in above it
+            (issue #303's reasoning, unchanged): a card grid needs the width,
+            and a canvas is meaningless while the operator is still deciding
+            which workflow they want. */}
+        {!detailOpen ? (
+          !loadingList && workflows.length === 0 ? (
+            // Issue #813's on-ramp, which used to live behind the canvas's
+            // empty selection. An empty company now lands here instead, so this
+            // is where it has to be — and it is shown INSTEAD of the index
+            // rather than inside it, because a Cards/List toggle over nothing
+            // is chrome for a decision there is nothing to make.
+            <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
+              <p>This company has no saved workflows yet.</p>
+              {/* Issue #813: a first-time author has no on-ramp otherwise. One
+                  compact prose block — what a workflow is, a worked example
+                  (mirroring the copilot placeholder), and the create-time
+                  copilot as the easiest path. Deliberately no template
+                  gallery. */}
+              <div className="max-w-md space-y-2 text-2xs leading-relaxed">
+                <p>
+                  A workflow runs a sequence of steps on a schedule or on demand: a{" "}
+                  <span className="font-medium text-foreground">trigger</span> starts it,{" "}
+                  <span className="font-medium text-foreground">agents</span> and{" "}
+                  <span className="font-medium text-foreground">tools</span> do the work,
+                  and an <span className="font-medium text-foreground">output</span> step
+                  reports the result somewhere.
+                </p>
+                <p className="italic">
+                  e.g. “Every Monday morning, have the writer draft the weekly digest
+                  and email it to the team.”
+                </p>
+                <p>
+                  Describe it in plain words when you create one — the copilot drafts
+                  the graph for you to review and edit.
+                </p>
+              </div>
+              {/* Issue #341: opens the same dialog as the toolbar button, and
+                  therefore must NOT carry the same name. "Create a workflow"
+                  rather than "Create the first workflow" because this state is
+                  also where deleting the last workflow lands, and by then there
+                  is nothing first about it. */}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setCreateOpen(true)}
+                data-testid="workflow-create-empty"
+              >
+                <Plus className="mr-1.5 size-4" />
+                Create a workflow
+              </Button>
+            </div>
+          ) : (
+            <WorkflowIndex
+              workflows={workflows}
+              runsByWorkflow={runsByWorkflow}
+              // Issue #1110: nothing is ever "the selected one" while the index
+              // is what you are looking at — selecting IS leaving the index. It
+              // is passed as null rather than dropped so the component keeps one
+              // shape, and so a future surface that lists workflows beside an
+              // open one can still say which.
+              selectedId={null}
+              onSelect={(id) => setSelectedId(id)}
+              mode={indexMode}
+              onModeChange={(mode) => {
+                setIndexMode(mode);
+                writeIndexMode(mode);
+              }}
+              loading={loadingList}
+              runsLoaded={indexRunsLoaded}
+            />
+          )
         ) : loadingList || loadingGraph ? (
           <div className="absolute inset-0 p-4">
             <Skeleton className="h-full w-full rounded-xl" />
-          </div>
-        ) : !selectedId ? (
-          <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
-            <p>This company has no saved workflows yet.</p>
-            {/* Issue #813: a first-time author has no on-ramp otherwise. One
-                compact prose block — what a workflow is, a worked example
-                (mirroring the copilot placeholder), and the create-time copilot
-                as the easiest path. Deliberately no template gallery. */}
-            <div className="max-w-md space-y-2 text-2xs leading-relaxed">
-              <p>
-                A workflow runs a sequence of steps on a schedule or on demand: a{" "}
-                <span className="font-medium text-foreground">trigger</span> starts it,{" "}
-                <span className="font-medium text-foreground">agents</span> and{" "}
-                <span className="font-medium text-foreground">tools</span> do the work,
-                and an <span className="font-medium text-foreground">output</span> step
-                reports the result somewhere.
-              </p>
-              <p className="italic">
-                e.g. “Every Monday morning, have the writer draft the weekly digest
-                and email it to the team.”
-              </p>
-              <p>
-                Describe it in plain words when you create one — the copilot drafts
-                the graph for you to review and edit.
-              </p>
-            </div>
-            {/* Issue #341: opens the same dialog as the toolbar button, and
-                therefore must NOT carry the same name. "Create a workflow"
-                rather than "Create the first workflow" because this state is
-                also where deleting the last workflow lands, and by then there
-                is nothing first about it. */}
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setCreateOpen(true)}
-              data-testid="workflow-create-empty"
-            >
-              <Plus className="mr-1.5 size-4" />
-              Create a workflow
-            </Button>
           </div>
         ) : (
           <>
@@ -2259,7 +2469,11 @@ export function WorkflowsView({
         )}
       </div>
 
-      {result && (
+      {/* Issue #1110: the three drawers below belong to ONE workflow, so
+          none of them may outlive leaving it. Their state is cleared on every
+          selection change, but a drawer is the wrong thing to be wrong about —
+          `detailOpen` makes it structural rather than a promise about ordering. */}
+      {detailOpen && result && (
         <RunResultPanel
           result={result}
           graph={graph}
@@ -2282,14 +2496,14 @@ export function WorkflowsView({
           The two are mutually exclusive by construction — `run()` clears both on
           dispatch and only one of its arms sets one — so they are rendered as
           siblings rather than as a branch. */}
-      {runFailure && (
+      {detailOpen && runFailure && (
         <RunFailurePanel
           failure={runFailure}
           onClose={() => setRunFailure(null)}
         />
       )}
 
-      {historyOpen && historySupported && (
+      {detailOpen && historyOpen && historySupported && (
         <RunHistoryPanel
           runs={historyRows}
           graph={graph}

--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -35,7 +35,6 @@ const STRIP_RUNS = 5;
 export function WorkflowIndex({
   workflows,
   runsByWorkflow,
-  selectedId,
   onSelect,
   mode,
   loading,
@@ -44,7 +43,13 @@ export function WorkflowIndex({
   workflows: WorkflowSummary[];
   /** The recent runs of each workflow, newest first, from the company-wide page. */
   runsByWorkflow: Map<string, WorkflowRunOutcome[]>;
-  selectedId: string | null;
+  /**
+   * Open one workflow. Issue #1110: there is no `selectedId` counterpart, and
+   * that is the point — selecting IS leaving this surface, so nothing here is
+   * ever "the selected one". The cards used to carry `aria-pressed`, which
+   * announced every one of them to a screen reader as a toggle that was off;
+   * they are links to a page, and they read as buttons that do something now.
+   */
   onSelect: (id: string) => void;
   /**
    * Cards or list. Owned and rendered by the caller (issue #1110): the index is
@@ -84,7 +89,6 @@ export function WorkflowIndex({
               workflow={w}
               runs={runsByWorkflow.get(w.id) ?? []}
               runsLoaded={runsLoaded}
-              selected={w.id === selectedId}
               onSelect={() => onSelect(w.id)}
             />
           ))}
@@ -97,7 +101,6 @@ export function WorkflowIndex({
               workflow={w}
               runs={runsByWorkflow.get(w.id) ?? []}
               runsLoaded={runsLoaded}
-              selected={w.id === selectedId}
               onSelect={() => onSelect(w.id)}
             />
           ))}
@@ -113,24 +116,19 @@ function WorkflowCard({
   workflow,
   runs,
   runsLoaded,
-  selected,
   onSelect,
 }: {
   workflow: WorkflowSummary;
   runs: WorkflowRunOutcome[];
   runsLoaded: boolean;
-  selected: boolean;
   onSelect: () => void;
 }) {
   return (
     <button
       type="button"
       onClick={onSelect}
-      aria-pressed={selected}
       data-testid="workflow-card"
-      className={`flex flex-col gap-2 rounded-xl border bg-card/60 p-3 text-left transition hover:bg-accent/40 ${
-        selected ? "ring-2 ring-primary/40" : ""
-      }`}
+      className="flex flex-col gap-2 rounded-xl border bg-card/60 p-3 text-left transition hover:bg-accent/40"
     >
       <div className="flex items-start justify-between gap-2">
         <span className="min-w-0 truncate text-sm font-semibold">{workflow.name}</span>
@@ -168,24 +166,19 @@ function WorkflowRow({
   workflow,
   runs,
   runsLoaded,
-  selected,
   onSelect,
 }: {
   workflow: WorkflowSummary;
   runs: WorkflowRunOutcome[];
   runsLoaded: boolean;
-  selected: boolean;
   onSelect: () => void;
 }) {
   return (
     <button
       type="button"
       onClick={onSelect}
-      aria-pressed={selected}
       data-testid="workflow-list-row"
-      className={`flex w-full flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 text-left transition hover:bg-accent/40 ${
-        selected ? "bg-accent/30" : ""
-      }`}
+      className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 text-left transition hover:bg-accent/40"
     >
       <span className="min-w-0 flex-1 truncate text-sm font-medium">{workflow.name}</span>
       {workflow.editable === false && (

--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -1,5 +1,9 @@
-// Issue #303: browse the company's workflows as CARDS or as a LIST, with a
-// toggle, instead of only through the toolbar's dropdown.
+// Issue #303: the company's workflows as CARDS or as a LIST.
+//
+// Issue #1110 promoted it from a panel that opened over the canvas to the body
+// of `#/workflows` itself, which is why it no longer draws a header: the tab's
+// own toolbar carries the title, the count, the Cards/List toggle and New
+// workflow, and this renders the list under it.
 //
 // Why this exists at all: before #303 the only way to see the company's
 // workflows was the `<Select>` in the toolbar — a combobox shows one workflow at
@@ -15,11 +19,8 @@
 // N+1 on every render of this panel. Showing "no schedule" without having
 // looked would be a lie, so the card says nothing at all about schedules.
 
-import { LayoutGrid, List as ListIcon } from "lucide-react";
-
 import type { WorkflowRunOutcome, WorkflowSummary } from "@/api/workflows";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { failedNodeOf } from "./graph";
@@ -37,7 +38,6 @@ export function WorkflowIndex({
   selectedId,
   onSelect,
   mode,
-  onModeChange,
   loading,
   runsLoaded,
 }: {
@@ -46,8 +46,14 @@ export function WorkflowIndex({
   runsByWorkflow: Map<string, WorkflowRunOutcome[]>;
   selectedId: string | null;
   onSelect: (id: string) => void;
+  /**
+   * Cards or list. Owned and rendered by the caller (issue #1110): the index is
+   * the whole body of `#/workflows` now, so its heading and the tab's heading
+   * were the same bar drawn twice — "Workflows 7" over "All workflows 7", with
+   * the toggle stranded under the duplicate. The control moved up into the one
+   * toolbar; this component reads the answer and renders it.
+   */
   mode: IndexMode;
-  onModeChange: (mode: IndexMode) => void;
   loading: boolean;
   /**
    * Whether the run page has come back yet.
@@ -59,77 +65,44 @@ export function WorkflowIndex({
   runsLoaded: boolean;
 }) {
   return (
-    <div className="flex h-full flex-col" data-testid="workflow-index">
-      <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">All workflows</span>
-          <Badge variant="secondary">{workflows.length}</Badge>
+    <div className="h-full overflow-auto p-4" data-testid="workflow-index">
+      {loading ? (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-28 rounded-xl" />
+          ))}
         </div>
-        <div className="flex items-center gap-1 rounded-lg border p-0.5">
-          <Button
-            size="sm"
-            variant={mode === "cards" ? "secondary" : "ghost"}
-            className="h-7 px-2"
-            onClick={() => onModeChange("cards")}
-            aria-pressed={mode === "cards"}
-            data-testid="workflow-index-cards"
-          >
-            <LayoutGrid className="mr-1.5 size-3.5" />
-            Cards
-          </Button>
-          <Button
-            size="sm"
-            variant={mode === "list" ? "secondary" : "ghost"}
-            className="h-7 px-2"
-            onClick={() => onModeChange("list")}
-            aria-pressed={mode === "list"}
-            data-testid="workflow-index-list"
-          >
-            <ListIcon className="mr-1.5 size-3.5" />
-            List
-          </Button>
+      ) : workflows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          This company has no saved workflows yet.
+        </p>
+      ) : mode === "cards" ? (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {workflows.map((w) => (
+            <WorkflowCard
+              key={w.id}
+              workflow={w}
+              runs={runsByWorkflow.get(w.id) ?? []}
+              runsLoaded={runsLoaded}
+              selected={w.id === selectedId}
+              onSelect={() => onSelect(w.id)}
+            />
+          ))}
         </div>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-auto p-4">
-        {loading ? (
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {[0, 1, 2].map((i) => (
-              <Skeleton key={i} className="h-28 rounded-xl" />
-            ))}
-          </div>
-        ) : workflows.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            This company has no saved workflows yet.
-          </p>
-        ) : mode === "cards" ? (
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {workflows.map((w) => (
-              <WorkflowCard
-                key={w.id}
-                workflow={w}
-                runs={runsByWorkflow.get(w.id) ?? []}
-                runsLoaded={runsLoaded}
-                selected={w.id === selectedId}
-                onSelect={() => onSelect(w.id)}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="divide-y rounded-xl border">
-            {workflows.map((w) => (
-              <WorkflowRow
-                key={w.id}
-                workflow={w}
-                runs={runsByWorkflow.get(w.id) ?? []}
-                runsLoaded={runsLoaded}
-                selected={w.id === selectedId}
-                onSelect={() => onSelect(w.id)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      ) : (
+        <div className="divide-y rounded-xl border">
+          {workflows.map((w) => (
+            <WorkflowRow
+              key={w.id}
+              workflow={w}
+              runs={runsByWorkflow.get(w.id) ?? []}
+              runsLoaded={runsLoaded}
+              selected={w.id === selectedId}
+              onSelect={() => onSelect(w.id)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/test/e2e/workflow-canvas-live.spec.ts
+++ b/frontend/test/e2e/workflow-canvas-live.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 
 import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+import { workflowDetailName } from "./workflows";
 
 /**
  * Issue #863: the canvas paints per-node state WHILE a run walks the graph.
@@ -147,7 +148,10 @@ test.describe("workflow canvas during a live run", () => {
     try {
       await page.goto(`/#/workflows/${id}`);
       await dismissTour(page);
-      await expect(page.getByRole("combobox").first()).toContainText(`Live canvas ${id}`, {
+      // Issue #1110: a `#/workflows/<id>` link opens that workflow's detail
+      // view directly, so this reads the heading the detail view names itself
+      // with rather than the picker it used to be asserted through.
+      await expect(workflowDetailName(page)).toHaveText(`Live canvas ${id}`, {
         timeout: 30_000,
       });
 

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page, type APIRequestContext } from "@playwright/test";
 
+import { expectWorkflowIndex, openWorkflow, workflowCard } from "./workflows";
+
 /**
  * Issue #259: a saved workflow used to be write-once. There was no `PUT` and no
  * `DELETE`, so a typo'd cron or a node pointed at the wrong teammate was
@@ -115,17 +117,24 @@ async function removeWorkflow(request: APIRequestContext, id: string) {
 }
 
 /**
- * Selects the workflow named `name` in the picker and waits for the selection
- * to settle.
+ * Opens the workflow named `name`, from the index, and waits for its detail
+ * view to settle.
  *
- * Asserts the trigger shows the **name**. It used to show the raw id — the
- * picker binds `<SelectItem value={w.id}>` and Base UI's `SelectValue` renders
- * the value, not the item's children — which is #270, fixed on this branch
- * because it is the same picker this issue's Delete affordance sits next to.
+ * Issue #1110: `#/workflows` is the index, and Edit and Delete are controls of
+ * one workflow — they exist only once one is open. This used to drive the
+ * toolbar picker, which was reachable on arrival because the view auto-selected
+ * the first row.
+ *
+ * The picker itself is still there — inside a workflow, where it switches
+ * between them — so the assertion #270 was pinned by is kept as a second line
+ * here rather than dropped: the trigger must show the **name**, not the raw id.
+ * (The picker binds `<SelectItem value={w.id}>` and Base UI's `SelectValue`
+ * renders the value, not the item's children, which is how #270 happened; #406
+ * is the other half, that the picker is controlled from its first render and so
+ * follows a selection this view made for itself.)
  */
 async function selectWorkflow(page: Page, name: string) {
-  await page.getByRole("combobox").first().click();
-  await page.getByRole("option", { name, exact: true }).click();
+  await openWorkflow(page, name);
   await expect(page.getByRole("combobox").first()).toContainText(name);
 }
 
@@ -251,11 +260,15 @@ test("confirming the delete removes it from the picker and from the host", async
       "confirming must dismiss the dialog, not leave its backdrop blocking the app",
     ).toBeHidden({ timeout: 15_000 });
 
-    // Gone from the picker: the selection moves off it and it is no longer an
-    // option.
-    await expect(page.getByRole("combobox").first()).not.toContainText(name, {
-      timeout: 15_000,
-    });
+    // Issue #1110: back on the INDEX, and the deleted workflow is not in it.
+    // The old assertion — that the picker no longer names it — could only be
+    // made from inside whichever neighbouring workflow the view auto-selected
+    // next, which is the behaviour this issue removed: deleting what you were
+    // working on returns you to the list, it does not hand you somebody else's
+    // graph. The URL going back to `#/workflows` is the other half of that.
+    await expectWorkflowIndex(page);
+    await expect(page).toHaveURL(/#\/workflows$/, { timeout: 15_000 });
+    await expect(workflowCard(page, name)).toHaveCount(0, { timeout: 15_000 });
 
     // And gone from the host — the console did not merely hide it.
     await expect

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test, type Page, type APIRequestContext } from "@playwright/test";
 
-import { expectWorkflowIndex, openWorkflow, workflowCard } from "./workflows";
+import {
+  expectWorkflowIndex,
+  openWorkflow,
+  workflowCard,
+  workflowDetailName,
+} from "./workflows";
 
 /**
  * Issue #259: a saved workflow used to be write-once. There was no `PUT` and no
@@ -233,7 +238,7 @@ test("deleting is confirm-gated, and the confirmation says what goes and what st
   }
 });
 
-test("confirming the delete removes it from the picker and from the host", async ({
+test("confirming the delete returns to the index, and removes it from the host", async ({
   page,
   request,
 }) => {
@@ -522,7 +527,16 @@ test("a field error raised on one graph never appears on another", async ({
     // on the node id (rather than on the freshly minted row key) would carry
     // this complaint straight over to the second graph, attached to a field the
     // author never touched.
-    await selectWorkflow(page, second.name);
+    // Issue #1110: switched through the PICKER, not back out through the index.
+    // The picker survives inside a workflow precisely for this — moving from one
+    // graph to the next without a round trip through the list — and it is the
+    // path an author debugging two workflows actually takes. It is also the
+    // harder case for the defect under test: the view never unmounts the
+    // toolbar, so a stale error map has every chance to ride across.
+    await page.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: second.name, exact: true }).click();
+    await expect(workflowDetailName(page)).toHaveText(second.name);
+
     const other = await openEditDialog(page, second.name);
     await expect(
       other,

--- a/frontend/test/e2e/workflow-inline-approval.spec.ts
+++ b/frontend/test/e2e/workflow-inline-approval.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
+import { gotoWorkflow } from "./workflows";
+
 /**
  * End-to-end proof for issue #1002 — a run parked on a gated node is unblocked
  * from the workflow window, without leaving it.
@@ -163,17 +165,11 @@ async function captureResolves(page: Page, bodies: unknown[]) {
   });
 }
 
-function picker(page: Page) {
-  return page.getByRole("combobox").first();
-}
-
-/** Opens Workflows, selects the spec's graph, and runs it. */
+/** Opens Workflows, opens the spec's graph, and runs it. */
 async function runTheWorkflow(page: Page) {
-  await page.goto("/#/workflows");
-  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
-  await picker(page).click();
-  await page.getByRole("option", { name: WORKFLOW.name, exact: true }).click();
-  await expect(picker(page)).toContainText(WORKFLOW.name);
+  // Issue #1110: `#/workflows` is the index. Run belongs to one workflow, so
+  // the graph is opened from the list before there is anything to run.
+  await gotoWorkflow(page, WORKFLOW.name);
   await page.getByRole("button", { name: "Run", exact: true }).click();
   await expect(page.getByTestId("workflow-run-result")).toBeVisible({ timeout: 60_000 });
 }

--- a/frontend/test/e2e/workflow-live-list.spec.ts
+++ b/frontend/test/e2e/workflow-live-list.spec.ts
@@ -2,9 +2,15 @@ import {
   expect,
   test,
   type APIRequestContext,
-  type Locator,
   type Page,
 } from "@playwright/test";
+
+import {
+  expectWorkflowIndex,
+  openWorkflow,
+  workflowCard,
+  workflowDetailName,
+} from "./workflows";
 
 /**
  * Issue #384: workflow create / update / delete events reached the console's
@@ -126,90 +132,33 @@ function picker(page: Page) {
   return page.getByRole("combobox").first();
 }
 
-/** Opens the Workflows tab and waits for the picker to settle. */
+/**
+ * Opens the Workflows tab and waits for the index to settle.
+ *
+ * Issue #1110: the tab lands on the index, so "settled" is the list being up
+ * rather than the picker being enabled — the picker is a control of an open
+ * workflow now, and there is none yet.
+ */
 async function openWorkflows(page: Page) {
   await page.goto("/#/workflows");
   await dismissTour(page);
-  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+  await expectWorkflowIndex(page);
 }
 
-/**
- * Returned by {@link pickerOptionCount} when the popup could not be read at
- * all — it never opened, or the click could not land.
- *
- * A sentinel rather than `0`, because `0` is a legitimate answer this file
- * asserts twice ("the probe does not exist yet", "the deleted one is gone").
- * Reporting an unread popup as zero would pass both of those against a console
- * that rendered nothing whatsoever. A negative count matches no expectation:
- * a poll keeps polling, and a direct assertion fails saying `-1`.
- */
-const UNREADABLE = -1;
+/* Issue #1110: `pickerOptionCount`, its `UNREADABLE` sentinel and the `settled`
+ * helper it was built on lived here. All three existed to read the picker's
+ * popup without letting a mid-re-render transient read as "the popup held
+ * nothing" — a subtlety of counting options in a dropdown that has to be opened
+ * to be read. The index renders every workflow as an ordinary element, so the
+ * counting is now `toHaveCount`, which retries on its own, and none of that
+ * machinery has a caller. */
 
-/** `waitFor` reduced to a boolean — a timeout is an answer here, not a throw. */
-function settled(
-  locator: Locator,
-  state: "visible" | "hidden",
-  timeout: number,
-): Promise<boolean> {
-  return locator.waitFor({ state, timeout }).then(
-    () => true,
-    () => false,
-  );
-}
-
-/**
- * How many options the picker offers under `name`, from a fresh open.
- *
- * Opened and closed around the count on purpose, so the reading never depends
- * on whether a mounted popup re-renders in place when its list changes. That is
- * a detail of the Select primitive, and it is not what this file is about — the
- * property under test is that the console re-read the list at all, and opening
- * a dropdown fetches nothing (the view lists on mount, on a company switch, and
- * on an SSE frame, and that is all).
- *
- * **Nothing in here throws**, which is a requirement and not a style: one call
- * site runs inside `expect.poll`, and the two automated reviews on this PR
- * disagreed about whether Playwright retries a rejected poll callback or lets
- * the rejection end the poll. The lockfile resolves `@playwright/test` to
- * 1.61.1 rather than the `^1.49.0` in `package.json`, so the semantics anyone
- * reasons about here may not be the semantics that run. A callback that cannot
- * reject is correct under either reading, and that is cheaper than settling the
- * argument.
- *
- * The transient this protects against is real: the popup is opened while an
- * SSE frame is re-rendering the list underneath it, so "no options for a
- * moment" is an ordinary state on the way to the answer, not a failure.
- */
-async function pickerOptionCount(page: Page, name: string): Promise<number> {
-  try {
-    await picker(page).click();
-    // Not `expect(...).toBeVisible()`: that throws, and a popup that is empty
-    // for one render is exactly what this must survive.
-    if (!(await settled(page.getByRole("option").first(), "visible", 15_000))) {
-      return UNREADABLE;
-    }
-    const count = await page.getByRole("option", { name, exact: true }).count();
-    await page.keyboard.press("Escape");
-    // Best effort. The count is already read, so a popup slow to close is not
-    // worth discarding it over — and if it really is stuck, the next attempt's
-    // click fails and reports UNREADABLE rather than a wrong number.
-    await settled(page.getByRole("option").first(), "hidden", 5_000);
-    return count;
-  } catch {
-    // A click that could not land, a detached locator mid-re-render: all of it
-    // is "could not read the popup this time", never "the popup held nothing".
-    return UNREADABLE;
-  }
-}
-
-/** Selects a workflow by name and waits for the selection to settle. */
+/** Opens a workflow from the index and waits for its detail view to settle. */
 async function selectWorkflow(page: Page, name: string) {
-  await picker(page).click();
-  await page.getByRole("option", { name, exact: true }).click();
-  await expect(picker(page)).toContainText(name);
+  await openWorkflow(page, name);
 }
 
-test("a workflow authored elsewhere reaches the picker, with no reload", async ({
+test("a workflow authored elsewhere reaches the list, with no reload", async ({
   page,
   request,
 }) => {
@@ -220,19 +169,24 @@ test("a workflow authored elsewhere reaches the picker, with no reload", async (
   try {
     await openWorkflows(page);
 
+    // Issue #1110: read off the INDEX rather than the picker popup. The two are
+    // rendered from the same `workflows` array, so this pins the same property
+    // — that the console re-read the list at all — against the surface the
+    // operator is actually looking at. The picker exists only inside a workflow
+    // now, and opening one to check whether a list contains something is the
+    // step this issue was about removing.
+    //
     // The baseline the fix has to move. Without it this stays at zero for the
     // life of the tab: the `workflow_created` frame reaches the console's
     // switch, matches no arm, and is discarded.
-    expect(
-      await pickerOptionCount(page, name),
+    await expect(
+      workflowCard(page, name),
       "the probe must not exist before it is created",
-    ).toBe(0);
+    ).toHaveCount(0);
 
     await createWorkflow(request, id, name);
 
-    await expect
-      .poll(() => pickerOptionCount(page, name), { timeout: 20_000 })
-      .toBe(1);
+    await expect(workflowCard(page, name)).toHaveCount(1, { timeout: 20_000 });
   } finally {
     await removeWorkflow(request, id);
   }
@@ -256,20 +210,24 @@ test("a workflow renamed elsewhere renames in the picker, with no reload", async
     // edit #259 made possible, and which nothing told this tab about.
     await renameWorkflow(request, id, after, createdVersion);
 
-    // Read off the trigger, which renders the *selected* workflow's name from
-    // the same list the options come from: the rename has to land on the
-    // selection, not merely somewhere in a dropdown nobody has open.
-    await expect(picker(page), "a rename elsewhere must reach the picker live").toContainText(
-      after,
-      { timeout: 20_000 },
-    );
+    // Read off the OPEN workflow's own heading and off the picker beside it,
+    // both of which render the selected workflow's name from the same list the
+    // options come from: the rename has to land on the workflow on screen, not
+    // merely somewhere in a dropdown nobody has open.
+    await expect(
+      workflowDetailName(page),
+      "a rename elsewhere must reach the open workflow live",
+    ).toHaveText(after, { timeout: 20_000 });
+    await expect(picker(page), "…and the picker beside it").toContainText(after, {
+      timeout: 20_000,
+    });
     await expect(picker(page)).not.toContainText(before);
   } finally {
     await removeWorkflow(request, id);
   }
 });
 
-test("deleting the workflow on screen elsewhere takes it out of the picker, not just greys it", async ({
+test("deleting the workflow on screen elsewhere returns to the list, and takes it out of the list", async ({
   page,
   request,
 }) => {
@@ -291,18 +249,18 @@ test("deleting the workflow on screen elsewhere takes it out of the picker, not 
     );
     expect(deleted.ok(), `delete ${id}: ${deleted.status()}`).toBeTruthy();
 
-    // The selection moves off it, so the canvas stops showing a graph the host
-    // no longer has.
-    await expect(picker(page), "the canvas must not stay on a deleted workflow").not.toContainText(
-      name,
-      { timeout: 20_000 },
-    );
+    // Issue #1110: the view leaves the deleted workflow for the INDEX, not for
+    // a neighbouring graph. Both halves matter — the canvas must stop showing a
+    // graph the host no longer has, and what replaces it must not be a workflow
+    // the operator never opened.
+    await expectWorkflowIndex(page);
+    await expect(workflowDetailName(page)).toHaveCount(0, { timeout: 20_000 });
 
-    // …and it is GONE from the options, not merely deselected or disabled.
-    expect(
-      await pickerOptionCount(page, name),
-      "a deleted workflow must leave the picker, not sit in it greyed out",
-    ).toBe(0);
+    // …and it is GONE from the list, not merely closed or greyed out.
+    await expect(
+      workflowCard(page, name),
+      "a deleted workflow must leave the list, not sit in it greyed out",
+    ).toHaveCount(0, { timeout: 20_000 });
   } finally {
     await removeWorkflow(request, id);
   }

--- a/frontend/test/e2e/workflow-node-config.spec.ts
+++ b/frontend/test/e2e/workflow-node-config.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page, type APIRequestContext } from "@playwright/test";
 
+import { workflowDetailName } from "./workflows";
+
 /**
  * Issue #541: the five withheld node kinds (`tool_call`, `http_request`,
  * `switch`, `output_parser`, `sub_workflow`) grew config forms in the workflow
@@ -30,13 +32,6 @@ async function dismissTour(page: Page) {
   }
   await skip.click();
   await expect(skip).toBeHidden();
-}
-
-/** Selects the workflow named `name` in the picker and waits for it to settle. */
-async function selectWorkflow(page: Page, name: string) {
-  await page.getByRole("combobox").first().click();
-  await page.getByRole("option", { name, exact: true }).click();
-  await expect(page.getByRole("combobox").first()).toContainText(name);
 }
 
 /** Best-effort teardown so a failed spec does not poison the next run. */
@@ -121,9 +116,14 @@ test("authoring a tool_call node's config through the form round-trips to the ho
 
     // Reopen from the saved graph (a fresh load, not local state) and click the
     // node: the inspector's Config block shows the slug the host round-tripped.
+    //
+    // Issue #1110: creating landed on the new workflow's own URL, so the reload
+    // comes back on its detail view with no picking to do — which is also this
+    // spec's incidental proof that a `#/workflows/<id>` survives a reload.
+    await expect(page).toHaveURL(new RegExp(`#/workflows/${id}$`));
     await page.reload();
     await dismissTour(page);
-    await selectWorkflow(page, name);
+    await expect(workflowDetailName(page)).toHaveText(name, { timeout: 30_000 });
 
     const node = page.locator('.react-flow__node[data-id="act"]');
     await expect(node).toBeVisible({ timeout: 15_000 });

--- a/frontend/test/e2e/workflow-run-history.spec.ts
+++ b/frontend/test/e2e/workflow-run-history.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+import { openFirstWorkflow } from "./workflows";
 
 /**
  * Issue #228: the Workflows view reads a workflow's finished runs back from the
@@ -45,14 +46,18 @@ async function dismissTour(page: import("@playwright/test").Page) {
 }
 
 /**
- * The History toggle, once the view has settled.
+ * The History toggle, once a workflow is open.
  *
- * Waits for it rather than probing `count()` immediately: the button renders
- * only after the workflow list resolves and a workflow is selected, so an
- * instant check races the first paint and would silently skip on a host that
- * DOES serve the route — turning a real failure into a green run. Only a
- * genuine timeout means the host predates `…/workflows/runs`, and that is the
- * one case worth skipping for.
+ * Issue #1110: the caller opens a workflow first. The toggle is a per-workflow
+ * control and the tab no longer opens inside one, so waiting for it on the
+ * index would time out and — through the `test.skip` below — report a host that
+ * does not serve `…/workflows/runs`, which would be a lie about the host to
+ * cover a spec that never navigated. Opening the workflow explicitly keeps the
+ * skip meaning only what it says.
+ *
+ * Still waits rather than probing `count()` immediately: the button renders
+ * only after the graph resolves, so an instant check races the first paint and
+ * would silently skip on a host that DOES serve the route.
  */
 async function historyToggle(page: import("@playwright/test").Page) {
   const toggle = page.getByTestId("workflow-history-toggle");
@@ -77,18 +82,30 @@ test("the console asks the host for the selected workflow's runs, not the whole 
   });
 
   await page.goto("/#/workflows");
+  await dismissTour(page);
 
-  // The view fetches history once a workflow is selected (the list auto-selects
-  // the first entry), so wait for the request rather than racing it.
-  await expect.poll(() => requested.length, { timeout: 30_000 }).toBeGreaterThan(0);
+  // Issue #1110: the tab opens on the INDEX, and the index reads the run
+  // journal UNSCOPED on purpose — one request has to feed every card's health
+  // line, and `?workflow=` covers exactly one graph. Stating that here is what
+  // makes the rule below a narrowing rather than a contradiction.
+  await expect
+    .poll(
+      () => requested.some((url) => !new URL(url).searchParams.get("workflow")),
+      { timeout: 30_000 },
+    )
+    .toBe(true);
 
-  for (const url of requested) {
-    const params = new URL(url).searchParams;
-    expect(
-      params.get("workflow"),
-      `history must be scoped server-side, got: ${url}`,
-    ).toBeTruthy();
-  }
+  // Open one, and the read that backs ITS history panel must name it. A console
+  // that fetched the company-wide page and filtered client-side would never
+  // issue this request — and would tell a rarely-run workflow it "hasn't
+  // finished a run yet" the moment busier workflows filled the page.
+  const id = await openFirstWorkflow(page);
+  await expect
+    .poll(
+      () => requested.some((url) => new URL(url).searchParams.get("workflow") === id),
+      { timeout: 30_000 },
+    )
+    .toBe(true);
 });
 
 test("the run-history panel opens and shows only the selected workflow's runs", async ({
@@ -96,6 +113,8 @@ test("the run-history panel opens and shows only the selected workflow's runs", 
 }) => {
   await page.goto("/#/workflows");
   await dismissTour(page);
+  // Issue #1110: History belongs to one workflow, so one has to be open.
+  await openFirstWorkflow(page);
 
   const toggle = await historyToggle(page);
   await toggle.click();
@@ -126,6 +145,11 @@ test("running a workflow adds it to the durable history and it survives a reload
 
   await page.goto("/#/workflows");
   await dismissTour(page);
+  // Issue #1110: open the workflow this test runs. The reload below keeps the
+  // `#/workflows/<id>` this pushes, so the console comes back on the same
+  // workflow's detail view — which is what makes the second read a re-read of
+  // the same journal rather than of whichever workflow sorted first.
+  await openFirstWorkflow(page);
 
   const toggle = await historyToggle(page);
   await toggle.click();

--- a/frontend/test/e2e/workflow-run-inference.spec.ts
+++ b/frontend/test/e2e/workflow-run-inference.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openWorkflow } from "./workflows";
+
 /**
  * Issue #528 / #514: a run the host refuses because the company has no inference
  * provider surfaces as a PERSISTENT, actionable banner — not a vanishing
@@ -27,16 +29,14 @@ async function dismissTour(page: Page) {
   await expect(skip).toBeHidden();
 }
 
-/** The workflow picker's trigger. */
-function picker(page: Page) {
-  return page.getByRole("combobox").first();
-}
-
-/** Selects a workflow by name and waits for the selection to settle. */
+/**
+ * Opens a workflow by name, from the index (issue #1110).
+ *
+ * `#/workflows` is the list now — the picker this used to drive exists only
+ * once a workflow is open, and Run has no subject until then.
+ */
 async function selectWorkflow(page: Page, name: string) {
-  await picker(page).click();
-  await page.getByRole("option", { name, exact: true }).click();
-  await expect(picker(page)).toContainText(name);
+  await openWorkflow(page, name);
 }
 
 /** The run POST, and only it — not `…/workflows/runs`, not `…/cron/preview`. */
@@ -63,7 +63,6 @@ test("a run refused for a missing inference provider shows a persistent, linked 
 
   await page.goto("/#/workflows");
   await dismissTour(page);
-  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
 
   await selectWorkflow(page, "Committed flow");
   await page.getByRole("button", { name: "Run", exact: true }).click();

--- a/frontend/test/e2e/workflow-run-result.spec.ts
+++ b/frontend/test/e2e/workflow-run-result.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { openWorkflow } from "./workflows";
+
 import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
 
 /**
@@ -35,16 +37,14 @@ async function dismissTour(page: Page) {
   await expect(skip).toBeHidden();
 }
 
-/** The workflow picker's trigger. */
-function picker(page: Page) {
-  return page.getByRole("combobox").first();
-}
-
-/** Selects a workflow by name and waits for the selection to settle. */
+/**
+ * Opens a workflow by name, from the index (issue #1110).
+ *
+ * `#/workflows` is the list now — the picker this used to drive exists only
+ * once a workflow is open, and Run has no subject until then.
+ */
 async function selectWorkflow(page: Page, name: string) {
-  await picker(page).click();
-  await page.getByRole("option", { name, exact: true }).click();
-  await expect(picker(page)).toContainText(name);
+  await openWorkflow(page, name);
 }
 
 test("running a workflow shows its per-node output in the result drawer", async ({
@@ -54,7 +54,6 @@ test("running a workflow shows its per-node output in the result drawer", async 
 
   await page.goto("/#/workflows");
   await dismissTour(page);
-  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
 
   // The source-defined fixture — its agent node ("Draft the note") is what the
   // drawer must render text for. Its ids and names are pinned by the harness.

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 
+import { expectWorkflowIndex, openWorkflow, workflowDetailName } from "./workflows";
+
 const COMPANY_SCOPE = "/api/v1/company";
 
 /** Dismisses the first-run tour if it is still visible. */
@@ -47,21 +49,26 @@ async function deleteWorkflow(request: APIRequestContext, id: string) {
   await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
 }
 
-/** The workflow picker's trigger. */
-function picker(page: Page) {
-  return page.getByRole("combobox").first();
-}
-
-async function selectWorkflow(page: Page, name: string) {
-  await picker(page).click();
-  await page.getByRole("option", { name, exact: true }).click();
-  await expect(picker(page)).toContainText(name);
+/**
+ * Which workflow is open, read off the detail view's own heading.
+ *
+ * Issue #1110 moved this assertion off the toolbar picker. The picker is still
+ * there — inside a workflow — but it is no longer what says "this workflow is
+ * the one on screen": the tab now opens on the index, where nothing is, and the
+ * heading is the surface that names the workflow whose canvas is up. Asserting
+ * on the picker would still pass for a view that opened the right workflow and
+ * would also pass for one that never left the index, since a stale combobox
+ * would simply be absent and `toContainText` on nothing is an error rather than
+ * a clear report.
+ */
+function openWorkflowName(page: Page) {
+  return workflowDetailName(page);
 }
 
 async function openWorkflows(page: Page) {
   await page.goto("/#/workflows");
   await dismissTour(page);
-  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+  await expectWorkflowIndex(page);
 }
 
 async function mockCompanySwitchApi(page: Page) {
@@ -138,22 +145,22 @@ test("workflows tab selection is preserved across tab switches (#864)", async ({
     await createWorkflow(request, secondId, secondName);
 
     await openWorkflows(page);
-    await selectWorkflow(page, secondName);
-    await expect(picker(page)).toContainText(secondName);
+    await openWorkflow(page, secondName);
+    await expect(page).toHaveURL(new RegExp(`#/workflows/${secondId}$`));
 
     await page.getByRole("button", { name: "Workspace" }).click();
     await page.getByRole("button", { name: "Workflows" }).click();
-    await expect(picker(page)).toContainText(secondName);
+    await expect(openWorkflowName(page)).toHaveText(secondName);
 
     await page.goto(`/#/workflows/${firstId}`);
     // A full navigation, so the view has to fetch the workflow list again
-    // before the picker can name anything — the default 5s assertion timeout
+    // before the heading can name anything — the default 5s assertion timeout
     // is the flake, not the console.
-    await expect(picker(page)).toContainText(firstName, { timeout: 30_000 });
+    await expect(openWorkflowName(page)).toHaveText(firstName, { timeout: 30_000 });
 
     await page.getByRole("button", { name: "Workspace" }).click();
     await page.getByRole("button", { name: "Workflows" }).click();
-    await expect(picker(page)).toContainText(firstName);
+    await expect(openWorkflowName(page)).toHaveText(firstName);
   } finally {
     await deleteWorkflow(request, firstId);
     await deleteWorkflow(request, secondId);
@@ -167,10 +174,23 @@ test("a company switch does not reuse the previous company's workflow route (#86
   await page.goto("/#/workflows/shared-workflow");
 
   await page.locator('[role="button"]').filter({ hasText: "Acme" }).click();
-  await expect(picker(page)).toContainText("Acme shared workflow", { timeout: 30_000 });
+  await expect(openWorkflowName(page)).toHaveText("Acme shared workflow", {
+    timeout: 30_000,
+  });
 
   await page.getByRole("button", { name: "Switch company" }).click();
   await page.getByRole("menuitem", { name: "Other", exact: true }).click();
-  await expect(picker(page)).toContainText("Other default workflow", { timeout: 30_000 });
-  await expect(page).toHaveURL(/#\/workflows\/other-default$/);
+  // Issue #1110 sharpened what this test proves. It used to assert the switch
+  // landed on the OTHER company's first workflow — `#/workflows/other-default`
+  // — which was the auto-select answering a question nobody asked, and which
+  // only happened to differ from the id being left behind. The switch now lands
+  // on the index, and the assertion is the one #864 was actually about: the
+  // previous company's route is gone from the address bar, and nothing was
+  // opened in its place.
+  await expectWorkflowIndex(page);
+  await expect(page).toHaveURL(/#\/workflows$/);
+  await expect(openWorkflowName(page)).toHaveCount(0);
+  // `other` has a `shared-workflow` of its own, so a view that merely kept the
+  // id would have resolved to a real graph and looked correct.
+  await expect(page.getByText("Other shared workflow", { exact: true })).toBeVisible();
 });

--- a/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
+++ b/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
@@ -6,6 +6,8 @@ import {
   type Page,
 } from "@playwright/test";
 
+import { openWorkflow } from "./workflows";
+
 /**
  * Issue #824: the workflows toolbar laid out wider than its container and
  * overflowed into an `overflow-hidden` ancestor, so its last control —
@@ -79,22 +81,19 @@ async function removeWorkflow(request: APIRequestContext) {
 }
 
 /**
- * Selects the workflow in the picker, so the per-workflow half of the toolbar
- * mounts and the row is at its **widest** — the state the defect appears in.
+ * Opens the workflow, so the per-workflow half of the toolbar mounts and the
+ * row is at its **widest** — the state the defect appears in.
  *
- * The view does auto-select when the list lands, so this is belt-and-braces
- * today. It is here anyway because the auto-select is not what this spec is
- * about: were it ever to change, the assertions below would start failing on a
- * toolbar that was simply never populated, which reads as a layout regression
- * and is not one. Selecting explicitly keeps the failure honest. Matches the
- * helper in `workflow-node-config.spec.ts`.
+ * Issue #1110 turned this from belt-and-braces into the load-bearing step it
+ * always claimed to be. The note that used to sit here — "the view does
+ * auto-select, so this is belt-and-braces today; were that ever to change, the
+ * assertions below would start failing on a toolbar that was simply never
+ * populated, which reads as a layout regression and is not one" — described
+ * exactly what has now changed. `#/workflows` is the index, the wide row exists
+ * only inside a workflow, and this is how the spec gets there.
  */
 async function selectWorkflow(page: Page, name: string) {
-  const picker = page.getByRole("combobox").first();
-  await expect(picker).toBeEnabled();
-  await picker.click();
-  await page.getByRole("option", { name, exact: true }).click();
-  await expect(picker).toContainText(name);
+  await openWorkflow(page, name);
 }
 
 /**
@@ -121,8 +120,12 @@ const CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
     find: (p) => p.getByRole("button", { name: "Test run" }).first(),
   },
   {
-    label: "Browse",
-    find: (p) => p.getByRole("button", { name: "Browse" }).first(),
+    // Issue #1110: what "Browse" became. It opened the index over the canvas;
+    // the index is the tab's front door now, so the control is the way back to
+    // it. Addressed by test id for the same reason Pause is — it sits in the
+    // heading group rather than the action row, and its name is prose.
+    label: "All workflows",
+    find: (p) => p.getByTestId("workflow-back-to-index"),
   },
   {
     label: "Copilot",

--- a/frontend/test/e2e/workflows.ts
+++ b/frontend/test/e2e/workflows.ts
@@ -1,0 +1,81 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * How a spec reaches a workflow, since issue #1110.
+ *
+ * `#/workflows` is the index — every workflow, and none of them open. The
+ * per-workflow toolbar (the picker, Run, Test run, Copilot, History, Edit,
+ * Delete) exists only once one is opened, so a spec that needs any of it has to
+ * open one first. Before #1110 the view auto-selected the first row, and eight
+ * specs relied on that without saying so; this module is where they say it.
+ *
+ * Deliberately shared rather than copied into each spec: "how do I get to a
+ * workflow" is one answer, and the next change to the flow should have one
+ * place to land.
+ */
+
+/** The index panel itself — the tab's front door. */
+export function workflowIndex(page: Page) {
+  return page.getByTestId("workflow-index");
+}
+
+/** The index card for one workflow, matched on its name exactly. */
+export function workflowCard(page: Page, name: string) {
+  return page
+    .getByTestId("workflow-card")
+    .filter({ has: page.getByText(name, { exact: true }) });
+}
+
+/** The heading that names the workflow whose detail view is on screen. */
+export function workflowDetailName(page: Page) {
+  return page.getByTestId("workflow-detail-name");
+}
+
+/** Wait for the index to be up and to have finished loading its rows. */
+export async function expectWorkflowIndex(page: Page, timeout = 30_000) {
+  await expect(workflowIndex(page)).toBeVisible({ timeout });
+}
+
+/**
+ * Open one workflow's detail view from the index, by name.
+ *
+ * Asserts the heading afterwards rather than the picker: the heading is the
+ * detail view's own claim about which workflow it is showing, and it is present
+ * before the graph has loaded, so it is the earliest honest signal that the
+ * navigation landed.
+ */
+export async function openWorkflow(page: Page, name: string, timeout = 30_000) {
+  await expectWorkflowIndex(page, timeout);
+  await workflowCard(page, name).first().click();
+  await expect(workflowDetailName(page)).toHaveText(name, { timeout });
+}
+
+/** Go to the Workflows tab and open one workflow, by name. */
+export async function gotoWorkflow(page: Page, name: string, timeout = 30_000) {
+  await page.goto("/#/workflows");
+  await openWorkflow(page, name, timeout);
+}
+
+/** Go back to the index from a workflow's detail view. */
+export async function backToWorkflowIndex(page: Page) {
+  await page.getByTestId("workflow-back-to-index").click();
+  await expectWorkflowIndex(page);
+}
+
+/**
+ * Open whichever workflow the index lists first.
+ *
+ * For specs that need *a* workflow rather than a named one — the ones that used
+ * to rely on the auto-select and so never learned the name of what they were
+ * driving. Returns the opened workflow's id, read out of the URL the detail
+ * view pushes, which is the only place a spec can learn it without a fixture.
+ */
+export async function openFirstWorkflow(page: Page, timeout = 30_000): Promise<string> {
+  await expectWorkflowIndex(page, timeout);
+  const first = page.getByTestId("workflow-card").first();
+  await expect(first).toBeVisible({ timeout });
+  await first.click();
+  await expect(workflowDetailName(page)).toBeVisible({ timeout });
+  await expect(page).toHaveURL(/#\/workflows\/[^/]+$/, { timeout });
+  return decodeURIComponent(new URL(page.url()).hash.split("/")[2] ?? "");
+}

--- a/frontend/test/unit/workflow-index-first.test.ts
+++ b/frontend/test/unit/workflow-index-first.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph, WorkflowSummary } from "@/api/workflows";
+
+/**
+ * Issue #1110: the Workflows tab lands on the INDEX, and opens one workflow
+ * only when the operator picks it.
+ *
+ * Every assertion here is about *which surface is on screen for a given URL*,
+ * which is a fact about rendered output and about nothing else — no pure helper
+ * can hold it, so this file renders the view, the way
+ * `workflow-run-failure.test.ts` earns the same exception.
+ *
+ * The five decisions the issue asked to be made deliberately are the five
+ * blocks below: no auto-select, a shareable detail URL, a dead link landing on
+ * the index with an explanation, a create landing on its own detail page, and a
+ * delete returning to the index rather than to a neighbour. The sixth — that
+ * browser Back moves index ↔ detail — is asserted through the history writes
+ * those transitions make, since jsdom's history does not run a real back stack.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount; jsdom has no layout and no
+// `ResizeObserver`. None of these three is under test.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+const ROWS: WorkflowSummary[] = [
+  { id: "alpha", name: "Alpha digest" },
+  { id: "beta", name: "Beta report" },
+];
+
+function graphFor(id: string): WorkflowGraph {
+  const row = ROWS.find((r) => r.id === id);
+  return {
+    id,
+    name: row?.name ?? id,
+    version: "v1",
+    nodes: [
+      { id: "start", kind: "trigger", name: "Start" },
+      { id: "done", kind: "output", name: "Done" },
+    ],
+    edges: [{ from: "start", to: "done" }],
+  };
+}
+
+/** A client over {@link ROWS}, recording the ids whose graph was fetched and
+ * the ids that were deleted. The graph fetch fires for exactly the open
+ * workflow, so it is also how a test reads back what got selected. */
+function makeClient(rows: WorkflowSummary[] = ROWS) {
+  const graphGets: string[] = [];
+  const deletes: string[] = [];
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return rows;
+      if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
+      if (path.includes("/workflows/wired-channels")) return { channels: [] };
+      if (path.includes("/workflows/runs")) return [];
+      const m = path.match(/\/workflows\/([^/?]+)$/);
+      if (m) {
+        const id = decodeURIComponent(m[1]);
+        graphGets.push(id);
+        return graphFor(id);
+      }
+      return null;
+    },
+    post: async () => ({}),
+    del: async (path: string) => {
+      const id = path.match(/\/workflows\/([^/?]+)/)?.[1];
+      if (id) deletes.push(decodeURIComponent(id));
+    },
+  } as unknown as OpenCompanyClient;
+  return { client, graphGets, deletes };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  window.location.hash = "";
+});
+
+/** Mount at a hash, with `sub` matching it the way the router would hand it over. */
+async function mountAt(hash: string, client: OpenCompanyClient, company = "acme") {
+  window.location.hash = hash;
+  const sub = hash.replace(/^#\/?/, "").split("?")[0].split("/").filter(Boolean)[1] ?? null;
+  await act(async () => {
+    root.render(createElement(WorkflowsView, { client, company, sub }));
+  });
+}
+
+const indexUp = () => container.querySelector('[data-testid="workflow-index"]') !== null;
+const cards = () =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="workflow-card"]'));
+const detailName = () =>
+  container.querySelector('[data-testid="workflow-detail-name"]')?.textContent ?? null;
+const named = (label: string) =>
+  Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  ) ?? null;
+
+describe("the Workflows tab opens on the index", () => {
+  it("selects nothing, and puts no per-workflow control on screen", async () => {
+    const { client, graphGets } = makeClient();
+    await mountAt("#/workflows", client);
+
+    expect(indexUp()).toBe(true);
+    expect(cards()).toHaveLength(2);
+    // The reading that is the issue: the view never fetched a graph, because it
+    // never picked one. On main it fetched `alpha`'s.
+    expect(graphGets).toEqual([]);
+    // None of the controls that need a subject is rendered.
+    expect(named("Run")).toBeNull();
+    expect(named("Test run")).toBeNull();
+    expect(named("Edit")).toBeNull();
+    expect(named("Delete")).toBeNull();
+    expect(container.querySelector('[role="combobox"]')).toBeNull();
+    // The one control that is not about a single workflow stays.
+    expect(named("New workflow")).not.toBeNull();
+    // …and nothing was written to the address bar, so the tab is still
+    // shareable as "the workflows list".
+    expect(window.location.hash).toBe("#/workflows");
+  });
+
+  it("opens a workflow when one is picked, and pushes its own URL", async () => {
+    const { client, graphGets } = makeClient();
+    await mountAt("#/workflows", client);
+
+    await act(async () => {
+      cards()[1].click();
+    });
+
+    expect(indexUp()).toBe(false);
+    expect(detailName()).toBe("Beta report");
+    expect(graphGets).toContain("beta");
+    expect(named("Run")).not.toBeNull();
+    // A push, not a replace: the index the operator came from is still behind
+    // them, so browser Back returns to it.
+    expect(window.location.hash).toBe("#/workflows/beta");
+  });
+
+  it("goes back to the index from the detail view, and drops the id again", async () => {
+    const { client } = makeClient();
+    await mountAt("#/workflows/alpha", client);
+    expect(detailName()).toBe("Alpha digest");
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="workflow-back-to-index"]')
+        ?.click();
+    });
+
+    expect(indexUp()).toBe(true);
+    expect(named("Run")).toBeNull();
+    expect(window.location.hash).toBe("#/workflows");
+  });
+});
+
+describe("a URL naming a workflow opens it", () => {
+  it("renders the detail view for the id in the hash, with no index in the way", async () => {
+    const { client, graphGets } = makeClient();
+    await mountAt("#/workflows/alpha", client);
+
+    expect(indexUp()).toBe(false);
+    expect(detailName()).toBe("Alpha digest");
+    expect(graphGets).toContain("alpha");
+    // The link survives verbatim — nothing rewrote the URL on the way in, which
+    // is what makes it shareable and reload-proof.
+    expect(window.location.hash).toBe("#/workflows/alpha");
+  });
+
+  it("lands on the index, explained, when the id names nothing", async () => {
+    const { client, graphGets } = makeClient();
+    await mountAt("#/workflows/gone", client);
+
+    expect(graphGets).not.toContain("gone");
+    expect(indexUp()).toBe(true);
+    const banner = container.querySelector('[data-testid="workflow-missing-link"]');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain("gone");
+    // No empty detail shell: nothing was auto-opened in its place either.
+    expect(detailName()).toBeNull();
+    expect(graphGets).toEqual([]);
+    // And the dead id is out of the address bar, in place — Back must not
+    // return to a workflow that does not exist.
+    expect(window.location.hash).toBe("#/workflows");
+  });
+});
+
+describe("leaving a workflow behind", () => {
+  it("returns to the index after deleting the open one, without picking a neighbour", async () => {
+    const { client, graphGets, deletes } = makeClient();
+    await mountAt("#/workflows/alpha", client);
+    expect(detailName()).toBe("Alpha digest");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="workflow-delete"]')?.click();
+    });
+    await act(async () => {
+      document
+        .querySelector<HTMLButtonElement>('[data-testid="workflow-delete-confirm"]')
+        ?.click();
+    });
+
+    expect(deletes).toEqual(["alpha"]);
+    expect(indexUp()).toBe(true);
+    // `beta` is all that is left, and it must NOT have been opened: the
+    // operator deleted a workflow, they did not ask to work on another one.
+    expect(graphGets).not.toContain("beta");
+    expect(cards().map((c) => c.textContent)).toHaveLength(1);
+    expect(window.location.hash).toBe("#/workflows");
+  });
+});

--- a/frontend/test/unit/workflow-index-first.test.ts
+++ b/frontend/test/unit/workflow-index-first.test.ts
@@ -241,6 +241,31 @@ describe("a URL naming a workflow opens it", () => {
 });
 
 describe("leaving a workflow behind", () => {
+  it("closes the per-workflow drawers, so the next one does not inherit them", async () => {
+    const { client } = makeClient();
+    await mountAt("#/workflows/alpha", client);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="workflow-history-toggle"]')?.click();
+    });
+    expect(container.querySelector('[data-testid="workflow-run-history"]')).not.toBeNull();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="workflow-back-to-index"]')
+        ?.click();
+    });
+    await act(async () => {
+      cards()[1].click();
+    });
+
+    expect(detailName()).toBe("Beta report");
+    // `beta`'s history panel was never asked for. Left open across the index it
+    // would come up over a workflow the operator has only just opened, showing
+    // that workflow's runs under a drawer they opened for a different one.
+    expect(container.querySelector('[data-testid="workflow-run-history"]')).toBeNull();
+  });
+
   it("returns to the index after deleting the open one, without picking a neighbour", async () => {
     const { client, graphGets, deletes } = makeClient();
     await mountAt("#/workflows/alpha", client);

--- a/frontend/test/unit/workflow-index-first.test.ts
+++ b/frontend/test/unit/workflow-index-first.test.ts
@@ -241,30 +241,50 @@ describe("a URL naming a workflow opens it", () => {
 });
 
 describe("leaving a workflow behind", () => {
-  it("closes the per-workflow drawers, so the next one does not inherit them", async () => {
-    const { client } = makeClient();
-    await mountAt("#/workflows/alpha", client);
+  // Both routes back to the index, because the rule lives on the selection
+  // rather than on the back button: the one nobody remembers to update is the
+  // delete, and it is the one that leaves the drawer open the longest.
+  for (const route of ["the back button", "a delete"] as const) {
+    it(`closes the per-workflow drawers on ${route}, so the next one does not inherit them`, async () => {
+      const { client } = makeClient();
+      await mountAt("#/workflows/alpha", client);
 
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="workflow-history-toggle"]')?.click();
-    });
-    expect(container.querySelector('[data-testid="workflow-run-history"]')).not.toBeNull();
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="workflow-history-toggle"]')
+          ?.click();
+      });
+      expect(container.querySelector('[data-testid="workflow-run-history"]')).not.toBeNull();
 
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('[data-testid="workflow-back-to-index"]')
-        ?.click();
-    });
-    await act(async () => {
-      cards()[1].click();
-    });
+      if (route === "the back button") {
+        await act(async () => {
+          container
+            .querySelector<HTMLButtonElement>('[data-testid="workflow-back-to-index"]')
+            ?.click();
+        });
+      } else {
+        await act(async () => {
+          container.querySelector<HTMLButtonElement>('[data-testid="workflow-delete"]')?.click();
+        });
+        await act(async () => {
+          document
+            .querySelector<HTMLButtonElement>('[data-testid="workflow-delete-confirm"]')
+            ?.click();
+        });
+      }
 
-    expect(detailName()).toBe("Beta report");
-    // `beta`'s history panel was never asked for. Left open across the index it
-    // would come up over a workflow the operator has only just opened, showing
-    // that workflow's runs under a drawer they opened for a different one.
-    expect(container.querySelector('[data-testid="workflow-run-history"]')).toBeNull();
-  });
+      expect(container.querySelector('[data-testid="workflow-index"]')).not.toBeNull();
+      await act(async () => {
+        cards()[route === "the back button" ? 1 : 0].click();
+      });
+
+      expect(detailName()).toBe("Beta report");
+      // `beta`'s history panel was never asked for. Left open across the index
+      // it would come up over a workflow the operator has only just opened,
+      // showing that workflow's runs under a drawer they opened for another.
+      expect(container.querySelector('[data-testid="workflow-run-history"]')).toBeNull();
+    });
+  }
 
   it("returns to the index after deleting the open one, without picking a neighbour", async () => {
     const { client, graphGets, deletes } = makeClient();

--- a/frontend/test/unit/workflow-live-node-state.test.ts
+++ b/frontend/test/unit/workflow-live-node-state.test.ts
@@ -220,12 +220,23 @@ function runStateOf(id: string): string | null {
   return null;
 }
 
+/**
+ * Render the view **on the workflow's detail page**, where the canvas is.
+ *
+ * `sub` names the graph (issue #1110). It used to be omitted: the view
+ * auto-selected the first — and only — row of the list, so a bare render landed
+ * on the canvas. `#/workflows` is the index now and has no canvas at all, so
+ * the deep link is how these tests reach one. The switch-away-and-back case
+ * still exercises exactly what it did: the clear effect keys on `company`, and
+ * that is the argument being changed.
+ */
 async function render(runEvents: Ev[], company = "acme") {
   await act(async () => {
     root.render(
       createElement(WorkflowsView, {
         client: fakeClient(),
         company,
+        sub: GRAPH.id,
         runEvents,
       }),
     );

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -132,10 +132,25 @@ afterEach(async () => {
   container.remove();
 });
 
+/**
+ * Mount the view **on the workflow's detail page**.
+ *
+ * `sub` names the graph, which is what puts the canvas and its Run / History
+ * controls on screen (issue #1110). It used to be omitted: the view auto-selected
+ * the first — and only — row of the list, so a bare mount landed inside the
+ * workflow. It lands on the index now, where a per-workflow Run button
+ * deliberately does not exist, so the deep link is how these tests reach the
+ * surface they are about. Nothing else here changed, and none of these tests is
+ * about how the workflow got opened.
+ */
 async function mount(post: () => Promise<unknown>) {
   await act(async () => {
     root.render(
-      createElement(WorkflowsView, { client: fakeClient(post), company: "acme" }),
+      createElement(WorkflowsView, {
+        client: fakeClient(post),
+        company: "acme",
+        sub: GRAPH.id,
+      }),
     );
   });
 }


### PR DESCRIPTION
Closes #1110

The Workflows tab auto-selected the first workflow the moment its list landed, so opening it dropped you *inside* a graph you had not chosen, under a toolbar — picker, Run, Test run, Copilot, History, Edit, Delete — addressed to it. The list of every workflow sat behind a **Browse** toggle.

`#/workflows` is now the index. `#/workflows/<id>` is that workflow's detail view. Both routes already existed; what changed is which one is the default and what the view does when nothing is selected.

## The change

One piece of state decides the whole tab: `selectedId`, which is the URL's second segment. `null` renders the index; an id renders that workflow's canvas and its controls. The two auto-selects are gone — `WorkflowsView.tsx`'s list effect no longer falls back to `rows[0]`, and nothing selects a workflow that an operator (or a URL) did not name.

`WorkflowIndex` stopped drawing its own header. Promoted to the body of the tab it sat directly under the tab's own bar — "Workflows 15" over "All workflows 15", with the Cards/List toggle stranded beneath the duplicate — so the toggle moved up into the one toolbar and the component renders just the list.

## The decisions, each made deliberately

**Back navigation.** Opening a workflow from the index (or the picker, or a create) **pushes** `#/workflows/<id>`, so browser Back returns to the list. That inverted the old rule: filling in a bare `#/workflows` used to be the view resolving its own default and was written with `replace`, because pushing left a duplicate-looking history entry. There is no default to resolve any more. Leaving a workflow the other way — the **All workflows** button — pushes too, so the button and browser Back are exact inverses. A detail URL is shareable and survives a reload: nothing rewrites it on arrival, which `workflow-node-config.spec.ts` now pins incidentally by reloading onto one.

Everything that leaves a workflow *because the workflow stopped existing* uses `replaceState` instead, through one `clearWorkflowFromHash()`: pushing would offer Back as a route to a graph that is gone. `workflow-live-list.spec.ts`'s history-length assertion still holds.

**An id that names nothing.** Lands on the index with the reason on screen — a dismissible banner naming the id, over the list of what this company *does* have, which is the answer a dead link raises. Not an empty detail shell, and not only a toast: the operator arrived from somebody else's link and may take a while to work out which workflow replaced it. The toast is kept as well, because the banner alone is silent for someone already looking at the index when a second card's link is followed into it. The dead id is taken out of the address bar in place.

**After creating.** Lands on the new workflow's detail page, and it reads right: nobody authors a workflow in order to look at a list of workflows — the next thing they want is its canvas, to run it or keep editing it. Because that is a push, Back returns to the index they created it from.

**After deleting the open workflow.** Back to the index, never to a neighbour. Both routes agree — the local Delete button and a delete from another session — so `remaining[0]` is gone from `remove()` and `rows[0]` is gone from the list effect's reconciliation. Handing someone a graph they never opened is the same wrong answer this issue is about, arriving a second way.

**Browse.** Removed, and its job as a way back is done by **← All workflows** at the head of the toolbar, where a back affordance belongs. A button that toggles the surface you arrived through is one control for two states with one name.

**The per-workflow drawers close on the way out.** History and Copilot belong to one workflow, so every route back to the index closes them — the back button, a delete here, a delete from another session. Left open, the *next* workflow opened came up wearing a drawer nobody asked it for, showing that workflow's runs. A workflow-to-workflow switch through the picker deliberately does not close them: someone comparing two histories opened that panel and still wants it. The rule lives on the selection rather than in the back-button handler, because the routes that are not the back button are exactly the ones nobody remembers to update.

**The picker stayed.** Kept inside a workflow, where it switches between them without a round trip through the list — which is a real affordance and the one #406 and #270 are pinned on. It is not on the index: selecting there *is* leaving the index.

## Verified

Against a host I brought up myself on a reserved port (`PW_BASE_URL`, own `--home`), not a shared one.

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean.
- `npm test` — **1058 passed**, 106 files.
- Full Playwright suite — **157 passed, 19 skipped, 0 failed** (skips are the live-brain and desktop-gated specs). The 12 workflow specs re-run after the rebase: 39 passed, 4 skipped.

### New test

`frontend/test/unit/workflow-index-first.test.ts` — eight cases, each of the decisions above. Six of them fail on `main` (checked by stashing the view): no auto-select and no per-workflow control on the index, a pick pushing its own URL, the back button dropping the id, a deep link opening the detail view, a dead id landing on the explained index, and a delete returning to the index without opening `beta`. The other two are the drawer rule, over both routes to the index, and both fail with the closing effect removed.

### Specs changed, and why

Eight specs reached a workflow by relying on the auto-select and then addressing the per-workflow toolbar. They open one from the index first, through one shared helper (`frontend/test/e2e/workflows.ts`) — "how do I get to a workflow" is one answer, and the next change to this flow should have one place to land. Navigation-only, no assertion weakened: `workflow-canvas-live`, `workflow-inline-approval`, `workflow-node-config`, `workflow-run-inference`, `workflow-run-result`, `workflow-toolbar-reachable` (its `Browse` row became the `All workflows` row), `workflow-run-history` (its `historyToggle` skip could otherwise have reported "this host does not serve …/workflows/runs" about a spec that had simply never navigated).

Three changed what they assert, because the behaviour legitimately changed:

- **`workflow-selection-persists.spec.ts`** — asserted through the picker's text; now through the detail view's heading, which is the surface that names the open workflow. Its company-switch test asserted the switch landed on the *other* company's first workflow (`#/workflows/other-default`) — that was the auto-select answering a question nobody asked. It now asserts what #864 was actually about: the previous company's route is gone and nothing was opened in its place. Sharper, not weaker — `other` has a `shared-workflow` of its own, so a view that merely kept the id would have resolved to a real graph and looked correct.
- **`workflow-edit-delete.spec.ts`** — "removes it from the picker" could only be checked from inside whichever neighbour the view auto-selected next. Now: back on the index, at `#/workflows`, with the deleted workflow's card gone. #270's "the picker shows the name, not the id" is kept as a second line in the open helper rather than dropped. One test switches graph through the picker on purpose — it is the harder case for the stale-error-map defect it pins, since the toolbar never unmounts.
- **`workflow-live-list.spec.ts`** — read liveness out of the picker popup; now off the index, rendered from the same `workflows` array. Its delete test asserts the return to the index as well as the row's disappearance. `pickerOptionCount` / `UNREADABLE` / `settled` existed only to survive counting options in a dropdown that has to be opened to be read; `toHaveCount` retries on its own, so all three are gone (with a note saying so).

`workflow-create-affordance` and `workflow-dialog-feedback` needed no change: #813's on-ramp and #341's single "New workflow" survive on the index, which is where an empty company now lands.

Two unit tests that rendered `WorkflowsView` with no `sub` relied on the auto-select to reach a canvas (`workflow-live-node-state`, `workflow-run-failure`). They pass `sub` now — a one-line deep link, no assertion touched; neither is about how the workflow got opened.

## Screenshots

Index (cards), index (list) and a detail view, light and dark, at 1440×900 against a company seeded with 15 workflows. The index is one bar — `Workflows 15`, Cards/List, New workflow — over a three-column grid; the detail view is `← All workflows / **Weekly digest** / Schedule paused / description` over the canvas and its controls. Both themes render from the existing tokens with no new colour.

## Conflicts

Branched from `upstream/main` including #1081 and #1020 (both merged), and rebased onto #1097. #1107's left run-history rail is not open as a PR yet; it belongs to the detail view in this structure, and this diff touches the branching and the toolbar rather than the history panel's internals.
