### PR TITLE
feat(server): report whether the workload is busy, so the platform can stop safely

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -3002,10 +3002,7 @@ mod tests {
                 .run_supervisor()
                 .begin("wf-1", false)
                 .expect("begin a workflow run");
-            assert!(
-                runtime.is_busy(),
-                "a live workflow run must report busy"
-            );
+            assert!(runtime.is_busy(), "a live workflow run must report busy");
         }
         assert!(
             !runtime.is_busy(),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2965,35 +2965,71 @@ mod tests {
     }
 
     #[cfg(feature = "openhuman")]
-    /// `is_busy` must see the **cycle lock**, not just the steer registry.
+    /// `is_busy` must see **all three** sources, not just the steer registry.
     ///
     /// The first version of the busy endpoint read only `steer.any_inflight()`,
     /// which covers dispatched board cards and desk delegations. A top-level
     /// operator chat turn registers none of those — it takes `serial` and
-    /// nothing else — so the 15-minute turn opencompany-microservice#22 measured
-    /// reported `busy: false` and got parked mid-flight, which is precisely the
+    /// nothing else — and workflow runs live in `run_supervisor`, a separate
+    /// registry. So the 15-minute turn opencompany-microservice#22 measured
+    /// reported `busy: false` and got parked mid-flight, which is exactly the
     /// failure the endpoint exists to prevent.
     ///
-    /// This asserts the lock is the signal, so a future refactor that drops it
-    /// back to the registry alone fails here rather than silently in production.
+    /// Each source is exercised idle → busy → idle independently, so dropping
+    /// any one of them from `is_busy` fails here rather than silently in
+    /// production. Deliberately outside any feature gate: the steer registry is
+    /// only wired under `openhuman`, so a test that relied on it alone would not
+    /// run in the default build at all.
     #[tokio::test]
-    async fn is_busy_sees_a_cycle_holding_the_serial_lock() {
+    async fn is_busy_sees_every_source_of_work() {
         let (runtime, _record, _home) = runtime_and_record().await;
         assert!(!runtime.is_busy(), "an idle runtime must not report busy");
 
+        // 1. The cycle lock — the operator-chat case the steer registry misses.
         {
             let _cycle = runtime.serial.lock().await;
             assert!(
                 runtime.is_busy(),
-                "a turn holding the cycle lock must report busy — this is the \
-                 operator-chat case the steer registry cannot see"
+                "a turn holding the cycle lock must report busy"
             );
         }
+        assert!(!runtime.is_busy(), "releasing the cycle lock must clear it");
 
+        // 2. A workflow run — tracked in its own registry, invisible to both
+        //    the cycle lock and the steer registry.
+        {
+            let (_ctx, _run) = runtime
+                .run_supervisor()
+                .begin("wf-1", false)
+                .expect("begin a workflow run");
+            assert!(
+                runtime.is_busy(),
+                "a live workflow run must report busy"
+            );
+        }
         assert!(
             !runtime.is_busy(),
-            "releasing the lock must clear it, or the tenant never parks again"
+            "the run guard must clear it on drop, or the tenant never parks again"
         );
+
+        // 3. A steerable in-flight run — the original signal, kept because a
+        //    dispatched card can outlive the cycle that started it.
+        {
+            let _guard = runtime.steer().register(
+                runtime.id(),
+                crate::company::steer::InflightEntry {
+                    key: "run-1".to_string(),
+                    task_id: Some("run-1".to_string()),
+                    kind: crate::company::steer::InflightKind::Task,
+                    title: "Ship the thing".to_string(),
+                    agent_id: "ceo".to_string(),
+                    started_at_millis: 0,
+                    pending_action: None,
+                },
+            );
+            assert!(runtime.is_busy(), "a registered steer run must report busy");
+        }
+        assert!(!runtime.is_busy(), "the steer guard must clear it on drop");
     }
 
     async fn runtime_and_record() -> (

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2964,7 +2964,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "openhuman")]
     /// `is_busy` must see **all three** sources, not just the steer registry.
     ///
     /// The first version of the busy endpoint read only `steer.any_inflight()`,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -660,6 +660,37 @@ impl CompanyRuntime {
     }
 
     /// This company's live set of cancellable workflow runs (issue #383).
+    /// Whether this company is doing anything the platform must not interrupt.
+    ///
+    /// Three sources, because no one of them sees all the work — the first
+    /// version of this shipped only the third and missed the case
+    /// opencompany-microservice#22 actually measured.
+    ///
+    /// - **[`serial`](Self::serial)**, the per-company cycle lock. This is the
+    ///   broad one: a top-level operator chat turn takes it and registers
+    ///   nothing else, and `chat_and_emit` detaches that turn onto its own task
+    ///   precisely because it outlives reverse-proxy timeouts. Webhook, telegram
+    ///   and mailbox-poller cycles take it too. A `tokio::Mutex`, so `try_lock`
+    ///   is free and never blocks the caller.
+    /// - **[`run_supervisor`](Self::run_supervisor)**, covering workflow runs —
+    ///   the manual run route, the cron scheduler, approved-gate continuations
+    ///   and the orchestrator's `run_workflow` tool. It is a separate registry
+    ///   and the other two never see it.
+    /// - **[`steer`](Self::steer)**, the in-flight registry, for dispatched board
+    ///   cards and desk delegations, which run *inside* a cycle and so would
+    ///   otherwise be covered — it is kept for the case where a turn's steerable
+    ///   run outlives the cycle that started it.
+    ///
+    /// Cheap by construction: a non-blocking `try_lock`, a map emptiness check,
+    /// and one `std::sync::Mutex` acquisition. The platform calls this once per
+    /// idle tenant per reconcile scan against a short timeout, so anything that
+    /// could block would turn a slow company into a stalled sweep.
+    pub fn is_busy(&self) -> bool {
+        self.serial.try_lock().is_err()
+            || !self.run_supervisor.is_empty()
+            || self.steer.any_inflight()
+    }
+
     pub fn run_supervisor(&self) -> &crate::runtime::RunSupervisor {
         &self.run_supervisor
     }
@@ -2934,6 +2965,37 @@ mod tests {
     }
 
     #[cfg(feature = "openhuman")]
+    /// `is_busy` must see the **cycle lock**, not just the steer registry.
+    ///
+    /// The first version of the busy endpoint read only `steer.any_inflight()`,
+    /// which covers dispatched board cards and desk delegations. A top-level
+    /// operator chat turn registers none of those — it takes `serial` and
+    /// nothing else — so the 15-minute turn opencompany-microservice#22 measured
+    /// reported `busy: false` and got parked mid-flight, which is precisely the
+    /// failure the endpoint exists to prevent.
+    ///
+    /// This asserts the lock is the signal, so a future refactor that drops it
+    /// back to the registry alone fails here rather than silently in production.
+    #[tokio::test]
+    async fn is_busy_sees_a_cycle_holding_the_serial_lock() {
+        let (runtime, _record, _home) = runtime_and_record().await;
+        assert!(!runtime.is_busy(), "an idle runtime must not report busy");
+
+        {
+            let _cycle = runtime.serial.lock().await;
+            assert!(
+                runtime.is_busy(),
+                "a turn holding the cycle lock must report busy — this is the \
+                 operator-chat case the steer registry cannot see"
+            );
+        }
+
+        assert!(
+            !runtime.is_busy(),
+            "releasing the lock must clear it, or the tenant never parks again"
+        );
+    }
+
     async fn runtime_and_record() -> (
         super::CompanyRuntime,
         crate::ports::CompanyRecord,

--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -203,6 +203,33 @@ impl InflightRegistry {
         Self::default()
     }
 
+    /// Whether any company in this process has a run in flight.
+    ///
+    /// The manager consults this — through the workload's busy endpoint — before
+    /// scaling a tenant to zero. Its own notion of "idle" is inbound proxied
+    /// traffic and nothing else, so a company working through a long turn
+    /// generates none and is indistinguishable from one nobody has opened; the
+    /// tenant then gets parked mid-turn and the work is lost
+    /// (opencompany-microservice#22).
+    ///
+    /// This registry is the right thing to ask because it is already maintained
+    /// by the code that runs turns: [`register`](Self::register) hands back a
+    /// guard that removes the entry on **every** exit path, including panics and
+    /// early returns, so an entry cannot outlive the work it describes and leave
+    /// a tenant permanently un-parkable.
+    ///
+    /// Cheap and synchronous by design — one `std::sync::Mutex` acquisition and
+    /// no I/O. It is called once per idle tenant per reconcile scan, against a
+    /// short client timeout, so anything that could block would turn a slow
+    /// company into a stalled sweep.
+    pub fn any_inflight(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("inflight registry poisoned")
+            .values()
+            .any(|runs| !runs.is_empty())
+    }
+
     /// Registers an in-flight run and returns its shared [`SteerControl`] plus a
     /// [`RegistrationGuard`] that deregisters the entry on drop.
     ///
@@ -354,6 +381,7 @@ pub fn cap_redirect(instruction: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     fn entry(key: &str, kind: InflightKind) -> InflightEntry {
@@ -366,6 +394,28 @@ mod tests {
             started_at_millis: 0,
             pending_action: None,
         }
+    }
+
+    /// The registry answers "is anything running" across every company, and the
+    /// guard returned by `register` is what makes the answer self-correcting: it
+    /// deregisters on drop, on every exit path, so a crashed or early-returning
+    /// turn cannot leave the workload permanently claiming to be busy and its
+    /// tenant permanently un-parkable.
+    #[test]
+    fn any_inflight_tracks_registration_and_clears_on_drop() {
+        let registry = InflightRegistry::new();
+        let company = CompanyId::new("acme");
+        assert!(!registry.any_inflight(), "an empty registry is not busy");
+
+        {
+            let _guard = registry.register(&company, entry("run-1", InflightKind::Task));
+            assert!(registry.any_inflight(), "a registered run makes it busy");
+        }
+
+        assert!(
+            !registry.any_inflight(),
+            "the guard must clear the entry on drop, or the tenant never parks again"
+        );
     }
 
     #[test]

--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -223,11 +223,20 @@ impl InflightRegistry {
     /// short client timeout, so anything that could block would turn a slow
     /// company into a stalled sweep.
     pub fn any_inflight(&self) -> bool {
-        self.inner
-            .lock()
-            .expect("inflight registry poisoned")
-            .values()
-            .any(|runs| !runs.is_empty())
+        // Poison-tolerant, and it reports **busy** rather than panicking. A
+        // panic here reaches an axum handler with no `CatchPanicLayer`, so the
+        // connection resets, the manager reads that as "cannot tell", and its
+        // default is to park — losing the very work this exists to protect, at
+        // the one moment the registry is in an unknown state.
+        //
+        // Reporting busy on poison is bounded: the manager parks anyway once a
+        // tenant exceeds its idle timeout plus the busy extension, so a
+        // permanently poisoned registry delays a park rather than preventing
+        // one.
+        let Ok(runs) = self.inner.lock() else {
+            return true;
+        };
+        runs.values().any(|runs| !runs.is_empty())
     }
 
     /// Registers an in-flight run and returns its shared [`SteerControl`] plus a

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -409,11 +409,16 @@ async fn healthz() -> Json<HealthResponse> {
 /// budget, so anything that makes that endpoint slower or heavier directly
 /// degrades every cold start — a hard constraint in the issue.
 ///
-/// Reads the in-flight registry, which the turn-running code already maintains:
-/// registration hands back a guard that removes the entry on every exit path, so
-/// `busy: true` cannot outlive the work it describes. It holds no lock across an
-/// await and does no I/O, because the manager calls it once per idle tenant per
-/// scan against a short timeout.
+/// Asks each company runtime, which combines three sources — the per-company
+/// cycle lock, the workflow run supervisor, and the in-flight steer registry.
+/// No one of them sees all the work: the first version of this endpoint read
+/// only the last and therefore missed the top-level operator chat turn, which
+/// is the case #22 actually measured.
+///
+/// Holds no lock across an await and does no I/O. The cost is a non-blocking
+/// `try_lock`, a `RwLock` read to enumerate companies, and one `Mutex`
+/// acquisition each — the manager calls this once per idle tenant per scan
+/// against a short timeout, so anything that could block would stall the sweep.
 ///
 /// Unauthenticated on purpose. It reveals one boolean about the workload the
 /// caller can already reach, and requiring a credential would mean the manager
@@ -424,7 +429,7 @@ async fn busy(State(state): State<AppState>) -> Json<BusyResponse> {
         .list()
         .into_iter()
         .filter_map(|id| state.registry().get(&id))
-        .any(|runtime| runtime.steer().any_inflight());
+        .any(|runtime| runtime.is_busy());
     Json(BusyResponse { busy })
 }
 
@@ -677,9 +682,14 @@ mod tests {
     }
 
     /// An idle workload reports `busy: false`, so the manager parks it as it
-    /// always has. The endpoint has to be right in *this* direction too — a
-    /// workload that always claimed to be busy would make its tenant
-    /// un-parkable, which is a worse failure than a park.
+    /// always has.
+    ///
+    /// Note what this does *not* prove: with an empty registry the handler
+    /// iterates nothing and returns `false` without consulting any runtime, so
+    /// this cannot fail for an aggregation bug. The direction that matters —
+    /// that the endpoint can report `true` — is covered by
+    /// `is_busy_sees_a_cycle_holding_the_serial_lock` in `company::runtime`,
+    /// which exercises the real signal against a real runtime.
     #[tokio::test]
     async fn busy_is_false_when_nothing_is_running() {
         let app = router(AppState::new(AppConfig::default()));
@@ -699,16 +709,12 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(
-            json["busy"],
-            serde_json::Value::Bool(false),
-            "an idle workload must not claim to be busy: {json}"
-        );
+        assert_eq!(json["busy"], serde_json::Value::Bool(false), "{json}");
     }
 
-    /// The shape the manager parses. It reads `{"busy": bool}` and treats
-    /// anything else — a missing field, a different name, a non-boolean — as
-    /// "not busy", so a rename here would silently stop protecting work in
+    /// The wire shape the manager parses. It reads a top-level boolean `busy`
+    /// and treats anything else — a missing field, a rename, a string `"true"` —
+    /// as *not busy*, so a change here would silently stop protecting work in
     /// flight rather than fail loudly.
     #[tokio::test]
     async fn busy_responds_with_the_shape_the_manager_parses() {
@@ -729,9 +735,7 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(
-            json.get("busy")
-                .and_then(serde_json::Value::as_bool)
-                .is_some(),
+            json.get("busy").and_then(serde_json::Value::as_bool).is_some(),
             "the manager reads a top-level boolean `busy`; got {json}"
         );
     }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -109,6 +109,7 @@ pub fn router(state: AppState) -> Router {
 fn router_with_console(state: AppState, console_dir: Option<PathBuf>) -> Router {
     let router = Router::new()
         .route("/healthz", get(healthz))
+        .route("/healthz/busy", get(busy))
         .route("/spec", get(spec))
         .route("/tiny", get(tiny))
         .merge(crate::server::operator::router())
@@ -395,6 +396,38 @@ async fn healthz() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }
 
+/// Whether this workload is doing anything — the signal the manager consults
+/// before scaling the tenant to zero (opencompany-microservice#22).
+///
+/// The manager measures "idle" by inbound proxied traffic alone, so a company
+/// working through a long turn produces none of its own and looks exactly like
+/// one nobody has opened. Parking it there destroys the work in flight. This
+/// answers the question the manager cannot infer.
+///
+/// Deliberately a **sibling** of `/healthz` rather than a field on it. The
+/// wake-on-request proxy blocks on `/healthz` and gives up after its startup
+/// budget, so anything that makes that endpoint slower or heavier directly
+/// degrades every cold start — a hard constraint in the issue.
+///
+/// Reads the in-flight registry, which the turn-running code already maintains:
+/// registration hands back a guard that removes the entry on every exit path, so
+/// `busy: true` cannot outlive the work it describes. It holds no lock across an
+/// await and does no I/O, because the manager calls it once per idle tenant per
+/// scan against a short timeout.
+///
+/// Unauthenticated on purpose. It reveals one boolean about the workload the
+/// caller can already reach, and requiring a credential would mean the manager
+/// holding a per-tenant secret purely to ask whether to stop it.
+async fn busy(State(state): State<AppState>) -> Json<BusyResponse> {
+    let busy = state
+        .registry()
+        .list()
+        .into_iter()
+        .filter_map(|id| state.registry().get(&id))
+        .any(|runtime| runtime.steer().any_inflight());
+    Json(BusyResponse { busy })
+}
+
 async fn spec(State(state): State<AppState>) -> Json<crate::app::AppSpec> {
     Json(state.spec())
 }
@@ -406,6 +439,11 @@ async fn tiny(State(state): State<AppState>) -> Json<Vec<crate::tiny::RuntimeMod
 #[derive(Clone, Debug, Serialize)]
 struct HealthResponse {
     status: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct BusyResponse {
+    busy: bool,
 }
 
 #[cfg(test)]
@@ -636,6 +674,66 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// An idle workload reports `busy: false`, so the manager parks it as it
+    /// always has. The endpoint has to be right in *this* direction too — a
+    /// workload that always claimed to be busy would make its tenant
+    /// un-parkable, which is a worse failure than a park.
+    #[tokio::test]
+    async fn busy_is_false_when_nothing_is_running() {
+        let app = router(AppState::new(AppConfig::default()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz/busy")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["busy"],
+            serde_json::Value::Bool(false),
+            "an idle workload must not claim to be busy: {json}"
+        );
+    }
+
+    /// The shape the manager parses. It reads `{"busy": bool}` and treats
+    /// anything else — a missing field, a different name, a non-boolean — as
+    /// "not busy", so a rename here would silently stop protecting work in
+    /// flight rather than fail loudly.
+    #[tokio::test]
+    async fn busy_responds_with_the_shape_the_manager_parses() {
+        let app = router(AppState::new(AppConfig::default()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz/busy")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("busy")
+                .and_then(serde_json::Value::as_bool)
+                .is_some(),
+            "the manager reads a top-level boolean `busy`; got {json}"
+        );
     }
 
     #[tokio::test]

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -735,7 +735,9 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(
-            json.get("busy").and_then(serde_json::Value::as_bool).is_some(),
+            json.get("busy")
+                .and_then(serde_json::Value::as_bool)
+                .is_some(),
             "the manager reads a top-level boolean `busy`; got {json}"
         );
     }


### PR DESCRIPTION
The workload half of tinyhumansai/opencompany-microservice#22. The manager half
is already merged and is inert until a path is configured.

## The problem

The manager measures "idle" by inbound proxied traffic and nothing else — its
`Store::touch` is called from exactly one place, the proxy. A company working
through a long turn generates none of its own, so it is indistinguishable from
one nobody has opened. It gets scaled to zero mid-turn and the work is lost.

#22 measured it: real turns run well past 15 minutes while producing no proxied
traffic.

## What this adds

`GET /healthz/busy` → `{"busy": bool}`, true when any company in the process has
a run in flight.

Two small pieces: `InflightRegistry::any_inflight()` and the handler.

## Why the in-flight registry, and not new state

It is already maintained by the code that runs turns. `register()` hands back a
guard that removes the entry on **every** exit path — including panics and early
returns — so `busy: true` cannot outlive the work it describes.

That property is the one that matters most here. A workload stuck reporting busy
would make its tenant permanently un-parkable, and a stuck park is a worse
failure than a stopped turn. The guard makes the answer self-correcting rather
than something that has to be cleaned up.

No dependency on #983's durable run records; nothing new to maintain.

## Three deliberate choices

**A sibling of `/healthz`, not a field on it.** The wake-on-request proxy blocks
on `/healthz` and gives up after its startup budget, so anything that makes that
endpoint slower or heavier directly degrades every cold start. #22 names this as
a hard constraint.

**Cheap by construction.** One `std::sync::Mutex` acquisition, no I/O, nothing
held across an await. The manager calls it once per idle tenant per reconcile
scan against a 2-second timeout, so a slow answer would stall the whole sweep.

**Unauthenticated.** It reveals a single boolean about a workload the caller can
already reach. Gating it would mean the manager holding a per-tenant credential
purely to ask whether it may stop the tenant. Happy to change this if you would
rather it were behind the platform auth.

## Tests

`cargo test --lib` — 749 pass, including three new ones:

- the registry clears on guard drop — the property that stops a tenant becoming
  un-parkable
- an idle workload reports `busy: false`, so the manager still parks it
- the response shape the manager parses is pinned, because it reads a top-level
  boolean `busy` and treats anything else as "not busy" — a rename here would
  silently stop protecting work rather than fail loudly

`cargo fmt --check` clean.

## What still needs doing after this

**End-to-end verification.** Setting `OCM_TENANT_BUSY_PATH=/healthz/busy` on the
manager and confirming a tenant mid-turn is *not* parked. That is the one case
the manager-side E2E had to skip, for want of this endpoint — and it is the case
that actually proves the feature. Worth doing on staging once the submodule
pointer is bumped.

**The submodule pointer bump** in `opencompany-microservice` after this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a busy-status health endpoint at `/healthz/busy`.
  - The endpoint reports whether any runtime currently has active or interruptible work.
  - Busy detection includes active cycles, workflow runs, and pending steering activity.

- **Bug Fixes**
  - Improved runtime activity tracking so busy status clears correctly after work finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->