### PR TITLE
fix(console): put the New-desk name error at the name field

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -3,18 +3,26 @@ import { Input as InputPrimitive } from "@base-ui/react/input"
 
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
-    <InputPrimitive
-      type={type}
-      data-slot="input"
-      className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+// `forwardRef` because React 18 does not pass `ref` through a plain function
+// component: a caller that needs to move focus to this field (the desk
+// creator's empty-name validation, issue #1100) would otherwise hold a ref
+// that is permanently `null`. The Base UI primitive underneath already
+// forwards to the native `<input>`.
+const Input = React.forwardRef<HTMLInputElement, React.ComponentPropsWithoutRef<"input">>(
+  function Input({ className, type, ...props }, ref) {
+    return (
+      <InputPrimitive
+        ref={ref as React.Ref<HTMLElement>}
+        type={type}
+        data-slot="input"
+        className={cn(
+          "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
 
 export { Input }

--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -8,7 +8,7 @@
 // Desks page, which #302 unmounted; between then and now nothing rendered this
 // dialog at all, so creating a desk was impossible outside the manifest.
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Crown } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -47,8 +47,16 @@ export function DeskCreateDialog({
   const [members, setMembers] = useState<string[]>([]);
   const [roster, setRoster] = useState<TeamMemberDto[]>([]);
   const [submitting, setSubmitting] = useState(false);
+  // Two kinds of message, deliberately kept apart (issue #1100). `nameError` is
+  // about one field and renders at that field; `error` is the host's refusal of
+  // the whole form and keeps the banner above the footer. Sharing one slot put
+  // "Give the desk a name." underneath the entire roster picker — below the
+  // fold on a real company, with nothing moving the operator to it.
+  const [nameError, setNameError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
   const formId = useId();
+  const nameErrorId = `${formId}-name-error`;
 
   // Reload the roster (the member picker) and reset the draft each time the
   // dialog opens, so a prior attempt never leaks into the next one.
@@ -57,6 +65,7 @@ export function DeskCreateDialog({
     setName("");
     setDescription("");
     setMembers([]);
+    setNameError(null);
     setError(null);
     let live = true;
     (async () => {
@@ -87,9 +96,19 @@ export function DeskCreateDialog({
 
   async function submit() {
     if (!name.trim()) {
-      setError("Give the desk a name.");
+      setNameError("Give the desk a name.");
+      setError(null);
+      // The frame AFTER the state change: the message does not exist in the DOM
+      // until this render commits, and the input can be scrolled far above the
+      // Create button the operator just pressed. `preventScroll` so the focus
+      // move does not jump the container out from under the smooth scroll.
+      requestAnimationFrame(() => {
+        nameRef.current?.focus({ preventScroll: true });
+        nameRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+      });
       return;
     }
+    setNameError(null);
     setSubmitting(true);
     setError(null);
     try {
@@ -125,10 +144,31 @@ export function DeskCreateDialog({
           <Label htmlFor={`${formId}-name`}>Name</Label>
           <Input
             id={`${formId}-name`}
+            ref={nameRef}
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              setName(e.target.value);
+              // The complaint was about the field being empty, so the first
+              // keystroke answers it; leaving it up would outlive its subject.
+              setNameError(null);
+            }}
+            aria-invalid={Boolean(nameError)}
+            aria-describedby={nameError ? nameErrorId : undefined}
             placeholder="e.g. Engineering"
           />
+          {nameError && (
+            // Announced as well as rendered: the focus move above is what a
+            // sighted operator notices, `role="alert"` is what a screen reader
+            // gets, and `aria-describedby` ties it to the field it is about.
+            <p
+              id={nameErrorId}
+              role="alert"
+              data-testid="desk-name-error"
+              className="text-xs text-destructive"
+            >
+              {nameError}
+            </p>
+          )}
         </div>
         <div className="grid gap-2">
           <Label htmlFor={`${formId}-desc`}>Description</Label>
@@ -188,8 +228,11 @@ export function DeskCreateDialog({
           )}
         </div>
 
+        {/* Whole-form failures only — what the host said when it refused the
+            create. Field-level complaints render at their field, above.
+            `Alert` carries `role="alert"` itself. */}
         {error && (
-          <Alert variant="destructive">
+          <Alert variant="destructive" data-testid="desk-create-error">
             <AlertDescription>{error}</AlertDescription>
           </Alert>
         )}

--- a/frontend/src/views/company/README.md
+++ b/frontend/src/views/company/README.md
@@ -97,6 +97,20 @@ renders normally. `useHashView` hands the second segment back unvalidated, and a
 stale bookmark deserves the company, not a banner. The hash is never rewritten:
 `#/company/<deskId>` is a shareable address.
 
+## Two kinds of message in the desk creator
+
+`DeskCreateDialog` keeps field-level complaints apart from whole-form ones
+(issue #1100). "Give the desk a name." renders **at the Name field** — inline
+under the input, `role="alert"`, wired to the input by `aria-describedby` with
+`aria-invalid` on it — and an invalid submit focuses that input and scrolls it
+into view. What the host says when it refuses the create stays in the banner
+above the footer, because it is about the whole form.
+
+They used to share the banner slot, which put a complaint about the first field
+below the entire roster picker: off-screen in a `max-h-[85vh] overflow-y-auto`
+dialog on any real company, with nothing moving the operator to it, so Create
+read as inert. The distance grew with the roster.
+
 ## Files
 
 | | |
@@ -109,6 +123,9 @@ stale bookmark deserves the company, not a banner. The hash is never rewritten:
 
 `test/unit/org-tree.test.ts` covers the derivation — lead by position,
 provenance, the unresolvable seat, the unplaced roster, and the cap.
+`test/unit/desk-create-name-error.test.ts` covers the create dialog's two
+message slots — which node holds each, where it sits relative to the field, its
+ARIA wiring, and the focus move.
 `test/e2e/org-tree.spec.ts` covers the surface in a browser, including the
 reachability failure this issue is about, and asserts every write survives a
 reload against a stateful stub.

--- a/frontend/test/unit/desk-create-name-error.test.ts
+++ b/frontend/test/unit/desk-create-name-error.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DeskDto, TeamMemberDto } from "@/api/types";
+import { DeskCreateDialog } from "@/views/company/DeskCreateDialog";
+
+/**
+ * Where the desk creator puts its refusal (issue #1100).
+ *
+ * Before this, "Give the desk a name." was set into the same state the host's
+ * refusal uses, and that state renders once — after the Name field, the
+ * Description field and the whole roster picker, inside a
+ * `max-h-[85vh] overflow-y-auto` dialog. On a company with a real roster the
+ * message therefore landed below the fold while the empty field sat at the top,
+ * nothing scrolled to it and nothing focused the input, so pressing Create
+ * looked like pressing nothing.
+ *
+ * These assertions are all about a mounted component: which node holds the
+ * message, where that node sits relative to the field, what the input's ARIA
+ * says, and where focus went. None of that survives extraction into a helper,
+ * which is why this earns a jsdom render.
+ */
+
+const ROSTER: TeamMemberDto[] = Array.from({ length: 12 }, (_, i) => ({
+  id: `member-${i}`,
+  name: `Teammate ${i}`,
+  role: "engineer",
+}));
+
+function stubClient(createDesk: () => Promise<DeskDto>) {
+  return {
+    listTeam: () => Promise.resolve(ROSTER),
+    createDesk,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let onOpenChange: ReturnType<typeof vi.fn>;
+let onCreated: ReturnType<typeof vi.fn>;
+
+/** The dialog renders through a portal, so it is on `document`, not `container`. */
+function inDialog<T extends Element>(selector: string): T | null {
+  return document.querySelector<T>(`[data-slot="dialog-content"] ${selector}`);
+}
+
+function nameInput(): HTMLInputElement {
+  const el = inDialog<HTMLInputElement>('[placeholder="e.g. Engineering"]');
+  expect(el, "the Name field did not render").toBeTruthy();
+  return el as HTMLInputElement;
+}
+
+function createButton(): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-slot="dialog-content"] button'),
+  ).find((b) => b.textContent?.trim().startsWith("Create desk"));
+  expect(match, 'no button labeled "Create desk"').toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
+/** Sets a controlled input the way a keystroke would: through the native value
+ * setter, so React's own descriptor sees the change and `onChange` fires. */
+function type(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function open(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(DeskCreateDialog, {
+        open: true,
+        onOpenChange,
+        onCreated,
+        client,
+        company: "acme",
+      }),
+    );
+  });
+}
+
+/** Presses Create and lets the post-commit frame run, which is where the focus
+ * and scroll move live. */
+async function pressCreate() {
+  await act(async () => {
+    createButton().click();
+  });
+  await act(async () => {
+    await new Promise((r) => requestAnimationFrame(r));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  // jsdom does no layout and ships no `scrollIntoView`; the component calls it
+  // on the frame after the refusal renders, where a throw would surface as an
+  // unhandled error rather than a test failure. Stubbed here rather than
+  // guarded in the component — the call is correct in a browser, and WHERE the
+  // container ends up scrolled is a layout property the e2e suite owns.
+  Element.prototype.scrollIntoView = vi.fn();
+  onOpenChange = vi.fn();
+  onCreated = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the desk creator when the name is empty", () => {
+  it("puts the message at the Name field, focuses it, and never posts", async () => {
+    const createDesk = vi.fn(() => Promise.reject(new Error("must not be called")));
+    await open(stubClient(createDesk));
+    // The picker really is long enough for the old bottom slot to be off-screen
+    // in a browser — this is the geometry the issue is about.
+    expect(document.querySelectorAll('[data-slot="dialog-content"] [aria-pressed]').length).toBe(
+      ROSTER.length,
+    );
+
+    await pressCreate();
+
+    expect(createDesk).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    const message = inDialog<HTMLElement>('[data-testid="desk-name-error"]');
+    expect(message, "the refusal did not render").toBeTruthy();
+    expect(message!.textContent).toBe("Give the desk a name.");
+
+    // Adjacent to the field it is about: same field group, immediately after
+    // the input — not the bottom of the form, past the whole roster.
+    const input = nameInput();
+    expect(input.nextElementSibling).toBe(message);
+    expect(message!.parentElement).toBe(input.parentElement);
+    const firstRosterButton = inDialog<HTMLElement>("[aria-pressed]")!;
+    expect(
+      message!.compareDocumentPosition(firstRosterButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      "the message renders after the roster picker",
+    ).toBeTruthy();
+    // ...and the whole-form banner, which belongs to host refusals, stayed away.
+    expect(inDialog('[data-testid="desk-create-error"]')).toBeNull();
+
+    // Announced, not merely rendered: without these a screen-reader operator
+    // gets exactly the silence a sighted one used to get.
+    expect(message!.getAttribute("role")).toBe("alert");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toBe(message!.id);
+    expect(message!.id).toBeTruthy();
+
+    // ...and the operator is taken to the problem rather than left looking at
+    // an unchanged screen.
+    expect(document.activeElement).toBe(input);
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("retires the message on the first keystroke", async () => {
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+    await pressCreate();
+    expect(inDialog('[data-testid="desk-name-error"]')).toBeTruthy();
+
+    await act(async () => {
+      type(nameInput(), "Engineering");
+    });
+
+    expect(inDialog('[data-testid="desk-name-error"]')).toBeNull();
+    expect(nameInput().getAttribute("aria-invalid")).toBe("false");
+    expect(nameInput().getAttribute("aria-describedby")).toBeNull();
+  });
+});
+
+describe("the desk creator when the host refuses", () => {
+  it("keeps that in the whole-form banner, away from the Name field", async () => {
+    const createDesk = vi.fn(() =>
+      Promise.reject(new Error("a desk named “Engineering” already exists")),
+    );
+    await open(stubClient(createDesk));
+
+    await act(async () => {
+      type(nameInput(), "Engineering");
+    });
+    await pressCreate();
+
+    expect(createDesk).toHaveBeenCalledTimes(1);
+    const banner = inDialog<HTMLElement>('[data-testid="desk-create-error"]');
+    expect(banner, "the host's refusal did not render").toBeTruthy();
+    expect(banner!.textContent).toContain("already exists");
+    expect(banner!.getAttribute("role")).toBe("alert");
+    // It is about the form, not the field, so the field is not marked invalid.
+    expect(inDialog('[data-testid="desk-name-error"]')).toBeNull();
+    expect(nameInput().getAttribute("aria-invalid")).toBe("false");
+    // The draft survives, and the form is live again to retry.
+    expect(nameInput().value).toBe("Engineering");
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(createButton().disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The New-desk dialog's empty-name refusal now renders **at the Name field** instead of at the bottom of the form.

`submit()` set `"Give the desk a name."` into the same `error` state the host's refusal uses, and that state renders once — after Name, after Description, after the entire roster picker, inside a `max-h-[85vh] overflow-y-auto` dialog. On a company with a real roster the message landed below the fold while the empty field sat at the top; nothing scrolled to it and nothing focused the input, so pressing **Create desk** looked like pressing nothing. The distance grew with the roster.

## What changed

- **Two message slots, kept apart.** A new `nameError` renders inline under the Name input; `error` keeps the banner above the footer for whole-form failures the host returns (those are genuinely about the form, and the banner already sits directly above the button that triggered them).
- **The operator is moved to the problem.** On an invalid submit, the frame after the state commits focuses the input (`preventScroll`, so the focus move does not jump the container out from under the smooth scroll) and `scrollIntoView({ block: "center", behavior: "smooth" })`.
- **Announced, not merely rendered.** `role="alert"` on the message, `aria-describedby` from the input to it, `aria-invalid` on the input — which also lights the destructive ring `ui/input` already styles. Without these a screen-reader operator got exactly the silence a sighted one got.
- **The first keystroke retires it**, so the complaint never outlives its subject.
- **`ui/input` now forwards its ref.** React 18 drops `ref` on a plain function component, so the focus move would otherwise hold a permanently `null` ref; the Base UI primitive underneath is already `forwardRef`. Behaviourally a no-op for every existing caller.

## Other validation paths

There is only one client-side validation on this dialog — the empty name. The only other message on the path is `createDesk`'s rejection, which is a whole-form failure and stays in the banner. So nothing else needed relocating; the two are now separate states rather than one shared slot, which is what would have made a second field-level rule land in the wrong place.

## Tests

`frontend/test/unit/desk-create-name-error.test.ts` (jsdom + `react-dom/client` + `act` + `createElement`, no testing-library) covers:

1. An empty-name submit never posts, renders the message as the Name input's next sibling in the same field group (and asserts the roster picker *follows* it), wires `role="alert"` / `aria-invalid` / `aria-describedby`, focuses the input and calls `scrollIntoView`.
2. The first keystroke drops the message and the invalid state.
3. A host refusal lands in the bottom banner with the draft intact, and leaves the Name field un-flagged.

`Element.prototype.scrollIntoView` is stubbed in the test file — jsdom does not ship it, and a throw from the effect would surface as an unhandled error on the Console lane even with every test passing. The component is deliberately not guarded; the call is correct in a browser.

## Commands run

```
npm run typecheck        # clean
npm run typecheck:unit   # clean
npm test                 # 116 files, 1123 tests passed
```

Closes #1100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added inline validation for missing desk names.
  * Automatically focuses and scrolls to the Name field when validation fails.
  * Clears the field error when users begin editing.
  * Keeps creation errors visible in a separate form-level banner while preserving entered details and allowing retries.

* **Accessibility**
  * Improved error messaging and field associations for assistive technologies.

* **Documentation**
  * Documented field-level and form-level validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->