### PR TITLE
workflows: two-row detail toolbar, New workflow on the index

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -67,13 +67,6 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
 import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
@@ -181,6 +174,20 @@ function clearWorkflowFromHash(): void {
   const { onWorkflows, workflowId } = readWorkflowHash();
   if (!onWorkflows || workflowId === null) return;
   window.history.replaceState(null, "", "#/workflows");
+}
+
+/**
+ * A hairline between two groups of toolbar controls (issue #1135).
+ *
+ * The row it sits in holds three groups — run intent, the secondary actions,
+ * and the two that change the workflow itself — and a uniform `gap-2` between
+ * nine buttons says nothing about which of them belong together. The rule is
+ * decoration only in the sense that it draws nothing new: it makes a grouping
+ * that is already true in the markup visible, which is what stopped `Run`
+ * reading as one pill among six and `Delete` as the neighbour of `Edit`.
+ */
+function ToolbarDivider() {
+  return <span aria-hidden className="mx-1 h-5 w-px shrink-0 bg-border" />;
 }
 
 /**
@@ -1749,15 +1756,6 @@ export function WorkflowsView({
 
   const selected = workflows.find((w) => w.id === selectedId) ?? null;
 
-  // id → display name, for the toolbar picker's closed state. A workflow's id
-  // is not its name, and the trigger renders the raw value unless it is handed
-  // this mapping — issue #270, where the closed picker read
-  // `e2e_conflict_1785687393855` while the open popup read "Conflict probe".
-  const workflowLabels = useMemo(
-    () => Object.fromEntries(workflows.map((w) => [w.id, w.name])),
-    [workflows],
-  );
-
   // The full node model (kind/name/summary/agent/config) for the clicked node,
   // looked up from the loaded graph so the inspector shows fields the laid-out
   // canvas node data doesn't carry (agent, config, …).
@@ -1900,374 +1898,391 @@ export function WorkflowsView({
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3">
-        {/* Issue #1110: the heading says where you are. On the index that is
-            the tab — "Workflows", and how many there are. In a workflow it is
-            that workflow's name, behind the control that goes back to the list,
-            which is the ordinary shape of a list → detail pair and is what
-            makes the two states tell themselves apart at a glance. */}
-        <div className="flex min-w-0 items-center gap-2">
-          {detailOpen ? (
-            <>
-              {/* Issue #1110: what "Browse" became. It used to toggle a panel
-                  over the canvas; the panel is the tab's front door now, so the
-                  button that pointed at it is the way back out. Named for the
-                  destination rather than the gesture — "Back" alone would be
-                  ambiguous next to the browser's own Back, which lands in the
-                  same place from here on purpose. */}
-              <Button
-                size="sm"
-                variant="ghost"
-                className="-ml-2 h-8 shrink-0 px-2 text-muted-foreground hover:text-foreground"
-                onClick={backToIndex}
-                data-testid="workflow-back-to-index"
-                title="Back to every workflow in this company."
-              >
-                <ArrowLeft className="mr-1.5 size-4" />
-                All workflows
-              </Button>
-              <h2 className="min-w-0 truncate text-sm font-semibold" data-testid="workflow-detail-name">
-                {selected?.name ?? graph?.name ?? selectedId}
-              </h2>
-              {/* Issue #228: the last run's outcome at a glance — including for
-                  a scheduled run nobody watched, which is the case the issue is
-                  about. Absent until this workflow has run at least once. */}
-              {lastRun && <LastRunChip run={lastRun} />}
-              {/* Issue #276: state an operator must not have to hover to learn.
-                  A paused workflow looks exactly like a live one otherwise, and
-                  the case that matters most — a schedule the disarm rule
-                  switched off on create — has never run, so there is no
-                  LastRunChip to hint at it. */}
-              {paused && (
-                <Badge variant="outline" data-testid="workflow-paused-badge">
-                  Schedule paused
-                </Badge>
-              )}
+      {/* Issue #1135: the tab's toolbar, in two shapes.
+
+          On the INDEX it is one row: where you are, and the two controls that
+          act on the list — how it is drawn, and `New workflow`, which is this
+          screen's primary action because making one is what an operator comes
+          to a list of workflows to do.
+
+          Inside a WORKFLOW it is two rows, because the controls answer two
+          different questions and one undifferentiated strip of nine made
+          neither of them readable. Row 1 is identity and state — where am I,
+          and how is it doing. Row 2 is action — what do I want to do to it.
+          `Run` is the only filled button on the detail screen: two primaries on
+          one screen means neither reads as the main action, which is why `New
+          workflow` moved to the index rather than being demoted here. */}
+      <div className="border-b px-4 py-3">
+        {detailOpen ? (
+          <div className="flex flex-col gap-3" data-testid="workflow-detail-toolbar">
+            {/* ── row 1 · identity and state ─────────────────────────────
+                Issue #1110: the heading says where you are — this workflow's
+                name, behind the control that goes back to the list, which is
+                the ordinary shape of a list → detail pair and is what makes
+                the two states tell themselves apart at a glance.
+
+                Issue #1135 dropped the workflow picker that used to sit below
+                it. You are already inside this workflow; its name is right
+                here and "All workflows" goes back. Switching between them is
+                what the index is for now. */}
+            <div
+              className="flex min-w-0 flex-col gap-1"
+              data-testid="workflow-detail-identity"
+            >
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                {/* Issue #1110: what "Browse" became. It used to toggle a panel
+                    over the canvas; the panel is the tab's front door now, so
+                    the button that pointed at it is the way back out. Named for
+                    the destination rather than the gesture — "Back" alone would
+                    be ambiguous next to the browser's own Back, which lands in
+                    the same place from here on purpose. */}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="-ml-2 h-8 shrink-0 px-2 text-muted-foreground hover:text-foreground"
+                  onClick={backToIndex}
+                  data-testid="workflow-back-to-index"
+                  title="Back to every workflow in this company."
+                >
+                  <ArrowLeft className="mr-1.5 size-4" />
+                  All workflows
+                </Button>
+                {/* Navigation is not identity. The hairline says so, so the
+                    name reads as a heading rather than as the next link. */}
+                <span aria-hidden className="h-4 w-px shrink-0 bg-border" />
+                <h2 className="min-w-0 truncate text-sm font-semibold" data-testid="workflow-detail-name">
+                  {selected?.name ?? graph?.name ?? selectedId}
+                </h2>
+                {/* Issue #228: the last run's outcome at a glance — including for
+                    a scheduled run nobody watched, which is the case the issue is
+                    about. Absent until this workflow has run at least once. */}
+                {lastRun && <LastRunChip run={lastRun} />}
+                {/* Issue #276: state an operator must not have to hover to learn.
+                    A paused workflow looks exactly like a live one otherwise, and
+                    the case that matters most — a schedule the disarm rule
+                    switched off on create — has never run, so there is no
+                    LastRunChip to hint at it. */}
+                {paused && (
+                  <Badge variant="outline" data-testid="workflow-paused-badge">
+                    Schedule paused
+                  </Badge>
+                )}
+              </div>
+              {/* Issue #1135: its own line. Beside the chips it was the flexible
+                  child of a row whose every other item is `shrink-0`, so it
+                  truncated first and hardest — often to a few words — while
+                  competing with them for the same reading. A line to itself both
+                  gives it the width to be read and leaves the chips alone. */}
               {selected?.description && (
-                <p className="hidden truncate text-xs text-muted-foreground sm:block">
+                <p
+                  className="truncate text-xs text-muted-foreground"
+                  data-testid="workflow-detail-description"
+                >
                   {selected.description}
                 </p>
               )}
-            </>
-          ) : (
-            <>
-              <h2 className="text-sm font-semibold">Workflows</h2>
-              <Badge variant="secondary">{workflows.length}</Badge>
-            </>
-          )}
-        </div>
-        {/* Issue #824. `flex-wrap` on the ACTION ROW, not just on the header
-            above it. The header already wraps, but that wrap only breaks
-            between its two children — and this row is one child whose buttons
-            are `shrink-0`, so on its own line it stayed 1386px wide inside a
-            1289px container and overflowed into an `overflow-hidden` ancestor.
-            Nothing in that chain scrolls, so `New workflow` was not merely
-            off-screen, it could not be clicked.
+            </div>
 
-            The row grows every time a control is added — `Pause` (#814) took
-            the overhang from 22px to 113px, which is what finally made it
-            visible — so it needs a break point of its own rather than a wider
-            budget. `justify-end` keeps the wrapped line aligned to the right
-            edge it belongs to instead of drifting left under the title. */}
-        <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
-          {/* Issue #1110: every control from here to `New workflow` acts on ONE
-              workflow, so none of them is on screen until one is open. That is
-              the issue in a line: an index with a Run button has no subject to
-              run, and a toolbar that keeps its subject by picking one for you is
-              how the tab came to open inside a workflow nobody chose.
-
-              `New workflow` stays outside this branch and is rendered in both
-              states, exactly as issue #341 requires of the control that answers
-              to that name. */}
-          {detailOpen && (
-            <>
-          <Select
-            // Issue #406, half one. NOT `selectedId ?? undefined`: Base UI
-            // decides controlled-vs-uncontrolled ONCE, on the first render,
-            // from `value !== undefined` — and on that render the list has not
-            // arrived, so `selectedId` is still null. Handing it `undefined`
-            // there locked the picker uncontrolled for its whole life, and
-            // every selection this view makes for itself — the auto-select
-            // when the list lands, a card in Browse, the re-select after a
-            // delete — then moved `selectedId` without ever reaching the
-            // picker, which went on rendering its own untouched initial value.
-            // Clicking an option worked, which is why only the operator saw
-            // this. `null` is Base UI's own "nothing is selected", so passing
-            // it keeps the picker controlled from the first render on.
-            value={selectedId}
-            onValueChange={(v) => setSelectedId(v)}
-            disabled={loadingList || workflows.length === 0}
-            // Issue #406, half two. This map is what makes the trigger show a
-            // name instead of an id (#270). It replaces a `SelectValue`
-            // function child that did the same lookup by hand — because a
-            // function child ALSO overrides `placeholder`, which is how an
-            // empty selection came to render nothing at all rather than "Pick
-            // a workflow". Formatting through `items` leaves the placeholder
-            // reachable.
-            items={workflowLabels}
-          >
-            <SelectTrigger className="h-8 w-56">
-              <SelectValue placeholder={loadingList ? "Loading…" : "Pick a workflow"} />
-            </SelectTrigger>
-            <SelectContent>
-              {workflows.map((w) => (
-                <SelectItem key={w.id} value={w.id}>
-                  {w.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
-            value={request}
-            onChange={(e) => setRequest(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && selectedId && !running && !loadingGraph) {
-                void run();
-              }
-            }}
-            disabled={!selectedId || running}
-            placeholder="What should this run work on?"
-            aria-label="Request for this run"
-            className="h-8 w-64"
-          />
-          <Button size="sm" onClick={() => void run()} disabled={!selectedId || running || loadingGraph}>
-            {running ? (
-              <Loader2 className="mr-1.5 size-4 animate-spin" />
-            ) : (
-              <Play className="mr-1.5 size-4" />
-            )}
-            Run
-          </Button>
-          {/* Issue #542: a dry run — the real graph over stubbed effects, so
-              nothing is sent and no tokens are spent. Shares the exact `run()`
-              dispatch (and its #528 error triage) as the Run button, passing the
-              dry flag; the result panel says what it was. */}
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => void run(true)}
-            disabled={!selectedId || running || loadingGraph}
-            data-testid="workflow-test-run"
-            title="Test run: walk the real workflow over stubbed effects to prove its routing and output shape. Nothing is sent, and no tokens are spent."
-          >
-            <FlaskConical className="mr-1.5 size-4" />
-            Test run
-          </Button>
-          {/* Issue #383. Present only while a run this view started is actually
-              in flight — which is knowable at all because the host now hands
-              back the run id before the run ends. Hidden once the host has told
-              us it cannot stop runs, rather than left there to fail every time. */}
-          {activeRunId && cancelUnsupportedFor !== activeRunId && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => void cancel()}
-              disabled={cancelling}
-              data-testid="workflow-cancel-run"
-              title="Stop this run. Steps that already finished stay in the run history; a step still executing is stopped where it is, not finished."
+            {/* ── row 2 · action ─────────────────────────────────────────
+                Three groups, hairline-separated, in the order an operator
+                reaches for them: what to run, then the things that inspect a
+                run, then the two that change or remove the workflow itself. */}
+            <div
+              className="flex flex-wrap items-center gap-2"
+              data-testid="workflow-detail-actions"
             >
-              {cancelling ? (
-                <Loader2 className="mr-1.5 size-4 animate-spin" />
-              ) : (
-                <Square className="mr-1.5 size-4" />
-              )}
-              Stop
-            </Button>
-          )}
-          {/* Issue #1110: the Browse toggle that used to sit here is gone. It
-              opened the index over the canvas, and the index is what the tab
-              opens on now — a button that toggles the surface you arrived
-              through is one control for two states with one name. Its job as a
-              way back is done by "All workflows" at the head of this bar, where
-              a back affordance belongs. */}
-          {/* Issue #303. Needs a loaded graph, not just a selection: the
-              copilot's whole grounding IS the graph, and opening it against a
-              workflow that failed to load would give it nothing to answer
-              from. */}
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setCopilotOpen((open) => !open);
-              // The inspector occupies the same corner. Two stacked panels on
-              // top of each other is worse than either alone.
-              setSelectedNodeId(null);
-            }}
-            disabled={!graph}
-            aria-pressed={copilotOpen}
-            data-testid="workflow-copilot-toggle"
-            title="Ask about this workflow — what it does, or why a run failed."
-          >
-            <Bot className="mr-1.5 size-4" />
-            Copilot
-          </Button>
-          {historySupported && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setHistoryOpen((open) => !open)}
-              aria-pressed={historyOpen}
-              data-testid="workflow-history-toggle"
-            >
-              <History className="mr-1.5 size-4" />
-              History
-              {historyRows.length > 0 && (
-                <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-3xs font-normal">
-                  {historyRows.length}
-                </Badge>
-              )}
-            </Button>
-          )}
-          {/* Issue #276. Pause stops the SCHEDULE, not the workflow — the title
-              says so, because "pause" on its own reads like "I can't run this",
-              and an operator debugging a workflow needs the opposite. Shown only
-              for a scheduled workflow: see `isScheduled`. */}
-          {isScheduled && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => void toggleEnabled()}
-              disabled={!canToggle}
-              aria-pressed={paused}
-              aria-label={paused ? "Resume schedule" : "Pause schedule"}
-              data-testid="workflow-toggle-enabled"
-              title={
-                paused
-                  ? "Start running this on its schedule again. It keeps its graph either way."
-                  : "Stop this running on its schedule. It keeps its graph and you can still run it by hand."
-              }
-            >
-              {toggling ? (
-                <Loader2 className="mr-1.5 size-4 animate-spin" />
-              ) : paused ? (
-                <Power className="mr-1.5 size-4" />
-              ) : (
-                <Pause className="mr-1.5 size-4" />
-              )}
-              {paused ? "Resume" : "Pause"}
-            </Button>
-          )}
-          {/* Issue #259. The wrapping span carries the explanation: a disabled
-              button swallows pointer events in most browsers, so a `title` on
-              the button itself would never show. */}
-          <span title={notEditable ? notEditableReason : undefined}>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setEditOpen(true)}
-              disabled={!canEdit}
-              aria-label="Edit workflow"
-              data-testid="workflow-edit"
-            >
-              <Pencil className="mr-1.5 size-4" />
-              Edit
-            </Button>
-          </span>
-          <span title={notEditable ? notEditableReason : undefined}>
-            <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-              <AlertDialogTrigger
-                render={
+              {/* run intent — the point of the screen, and the only filled
+                  button on it. */}
+              <div className="flex min-w-0 items-center gap-2">
+                <Input
+                  value={request}
+                  onChange={(e) => setRequest(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && selectedId && !running && !loadingGraph) {
+                      void run();
+                    }
+                  }}
+                  disabled={!selectedId || running}
+                  placeholder="What should this run work on?"
+                  aria-label="Request for this run"
+                  className="h-8 w-64 max-w-full"
+                />
+                <Button
+                  size="sm"
+                  onClick={() => void run()}
+                  disabled={!selectedId || running || loadingGraph}
+                  data-testid="workflow-run"
+                >
+                  {running ? (
+                    <Loader2 className="mr-1.5 size-4 animate-spin" />
+                  ) : (
+                    <Play className="mr-1.5 size-4" />
+                  )}
+                  Run
+                </Button>
+                {/* Issue #383. Present only while a run this view started is actually
+                    in flight — which is knowable at all because the host now hands
+                    back the run id before the run ends. Hidden once the host has told
+                    us it cannot stop runs, rather than left there to fail every time.
+                    It belongs to the run group: it is the same run, undone. */}
+                {activeRunId && cancelUnsupportedFor !== activeRunId && (
                   <Button
                     size="sm"
                     variant="outline"
-                    disabled={!canDelete}
-                    aria-label="Delete workflow"
-                    data-testid="workflow-delete"
+                    onClick={() => void cancel()}
+                    disabled={cancelling}
+                    data-testid="workflow-cancel-run"
+                    title="Stop this run. Steps that already finished stay in the run history; a step still executing is stopped where it is, not finished."
                   >
-                    {deleting ? (
+                    {cancelling ? (
                       <Loader2 className="mr-1.5 size-4 animate-spin" />
                     ) : (
-                      <Trash2 className="mr-1.5 size-4" />
+                      <Square className="mr-1.5 size-4" />
                     )}
-                    Delete
+                    Stop
                   </Button>
-                }
-              />
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete “{graph?.name ?? selectedId}”?</AlertDialogTitle>
-                  {/* Say exactly what goes and what stays. "Stops its schedule"
-                      is the consequence an operator most needs spelled out, and
-                      "past runs stay" stops them hesitating over losing history. */}
-                  <AlertDialogDescription>
-                    This removes the workflow and stops it running on its schedule. Past runs stay
-                    in the run history. This can&apos;t be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Keep it</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => {
-                      // Close FIRST: `remove()` clears the selection, so a
-                      // dialog left mounted would re-render its title as
-                      // `Delete “”?` over a backdrop nothing can click past.
-                      setConfirmOpen(false);
-                      void remove();
-                    }}
-                    className="bg-destructive text-white hover:bg-destructive/90"
-                    data-testid="workflow-delete-confirm"
-                  >
-                    Delete workflow
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </span>
-            </>
-          )}
-          {/* Issue #1110: the index's Cards/List toggle, in the tab's one
-              toolbar. It used to sit in a header the index drew for itself,
-              which was fine while the index was a panel over the canvas and
-              wrong the moment it became the page — "Workflows 7" and "All
-              workflows 7" one above the other, with the toggle stranded under
-              the duplicate.
+                )}
+              </div>
 
-              Segmented rather than two loose buttons, because the pair is one
-              question with two answers and reads as a switch. Shown only on the
-              index: it decides how the list is drawn, and there is no list to
-              draw inside a workflow. */}
-          {!detailOpen && workflows.length > 0 && (
-            <div className="flex items-center gap-1 rounded-lg border p-0.5">
-              {(
-                [
-                  { value: "cards", label: "Cards", Icon: LayoutGrid },
-                  { value: "list", label: "List", Icon: ListIcon },
-                ] as const
-              ).map(({ value, label, Icon }) => (
+              {/* secondary — prove it, ask about it, read what it did, put its
+                  schedule back. None of these is the main action, and they all
+                  look alike so that Run does not.
+
+                  The rule is INSIDE the group it introduces, not between the
+                  two: at narrow widths the row wraps, and a divider that is a
+                  sibling of both groups gets left dangling at the end of the
+                  line the group it belonged to just left. */}
+              <div className="flex flex-wrap items-center gap-2">
+                <ToolbarDivider />
+                {/* Issue #542: a dry run — the real graph over stubbed effects, so
+                    nothing is sent and no tokens are spent. Shares the exact `run()`
+                    dispatch (and its #528 error triage) as the Run button, passing the
+                    dry flag; the result panel says what it was. */}
                 <Button
-                  key={value}
                   size="sm"
-                  variant={indexMode === value ? "secondary" : "ghost"}
-                  className="h-7 px-2"
-                  onClick={() => {
-                    setIndexMode(value);
-                    writeIndexMode(value);
-                  }}
-                  aria-pressed={indexMode === value}
-                  data-testid={`workflow-index-${value}`}
+                  variant="outline"
+                  onClick={() => void run(true)}
+                  disabled={!selectedId || running || loadingGraph}
+                  data-testid="workflow-test-run"
+                  title="Test run: walk the real workflow over stubbed effects to prove its routing and output shape. Nothing is sent, and no tokens are spent."
                 >
-                  <Icon className="mr-1.5 size-3.5" />
-                  {label}
+                  <FlaskConical className="mr-1.5 size-4" />
+                  Test run
                 </Button>
-              ))}
+                {/* Issue #1110: the Browse toggle that used to sit here is gone. It
+                    opened the index over the canvas, and the index is what the tab
+                    opens on now — a button that toggles the surface you arrived
+                    through is one control for two states with one name. Its job as a
+                    way back is done by "All workflows" at the head of row 1, where
+                    a back affordance belongs. */}
+                {/* Issue #303. Needs a loaded graph, not just a selection: the
+                    copilot's whole grounding IS the graph, and opening it against a
+                    workflow that failed to load would give it nothing to answer
+                    from. */}
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setCopilotOpen((open) => !open);
+                    // The inspector occupies the same corner. Two stacked panels on
+                    // top of each other is worse than either alone.
+                    setSelectedNodeId(null);
+                  }}
+                  disabled={!graph}
+                  aria-pressed={copilotOpen}
+                  data-testid="workflow-copilot-toggle"
+                  title="Ask about this workflow — what it does, or why a run failed."
+                >
+                  <Bot className="mr-1.5 size-4" />
+                  Copilot
+                </Button>
+                {historySupported && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setHistoryOpen((open) => !open)}
+                    aria-pressed={historyOpen}
+                    data-testid="workflow-history-toggle"
+                  >
+                    <History className="mr-1.5 size-4" />
+                    History
+                    {historyRows.length > 0 && (
+                      <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-3xs font-normal">
+                        {historyRows.length}
+                      </Badge>
+                    )}
+                  </Button>
+                )}
+                {/* Issue #276. Pause stops the SCHEDULE, not the workflow — the title
+                    says so, because "pause" on its own reads like "I can't run this",
+                    and an operator debugging a workflow needs the opposite. Shown only
+                    for a scheduled workflow: see `isScheduled`. */}
+                {isScheduled && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void toggleEnabled()}
+                    disabled={!canToggle}
+                    aria-pressed={paused}
+                    aria-label={paused ? "Resume schedule" : "Pause schedule"}
+                    data-testid="workflow-toggle-enabled"
+                    title={
+                      paused
+                        ? "Start running this on its schedule again. It keeps its graph either way."
+                        : "Stop this running on its schedule. It keeps its graph and you can still run it by hand."
+                    }
+                  >
+                    {toggling ? (
+                      <Loader2 className="mr-1.5 size-4 animate-spin" />
+                    ) : paused ? (
+                      <Power className="mr-1.5 size-4" />
+                    ) : (
+                      <Pause className="mr-1.5 size-4" />
+                    )}
+                    {paused ? "Resume" : "Pause"}
+                  </Button>
+                )}
+              </div>
+
+              {/* utility · destructive — the two that change the workflow
+                  rather than run it, Delete last and in the destructive tone.
+                  Issue #1135's fourth complaint was that it sat flush against
+                  Edit with nothing separating it: an outline button one gap
+                  away from another outline button is a misclick away from a
+                  deletion. */}
+              <div className="flex items-center gap-2">
+                <ToolbarDivider />
+                {/* Issue #259. The wrapping span carries the explanation: a disabled
+                    button swallows pointer events in most browsers, so a `title` on
+                    the button itself would never show. */}
+                <span title={notEditable ? notEditableReason : undefined}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setEditOpen(true)}
+                    disabled={!canEdit}
+                    aria-label="Edit workflow"
+                    data-testid="workflow-edit"
+                  >
+                    <Pencil className="mr-1.5 size-4" />
+                    Edit
+                  </Button>
+                </span>
+                <span title={notEditable ? notEditableReason : undefined}>
+                  <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                    <AlertDialogTrigger
+                      render={
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          disabled={!canDelete}
+                          aria-label="Delete workflow"
+                          data-testid="workflow-delete"
+                        >
+                          {deleting ? (
+                            <Loader2 className="mr-1.5 size-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="mr-1.5 size-4" />
+                          )}
+                          Delete
+                        </Button>
+                      }
+                    />
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete “{graph?.name ?? selectedId}”?</AlertDialogTitle>
+                        {/* Say exactly what goes and what stays. "Stops its schedule"
+                            is the consequence an operator most needs spelled out, and
+                            "past runs stay" stops them hesitating over losing history. */}
+                        <AlertDialogDescription>
+                          This removes the workflow and stops it running on its schedule. Past runs
+                          stay in the run history. This can&apos;t be undone.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Keep it</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => {
+                            // Close FIRST: `remove()` clears the selection, so a
+                            // dialog left mounted would re-render its title as
+                            // `Delete “”?` over a backdrop nothing can click past.
+                            setConfirmOpen(false);
+                            void remove();
+                          }}
+                          className="bg-destructive text-white hover:bg-destructive/90"
+                          data-testid="workflow-delete-confirm"
+                        >
+                          Delete workflow
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </span>
+              </div>
             </div>
-          )}
-          {/* Issue #341: THE control named "New workflow". It is in the
-              toolbar in every state, so it is the one an operator — or a
-              screen reader, or a spec — should find under that name. The
-              empty-state call to action below is named differently on
-              purpose; two buttons answering to one name is an ambiguity
-              nothing can resolve. */}
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setCreateOpen(true)}
-            data-testid="workflow-create"
-          >
-            <Plus className="mr-1.5 size-4" />
-            New workflow
-          </Button>
-        </div>
+          </div>
+        ) : (
+          /* The index's one row: the tab's own heading, and the controls that
+             act on the list rather than on any workflow in it. */
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <h2 className="text-sm font-semibold">Workflows</h2>
+              <Badge variant="secondary">{workflows.length}</Badge>
+            </div>
+            <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+              {/* Issue #1110: the index's Cards/List toggle, in the tab's one
+                  toolbar. It used to sit in a header the index drew for itself,
+                  which was fine while the index was a panel over the canvas and
+                  wrong the moment it became the page — "Workflows 7" and "All
+                  workflows 7" one above the other, with the toggle stranded under
+                  the duplicate.
+
+                  Segmented rather than two loose buttons, because the pair is one
+                  question with two answers and reads as a switch. */}
+              {workflows.length > 0 && (
+                <div className="flex items-center gap-1 rounded-lg border p-0.5">
+                  {(
+                    [
+                      { value: "cards", label: "Cards", Icon: LayoutGrid },
+                      { value: "list", label: "List", Icon: ListIcon },
+                    ] as const
+                  ).map(({ value, label, Icon }) => (
+                    <Button
+                      key={value}
+                      size="sm"
+                      variant={indexMode === value ? "secondary" : "ghost"}
+                      className="h-7 px-2"
+                      onClick={() => {
+                        setIndexMode(value);
+                        writeIndexMode(value);
+                      }}
+                      aria-pressed={indexMode === value}
+                      data-testid={`workflow-index-${value}`}
+                    >
+                      <Icon className="mr-1.5 size-3.5" />
+                      {label}
+                    </Button>
+                  ))}
+                </div>
+              )}
+              {/* Issue #341: THE control named "New workflow" — the one an
+                  operator, a screen reader or a spec should find under that
+                  name. The empty-state call to action below is named
+                  differently on purpose; two buttons answering to one name is
+                  an ambiguity nothing can resolve.
+
+                  Issue #1135 put it here and only here. It is an index-level
+                  action, and it used to render in both states — stranded on a
+                  third toolbar row inside a workflow, where "new" is the one
+                  thing the screen is not about. Filled, because on the index it
+                  is the primary action; the detail screen's primary is Run. */}
+              <Button size="sm" onClick={() => setCreateOpen(true)} data-testid="workflow-create">
+                <Plus className="mr-1.5 size-4" />
+                New workflow
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Issue #259: a write refused because the graph moved under us. Distinct

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page, type APIRequestContext } from "@playwright/test";
 
 import {
+  backToWorkflowIndex,
   expectWorkflowIndex,
   openWorkflow,
   workflowCard,
@@ -29,7 +30,8 @@ import {
  * Edit mode landed after the rest of #259 (the backend, the client and Delete
  * shipped in #279), and its specs are here rather than in their own file
  * because they are the same feature and share this file's fixtures — a graph
- * created over HTTP, the tour dismissal, the picker helper. They cover:
+ * created over HTTP, the tour dismissal, the helper that opens one. They
+ * cover:
  *
  * * an edit round trip that the host actually stored;
  * * the id being **read-only**, not merely rejected on save (the host answers
@@ -130,17 +132,19 @@ async function removeWorkflow(request: APIRequestContext, id: string) {
  * toolbar picker, which was reachable on arrival because the view auto-selected
  * the first row.
  *
- * The picker itself is still there — inside a workflow, where it switches
- * between them — so the assertion #270 was pinned by is kept as a second line
- * here rather than dropped: the trigger must show the **name**, not the raw id.
- * (The picker binds `<SelectItem value={w.id}>` and Base UI's `SelectValue`
- * renders the value, not the item's children, which is how #270 happened; #406
- * is the other half, that the picker is controlled from its first render and so
- * follows a selection this view made for itself.)
+ * Issue #1135 then took the picker out of the detail toolbar altogether: you
+ * are inside this workflow, its name is the heading, and "All workflows" goes
+ * back. #270's property — the console names the workflow, it does not show the
+ * raw id — survives on that heading, which `openWorkflow` asserts by exact
+ * text. The second line here pins the removal itself, so a picker cannot creep
+ * back into the bar the issue cleared.
  */
 async function selectWorkflow(page: Page, name: string) {
   await openWorkflow(page, name);
-  await expect(page.getByRole("combobox").first()).toContainText(name);
+  await expect(
+    page.getByTestId("workflow-detail-toolbar").getByRole("combobox"),
+    "the detail toolbar no longer offers the workflow you are already in",
+  ).toHaveCount(0);
 }
 
 const DELETE = "workflow-delete";
@@ -527,14 +531,16 @@ test("a field error raised on one graph never appears on another", async ({
     // on the node id (rather than on the freshly minted row key) would carry
     // this complaint straight over to the second graph, attached to a field the
     // author never touched.
-    // Issue #1110: switched through the PICKER, not back out through the index.
-    // The picker survives inside a workflow precisely for this — moving from one
-    // graph to the next without a round trip through the list — and it is the
-    // path an author debugging two workflows actually takes. It is also the
-    // harder case for the defect under test: the view never unmounts the
-    // toolbar, so a stale error map has every chance to ride across.
-    await page.getByRole("combobox").first().click();
-    await page.getByRole("option", { name: second.name, exact: true }).click();
+    // Issue #1135: switched through the INDEX, because that is now the only way
+    // to move between two graphs — the toolbar picker this step used to drive
+    // is gone, and "All workflows" is the way out.
+    //
+    // Still the case the defect needs: `WorkflowsView` itself never unmounts on
+    // this trip (only the branch inside it re-renders), so the field-error map
+    // the issue is about survives the switch exactly as it did through the
+    // picker and has every chance to ride across.
+    await backToWorkflowIndex(page);
+    await openWorkflow(page, second.name);
     await expect(workflowDetailName(page)).toHaveText(second.name);
 
     const other = await openEditDialog(page, second.name);

--- a/frontend/test/e2e/workflow-live-list.spec.ts
+++ b/frontend/test/e2e/workflow-live-list.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@playwright/test";
 
 import {
+  backToWorkflowIndex,
   expectWorkflowIndex,
   openWorkflow,
   workflowCard,
@@ -127,10 +128,11 @@ async function removeWorkflow(request: APIRequestContext, id: string) {
   await request.delete(`${COMPANY_SCOPE}/workflows/${id}${query}`).catch(() => undefined);
 }
 
-/** The workflow picker's trigger. */
-function picker(page: Page) {
-  return page.getByRole("combobox").first();
-}
+/* Issue #1135: `picker`, the workflow selector's trigger, lived here. The
+ * detail toolbar no longer carries one — the workflow you are in is the
+ * heading, and switching between them is what the index is for — so the rename
+ * test below reads the open workflow's heading and then its index card, which
+ * is every surface the console names a workflow on. */
 
 /**
  * Opens the Workflows tab and waits for the index to settle.
@@ -192,7 +194,7 @@ test("a workflow authored elsewhere reaches the list, with no reload", async ({
   }
 });
 
-test("a workflow renamed elsewhere renames in the picker, with no reload", async ({
+test("a workflow renamed elsewhere renames on screen, with no reload", async ({
   page,
   request,
 }) => {
@@ -210,18 +212,23 @@ test("a workflow renamed elsewhere renames in the picker, with no reload", async
     // edit #259 made possible, and which nothing told this tab about.
     await renameWorkflow(request, id, after, createdVersion);
 
-    // Read off the OPEN workflow's own heading and off the picker beside it,
-    // both of which render the selected workflow's name from the same list the
-    // options come from: the rename has to land on the workflow on screen, not
-    // merely somewhere in a dropdown nobody has open.
+    // Read off the OPEN workflow's own heading first: the rename has to land on
+    // the workflow the operator is looking at, not merely somewhere in a list.
     await expect(
       workflowDetailName(page),
       "a rename elsewhere must reach the open workflow live",
     ).toHaveText(after, { timeout: 20_000 });
-    await expect(picker(page), "…and the picker beside it").toContainText(after, {
+
+    // …and then off the index, which is the other surface the same `workflows`
+    // array feeds. Issue #1135 retired the toolbar picker this used to check;
+    // the index card is where a name that failed to update would now be stale,
+    // and it is checked for the OLD name too, so a list that grew a second row
+    // rather than renaming its one row fails here.
+    await backToWorkflowIndex(page);
+    await expect(workflowCard(page, after), "…and the index card").toHaveCount(1, {
       timeout: 20_000,
     });
-    await expect(picker(page)).not.toContainText(before);
+    await expect(workflowCard(page, before)).toHaveCount(0);
   } finally {
     await removeWorkflow(request, id);
   }

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -52,14 +52,10 @@ async function deleteWorkflow(request: APIRequestContext, id: string) {
 /**
  * Which workflow is open, read off the detail view's own heading.
  *
- * Issue #1110 moved this assertion off the toolbar picker. The picker is still
- * there — inside a workflow — but it is no longer what says "this workflow is
- * the one on screen": the tab now opens on the index, where nothing is, and the
- * heading is the surface that names the workflow whose canvas is up. Asserting
- * on the picker would still pass for a view that opened the right workflow and
- * would also pass for one that never left the index, since a stale combobox
- * would simply be absent and `toContainText` on nothing is an error rather than
- * a clear report.
+ * Issue #1110 moved this assertion off the toolbar picker, and issue #1135
+ * removed that picker outright. Either way the heading is the surface that says
+ * "this workflow is the one on screen": the tab opens on the index, where
+ * nothing is open, and the heading is what the detail view names itself with.
  */
 function openWorkflowName(page: Page) {
   return workflowDetailName(page);
@@ -135,8 +131,8 @@ test("workflows tab selection is preserved across tab switches (#864)", async ({
   const firstId = `e2e-864-first-${stamp}`;
   const secondId = `e2e-864-second-${stamp}`;
   // Stamped like every other probe here: a run that dies before its cleanup
-  // leaves these workflows behind, and a static name would then match twice in
-  // the picker and fail the NEXT run on a strict-mode violation.
+  // leaves these workflows behind, and a static name would then match twice on
+  // the index and fail the NEXT run on a strict-mode violation.
   const firstName = `Workflow selector probe A ${stamp}`;
   const secondName = `Workflow selector probe B ${stamp}`;
 

--- a/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
+++ b/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
@@ -6,13 +6,21 @@ import {
   type Page,
 } from "@playwright/test";
 
-import { openWorkflow } from "./workflows";
+import { expectWorkflowIndex, openWorkflow } from "./workflows";
 
 /**
  * Issue #824: the workflows toolbar laid out wider than its container and
  * overflowed into an `overflow-hidden` ancestor, so its last control —
  * **New workflow** — was clipped off the right edge. Nothing in that chain
  * scrolls, so the button was not merely off-screen: it could not be clicked.
+ *
+ * Issue #1135 split the bar in two and moved `New workflow` out of the detail
+ * view to the index, so the control the defect was reported against is no
+ * longer on the crowded row at all. That does not retire the spec: the property
+ * it pins is "every control the operator can see is reachable", which now has
+ * to hold on **two** surfaces. So the controls are listed per surface, the
+ * detail row is measured inside a workflow, and the index row on the index —
+ * and the clickability test moved with the button it is about.
  *
  * This is a **layout** defect, so it is only observable in a browser. jsdom
  * computes no geometry, and a unit test asserting the class string would pass
@@ -97,7 +105,10 @@ async function selectWorkflow(page: Page, name: string) {
 }
 
 /**
- * The toolbar's controls, each with the locator that finds it.
+ * The **detail** toolbar's controls, each with the locator that finds it —
+ * every control issue #1135 kept on a workflow's own two rows, in the order it
+ * put them: row 1's way back, then row 2's run intent, secondary group, and the
+ * utility pair ending in Delete.
  *
  * `Pause` is not addressed by name like the rest: its accessible name comes
  * from an `aria-label` that flips to `Resume schedule` once the schedule is
@@ -110,7 +121,15 @@ async function selectWorkflow(page: Page, name: string) {
  * visible, taking the overhang from 22px to 113px, so a version of this spec
  * that skipped it would be measuring the row that fits.
  */
-const CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
+const DETAIL_CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
+  {
+    // Issue #1110: what "Browse" became. It opened the index over the canvas;
+    // the index is the tab's front door now, so the control is the way back to
+    // it. Addressed by test id for the same reason Pause is — it sits in row 1
+    // with the heading rather than in the action row, and its name is prose.
+    label: "All workflows",
+    find: (p) => p.getByTestId("workflow-back-to-index"),
+  },
   {
     label: "Run",
     find: (p) => p.getByRole("button", { name: "Run", exact: false }).first(),
@@ -118,14 +137,6 @@ const CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
   {
     label: "Test run",
     find: (p) => p.getByRole("button", { name: "Test run" }).first(),
-  },
-  {
-    // Issue #1110: what "Browse" became. It opened the index over the canvas;
-    // the index is the tab's front door now, so the control is the way back to
-    // it. Addressed by test id for the same reason Pause is — it sits in the
-    // heading group rather than the action row, and its name is prose.
-    label: "All workflows",
-    find: (p) => p.getByTestId("workflow-back-to-index"),
   },
   {
     label: "Copilot",
@@ -144,6 +155,16 @@ const CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
     label: "Delete",
     find: (p) => p.getByRole("button", { name: "Delete" }).first(),
   },
+];
+
+/**
+ * The index's own row. Short by comparison, and that is the point of #1135 —
+ * but it is the row `New workflow` lives on now, so this is where the control
+ * the original defect clipped has to be measured.
+ */
+const INDEX_CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
+  { label: "Cards", find: (p) => p.getByTestId("workflow-index-cards") },
+  { label: "List", find: (p) => p.getByTestId("workflow-index-list") },
   {
     label: "New workflow",
     find: (p) => p.getByRole("button", { name: "New workflow" }),
@@ -161,7 +182,7 @@ test.describe("workflows toolbar reachability (#824)", () => {
   });
 
   for (const width of [1280, 1024]) {
-    test(`every toolbar control is inside the viewport at ${width}px`, async ({
+    test(`every detail toolbar control is inside the viewport at ${width}px`, async ({
       page,
     }) => {
       await page.setViewportSize({ width, height: 800 });
@@ -174,12 +195,39 @@ test.describe("workflows toolbar reachability (#824)", () => {
       ).toBeVisible();
       await selectWorkflow(page, WORKFLOW_NAME);
 
-      for (const { label, find } of CONTROLS) {
+      for (const { label, find } of DETAIL_CONTROLS) {
         const control = find(page);
         await expect(control, `${label} should be mounted`).toBeVisible();
         // The assertion that matters. `toBeVisible` is true for a button that
         // has been pushed past the right edge — it is painted, just not
         // anywhere reachable. `toBeInViewport` is what distinguishes the two.
+        await expect(
+          control,
+          `${label} should be reachable at ${width}px`,
+        ).toBeInViewport();
+      }
+
+      // Issue #1135: `New workflow` is an index action, and the detail toolbar
+      // is where it used to be stranded on a row of its own. Its absence here
+      // is the other half of the reachability property — a control nobody can
+      // see cannot be clipped.
+      await expect(
+        page.getByRole("button", { name: "New workflow" }),
+        "New workflow belongs to the index, not to one workflow",
+      ).toHaveCount(0);
+    });
+
+    test(`every index toolbar control is inside the viewport at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto("/#/workflows");
+      await dismissTour(page);
+      await expectWorkflowIndex(page);
+
+      for (const { label, find } of INDEX_CONTROLS) {
+        const control = find(page);
+        await expect(control, `${label} should be mounted`).toBeVisible();
         await expect(
           control,
           `${label} should be reachable at ${width}px`,
@@ -194,12 +242,15 @@ test.describe("workflows toolbar reachability (#824)", () => {
     // The defect's real cost. Every control above could be in the viewport and
     // this could still fail if something overlapped it, so the last word is an
     // actual click with its actual consequence.
+    //
+    // Issue #1135: on the INDEX, which is where the button lives now. The
+    // "click against the crowded row" reasoning went with it — the crowded row
+    // no longer has this button on it, and the row it does have is the one the
+    // test above measures.
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/#/workflows");
     await dismissTour(page);
-    // Selected, because that is the crowded row. Clicking against the short
-    // one would prove nothing: the short row never clipped anything.
-    await selectWorkflow(page, WORKFLOW_NAME);
+    await expectWorkflowIndex(page);
 
     const newWorkflow = page.getByRole("button", { name: "New workflow" });
     // Measured before the click, and the reason is not belt-and-braces: a

--- a/frontend/test/e2e/workflows.ts
+++ b/frontend/test/e2e/workflows.ts
@@ -4,10 +4,14 @@ import { expect, type Page } from "@playwright/test";
  * How a spec reaches a workflow, since issue #1110.
  *
  * `#/workflows` is the index — every workflow, and none of them open. The
- * per-workflow toolbar (the picker, Run, Test run, Copilot, History, Edit,
- * Delete) exists only once one is opened, so a spec that needs any of it has to
- * open one first. Before #1110 the view auto-selected the first row, and eight
- * specs relied on that without saying so; this module is where they say it.
+ * per-workflow toolbar (Run, Test run, Copilot, History, Resume, Edit, Delete)
+ * exists only once one is opened, so a spec that needs any of it has to open
+ * one first. Before #1110 the view auto-selected the first row, and eight specs
+ * relied on that without saying so; this module is where they say it.
+ *
+ * Issue #1135 made that the only route. The toolbar picker a spec could once
+ * use to hop straight from one workflow to the next is gone — switching is
+ * {@link backToWorkflowIndex} followed by {@link openWorkflow}.
  *
  * Deliberately shared rather than copied into each spec: "how do I get to a
  * workflow" is one answer, and the next change to the flow should have one

--- a/frontend/test/unit/workflow-toolbar-layout.test.ts
+++ b/frontend/test/unit/workflow-toolbar-layout.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph, WorkflowSummary } from "@/api/workflows";
+
+/**
+ * Issue #1135: the workflow detail toolbar carried index-level controls, on
+ * three ragged rows.
+ *
+ * Every assertion here is about *what is on screen and how it is grouped*,
+ * which is a fact about rendered output and about nothing else — no pure helper
+ * can hold it, so this file renders the view, the way
+ * `workflow-index-first.test.ts` earns the same exception.
+ *
+ * The four decisions the issue asked for are the four blocks below: the
+ * workflow picker is gone from the detail view, `New workflow` belongs to the
+ * index and is that screen's primary, the detail screen's one primary is `Run`,
+ * and the toolbar is two rows with the description on its own line and `Delete`
+ * set apart at the end.
+ *
+ * The primary assertions read the `bg-primary` fill off the rendered class
+ * string on purpose. "Exactly one filled button per screen" is the issue's
+ * third complaint stated exactly, and the fill is the only place that fact
+ * exists — a `variant` prop is not observable once `cva` has flattened it.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount; jsdom has no layout and no
+// `ResizeObserver`. None of these three is under test.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+const ROWS: WorkflowSummary[] = [
+  {
+    id: "alpha",
+    name: "Daily Agent Harness Tweets",
+    description:
+      "Every day at 9am, searches for trending tweets matching 'Agent harness' and drafts a reply for review.",
+  },
+  { id: "beta", name: "Beta report" },
+];
+
+function graphFor(id: string): WorkflowGraph {
+  const row = ROWS.find((r) => r.id === id);
+  return {
+    id,
+    name: row?.name ?? id,
+    version: "v1",
+    nodes: [
+      // Scheduled, so the Pause/Resume control mounts — it is one of the four
+      // the issue names in the secondary group.
+      { id: "start", kind: "trigger", name: "Start", schedule: "0 9 * * *" },
+      { id: "done", kind: "output", name: "Done" },
+    ],
+    edges: [{ from: "start", to: "done" }],
+  };
+}
+
+function makeClient(rows: WorkflowSummary[] = ROWS) {
+  const client = {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return rows;
+      if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
+      if (path.includes("/workflows/wired-channels")) return { channels: [] };
+      if (path.includes("/workflows/runs")) return [];
+      const m = path.match(/\/workflows\/([^/?]+)$/);
+      if (m) return graphFor(decodeURIComponent(m[1]));
+      return null;
+    },
+    post: async () => ({}),
+    del: async () => undefined,
+  } as unknown as OpenCompanyClient;
+  return client;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  window.location.hash = "";
+});
+
+/** Mount at a hash, with `sub` matching it the way the router would hand it over. */
+async function mountAt(hash: string, client: OpenCompanyClient, company = "acme") {
+  window.location.hash = hash;
+  const sub = hash.replace(/^#\/?/, "").split("?")[0].split("/").filter(Boolean)[1] ?? null;
+  await act(async () => {
+    root.render(createElement(WorkflowsView, { client, company, sub }));
+  });
+}
+
+const buttons = () => Array.from(container.querySelectorAll<HTMLButtonElement>("button"));
+const named = (label: string) =>
+  buttons().find((b) => b.textContent?.trim() === label) ?? null;
+/** Every button drawn with the primary fill — the screen's declared main action. */
+const filled = () =>
+  buttons()
+    .filter((b) => b.className.split(/\s+/).includes("bg-primary"))
+    .map((b) => b.textContent?.trim() ?? "");
+const testId = (id: string) => container.querySelector<HTMLElement>(`[data-testid="${id}"]`);
+const idsWithin = (id: string) =>
+  Array.from(testId(id)?.querySelectorAll<HTMLElement>("[data-testid]") ?? []).map(
+    (el) => el.dataset.testid,
+  );
+
+describe("the detail toolbar carries only this workflow's controls (#1135)", () => {
+  it("drops the workflow picker — the name is the heading and the index is the switch", async () => {
+    await mountAt("#/workflows/alpha", makeClient());
+
+    expect(testId("workflow-detail-name")?.textContent).toBe("Daily Agent Harness Tweets");
+    // The `<Select>` that used to sit under the heading, offering the workflow
+    // you are already inside. Nothing on the detail screen is a combobox now.
+    expect(container.querySelector('[role="combobox"]')).toBeNull();
+    // The way back is a back link, not a dropdown.
+    expect(testId("workflow-back-to-index")).not.toBeNull();
+  });
+
+  it("leaves `New workflow` to the index, where the list it makes one for lives", async () => {
+    const client = makeClient();
+    await mountAt("#/workflows/alpha", client);
+    expect(named("New workflow")).toBeNull();
+    expect(testId("workflow-create")).toBeNull();
+
+    await act(async () => {
+      testId("workflow-back-to-index")?.click();
+    });
+    expect(testId("workflow-create")).not.toBeNull();
+  });
+});
+
+describe("one filled button per screen (#1135)", () => {
+  it("makes Run the detail screen's primary, and nothing else", async () => {
+    await mountAt("#/workflows/alpha", makeClient());
+    expect(filled()).toEqual(["Run"]);
+  });
+
+  it("makes New workflow the index's primary, and nothing else", async () => {
+    await mountAt("#/workflows", makeClient());
+    expect(filled()).toEqual(["New workflow"]);
+  });
+});
+
+describe("the detail toolbar is two rows (#1135)", () => {
+  it("puts identity and state on row 1, with the description on its own line", async () => {
+    await mountAt("#/workflows/alpha", makeClient());
+
+    const identity = testId("workflow-detail-identity");
+    expect(identity).not.toBeNull();
+    expect(idsWithin("workflow-detail-identity")).toEqual([
+      "workflow-back-to-index",
+      "workflow-detail-name",
+      "workflow-detail-description",
+    ]);
+
+    // "Its own line" is the fix for the description losing a width fight with
+    // the chips, so it must be a sibling of the row they sit in, not a member
+    // of it — a `<p>` inside that row would truncate exactly as before.
+    const description = testId("workflow-detail-description");
+    expect(description?.textContent).toContain("Every day at 9am");
+    expect(description?.parentElement).toBe(identity);
+    expect(description?.previousElementSibling?.contains(testId("workflow-detail-name"))).toBe(
+      true,
+    );
+  });
+
+  it("puts the actions on row 2, run intent first and Delete last", async () => {
+    await mountAt("#/workflows/alpha", makeClient());
+
+    const order = idsWithin("workflow-detail-actions");
+    expect(order).toEqual([
+      "workflow-run",
+      "workflow-test-run",
+      "workflow-copilot-toggle",
+      "workflow-history-toggle",
+      "workflow-toggle-enabled",
+      "workflow-edit",
+      "workflow-delete",
+    ]);
+
+    // Grouped, not one undifferentiated strip. Asserted as what each group
+    // EXCLUDES as well as what it holds: "Run and the field share a parent" is
+    // also true of the flat row this issue replaced, since everything shared
+    // one parent there.
+    const requestField = container.querySelector('input[aria-label="Request for this run"]');
+    const runGroup = testId("workflow-run")?.parentElement;
+    expect(runGroup).toBe(requestField?.parentElement);
+    expect(runGroup?.contains(testId("workflow-test-run"))).toBe(false);
+
+    const utility = testId("workflow-delete")?.closest("div");
+    expect(utility?.contains(testId("workflow-edit"))).toBe(true);
+    expect(utility?.contains(testId("workflow-history-toggle"))).toBe(false);
+    // And the destructive action is not another outline button one gap from
+    // Edit: it carries the destructive tone.
+    expect(testId("workflow-delete")?.className).toContain("text-destructive");
+  });
+});


### PR DESCRIPTION
## Summary

The workflow detail toolbar carried index-level controls on three ragged rows. This rebuilds it to the layout approved in #1135.

**Row 1 · identity and state** — `← All workflows │ Name  ● last-run chip  [Schedule paused]`, with the description on its own line beneath. Beside the chips it was the one flexible child of a row whose every other item is `shrink-0`, so it truncated first and hardest while competing with them for the same reading; a line to itself gives it the width to be read and leaves the chips alone.

**Row 2 · action** — the run-input and **Run**, then a hairline, then the secondary group (Test run · Copilot · History · Pause/Resume), then a hairline, then Edit and Delete with Delete last and in the design system's `destructive` tone. The rules sit *inside* the group they introduce rather than between two groups, so a row that wraps at a narrow width does not leave one dangling at the end of the line its group just left.

**The workflow selector is gone.** You are already inside this workflow — its name is the heading and "All workflows" goes back. Since #1110 switching workflows is what the index is for.

**`New workflow` moved to the index and is that screen's primary.** It is an index-level action, and it used to render in both states — stranded on a third toolbar row inside a workflow, where "new" is the one thing the screen is not about. The detail screen's primary is **Run**; exactly one filled button per screen, so each one reads as the main action of the screen it is on.

## Verified in a browser

Driven with Playwright against a real host (`opencompany serve` + `vite dev`), signed in over the loopback `dev_code`, tour dismissed, at **1440** and **1100** wide in **light** and **dark**:

- **Detail, 1440** — one line: back link · hairline · name · `Schedule paused`; the full description on the line beneath; then the action row on one line with Run as the only filled control and the two hairlines separating the three groups.
- **Detail, 1100** — the action row wraps after `Resume`; `│ Edit  Delete` continues on the next line with the group's own rule leading it.
- **Index, both widths** — `Workflows 4` on the left, `[Cards|List]` and a filled `New workflow` on the right; no per-workflow control anywhere.

## Commands run

- `npm run typecheck`, `npm run typecheck:e2e`, `npm run typecheck:unit`
- `npm test` — 116 files, 1126 tests
- `npx playwright test workflow` — 41 passed, 4 skipped (live-brain lane)
- `scripts/ci/assert-design-tokens.sh`

## Tests updated (not weakened)

- **`test/unit/workflow-toolbar-layout.test.ts`** (new, 6 tests) — the picker is gone from the detail view; `New workflow` renders on the index and not in a workflow; exactly one filled button per screen and it is `Run` / `New workflow` respectively; row 1 holds back link → name → description with the description a *sibling* of the chips row rather than a member of it; row 2's order ends in `Delete`, the run group excludes Test run and the utility group excludes History.
- **`test/e2e/workflow-toolbar-reachable.spec.ts`** (#824) — split into `DETAIL_CONTROLS` and `INDEX_CONTROLS` and measured on the surface each belongs to, since the control the original defect clipped now lives on the index. The detail test additionally asserts `New workflow` has *count 0* there, and the "can actually be clicked" test moved to the index with it.
- **`test/e2e/workflow-edit-delete.spec.ts`** — `selectWorkflow` no longer reads the workflow's name off the picker (#270's property lives on the heading, which `openWorkflow` asserts by exact text); it now asserts the detail toolbar holds **no** combobox, so a picker cannot creep back. "A field error raised on one graph never appears on another" switches graphs through the index instead of the picker — still the case the defect needs, since `WorkflowsView` itself never unmounts on that trip.
- **`test/e2e/workflow-live-list.spec.ts`** — the rename test read the picker; it now reads the open workflow's heading *and* its index card, and checks the old name is gone from the index too, so a list that grew a second row instead of renaming its one row fails.
- **`test/e2e/workflows.ts`**, **`workflow-selection-persists.spec.ts`** — doc comments that described the picker as still present.

## Notes

- Design tokens only — no raw hex, no palette classes. `Delete` uses the existing `destructive` button variant.
- PR #1111 (run-history left rail) also edits `WorkflowsView.tsx`; on conflict both changes should be kept.

Closes #1135
