### PR TITLE
console: one word for a teammate

### DIFF
--- a/frontend/src/api/memory.ts
+++ b/frontend/src/api/memory.ts
@@ -93,7 +93,7 @@ export const CONTEXT_ORIGINS: Exclude<MemoryOrigin, "fact">[] = ["agent-memory",
 /** Human labels for each origin, for badges and the type filter. */
 export const ORIGIN_LABELS: Record<MemoryOrigin, string> = {
   fact: "Fact",
-  "agent-memory": "Agent memory",
+  "agent-memory": "Teammate memory",
   "task-outcome": "Task outcome",
 };
 

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -40,7 +40,7 @@ export const OPERATOR_ORIGIN: WorkspaceOrigin = { kind: "operator" };
 export function originLabel(origin: WorkspaceOrigin | undefined): string | null {
   switch (origin?.kind) {
     case "agent":
-      return `Agent · ${origin.id}`;
+      return `Teammate · ${origin.id}`;
     case "seed":
       return "Seeded";
     default:

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1112,7 +1112,7 @@ export function AppShell({
       // An approve needs no line: the continuation lands as a real reply, which
       // is the whole point of deciding here.
       if (verdict === "deny") {
-        noteInChannel(approval.thread, "Declined — the agent will not take that action.");
+        noteInChannel(approval.thread, "Declined — the teammate will not take that action.");
       }
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : "something went wrong";

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -119,7 +119,7 @@ export function ApprovalMeta({
   approval: ApprovalSummary;
   now: number;
   askerNames: Map<string, string>;
-  /** Trailing status text ("Waiting for the agent…", "Approved"), if any. */
+  /** Trailing status text ("Waiting for the teammate…", "Approved"), if any. */
   status?: React.ReactNode;
 }) {
   const taskId = a.task?.link === "task" ? a.task.id : null;

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -173,7 +173,7 @@ export function PolicySettings({ client, company }: Props) {
           Approvals
         </CardTitle>
         <CardDescription>
-          How much the agents do on their own, and what they always ask about
+          How much the teammates do on their own, and what they always ask about
           first.
         </CardDescription>
       </CardHeader>

--- a/frontend/src/lib/agent.ts
+++ b/frontend/src/lib/agent.ts
@@ -18,7 +18,7 @@ export interface AgentFieldSpec {
 /**
  * The single definition of an agent's authored fields.
  *
- * Shared deliberately by "Define an agent" and the detail view's edit form: the
+ * Shared deliberately by "Define a teammate" and the detail view's edit form: the
  * two collect the same three things, and before this they would have collected
  * them under two sets of labels and placeholders that drifted apart. The host
  * accepts exactly these keys in a `PATCH`, so the list is also the client half

--- a/frontend/src/lib/approval-wording.ts
+++ b/frontend/src/lib/approval-wording.ts
@@ -25,7 +25,7 @@ export type StillAwaiting = number | undefined;
  *
  * Three states, and the middle one is the whole point:
  *
- * * `0` — this decision released the turn, so the agent really is picking it up;
+ * * `0` — this decision released the turn, so the teammate really is picking it up;
  * * `n > 0` — it did not, and the operator is told what is still owed rather
  *   than being left to watch for work that nothing has started;
  * * `undefined` — the host predates the field, so nothing is claimed about what
@@ -34,16 +34,16 @@ export type StillAwaiting = number | undefined;
 export function approvedLine(stillAwaiting: StillAwaiting, detail?: string): string {
   const suffix = detail ? `: ${detail}` : "";
   if (stillAwaiting === undefined) return `Approved — recorded${suffix}`;
-  if (stillAwaiting === 0) return `Approved — the agent is picking it up now${suffix}`;
+  if (stillAwaiting === 0) return `Approved — the teammate is picking it up now${suffix}`;
   return `Approved — waiting on ${stillAwaiting} more sign-off${
     stillAwaiting === 1 ? "" : "s"
-  } before the agent continues${suffix}`;
+  } before the teammate continues${suffix}`;
 }
 
 /**
  * The same answer for a card the runtime performs itself — a paused workflow
- * gate, a cold-recipient report (issue #395). There is no agent to re-dispatch,
- * so "the agent" must not appear; the work is still gated on the rest of the
+ * gate, a cold-recipient report (issue #395). There is no teammate to re-dispatch,
+ * so "the teammate" must not appear; the work is still gated on the rest of the
  * turn's decisions in exactly the same way.
  */
 export function approvedByRuntimeLine(stillAwaiting: StillAwaiting, detail?: string): string {

--- a/frontend/src/lib/connection-detail.ts
+++ b/frontend/src/lib/connection-detail.ts
@@ -128,7 +128,7 @@ export interface McpStanding {
  */
 export function mcpStanding(server: McpServer, health: McpHealth | undefined): McpStanding {
   const summary = !server.enabled
-    ? "turned off — no agent receives its tools"
+    ? "turned off — no teammate receives its tools"
     : server.authConfigured
       ? "on, calling with a stored credential"
       : "on, calling with no credential";

--- a/frontend/src/lib/mcp-bridge.ts
+++ b/frontend/src/lib/mcp-bridge.ts
@@ -11,7 +11,7 @@
 //
 // The three-state answer matters more than it looks. `mcpInBuild` is optional on
 // the wire: a host predating the field sends nothing, and rendering that silence
-// as "no agent can use these" would be a fresh lie in the other direction. Only
+// as "no teammate can use these" would be a fresh lie in the other direction. Only
 // an explicit `false` is absence.
 
 import type { CapabilityStatusDto } from "@/api/types";
@@ -56,6 +56,6 @@ export function mcpBridgeState(status: CapabilityStatusDto | null | undefined): 
  */
 export function mcpAddedMessage(name: string, bridge: McpBridgeState): string {
   return bridge === "absent"
-    ? `Added ${name}. It is stored, but no agent can call it until this deployment is rebuilt with the MCP bridge.`
-    : `Added ${name}. Agents pick it up on their next turn.`;
+    ? `Added ${name}. It is stored, but no teammate can call it until this deployment is rebuilt with the MCP bridge.`
+    : `Added ${name}. Teammates pick it up on their next turn.`;
 }

--- a/frontend/src/lib/workflow-node-config.ts
+++ b/frontend/src/lib/workflow-node-config.ts
@@ -510,7 +510,7 @@ export function nodeKindConfigProblem(node: {
       // take the whole validation down instead of refusing the one node).
       return typeof node.agent === "string" && node.agent.trim()
         ? null
-        : "An agent step names no teammate — set its `agent` field to a roster member (not inside `config`).";
+        : "An agent step names no teammate — set its `agent` field to a roster teammate (not inside `config`).";
     case "tool_call":
       return nonEmpty("slug")
         ? null

--- a/frontend/src/tour/steps.ts
+++ b/frontend/src/tour/steps.ts
@@ -50,14 +50,14 @@ export const TOUR: TourStop[] = [
     target: '[data-tour="nav-chat"]',
     placement: "right",
     title: "Your AI staff",
-    body: "The agents that actually do the work each have a channel and a direct message here. Open the members pane to see the whole roster.",
+    body: "The teammates that actually do the work each have a channel and a direct message here. Open the team pane to see the whole roster.",
   },
   {
     view: "workflows",
     target: '[data-tour="nav-workflows"]',
     placement: "right",
     title: "Workflows",
-    body: "Turn recurring work into a repeatable workflow — a graph of steps your agents run end to end.",
+    body: "Turn recurring work into a repeatable workflow — a graph of steps your teammates run end to end.",
   },
   {
     view: "approvals",
@@ -74,7 +74,7 @@ export const TOUR: TourStop[] = [
     target: '[data-tour="nav-settings"]',
     placement: "right",
     title: "Connect your tools",
-    body: "Plug in the tools your company already uses — Gmail, Slack, GitHub — so your agents can act for real.",
+    body: "Plug in the tools your company already uses — Gmail, Slack, GitHub — so your teammates can act for real.",
   },
   {
     view: "chat",

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -193,9 +193,9 @@ export function ApprovalsView({
       // for a one-off and for a week-long permission, and the operator has to be
       // able to tell those apart from the confirmation they just got.
       //
-      // …and only say "the agent" when there IS one (#395). A card with no
+      // …and only say "the teammate" when there IS one (#395). A card with no
       // `agent` is one the runtime performs itself — a paused workflow gate, a
-      // cold-recipient report — and naming an agent there is the same shape of
+      // cold-recipient report — and naming a teammate there is the same shape of
       // small lie the wording above exists to remove. The work is still in
       // flight either way, so both halves say so; only the actor changes.
       // Issue #561: what happens next is the host's answer, not this view's
@@ -231,7 +231,7 @@ export function ApprovalsView({
       if (mayHaveLanded(err, Date.now() - startedAt)) {
         const line =
           verdict === "approve"
-            ? "Approved — the host didn't answer in time, but your decision was recorded. The agent may still be working; no need to approve again."
+            ? "Approved — the host didn't answer in time, but your decision was recorded. The teammate may still be working; no need to approve again."
             : "Declined — the host didn't answer in time, but your decision was recorded. No need to decline again.";
         onResolved(line);
         // Neither a success nor an error: the verdict is durable, the
@@ -627,7 +627,7 @@ function ApprovalCard({
           status={
             deciding
               ? deciding === "approve"
-                ? "Waiting for the agent…"
+                ? "Waiting for the teammate…"
                 : "Recording…"
               : batchTotal > 1
                 ? // Deliberately a count and not a link: the row is decided

--- a/frontend/src/views/ArtifactsTab.tsx
+++ b/frontend/src/views/ArtifactsTab.tsx
@@ -487,8 +487,8 @@ function ArtifactDetail({
           // reading a refusal message should not have to work out why a blocker
           // is filed as a deliverable.
           <p className="mt-1.5 text-2xs italic text-muted-foreground">
-            Captured from the agent's chat reply before deliverables were published explicitly —
-            this is a record of what was said, not a file the teammate produced.
+            Captured from the teammate's chat reply before deliverables were published
+            explicitly — this is a record of what was said, not a file the teammate produced.
           </p>
         )}
         <p className="mt-2 text-2xs text-muted-foreground">
@@ -554,7 +554,7 @@ function ArtifactDetail({
       {editing ? (
         <div className="rounded-xl border bg-card p-3">
           <p className="mb-2 text-2xs text-muted-foreground">
-            Saving appends a new version authored by you. The agent's version is never
+            Saving appends a new version authored by you. The teammate's version is never
             overwritten — that is what keeps the diff answerable later.
           </p>
           <Textarea

--- a/frontend/src/views/ArtifactsTab.tsx
+++ b/frontend/src/views/ArtifactsTab.tsx
@@ -277,7 +277,7 @@ export function ArtifactsTab({
           <div className="rounded-xl border border-dashed py-10 text-center">
             <p className="text-sm font-medium">No deliverables for this task</p>
             <p className="mx-auto mt-1 max-w-sm text-xs text-muted-foreground">
-              An agent publishes a file it wrote to put it here, where you can browse, edit and
+              A teammate publishes a file it wrote to put it here, where you can browse, edit and
               version it. Plenty of tasks produce no file at all — a question answered, a check
               run — and this stays empty for those. Nothing is captured automatically, so an empty
               tab means nothing was produced, not that something was lost.
@@ -448,7 +448,7 @@ function ArtifactDetail({
       setSelected(null);
       stopEditing();
       onRefresh();
-      toast.success("Saved as a new version — the diff against the agent's draft is below.");
+      toast.success("Saved as a new version — the diff against the teammate's draft is below.");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "could not save the edit");
     } finally {
@@ -488,7 +488,7 @@ function ArtifactDetail({
           // is filed as a deliverable.
           <p className="mt-1.5 text-2xs italic text-muted-foreground">
             Captured from the agent's chat reply before deliverables were published explicitly —
-            this is a record of what was said, not a file the agent produced.
+            this is a record of what was said, not a file the teammate produced.
           </p>
         )}
         <p className="mt-2 text-2xs text-muted-foreground">
@@ -530,7 +530,7 @@ function ArtifactDetail({
             version this run produced. v{latest.version} exists
             {editedSince
               ? `, edited by ${latest.authorId || "an operator"}`
-              : `, written by ${latest.authorId || "the agent"}`}
+              : `, written by ${latest.authorId || "the teammate"}`}
             .
           </p>
           <Button
@@ -618,7 +618,7 @@ function ArtifactDetail({
       {artifact.humanEditDiff && (
         <DiffPanel
           title="What the operator changed"
-          note={`v${artifact.humanEditDiff.fromVersion} (agent) → v${artifact.humanEditDiff.toVersion} (operator)`}
+          note={`v${artifact.humanEditDiff.fromVersion} (teammate) → v${artifact.humanEditDiff.toVersion} (operator)`}
           diff={artifact.humanEditDiff}
         />
       )}

--- a/frontend/src/views/AssigneeSelect.tsx
+++ b/frontend/src/views/AssigneeSelect.tsx
@@ -134,7 +134,7 @@ export function AssigneeSelect({
         // to staff is a legitimate write. Say that it is empty; don't hide it.
         hint:
           desk.members.length === 0
-            ? "no members yet"
+            ? "no teammates yet"
             : `${desk.members.length} teammate${desk.members.length === 1 ? "" : "s"}`,
       })),
     [desks],

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -781,7 +781,7 @@ export function ChatView({
             kind: "partial",
             name: fields.name,
             missed: "their inbox couldn't be switched on.",
-            fix: "Add it from the member's actions menu.",
+            fix: "Add it from the teammate's actions menu.",
           };
         }
       }

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -522,9 +522,9 @@ export function ConnectionsView({ client, company }: Props) {
             <Info className="size-4" />
             <AlertTitle>Only an admin can change what this company connects through</AlertTitle>
             <AlertDescription>
-              A connection belongs to the company — it is the account your teammates act through — so
-              an admin manages it. You can see everything that is wired here; ask an admin to add,
-              change or remove one.
+              A connection belongs to the company — it is the account your teammates act
+              through — so an admin manages it. You can see everything that is wired here; ask an
+              admin to add, change or remove one.
             </AlertDescription>
           </Alert>
         )}

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -522,7 +522,7 @@ export function ConnectionsView({ client, company }: Props) {
             <Info className="size-4" />
             <AlertTitle>Only an admin can change what this company connects through</AlertTitle>
             <AlertDescription>
-              A connection belongs to the company — it is the account your agents act through — so
+              A connection belongs to the company — it is the account your teammates act through — so
               an admin manages it. You can see everything that is wired here; ask an admin to add,
               change or remove one.
             </AlertDescription>
@@ -579,7 +579,7 @@ export function ConnectionsView({ client, company }: Props) {
         />
 
         {/* Only renders for a provider this company holds two or more accounts
-            for — the one case where "which account do agents act as" is a
+            for — the one case where "which account do teammates act as" is a
             question the product can answer (issue #820). */}
         <AccountChoiceSection
           client={client}

--- a/frontend/src/views/InboxView.tsx
+++ b/frontend/src/views/InboxView.tsx
@@ -177,7 +177,7 @@ export function InboxView({ client, company }: Props) {
         <div className="space-y-1">
           <p className="font-medium text-foreground">No inboxes yet</p>
           <p className="max-w-sm text-sm">
-            Give an agent its own inbox from the <span className="font-medium">Team</span> page —
+            Give a teammate its own inbox from the <span className="font-medium">Team</span> page —
             flip on the inbox toggle for anyone who needs to receive email. Mail sent to that
             address shows up here.
           </p>

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -52,7 +52,7 @@ export function McpServersView({ client, company }: Props) {
         <div className="space-y-1">
           <h2 className="text-2xl font-semibold tracking-tight">MCP Servers</h2>
           <p className="text-sm text-muted-foreground">
-            The tool servers this company&apos;s agents can call, from its manifest and the ones you
+            The tool servers this company&apos;s teammates can call, from its manifest and the ones you
             add here.
           </p>
         </div>
@@ -62,7 +62,7 @@ export function McpServersView({ client, company }: Props) {
             <Info className="size-4" />
             <AlertTitle>Only an admin can change this company&apos;s tool servers</AlertTitle>
             <AlertDescription>
-              A server here hands every agent a new set of tools, so an admin adds and removes them.
+              A server here hands every teammate a new set of tools, so an admin adds and removes them.
               You can see what is installed.
             </AlertDescription>
           </Alert>

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -52,8 +52,8 @@ export function McpServersView({ client, company }: Props) {
         <div className="space-y-1">
           <h2 className="text-2xl font-semibold tracking-tight">MCP Servers</h2>
           <p className="text-sm text-muted-foreground">
-            The tool servers this company&apos;s teammates can call, from its manifest and the ones you
-            add here.
+            The tool servers this company&apos;s teammates can call, from its manifest and the
+            ones you add here.
           </p>
         </div>
 
@@ -62,8 +62,8 @@ export function McpServersView({ client, company }: Props) {
             <Info className="size-4" />
             <AlertTitle>Only an admin can change this company&apos;s tool servers</AlertTitle>
             <AlertDescription>
-              A server here hands every teammate a new set of tools, so an admin adds and removes them.
-              You can see what is installed.
+              A server here hands every teammate a new set of tools, so an admin adds and removes
+              them. You can see what is installed.
             </AlertDescription>
           </Alert>
         )}

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -194,8 +194,8 @@ export function MemoryView({ client, company }: Props) {
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold tracking-tight">Brain</h2>
             <p className="text-sm text-muted-foreground">
-              What your company remembers — facts, people, projects, and preferences your teammates can
-              recall.
+              What your company remembers — facts, people, projects, and preferences your
+              teammates can recall.
             </p>
           </div>
           <Button onClick={() => setAddOpen(true)} data-testid="memory-add">

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -194,7 +194,7 @@ export function MemoryView({ client, company }: Props) {
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold tracking-tight">Brain</h2>
             <p className="text-sm text-muted-foreground">
-              What your company remembers — facts, people, projects, and preferences your agents can
+              What your company remembers — facts, people, projects, and preferences your teammates can
               recall.
             </p>
           </div>
@@ -273,9 +273,9 @@ function HealthStrip({
   }
   const tiles: { label: string; value: string }[] = [
     { label: "Total items", value: String(total) },
-    { label: "Agent memory", value: String(stats?.agentChunks ?? 0) },
+    { label: "Teammate memory", value: String(stats?.agentChunks ?? 0) },
     { label: "Task outcomes", value: String(stats?.taskOutcomes ?? 0) },
-    // Across every memory source, not just operator facts — agents write only
+    // Across every memory source, not just operator facts — teammates write only
     // context chunks, so a facts-only figure left this stat at "—" forever.
     { label: "Last updated", value: formatUpdated(stats?.lastUpdatedAtMillis ?? 0) },
   ];

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -281,7 +281,7 @@ function ColorSection() {
               ink-hint — subtitles, empty-state prompts. 5.4:1
             </p>
             <p className="text-sm text-ink-muted">
-              ink-muted — member counts, metadata. 4.5:1
+              ink-muted — teammate counts, metadata. 4.5:1
             </p>
             <p className="text-sm text-primary">primary — links and emphasis. 4.7:1</p>
             <p className="text-sm text-destructive">destructive — errors. 3.8:1 (marks)</p>

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -316,11 +316,11 @@ export function TeamView({ client, company, sub, onOpenAgent }: Props) {
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold tracking-tight">Team</h2>
             <p className="text-sm text-muted-foreground">
-              The agents that make up your company. {fromHost ? "Defined by this company." : "Start from these and shape your own."}
+              The teammates that make up your company. {fromHost ? "Defined by this company." : "Start from these and shape your own."}
             </p>
           </div>
           <Button onClick={() => setAddOpen(true)}>
-            <UserPlus className="size-4" /> Add member
+            <UserPlus className="size-4" /> Add teammate
           </Button>
         </div>
 
@@ -358,7 +358,7 @@ export function TeamView({ client, company, sub, onOpenAgent }: Props) {
               className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-sm text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground"
             >
               <Plus className="size-5" />
-              Define an agent
+              Define a teammate
             </button>
           </div>
         )}
@@ -474,7 +474,7 @@ function MemberCard({
           )}
           <DropdownMenu>
             <DropdownMenuTrigger
-              render={<Button variant="ghost" size="icon" className="-mr-1 -mt-1 size-7" aria-label="Member actions" />}
+              render={<Button variant="ghost" size="icon" className="-mr-1 -mt-1 size-7" aria-label="Teammate actions" />}
             >
               <MoreHorizontal className="size-4" />
             </DropdownMenuTrigger>
@@ -482,7 +482,7 @@ function MemberCard({
               {onOpen && (
                 <>
                   <DropdownMenuItem onClick={onOpen} data-testid="team-open-agent">
-                    View agent
+                    View teammate
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                 </>
@@ -518,7 +518,7 @@ function MemberCard({
         <DailyBudgetLine member={member} setByLabel={setByLabel} />
         <div className="mt-auto flex items-center justify-between gap-2 border-t pt-3">
           <Badge variant="secondary" className="gap-1">
-            <Sparkles className="size-3" /> Agent
+            <Sparkles className="size-3" /> Teammate
           </Badge>
           <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
             <Mail className="size-3.5" />
@@ -526,7 +526,7 @@ function MemberCard({
             <Switch
               checked={inboxOn}
               onCheckedChange={onToggleInbox}
-              aria-label="Give this agent an inbox"
+              aria-label="Give this teammate an inbox"
               data-testid="team-inbox-toggle"
             />
           </label>
@@ -666,7 +666,7 @@ function AddMemberDialog({
   canSetBudget: boolean;
 }) {
   // The same three authored fields the detail view edits, held in the same
-  // shape (issue #264) so "Define an agent" and "Edit agent" cannot drift into
+  // shape (issue #264) so "Define a teammate" and "Edit teammate" cannot drift into
   // two different sets of labels for one set of values.
   const [draft, setDraft] = useState<AgentDraft>(emptyDraft);
   const [inbox, setInbox] = useState(false);
@@ -709,7 +709,7 @@ function AddMemberDialog({
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Define an agent</DialogTitle>
+          <DialogTitle>Define a teammate</DialogTitle>
           <DialogDescription>Add a teammate to your company&apos;s roster.</DialogDescription>
         </DialogHeader>
         <AgentFields
@@ -735,9 +735,9 @@ function AddMemberDialog({
         )}
         <label className="flex items-center justify-between rounded-lg border p-3">
           <span className="flex items-center gap-2 text-sm">
-            <Mail className="size-4 text-muted-foreground" /> Give this agent an inbox
+            <Mail className="size-4 text-muted-foreground" /> Give this teammate an inbox
           </span>
-          <Switch checked={inbox} onCheckedChange={setInbox} aria-label="Give this agent an inbox" />
+          <Switch checked={inbox} onCheckedChange={setInbox} aria-label="Give this teammate an inbox" />
         </label>
         <DialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
@@ -747,7 +747,7 @@ function AddMemberDialog({
             onClick={submit}
             disabled={!draft.name.trim() || !draft.role.trim() || budgetInvalid}
           >
-            Add member
+            Add teammate
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1143,7 +1143,7 @@ export function WorkflowsView({
           // sent — which is the opposite of what the operator intended.
           toast.error("This host ran the workflow for real — it doesn't support test runs.", {
             description:
-              "Your test run executed real effects (agent turns, tools, and any report delivery). Update the host to get true no-effect test runs.",
+              "Your test run executed real effects (teammate turns, tools, and any report delivery). Update the host to get true no-effect test runs.",
           });
         } else {
           toast.success(dryRun ? "Test run complete — nothing was sent." : "Workflow ran.");
@@ -2410,7 +2410,7 @@ export function WorkflowsView({
                 <p>
                   A workflow runs a sequence of steps on a schedule or on demand: a{" "}
                   <span className="font-medium text-foreground">trigger</span> starts it,{" "}
-                  <span className="font-medium text-foreground">agents</span> and{" "}
+                  <span className="font-medium text-foreground">teammates</span> and{" "}
                   <span className="font-medium text-foreground">tools</span> do the work,
                   and an <span className="font-medium text-foreground">output</span> step
                   reports the result somewhere.

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1672,7 +1672,7 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
             <Badge
               variant="outline"
               className={cn("shrink-0 px-1 py-0 text-3xs", ORIGIN_STYLES.agent)}
-              title={`Created by agent ${node.createdBy.id}`}
+              title={`Created by teammate ${node.createdBy.id}`}
               data-testid="workspace-tree-agent-badge"
             >
               {node.createdBy.id}

--- a/frontend/src/views/chat/AddMemberDialog.tsx
+++ b/frontend/src/views/chat/AddMemberDialog.tsx
@@ -28,7 +28,7 @@ interface Props {
   onAdd: (fields: NewMemberFields) => void;
 }
 
-/** Define a teammate. Reached from the member pane's "Add" button. */
+/** Define a teammate. Reached from the team pane's "Add" button. */
 export function AddMemberDialog({ open, onOpenChange, onAdd }: Props) {
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
@@ -58,7 +58,7 @@ export function AddMemberDialog({ open, onOpenChange, onAdd }: Props) {
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Define an agent</DialogTitle>
+          <DialogTitle>Define a teammate</DialogTitle>
           <DialogDescription>Add a teammate to your company&apos;s roster.</DialogDescription>
         </DialogHeader>
         <div className="grid gap-2">
@@ -91,16 +91,16 @@ export function AddMemberDialog({ open, onOpenChange, onAdd }: Props) {
         </div>
         <label className="flex items-center justify-between rounded-lg border p-3">
           <span className="flex items-center gap-2 text-sm">
-            <Mail className="size-4 text-muted-foreground" /> Give this agent an inbox
+            <Mail className="size-4 text-muted-foreground" /> Give this teammate an inbox
           </span>
-          <Switch checked={inbox} onCheckedChange={setInbox} aria-label="Give this agent an inbox" />
+          <Switch checked={inbox} onCheckedChange={setInbox} aria-label="Give this teammate an inbox" />
         </label>
         <DialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button onClick={submit} disabled={!name.trim() || !role.trim()}>
-            Add member
+            Add teammate
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -83,12 +83,12 @@ function settledReceipt(approvals: ApprovalSummary[], decided: Record<string, Ve
     return approved === 1 ? approvedLine(undefined) : "Declined — recorded, and nothing will run";
   }
   if (approved === approvals.length) {
-    return `Approved ${actionCount(approved)} — the agent is picking it up now`;
+    return `Approved ${actionCount(approved)} — the teammate is picking it up now`;
   }
   if (declined === approvals.length) {
-    return `Declined ${actionCount(declined)} — the agent will not take them`;
+    return `Declined ${actionCount(declined)} — the teammate will not take them`;
   }
-  return `Approved ${actionCount(approved)} and declined ${actionCount(declined)} — the agent is picking it up now`;
+  return `Approved ${actionCount(approved)} and declined ${actionCount(declined)} — the teammate is picking it up now`;
 }
 
 /**
@@ -309,7 +309,7 @@ export function ApprovalRow({
             status={
               busy
                   ? awaiting("approve")
-                    ? "Waiting for the agent…"
+                    ? "Waiting for the teammate…"
                     : "Recording…"
                   : // A failure outranks the partial count, because it is the
                     // one thing here the operator has to act on. It also has to

--- a/frontend/src/views/chat/ChatHeader.tsx
+++ b/frontend/src/views/chat/ChatHeader.tsx
@@ -92,7 +92,7 @@ export function ChatHeader({
       >
         <Users className="size-3.5" />
         <span className="tabular-nums">{memberCount}</span>
-        <span className="sr-only">{membersOpen ? "Hide" : "Show"} members</span>
+        <span className="sr-only">{membersOpen ? "Hide" : "Show"} teammates</span>
       </Button>
     </header>
   );

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -113,7 +113,7 @@ export function MembersPane({
   // two numbers the header's count refers to.
   const subtitle = channelMembers
     ? `${channelMembers.length} in this channel · ${total} in the company`
-    : `${total} ${total === 1 ? "agent" : "agents"} · ${
+    : `${total} ${total === 1 ? "teammate" : "teammates"} · ${
         fromHost ? "defined by this company" : "starter roster"
       }`;
 
@@ -129,8 +129,8 @@ export function MembersPane({
           size="icon"
           className="size-8"
           onClick={onAdd}
-          aria-label="Add member"
-          title="Add member"
+          aria-label="Add teammate"
+          title="Add teammate"
         >
           <UserPlus className="size-4" />
         </Button>
@@ -325,7 +325,7 @@ function MemberRow({
             <MessageSquare className="size-4" /> Message
           </DropdownMenuItem>
           <DropdownMenuCheckboxItem checked={inboxOn} onCheckedChange={onToggleInbox}>
-            Give this agent an inbox
+            Give this teammate an inbox
           </DropdownMenuCheckboxItem>
           {canEditBudget && (
             <>

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -291,7 +291,7 @@ function ChannelIntro({
       </p>
       {/* The two openings a new channel actually has. Held back until the
           history has answered, for the same reason the sentence above is:
-          offering "add an agent here" over a channel that turns out to be full
+          offering "add a teammate here" over a channel that turns out to be full
           of conversation reads as data loss. */}
       {empty && !loading && channel.kind === "channel" && (
         <ActionCards onAddPeople={onAddPeople} />
@@ -314,8 +314,8 @@ function ActionCards({ onAddPeople }: { onAddPeople?: () => void }) {
     <div className="mt-5 flex flex-wrap gap-4">
       <ActionCard
         icon={Bot}
-        title="Create agent"
-        hint="Add an agent here."
+        title="Create teammate"
+        hint="Add a teammate here."
         href="#/company"
       />
       <ActionCard

--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -142,7 +142,7 @@ export function DeskCreateDialog({
         </div>
 
         <div className="grid gap-2">
-          <Label>Members</Label>
+          <Label>Teammates</Label>
           {roster.length === 0 ? (
             <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
               No roster teammates to add — you can add them after the desk exists.

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -869,7 +869,7 @@ function Unplaced({ tree }: { tree: OrgTree }) {
         <section className="space-y-2">
           <h3 className="text-sm font-medium">People</h3>
           <p className="text-xs text-muted-foreground">
-            The humans who can sign in. Desks staff agents, so the company
+            The humans who can sign in. Desks staff teammates, so the company
             declares no desk for a person, and this chart does not guess one.
           </p>
           <ul className="flex flex-wrap gap-1.5">

--- a/frontend/src/views/connections/AccountChoiceSection.tsx
+++ b/frontend/src/views/connections/AccountChoiceSection.tsx
@@ -140,13 +140,13 @@ export function AccountChoiceSection({ client, company, canManage, generation = 
       <div className="flex items-center gap-2">
         <Users className="size-4 text-muted-foreground" />
         <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          Which account agents act as
+          Which account teammates act as
         </h3>
       </div>
       <p className="text-sm text-muted-foreground">
         {canManage
-          ? "This company holds more than one account for these providers. Choose which one your agents act as — the choice applies to every agent, and takes effect on their next turn. The other accounts stay connected."
-          : "This company holds more than one account for these providers. Which one agents act as is an admin's choice."}
+          ? "This company holds more than one account for these providers. Choose which one your teammates act as — the choice applies to every teammate, and takes effect on their next turn. The other accounts stay connected."
+          : "This company holds more than one account for these providers. Which one teammates act as is an admin's choice."}
       </p>
 
       <Card>
@@ -194,7 +194,7 @@ export function AccountChoiceSection({ client, company, canManage, generation = 
                     {account.isDefault ? (
                       <>
                         <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-                          <CircleCheck className="size-3" /> agents act as this
+                          <CircleCheck className="size-3" /> teammates act as this
                         </span>
                         {canManage && (
                           <Button
@@ -223,7 +223,7 @@ export function AccountChoiceSection({ client, company, canManage, generation = 
                           title={
                             account.connected
                               ? undefined
-                              : `This account is ${account.status.toLowerCase()} — re-authorize it before agents can act as it.`
+                              : `This account is ${account.status.toLowerCase()} — re-authorize it before teammates can act as it.`
                           }
                           onClick={() => void choose(row.toolkit, account)}
                         >

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -157,12 +157,12 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
       </div>
       <p className="text-sm text-muted-foreground">
         {!canManage
-          ? "Your agents reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
+          ? "Your teammates reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
           : attested
-            ? "Your agents reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
+            ? "Your teammates reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
             : companyKey
-              ? "Your agents reach providers through Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Connect providers in the grid below; every agent in the company can then use what you connect."
-              : "Your agents reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
+              ? "Your teammates reach providers through Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Connect providers in the grid below; every teammate in the company can then use what you connect."
+              : "Your teammates reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
       </p>
 
       {load === "loading" ? (
@@ -195,7 +195,7 @@ export function ComposioSection({ client, company, canManage, onChanged }: Props
           {status && !status.granted && (
             <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
               This company does not grant the <span className="font-mono">composio</span> tool
-              namespace, so agents will not receive Composio tools even once connected. Add
+              namespace, so teammates will not receive Composio tools even once connected. Add
               <span className="font-mono"> composio</span> to the company&apos;s tool grants first.
             </p>
           )}

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -232,15 +232,15 @@ export function InferenceSection({
       // Issue #266: only the host knows whether the *running* brain can act on
       // what was just saved. Which brain a company runs is fixed when it is
       // built, so a company that started with no inference source keeps echoing
-      // no matter what lands here — "agents use it on their next turn" was a
+      // no matter what lands here — "teammates use it on their next turn" was a
       // promise the runtime could not keep for exactly the transition an
       // operator makes first. Follow the response instead of asserting.
       if (result.status.restartRequired) {
-        toast.warning("Inference saved — restart the company for agents to use it.", {
+        toast.warning("Inference saved — restart the company for teammates to use it.", {
           description: result.note,
         });
       } else {
-        toast.success("Inference updated. Agents use it on their next turn.");
+        toast.success("Inference updated. Teammates use it on their next turn.");
       }
       setKey("");
       setTest({ kind: "idle" });
@@ -268,7 +268,7 @@ export function InferenceSection({
         models: status && Object.keys(status.models).length ? status.models : undefined,
         key: "",
       });
-      toast.success("Removed the company key. Agents fall back on their next turn.");
+      toast.success("Removed the company key. Teammates fall back on their next turn.");
       setKey("");
       setTest({ kind: "idle" });
       await refresh();
@@ -301,7 +301,7 @@ export function InferenceSection({
         // host's note, which names the process restart that would work.
         toast.warning("Still needs a restart.", { description: result.note });
       } else {
-        toast.success("Restarted. Agents think with the new provider from their next turn.");
+        toast.success("Restarted. Teammates think with the new provider from their next turn.");
       }
       setStatus(result.status);
     } catch (err) {
@@ -363,11 +363,11 @@ export function InferenceSection({
             so each says in one line which it is — the distinction is otherwise
             only in a module doc no operator reads (#637). */}
         <span className="text-xs text-muted-foreground">
-          the key your agents think with — not the company account key
+          the key your teammates think with — not the company account key
         </span>
       </div>
       <p className="text-sm text-muted-foreground">
-        Choose which model provider your agents think with. Bring your own key for OpenRouter, a
+        Choose which model provider your teammates think with. Bring your own key for OpenRouter, a
         custom OpenAI-compatible endpoint, or a local Ollama server — the key is stored securely and
         never shown again. Switching provider or model takes effect on the agents' next turn. Giving
         inference to a company that started without any does not: the brain is chosen at startup, so
@@ -428,7 +428,7 @@ export function InferenceSection({
                         <span className="font-medium">Restart required.</span> This company started
                         with no inference source, so it is running the offline echo brain and its
                         scheduled workflows cannot fire. The brain is chosen at startup — this
-                        configuration is saved, but agents keep echoing until the company is
+                        configuration is saved, but teammates keep echoing until the company is
                         restarted.
                       </span>
                       {/* The action, not just the diagnosis. Telling a hosted

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -369,9 +369,9 @@ export function InferenceSection({
       <p className="text-sm text-muted-foreground">
         Choose which model provider your teammates think with. Bring your own key for OpenRouter, a
         custom OpenAI-compatible endpoint, or a local Ollama server — the key is stored securely and
-        never shown again. Switching provider or model takes effect on the agents' next turn. Giving
-        inference to a company that started without any does not: the brain is chosen at startup, so
-        that first setup needs a restart.
+        never shown again. Switching provider or model takes effect on the teammates' next turn.
+        Giving inference to a company that started without any does not: the brain is chosen at
+        startup, so that first setup needs a restart.
       </p>
 
       {load === "loading" ? (

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -391,8 +391,8 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         </div>
       )}
       <p className="text-sm text-muted-foreground">
-        Remote MCP tool servers your teammates can call. Add an HTTP endpoint and (optionally) a token —
-        the token is stored securely and never shown again.
+        Remote MCP tool servers your teammates can call. Add an HTTP endpoint and (optionally) a
+        token — the token is stored securely and never shown again.
       </p>
 
       {/* Issue #567: this screen's routes ship in every build, the agent-side

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -391,7 +391,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         </div>
       )}
       <p className="text-sm text-muted-foreground">
-        Remote MCP tool servers your agents can call. Add an HTTP endpoint and (optionally) a token —
+        Remote MCP tool servers your teammates can call. Add an HTTP endpoint and (optionally) a token —
         the token is stored securely and never shown again.
       </p>
 
@@ -402,12 +402,12 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       {bridge === "absent" && (
         <Alert data-testid="mcp-bridge-absent">
           <AlertTriangle className="size-4" />
-          <AlertTitle>No agent can use tool servers in this deployment</AlertTitle>
+          <AlertTitle>No teammate can use tool servers in this deployment</AlertTitle>
           <AlertDescription>
             The MCP bridge isn&apos;t compiled into this build, so servers added here are stored and
             can be probed, but no teammate ever receives their tools. The configuration survives —
             rebuild this deployment with the <code className="font-mono">mcp</code> feature and the
-            servers below start reaching agents on the next turn.
+            servers below start reaching teammates on the next turn.
           </AlertDescription>
         </Alert>
       )}
@@ -539,9 +539,9 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           >
                             <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                             <span>
-                              No agent can reach this server — no teammate&apos;s tool grants cover{" "}
+                              No teammate can reach this server — no tool grant covers{" "}
                               <code className="font-mono">mcp:{server.name}</code>. Widen a company or
-                              per-agent tool grant, or this server is unused.
+                              per-teammate tool grant, or this server is unused.
                             </span>
                           </p>
                         ) : (

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -314,7 +314,7 @@ function ComposioBody({
                   provider that has never been connected is a third. The empty
                   case says which of them this is rather than "not connected",
                   which would cover all three. */}
-              No Composio account is connected for {provider.label}, so its agents have none of its
+              No Composio account is connected for {provider.label}, so its teammates have none of its
               tools.
             </p>
           )}
@@ -329,9 +329,9 @@ function ComposioBody({
           <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
             <AlertTriangle className="mt-px size-3 shrink-0" />
             <span>
-              Holding several accounts is fine — they are the company&apos;s, and every member works
-              through them. Which one an agent acts as is set under{" "}
-              <span className="font-medium">Which account agents act as</span> on the Connections
+              Holding several accounts is fine — they are the company&apos;s, and every teammate
+              works through them. Which one a teammate acts as is set under{" "}
+              <span className="font-medium">Which account teammates act as</span> on the Connections
               page; until one is chosen, Composio resolves it for the company as it always has.
             </span>
           </p>
@@ -341,9 +341,9 @@ function ComposioBody({
           <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
             <AlertTriangle className="mt-px size-3 shrink-0" />
             <span>
-              This company also stores a self-hosted OAuth credential for {provider.label}. No agent
-              reads it (issue #396), it is not what the accounts above are, and disconnecting here
-              does not touch it.
+              This company also stores a self-hosted OAuth credential for {provider.label}. No
+              teammate reads it (issue #396), it is not what the accounts above are, and
+              disconnecting here does not touch it.
             </span>
           </p>
         )}
@@ -386,7 +386,7 @@ function ComposioBody({
               )}
               {accounts.length > 0 && (
                 <p className="text-xs text-muted-foreground">
-                  Disconnecting removes the connection at Composio, so agents lose these tools on
+                  Disconnecting removes the connection at Composio, so teammates lose these tools on
                   their next turn. It does not sign the company out of {provider.label}, and it does
                   not delete anything there.
                 </p>
@@ -502,7 +502,7 @@ function McpBody({
               <>
                 <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                 <span>
-                  No agent can reach this server — no teammate&apos;s tool grants cover{" "}
+                  No teammate can reach this server — no tool grant covers{" "}
                   <code className="font-mono">mcp:{server.name}</code>. Whatever usage says below
                   happened before that was true.
                 </span>
@@ -523,7 +523,7 @@ function McpBody({
 
         <UsageSection
           usage={usage}
-          perConnection={`Successful tool calls your agents made through ${server.name}, counted under mcp:${server.name.trim().toLowerCase()} so a Composio provider of the same name cannot be read as this one.`}
+          perConnection={`Successful tool calls your teammates made through ${server.name}, counted under mcp:${server.name.trim().toLowerCase()} so a Composio provider of the same name cannot be read as this one.`}
         />
 
         <Separator />
@@ -534,8 +534,8 @@ function McpBody({
           </h4>
           <p className="text-xs text-muted-foreground" data-testid="mcp-detail-disconnect-scope">
             {server.source === "manifest"
-              ? "This server is declared in company.toml, so it cannot be removed from the console — turning it off drops it from every agent's tool belt on the next turn, and it returns on the next boot unless the manifest changes."
-              : "Removing it drops it from every agent's tool belt on the next turn and deletes the credential stored here for it."}{" "}
+              ? "This server is declared in company.toml, so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn, and it returns on the next boot unless the manifest changes."
+              : "Removing it drops it from every teammate's tool belt on the next turn and deletes the credential stored here for it."}{" "}
             Nothing is revoked at the server&apos;s own end: no token it issued is invalidated and no
             session there is closed. Revoke those where they were issued.
           </p>

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -314,8 +314,8 @@ function ComposioBody({
                   provider that has never been connected is a third. The empty
                   case says which of them this is rather than "not connected",
                   which would cover all three. */}
-              No Composio account is connected for {provider.label}, so its teammates have none of its
-              tools.
+              No Composio account is connected for {provider.label}, so its teammates have none of
+              its tools.
             </p>
           )}
         </section>

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -133,8 +133,8 @@ export function ProvidersSection({
               <AlertTriangle className="mt-px size-3 shrink-0" />
               <span>
                 These accounts are connected, but this company does not grant the{" "}
-                <span className="font-mono">composio</span> tool namespace, so its teammates will not
-                receive their tools yet. Add <span className="font-mono">composio</span> to the
+                <span className="font-mono">composio</span> tool namespace, so its teammates will
+                not receive their tools yet. Add <span className="font-mono">composio</span> to the
                 company&apos;s tool grants.
               </span>
             </p>

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -133,7 +133,7 @@ export function ProvidersSection({
               <AlertTriangle className="mt-px size-3 shrink-0" />
               <span>
                 These accounts are connected, but this company does not grant the{" "}
-                <span className="font-mono">composio</span> tool namespace, so its agents will not
+                <span className="font-mono">composio</span> tool namespace, so its teammates will not
                 receive their tools yet. Add <span className="font-mono">composio</span> to the
                 company&apos;s tool grants.
               </span>
@@ -231,7 +231,7 @@ export function ProvidersSection({
             // "No provider in All."
             <p className="py-2 text-xs text-muted-foreground" data-testid="providers-empty">
               This host has no providers to offer yet. They come from Composio,
-              which runs the sign-in and turns the result into tools your agents
+              which runs the sign-in and turns the result into tools your teammates
               actually receive
               {canManage
                 ? " — set the company's credential above to see its catalog here."

--- a/frontend/src/views/connections/RepositoriesCard.tsx
+++ b/frontend/src/views/connections/RepositoriesCard.tsx
@@ -174,8 +174,8 @@ export function RepositoriesCard({ client, company, canManage }: Props) {
             <p className="text-sm text-muted-foreground">
               Bind a repository and this host keeps its own copy, refreshed with the token you
               give it. Teammates granted <code className="font-mono">repo</code> can check that
-              copy out and read pull requests. The token stays on the host — it is never written into a workspace, an
-              agent&apos;s environment, or any file your agents can read.
+              copy out and read pull requests. The token stays on the host — it is never written into a
+              workspace, a teammate&apos;s environment, or any file your teammates can read.
             </p>
           </div>
 

--- a/frontend/src/views/connections/RepositoriesCard.tsx
+++ b/frontend/src/views/connections/RepositoriesCard.tsx
@@ -174,8 +174,8 @@ export function RepositoriesCard({ client, company, canManage }: Props) {
             <p className="text-sm text-muted-foreground">
               Bind a repository and this host keeps its own copy, refreshed with the token you
               give it. Teammates granted <code className="font-mono">repo</code> can check that
-              copy out and read pull requests. The token stays on the host — it is never written into a
-              workspace, a teammate&apos;s environment, or any file your teammates can read.
+              copy out and read pull requests. The token stays on the host — it is never written
+              into a workspace, a teammate&apos;s environment, or any file your teammates can read.
             </p>
           </div>
 

--- a/frontend/src/views/overview/kg/KnowledgeDetail.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeDetail.tsx
@@ -115,7 +115,7 @@ export function DeptOverviewCard({
         )}
 
         <div className="mt-4">
-          <SectionLabel icon={User}>Agents ({agents.length})</SectionLabel>
+          <SectionLabel icon={User}>Teammates ({agents.length})</SectionLabel>
           <div className="flex flex-col gap-1.5">
             {agents.map((a) => (
               <Row key={a.id} color="var(--accent)" title={a.name} sub={`${a.role} · ${a.model}`} onClick={() => onAgent(a.id)} />
@@ -444,7 +444,7 @@ export function PersonDetailCard({
       <PanelHeader title={person.name} sub={person.role} color={color} onBack={onBack} onClose={onClose} />
       <div className="flex-1 overflow-y-auto px-3 py-2.5">
         <p className="mb-3 text-2xs leading-relaxed text-os-muted">
-          Leads <span className="font-semibold" style={{ color }}>{deptName}</span> — manages {agents.length} agent{agents.length === 1 ? '' : 's'}.
+          Leads <span className="font-semibold" style={{ color }}>{deptName}</span> — manages {agents.length} teammate{agents.length === 1 ? '' : 's'}.
         </p>
         <SectionLabel icon={FileText}>context</SectionLabel>
         <div className="mb-4"><WikiLink label={`${person.name.toLowerCase()}.md`} /></div>

--- a/frontend/src/views/overview/kg/KnowledgeDetail.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeDetail.tsx
@@ -110,7 +110,7 @@ export function DeptOverviewCard({
           <Row color={dept.color} title={head.name} sub={head.role} badge="lead" onClick={() => onPerson(dept.deptId)} />
         ) : (
           <p className="rounded-md-t border border-dashed border-os-border px-3 py-2 font-mono text-2xs text-os-dim">
-            No human lead yet — this team runs on agents.
+            No human lead yet — this team runs on teammates.
           </p>
         )}
 
@@ -177,7 +177,7 @@ export function AgentHarnessCard({
 }) {
   return (
     <div className="flex h-full flex-col">
-      <PanelHeader title={agent.name} sub={`${agent.role} · AI agent`} onBack={onBack} onClose={onClose} />
+      <PanelHeader title={agent.name} sub={`${agent.role} · AI teammate`} onBack={onBack} onClose={onClose} />
       <div className="flex-1 overflow-y-auto px-3 py-2.5">
         <p className="mb-3 text-2xs leading-relaxed text-os-muted">{agent.description}</p>
 
@@ -284,7 +284,7 @@ export function ToolDetailCard({
         </div>
         <SectionLabel icon={User}>used by ({wiki.usedBy.length})</SectionLabel>
         {wiki.usedBy.length === 0 ? (
-          <p className="font-mono text-2xs text-os-dim">no agents in view</p>
+          <p className="font-mono text-2xs text-os-dim">no teammates in view</p>
         ) : (
           <div className="flex flex-col gap-1">
             {wiki.usedBy.map((n) => (
@@ -340,7 +340,7 @@ export function SopTaskDetailCard({
 }: {
   task: SopTask;
   assigneeName: string;
-  assigneeKindLabel: string; // 'human' | 'AI agent'
+  assigneeKindLabel: string; // 'human' | 'AI teammate'
   assigneeColor: string;
   /** what executes this SOP, e.g. 'builtin · imapflow' or 'human · judgment call' */
   runtime?: string | null;

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -51,7 +51,7 @@ const CAT: Record<KGNodeKind, { color: string; Icon: LucideIcon; label: string; 
   step: { color: 'var(--brain-2)', Icon: Milestone, label: 'Stages', r: 6 },
   task: { color: 'var(--muted)', Icon: ClipboardList, label: 'SOP tasks', r: 7 },
   person: { color: 'var(--warn)', Icon: UserRound, label: 'Humans', r: 10 },
-  employee: { color: 'var(--accent)', Icon: User, label: 'AI agents', r: 10 },
+  employee: { color: 'var(--accent)', Icon: User, label: 'AI teammates', r: 10 },
   tool: { color: 'var(--kg-tool)', Icon: Wrench, label: 'Tools', r: 7.5 },
 };
 
@@ -1489,7 +1489,7 @@ export function KnowledgeGraph({
         [
           { label: 'Notes', color: HUB_COLOR, Icon: CAT.self.Icon },
           { label: 'Human', color: CAT.person.color, Icon: CAT.person.Icon },
-          { label: 'AI agent', color: CAT.employee.color, Icon: CAT.employee.Icon },
+          { label: 'AI teammate', color: CAT.employee.color, Icon: CAT.employee.Icon },
           { label: 'Tool', color: CAT.tool.color, Icon: CAT.tool.Icon },
           { label: 'Workflow', color: CAT.workflow.color, Icon: CAT.workflow.Icon },
           { label: 'Stage', color: CAT.step.color, Icon: CAT.step.Icon },
@@ -1612,7 +1612,7 @@ export function KnowledgeGraph({
     <SopTaskDetailCard
       task={selectedTask}
       assigneeName={selectedTaskWorkerNode?.label ?? selectedTask.assigneeId}
-      assigneeKindLabel={selectedTask.assigneeKind === 'person' ? 'human employee' : 'AI agent'}
+      assigneeKindLabel={selectedTask.assigneeKind === 'person' ? 'human employee' : 'AI teammate'}
       assigneeColor={selectedTask.assigneeKind === 'person' ? 'var(--warn)' : 'var(--accent)'}
       runtime={taskRuntime}
       tools={toolChips(selectedTaskWorker)}

--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -130,14 +130,14 @@ export function AgentDetailView({
       setAgent(updated);
       setDraft(draftFrom(updated));
       setEditing(false);
-      toast.success("Agent updated.");
+      toast.success("Teammate updated.");
     } catch (error) {
       toast.error(
         error instanceof ApiError && error.status === 409
           ? error.message
           : error instanceof Error
             ? error.message
-            : "Couldn't save this agent.",
+            : "Couldn't save this teammate.",
       );
     } finally {
       setSaving(false);
@@ -155,21 +155,21 @@ export function AgentDetailView({
 
         {load === "missing" && (
           <EmptyState
-            title="This agent is no longer on the roster."
+            title="This teammate is no longer on the roster."
             body="It may have been removed. Go back to the team to see who is here now."
           />
         )}
 
         {load === "unsupported" && (
           <EmptyState
-            title="This host can't open an agent yet."
-            body="Opening an agent needs a newer host. The roster still works."
+            title="This host can't open a teammate yet."
+            body="Opening a teammate needs a newer host. The roster still works."
           />
         )}
 
         {load === "error" && (
           <EmptyState
-            title="Couldn't load this agent."
+            title="Couldn't load this teammate."
             body="The company host didn't answer. Try again in a moment."
           />
         )}
@@ -180,7 +180,7 @@ export function AgentDetailView({
 
             <Section
               title="Instructions"
-              subtitle="What this agent was defined to do. It frames every turn the agent takes."
+              subtitle="What this teammate was defined to do. It frames every turn they take."
               action={
                 agent.editable.length > 0 &&
                 !editing && (
@@ -231,11 +231,11 @@ export function AgentDetailView({
                     data-testid="agent-description"
                   >
                     {agent.description?.trim() ||
-                      "No instructions were written for this agent."}
+                      "No instructions were written for this teammate."}
                   </p>
                   {agent.editable.length === 0 && (
                     <p className="text-xs text-muted-foreground" data-testid="agent-readonly-note">
-                      This agent is part of your company blueprint, so its name, role and
+                      This teammate is part of your company blueprint, so its name, role and
                       instructions are set in company.toml. Its daily budget can still be changed
                       from the team page.
                     </p>
@@ -314,8 +314,8 @@ function Tools({ agent }: { agent: AgentDetailDto }) {
       title="Tools"
       subtitle={
         summary.standardGrant
-          ? "This agent lists no tools of its own, so it holds everything the company allows."
-          : "What this agent asked for, narrowed by what the company allows."
+          ? "This teammate lists no tools of its own, so it holds everything the company allows."
+          : "What this teammate asked for, narrowed by what the company allows."
       }
     >
       {summary.effective.length === 0 ? (
@@ -324,8 +324,8 @@ function Tools({ agent }: { agent: AgentDetailDto }) {
               fact. An agent that asked for nothing under a company that allows
               nothing has been refused nothing. */}
           {summary.standardGrant
-            ? "This agent has no tools, because the company allows none."
-            : "This agent has no tools. Nothing it asked for is covered by the company tool list."}
+            ? "This teammate has no tools, because the company allows none."
+            : "This teammate has no tools. Nothing it asked for is covered by the company tool list."}
         </p>
       ) : (
         <div className="flex flex-wrap gap-2" data-testid="agent-tools">
@@ -362,11 +362,11 @@ function Desks({ agent }: { agent: AgentDetailDto }) {
   return (
     <Section
       title="Desks"
-      subtitle="The desks this agent works on. A desk hands its work to its lead first."
+      subtitle="The desks this teammate works on. A desk hands its work to its lead first."
     >
       {agent.desks.length === 0 ? (
         <p className="text-sm text-muted-foreground" data-testid="agent-desks-empty">
-          This agent is not on any desk.
+          This teammate is not on any desk.
         </p>
       ) : (
         <div className="flex flex-wrap gap-2" data-testid="agent-desks">

--- a/frontend/src/views/team/AgentFields.tsx
+++ b/frontend/src/views/team/AgentFields.tsx
@@ -6,7 +6,7 @@ import { AGENT_FIELDS, type AgentDraft, type AgentFieldKey } from "@/lib/agent";
 /**
  * An agent's authored fields, rendered from one definition (issue #264).
  *
- * Used by both "Define an agent" and the detail view's edit form. They collect
+ * Used by both "Define a teammate" and the detail view's edit form. They collect
  * the same three things, and rendering them from
  * [`AGENT_FIELDS`](@/lib/agent) is what keeps the labels, the placeholders and
  * the order the same in both places rather than the same by coincidence.

--- a/frontend/src/views/workflows/NodeDetailPanel.tsx
+++ b/frontend/src/views/workflows/NodeDetailPanel.tsx
@@ -88,7 +88,7 @@ export function NodeDetailPanel({
         )}
 
         {node.agent && (
-          <DetailField label="Assigned agent">
+          <DetailField label="Assigned teammate">
             <p className="font-mono text-xs">{node.agent}</p>
           </DetailField>
         )}

--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -425,7 +425,7 @@ export function layout(
         kind: n.kind,
         name: n.name,
         // Agent nodes surface their roster id; otherwise the node's summary.
-        summary: n.summary ?? (n.agent ? `Agent: ${n.agent}` : ""),
+        summary: n.summary ?? (n.agent ? `Teammate: ${n.agent}` : ""),
         emoji: meta.emoji,
         color: meta.color,
         runState: runStates[n.id],

--- a/frontend/test/e2e/agent-detail.spec.ts
+++ b/frontend/test/e2e/agent-detail.spec.ts
@@ -141,12 +141,12 @@ test("an agent defined in the console can be read back and edited", async ({ pag
   // and leaves a second card for `card(page, role)` to match.
   try {
     // Define one through the dialog the issue calls create-only.
-    await page.getByRole("button", { name: "Add member" }).first().click();
+    await page.getByRole("button", { name: "Add teammate" }).first().click();
     const dialog = page.getByRole("dialog");
     await dialog.getByTestId("agent-field-name").fill("Detail Spec");
     await dialog.getByTestId("agent-field-role").fill(role);
     await dialog.getByTestId("agent-field-description").fill("Original instructions.");
-    await dialog.getByRole("button", { name: "Add member" }).click();
+    await dialog.getByRole("button", { name: "Add teammate" }).click();
     await expect(card(page, role)).toBeVisible({ timeout: 30_000 });
 
     // Open it. This is the half that was impossible: the roster was write-once
@@ -198,7 +198,7 @@ test("an agent defined in the console can be read back and edited", async ({ pag
     await goToTeam(page);
     const leftover = page.getByTestId("team-card").filter({ hasText: "Detail Spec" }).first();
     if (await leftover.count()) {
-      await leftover.getByLabel("Member actions").click();
+      await leftover.getByLabel("Teammate actions").click();
       await page.getByRole("menuitem", { name: "Remove" }).click();
       await expect(leftover).toHaveCount(0, { timeout: 30_000 });
     }

--- a/frontend/test/e2e/assignee-picker.spec.ts
+++ b/frontend/test/e2e/assignee-picker.spec.ts
@@ -123,7 +123,7 @@ test("the edit dialog offers Unassigned, desks and teammates instead of a text f
   await expect(page.getByRole("option", { name: /^ceo —/ })).toBeVisible();
 
   // A desk with nobody on it stays assignable (EmptyDesk is real), and says so.
-  await expect(page.getByRole("option", { name: /Legal — no members yet/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /Legal — no teammates yet/ })).toBeVisible();
   // A staffed desk shows its headcount.
   await expect(page.getByRole("option", { name: /Engineering desk — 1 teammate/ })).toBeVisible();
 });

--- a/frontend/test/e2e/chat-channel-membership.spec.ts
+++ b/frontend/test/e2e/chat-channel-membership.spec.ts
@@ -113,7 +113,7 @@ async function mockApi(page: Page, mode: () => DesksMode) {
 }
 
 /** The header's member toggle — its label ends in "members". */
-const membersToggle = (page: Page) => page.getByRole("button", { name: /members$/i });
+const membersToggle = (page: Page) => page.getByRole("button", { name: /teammates$/i });
 
 /** The member pane; the channel rail is the other `complementary` on screen. */
 const pane = (page: Page) => page.getByRole("complementary").last();
@@ -189,7 +189,7 @@ test("#369 a host with no desks surface still shows the whole roster", async ({ 
   // behaviour on purpose — one plain roster, no "in this channel" claim.
   await expect(membersToggle(page)).toHaveText(/17/);
   await openPane(page);
-  await expect(pane(page)).toContainText("17 agents");
+  await expect(pane(page)).toContainText("17 teammates");
   await expect(pane(page).getByRole("heading", { name: "In this channel" })).toHaveCount(0);
   await expect(pane(page).locator("ul").first().locator("li")).toHaveCount(17);
 });

--- a/frontend/test/e2e/chat-inline-approval.spec.ts
+++ b/frontend/test/e2e/chat-inline-approval.spec.ts
@@ -194,7 +194,7 @@ test("declining inline says so in the thread rather than leaving it stalled", as
   // as a stall. The line is addressed to this channel, not to "wherever the
   // operator last looked".
   await expect(
-    page.getByText(/Declined — the agent will not take that action/),
+    page.getByText(/Declined — the teammate will not take that action/),
   ).toBeVisible({ timeout: 30_000 });
 });
 

--- a/frontend/test/e2e/composio-account-choice.spec.ts
+++ b/frontend/test/e2e/composio-account-choice.spec.ts
@@ -172,14 +172,14 @@ test("an operator names the account, and the page says so", async ({ page }) => 
   // The claim is the host's, re-read: the mark is drawn from `GET
   // …/composio/connections`, so a passing assertion here means the choice was
   // stored and reported, not merely painted locally.
-  await expect(gmail.getByTestId("account-ca_billing")).toContainText("agents act as this");
+  await expect(gmail.getByTestId("account-ca_billing")).toContainText("teammates act as this");
   await expect(gmail).not.toContainText("Composio picks");
 
   await page.reload();
   await openConnections(page);
   await expect(
     page.getByTestId("accounts-gmail").getByTestId("account-ca_billing"),
-  ).toContainText("agents act as this", { timeout: 30_000 });
+  ).toContainText("teammates act as this", { timeout: 30_000 });
 
   // Choosing for Gmail says nothing about any other provider.
   const rows = await page.request.get("/api/v1/company/composio/connections");
@@ -317,7 +317,7 @@ test.describe("the agent acts as the chosen account", () => {
       .click();
     await expect(
       page.getByTestId("accounts-gmail").getByTestId("account-ca_billing"),
-    ).toContainText("agents act as this");
+    ).toContainText("teammates act as this");
 
     // …and the next turn acts as it. This is the whole issue in one assertion:
     // the choice made on the page reaches the request the harness sends, which

--- a/frontend/test/e2e/composio-provider-detail.spec.ts
+++ b/frontend/test/e2e/composio-provider-detail.spec.ts
@@ -211,8 +211,8 @@ test("the panel names every account the company holds, and marks none of them", 
   await expect(panel, "no account may be marked as the one agents use").not.toContainText(
     "Default",
   );
-  await expect(panel).not.toContainText("agents act as this");
-  await expect(panel).toContainText("Which account agents act as");
+  await expect(panel).not.toContainText("teammates act as this");
+  await expect(panel).toContainText("Which account teammates act as");
   await expect(panel).toContainText("Composio resolves it for the company");
 
   // And specifically NOT the claim it replaced. #819 wrote "`composio_execute`

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -473,7 +473,7 @@ test("#839 creates a teammate on a selected desk and persists it", async ({
   await dialog.getByLabel("Name").fill("Babbage");
   await dialog.getByLabel("Role").fill("Platform Engineer");
   await dialog.getByLabel("What they do").fill("Builds the platform");
-  await dialog.getByRole("button", { name: "Add member" }).click();
+  await dialog.getByRole("button", { name: "Add teammate" }).click();
 
   await expect(growth).toContainText("Babbage");
   expect(
@@ -501,7 +501,7 @@ test("#839 creates a teammate with no desk as unplaced", async ({ page }) => {
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("No Desk");
   await dialog.getByLabel("Role").fill("Roaming Engineer");
-  await dialog.getByRole("button", { name: "Add member" }).click();
+  await dialog.getByRole("button", { name: "Add teammate" }).click();
 
   await expect(
     page.getByRole("heading", { name: "Not on a desk" }),
@@ -521,7 +521,7 @@ test("#839 refuses a company-page teammate add when the host has no team write p
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Not Saved");
   await dialog.getByLabel("Role").fill("Unavailable");
-  await dialog.getByRole("button", { name: "Add member" }).click();
+  await dialog.getByRole("button", { name: "Add teammate" }).click();
 
   await expect(toasts(page)).toContainText("can't create teammates");
   await expect(chart(page).locator("text=Not Saved")).toHaveCount(0);
@@ -537,7 +537,7 @@ test("#1099 a teammate added from the company page is confirmed by name", async 
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Katherine");
   await dialog.getByLabel("Role").fill("Navigator");
-  await dialog.getByRole("button", { name: "Add member" }).click();
+  await dialog.getByRole("button", { name: "Add teammate" }).click();
 
   // The whole of #1099 on this surface: the operator is told, by name, rather
   // than left to infer the add from a chart that repaints a moment later.
@@ -600,7 +600,7 @@ test("#839 a teammate created but not placed is still on the chart to place by h
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Hopper");
   await dialog.getByLabel("Role").fill("Compiler");
-  await dialog.getByRole("button", { name: "Add member" }).click();
+  await dialog.getByRole("button", { name: "Add teammate" }).click();
 
   const halfLanded = toasts(page).first();
   await expect(halfLanded).toContainText("couldn't be added to that desk");

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -301,7 +301,7 @@ const memberPane = (page: Page) => page.getByRole("complementary").last();
  * chart, and a blind click would close what a previous call opened.
  */
 async function openMemberPane(page: Page) {
-  const toggle = page.getByRole("button", { name: /members$/i });
+  const toggle = page.getByRole("button", { name: /teammates$/i });
   if ((await toggle.getAttribute("aria-pressed")) !== "true")
     await toggle.click();
   await expect(page.getByRole("heading", { name: "Team" })).toBeVisible();

--- a/frontend/test/e2e/team-budget-edit.spec.ts
+++ b/frontend/test/e2e/team-budget-edit.spec.ts
@@ -30,7 +30,7 @@ function card(page: Page, role: string) {
  * and `getByRole("button", …)` does not resolve it.
  */
 async function openMenu(page: Page, role: string) {
-  await card(page, role).getByLabel("Member actions").click();
+  await card(page, role).getByLabel("Teammate actions").click();
 }
 
 /**

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -282,7 +282,7 @@ describe("the consolidated approval card", () => {
     // transcript rows. The receipt is about the one release, not the clicks.
     expect(receipts()).toHaveLength(1);
     expect(receipts()[0].textContent).toContain(
-      "Approved 3 actions — the agent is picking it up now",
+      "Approved 3 actions — the teammate is picking it up now",
     );
     expect(container.querySelectorAll("button")).toHaveLength(0);
 
@@ -306,7 +306,7 @@ describe("the consolidated approval card", () => {
 
     expect(receipts()).toHaveLength(1);
     expect(receipts()[0].textContent).toContain(
-      "Approved 1 action and declined 1 action — the agent is picking it up now",
+      "Approved 1 action and declined 1 action — the teammate is picking it up now",
     );
     // Nothing left to decide, so nothing left to press.
     expect(container.querySelectorAll("button")).toHaveLength(0);
@@ -317,7 +317,7 @@ describe("the consolidated approval card", () => {
 
     expect(receipts()).toHaveLength(1);
     expect(receipts()[0].textContent).toContain(
-      "Declined 2 actions — the agent will not take them",
+      "Declined 2 actions — the teammate will not take them",
     );
     expect(receipts()[0].querySelector("details")?.open).toBe(false);
   });

--- a/frontend/test/unit/approval-wording.test.ts
+++ b/frontend/test/unit/approval-wording.test.ts
@@ -5,26 +5,26 @@ import { approvedByRuntimeLine, approvedLine } from "@/lib/approval-wording";
 /**
  * Issue #561: the confirmation an operator reads after approving.
  *
- * Approving does not resume a suspended call — the host re-dispatches the agent,
+ * Approving does not resume a suspended call — the host re-dispatches the teammate,
  * and since #469 it does that once per turn, when the LAST decision that turn
- * parked lands. The console used to say "the agent is completing the action"
+ * parked lands. The console used to say "the teammate is completing the action"
  * for every click, including the three out of four that release nothing. What
  * these pin is that the sentence follows the host's count.
  */
 describe("the line an approve leaves behind", () => {
-  it("says the agent is picking it up only when this decision released the turn", () => {
-    expect(approvedLine(0)).toBe("Approved — the agent is picking it up now");
+  it("says the teammate is picking it up only when this decision released the turn", () => {
+    expect(approvedLine(0)).toBe("Approved — the teammate is picking it up now");
     expect(approvedLine(0, "send an email")).toBe(
-      "Approved — the agent is picking it up now: send an email",
+      "Approved — the teammate is picking it up now: send an email",
     );
   });
 
   it("names what is still owed when the turn is still blocked", () => {
     expect(approvedLine(1)).toBe(
-      "Approved — waiting on 1 more sign-off before the agent continues",
+      "Approved — waiting on 1 more sign-off before the teammate continues",
     );
     expect(approvedLine(3)).toBe(
-      "Approved — waiting on 3 more sign-offs before the agent continues",
+      "Approved — waiting on 3 more sign-offs before the teammate continues",
     );
   });
 
@@ -37,15 +37,15 @@ describe("the line an approve leaves behind", () => {
     );
   });
 
-  it("never says 'the agent' for work the runtime performs itself", () => {
+  it("never says 'the teammate' for work the runtime performs itself", () => {
     // Issue #395: a paused workflow gate or a cold-recipient report has no
-    // agent to re-dispatch, and naming one is the same small lie.
+    // teammate to re-dispatch, and naming one is the same small lie.
     for (const line of [
       approvedByRuntimeLine(0),
       approvedByRuntimeLine(2),
       approvedByRuntimeLine(undefined),
     ]) {
-      expect(line).not.toContain("agent");
+      expect(line).not.toContain("teammate");
     }
     expect(approvedByRuntimeLine(0)).toBe("Approved — carrying it out now");
     expect(approvedByRuntimeLine(2)).toBe(

--- a/frontend/test/unit/mcp-bridge.test.ts
+++ b/frontend/test/unit/mcp-bridge.test.ts
@@ -48,7 +48,7 @@ describe("mcpBridgeState", () => {
 
 /**
  * The add-success message, which is where the screen's other claim used to
- * live: "Agents pick it up on the next rebuild" — fired at the moment the
+ * live: "Teammates pick it up on the next rebuild" — fired at the moment the
  * operator acts, and false twice over on a build with no bridge (nothing picks
  * it up, and since #566 a rebuild is not how pickup happens either).
  */
@@ -59,7 +59,7 @@ describe("mcpAddedMessage", () => {
     // Still a success: the server IS stored, and survives the rebuild that adds
     // the feature. Saying otherwise would report a working add as a failure.
     expect(message).toMatch(/stored/i);
-    expect(message).not.toMatch(/agents pick it up/i);
+    expect(message).not.toMatch(/teammates pick it up/i);
   });
 
   it("promises next-turn pickup when the bridge is present", () => {

--- a/frontend/test/unit/provider-detail-render.test.ts
+++ b/frontend/test/unit/provider-detail-render.test.ts
@@ -175,7 +175,7 @@ describe("the provider detail view", () => {
       true,
     );
     expect(text()).not.toContain("Default");
-    expect(text()).toContain("Which account agents act as");
+    expect(text()).toContain("Which account teammates act as");
     // And specifically not the claim it replaced: an operator reading this
     // panel must not be told to disconnect an account to control which one acts.
     expect(text()).not.toContain("sends no connection id");
@@ -237,7 +237,7 @@ describe("the provider detail view", () => {
     await render(unconnectedGmail(), true);
     expect(text()).toContain("not connected");
     expect(text()).toContain("Connect an account");
-    expect(text()).toContain("agents have none of its tools");
+    expect(text()).toContain("teammates have none of its tools");
   });
 
   it("shows no usage figure for a provider that was never connected or used", async () => {
@@ -263,7 +263,7 @@ describe("the provider detail view", () => {
     // #396: the native `oauth/{provider}` entry is written and read by nothing.
     // A detail view is where that would look healthiest, so it is stated.
     await render(gmail([account()], ["composio", "native"]), true);
-    expect(text()).toContain("No agent reads it");
+    expect(text()).toContain("No teammate reads it");
   });
 });
 
@@ -358,7 +358,7 @@ describe("the same panel, opened on a remote MCP server (#821)", () => {
 
   it("states what removing a runtime server reaches, and what it does not", async () => {
     await openMcp(mcpServer({ source: "runtime" }));
-    expect(text()).toContain("drops it from every agent's tool belt on the next turn");
+    expect(text()).toContain("drops it from every teammate's tool belt on the next turn");
     expect(text()).toContain("Nothing is revoked at the server's own end");
   });
 
@@ -379,7 +379,7 @@ describe("the same panel, opened on a remote MCP server (#821)", () => {
     // #568, restated where the panel can afford the sentence the row could not:
     // usage above it is history, not evidence that it is reachable now.
     await openMcp(mcpServer({ reachableBy: [] }));
-    expect(text()).toContain("No agent can reach this server");
+    expect(text()).toContain("No teammate can reach this server");
     // #931: the line prints each teammate's display name. An operator-added
     // teammate's id is a minted internal string, and printing it told a reader
     // nothing about who can reach the server — which is the line's whole point.

--- a/frontend/test/unit/workspace-origin.test.ts
+++ b/frontend/test/unit/workspace-origin.test.ts
@@ -20,7 +20,7 @@ const client = (payload: unknown) =>
 
 describe("originLabel", () => {
   it("names the agent that authored a node", () => {
-    expect(originLabel({ kind: "agent", id: "ceo" })).toBe("Agent · ceo");
+    expect(originLabel({ kind: "agent", id: "ceo" })).toBe("Teammate · ceo");
   });
 
   it("distinguishes a seeded node from one somebody wrote", () => {


### PR DESCRIPTION
Closes #1103

## What changed

One word for a roster member, everywhere the operator reads it: **teammate**.

`docs/spec/glossary.md:18` is normative — *"**Teammate** | A Roster member with a mandate (internally: an agent). *Teammate* is the prosumer-facing word."* — and `:113` maps *agent, agent graph → your team / a teammate*. The host already routes its own strings through `src/server/ops/language.rs` (`/// A teammate (never "agent")`). The console was the half that disagreed, and `TeamView`'s add dialog managed all three words at once: title "Define an agent", submit "Add member", opened by a button reading "Add member", with the empty-state action saying "Define an agent" again.

**128 user-visible occurrences of *agent*/*member* became *teammate*, across 40 source files** (plus 13 in code comments that quote UI copy verbatim, so the quotes still match the screen). Copy only — not one identifier, prop, API field, route, or test id was renamed.

Count is reproducible from the diff:

```
git diff main -- frontend/src | grep '^+' | grep -v '^+++' | grep -civ '^\+\s*\(//\|\*\)' # …
```

### Per file

| n | file | what moved |
| --- | --- | --- |
| 15 | `frontend/src/views/team/AgentDetailView.tsx` | every "this agent" in the detail page's prose, its toasts and its four error cards |
| 11 | `frontend/src/views/TeamView.tsx` | "Add teammate" (header + submit), "Define a teammate" (title + empty state), "Teammate actions", "View teammate", "Give this teammate an inbox" ×3, the `Teammate` badge, "The teammates that make up your company." |
| 9 | `frontend/src/views/connections/ProviderDetail.tsx` | "your teammates", "every teammate's tool belt" ×2, "No teammate reads it", "No teammate can reach this server" |
| 8 | `frontend/src/views/connections/InferenceSection.tsx` | four toasts + "the key your teammates think with", "the teammates' next turn" |
| 7 | `frontend/src/views/ArtifactsTab.tsx` | empty state, save toast, version attribution, the `(teammate) → (operator)` diff note, "The teammate's version is never overwritten" |
| 6 | `frontend/src/views/connections/AccountChoiceSection.tsx` | the **"Which account teammates act as"** heading, its two descriptions, the "teammates act as this" chip, the re-authorize tooltip |
| 6 | `frontend/src/views/connections/ComposioSection.tsx` | the four "Your teammates reach providers through Composio" branches, the ungranted-namespace note |
| 6 | `frontend/src/views/overview/kg/KnowledgeDetail.tsx` | "AI teammate", "Teammates (n)" section, "manages N teammates", "no teammates in view", "this team runs on teammates" |
| 5 | `frontend/src/views/chat/MembersPane.tsx` | "Add teammate" (label + tooltip), the "N teammates · …" subtitle, the inbox menu item |
| 4 | `frontend/src/views/chat/AddMemberDialog.tsx` | the same title / submit / inbox strings as `TeamView` |
| 4 | `frontend/src/views/chat/ApprovalRow.tsx` | the three settled-batch receipts and "Waiting for the teammate…" |
| 4 | `frontend/src/views/connections/McpServersSection.tsx` | "No teammate can use tool servers in this deployment", the reachability warning, the section blurb |
| 3 | `frontend/src/tour/steps.ts` | the chat, workflows and connections tour stops |
| 3 | `frontend/src/views/chat/MessageTimeline.tsx` | the empty-channel "Create teammate" / "Add a teammate here." card |
| 3 | `frontend/src/views/overview/kg/KnowledgeGraph.tsx` | the "AI teammates" legend category and the SOP assignee label |
| 2 | `frontend/src/lib/approval-wording.ts` | "the teammate is picking it up now", "before the teammate continues" |
| 2 | `frontend/src/lib/mcp-bridge.ts` | both arms of `mcpAddedMessage` |
| 2 | `frontend/src/views/ApprovalsView.tsx` | the lost-in-transit approve line and "Waiting for the teammate…" |
| 2 | `frontend/src/views/ConnectionsView.tsx`, `McpServersView.tsx`, `MemoryView.tsx`, `WorkflowsView.tsx`, `connections/ProvidersSection.tsx`, `connections/RepositoriesCard.tsx` | one or two prose blocks each |
| 1 | `frontend/src/api/memory.ts` | the `agent-memory` origin label → "Teammate memory" |
| 1 | `frontend/src/api/workspace.ts` | `originLabel` → "Teammate · ceo" |
| 1 | `frontend/src/components/app-shell.tsx`, `components/policy-settings.tsx`, `lib/connection-detail.ts`, `lib/workflow-node-config.ts`, `views/AssigneeSelect.tsx`, `views/ChatView.tsx`, `views/InboxView.tsx`, `views/StyleguideView.tsx`, `views/WorkspaceView.tsx`, `views/chat/ChatHeader.tsx`, `views/company/DeskCreateDialog.tsx`, `views/company/OrgChartView.tsx`, `views/workflows/NodeDetailPanel.tsx`, `views/workflows/graph.ts` | one string each |

Three pairs had to move **together** or the console would have contradicted itself across files:

- **"Which account agents act as"** is a heading in `AccountChoiceSection` *and* a by-name cross-reference in `ProviderDetail` ("is set under *Which account agents act as* on the Connections page"). Renaming one would point the reader at a heading that no longer exists.
- **Memory** reads its stat tile from `MemoryView` and its row badge from `ORIGIN_LABELS` in `api/memory.ts`. Both said "Agent memory".
- `AssigneeSelect` and `DeskCreateDialog` each already said "teammate" in the sentence next to the one that said "member" ("no members yet" beside "N teammates"; a `Members` label above "No roster teammates to add").

Two sentences were reworded rather than word-swapped, because the swap made them repeat themselves: the MCP unreachable warning now reads "No teammate can reach this server — no tool grant covers …" (it previously said "No agent … no teammate's tool grants" *in one sentence*), and the `RepositoriesCard` token paragraph. Six JSX prose blocks were reflowed because the longer word pushed them past the file's 100-column wrap.

## Deliberately left alone

This is the interesting half. Nothing below was touched.

**Internal identifiers — the glossary itself says *internally: an agent*:**

- Type and component names: `TeamMember`, `TeamMemberDto`, `AgentDetailView`, `AddMemberDialog`, `MembersPane`, `AgentFields`, `AgentDraft`, `NewMemberFields`
- Props, fields, and wire values: `agentId`, `node.agent`, `desk.members`, `member.inboxEnabled`, `assigneeKind: "agent"`, `SenderKind`, `WorkspaceOrigin.kind === "agent"`, `MemoryOrigin` `"agent-memory"`, the `member` KG edge kind
- Route segments: `#/team/<agentId>`, `#/chat/dm:member-…`
- Element ids and their `htmlFor` targets: `member-name`, `member-role`, `member-desc`, `member-budget`, `member-budget-new`, `idPrefix="member"`, `idPrefix="agent-edit"`
- `data-testid`s: `team-open-agent`, `agent-name`, `agent-tools`, `agent-desks-empty`, `workspace-tree-agent-badge`, … — renaming these churns every spec for no reader benefit
- CSS classes: `group/member`, `group-hover/member:`
- Internal state keys: `setBusy("add-member")`

**Words that genuinely mean something else:**

- **The org role "Member"** (`PeopleView.tsx`) — `UserRole = "admin" | "member"`, an auth role for a human who can sign in. "Make member", "Member — use the company", the "Members · N" count, and the `Admin`/`Member` labels in `kg/adapter.ts` all stay.
- **"Invite members."** on the empty-channel "Add people" card (`MessageTimeline.tsx`) — its sibling card is the teammate one; this one invites humans. (Its title, "Create agent", *did* change.)
- **"spend cannot be attributed back to individual members"** (`InferenceSection.tsx`) — the sentence opens "everyone you invite spends on it", so these are the human members.
- **The workflow node kind `agent`** — `CREATABLE_NODE_KINDS` shows "Agent — a teammate performs a step", the validator says "is an agent node — pick who does it", and `workflow-node-config.ts` names the node's `agent` field. `agent` is the value written into the saved graph and shown in copilot proposal diffs, so those labels name a schema kind, not a person. The teammate *picker* inside that node already said "Pick a teammate" and still does; its read-only twin in `NodeDetailPanel` was the inconsistency, and that one moved ("Assigned agent" → "Assigned teammate").
- **The `Agents/` workspace folder** — "Tidy empty agent folders" and its dialog, whose own body says "Removed N empty folders from `Agents/`". The label names a literal on-disk path; moving the label alone would leave label and path disagreeing.
- **"the agent harness is off"** (`McpServersSection.tsx` ×3) and `SetupWizard.tsx`'s "Agent harness" / "Agent Client Protocol (ACP)" — a build feature and a protocol name, not a roster member.
- **"Sub-agents"** (`UsageView.tsx` cost category, `KnowledgeDetail.tsx`) — a runtime spawn/spend concept, not a seat on the roster.
- **`KnowledgeDetail.tsx:261` "never run — trigger it from /agents"** — a stale pointer at a route that does not exist (the console's is `#/team`). A broken reference, not a vocabulary problem; fixing it is a behaviour question this PR should not smuggle in.
- **Code comments about runtime mechanics** ("the host re-dispatches the agent", "an agent turn", "`agent` is what makes this a blocked harness tool call") — internal by definition. The 13 comment changes here are only the ones that quote UI copy verbatim.

Nothing in `src/` (Rust), `docs/`, or the manifests changed — the host already used the right word.

## Tests updated, not weakened

Seven unit tests failed on the old wording. Each was moved to the new string; **two negative assertions had to move or they would have silently gone vacuous**, and one of those was not among the failures.

- `test/unit/approval-wording.test.ts` — 2 failures (`approvedLine(0)`, `approvedLine(1)`/`(3)`). **Also `expect(line).not.toContain("agent")` → `not.toContain("teammate")`**: that assertion exists to prove `approvedByRuntimeLine` never names an actor, and after the copy change the string "agent" could not appear regardless — it would have passed for the wrong reason forever. The `it(...)` title moved with it.
- `test/unit/approval-batch-card.test.ts` — 3 failures (fully approved / mixed / fully declined receipts).
- `test/unit/provider-detail-render.test.ts` — 2 failures, 6 assertions once the cascade settled: "Which account teammates act as", "drops it from every teammate's tool belt on the next turn", "No teammate can reach this server", "teammates have none of its tools", "No teammate reads it".
- `test/unit/mcp-bridge.test.ts` — **`not.toMatch(/agents pick it up/i)` → `/teammates pick it up/i`**. This one did *not* fail. It is the guard that a bridge-less host must not promise pickup, and the moment `mcpAddedMessage` started saying "Teammates pick it up", the old pattern could never match and the guard was dead. Same class of bug as the one above, caught by grepping the tests for every string the diff removed rather than by trusting a green run.
- `test/unit/workspace-origin.test.ts` — `originLabel({kind:"agent"})` now returns "Teammate · ceo".

E2E specs updated for the same reason — `npm test` does not run them, so these would have failed on the Playwright lane rather than here: `agent-detail.spec.ts` (Add teammate ×2, Teammate actions), `org-tree.spec.ts` (dialog submit ×5), `team-budget-edit.spec.ts` (Teammate actions), `chat-inline-approval.spec.ts`, `assignee-picker.spec.ts` ("no teammates yet"), `composio-provider-detail.spec.ts` and `composio-account-choice.spec.ts` ("Which account teammates act as", "teammates act as this").

## Not done

Issue item 4 suggests a lint or test over user-facing strings so this does not drift back. Not attempted here: the legitimate remaining uses of `agent` (node kind, harness, `Agents/`, sub-agents, and every identifier above) mean a naive rule is mostly false positives, and designing one that is not is its own change with its own review. Worth a follow-up issue.

## Commands run

```
cd frontend
npm ci
npm run typecheck        # clean
npm run typecheck:unit   # clean
npm run typecheck:e2e    # clean
npm test                 # 115 files, 1120 tests, all passing
npm run build            # built in 3.31s
```
