### PR TITLE
harness: say when a turn was stopped for spend

### DIFF
--- a/src/harness/acp_run_turn.rs
+++ b/src/harness/acp_run_turn.rs
@@ -206,6 +206,11 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         // protocol carries no iteration-cap signal — there is nothing to read,
         // and inventing `true` here would label every ACP reply a pause.
         hit_iteration_cap: false,
+        // Issue #1032: nor is there a spend halt to report. The stop hooks are
+        // installed around THIS crate's `agent.turn`, and an ACP turn does not
+        // run through it — the external process bills and stops on its own
+        // terms, which this side neither arms nor observes.
+        halted_for_spend: None,
     }
 }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -83,6 +83,45 @@ The reply above is a pause, not a finished answer: this turn reached the maximum
 it may take for a single reply, so it stopped and wrote up where it had got to. Nothing errored — \
 the work so far stands. Reply \"continue\" to ask it to pick up from there.";
 
+/// The system bubble emitted when a turn was halted by its in-turn spend brake
+/// (issue #1032).
+///
+/// The sibling of [`ITERATION_CAP_PAUSE_NOTICE`], and deliberately **not**
+/// interchangeable with it. Both say a turn stopped short, but the operator's
+/// next move is opposite:
+///
+/// - a step pause is resumable — the work fits, the turn just ran out of room,
+///   so `"continue"` finishes it;
+/// - a spend halt is not — the work costs more than the budget allows, and
+///   asking again only spends more against the same cap. So this notice must
+///   never tell the operator to reply `"continue"`; that would invite them to
+///   burn the rest of a budget that had already run out.
+///
+/// It names the teammate and quotes both figures. The iteration-cap notice
+/// deliberately quotes no number, because one bubble can cover a responder, a
+/// desk and a relay turn and naming one of *their* caps would be a number the
+/// operator cannot map back to anything. Naming the teammate is what removes
+/// that objection here: `$X of $Y, by this teammate` is attributable in a way a
+/// bare cap is not.
+///
+/// `spent` can exceed `cap` and the wording allows for it: the brake fires
+/// between tool iterations, so the call that crossed the line was already paid
+/// for. Reporting the real figure is the honest answer — rounding it down to the
+/// cap would hide exactly the overshoot an operator setting a budget wants to
+/// see.
+pub(crate) fn spend_halt_notice(halt: &crate::harness::SpendHalt) -> String {
+    format!(
+        "The reply above is where this turn stopped, not a finished answer: {agent} reached its \
+         spend cap partway through, so the work was halted before it was done. This turn spent \
+         ${spent:.2} against a cap of ${cap:.2}. Nothing errored — the work so far stands, but \
+         asking again runs a new turn against the same cap. Raising {agent}'s budget, or narrowing \
+         what it was asked to do, is what lets the work finish.",
+        agent = halt.agent,
+        spent = halt.spent_usd,
+        cap = halt.cap_usd,
+    )
+}
+
 use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
@@ -2817,6 +2856,17 @@ impl HarnessBrain {
                     // filed through the same `file_conversation_batch` path
                     // rather than being silently discarded when the claim
                     // releases.
+                    //
+                    // Issue #1032 deliberately does NOT extend this to a spend
+                    // halt, and the omission is the decision rather than an
+                    // oversight. `nudge_for_unpublished` runs ANOTHER model
+                    // turn — that is what makes it a nudge — and the teammate
+                    // this would fire for has just been stopped for running out
+                    // of money. Spending more of a budget that had already run
+                    // out, to tidy up after the brake that enforced it, defeats
+                    // the brake. The spend notice tells the operator the work
+                    // stopped short; deciding whether it is worth more money is
+                    // theirs to make, not this layer's to make for them.
                     if turn.hit_iteration_cap {
                         let changed = cap_scan_baseline.changed_since(&cap_scan_workspace);
                         let unpublished = publish::unpublished(&changed.files, &published_sources);
@@ -2942,6 +2992,31 @@ impl HarnessBrain {
                             channel: "operator".to_string(),
                             agent: None,
                             text: ITERATION_CAP_PAUSE_NOTICE.to_string(),
+                            steps: Vec::new(),
+                            reply_to: None,
+                        });
+                    }
+                    // Issue #1032: and a turn halted for spend says so, in its
+                    // own bubble, for every reason the block above gives —
+                    // sibling not appended (`HarnessPool::run` persists
+                    // `outcome.reply`, so appending would file "you ran out of
+                    // budget" as something the teammate said and recall it
+                    // later), unauthored, no steps.
+                    //
+                    // A separate `if`, not an `else`: one operator message can
+                    // run several turns, so a responder that paused at its step
+                    // cap and a delegate that ran out of money are both true of
+                    // the same bubble, and the operator is owed both facts. They
+                    // cannot both come from ONE turn — #988 pins that a spend
+                    // halt reads `hit_iteration_cap == false` — so this is only
+                    // ever two notices for two different turns.
+                    if let Some(halt) = &turn.halted_for_spend {
+                        channel_responses.push(OutboundMessage {
+                            message_id: None,
+                            task_id: None,
+                            channel: "operator".to_string(),
+                            agent: None,
+                            text: spend_halt_notice(halt),
                             steps: Vec::new(),
                             reply_to: None,
                         });
@@ -8791,6 +8866,7 @@ members = ["eng1", "eng2"]
             reply: "here is what that node does".to_string(),
             steps: Vec::new(),
             hit_iteration_cap: false,
+            halted_for_spend: None,
         });
         assert_eq!(bubble.channel, "operator", "the destination is unchanged");
         assert_eq!(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -155,6 +155,9 @@ pub mod search;
 #[cfg(test)]
 mod search_turn_test;
 pub mod skills;
+pub mod spend;
+#[cfg(test)]
+mod spend_halt_turn_test;
 pub mod steer;
 pub mod steps;
 pub mod tool_dispatcher;
@@ -754,6 +757,57 @@ pub struct TurnOutcome {
     /// ACP fold) — a refusal is not a pause, and labelling one as a cap hit
     /// would tell the operator to reply "continue" to a turn that never ran.
     pub hit_iteration_cap: bool,
+    /// The in-turn **spend halt**, when one stopped this turn (issue #1032).
+    ///
+    /// `Some` exactly when the teammate declared a `budget_usd_daily`, the
+    /// [`SpendStopHook`](crate::harness::spend::SpendStopHook) armed for it
+    /// fired, and the turn therefore stopped short of the answer it was working
+    /// towards. `None` on every other path, including every turn by a teammate
+    /// who declared no budget — no hook is installed for them, so there is
+    /// nothing that could have halted them.
+    ///
+    /// A **separate** field from [`hit_iteration_cap`](Self::hit_iteration_cap)
+    /// rather than another reading of it, because the two are different
+    /// outcomes needing different operator actions: a step pause is resumable
+    /// with "continue", a spend halt means the work costs more than its budget
+    /// allows and asking again just spends more. #988 pinned that they are
+    /// distinguishable — a budget halt reads `last_turn_hit_cap() == false`,
+    /// because the run paused *below* `max_tool_iterations` — which is why this
+    /// could not be folded into the existing flag.
+    ///
+    /// Carries the figures rather than a bare `bool` so the notice can say what
+    /// was spent against which cap, and names the teammate so a chain of turns
+    /// cannot report a number the operator has no way to attribute.
+    pub halted_for_spend: Option<SpendHalt>,
+}
+
+/// What one in-turn spend halt cost, and whose cap it was measured against
+/// (issue #1032).
+///
+/// The figures are the ones this crate already owns: the cap is
+/// [`CompanyAgent::turn_spend_cap_usd`], and the spend is the sum of the
+/// [`TurnUsage::cost_usd`](crate::harness::cost::TurnUsage::cost_usd) totals the
+/// turn already reports. Deliberately **not** parsed out of the vendored hook's
+/// `reason` string, which is a developer-facing trace line whose shape is
+/// upstream's to change.
+///
+/// `agent` is carried because one operator bubble can cover a responder turn, a
+/// desk turn and a relay turn, each with its own cap. The iteration-cap notice
+/// declines to name a number for exactly that reason; naming the teammate is
+/// what makes a number attributable, and is why this one can be quoted where
+/// that one could not.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpendHalt {
+    /// The teammate whose cap was reached.
+    pub agent: String,
+    /// What that teammate's turn had spent when the brake fired, in USD.
+    ///
+    /// Can exceed [`cap_usd`](Self::cap_usd): the brake fires *between* tool
+    /// iterations, so the call that crossed the line has already been paid for.
+    pub spent_usd: f64,
+    /// The cap it was measured against, in USD — the teammate's declared
+    /// `budget_usd_daily`.
+    pub cap_usd: f64,
 }
 
 impl CompanyAgent {
@@ -887,8 +941,22 @@ impl CompanyAgent {
                 control.clone(),
             )));
         }
+        // Issue #1032: the budget hook is *wrapped* rather than pushed bare, so
+        // the halt survives the boundary. Upstream's `StopDecision::Stop` is
+        // consumed inside openhuman's tool loop, which returns the run's text as
+        // an ordinary `Ok(reply)`; `with_stop_hooks` hands back only the
+        // future's value; and `last_turn_hit_cap()` is `false` here by design.
+        // Without the wrapper there is nothing left to read, and a turn stopped
+        // for spend is indistinguishable from one that finished.
+        //
+        // The predicate itself stays upstream's — the wrapper only observes it.
+        let mut spend_brake: Option<(f64, Arc<std::sync::atomic::AtomicBool>)> = None;
         if let Some(cap) = self.turn_spend_cap_usd() {
-            hooks.push(Arc::new(oh::agent::stop_hooks::BudgetStopHook::new(cap)));
+            let hook = crate::harness::spend::SpendStopHook::new(cap);
+            // Taken before the hook is boxed into the task-local list; once it
+            // is an `Arc<dyn StopHook>` the concrete type is unreachable.
+            spend_brake = Some((cap, hook.halted()));
+            hooks.push(Arc::new(hook));
         }
 
         // `Box::pin` at the task-local scope boundary (the nested-scope
@@ -962,6 +1030,32 @@ impl CompanyAgent {
                 "[turn] paused at the tool-iteration cap; the reply is a resumable checkpoint, not a finished answer"
             );
         }
+        // Issue #1032: read the spend brake the same way. Not under the agent
+        // lock — the flag lives on the hook, not on the vendored session, and
+        // the hook has already finished running by the time `with_stop_hooks`
+        // returns.
+        //
+        // The spend is summed over every attempt's usage rather than read from
+        // the hook, so the figure covers the retry path's second attempt too:
+        // both were paid for, and reporting only one would understate what the
+        // turn actually cost.
+        let halted_for_spend = spend_brake.and_then(|(cap_usd, halted)| {
+            halted
+                .load(std::sync::atomic::Ordering::SeqCst)
+                .then(|| SpendHalt {
+                    agent: self.agent_id.clone(),
+                    spent_usd: usages.iter().map(|usage| usage.cost_usd).sum(),
+                    cap_usd,
+                })
+        });
+        if let Some(halt) = &halted_for_spend {
+            tracing::info!(
+                agent = %self.agent_id,
+                spent_usd = halt.spent_usd,
+                cap_usd = halt.cap_usd,
+                "[turn] halted at the in-turn spend cap; the reply stops short of the work it was doing"
+            );
+        }
         let steps = steps::fold_steps(events);
 
         let reply = reply?;
@@ -970,6 +1064,7 @@ impl CompanyAgent {
                 reply,
                 steps,
                 hit_iteration_cap,
+                halted_for_spend,
             },
             usages,
         ))
@@ -2142,6 +2237,11 @@ impl HarnessPool {
                                 // No model call ran, so no cap was reached
                                 // (issue #926). A refusal is not a pause.
                                 hit_iteration_cap: false,
+                                // And no in-turn hook fired, because no turn
+                                // ran (issue #1032). The reply already IS the
+                                // budget notice; labelling this as a halt too
+                                // would tell the operator the same thing twice.
+                                halted_for_spend: None,
                             });
                         }
                     }
@@ -2388,6 +2488,11 @@ impl HarnessPool {
                                     // No model call ran, so no cap was reached
                                     // (issue #926). A refusal is not a pause.
                                     hit_iteration_cap: false,
+                                    // Same teammate cap, refused BEFORE the
+                                    // turn (issue #1032). The in-turn brake
+                                    // never armed, and the reply above already
+                                    // names the cap it refused against.
+                                    halted_for_spend: None,
                                 });
                             }
                         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -976,7 +976,41 @@ impl CompanyAgent {
                             // Retry-guard edge: skip the one-shot retry when an
                             // operator steer already pends, so a cancel/pause
                             // before any text can't restart the work.
-                            if steer.map(|c| c.requested()).unwrap_or(false) {
+                            //
+                            // Issue #1032 adds the second guard, on the same
+                            // reasoning: the work was stopped on purpose, and an
+                            // empty reply is not licence to restart it. The
+                            // retry is a fresh `agent.turn`, so openhuman builds
+                            // it a fresh `TurnCost` — the brake's accumulator
+                            // starts back at zero, and a teammate that had just
+                            // exhausted its cap could spend up to a whole cap
+                            // again before the hook fired a second time. The
+                            // brake is armed per turn, so nothing else here
+                            // would stop it.
+                            //
+                            // **Defence in depth, not a fix to an observed bug,
+                            // and the difference is recorded so nobody re-derives
+                            // it.** The `Empty` arm appears to be unreachable
+                            // after a halt: a halt implies at least one completed
+                            // tool iteration, and openhuman answers the post-halt
+                            // wrap-up with its own synthesised "here's what I did
+                            // this turn" summary — which it substitutes even when
+                            // the wrap-up call returns blank text OR no choices
+                            // at all. Both were scripted against the real turn
+                            // loop and neither reached this arm, so there is no
+                            // test here that would fail without this guard, and
+                            // one was deliberately not left behind pretending
+                            // otherwise. What the guard buys is that the
+                            // invariant stops depending on that substitution
+                            // staying true across a vendored bump.
+                            //
+                            // `halted_for_spend` below still reports the halt
+                            // either way, so the operator gets the notice that
+                            // explains a stub reply rather than silence.
+                            let spend_halted = spend_brake.as_ref().is_some_and(|(_, halted)| {
+                                halted.load(std::sync::atomic::Ordering::SeqCst)
+                            });
+                            if steer.map(|c| c.requested()).unwrap_or(false) || spend_halted {
                                 Ok(crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]))
                             } else {
                                 let second = agent.turn(message).await;

--- a/src/harness/spend.rs
+++ b/src/harness/spend.rs
@@ -1,0 +1,145 @@
+//! [`SpendStopHook`]: the openhuman [`StopHook`] that makes an in-turn budget
+//! halt **observable** to this crate (issue #1032).
+//!
+//! #988 armed the in-turn spend brake by pushing the vendored
+//! [`BudgetStopHook`] onto the turn's hook list. It works — a turn that outruns
+//! its teammate's declared `budget_usd_daily` stops before the next provider
+//! call — but the fact that it stopped is destroyed at the boundary:
+//!
+//! * the hook's [`StopDecision::Stop { reason }`](StopDecision::Stop) is
+//!   consumed inside openhuman's tool loop, which simply stops iterating and
+//!   returns the run's text as an ordinary `Ok(reply)`;
+//! * [`with_stop_hooks`](oh::agent::stop_hooks::with_stop_hooks) returns only
+//!   the future's value — the hook list rides a `tokio::task_local` and nothing
+//!   reads back out of it;
+//! * and [`Agent::last_turn_hit_cap`](oh::agent::Agent::last_turn_hit_cap) is
+//!   `false`, because a hook-driven halt pauses *below* `max_tool_iterations`
+//!   so the iteration-cap predicate does not hold. #988 pins that distinction
+//!   deliberately, which is exactly why the #926 flag cannot be reused here.
+//!
+//! So the halt has to be captured **in the hook itself**, on the way past. This
+//! hook wraps the vendored one, delegates the decision to it unchanged, and
+//! flips a shared [`AtomicBool`] when the delegate answers `Stop`.
+//!
+//! ## Why it wraps rather than reimplements
+//!
+//! The predicate stays upstream's — including its fail-closed handling of a
+//! malformed cap, which turns a NaN or non-positive `max_usd` into an immediate
+//! stop rather than a silently disabled guard. Reimplementing it here would
+//! leave two copies of "when does a turn run out of money" free to disagree the
+//! next time the vendored crate moves, and the copy this crate renders to the
+//! operator would be the one that drifted.
+//!
+//! ## Why an `AtomicBool` and not the reason string
+//!
+//! The reason openhuman formats (`"turn cost $X reached cap $Y"`) is a
+//! developer-facing trace line, not an operator-facing sentence, and its shape
+//! is upstream's to change. The figures it quotes are already to hand outside
+//! the hook — the cap from
+//! [`turn_spend_cap_usd`](crate::harness::CompanyAgent::turn_spend_cap_usd) and
+//! the spend from the [`TurnUsage`](crate::harness::cost::TurnUsage) totals the
+//! turn already returns — so the flag carries the one bit that cannot be
+//! recovered afterwards, and the notice is composed from figures this crate
+//! owns.
+//!
+//! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+
+use openhuman_core::openhuman as oh;
+
+use oh::agent::stop_hooks::{BudgetStopHook, StopDecision, StopHook, TurnState};
+
+/// A [`StopHook`] that delegates to the vendored [`BudgetStopHook`] and records
+/// that it fired.
+///
+/// The recording is one-way: the flag is only ever set, never cleared, because
+/// one hook instance is built per turn and a turn that halted stays halted.
+pub struct SpendStopHook {
+    /// The vendored predicate, unchanged. `BudgetStopHook` is
+    /// `#[derive(Debug, Clone, Copy)]`, so it composes by value.
+    inner: BudgetStopHook,
+    /// Set when `inner` answers [`StopDecision::Stop`]. Shared with the turn
+    /// that installed the hook, which reads it once the turn has returned.
+    halted: Arc<AtomicBool>,
+}
+
+impl SpendStopHook {
+    /// Builds a hook that halts the turn at `cap_usd`, exactly as the vendored
+    /// hook would on its own.
+    pub fn new(cap_usd: f64) -> Self {
+        Self {
+            inner: BudgetStopHook::new(cap_usd),
+            halted: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// The shared flag this hook sets when it halts a turn.
+    ///
+    /// Take this **before** the hook is boxed into the task-local list; once it
+    /// is an `Arc<dyn StopHook>` there is no way back to the concrete type.
+    pub fn halted(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.halted)
+    }
+}
+
+#[async_trait]
+impl StopHook for SpendStopHook {
+    /// The delegate's name, not a new one: this hook changes nothing about when
+    /// a turn stops, and openhuman's own trace lines name the hook that stopped
+    /// it. A second spelling would make the same halt look like two.
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    async fn check(&self, ctx: &TurnState<'_>) -> StopDecision {
+        let decision = self.inner.check(ctx).await;
+        if matches!(decision, StopDecision::Stop { .. }) {
+            self.halted.store(true, Ordering::SeqCst);
+        }
+        decision
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // As `SteerStopHook`'s own test records: `TurnState.cost` names
+    // `openhuman::agent::cost::TurnCost`, whose module is crate-private to
+    // openhuman, so a `TurnState` cannot be constructed from here and the
+    // hook's Continue/Stop decision cannot be unit-tested. It is proven
+    // end-to-end instead, by `harness::spend_halt_turn_test`, which drives a
+    // real turn through `with_stop_hooks` against a scripted provider.
+    //
+    // What is testable here is the wiring either side of that decision: the
+    // name the delegate lends it, and that the flag starts clear and is shared
+    // rather than copied.
+    #[test]
+    fn the_hook_borrows_the_delegates_name() {
+        let hook = SpendStopHook::new(1.0);
+        assert_eq!(
+            hook.name(),
+            BudgetStopHook::new(1.0).name(),
+            "a second spelling would make one halt look like two in the trace"
+        );
+    }
+
+    #[test]
+    fn the_flag_starts_clear_and_is_shared_not_copied() {
+        let hook = SpendStopHook::new(1.0);
+        let flag = hook.halted();
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "a turn that has not run cannot have been halted"
+        );
+        // The handle the turn keeps must observe what the hook stores, or the
+        // halt is recorded into a copy nobody reads — the exact failure this
+        // module exists to prevent.
+        hook.halted.store(true, Ordering::SeqCst);
+        assert!(flag.load(Ordering::SeqCst));
+    }
+}

--- a/src/harness/spend_halt_turn_test.rs
+++ b/src/harness/spend_halt_turn_test.rs
@@ -1,0 +1,764 @@
+//! Issue #1032: end-to-end proof that a turn stopped by its in-turn spend brake
+//! **says so** — and that it says something different from a turn that paused at
+//! its step cap.
+//!
+//! The bug is a silence, and a silence built in by construction rather than
+//! forgotten. #988 armed the brake: a teammate that declares a
+//! `budget_usd_daily` gets a [`BudgetStopHook`] that halts a turn outrunning it.
+//! But openhuman's tool loop consumes the hook's `StopDecision::Stop { reason }`
+//! internally, stops iterating, and returns the run's text as an ordinary
+//! `Ok(reply)` — so "I ran out of budget" and "I finished the work" arrive at the
+//! operator as the same bubble. `Agent::last_turn_hit_cap()` cannot stand in
+//! either: it is `false` for a spend halt, which is exactly what #988 pinned.
+//!
+//! Nothing shorter than a real turn can show this.
+//! [`MockProvider`](crate::harness::provider::MockProvider) issues no tool
+//! calls, so a turn against it is one iteration long and no between-iteration
+//! hook ever fires. So this drives the **real** harness — real `build_agent`,
+//! real [`HostedProvider`], real pool, real brain — and scripts exactly one
+//! thing: the model's choices, over a loopback OpenAI-compatible endpoint. The
+//! shape [`cap_turn_test`](super::cap_turn_test) and
+//! [`iteration_cap_turn_test`](super::iteration_cap_turn_test) established.
+//!
+//! The lever that makes the brake fire is `prompt_tokens`: the stop-hook
+//! middleware folds the usage the *provider* reports into openhuman's turn cost,
+//! so a script that reports a million prompt tokens crosses a five-cent cap on
+//! its first iteration.
+//!
+//! What each test is for:
+//!
+//! - the halt reaches [`TurnOutcome::halted_for_spend`] with the right figures,
+//!   and — the negative control that stops a hardcoded `Some` passing — a turn
+//!   that finishes reports `None`;
+//! - a teammate that declared no budget can never report one, because no hook is
+//!   installed for it;
+//! - the brain emits the halt as a **second, unauthored** bubble;
+//! - the spend notice and the step-cap notice do **not** cross-fire, asserted in
+//!   both directions;
+//! - and the notice never reaches memory, for the reason #926 established.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::CompanyManifest;
+use crate::company::credentials::Credential;
+use crate::harness::brain::{ITERATION_CAP_PAUSE_NOTICE, spend_halt_notice};
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::memory_loop;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
+use crate::ports::ContextStore;
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::types::{
+    ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
+    Effect, EffectDisposition, OutboundMessage, ToolCall, ToolResult,
+};
+use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+/// The agent every test here talks to.
+const AGENT: &str = "ceo";
+
+/// The declared daily cap the in-turn brake arms at, in USD.
+///
+/// Small enough that one scripted call crosses it, and quoted in the notice —
+/// so the assertions below can look for `$0.05` and know where it came from.
+const CAP_USD: f64 = 0.05;
+
+/// `prompt_tokens` a *cheap* call reports — well inside [`CAP_USD`], so a turn
+/// scripted with it finishes on its own.
+const CHEAP_TOKENS: u64 = 12;
+
+/// `prompt_tokens` an *expensive* call reports. On the `chat-v1` tier this
+/// estimates to roughly $0.14, so the very first iteration crosses
+/// [`CAP_USD`] and the brake halts the turn.
+const EXPENSIVE_TOKENS: u64 = 1_000_000;
+
+/// The tool-iteration cap a turn actually runs under, bound to the constant
+/// rather than re-hardcoded so a vendor bump cannot quietly weaken the
+/// cross-fire test below into scripting the wrong turn shape.
+const CAP: usize = crate::harness::build::MAX_TOOL_ITERATIONS;
+
+/// The answer the scripted model gives when it is allowed to finish.
+const ANSWER: &str = "Spec published.";
+
+/// A slice of the spend notice unique to the platform's voice, for proving the
+/// notice is *absent* — from memory, and from a turn that finished.
+///
+/// A substring rather than the whole notice: an absence assertion on the full
+/// string would pass the moment the wording changed by a comma.
+const SPEND_MARKER: &str = "reached its spend cap partway through";
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+/// What the scripted model does on each successive call.
+#[derive(Clone, Debug)]
+enum Turn {
+    /// Emit a native tool call with these literal arguments.
+    Call { tool: String, args: Value },
+    /// Finish with plain assistant text.
+    Say(String),
+}
+
+/// A scripted OpenAI-compatible `/chat/completions` endpoint.
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+    seen: Mutex<Vec<Value>>,
+    /// `prompt_tokens` echoed on every response — the knob that decides whether
+    /// the budget hook fires, because the stop-hook middleware folds it into
+    /// openhuman's turn cost.
+    prompt_tokens: u64,
+}
+
+impl Script {
+    /// How many model calls the turn actually made.
+    fn calls(&self) -> usize {
+        self.seen.lock().unwrap().len()
+    }
+}
+
+/// One assistant message carrying a native `tool_calls` array — the shape the
+/// provider's `tool_calling: true` profile puts the turn loop on.
+fn tool_call_message(tool: &str, args: &Value) -> Value {
+    json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [{
+            "id": format!("call-{tool}"),
+            "type": "function",
+            "function": { "name": tool, "arguments": args.to_string() }
+        }]
+    })
+}
+
+/// Serve the script on loopback and return its base URL plus the shared handle.
+async fn spawn_script(turns: Vec<Turn>, prompt_tokens: u64) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
+        prompt_tokens,
+    });
+    let handle = Arc::clone(&script);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().unwrap().push(body.clone());
+                let next = {
+                    let mut turns = script.turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                // Running off the end means the turn looped more than the script
+                // expected. End it with text rather than hanging — the
+                // call-count assertions are what report the mismatch.
+                let next = next.unwrap_or_else(|| Turn::Say("ran off the script".to_string()));
+                let message = match next {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => tool_call_message(&tool, &args),
+                };
+                (
+                    axum::http::StatusCode::OK,
+                    Json(json!({
+                        "choices": [{ "index": 0, "message": message }],
+                        "usage": {
+                            "prompt_tokens": script.prompt_tokens,
+                            "completion_tokens": 4
+                        }
+                    })),
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+/// A script that writes `n` distinct files and then answers.
+///
+/// **Distinct paths and bodies** on purpose: an identical successful tool batch
+/// reissued back to back is what openhuman's repeat-progress guard halts on, and
+/// a run stopped by *that* would prove nothing about the brake under test. The
+/// writes must also succeed every time, or the repeated-failure breaker halts
+/// the run for a third unrelated reason.
+fn write_then_answer(n: usize) -> Vec<Turn> {
+    let mut turns: Vec<Turn> = (1..=n)
+        .map(|i| Turn::Call {
+            tool: "file_write".to_string(),
+            args: json!({ "path": format!("step-{i}.md"), "content": format!("step {i}") }),
+        })
+        .collect();
+    turns.push(Turn::Say(ANSWER.to_string()));
+    turns
+}
+
+// ---------------------------------------------------------------------------
+// The fixture
+// ---------------------------------------------------------------------------
+
+/// An inert `CycleHost` — these tests are about the turn, not the effect gate.
+struct NoopHost;
+
+#[async_trait]
+impl CycleHost for NoopHost {
+    async fn call_tool(&self, _call: ToolCall) -> crate::Result<ToolResult> {
+        Ok(ToolResult {
+            ok: true,
+            output: Value::Null,
+        })
+    }
+    async fn context_op(&self, _op: ContextOp) -> crate::Result<ContextOpResult> {
+        Ok(ContextOpResult::Text(String::new()))
+    }
+    async fn emit_effect(&self, _effect: Effect) -> crate::Result<EffectDisposition> {
+        Ok(EffectDisposition::Executed)
+    }
+    async fn park_effect(&self, _effect: Effect) -> crate::Result<ApprovalId> {
+        Ok(ApprovalId::new("appr-parked"))
+    }
+}
+
+fn company() -> CompanyId {
+    CompanyId::new("acme")
+}
+
+/// A one-agent company on `full` policy, so an ordinary turn is not parked for
+/// approval — the gate under test is the spend brake, not the approval one.
+///
+/// `budget` is the teammate's declared `budget_usd_daily`. `None` renders the
+/// key away entirely, which is the state in which #988 arms no hook at all —
+/// the negative control this file needs, and not something a zero could stand
+/// in for (a zero is a *malformed* cap, which `turn_spend_cap_usd` also ignores,
+/// for a different reason).
+fn manifest(budget: Option<f64>) -> CompanyManifest {
+    let budget_line = match budget {
+        Some(usd) => format!("budget_usd_daily = {usd}\n"),
+        None => String::new(),
+    };
+    toml::from_str(&format!(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["*"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+{budget_line}"#
+    ))
+    .expect("manifest parses")
+}
+
+fn record(budget: Option<f64>) -> CompanyRecord {
+    CompanyRecord {
+        id: company(),
+        manifest: manifest(budget),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        overlay_policy: None,
+        overlay_desk_tools: Default::default(),
+        disabled_workflows: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Real deps pointed at the scripted endpoint, with a workspace on disk so
+/// `file_write` genuinely succeeds.
+///
+/// `meter: Some(ops)` on purpose. The **pre-dispatch** daily-spend gate reads
+/// it, and with a fresh store it reports zero spend — so the turn is dispatched
+/// and the *in-turn* brake is the thing that stops it. A `None` meter would let
+/// the turn run too, but for the wrong reason (that gate fails open), and the
+/// test would no longer distinguish the two controls it exists to separate.
+fn deps_for(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc<FsOps>) {
+    let ops = Arc::new(FsOps::new(dir));
+    let deps = HarnessDeps {
+        ledgers: None,
+        ledger_registry: Default::default(),
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: Some(ops.clone()),
+        workspace_root: dir.to_path_buf(),
+        workspace_git_enabled: false,
+        audit_root: dir.to_path_buf(),
+        // Left unset so the turn runs on the tier the manifest resolves
+        // (`chat-v1`), which is a *priced* row in openhuman's tier table. The
+        // budget hook reads an estimate off that table when the backend echoes
+        // no charged amount, so pinning a made-up model name here would make the
+        // spend figure depend on a pricing fallback instead of a stated rate.
+        model_override: None,
+        tasks: Some(ops.clone()),
+        artifacts: None,
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: Arc::from([]),
+        default_mcp_servers: Vec::new(),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
+        run_outputs: Default::default(),
+        run_output_store: None,
+        workflow_revisions: None,
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        composio: None,
+        #[cfg(feature = "chargebee")]
+        chargebee: None,
+        #[cfg(feature = "paypal")]
+        paypal: None,
+        hosting: None,
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: None,
+        workspace: None,
+        repos: None,
+        repo_bindings: Vec::new(),
+        checkouts: crate::harness::repo::CheckoutLedger::default(),
+        search: None,
+    };
+    (deps, ops)
+}
+
+/// An operator message, the shape a chat turn arrives as.
+fn chat(text: &str) -> CycleRequest {
+    CycleRequest {
+        cycle_id: "cycle-1".to_string(),
+        company_id: company(),
+        events: vec![CompanyEvent::OperatorMessage {
+            text: text.to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+        }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+/// The operator-channel bubbles a cycle produced.
+fn operator_bubbles(responses: &[OutboundMessage]) -> Vec<&OutboundMessage> {
+    responses
+        .iter()
+        .filter(|m| m.channel == "operator")
+        .collect()
+}
+
+/// Everything the turn wrote back to memory.
+async fn memory_bodies(context: &FsContextStore) -> Vec<String> {
+    let metas = context
+        .list(&company(), memory_loop::OUTCOME_LABEL_PREFIX)
+        .await
+        .expect("list memory");
+    let mut bodies = Vec::new();
+    for meta in metas {
+        bodies.push(
+            context
+                .peek(&company(), &meta.addr, None)
+                .await
+                .expect("peek memory"),
+        );
+    }
+    bodies
+}
+
+// ---------------------------------------------------------------------------
+// The flag
+// ---------------------------------------------------------------------------
+
+/// **The headline.** A turn halted by the in-turn spend brake reports the halt,
+/// with the figures the operator needs, and still comes back `Ok` — because a
+/// halt is a stop, not an error.
+#[tokio::test]
+async fn a_turn_halted_for_spend_reports_the_halt_and_its_figures() {
+    let (base_url, script) = spawn_script(write_then_answer(CAP), EXPENSIVE_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record(Some(CAP_USD));
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("a spend halt is a stop, not an error — the turn must return Ok");
+
+    let halt = outcome
+        .halted_for_spend
+        .as_ref()
+        .expect("the brake fired, so the turn must say so — that is the whole of #1032");
+    assert_eq!(
+        halt.agent, AGENT,
+        "the halt names the teammate whose cap was reached"
+    );
+    assert_eq!(halt.cap_usd, CAP_USD, "measured against the declared cap");
+    assert!(
+        halt.spent_usd > 0.0,
+        "the turn made a paid model call, so the spend cannot be zero: {}",
+        halt.spent_usd
+    );
+
+    // It really was halted, not merely finished: the script offered `CAP` tool
+    // rounds and the turn spent a small handful. (Left loose because the
+    // vendored turn adds a wrap-up call after a partial run, and that call is
+    // not the thing under test.)
+    assert!(
+        script.calls() < CAP,
+        "expected the brake to cut the turn well short of its {CAP} scripted rounds, got {}",
+        script.calls()
+    );
+    // And it is NOT an iteration-cap pause. #988 pinned this; the two notices
+    // must never be interchangeable, because the operator's next move differs.
+    assert!(
+        !outcome.hit_iteration_cap,
+        "a spend halt must not also report a step pause — they are different outcomes"
+    );
+}
+
+/// **The negative control.** The same declared cap, a turn cheap enough to
+/// finish, and the halt stays `None`.
+///
+/// Without this, `halted_for_spend` wired to a hardcoded `Some` at the read site
+/// would pass every other test in this file.
+#[tokio::test]
+async fn a_turn_that_finishes_inside_its_budget_reports_no_halt() {
+    let (base_url, script) = spawn_script(write_then_answer(2), CHEAP_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record(Some(CAP_USD));
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("turn runs");
+
+    assert!(
+        outcome.halted_for_spend.is_none(),
+        "a turn that finished well inside its budget owes no halt notice: {:?}",
+        outcome.halted_for_spend
+    );
+    assert!(
+        outcome.reply.contains(ANSWER),
+        "the control must actually finish to be a control at all: {}",
+        outcome.reply
+    );
+    assert_eq!(
+        script.calls(),
+        3,
+        "two tool rounds plus the answer — the fixture is armed, just not tripped"
+    );
+}
+
+/// A teammate that declared **no** `budget_usd_daily` can never report a spend
+/// halt, however expensive its turn — because #988 installs no hook for it.
+///
+/// Same million-token script as the headline test, with the manifest key omitted
+/// instead of set. If this fails, either a hook is being armed for a teammate
+/// who declared nothing, or a blanket default crept back in.
+#[tokio::test]
+async fn a_teammate_with_no_declared_budget_can_never_report_a_halt() {
+    let (base_url, script) = spawn_script(write_then_answer(3), EXPENSIVE_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record(None);
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("turn runs");
+
+    assert!(
+        outcome.halted_for_spend.is_none(),
+        "no cap was declared, so no brake exists to have fired: {:?}",
+        outcome.halted_for_spend
+    );
+    assert!(
+        outcome.reply.contains(ANSWER),
+        "an undeclared teammate must not be halted at any cost: {}",
+        outcome.reply
+    );
+    assert_eq!(
+        script.calls(),
+        4,
+        "every scripted round should have run — nothing should have cut it short"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What the operator sees
+// ---------------------------------------------------------------------------
+
+/// A spend-halted chat turn reaches the operator as **two** bubbles: whatever
+/// the agent had, then the system saying it was stopped for money.
+///
+/// The second bubble is unauthored — no teammate said it — and carries no steps,
+/// because the timeline already rode in on the first.
+#[tokio::test]
+async fn a_spend_halted_chat_turn_says_so_in_a_second_bubble() {
+    let (base_url, _script) = spawn_script(write_then_answer(CAP), EXPENSIVE_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain =
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record(Some(CAP_USD))).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bubbles = operator_bubbles(&result.channel_responses);
+    assert_eq!(
+        bubbles.len(),
+        2,
+        "a halted turn owes the operator the reply AND the halt notice: {:?}",
+        bubbles.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+
+    // The agent's text, attributed to the agent.
+    assert_eq!(bubbles[0].agent.as_deref(), Some(AGENT));
+
+    // The system's notice, attributed to nobody.
+    let notice = &bubbles[1].text;
+    assert!(
+        bubbles[1].agent.is_none(),
+        "the platform's words must not be put in the agent's mouth"
+    );
+    assert!(
+        bubbles[1].steps.is_empty(),
+        "the timeline is already on the reply bubble; repeating it doubles every row"
+    );
+
+    // It has to actually say the things the operator needs.
+    assert!(
+        notice.contains(SPEND_MARKER),
+        "it must name the spend halt: {notice}"
+    );
+    assert!(
+        notice.contains(AGENT),
+        "it must name whose cap was reached, or the figures are unattributable: {notice}"
+    );
+    assert!(
+        notice.contains("$0.05"),
+        "it must quote the cap it was measured against: {notice}"
+    );
+    assert!(
+        notice.contains("Nothing errored"),
+        "it must say nothing failed, or a budget reads as a crash: {notice}"
+    );
+    // The one thing it must NOT say. A step pause is resumable with "continue";
+    // a spend halt is not, and inviting the operator to reply "continue" here
+    // would invite them to burn the rest of a budget that had already run out.
+    assert!(
+        !notice.contains("continue"),
+        "the spend notice must never tell the operator to reply \"continue\": {notice}"
+    );
+    assert_ne!(
+        notice, ITERATION_CAP_PAUSE_NOTICE,
+        "the two notices must not be interchangeable — the operator's next action differs"
+    );
+}
+
+/// The same cycle with the turn inside its budget: exactly **one** bubble.
+///
+/// The pair is the real assertion — a notice that fires on every turn is as
+/// useless as one that never fires.
+#[tokio::test]
+async fn a_turn_inside_its_budget_says_nothing_extra() {
+    let (base_url, _script) = spawn_script(write_then_answer(2), CHEAP_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain =
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record(Some(CAP_USD))).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bubbles = operator_bubbles(&result.channel_responses);
+    assert_eq!(
+        bubbles.len(),
+        1,
+        "a turn that finished owes no halt notice: {:?}",
+        bubbles.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+    assert!(
+        !bubbles[0].text.contains(SPEND_MARKER),
+        "and it must not be smuggled into the reply either"
+    );
+}
+
+/// **The cross-fire assertion, both directions.** A step pause emits the step
+/// notice and not the spend one; a spend halt emits the spend notice and not the
+/// step one.
+///
+/// This is what stops the two becoming interchangeable. They are not two
+/// spellings of one condition: a step pause means the work fits and the turn ran
+/// out of room, so `"continue"` finishes it; a spend halt means the work costs
+/// more than the budget allows, and asking again just spends more.
+///
+/// Run as one test over two cycles because the assertion IS the comparison —
+/// split apart, each half could pass while the pair stayed wrong.
+#[tokio::test]
+async fn the_step_notice_and_the_spend_notice_do_not_cross_fire() {
+    // Direction one: a turn that exhausts its iterations, by a teammate with no
+    // budget to run out of. `CAP` tool rounds, then the tools-disabled wrap-up.
+    let (base_url, _script) = spawn_script(write_then_answer(CAP), CHEAP_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record(None)).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+    let texts: Vec<&str> = operator_bubbles(&result.channel_responses)
+        .iter()
+        .map(|b| b.text.as_str())
+        .collect();
+    assert!(
+        texts.contains(&ITERATION_CAP_PAUSE_NOTICE),
+        "a turn that ran out of steps must emit the STEP notice: {texts:?}"
+    );
+    assert!(
+        texts.iter().all(|t| !t.contains(SPEND_MARKER)),
+        "a step pause must not be reported as a spend halt: {texts:?}"
+    );
+
+    // Direction two: a turn halted for spend, by a teammate that declared a cap.
+    let (base_url, _script) = spawn_script(write_then_answer(CAP), EXPENSIVE_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain =
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record(Some(CAP_USD))).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+    let texts: Vec<&str> = operator_bubbles(&result.channel_responses)
+        .iter()
+        .map(|b| b.text.as_str())
+        .collect();
+    assert!(
+        texts.iter().any(|t| t.contains(SPEND_MARKER)),
+        "a turn halted for money must emit the SPEND notice: {texts:?}"
+    );
+    assert!(
+        !texts.contains(&ITERATION_CAP_PAUSE_NOTICE),
+        "a spend halt must not be reported as a step pause: {texts:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What memory keeps
+// ---------------------------------------------------------------------------
+
+/// The turn's memory write carries the agent's own text and **not** the
+/// platform's notice.
+///
+/// This is why the notice is a sibling bubble rather than text appended to the
+/// reply. `HarnessPool::run` persists `outcome.reply` to the context store, so
+/// appending would file "you ran out of budget" as something the agent said, and
+/// the memory loop would recall it into a later turn as prior work.
+#[tokio::test]
+async fn the_spend_notice_never_reaches_memory() {
+    let (base_url, _script) = spawn_script(write_then_answer(CAP), EXPENSIVE_TOKENS).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let context = FsContextStore::new(dir.path());
+    let brain =
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record(Some(CAP_USD))).with_runs(ops);
+
+    brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bodies = memory_bodies(&context).await;
+    assert!(
+        !bodies.is_empty(),
+        "the turn must have written its outcome back, or this proves nothing"
+    );
+    assert!(
+        bodies.iter().all(|b| !b.contains(SPEND_MARKER)),
+        "the platform's halt notice must never be recalled as something the agent said: {bodies:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The notice itself
+// ---------------------------------------------------------------------------
+
+/// The notice quotes the figures it was given, and stays distinct from the step
+/// notice.
+///
+/// A direct test of the formatter so the wording contract does not rely on a
+/// turn that takes seconds to drive.
+#[test]
+fn the_notice_quotes_the_spend_the_cap_and_the_teammate() {
+    let notice = spend_halt_notice(&crate::harness::SpendHalt {
+        agent: "researcher".to_string(),
+        spent_usd: 4.02,
+        cap_usd: 4.0,
+    });
+    assert!(notice.contains("researcher"), "{notice}");
+    assert!(
+        notice.contains("$4.02"),
+        "the real spend, not the cap: {notice}"
+    );
+    assert!(notice.contains("$4.00"), "{notice}");
+    assert!(
+        !notice.contains("continue"),
+        "a spend halt is not resumable by asking again: {notice}"
+    );
+}

--- a/src/harness/spend_halt_turn_test.rs
+++ b/src/harness/spend_halt_turn_test.rs
@@ -286,6 +286,7 @@ fn record(budget: Option<f64>) -> CompanyRecord {
         overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
+        setup: None,
     }
 }
 

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -307,6 +307,19 @@ pub(crate) struct DeskReply {
     /// folded INTO this member's answer rather than surfacing on its own, so a
     /// cap two levels down is a cap on what the operator reads here.
     pub(crate) hit_iteration_cap: bool,
+    /// The in-turn spend halt behind this answer, if one stopped it — this
+    /// teammate's own turn or any turn nested beneath it (issue #1032).
+    ///
+    /// Folded exactly as `hit_iteration_cap` is, and for the same reason: a
+    /// deeper delegate's work is folded INTO this member's reply, so a halt two
+    /// levels down is a halt on what the operator ends up reading.
+    ///
+    /// **First halt wins** rather than last, because this carries figures and a
+    /// teammate name rather than a bare flag — there is one bubble and it can
+    /// name one cap. The first is the one that cut work short earliest, and the
+    /// claim it makes is incomplete but never wrong, the same trade the
+    /// first-wins `spawned_task` beside it already takes.
+    pub(crate) halted_for_spend: Option<crate::harness::SpendHalt>,
 }
 
 /// What was already decided about the operator message a drain belongs to
@@ -431,6 +444,16 @@ pub(crate) struct OperatorTurn {
     /// delegate hit — the operator would read a relayed answer that quietly
     /// omits that a branch of it stopped half-done.
     pub(crate) hit_iteration_cap: bool,
+    /// The in-turn spend halt behind **any** turn on this bubble (issue #1032)
+    /// — the responder's, a desk lead's, or the CEO relay's.
+    ///
+    /// First-wins for the same reason the sticky OR beside it exists: one
+    /// operator message can run several turns and the operator gets exactly ONE
+    /// bubble for the whole chain, and the relay turn *replaces* the reply text,
+    /// so tracking the last value would erase a halt the responder or a delegate
+    /// hit. Where the flag beside it ORs, this keeps the first `Some` — it
+    /// carries figures, and one notice can quote one cap.
+    pub(crate) halted_for_spend: Option<crate::harness::SpendHalt>,
 }
 
 /// What a **dispatched card's** turn handed off (issue #204).
@@ -1033,6 +1056,10 @@ impl<'a> DelegationRunner<'a> {
         // reassigned, only OR'd — so a cap the responder hit survives the relay
         // turn replacing the reply text.
         let mut hit_iteration_cap = outcome.hit_iteration_cap;
+        // Issue #1032: sticky the same way, kept as first-wins — never
+        // overwritten, only filled when still empty — so a spend halt the
+        // responder hit survives the relay turn replacing the reply text.
+        let mut halted_for_spend = outcome.halted_for_spend;
         // Settle the direct-answer card from the turn that just ran. Done before
         // the delegation drain because a direct responder queues nothing — it
         // has no delegation tools — so there is no relay turn coming that could
@@ -1080,6 +1107,7 @@ impl<'a> DelegationRunner<'a> {
             // remember the answer to relay.
             operator_steps.extend(desk.steps);
             hit_iteration_cap |= desk.hit_iteration_cap;
+            halted_for_spend = halted_for_spend.or(desk.halted_for_spend);
             desk_replies.push((desk.member, desk.reply));
         }
         // CEO-relay hand-back: when a synchronous desk delegation answered, run
@@ -1149,6 +1177,7 @@ impl<'a> DelegationRunner<'a> {
             operator_reply = relay.reply;
             operator_steps.extend(relay.steps);
             hit_iteration_cap |= relay.hit_iteration_cap;
+            halted_for_spend = halted_for_spend.or(relay.halted_for_spend);
         }
         // Drained after the relay, not before it: a relay turn carries the same
         // inline `create_workflow` tool, so draining at the responder's turn
@@ -1173,6 +1202,7 @@ impl<'a> DelegationRunner<'a> {
             bubbles,
             spawned_task,
             hit_iteration_cap,
+            halted_for_spend,
         })
     }
 
@@ -1728,6 +1758,13 @@ impl<'a> DelegationRunner<'a> {
         // deeper delegate that stopped half-done is folded into THIS member's
         // answer, so its pause is a pause on what the operator ends up reading.
         let mut hit_iteration_cap = outcome.hit_iteration_cap;
+        // Issue #1032: and so does the spend halt. This is the fold that makes
+        // a halt two levels down reach the operator at all — the deeper reply is
+        // folded into THIS member's text, so without carrying its halt with it
+        // the operator reads an answer whose missing half was cut for money and
+        // is told nothing. First-wins, so the shallower halt (the one nearest
+        // the answer the operator reads) is the one named.
+        let mut halted_for_spend = outcome.halted_for_spend;
         for deeper in nested.desk_replies {
             reply.push_str(&format!(
                 "\n\n{} (delegated by {member}) replied:\n{}",
@@ -1735,6 +1772,7 @@ impl<'a> DelegationRunner<'a> {
             ));
             steps.extend(deeper.steps);
             hit_iteration_cap |= deeper.hit_iteration_cap;
+            halted_for_spend = halted_for_spend.or(deeper.halted_for_spend);
         }
         // A cancelled nested run folds in as a cancellation, NEVER as a
         // reply: the member said it was handing that slice on, and an
@@ -1775,6 +1813,7 @@ impl<'a> DelegationRunner<'a> {
                 reply,
                 steps,
                 hit_iteration_cap,
+                halted_for_spend,
             }),
             cancelled: false,
             // Issue #442: the hand-off's own card, reported the same way
@@ -3148,6 +3187,12 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
         /// the call would be wiped by the pre-turn clear, and one that staged
         /// after would skip the boundary the drain reads.
         authors: Vec<TaskOutputWorkflow>,
+        /// The in-turn spend halt this turn reports (issue #1032), standing in
+        /// for the real [`SpendStopHook`](crate::harness::spend::SpendStopHook)
+        /// firing. There is no way to arm the real hook here — these fixtures
+        /// run no model — so this is how a test scripts "this teammate ran out
+        /// of money mid-turn" and then asserts where that fact ends up.
+        spend_halt: Option<crate::harness::SpendHalt>,
     }
 
     impl Turn {
@@ -3201,6 +3246,20 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             Self {
                 reply: reply.to_string(),
                 refuses: desks.iter().map(|d| d.to_string()).collect(),
+                ..Self::default()
+            }
+        }
+
+        /// A turn the in-turn spend brake halted (issue #1032): it replies with
+        /// whatever it had, and reports the halt alongside.
+        fn spend_halted(reply: &str, agent: &str, spent_usd: f64, cap_usd: f64) -> Self {
+            Self {
+                reply: reply.to_string(),
+                spend_halt: Some(crate::harness::SpendHalt {
+                    agent: agent.to_string(),
+                    spent_usd,
+                    cap_usd,
+                }),
                 ..Self::default()
             }
         }
@@ -3386,6 +3445,12 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
                 // These fixtures script delegation shapes, not cap behaviour;
                 // the cap path is proved end-to-end in `cap_turn_test`.
                 hit_iteration_cap: false,
+                // Issue #1032: scripted, for the same reason — the real hook
+                // needs a real model turn to fire, which is proved end-to-end
+                // in `spend_halt_turn_test`. What these fixtures can prove, and
+                // that one cannot, is that the halt survives the DELEGATION
+                // folds, including the nested one.
+                halted_for_spend: turn.spend_halt,
             }
         }
     }
@@ -6103,6 +6168,170 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                 .contains("everyone lands around 100 rps"),
             "the nested answer must be on the card note: {:?}",
             cards[0].note
+        );
+    }
+
+    // ── issue #1032: the spend halt folds like the answer does ──────────────
+
+    /// **The plumbing this issue is really about.** A delegate two levels down
+    /// runs out of money, and the operator is told — because its halt folds into
+    /// the member's answer exactly as its reply and steps already do.
+    ///
+    /// The researcher's answer does not surface as its own bubble: it is folded
+    /// into the engineer's reply, which the CEO relay then *replaces* with one
+    /// coherent sentence. So there are two places the halt can be dropped
+    /// silently — the nested fold in `run_hand_off`, and the relay overwrite in
+    /// `handle_operator_message` — and either one leaves the operator reading a
+    /// confident answer whose missing half was cut for spend.
+    #[tokio::test]
+    async fn a_nested_delegates_spend_halt_reaches_the_operator_turn() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                Turn::tooling(
+                    "I built it; asking research about the rate limits",
+                    vec![nested_handoff("what rate limits do competitors use?")],
+                ),
+                // Two levels down, and out of money partway through.
+                Turn::spend_halted("I got as far as two competitors", "researcher", 4.02, 4.0),
+                Turn::reply("Built. Research is partial."),
+            ],
+        );
+
+        let out = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let halt = out
+            .halted_for_spend
+            .expect("a halt two levels down must reach the operator bubble");
+        assert_eq!(
+            halt.agent, "researcher",
+            "the notice must name the teammate that actually ran out, not the one relaying it"
+        );
+        assert_eq!(halt.cap_usd, 4.0);
+        assert_eq!(halt.spent_usd, 4.02);
+        // The relay really did replace the reply — so the halt survived an
+        // overwrite rather than riding along on text that happened to persist.
+        assert_eq!(out.reply, "Built. Research is partial.");
+    }
+
+    /// The negative control the test above needs: the same four-turn chain with
+    /// nobody halted reports no halt.
+    ///
+    /// Without this, `halted_for_spend` wired to a hardcoded `Some` would pass
+    /// every other assertion in this file.
+    #[tokio::test]
+    async fn a_chain_where_nobody_ran_out_reports_no_spend_halt() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                Turn::tooling(
+                    "I built it; asking research about the rate limits",
+                    vec![nested_handoff("what rate limits do competitors use?")],
+                ),
+                Turn::reply("everyone lands around 100 rps"),
+                Turn::reply("Built, and research says ~100 rps is the norm."),
+            ],
+        );
+
+        let out = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            out.halted_for_spend.is_none(),
+            "a notice that fires on every turn is as useless as one that never fires: {:?}",
+            out.halted_for_spend
+        );
+    }
+
+    /// The responder's own halt survives the relay turn replacing its text.
+    ///
+    /// This is the sibling of the sticky OR beside it, and the same trap: the
+    /// relay overwrites `operator_reply` wholesale, so a halt tracked as "the
+    /// last turn's value" would be erased by a relay turn that itself ran fine.
+    #[tokio::test]
+    async fn a_responders_own_halt_survives_the_relay_replacing_the_reply() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                // The orchestrator runs out of money AND still manages to hand
+                // off — the halt is on the turn that queued the delegation.
+                Turn {
+                    reply: "handing it to engineering".to_string(),
+                    tool_pushes: vec![handoff("ship the API")],
+                    spend_halt: Some(crate::harness::SpendHalt {
+                        agent: "chief".to_string(),
+                        spent_usd: 2.5,
+                        cap_usd: 2.0,
+                    }),
+                    ..Turn::default()
+                },
+                Turn::reply("shipped"),
+                Turn::reply("All shipped."),
+            ],
+        );
+
+        let out = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let halt = out
+            .halted_for_spend
+            .expect("the responder's halt must survive the relay overwriting the reply");
+        assert_eq!(halt.agent, "chief");
+        assert_eq!(out.reply, "All shipped.", "the relay did replace the text");
+    }
+
+    /// Two halts in one chain report the **first**, not the last.
+    ///
+    /// One operator message, one bubble, one cap it can name. First-wins keeps
+    /// the claim incomplete but never wrong — and keeps it anchored to the
+    /// teammate nearest the answer the operator reads, rather than to whichever
+    /// turn happened to run last.
+    #[tokio::test]
+    async fn two_halts_in_one_chain_report_the_first() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn {
+                    reply: "handing it to engineering".to_string(),
+                    tool_pushes: vec![handoff("ship the API")],
+                    spend_halt: Some(crate::harness::SpendHalt {
+                        agent: "chief".to_string(),
+                        spent_usd: 2.5,
+                        cap_usd: 2.0,
+                    }),
+                    ..Turn::default()
+                },
+                Turn::spend_halted("partly done", "engineer", 9.1, 9.0),
+                Turn::reply("Partly shipped."),
+            ],
+        );
+
+        let out = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let halt = out.halted_for_spend.expect("a halt is reported");
+        assert_eq!(
+            halt.agent, "chief",
+            "the first halt in the chain is the one named"
         );
     }
 


### PR DESCRIPTION
## Summary

A turn halted by #988's in-turn budget brake reached the operator as an ordinary bubble. "I ran out
of budget" and "I finished the work" read identically, so a truncated answer was indistinguishable
from a complete one.

The bubble is not even ambiguous. This is what the operator actually got, captured from the test with
the fix reverted — on work that was cut off partway for money:

```
Here's a summary of what I did this turn:

- `file_write` — ok

Let me know if you'd like me to go further.
```

**The halt was invisible by construction, not by omission.** Upstream's `BudgetStopHook::check`
returns `StopDecision::Stop { reason }`; openhuman's tool loop consumes it, stops iterating, and
returns the run's text as an ordinary `Ok(reply)`. `with_stop_hooks` hands back only the future's
value — the hook list rides a `tokio::task_local` and nothing reads back out of it. And
`Agent::last_turn_hit_cap()` is `false`, because the run paused *below* `max_tool_iterations`, which
is exactly what #988 pinned and exactly why #926's iteration-cap flag cannot be reused. The fact is
destroyed at the boundary, so it has to be captured **in the hook**.

## What changed

**`SpendStopHook` wraps the vendored hook rather than reimplementing it** (`src/harness/spend.rs`).
It delegates `check()` and `name()` and flips a shared `AtomicBool` when the delegate answers `Stop`:

```rust
async fn check(&self, ctx: &TurnState<'_>) -> StopDecision {
    let decision = self.inner.check(ctx).await;
    if matches!(decision, StopDecision::Stop { .. }) {
        self.halted.store(true, Ordering::SeqCst);
    }
    decision
}
```

Delegating is the point: the predicate stays upstream's, including its fail-closed handling of a
malformed cap, so a vendored bump cannot leave two copies disagreeing about when a turn stops. The
name is borrowed too, so one halt does not appear twice in the trace under two spellings.

From there the halt rides #926's seam exactly:

| Seam | Change |
| --- | --- |
| `harness/mod.rs:887` | build the wrapper, keep its flag before it is boxed into the task-local list |
| `harness/mod.rs:940` | read the flag beside `last_turn_hit_cap()`, compose `SpendHalt` from figures this crate already owns |
| `harness/mod.rs:753` | `TurnOutcome::halted_for_spend: Option<SpendHalt>` |
| `delegation.rs:309`, `:425` | the field on `DeskReply` and `OperatorTurn` |
| `delegation.rs:981`, `:1028`, `:1097`, `:1121` | the responder / desk / relay fold |
| `delegation.rs:1668`, `:1675`, `:1715` | **the nested `run_hand_off` fold** — the real plumbing |
| `brain.rs:81`, `:2927` | `spend_halt_notice` and its render site |

The nested fold is the piece that is not a field copy. A delegate two levels down folds its reply
*into* the member's answer, which the CEO relay then *replaces* wholesale — two places the halt can
be dropped silently, each leaving the operator reading a confident answer whose missing half was cut
for money. `a_nested_delegates_spend_halt_reaches_the_operator_turn` fails on either.

### Why it is `Option<SpendHalt>` and not a second `bool`

Scope item 3 asks the notice to say what was spent against which limit, and the figures are available
with no new plumbing: the cap from `turn_spend_cap_usd()`, the spend from the `Vec<TurnUsage>` the
turn already returns. Not parsed out of the vendored `reason` string, which is a developer-facing
trace line whose shape is upstream's.

It also carries the **teammate**. `hit_iteration_cap` deliberately quotes no number, and its comment
says why: one bubble can cover a responder, a desk and a relay turn, so naming one of *their* caps
would be a number the operator cannot map back to anything. Naming the teammate is what removes that
objection — `$4.02 of $4.00, by researcher` is attributable in a way a bare cap is not.

Folded **first-wins** rather than as a sticky OR, because it carries figures and one notice can quote
one cap. The first halt is the one nearest the answer the operator reads. The claim is incomplete but
never wrong — the same trade the `spawned_task` field beside it already takes.

### The notice

Distinct from `ITERATION_CAP_PAUSE_NOTICE` because the operator's next action is opposite. A step
pause is resumable — `"continue"` finishes it. A spend halt is not: the work costs more than the
budget allows, and asking again only spends more against the same cap. So the spend notice **never**
tells the operator to reply `"continue"`; a test asserts the absence of that word.

## Deliberately out of scope, and why

**The unpublished-file nudge** (`brain.rs:2809`) gates on `hit_iteration_cap`, and a spend halt cuts a
turn short the same way — files written but never offered. It is **not** extended here, and the
omission is the decision rather than an oversight: `nudge_for_unpublished` runs *another model turn*,
and the teammate this would fire for has just been stopped for running out of money. Spending more of
an exhausted budget to tidy up after the brake that enforced it defeats the brake. The notice tells
the operator the work stopped short; whether it is worth more money is theirs to judge. Recorded in a
comment at the site, not left silent.

## API Or Behavior Changes

No wire-schema change — the fact stays inside `TurnOutcome` / `DeskReply` / `OperatorTurn`, and
`OutboundMessage` is untouched, per #926's precedent. One new operator-facing bubble, emitted only for
a teammate that declared a finite positive `budget_usd_daily` whose turn the brake actually halted.
`TurnOutcome` gains a public field and `SpendHalt` is new public API.

## Tests

Twelve new tests. **All commands run on the gated feature set** (`--features openhuman,tinycortex`) —
the whole seam is behind `feature = "openhuman"` and the default lane compiles none of it.

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — run both ways: default features (the bare `Rust`
      lane's own command) exit 0, **and** `--locked --no-deps --features openhuman,tinycortex
      --all-targets` exit 0.
- [x] `cargo build --all-targets` — `--locked --features openhuman,tinycortex --all-targets`, exit 0.
- [x] `cargo test` — both configurations: `--locked --features openhuman,tinycortex --tests` →
      **4451 passed, 0 failed, 3 ignored** (plus 26 across the integration targets); `cargo test
      --locked` (default features) → **2916 passed, 0 failed**.

`src/harness/spend_halt_turn_test.rs` drives the **real** harness — real `build_agent`, real
`HostedProvider`, real pool, real brain — against a scripted OpenAI-compatible endpoint on loopback.
`MockProvider` cannot reach this: it issues no tool calls, so a turn against it is one iteration long
and no between-iteration hook ever fires. The lever is `prompt_tokens`: a script reporting a million
crosses a five-cent cap on the first iteration.

Covering every acceptance criterion:

* `a_turn_halted_for_spend_reports_the_halt_and_its_figures` — the halt, the teammate, the cap, a
  non-zero spend, still `Ok`, and `hit_iteration_cap == false`.
* `a_turn_that_finishes_inside_its_budget_reports_no_halt` — same declared cap, cheap turn, `None`.
* `a_teammate_with_no_declared_budget_can_never_report_a_halt` — the million-token script with the
  manifest key omitted; no hook, no halt, every scripted round runs.
* `a_spend_halted_chat_turn_says_so_in_a_second_bubble` — two bubbles, second unauthored with empty
  steps, quoting the teammate and `$0.05`, and **not** containing `"continue"`.
* `a_turn_inside_its_budget_says_nothing_extra` — exactly one bubble.
* `the_step_notice_and_the_spend_notice_do_not_cross_fire` — **both directions in one test**, because
  the assertion *is* the comparison: split apart, each half could pass while the pair stayed wrong.
* `the_spend_notice_never_reaches_memory` — the #926 reason, re-pinned.
* four in `runtime::delegation::tests` for the folds: the nested two-levels-down case, a
  no-halt control, the responder's halt surviving the relay overwrite, and first-wins.

### Prove-red — each half of the fix reverted independently

| Reverted | Test | Result |
| --- | --- | --- |
| the hook wrapper (push the bare `BudgetStopHook`) | `a_turn_halted_for_spend_reports_the_halt_and_its_figures` | FAILED — *"the brake fired, so the turn must say so"* |
| the bubble emission | `a_spend_halted_chat_turn_says_so_in_a_second_bubble` + `the_step_notice_and_the_spend_notice_do_not_cross_fire` | FAILED — 1 bubble, not 2 |
| the nested `run_hand_off` fold only | `a_nested_delegates_spend_halt_reaches_the_operator_turn` | FAILED — *"a halt two levels down must reach the operator bubble"* |

The `SpendStopHook` unit tests pin the wiring either side of the decision, not the predicate: as
`SteerStopHook`'s own test records, `TurnState.cost` names a type in a module openhuman keeps
crate-private, so a `TurnState` cannot be constructed here and the halt decision cannot be
unit-tested. It is proven end-to-end instead.

## Documentation

No spec doc changes. The reasoning — why the hook wraps rather than reimplements, why the notice
quotes figures where the step notice quotes none, why first-wins, and why the unpublished nudge is
left alone — is recorded on the types and at the sites.

Closes #1032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spend-cap monitoring for operator chat turns.
  * Displays a clear notice when a teammate’s turn stops due to spending, including actual spend, cap, and next-step guidance.
  * Preserves spend-cap information across delegated and relayed work.
* **Bug Fixes**
  * Prevented spend-cap notices from triggering additional model turns or being saved as persistent memory.
  * Keeps spend-cap and step-cap notifications distinct, including across separate turns.
* **Tests**
  * Added coverage for capped, uncapped, delegated, relayed, and budget-compliant turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->