### PR TITLE
fix(console): collapse empty board columns so the work is on screen

### DIFF
--- a/docs/spec/runtime/ledgers.md
+++ b/docs/spec/runtime/ledgers.md
@@ -327,6 +327,34 @@ Ledgers section, and that re-implementation silently lost all three of issue
 Nothing failed — there was no test on the new path — until the ported drag spec
 was actually run. The board is one component now so that cannot happen again.
 
+#### An empty column collapses to a rail
+
+Six columns are wider than an ordinary window, and the three that fit are the
+three a working company empties first. So an operator opened Tasks, read three
+confident zeros, and never learned that the hundred cards they came for were two
+columns off the right edge (issue #1101): the board that had moved the most work
+looked the most finished.
+
+A column holding nothing therefore renders as a ~40px rail — label set
+vertically, count beneath it — and the populated columns take the room back.
+Three rules keep that from breaking the gesture the board exists for, since the
+empty columns are precisely the ones a card is dragged *into*:
+
+* **A rail is a whole drop target.** The drop handlers sit on the column
+  wrapper, which is the element that shrinks.
+* **A rail opens under a drag.** The `over` state that draws the drop highlight
+  also suppresses the collapse, and the empty placeholder becomes a dashed
+  "Drop it here" while a card is in hand.
+* **Nothing collapses unless another column is populated.** Six rails and no
+  board would answer "show me the work" worse than the zeros this fixes.
+
+Clicking a rail pins it open — a real button, with the column and its count in
+its accessible name — and a pinned column stays open until the operator folds it
+back. A column that re-collapsed itself while somebody was reading it would be
+this bug's mirror image. A column whose `columnHeader` slot holds a control
+never collapses either: a rail has nowhere to put it, so folding one would hide
+an affordance rather than some whitespace.
+
 ### What the ledger drives, and what it does not
 
 **Drives**: the columns, their order, their labels, which one closes a card, and

--- a/frontend/src/views/LedgerBoard.tsx
+++ b/frontend/src/views/LedgerBoard.tsx
@@ -30,8 +30,46 @@
 // 3. **The trailing gutter exists.** A flex scroll container drops its
 //    `padding-inline-end`, so without the spacer the last column hugs the edge
 //    and a near miss becomes the common case.
+//
+// # Empty columns collapse to a rail (issue #1101)
+//
+// A healthy company's board reads as dead. To-do, Planning and In progress are
+// the three columns that fit an ordinary window, and they are exactly the three
+// that empty out first — so an operator opens Tasks, gets three confident
+// zeros, and never learns that the 101 cards they came for are two columns off
+// the right edge. The board that has moved the most work is the board that
+// looks the most finished.
+//
+// So a column holding nothing shrinks to a ~40px rail — its label set vertically
+// and its zero underneath — and the columns holding the work take the room back.
+// Three properties keep that from breaking the board's main gesture, and each
+// one is a line somebody will be tempted to delete:
+//
+// * **A rail is still a whole drop target.** Empty columns are precisely the
+//   ones you drag *into*: To-do is where returned work lands, In progress is
+//   where a card is handed to its assignee. The drop handlers sit on the column
+//   wrapper, which is the element that shrinks — never on the expanded body.
+// * **A rail opens under the drag.** `over` already tracks the column the
+//   pointer is on, so the same state that draws the drop highlight suppresses
+//   the collapse. Dropping into an empty column looks the way it always did.
+// * **Nothing collapses unless something else is populated.** A board that is
+//   empty everywhere would otherwise render as six rails and no board, which is
+//   a worse answer to "show me the work" than the one this fixes.
+//
+// Clicking a rail pins it open, and a pinned column stays open until the
+// operator collapses it again. Nothing else may re-collapse it: a column that
+// folded itself back up while somebody was reading it would be this bug's
+// mirror image.
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ChevronsLeft } from "lucide-react";
 
 import type { TaskColumn } from "@/lib/board-columns";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -72,6 +110,15 @@ const EDGE_SPEED_PX = 16;
  */
 const CARD_MIME = "application/x-opencompany-task";
 
+/**
+ * The collapsed column's width.
+ *
+ * Wide enough for the vertical label and the count badge under it, narrow
+ * enough that three of them cost less than half of one open column — which is
+ * the whole point: the room has to go somewhere the operator can use it.
+ */
+const RAIL_WIDTH = "w-10";
+
 export interface BoardProps<T extends BoardRow> {
   /** The columns, in board order. The host declares them; nothing here does. */
   columns: TaskColumn[];
@@ -105,6 +152,10 @@ export function LedgerBoard<T extends BoardRow>({
 }: BoardProps<T>) {
   const [dragId, setDragId] = useState<string | null>(null);
   const [over, setOver] = useState<string | null>(null);
+  // The columns the operator has clicked open. Only a click puts an id in here
+  // and only a click takes it out again — see the header note on why nothing
+  // else is allowed to.
+  const [pinned, setPinned] = useState<ReadonlySet<string>>(() => new Set());
   const boardRef = useRef<HTMLDivElement | null>(null);
   // Refs rather than state: this is driven by `dragover` at pointer rate and
   // must not re-render the board on every move.
@@ -129,10 +180,13 @@ export function LedgerBoard<T extends BoardRow>({
       const board = boardRef.current;
       if (!board) return;
       const { left, right } = board.getBoundingClientRect();
-      const ramp = (depth: number) => Math.min(1, Math.max(0, 1 - depth / EDGE_BAND_PX));
+      const ramp = (depth: number) =>
+        Math.min(1, Math.max(0, 1 - depth / EDGE_BAND_PX));
       let speed = 0;
-      if (clientX < left + EDGE_BAND_PX) speed = -EDGE_SPEED_PX * ramp(clientX - left);
-      else if (clientX > right - EDGE_BAND_PX) speed = EDGE_SPEED_PX * ramp(right - clientX);
+      if (clientX < left + EDGE_BAND_PX)
+        speed = -EDGE_SPEED_PX * ramp(clientX - left);
+      else if (clientX > right - EDGE_BAND_PX)
+        speed = EDGE_SPEED_PX * ramp(right - clientX);
       if (speed === 0) {
         stopEdgeScroll();
         return;
@@ -156,6 +210,41 @@ export function LedgerBoard<T extends BoardRow>({
   // A drag interrupted by anything that unmounts the board — switching ledgers,
   // opening a card — must not leave a frame running against a detached node.
   useEffect(() => stopEdgeScroll, [stopEdgeScroll]);
+
+  const togglePin = useCallback((id: string) => {
+    setPinned((current) => {
+      const next = new Set(current);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+  }, []);
+
+  /**
+   * Each column's rows, bucketed once.
+   *
+   * A `filter` per column is one pass over every row per column, which at the
+   * hundred-card boards this issue was reported on is six passes on every
+   * `dragover`. Bucketing keeps declaration order within a column, which is the
+   * order the caller handed the rows in.
+   */
+  const held = useMemo(() => {
+    const buckets = new Map<string, T[]>(
+      columns.map((column) => [column.id, []]),
+    );
+    for (const row of rows) buckets.get(statusOf(row))?.push(row);
+    return buckets;
+  }, [columns, rows, statusOf]);
+
+  /**
+   * Whether an empty column is allowed to collapse at all.
+   *
+   * Only once some *other* column has work in it. A board that is empty
+   * everywhere has nothing to make room for, and six rails would answer "show
+   * me the work" worse than the three honest zeros this issue is about.
+   */
+  const collapsible =
+    !loading &&
+    columns.some((column) => (held.get(column.id)?.length ?? 0) > 0);
 
   /** Reads the dragged row out of the event, falling back to our own state. */
   const dragged = (event: React.DragEvent): T | undefined => {
@@ -202,10 +291,31 @@ export function LedgerBoard<T extends BoardRow>({
       className="flex min-h-0 flex-1 gap-4 overflow-x-auto py-1"
     >
       {columns.map((column) => {
-        const held = rows.filter((row) => statusOf(row) === column.id);
+        const cards = held.get(column.id) ?? [];
+        const head = columnHeader?.(column);
+        // A column whose header slot is filled carries an affordance — the
+        // intake `+` is the one this board was built for — and a rail has
+        // nowhere to put it. Collapsing it would hide a control rather than
+        // some whitespace, so it stays open. `false` counts as empty: a caller
+        // writing `column.id === ADD_TASK_COLUMN && <Plus/>` returns it for
+        // every other column.
+        const hasHead = head != null && head !== false && head !== "";
+        const collapsed =
+          collapsible &&
+          cards.length === 0 &&
+          !hasHead &&
+          !pinned.has(column.id) &&
+          over !== column.id;
+        // Offered only where it undoes something: on a column the operator
+        // pinned open that would otherwise have collapsed itself.
+        const canCollapse =
+          collapsible && cards.length === 0 && pinned.has(column.id);
         return (
           <div
             key={column.id}
+            data-testid="board-column"
+            data-column={column.id}
+            data-collapsed={collapsed ? "true" : "false"}
             onDragOver={(event) => {
               event.preventDefault();
               // Runs before the board's own dragover (this is the inner
@@ -214,9 +324,18 @@ export function LedgerBoard<T extends BoardRow>({
               if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
               setOver(column.id);
             }}
-            onDragLeave={() =>
-              setOver((current) => (current === column.id ? null : current))
-            }
+            onDragLeave={(event) => {
+              // Only when the pointer has genuinely left the column. A rail
+              // that opens under the drag replaces its own contents, and an
+              // element removed from under a pointer can fire `dragleave` —
+              // which without this guard would collapse the column again on
+              // the frame it opened, forever.
+              if (
+                event.currentTarget.contains(event.relatedTarget as Node | null)
+              )
+                return;
+              setOver((current) => (current === column.id ? null : current));
+            }}
             onDrop={(event) => {
               event.preventDefault();
               // Claim the drop, so anything still reaching the board's own
@@ -232,52 +351,116 @@ export function LedgerBoard<T extends BoardRow>({
               if (row && statusOf(row) !== column.id) onMove(row, column.id);
             }}
             className={cn(
-              "flex min-h-0 w-72 shrink-0 flex-col rounded-xl border bg-card/40 transition-colors",
+              "flex min-h-0 shrink-0 flex-col rounded-xl border bg-card/40 transition-colors",
+              collapsed ? RAIL_WIDTH : "w-72",
               over === column.id && "border-primary/40 bg-accent/40",
             )}
           >
-            <div className="mx-3 flex shrink-0 items-center gap-2 border-b py-2.5">
-              <span className="text-sm font-medium">{column.label}</span>
-              <span className="rounded-full bg-muted px-1.5 text-2xs font-medium tabular-nums text-muted-foreground">
-                {held.length}
-              </span>
-              <div className="ml-auto">{columnHeader?.(column)}</div>
-            </div>
-            <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
-              {loading && held.length === 0 ? (
-                <Skeleton className="h-20 rounded-lg" />
-              ) : (
-                held.map((row) => (
-                  <div
-                    key={row.id}
-                    draggable
-                    onDragStart={(event) => {
-                      setDragId(row.id);
-                      if (event.dataTransfer) {
-                        event.dataTransfer.effectAllowed = "move";
-                        // The id is what a drop reads back. The `text/plain`
-                        // copy is what makes the drag well-formed for browsers
-                        // that abort one carrying no data at all.
-                        event.dataTransfer.setData(CARD_MIME, row.id);
-                        event.dataTransfer.setData("text/plain", row.id);
-                      }
-                    }}
-                    onDragEnd={() => {
-                      setDragId(null);
-                      setOver(null);
-                      stopEdgeScroll();
-                    }}
+            {collapsed ? (
+              // The whole rail is the control, so the target is the thing the
+              // eye reads rather than a chevron tucked inside it. The label and
+              // count are `aria-hidden` and restated in the button's own name:
+              // read as text they run together ("To-do0"), and a vertical
+              // writing mode is a paint instruction that a screen reader cannot
+              // see at all.
+              <button
+                type="button"
+                onClick={() => togglePin(column.id)}
+                aria-label={`Expand ${column.label}, ${cards.length} cards`}
+                title={`Expand ${column.label}`}
+                className="flex min-h-0 flex-1 cursor-pointer flex-col items-center gap-2 rounded-xl py-3 outline-none transition-colors hover:bg-accent/60 focus-visible:ring-3 focus-visible:ring-ring/50"
+              >
+                <span
+                  aria-hidden
+                  data-testid="column-label"
+                  className="min-h-0 [writing-mode:vertical-rl] truncate text-sm font-medium text-muted-foreground"
+                >
+                  {column.label}
+                </span>
+                <span
+                  aria-hidden
+                  className="mt-auto rounded-full bg-muted px-1.5 text-2xs font-medium tabular-nums text-muted-foreground"
+                >
+                  {cards.length}
+                </span>
+              </button>
+            ) : (
+              <>
+                <div className="mx-3 flex shrink-0 items-center gap-2 border-b py-2.5">
+                  <span
+                    data-testid="column-label"
+                    className="text-sm font-medium"
                   >
-                    {renderCard(row, dragId === row.id)}
+                    {column.label}
+                  </span>
+                  <span className="rounded-full bg-muted px-1.5 text-2xs font-medium tabular-nums text-muted-foreground">
+                    {cards.length}
+                  </span>
+                  <div className="ml-auto flex items-center gap-1">
+                    {head}
+                    {canCollapse && (
+                      <button
+                        type="button"
+                        onClick={() => togglePin(column.id)}
+                        aria-label={`Collapse ${column.label}`}
+                        title={`Collapse ${column.label}`}
+                        className="flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50"
+                      >
+                        <ChevronsLeft className="size-3.5" />
+                      </button>
+                    )}
                   </div>
-                ))
-              )}
-              {!loading && held.length === 0 && (
-                <p className="mt-2 flex h-38 items-center justify-center rounded-lg bg-muted/50 px-1 text-center text-xs text-muted-foreground">
-                  {emptyHint}
-                </p>
-              )}
-            </div>
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
+                  {loading && cards.length === 0 ? (
+                    <Skeleton className="h-20 rounded-lg" />
+                  ) : (
+                    cards.map((row) => (
+                      <div
+                        key={row.id}
+                        draggable
+                        onDragStart={(event) => {
+                          setDragId(row.id);
+                          if (event.dataTransfer) {
+                            event.dataTransfer.effectAllowed = "move";
+                            // The id is what a drop reads back. The `text/plain`
+                            // copy is what makes the drag well-formed for browsers
+                            // that abort one carrying no data at all.
+                            event.dataTransfer.setData(CARD_MIME, row.id);
+                            event.dataTransfer.setData("text/plain", row.id);
+                          }
+                        }}
+                        onDragEnd={() => {
+                          setDragId(null);
+                          setOver(null);
+                          stopEdgeScroll();
+                        }}
+                      >
+                        {renderCard(row, dragId === row.id)}
+                      </div>
+                    ))
+                  )}
+                  {!loading && cards.length === 0 && (
+                    <p
+                      className={cn(
+                        "mt-2 flex h-38 items-center justify-center rounded-lg px-1 text-center text-xs",
+                        over === column.id && dragId
+                          ? // A column that opened to receive a card says so. The
+                            // rail is a small target and the operator is holding
+                            // something: the empty column has to read as a landing
+                            // spot, not as the same "nothing here" it shows at rest.
+                            "border border-dashed border-primary/50 bg-accent/60 font-medium text-foreground"
+                          : "bg-muted/50 text-muted-foreground",
+                      )}
+                    >
+                      {over === column.id && dragId
+                        ? "Drop it here"
+                        : emptyHint}
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
           </div>
         );
       })}

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 
 import { LIVE_BRAIN } from "./capabilities";
 
@@ -42,6 +42,26 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+/**
+ * Moves every card out of one column, so a claim about that column being empty
+ * is a precondition this test set up rather than one it inherited.
+ *
+ * Needed since issue #1101: an empty column collapses to a rail, and whether a
+ * given column is empty at this point in the run depends on what earlier specs
+ * left behind — the host's data root survives between runs against a host you
+ * brought up yourself.
+ */
+async function emptyOut(request: APIRequestContext, column: string) {
+  const listed = await request.get(`${API}/tasks`);
+  expect(listed.ok()).toBeTruthy();
+  const tasks = (await listed.json()) as Array<{ id: string; column: string }>;
+  for (const task of tasks) {
+    if (task.column !== column) continue;
+    const parked = await request.patch(`${API}/tasks/${task.id}`, { data: { column: "done" } });
+    expect(parked.ok()).toBeTruthy();
+  }
+}
+
 async function dismissTour(page: Page) {
   const skip = page.getByRole("button", { name: "Skip for now" });
   for (let attempt = 0; attempt < 5; attempt += 1) {
@@ -54,7 +74,11 @@ async function dismissTour(page: Page) {
 
 /** The column headers the board actually renders, left to right. */
 function columnLabels(page: Page) {
-  return page.getByTestId("ledger-board").locator("div.w-72 > div > span.text-sm.font-medium");
+  // By testid, not by shape. An empty column collapses to a rail (issue #1101)
+  // and renders its label inside a button rather than the open column's header
+  // row, so a structural selector would silently stop counting the very columns
+  // this asserts the order of.
+  return page.getByTestId("ledger-board").getByTestId("column-label");
 }
 
 test("the board renders the six #183 columns in order, with Backlog gone", async ({ page }) => {
@@ -140,6 +164,9 @@ test("dragging into Planning moves the card without dispatching it", async ({ pa
       "contract is covered by the live-brain test below. Issue #501.",
   );
   const title = `e2e planning drag ${Date.now()}`;
+  // Planning has to be empty for the collapse assertions below to mean
+  // anything, and an earlier run of this very test may have left a card in it.
+  await emptyOut(request, "planning");
   const seeded = await request.post(`${API}/tasks`, { data: { title } });
   expect(seeded.ok()).toBeTruthy();
   const id = (await seeded.json()).id as string;
@@ -165,9 +192,18 @@ test("dragging into Planning moves the card without dispatching it", async ({ pa
   // `dragstart`, `getData` at `drop`, and nothing in between that a re-render
   // can touch.
   const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
-  const planning = page.locator("div.w-72").nth(EXPECTED_COLUMNS.indexOf("Planning"));
+  const planning = page.getByTestId("board-column").nth(EXPECTED_COLUMNS.indexOf("Planning"));
+  // Issue #1101: the card just seeded makes the board non-empty, so Planning —
+  // which holds nothing — has collapsed to a rail. That is the state this drop
+  // has to survive, and it is not incidental: the columns an operator drags
+  // *into* are exactly the columns that are empty, so a rail that stopped
+  // taking a drop would break the board's main gesture on every board the
+  // collapse is for.
+  await expect(planning).toHaveAttribute("data-collapsed", "true");
   await card.dispatchEvent("dragstart", { dataTransfer });
   await planning.dispatchEvent("dragover", { dataTransfer });
+  // And it opened to receive the card rather than taking the drop blind.
+  await expect(planning).toHaveAttribute("data-collapsed", "false");
   await planning.dispatchEvent("drop", { dataTransfer });
 
   await expect
@@ -242,7 +278,7 @@ test("a card dropped into Planning is planned and settled, never left parked", a
   // The same faithful gesture as the test above: one DataTransfer across all
   // three events, so the id travels where a real drag puts it.
   const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
-  const planning = page.locator("div.w-72").nth(EXPECTED_COLUMNS.indexOf("Planning"));
+  const planning = page.getByTestId("board-column").nth(EXPECTED_COLUMNS.indexOf("Planning"));
   await card.dispatchEvent("dragstart", { dataTransfer });
   await planning.dispatchEvent("dragover", { dataTransfer });
   await planning.dispatchEvent("drop", { dataTransfer });

--- a/frontend/test/e2e/board-drag.spec.ts
+++ b/frontend/test/e2e/board-drag.spec.ts
@@ -93,7 +93,30 @@ async function dismissTour(page: Page) {
 }
 
 const board = (page: Page) => page.getByTestId("ledger-board");
-const column = (page: Page, index: number) => board(page).locator("div.w-72").nth(index);
+const column = (page: Page, index: number) => board(page).getByTestId("board-column").nth(index);
+
+/**
+ * Opens every column that has collapsed itself to a rail (issue #1101).
+ *
+ * An empty column is now ~40px wide, and every geometry claim in this file is
+ * about the board at its full six-column width: whether the last one is a
+ * whole drop target, and whether a drag held against the edge can scroll to
+ * reach it. A board of five rails and one column does not overflow at all, so
+ * without this the edge-scroll assertion would pass by never being tested.
+ *
+ * Clicking a rail pins it open, which is the operator's own control — so this
+ * puts the board in a state a person can reach, rather than defeating the
+ * feature with a style override.
+ */
+async function expandAll(page: Page) {
+  const rails = board(page).locator("button[aria-label^='Expand ']");
+  // Bounded: each click removes one rail, and the board has six columns.
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    if ((await rails.count()) === 0) return;
+    await rails.first().click();
+  }
+  await expect(rails).toHaveCount(0);
+}
 
 /** Opens the board and waits for the host's columns to arrive. */
 async function openBoard(page: Page) {
@@ -103,6 +126,7 @@ async function openBoard(page: Page) {
   // has one. Every assertion below measures a column's box; none of them mean
   // anything against a board still showing none.
   await expect(column(page, DONE)).toHaveCount(1, { timeout: 15_000 });
+  await expandAll(page);
 }
 
 /** Seeds a card straight into In review and opens the board on it. */

--- a/frontend/test/unit/board-collapsed-columns.test.ts
+++ b/frontend/test/unit/board-collapsed-columns.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { TaskColumn } from "@/lib/board-columns";
+import { LedgerBoard } from "@/views/LedgerBoard";
+
+/**
+ * Issue #1101 — a board whose work is all in later columns reads as empty.
+ *
+ * The report: To-do, Planning and In progress are the three columns that fit an
+ * ordinary window, and on a company that has actually shipped something they
+ * are the three that are empty. The operator gets three confident zeros and no
+ * hint that 101 cards are two columns off the right edge.
+ *
+ * The fix collapses an empty column to a rail so the populated ones fit, and
+ * the whole risk of it is the board's main gesture: **empty columns are exactly
+ * the columns you drag into.** To-do is where returned work lands, In progress
+ * is where a card is handed to its assignee. So the claims that matter here are
+ * not "it looks narrower" — they are that a rail is still a drop target, that it
+ * opens under a drag, and that a column the operator pinned open stays open.
+ *
+ * This suite is normally for pure functions (see `vitest.config.ts`), and it
+ * earns the exception the same way `task-blocked-card.test.ts` does: every
+ * claim above only exists at the rendered board. A helper returning
+ * `collapsed: true` would prove nothing about whether the element under the
+ * pointer still takes a drop.
+ */
+
+const COLUMNS: TaskColumn[] = [
+  { id: "todo", label: "To-do", closed: false },
+  { id: "planning", label: "Planning", closed: false },
+  { id: "in_progress", label: "In progress", closed: false },
+  { id: "paused", label: "Paused", closed: false },
+  { id: "in_review", label: "In review", closed: false },
+  { id: "done", label: "Done", closed: true },
+];
+
+interface Row {
+  id: string;
+  status: string;
+}
+
+/** The board as the issue found it: everything parked in the later columns. */
+function laterColumnsOnly(): Row[] {
+  return [
+    ...Array.from({ length: 47 }, (_, n) => ({ id: `p${n}`, status: "paused" })),
+    ...Array.from({ length: 54 }, (_, n) => ({ id: `r${n}`, status: "in_review" })),
+  ];
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let moves: Array<{ id: string; status: string }>;
+
+async function render(rows: Row[], extra: { columnHeader?: boolean } = {}) {
+  moves = [];
+  await act(async () => {
+    root.render(
+      createElement(LedgerBoard<Row>, {
+        columns: COLUMNS,
+        rows,
+        statusOf: (row) => row.status,
+        renderCard: (row) => createElement("span", null, row.id),
+        onMove: (row, status) => {
+          moves.push({ id: row.id, status });
+        },
+        onMiss: () => {},
+        columnHeader: extra.columnHeader
+          ? (column) => (column.id === "todo" ? createElement("button", null, "+") : null)
+          : undefined,
+      }),
+    );
+  });
+}
+
+function column(id: string): HTMLElement {
+  const found = container.querySelector<HTMLElement>(`[data-column="${id}"]`);
+  if (!found) throw new Error(`no ${id} column in:\n${container.innerHTML}`);
+  return found;
+}
+
+const isCollapsed = (id: string) => column(id).dataset.collapsed === "true";
+
+/** Dispatches a bare DOM event React will wrap. jsdom has no `DragEvent`. */
+async function fire(target: Element, type: string) {
+  await act(async () => {
+    target.dispatchEvent(new Event(type, { bubbles: true, cancelable: true }));
+  });
+}
+
+/** Picks a card up, so the board's `dragId` fallback holds it like a real drag. */
+async function pickUp(id: string) {
+  const card = Array.from(container.querySelectorAll<HTMLElement>("[draggable=true]")).find(
+    (held) => held.textContent === id,
+  );
+  if (!card) throw new Error(`no card ${id} to pick up`);
+  await fire(card, "dragstart");
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("a board whose work has moved to the later columns", () => {
+  it("collapses the empty columns and leaves the populated ones alone", async () => {
+    await render(laterColumnsOnly());
+
+    expect(isCollapsed("todo")).toBe(true);
+    expect(isCollapsed("planning")).toBe(true);
+    expect(isCollapsed("in_progress")).toBe(true);
+    expect(isCollapsed("done")).toBe(true);
+    expect(isCollapsed("paused")).toBe(false);
+    expect(isCollapsed("in_review")).toBe(false);
+  });
+
+  it("gives a rail an accessible name carrying the column and its count", async () => {
+    await render(laterColumnsOnly());
+
+    // The label is painted sideways and the count sits under it, which a screen
+    // reader cannot see and would otherwise read as "To-do0". The name is the
+    // one place both facts are actually available.
+    const rail = column("todo").querySelector("button");
+    expect(rail).not.toBeNull();
+    expect(rail?.getAttribute("aria-label")).toBe("Expand To-do, 0 cards");
+  });
+
+  it("collapses nothing when the board is empty everywhere", async () => {
+    // Six rails and no board is a worse answer to "show me the work" than the
+    // three honest zeros this issue is about.
+    await render([]);
+
+    for (const held of COLUMNS) expect(isCollapsed(held.id)).toBe(false);
+  });
+
+  it("keeps a column open when its header slot holds a control", async () => {
+    // A rail has nowhere to put the intake `+`, so collapsing To-do would hide
+    // a control rather than some whitespace.
+    await render(laterColumnsOnly(), { columnHeader: true });
+
+    expect(isCollapsed("todo")).toBe(false);
+    expect(isCollapsed("planning")).toBe(true);
+  });
+});
+
+describe("dragging a card into a collapsed column", () => {
+  it("opens the rail under the drag and takes the drop", async () => {
+    await render(laterColumnsOnly());
+    await pickUp("p0");
+
+    await fire(column("in_progress"), "dragover");
+    expect(isCollapsed("in_progress")).toBe(false);
+    // And it reads as a landing spot rather than the same "nothing here" it
+    // shows at rest.
+    expect(column("in_progress").textContent).toContain("Drop it here");
+
+    await fire(column("in_progress"), "drop");
+    expect(moves).toEqual([{ id: "p0", status: "in_progress" }]);
+  });
+
+  it("folds the rail back once the drag moves on, without pinning it", async () => {
+    await render(laterColumnsOnly());
+    await pickUp("p0");
+
+    await fire(column("todo"), "dragover");
+    expect(isCollapsed("todo")).toBe(false);
+
+    await fire(column("todo"), "dragleave");
+    expect(isCollapsed("todo")).toBe(true);
+  });
+
+  it("leaves the other empty columns collapsed while one is hovered", async () => {
+    await render(laterColumnsOnly());
+    await pickUp("p0");
+
+    await fire(column("in_progress"), "dragover");
+    expect(isCollapsed("todo")).toBe(true);
+    expect(isCollapsed("planning")).toBe(true);
+  });
+});
+
+describe("pinning a collapsed column open", () => {
+  it("opens on a click and stays open", async () => {
+    await render(laterColumnsOnly());
+
+    const rail = column("todo").querySelector("button");
+    await act(async () => rail?.click());
+    expect(isCollapsed("todo")).toBe(false);
+
+    // Nothing but another click may fold it: a column that re-collapsed itself
+    // while somebody was reading it would be this bug's mirror image. A drag
+    // over its neighbour is the cheapest re-render to prove that with.
+    await pickUp("p0");
+    await fire(column("planning"), "dragover");
+    await fire(column("planning"), "dragleave");
+    expect(isCollapsed("todo")).toBe(false);
+  });
+
+  it("offers a control that folds it back up", async () => {
+    await render(laterColumnsOnly());
+
+    await act(async () => column("todo").querySelector("button")?.click());
+    const fold = column("todo").querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse To-do"]',
+    );
+    expect(fold).not.toBeNull();
+
+    await act(async () => fold?.click());
+    expect(isCollapsed("todo")).toBe(true);
+  });
+
+  it("offers no fold control on a column that holds work", async () => {
+    await render(laterColumnsOnly());
+
+    expect(column("paused").querySelector('button[aria-label="Collapse Paused"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1101.

## What the operator saw

To-do, Planning and In progress are the three columns that fit on screen. With the real work in Paused and In review — **101 cards** in the reported case — the board showed three zeroes and nothing else. Nothing scrolled there, and nothing on screen said there was anything to scroll to.

## What changed

Empty columns collapse to a narrow rail carrying the column name and its `0`, so the columns holding work get the width. Clicking a rail pins it open.

```
before                                     after
┌────────────────────────────────────┐    ┌────────────────────────────────────┐
│ To-do (0) │ Planning (0) │ In pr…  │    │ T │ P │ I │ Paused (47) │ In rev…  │
│  (empty)  │   (empty)    │ (empty) │    │ o │ l │ n │ ▸ Fix #883  │ ▸ SSE…   │
└────────────────────────────────────┘    │ 0 │ 0 │ 0 │ ▸ …44 more  │ ▸ …51    │
   Paused (47) · In review (54) → off      └────────────────────────────────────┘
```

## The constraint that shaped it

An empty column is exactly the column you drag *into* — To-do is where new work lands, and In progress is where a card is dropped to hand it to its assignee. Collapsing those without care would have made the board tidier and broken its primary gesture.

So a collapsed rail **stays a full drop target and expands while a card is dragged over it**. From the operator's side the drag is unchanged.

Columns still come from the `tasks` ledger (declared in Rust at `src/ledger/board.rs`), not from anything hardcoded in TS.

## Verification

- `npm run typecheck` — clean
- `npm test` — **1060 passed across 106 files**, including a new `board-collapsed-columns.test.ts`
- `board-columns.spec.ts` and `board-drag.spec.ts` extended for the collapsed and drag-over cases

## Note on provenance

The implementing agent was interrupted by a session limit after reporting the e2e suite green but before committing. I re-ran typecheck and the unit suite myself on the exact tree being pushed, and reverted an accidental `vendor/openhuman` submodule pointer change that was in the working tree. The docs edit to `docs/spec/runtime/ledgers.md` is included as authored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Empty ledger columns now collapse into labeled, count-bearing rails when other columns contain cards.
  * Rails remain full drop targets and expand automatically during drag-and-drop.
  * Users can pin columns open or collapse them with accessible controls.
  * Columns with header controls remain expanded.
  * Empty drop targets display a highlighted “Drop it here” state during dragging.

* **Documentation**
  * Added documentation describing responsive empty-column behavior.

* **Tests**
  * Added coverage for collapsing, pinning, drag-and-drop expansion, and accessible controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->