### PR TITLE
fix(workflows): align the dry-run SSRF pre-flight with the real guard

### DIFF
--- a/src/workflows/caps/dry_run.rs
+++ b/src/workflows/caps/dry_run.rs
@@ -330,15 +330,12 @@ mod tests {
     /// and asserts the two agree, so it keeps holding when upstream changes its
     /// internals and fails loudly the day upstream loosens a rule.
     ///
-    /// Only refusals are compared, and that is not a gap: the real guard rejects
-    /// these **before it dials anything**, so the comparison needs no network and
-    /// performs no effect. An *allowed* URL cannot be compared this way, because
-    /// confirming it would mean actually issuing the request — which is the one
-    /// thing neither a dry run nor this suite may do.
-    ///
-    /// The direction that matters is the one this covers. A dry run that refuses
-    /// what a real run would allow blocks a working graph, and an operator cannot
-    /// tell that from a real refusal without arming it anyway.
+    /// This half covers the *too permissive* direction only — the real guard
+    /// rejects every URL below **before it dials anything**, so the comparison
+    /// needs no network and performs no effect. The other direction, a dry run
+    /// stricter than the guard, is covered by
+    /// [`dry_run_does_not_refuse_what_the_real_client_allows`]; asserting only
+    /// this one is what let #1075's trailing-dot break sit on `main` unnoticed.
     #[tokio::test]
     async fn dry_run_refusal_matches_the_real_client() {
         use crate::workflows::caps::http::GuardedHttpClient;
@@ -369,6 +366,92 @@ mod tests {
             assert!(
                 dry.is_err(),
                 "the real client refuses {url} but the dry run reported success —                  that is the false green issue #1048 is about"
+            );
+        }
+
+        // Open-allowlist mode. Each of these is refused by the *shape* of the
+        // URL, before any allowlist is consulted, so an empty list is no excuse
+        // for the dry run to stay quiet — and each one did slip through it until
+        // #1075, because the copy read past userinfo, unwrapped IPv6 brackets and
+        // left a trailing dot on the host.
+        let open_cases = [
+            "https://user@example.com/x",
+            "http://[2606:4700::1111]/x",
+            "http://127.0.0.1./",
+            "ftp://example.com/x",
+        ];
+        let open = GuardedHttpClient::new(Arc::new(SecurityPolicy::default()), Vec::new());
+        for url in open_cases {
+            let request = json!({ "method": "GET", "url": url });
+            let dry = DryRunHttp::new(Vec::new())
+                .request(request.clone(), None)
+                .await;
+            let live = open.request(request, None).await;
+            assert!(
+                live.is_err(),
+                "{url} must be refused by the real client for this comparison to mean anything"
+            );
+            assert!(
+                dry.is_err(),
+                "the real client refuses {url} but the dry run reported success: {dry:?}"
+            );
+        }
+    }
+
+    /// **The other direction: the real guard allows ⇒ the dry run must not refuse.**
+    ///
+    /// [`dry_run_refusal_matches_the_real_client`] only ever asserts that both
+    /// sides refuse, so it is structurally blind to this copy becoming *stricter*
+    /// than the guard — and that is the failure that costs something. Issue
+    /// #1075: `https://example.com./x` against `["example.com"]` was allowed by
+    /// the real guard (which trims the trailing dot off the host) and refused
+    /// here (which trimmed it off allowlist *entries* only), so Test run blocked
+    /// a graph that runs, and an operator could not tell that from a real
+    /// refusal without arming it.
+    ///
+    /// The real client cannot be driven all the way to "allowed" without issuing
+    /// the request, which this suite may not do. So the host is an RFC 2606
+    /// `.invalid` name: it clears every guard rule and the run then stops at DNS
+    /// resolution, which cannot succeed — no connection is ever made. The
+    /// assertion is "the guard did not refuse it", which is the claim under test.
+    #[tokio::test]
+    async fn dry_run_does_not_refuse_what_the_real_client_allows() {
+        use crate::workflows::caps::http::GuardedHttpClient;
+        use openhuman_core::openhuman::security::SecurityPolicy;
+        use std::sync::Arc;
+
+        let allowed = vec!["parity.invalid".to_string()];
+        let cases = [
+            // The regression: a legal fully-qualified host.
+            "https://parity.invalid./x",
+            "https://parity.invalid/x",
+            "https://sub.parity.invalid/x",
+        ];
+
+        let real = GuardedHttpClient::new(Arc::new(SecurityPolicy::default()), allowed.clone());
+        for url in cases {
+            let request = json!({ "method": "GET", "url": url });
+            let live = real.request(request.clone(), None).await;
+            let guard_refused = matches!(
+                &live,
+                Err(EngineError::Capability(message))
+                    if message.contains("allowed websites")
+                        || message.contains("Blocked local/private host")
+                        || message.contains("URL userinfo")
+                        || message.contains("IPv6 hosts are not supported")
+            );
+            assert!(
+                !guard_refused,
+                "{url} must pass the real guard for this comparison to mean anything: {live:?}"
+            );
+
+            let dry = DryRunHttp::new(allowed.clone())
+                .request(request, None)
+                .await;
+            assert!(
+                dry.is_ok(),
+                "the real guard allows {url} but the dry run refused it — a dry run \
+                 stricter than the guard blocks a graph that would run: {dry:?}"
             );
         }
     }

--- a/src/workflows/caps/http.rs
+++ b/src/workflows/caps/http.rs
@@ -136,7 +136,8 @@ fn parse_http_output(output: &str) -> (Value, String) {
 /// Decided — pure functions of the URL and the company's own config, answerable
 /// without performing anything:
 ///
-/// * the scheme (only `http`/`https` reach the real client at all);
+/// * the shape of the URL — scheme, whitespace, userinfo, an IPv6 literal —
+///   each of which the real guard refuses before it reads a host at all;
 /// * a **private / loopback / link-local literal** in the URL, which the real
 ///   guard refuses *regardless of the company's allowlist*;
 /// * the company's [`web_allowed_domains`] list, when it is unambiguous.
@@ -157,13 +158,36 @@ fn parse_http_output(output: &str) -> (Value, String) {
 /// malformed allowlist, an unparseable URL — this returns `None` and checks
 /// nothing rather than guessing.
 ///
+/// That invariant held only by inspection until #1075, and inspection had already
+/// missed a break: allowlist *entries* were normalized with
+/// `trim_end_matches('.')` while the **host** was not, so `https://example.com./x`
+/// against `["example.com"]` was refused here and allowed by the real guard —
+/// exactly the blocked-working-graph failure the paragraph above rules out.
+///
 /// `dry_run_refusal_matches_the_real_client` pins the agreement **behaviourally**,
 /// by driving the same URLs through [`GuardedHttpClient`], so this stays correct
 /// when upstream changes its internals rather than only when someone re-reads
-/// them.
+/// them. It is two-directional as of #1075: a one-directional "both refuse"
+/// comparison structurally cannot see this copy becoming *too strict*, which is
+/// why the trailing-dot break survived it.
 pub(super) fn preflight_refusal(request: &Value, allowed_domains: &[String]) -> Option<String> {
     let url = request.get("url")?.as_str()?.trim();
-    let host = host_of(url)?;
+
+    // The real guard refuses all three before it reads a host.
+    if url.is_empty() {
+        return Some("URL cannot be empty".to_string());
+    }
+    if url.chars().any(char::is_whitespace) {
+        return Some("URL cannot contain whitespace".to_string());
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Some("Only http:// and https:// URLs are allowed".to_string());
+    }
+
+    let host = match host_of(url) {
+        Ok(host) => host,
+        Err(reason) => return Some(reason.to_string()),
+    };
 
     if is_private_or_local_host(&host) {
         return Some(format!("Blocked local/private host: {host}"));
@@ -194,21 +218,41 @@ pub(super) fn preflight_refusal(request: &Value, allowed_domains: &[String]) -> 
     (!allowed).then(|| format!("URL not in allowed domains: {host}"))
 }
 
-/// The host of an `http`/`https` URL, lowercased, without port or brackets
-/// stripped — `None` for anything this cannot read, which checks nothing.
-fn host_of(url: &str) -> Option<String> {
+/// The host of an `http`/`https` URL as the real guard's `extract_host` reads
+/// it: lowercased, port stripped, **trailing dot stripped**, and rejected —
+/// not read past — when the authority carries userinfo or an IPv6 literal.
+///
+/// Every `Err` is a rule the real guard applies before the allowlist, so the
+/// message is its message. This used to read past userinfo and unwrap IPv6
+/// brackets (a *missing* refusal) and to leave a trailing dot on the host
+/// (a *false* refusal, since [`normalize`] strips one from allowlist entries).
+/// See #1075.
+fn host_of(url: &str) -> Result<String, &'static str> {
     let rest = url
         .strip_prefix("http://")
-        .or_else(|| url.strip_prefix("https://"))?;
-    let authority = rest.split(['/', '?', '#']).next()?;
-    // Userinfo is not part of the host; `user@host` must not read as a host.
-    let authority = authority.rsplit('@').next()?;
-    let host = match authority.strip_prefix('[') {
-        // IPv6 literal: the port sits after the closing bracket.
-        Some(inner) => inner.split(']').next()?.to_string(),
-        None => authority.split(':').next()?.to_string(),
-    };
-    (!host.is_empty()).then(|| host.to_lowercase())
+        .or_else(|| url.strip_prefix("https://"))
+        .ok_or("Only http:// and https:// URLs are allowed")?;
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    if authority.is_empty() {
+        return Err("URL must include a host");
+    }
+    if authority.contains('@') {
+        return Err("URL userinfo is not allowed");
+    }
+    if authority.starts_with('[') {
+        return Err("IPv6 hosts are not supported in http_request");
+    }
+    let host = authority
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('.')
+        .to_lowercase();
+    if host.is_empty() {
+        return Err("URL must include a valid host");
+    }
+    Ok(host)
 }
 
 /// Mirrors the real guard's allowlist entry normalization.


### PR DESCRIPTION
## Summary

`preflight_refusal` in `src/workflows/caps/http.rs` is a hand copy of openhuman's
private `url_guard` predicates — it exists only because `mod url_guard;` is private
upstream (`src/openhuman/tools/impl/network/mod.rs:14`) and a dry run performs
nothing, so it cannot call `HttpRequestTool` to get the guard's verdict.

The copy had already drifted, **including once in the direction the module header
explicitly rules out**. This is a live false refusal on `main`, not a future risk.

**The defect.** `host_of` did not trim a trailing dot from the **host**, while
`normalize` trims one from allowlist **entries** (`http.rs:224`, mirroring
upstream's `normalize_domain:205`). Upstream's `extract_host:220-255` trims both.
So with `web_allowed_domains = ["example.com"]` and node URL
`https://example.com./x`:

| | verdict |
|---|---|
| real guard | `extract_host` trims the dot → `example.com` matches → **allowed** |
| dry run | host stays `example.com.` → **`URL not in allowed domains: example.com.`** |

A fully-qualified trailing dot is legal and appears in real configuration, so Test
run blocked a graph that runs — and an operator cannot tell that from a genuine
refusal without arming it, which is the whole point of the control.

**Three further divergences**, all in the safer *missing refusal* direction: the
copy read past userinfo with `rsplit('@')` and unwrapped IPv6 brackets where
upstream bails outright, and it refused neither a non-http scheme nor whitespace
even though the module header claims the scheme is decided here.

**Why nothing caught it.** `dry_run_refusal_matches_the_real_client`
(`dry_run.rs:343-374`) asserts, for six URLs, that the real client refuses **and**
the dry run refuses. It is one-directional: it proves the dry run is not too
*permissive*, and contains no case where the real client allows, so it structurally
cannot see the dry run becoming too *strict*. That is the failure mode the test
exists to prevent.

### What changed

- `host_of` now mirrors `extract_host` exactly — trailing dot trimmed off the host,
  userinfo and IPv6 literals rejected outright rather than parsed past, each with
  upstream's own wording. It returns `Result<String, &'static str>` instead of
  `Option<String>`, because "the guard refuses this" and "this is unreadable here"
  are different answers and the old signature collapsed them.
- `preflight_refusal` mirrors `validate_url`'s preamble (empty / whitespace /
  scheme), which the header already claimed was decided here.
- `dry_run_refusal_matches_the_real_client` gains an open-allowlist block covering
  the URL-shape refusals, and a **new second direction**:
  `dry_run_does_not_refuse_what_the_real_client_allows`.

### Scope, and what this is not

This is the fallback the issue names, **not** its resolution. The copy exists only
because `url_guard` is private, and it should be deleted — `preflight_refusal`
collapsing to `validate_url(url, allowed_domains).err().map(|e| e.to_string())` —
once upstream exports the predicates. That needs openhuman to move first, and
nothing was filed there, so I opened **tinyhumansai/openhuman#5589** asking for a
narrow `pub use` façade over the DNS-free half (deliberately excluding
`validate_url_with_dns_check`, since resolving is a network effect a dry run must
not perform). The OpenCompany deletion then follows a submodule pin bump; it is not
in this PR.

Deliberately left as-is: the **fail-closed sentinel**. Upstream substitutes
`<misconfigured-allowlist>` when every entry is malformed and then refuses
everything (`normalize_allowed_domains:176-186`); the copy returns `None` and checks
nothing (`http.rs:180-186`). That is the safe direction, it is deliberate and
documented in place, and it disappears on its own once `validate_url` is the single
implementation.

## API Or Behavior Changes

Dry-run behavior only — no public API, no live request path. The real client is
untouched; `GuardedHttpClient` still routes everything through openhuman's guard.

- Test run **no longer refuses** a URL whose host carries a trailing dot when the
  bare host is allowlisted (`https://example.com./x` vs `["example.com"]`). This is
  the fix.
- Test run **now refuses** four shapes it used to wave through, each of which the
  real run refuses: `user@host` userinfo, an IPv6 literal, a private-IP literal
  written with a trailing dot (`http://127.0.0.1./`), and a non-http(s) scheme.
  A node aimed at any of these was already failing on the real run; it now fails on
  Test run too, in the same shape and with upstream's wording.

## Tests

Run on the feature lane — `src/workflows/` is gated behind `feature = "openhuman"`
(`src/lib.rs:66`), so a default-feature run compiles none of the changed code.

- [x] `cargo fmt --all -- --check` — pass.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI does, `cargo clippy
      --locked --no-deps --features openhuman,tinycortex --all-targets -- -D
      warnings`: pass (the bare form fails on vendored-dependency lints CI never
      reaches).
- [x] `cargo build --all-targets` — N/A as written; `cargo check --locked --features
      openhuman,tinycortex --lib` was run instead (pass). A full `--all-targets`
      build of this tree is what the `cargo test --tests` run below already links.
- [x] `cargo test` — ran as `cargo test --locked --features openhuman,tinycortex
      --tests`: **4438 + 10 + 1 + 2 + 11 + 2 passed, 0 failed**, 3 ignored.

**Both new directions were proven against the reverted fix.** With
`src/workflows/caps/http.rs` stashed and only the new tests in place:

```
dry_run_does_not_refuse_what_the_real_client_allows ... FAILED
  the real guard allows https://parity.invalid./x but the dry run refused it
  — Err(Capability("http_request: URL not in allowed domains: parity.invalid."))

dry_run_refusal_matches_the_real_client ... FAILED
  PROOF-RUN missing refusals: ["https://user@example.com/x",
    "http://[2606:4700::1111]/x", "http://127.0.0.1./", "ftp://example.com/x"]
```

(the second line is from a one-off run with the per-case assert swapped for an
accumulator, so every open-allowlist case is shown failing rather than just the
first; the accumulator was not committed). Both pass with the fix restored.

**On the new test making no request.** The real client cannot be driven all the way
to "allowed" without issuing the request, which this suite may not do. So the
allow-direction host is an RFC 2606 `.invalid` name: it clears every guard rule and
the run then stops at DNS resolution, which cannot succeed — no connection is ever
made. The assertion is "the guard did not refuse it", which is exactly the claim
under test.

Frontend: N/A — no frontend files touched, no user-facing strings, no i18n keys.

## Documentation

N/A as a separate doc change — the rationale lives in the module's own doc comments,
which are the documentation for this code and were updated in place: the "never
stricter than the real guard" section now records that the invariant was broken by
inspection alone and why a one-directional parity test could not see it, and
`host_of`'s doc names each rule it mirrors.

Closes #1075
