### PR TITLE
console: link teammates on the Company page to their detail page

### DIFF
--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -19,9 +19,11 @@ import {
   useRef,
   useState,
   type DragEvent,
+  type ReactNode,
 } from "react";
 import {
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   Crown,
   Plus,
@@ -69,6 +71,30 @@ import {
 } from "@/views/chat/AddMemberDialog";
 
 const SEAT_MIME = "application/x-opencompany-seat";
+
+/**
+ * Where a teammate named on this chart opens: `#/team/<agentId>`, the sub-page
+ * `TeamView` already routes to `AgentDetailView` (issue #1102).
+ *
+ * A **link**, not a click handler on a `div`. The console routes on the hash,
+ * so an `<a href>` is the real address: middle-click and cmd-click open a
+ * second console, the browser shows the target on hover, and the keyboard
+ * reaches it without this file re-implementing Enter/Space and a focus ring.
+ *
+ * The id is the one the desk itself names — `OrgSeat.id` is `DeskDto.members[i]`
+ * and `TeamMember.id` is the roster id, and `buildOrgTree` resolves the seat by
+ * matching those two. That is exactly the id `AgentDetailView` asks the host
+ * for, so no translation is needed here — and none should be invented.
+ *
+ * `null` for an id that is blank or missing, which is the whole point of
+ * routing through this function: a teammate with no usable id must render as
+ * plain text rather than as a link to `#/team/undefined`, which is a page that
+ * cannot exist and would report the teammate as deleted.
+ */
+function teamHref(agentId: string | null | undefined): string | null {
+  const id = agentId?.trim();
+  return id ? `#/team/${encodeURIComponent(id)}` : null;
+}
 
 interface Props {
   client: OpenCompanyClient;
@@ -746,6 +772,40 @@ function Seat({
     if (sourceDeskId === deskId && Number.isInteger(fromIndex)) onDrop(index);
   }
 
+  // Where this seat opens, or `null` when it opens nowhere. A seat the roster
+  // cannot resolve is deliberately *not* a link: `#/team/<id>` for an id the
+  // host has never heard of lands on the detail view's "no such teammate"
+  // state, so offering the link would send the operator to a dead end to
+  // discover what the badge beside the name already says.
+  const href = seat.known ? teamHref(seat.id) : null;
+
+  const label = (
+    <>
+      {seat.lead && (
+        <Crown
+          role="img"
+          aria-label="Desk lead"
+          className="size-3.5 shrink-0 text-muted-foreground"
+        />
+      )}
+      <span className={cn("truncate", !seat.known && "text-muted-foreground")}>
+        {seat.name}
+      </span>
+      {seat.role && (
+        <span className="truncate text-xs text-muted-foreground">
+          {seat.role}
+        </span>
+      )}
+      {/* A seat naming somebody the roster no longer has. Shown, not hidden:
+          it is a fact about the structure only the operator can fix. */}
+      {!seat.known && (
+        <Badge variant="outline" className="shrink-0 text-3xs">
+          Not on the roster
+        </Badge>
+      )}
+    </>
+  );
+
   return (
     <div
       role="treeitem"
@@ -761,32 +821,27 @@ function Seat({
         busy && "opacity-50",
       )}
     >
-      <span className="flex min-w-0 items-center gap-1.5">
-        {seat.lead && (
-          <Crown
-            role="img"
-            aria-label="Desk lead"
-            className="size-3.5 shrink-0 text-muted-foreground"
-          />
-        )}
-        <span
-          className={cn("truncate", !seat.known && "text-muted-foreground")}
+      {href ? (
+        <a
+          href={href}
+          title={`Open ${seat.name}`}
+          // The name is the target, not the whole row: the row is the drag
+          // handle for re-ordering, and a full-row link would make every
+          // attempt to drag a seat read as a click on it.
+          //
+          // `draggable={false}` so a drag that starts on the name is not the
+          // browser's own drag-a-link gesture — it falls through to the row,
+          // which is the draggable ancestor, and re-ordering keeps working
+          // from anywhere on the seat.
+          draggable={false}
+          className="-mx-1 flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-1 outline-none hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50"
         >
-          {seat.name}
-        </span>
-        {seat.role && (
-          <span className="truncate text-xs text-muted-foreground">
-            {seat.role}
-          </span>
-        )}
-        {/* A seat naming somebody the roster no longer has. Shown, not hidden:
-            it is a fact about the structure only the operator can fix. */}
-        {!seat.known && (
-          <Badge variant="outline" className="shrink-0 text-3xs">
-            Not on the roster
-          </Badge>
-        )}
-      </span>
+          {label}
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+        </a>
+      ) : (
+        <span className="flex min-w-0 items-center gap-1.5">{label}</span>
+      )}
       <span className="flex shrink-0 items-center gap-0.5">
         {/* Moving the second seat up is how the lead changes: `members[0]` IS
             the lead, so there is no separate set-lead call to make. */}
@@ -854,14 +909,33 @@ function Unplaced({ tree }: { tree: OrgTree }) {
             desk above.
           </p>
           <ul className="flex flex-wrap gap-1.5">
-            {tree.unassigned.map((member) => (
-              <li
-                key={member.id}
-                className="rounded-md border px-2 py-1 text-xs"
-              >
-                {member.name}
-              </li>
-            ))}
+            {tree.unassigned.map((member) => {
+              // These chips name roster teammates, so they open the same page
+              // a seat does (issue #1102) — they were the worse half of that
+              // bug, bordered pills that read as controls and did nothing.
+              const href = teamHref(member.id);
+              return (
+                <li key={member.id}>
+                  {href ? (
+                    <a
+                      href={href}
+                      title={`Open ${member.name}`}
+                      className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs outline-none hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50"
+                    >
+                      {member.name}
+                      <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
+                    </a>
+                  ) : (
+                    // No usable id, so there is nothing to open. Rendered flat
+                    // rather than as a pill: the border is what made the inert
+                    // version of this chip a lie.
+                    <InertChip title="This teammate has no id, so their page can't be opened.">
+                      {member.name}
+                    </InertChip>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </section>
       )}
@@ -873,20 +947,47 @@ function Unplaced({ tree }: { tree: OrgTree }) {
             declares no desk for a person, and this chart does not guess one.
           </p>
           <ul className="flex flex-wrap gap-1.5">
+            {/* Deliberately inert, and styled to say so (issue #1102). A person
+                is a console user, not an agent: `#/team/<id>` resolves against
+                the roster, so pointing a person's id at it would 404 every
+                time. There is no person detail page to link to instead, so the
+                pill treatment is dropped rather than left promising one. */}
             {tree.people.map((person) => (
-              <li
-                key={person.id}
-                className="rounded-md border px-2 py-1 text-xs"
-              >
-                {person.name}
-                <span className="ml-1.5 text-muted-foreground">
-                  {person.role}
-                </span>
+              <li key={person.id}>
+                <InertChip title="People sign in to the console. Desks staff agents, so a person has no teammate page.">
+                  {person.name}
+                  <span className="ml-1.5">{person.role}</span>
+                </InertChip>
               </li>
             ))}
           </ul>
         </section>
       )}
     </div>
+  );
+}
+
+/**
+ * A name that is only a name.
+ *
+ * Filled and borderless, with the muted foreground a caption uses: the outlined
+ * pill it replaces was indistinguishable from an outline button, which is why
+ * #1102 reports these as clicked and inert. Nothing here reacts to a pointer —
+ * no hover, no cursor change, no focus ring — because nothing here happens.
+ */
+function InertChip({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      title={title}
+      className="inline-block rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground"
+    >
+      {children}
+    </span>
   );
 }

--- a/frontend/src/views/company/README.md
+++ b/frontend/src/views/company/README.md
@@ -63,6 +63,38 @@ Here it is a fact about the structure that only the operator can fix.
 That divergence is **load-bearing**, not incidental: it is the reason membership
 editing lives here and not on the member pane. See below.
 
+## A teammate on the chart opens (#1102)
+
+Every name this surface draws is a link to `#/team/<agentId>` — the sub-page
+`TeamView` has routed to `AgentDetailView` since #264. Before this the chart
+drew teammates and wired none of them: a seat's name was plain text, and the
+**Not on a desk** chips were bordered pills with no `href`, no handler and no
+tooltip. The destination was never missing; only the link was.
+
+Three decisions, so they are not re-argued:
+
+**A real `<a href>`, never a `div` with an `onClick`.** The console routes on
+the hash, so the hash *is* the address. An anchor gets middle-click, cmd-click,
+the browser's own hover preview of the target, and keyboard reach with a focus
+ring — none of which a handler on a `div` gets without re-implementing all four.
+
+**The name is the target, not the whole row.** The seat row is the drag handle
+for re-ordering. A full-row link would make every attempt to drag a seat read as
+a click on it, so the anchor is the name (with a chevron), and it carries
+`draggable={false}` so a drag starting on it falls through to the row.
+
+**A seat the roster cannot resolve is not linked.** `#/team/<id>` for an id the
+host has never heard of lands on the detail view's "no such teammate" state —
+a dead end that only repeats what the badge beside the name already says.
+
+The **People** chips are the deliberate exception, and they say so in their
+styling. A person is a console user, not an agent: `#/team/<id>` resolves
+against the roster, and there is no person detail page to link to instead. So
+the pill treatment is dropped — a filled, borderless label with a `title`
+explaining what it is — rather than left promising a page that does not exist.
+`teamHref()` is the one place an id becomes an address, and it answers `null`
+for a blank one, so no chip can render `#/team/undefined`.
+
 ## How chat reaches this surface (#485)
 
 `#/company/<deskId>` opens the chart with that desk scrolled to, focused, and
@@ -112,6 +144,11 @@ provenance, the unresolvable seat, the unplaced roster, and the cap.
 `test/e2e/org-tree.spec.ts` covers the surface in a browser, including the
 reachability failure this issue is about, and asserts every write survives a
 reload against a stateful stub.
+`test/unit/org-chart-teammate-links.test.ts` renders the chart and reads the
+DOM for #1102: the failure was invisible to every derivation test above, because
+`buildOrgTree` was correct the whole time the surface was inert. It pins the
+`href` rather than a handler — a `div` with an `onClick` would type-check, look
+identical and still break middle-click, cmd-click and the keyboard.
 
 ## Deliberately not here
 

--- a/frontend/src/views/company/README.md
+++ b/frontend/src/views/company/README.md
@@ -65,11 +65,14 @@ editing lives here and not on the member pane. See below.
 
 ## A teammate on the chart opens (#1102)
 
-Every name this surface draws is a link to `#/team/<agentId>` — the sub-page
-`TeamView` has routed to `AgentDetailView` since #264. Before this the chart
-drew teammates and wired none of them: a seat's name was plain text, and the
-**Not on a desk** chips were bordered pills with no `href`, no handler and no
-tooltip. The destination was never missing; only the link was.
+Every **roster teammate** this surface names — a staffed seat the roster
+resolves, and a **Not on a desk** chip — is a link to `#/team/<agentId>`, the
+sub-page `TeamView` has routed to `AgentDetailView` since #264. The two
+exceptions are deliberate and are set out below: a seat the roster cannot
+resolve, and the **People** chips. Before this the chart drew teammates and
+wired none of them: a seat's name was plain text, and the chips were bordered
+pills with no `href`, no handler and no tooltip. The destination was never
+missing; only the link was.
 
 Three decisions, so they are not re-argued:
 

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -237,6 +237,23 @@ async function mockApi(page: Page) {
       return json(created, 201);
     }
     if (path.endsWith("/team")) return json(roster);
+    // GET .../team/{agentId} — the detail page the chart's teammate links open
+    // (issue #1102). Stubbed so following one lands on a real screen rather
+    // than on the catch-all's `[]`, which is an agent with none of its fields.
+    const agent = path.match(/\/team\/([^/]+)$/);
+    if (agent && method === "GET") {
+      const found = roster.find((m) => m.id === agent[1]);
+      if (!found) return json({ error: "no such teammate" }, 404);
+      return json({
+        ...found,
+        source: "manifest",
+        editable: [],
+        isOrchestrator: false,
+        tools: { requested: [], companyAllow: [], effective: [] },
+        desks: [],
+        inboxEnabled: false,
+      });
+    }
     if (path.endsWith("/users")) {
       return json([
         {
@@ -872,4 +889,57 @@ test("#311 a seat naming nobody on the roster is shown, not hidden", async ({
   await expect(seats).toHaveCount(2);
   await expect(seats.nth(1)).toContainText("ghost");
   await expect(seats.nth(1)).toContainText("Not on the roster");
+});
+
+test("#1102 a teammate on the chart opens their detail page", async ({
+  page,
+}) => {
+  await mockApi(page);
+  await openChart(page);
+
+  // A **link**, not a handler: the address has to be on the element, because
+  // that is what makes middle-click, cmd-click, the keyboard and the browser's
+  // own hover preview work. `toHaveAttribute` is the assertion a `div` with an
+  // `onClick` — the shape this issue warns against — could never pass.
+  const grace = deskNode(page, "Engineering")
+    .locator('[role="treeitem"][aria-level="3"]')
+    .first()
+    .getByRole("link", { name: "Grace" });
+  await expect(grace).toHaveAttribute("href", "#/team/grace");
+  await grace.click();
+  await expect.poll(() => page.url()).toContain("#/team/grace");
+  await expect(
+    page.getByRole("button", { name: "Back to team" }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // The chips under "Not on a desk" name the same teammates and were the worse
+  // half of #1102 — bordered pills that read as controls and did nothing.
+  await openChart(page);
+  const unplaced = page
+    .locator("section", {
+      has: page.getByRole("heading", { name: "Not on a desk" }),
+    })
+    .last();
+  const turing = unplaced.getByRole("link", { name: "Turing" });
+  await expect(turing).toHaveAttribute("href", "#/team/turing");
+  await turing.click();
+  await expect.poll(() => page.url()).toContain("#/team/turing");
+});
+
+test("#1102 a seat naming nobody on the roster is not offered as a link", async ({
+  page,
+}) => {
+  reset();
+  desks[0].members = ["grace", "ghost"];
+  await mockApi(page);
+  await openChart(page);
+
+  // `#/team/ghost` is a dead end that only repeats the badge beside the name,
+  // so the ghost seat stays text. The link on the seat above it is the teeth:
+  // without it this would pass on a chart that linked nothing at all.
+  const seats = deskNode(page, "Engineering").locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
+  await expect(seats.first().getByRole("link")).toHaveCount(1);
+  await expect(seats.nth(1).getByRole("link")).toHaveCount(0);
 });

--- a/frontend/test/unit/org-chart-teammate-links.test.ts
+++ b/frontend/test/unit/org-chart-teammate-links.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DeskDto, TeamMemberDto } from "@/api/types";
+import { OrgChartView } from "@/views/company/OrgChartView";
+
+/**
+ * Teammates on the Company page open (issue #1102).
+ *
+ * The chart drew every teammate it knew about and wired none of them: a staffed
+ * row's name was plain text, and the "Not on a desk" chips were bordered pills
+ * with no `href`, no handler and no tooltip — every visual signal of a control
+ * and none of the behaviour. `AgentDetailView` had existed at `#/team/<agentId>`
+ * since #264, so the destination was never missing; only the link was.
+ *
+ * These assertions read the DOM the operator actually gets, because the failure
+ * is invisible to a type check and to every derivation test in
+ * `org-tree.test.ts`: `buildOrgTree` was already correct, and stayed correct,
+ * the whole time the surface was inert. What has to be pinned is that the
+ * element is an **anchor with a real href** — not a `div` with an `onClick`,
+ * which would type-check, look identical, and still break middle-click,
+ * cmd-click, keyboard focus and the browser's own hover preview.
+ */
+
+function desk(over: Partial<DeskDto> & Pick<DeskDto, "id" | "name">): DeskDto {
+  return { members: [], ...over } as DeskDto;
+}
+
+function member(id: string, name: string, role = "Analyst"): TeamMemberDto {
+  return { id, name, role };
+}
+
+/** A fake host: desks, roster, users and status, and nothing else. */
+function client(over: {
+  desks?: DeskDto[];
+  team?: TeamMemberDto[];
+  users?: { id: string; email: string; displayName?: string; role: string }[];
+}): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    listDesks: vi.fn().mockResolvedValue(over.desks ?? []),
+    listTeam: vi.fn().mockResolvedValue(over.team ?? []),
+    get: vi.fn().mockResolvedValue(over.users ?? []),
+    status: vi.fn().mockResolvedValue({ name: "Acme" }),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(host: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(OrgChartView, { client: host, company: "acme" }));
+  });
+  // The chart's four reads resolve as one `Promise.all`, but the state it sets
+  // lands a tick later; give React that tick rather than assuming one flush.
+  await act(async () => {});
+}
+
+/** Every anchor on the page, as `[text, href]`. */
+function links(): [string, string][] {
+  return [...container.querySelectorAll("a")].map((a) => [
+    a.textContent ?? "",
+    a.getAttribute("href") ?? "",
+  ]);
+}
+
+/** The anchor whose text names `who`, or `undefined` when they are not linked. */
+function linkFor(who: string): [string, string] | undefined {
+  return links().find(([text]) => text.includes(who));
+}
+
+describe("a staffed seat", () => {
+  it("is an anchor to that teammate's detail page", async () => {
+    await render(
+      client({
+        desks: [desk({ id: "research", name: "Research Desk", members: ["maya", "ravi"] })],
+        team: [member("maya", "Maya", "Research Lead"), member("ravi", "Ravi")],
+      }),
+    );
+
+    // The href is the whole assertion: the id routed on is the desk's own
+    // member id, which is the id `AgentDetailView` resolves against the host.
+    expect(linkFor("Maya")?.[1]).toBe("#/team/maya");
+    expect(linkFor("Ravi")?.[1]).toBe("#/team/ravi");
+  });
+
+  it("does not swallow the row's drag handle", async () => {
+    await render(
+      client({
+        desks: [desk({ id: "research", name: "Research Desk", members: ["maya"] })],
+        team: [member("maya", "Maya", "Research Lead")],
+      }),
+    );
+
+    // Re-ordering a desk is a drag on the row. A link is draggable by default,
+    // and the browser's drag-a-link gesture would take precedence over the
+    // row's — so the anchor opts out and the drag falls through to the row.
+    const anchor = container.querySelector<HTMLAnchorElement>('a[href="#/team/maya"]');
+    expect(anchor?.getAttribute("draggable")).toBe("false");
+    expect(container.querySelector('[data-seat-id="maya"]')?.getAttribute("draggable")).toBe(
+      "true",
+    );
+  });
+
+  it("leaves a seat the roster cannot resolve unlinked", async () => {
+    await render(
+      client({
+        desks: [desk({ id: "research", name: "Research Desk", members: ["ghost"] })],
+        team: [],
+      }),
+    );
+
+    // `#/team/ghost` would land on "no such teammate" — a dead end that only
+    // repeats what the badge beside the name already says.
+    expect(container.textContent).toContain("Not on the roster");
+    expect(linkFor("ghost")).toBeUndefined();
+  });
+});
+
+describe("a Not-on-a-desk chip", () => {
+  it("is an anchor to the same detail page a seat links to", async () => {
+    await render(
+      client({
+        desks: [desk({ id: "research", name: "Research Desk", members: ["maya"] })],
+        team: [
+          member("maya", "Maya", "Research Lead"),
+          member("priya", "Priya"),
+          member("sam", "Sam"),
+        ],
+      }),
+    );
+
+    expect(container.textContent).toContain("Not on a desk");
+    expect(linkFor("Priya")?.[1]).toBe("#/team/priya");
+    expect(linkFor("Sam")?.[1]).toBe("#/team/sam");
+  });
+
+  it("never renders #/team/undefined for a teammate with no id", async () => {
+    await render(
+      client({
+        desks: [],
+        team: [member("", "Nameless id")],
+      }),
+    );
+
+    // The guard this test exists for: an id-less teammate must be flat text
+    // with an explanation, not a pill pointing at a page that cannot exist.
+    expect(links().map(([, href]) => href)).not.toContain("#/team/undefined");
+    expect(linkFor("Nameless id")).toBeUndefined();
+    expect(container.textContent).toContain("Nameless id");
+  });
+});
+
+describe("a People chip", () => {
+  it("is inert, and drops the pill treatment that said otherwise", async () => {
+    await render(
+      client({
+        desks: [],
+        team: [],
+        users: [{ id: "u1", email: "dana@acme.test", displayName: "Dana", role: "admin" }],
+      }),
+    );
+
+    expect(container.textContent).toContain("Dana");
+    // A person is a console user, not an agent: `#/team/u1` would 404, and
+    // there is no person page to link to instead. So it must not be a link —
+    // and must not keep the border that made the inert version read as one.
+    expect(linkFor("Dana")).toBeUndefined();
+    const chip = [...container.querySelectorAll("span[title]")].find((el) =>
+      el.textContent?.includes("Dana"),
+    );
+    expect(chip?.className).not.toContain("border");
+    expect(chip?.getAttribute("title")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #1102

## Summary

Teammates on the Company page were drawn but never wired. A staffed seat's name
was plain text on a `div`; the **Not on a desk** chips were bordered pills with
no `href`, no handler and no `title` — every visual signal of a control and none
of the behaviour, which is why they get clicked. `AgentDetailView` has answered
`#/team/<agentId>` since #264, so the destination was never missing, only the
link.

```
BEFORE                           AFTER
│ Research Desk            │     │ Research Desk            │
│  ● Maya  Research Lead   │ ←   │  ● Maya  Research Lead › │ ← link → #/team/maya
│  ● Ravi  Analyst         │ nil │  ● Ravi  Analyst       › │   hover: bg + cursor
│ Not on a desk            │     │ Not on a desk            │
│  ( Priya ) ( Sam )       │ ←   │  [Priya ›] [Sam ›]       │ ← same target
```

## Decisions

**Real `<a href>`, never a `div` with an `onClick`.** The console routes on the
hash, so the hash *is* the address: an anchor gets middle-click, cmd-click, the
browser's own hover preview of the target, and keyboard reach with a focus ring
— none of which a handler on a `div` gets without re-implementing all four.

**The name is the target, not the whole row.** The seat row is the drag handle
for re-ordering (#839), and a full-row link would make every attempt to drag a
seat read as a click. The anchor carries `draggable={false}` so a drag starting
on the name falls through to the row and re-ordering keeps working.

**The id is the desk's own member id**, which is what `buildOrgTree` resolves
the seat against and exactly what `AgentDetailView` asks the host for — no
translation invented here. `teamHref()` is the single place an id becomes an
address and answers `null` for a blank one, so nothing can render
`#/team/undefined`.

**A seat the roster cannot resolve is not linked.** `#/team/<id>` for an id the
host has never heard of lands on the detail view's "no such teammate" state — a
dead end that only repeats what the "Not on the roster" badge already says.

**The People chips are deliberately inert, and now look it.** A person is a
console user, not an agent: `#/team/<id>` resolves against the roster and would
404 every time, and there is no person detail page to link to instead. So the
pill treatment is dropped — a filled, borderless label with a `title` explaining
what it is — rather than left promising a page that does not exist. That is the
issue's third option, chosen explicitly.

## Commands run locally

| | |
|---|---|
| `npm run typecheck` | pass |
| `npm run typecheck:unit` | pass |
| `npm run typecheck:e2e` | pass |
| `npm test` | 116 files, 1126 tests, pass |
| `npm run build` | pass |
| `./scripts/ci/assert-design-tokens.sh` | pass |
| `./scripts/ci/assert-md-line-cap.sh` | pass |

## Tests

`frontend/test/unit/org-chart-teammate-links.test.ts` renders the real chart
against a fake host and reads the DOM: a staffed seat is an anchor to
`#/team/maya`, a chip is an anchor to `#/team/priya`, the ghost seat is not a
link, an id-less teammate never produces `#/team/undefined`, and a People chip
is inert with no border. It pins the `href` rather than a handler, because a
`div` with an `onClick` would type-check, look identical and still break
middle-click, cmd-click and the keyboard.

`frontend/test/e2e/org-tree.spec.ts` gains two browser cases — following a seat
link and a chip link lands on the detail page — plus a stub for
`GET .../team/{agentId}` so the click lands on a real screen.

## Behaviour changes

Frontend only. No API change. The only visual change beyond the new chevron and
hover state is the People chips losing their border.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart names now link directly to teammate detail pages.
  * Unplaced teammates also link to their detail pages.
  * Links remain compatible with row dragging.

* **Bug Fixes**
  * Unknown or invalid teammate IDs no longer create broken links.
  * Unresolved seats and People chips are clearly shown as non-clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->