### PR TITLE
fix(desktop): assert the key SET, not the key order (#1127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1784,8 +1784,15 @@ jobs:
 
       # `--no-deps`, matching the gated lane: the host is a path dependency and
       # its lints are that crate's business, not this one's.
+      #
+      # `--locked` here as well as on `Test` below, and that is the whole point
+      # (issue #1127): this step runs FIRST, so without it a stale lock was
+      # silently regenerated here and `Test`'s `--locked` then inspected a file
+      # the previous step had already fixed. The guard read as present and was
+      # decorative. The console wrapper's clippy below always passed it, so this
+      # was an inconsistency inside one job rather than a deliberate choice.
       - name: Clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --no-deps -- -D warnings
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --no-deps -- -D warnings
 
       # `--locked`, so a manifest edit whose lock was never regenerated is named
       # here rather than absorbed — the desktop keeps its own `Cargo.lock`.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3991,6 +3991,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -420,10 +420,22 @@ mod test {
         })
         .expect("serialise");
 
-        let object = wire.as_object().expect("an object");
+        // Sorted, for the same reason as the instance row below: the closed set
+        // is the claim. `PairedDevice`'s field order happens to be alphabetical
+        // today, so an ordered comparison passes by coincidence rather than by
+        // design — and would go red the moment a field is inserted out of that
+        // position, for a reason that has nothing to do with what this test is
+        // about.
+        let mut keys: Vec<&str> = wire
+            .as_object()
+            .expect("an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
         assert_eq!(
-            object.keys().map(String::as_str).collect::<Vec<_>>(),
-            vec!["company", "deviceId", "expiresAtMillis"],
+            keys,
+            ["company", "deviceId", "expiresAtMillis"],
             "pairing must answer with these three fields and nothing else"
         );
         assert!(!wire.to_string().to_lowercase().contains("token"));
@@ -450,12 +462,24 @@ mod test {
         })
         .expect("serialise");
 
-        let object = wire.as_object().expect("an object");
+        // Sorted before comparing, because the set is what this asserts and the
+        // order is not. This crate inherits `serde_json`'s `preserve_order`
+        // through its path dependency on `opencompany` (root `Cargo.toml:86`),
+        // so a JSON object is backed by an `IndexMap` and emits **struct field
+        // order**, not alphabetical order. Pinning the order here asserted a
+        // property nothing needs — JSON object order means nothing to the
+        // TypeScript that reads these by name — and it would break again the
+        // next time a field is added in the middle of the struct.
+        let mut keys: Vec<&str> = wire
+            .as_object()
+            .expect("an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
         assert_eq!(
-            object.keys().map(String::as_str).collect::<Vec<_>>(),
-            // Sorted: `serde_json` maps are ordered, so this is the wire's
-            // order rather than the struct's.
-            vec![
+            keys,
+            [
                 "baseUrl",
                 "companies",
                 "dataDir",
@@ -465,6 +489,7 @@ mod test {
                 "operatorEmail",
                 "running",
             ],
+            "the instance row answers in exactly these keys: {wire}"
         );
     }
 
@@ -604,10 +629,21 @@ mod test {
         })
         .expect("serialise");
 
-        let object = wire.as_object().expect("an object");
+        // Sorted, as above. `EmbeddedInfo`'s field order is simultaneously
+        // struct order and alphabetical, which is why this test passed either
+        // way and why it could never have established the precedent the
+        // instance-row test cited it for.
+        let mut keys: Vec<&str> = wire
+            .as_object()
+            .expect("an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
         assert_eq!(
-            object.keys().map(String::as_str).collect::<Vec<_>>(),
-            vec!["baseUrl", "dataDir", "instanceId", "operatorEmail"],
+            keys,
+            ["baseUrl", "dataDir", "instanceId", "operatorEmail"],
+            "the embedded record answers in exactly these keys: {wire}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The `Desktop` lane is red on `main` and on **every** pull request whose run was created after 2026-08-19 11:26:22Z. One test asserts a JSON object's keys alphabetically while the crate it runs in emits them in struct order.

Neither of the two commits that produced it is wrong alone, and they merged **19 seconds apart**, so no lane on either pull request could have seen the other:

| | PR | Merged | Did |
|---|---|---|---|
| `40e75970` | **#985** | 11:26:03Z | added `serde_json`'s `preserve_order` at `Cargo.toml:86` |
| `b9833a9f` | **#1096** | 11:26:22Z | added `an_instance_row_answers_in_the_keys_the_console_reads` |

`preserve_order` swaps a JSON object's backing map from `BTreeMap` (alphabetical) to `IndexMap` (insertion order, which for a derived `Serialize` is struct field order), and it reaches this crate through its path dependency on `opencompany`. `default-features = false` does not stop it — `serde_json` is an unconditional entry in that crate's `[dependencies]`, so Cargo unions the feature.

### Keep the feature, fix the assertion

`preserve_order` is load-bearing. Two SSE tests assert the raw, unsorted key order of a frame built by appending to a `json!` envelope in `project_event`, and reverting re-breaks both:

- `projects_turn_started_with_structural_keys_only` — `src/server/operator.rs:6666-6670`, expects `["type","seq","atMillis","turnId","chatId","parentId"]`
- `projects_turn_settled_without_the_failure_reason` — `:6698-6702`, expects `["type","seq","atMillis","turnId"]`

The wider radius of a revert is 26 `.keys()` call sites across 17 files and is unmeasured. `Cargo.toml:86` is untouched by this PR.

### Order was never what the test is about

Its own doc says it exists to catch a key **renamed**, because nothing type-checks a Rust struct against the TypeScript that reads it and a wrong key lands as "the instance list is full of blank rows" rather than as an error. A sorted comparison catches a rename, an addition and a removal equally well, and JSON object key order carries no meaning to the consumer. Asserting order was over-specification.

So this adopts the idiom the suite already uses, seven hundred lines away in `projects_the_per_node_finished_bracket` (`src/server/operator.rs:7367-7387`): collect the keys, `sort_unstable()`, compare against a closed alphabetical set. Both patterns already existed in this tree; the sorted one is the right one for this purpose.

The comment justifying the old assertion is gone. It read *"Sorted: `serde_json` maps are ordered, so this is the wire's order rather than the struct's"* — the mistaken generalisation that caused this — and cited `the_embedded_record_answers_in_the_keys_the_console_reads` as precedent. That precedent could never establish anything about order: `EmbeddedInfo`'s field order is simultaneously struct order and alphabetical, so it passes either way.

### Two sibling tests were latent, not correct

`a_paired_device_carries_no_token` and `the_embedded_record_answers_in_the_keys_the_console_reads` assert order the same way and pass today **only** because their structs' field order happens to be alphabetical. Both go red the moment a field is inserted out of position, for a reason having nothing to do with what they check. Given the same treatment here rather than left as a landmine.

### The `--locked` guard on this job did not work

`src-tauri/Cargo.lock` on `main` is stale: any cargo command against the desktop manifest adds `indexmap 2.14.0` under `serde_json`. Reproduced directly —

```
$ cargo metadata --manifest-path src-tauri/Cargo.toml --locked
error: cannot update the lock file … because --locked was passed to prevent this
```

The regenerated lock is committed here (a one-line diff). `ci.yml` said `--locked` was on `Test` "so a manifest edit whose lock was never regenerated is named here rather than absorbed", and it did not name this one: the `Clippy` step **above** it ran without `--locked` and absorbed the update, so `Test` inspected a file the previous step had already fixed. The console wrapper's clippy immediately below always passed `--locked`, so this was an inconsistency inside one job rather than a deliberate choice. Added the flag; verified locally that the step passes with it.

## API Or Behavior Changes

None. Test-only, plus a lockfile regeneration and one CI flag. No production code path changes, and `Cargo.toml:86` is untouched.

## Tests

Run against the desktop manifest, which is an independent workspace (`src-tauri/Cargo.toml:16`) — no root `cargo` command reaches it.

- [x] `cargo fmt --all -- --check` — clean. Also `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` — clean, which is the lane that actually covers this file.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A for the root crate: no Rust in it changed. Ran the lane that does cover the change, exactly as the edited step will invoke it: `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --no-deps -- -D warnings` — clean.
- [x] `cargo build --all-targets` — N/A for the root crate, same reason. The desktop crate was built as part of the test and clippy runs below.
- [x] `cargo test` — N/A for the root crate. Ran what CI's `Desktop` job runs: `cargo test --manifest-path src-tauri/Cargo.toml --locked` — **94 passed, 0 failed** (it is 93 passed / 1 failed on `main`).

### Proven, not assumed

**The fix is load-bearing.** Removing only `keys.sort_unstable()` from the instance-row test reproduces the exact failure `main`'s CI reports:

```
left:  ["id","label","dataDir","running","baseUrl","instanceId","operatorEmail","companies"]
right: ["baseUrl","companies","dataDir","id","instanceId","label","operatorEmail","running"]
```

**The test still does its job.** Adding `#[serde(rename = "dataDirectory")]` to `LocalInstanceInfo::data_dir` turns it red:

```
left:  [… ,"dataDirectory", …]
right: [… ,"dataDir", …]
```

Both changes reverted; the suite is green again at the committed state.

## Documentation

None needed. The three comments that were wrong are corrected in place, and the `ci.yml` note now says why `--locked` is on both steps rather than one.

---

Closes #1127
