### PR TITLE
fix(workflows): give the List view three columns with fixed edges

### DIFF
--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -24,13 +24,27 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { failedNodeOf } from "./graph";
-import { pendingCount, relativeTime, runTone, undeliveredCount } from "./run-health";
+import {
+  pendingCount,
+  relativeTime,
+  runSummaryLine,
+  runTone,
+  undeliveredCount,
+} from "./run-health";
 
 /** Which rendering the index is showing. Persisted by the caller. */
 export type IndexMode = "cards" | "list";
 
 /** How many recent runs the health strip shows per workflow. */
 const STRIP_RUNS = 5;
+
+/** The two "no run to report" readings, named once because a card and a list
+ * row both say them (issue #1136) and two copies of a sentence this careful
+ * drift apart. What each one means is argued in {@link HealthLine}. */
+const NO_RUNS_LABEL = "No recent runs";
+const NO_RUNS_TITLE =
+  "No runs in the recent company-wide page. Open the workflow to read its own run history.";
+const LOADING_RUNS_LABEL = "Loading runs…";
 
 export function WorkflowIndex({
   workflows,
@@ -94,7 +108,11 @@ export function WorkflowIndex({
           ))}
         </div>
       ) : (
-        <div className="divide-y rounded-xl border">
+        // `@container`: the row's breakpoint is the LIST's width, not the
+        // window's — the tab sits beside a sidebar, so a viewport breakpoint
+        // would drop the description while there was still room for it, and
+        // keep it past the point where there wasn't (issue #1136).
+        <div className="@container divide-y rounded-xl border">
           {workflows.map((w) => (
             <WorkflowRow
               key={w.id}
@@ -161,7 +179,27 @@ function WorkflowCard({
 }
 
 /** One workflow as a list row — the same facts, laid out for scanning down a
- * column rather than across a grid. */
+ * column rather than across a grid.
+ *
+ * WHY EVERY COLUMN BUT ONE IS A FIXED LENGTH (issue #1136). A row is its own
+ * element, so a grid drawn here is a grid of ONE row: `auto` and `fr` tracks are
+ * measured against that row's own content and nothing else. Sized that way the
+ * columns land wherever each row's own text happens to end, which is exactly the
+ * ragged edge the flex version had — the description's left edge zigzagging by a
+ * couple of hundred pixels and the status dots never forming a line. Fixed
+ * lengths are what a shared vertical edge is made of; the single `1fr` is the
+ * description, and it is the same width on every row because everything around
+ * it is.
+ *
+ * NARROW VIEWPORTS: the description is the column that yields. Below `@3xl`
+ * (48rem of *list* width — a container query, because the sidebar means the
+ * viewport is not the width this list gets) the three fixed tracks plus a
+ * readable description no longer fit, and the description would be truncated to
+ * a word or two. It is dropped entirely there and the name takes the space: a
+ * name identifies the row, a five-character description fragment identifies
+ * nothing. `hidden` rather than a conditional render on purpose — a
+ * `display: none` cell is not a grid item, so the remaining three cells fall
+ * into the three-track template with no second code path. */
 function WorkflowRow({
   workflow,
   runs,
@@ -178,25 +216,78 @@ function WorkflowRow({
       type="button"
       onClick={onSelect}
       data-testid="workflow-list-row"
-      className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 text-left transition hover:bg-accent/40"
+      className="grid w-full grid-cols-[minmax(0,1fr)_13rem_4.5rem] items-center gap-x-3 px-3 py-2 text-left transition hover:bg-accent/40 @3xl:grid-cols-[17.5rem_minmax(0,1fr)_13rem_4.5rem]"
     >
-      <span className="min-w-0 flex-1 truncate text-sm font-medium">{workflow.name}</span>
-      {workflow.editable === false && (
-        <Badge
-          variant="outline"
-          className="h-4 shrink-0 px-1.5 text-3xs font-normal"
-          title="Defined by a file in the company source tree, so it can't be changed or removed from the console."
-        >
-          in source
-        </Badge>
-      )}
-      <span className="hidden min-w-0 flex-1 truncate text-xs text-muted-foreground sm:block">
+      <span className="flex min-w-0 items-center gap-2">
+        {/* `title` because the column is fixed: a truncated name is unreadable
+            without one, and this is the only place the row says which workflow
+            it is. */}
+        <span className="truncate text-sm font-medium" title={workflow.name}>
+          {workflow.name}
+        </span>
+        {/* Issue #1136: inside the name cell, not floating between columns —
+            the badge qualifies the name, so it travels with it. */}
+        {workflow.editable === false && (
+          <Badge
+            variant="outline"
+            className="h-4 shrink-0 px-1.5 text-3xs font-normal"
+            title="Defined by a file in the company source tree, so it can't be changed or removed from the console."
+          >
+            in source
+          </Badge>
+        )}
+      </span>
+      <span
+        className="hidden min-w-0 truncate text-xs text-muted-foreground @3xl:block"
+        title={workflow.description ?? undefined}
+      >
         {workflow.description ?? ""}
       </span>
-      <span className="shrink-0">
-        <HealthLine runs={runs} runsLoaded={runsLoaded} />
-      </span>
+      <RowHealth runs={runs} runsLoaded={runsLoaded} />
     </button>
+  );
+}
+
+/** The last two cells of a list row: how the most recent run went, and when.
+ *
+ * The same reading {@link HealthLine} gives a card, split across two grid cells
+ * (issue #1136) — a fragment, so the row's grid places each one itself. The
+ * status text starts at the left edge of its own fixed column, which is what
+ * puts the dots in a vertical line; the time sits right-aligned in a column
+ * narrow enough that "21h ago" and "7d ago" end on the same pixel.
+ *
+ * Both are single-line and truncate: a row that wraps is a row that is taller
+ * than its neighbours, and the alignment this is all for is the first thing an
+ * uneven row height destroys. */
+function RowHealth({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoaded: boolean }) {
+  const last = runs[0];
+
+  // Nothing to show, and the two reasons for that are NOT the same thing — see
+  // {@link HealthLine}, which owns the wording both surfaces use. The time cell
+  // is simply absent; it is the last column, so nothing follows it to shift.
+  if (!last) {
+    return runsLoaded ? (
+      <span className="truncate text-2xs text-muted-foreground" title={NO_RUNS_TITLE}>
+        {NO_RUNS_LABEL}
+      </span>
+    ) : (
+      <span className="truncate text-2xs text-muted-foreground/60">{LOADING_RUNS_LABEL}</span>
+    );
+  }
+
+  const tone = runTone(last);
+  const label = runSummaryLine(last, tone.label, last.error ? failedNodeOf(last) : null);
+
+  return (
+    <>
+      <span className="flex min-w-0 items-center gap-1.5 text-2xs" title={label}>
+        <span className={`size-1.5 shrink-0 rounded-full ${tone.dot}`} />
+        <span className="truncate text-muted-foreground">{label}</span>
+      </span>
+      <span className="truncate text-right text-2xs text-muted-foreground/70">
+        {relativeTime(last.atMillis)}
+      </span>
+    </>
   );
 }
 
@@ -211,7 +302,7 @@ function HealthLine({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoad
   if (!last) {
     // Nothing yet, and the two reasons for that are NOT the same thing.
     if (!runsLoaded) {
-      return <span className="text-2xs text-muted-foreground/60">Loading runs…</span>;
+      return <span className="text-2xs text-muted-foreground/60">{LOADING_RUNS_LABEL}</span>;
     }
     // "No recent runs", never "never run". The company-wide run page is cut by
     // a limit, so a workflow whose last run has scrolled off it is
@@ -220,11 +311,8 @@ function HealthLine({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoad
     // Selecting the workflow re-reads its history scoped server-side, which
     // does answer the stronger question.
     return (
-      <span
-        className="text-2xs text-muted-foreground"
-        title="No runs in the recent company-wide page. Open the workflow to read its own run history."
-      >
-        No recent runs
+      <span className="text-2xs text-muted-foreground" title={NO_RUNS_TITLE}>
+        {NO_RUNS_LABEL}
       </span>
     );
   }

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -112,6 +112,14 @@ export function relativeTime(atMillis: number): string {
   return `${Math.round(hours / 24)}d ago`;
 }
 
+/**
+ * Two of {@link runTone}'s labels, named because {@link runSummaryLine} has to
+ * recognise them: they are the states whose *count* is a separate fact, and the
+ * only ones where repeating the words would say the same thing twice.
+ */
+const NOT_DELIVERED = "not delivered";
+const AWAITING_APPROVAL = "awaiting approval";
+
 /** The status dot for a whole run.
  *
  * Every arm returns one of the console's five run states, so a dot here means
@@ -151,7 +159,7 @@ export function runTone(run: WorkflowRunOutcome): {
   // parked belongs on the row beneath.
   if (isBlocked(run)) return { dot: "bg-status-blocked", label: "blocked" };
   if (undeliveredCount(run.deliveries) > 0)
-    return { dot: "bg-status-failed", label: "not delivered" };
+    return { dot: "bg-status-failed", label: NOT_DELIVERED };
   // Blocked, not running. This was the running colour, which said "the machine
   // is working on it" about the one state that means the opposite: it is
   // parked until a human decides. Amber is the colour that gets looked at.
@@ -161,8 +169,54 @@ export function runTone(run: WorkflowRunOutcome): {
   // read scored it green and the operator was told a run that did none of its
   // work had succeeded.
   if (awaitingCount(run) > 0)
-    return { dot: "bg-status-blocked", label: "awaiting approval" };
+    return { dot: "bg-status-blocked", label: AWAITING_APPROVAL };
   return { dot: "bg-status-done", label: "ok" };
+}
+
+/**
+ * How the most recent run went, as ONE sentence: what it did, where it failed if
+ * it failed, and the counts a card carries as badges beside the words.
+ *
+ * For a fixed-width column (issue #1136: the workflow list's status column is a
+ * fixed 13rem so the dots line up down the page). A badge cannot truncate — one
+ * "2 not delivered" pill beside the label leaves the label four characters and
+ * two pills leave it none — but a sentence can, and it truncates from the right,
+ * which drops the counts before it drops the state. Callers hang the full string
+ * on a `title`, so nothing is unrecoverable.
+ *
+ * `state` is {@link runTone}'s label, passed in rather than recomputed so the
+ * words and the dot beside them can never come from two different readings.
+ *
+ * Nothing is lost against the card's badges: an undelivered report and a waiting
+ * approval are already the run's *state* by the time `runTone` has spoken, so
+ * what the badges add is the number — and that is what this appends.
+ */
+export function runSummaryLine(
+  run: WorkflowRunOutcome,
+  state: string,
+  failedNode?: string | null,
+): string {
+  const undelivered = undeliveredCount(run.deliveries);
+  const pending = pendingCount(run.deliveries);
+
+  let head = `${run.scheduled ? "Scheduled" : "Manual"} run ${state}${
+    failedNode ? ` at “${failedNode}”` : ""
+  }`;
+  // A count goes in brackets beside the words it counts when the state IS that
+  // condition, and spells itself out when the state is something else. Joining
+  // both cases the same way produces "not delivered · 2 not delivered" — the
+  // card's badge has the same redundancy and can afford it; a column that
+  // truncates cannot.
+  const also: string[] = [];
+  if (undelivered > 0) {
+    if (state === NOT_DELIVERED) head += ` (${undelivered})`;
+    else also.push(`${undelivered} ${NOT_DELIVERED}`);
+  }
+  if (pending > 0) {
+    if (state === AWAITING_APPROVAL) head += ` (${pending})`;
+    else also.push(`${pending} ${AWAITING_APPROVAL}`);
+  }
+  return [head, ...also].join(" · ");
 }
 
 /**

--- a/frontend/test/e2e/workflow-list-columns.spec.ts
+++ b/frontend/test/e2e/workflow-list-columns.spec.ts
@@ -1,0 +1,205 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+/**
+ * Issue #1136: in List mode the workflow index had three columns and not one
+ * shared vertical edge between them.
+ *
+ * Every row laid itself out with `justify-between`, so each one sized its own
+ * cells: the descriptions were pushed right and their left edge zigzagged by a
+ * couple of hundred pixels from row to row, the status cell floated so the state
+ * dots never formed a line, and "No recent runs" landed somewhere different
+ * again. The eye had nothing to track down.
+ *
+ * **Geometry is the assertion**, because geometry is the defect. Nothing about
+ * the text changed — a spec that read the rendered strings passes just as
+ * happily against the broken build. What is pinned here is that every cell in a
+ * column starts on the same pixel, over enough rows and enough description
+ * lengths for a ragged edge to have somewhere to hide.
+ *
+ * The list and the run page are both stubbed. The harness company ships three
+ * workflows and a host with no inference source can never journal a failed,
+ * blocked or running one — and three near-identical rows would report a
+ * straight edge whether or not the columns are fixed.
+ *
+ * Runs against the live host `playwright.config.ts` brings up.
+ */
+
+/** The workflows list route, and only it — not `…/workflows/{id}` or `/runs`. */
+function isWorkflowList(url: URL): boolean {
+  return /\/api\/v1\/(company|companies\/[^/]+)\/workflows$/.test(url.pathname);
+}
+
+/** The company-wide run page. */
+function isRunPage(url: URL): boolean {
+  return /\/api\/v1\/(company|companies\/[^/]+)\/workflows\/runs$/.test(url.pathname);
+}
+
+/**
+ * Twelve workflows whose names and descriptions vary as widely as real ones do
+ * — one word to a full sentence, and one with no description at all. The width
+ * spread is the point: it is what a per-row layout turns into a ragged edge.
+ */
+const WORKFLOWS = [
+  { id: "feature_pipeline", name: "Feature pipeline", description: "A feature request goes from spec to a tested, documented ship.", editable: false },
+  { id: "aj", name: "AJ", description: "Should triage across all closed github issues and reopen anything that regressed since the last release." },
+  { id: "ai_trends", name: "AI trends", description: "Every day at 9 am look for trending ai papers." },
+  { id: "incident_postmortem", name: "Incident postmortem drafting service", description: "Reads the incident channel, the run journal and the deploy log, then drafts a blameless postmortem with a timeline and follow-up actions." },
+  { id: "release_notes", name: "Release notes", description: "Turn merged pull requests into notes." },
+  { id: "customer_digest", name: "Customer digest", description: "Collect support threads from the last seven days and send the product team one digest." },
+  { id: "dep_bumps", name: "Dependency bumps", description: "Bump." },
+  { id: "security_sweep", name: "Security sweep of the vendored tree", description: "Walk every vendored dependency and open one issue per unpatched advisory." },
+  { id: "onboarding_buddy", name: "Onboarding buddy", description: "Answer a new hire's first-week questions from the handbook." },
+  { id: "cost_watch", name: "Cost watch", description: "Compare this month's model spend against the last three." },
+  { id: "docs_linter", name: "Docs linter", description: "Check every markdown file for broken links and stale command names." },
+  { id: "standup_summary", name: "Standup summary" },
+].map((w) => ({ enabled: true, ...w }));
+
+/** One run each for most of them, in a spread of states — and none at all for
+ * three, so the "No recent runs" reading is in the sample too. */
+const RUNS = (() => {
+  const now = Date.now();
+  const hour = 3_600_000;
+  const base = (workflowId: string, seq: number, ageHours: number) => ({
+    seq,
+    atMillis: now - ageHours * hour,
+    workflowId,
+    scheduled: false,
+    runId: `${workflowId}-run`,
+    deliveries: [] as { status: string; destination: string }[],
+    pendingApprovals: [] as string[],
+  });
+  return [
+    { ...base("feature_pipeline", 40, 21), blockedNodes: [{ nodeId: "spec", tools: ["publish_artifact"], approvalIds: ["a1"] }], pendingApprovals: ["spec"] },
+    { ...base("aj", 39, 168) },
+    { ...base("incident_postmortem", 38, 2), error: "boom" },
+    { ...base("release_notes", 37, 0.2), scheduled: true },
+    { ...base("customer_digest", 36, 30), running: true, startedAtMillis: now - 30 * hour, startedNodes: ["collect"] },
+    { ...base("dep_bumps", 35, 400), scheduled: true, deliveries: [{ status: "failed", destination: "email" }, { status: "failed", destination: "slack" }] },
+    { ...base("security_sweep", 34, 9), cancelled: true },
+    { ...base("cost_watch", 33, 0.01), scheduled: true },
+    { ...base("docs_linter", 32, 72), deliveries: [{ status: "pending", destination: "email" }] },
+  ];
+})();
+
+/**
+ * Serves the stubbed index, in List mode.
+ *
+ * The mode is set through the key the view persists it under rather than by
+ * clicking the toolbar's Cards/List toggle: which control switches it, and what
+ * it is called, is the toolbar's business (issue #1110), and this spec is about
+ * what the rows do once the mode is on.
+ */
+async function openList(page: Page) {
+  await page.route(
+    (url) => isWorkflowList(url),
+    async (route: Route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(WORKFLOWS) });
+    },
+  );
+  await page.route(
+    (url) => isRunPage(url),
+    async (route: Route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(RUNS) });
+    },
+  );
+  await page.addInitScript(() => {
+    window.localStorage.setItem("oc.workflows.indexMode", "list");
+  });
+
+  await page.goto("/#/workflows");
+
+  // The first-run tour's overlay swallows pointer events and blurs the page.
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+    await skip.click();
+    await expect(skip).toBeHidden();
+  } catch {
+    /* a company that has seen it never shows it again */
+  }
+
+  const rows = page.getByTestId("workflow-list-row");
+  await expect(rows).toHaveCount(WORKFLOWS.length);
+  return rows;
+}
+
+/** The left and right edge of every visible cell of every row. */
+async function cellEdges(page: Page): Promise<{ left: number; right: number; text: string }[][]> {
+  return page.evaluate(() =>
+    [...document.querySelectorAll('[data-testid="workflow-list-row"]')].map((row) =>
+      [...row.children]
+        .filter((cell) => (cell as HTMLElement).offsetParent !== null)
+        .map((cell) => {
+          const box = cell.getBoundingClientRect();
+          return { left: Math.round(box.left), right: Math.round(box.right), text: cell.textContent ?? "" };
+        }),
+    ),
+  );
+}
+
+/** Every value in `xs`, deduplicated — one entry means one shared edge. */
+function distinct(xs: number[]): number[] {
+  return [...new Set(xs)];
+}
+
+test("every column of the list shares one vertical edge", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openList(page);
+
+  const rows = await cellEdges(page);
+  // Name, description, status, time. A row whose last run is missing has no
+  // time cell — it is the last column, so nothing follows it to shift.
+  expect(distinct(rows.map((cells) => cells.length)).sort()).toEqual([3, 4]);
+
+  for (const column of [0, 1, 2]) {
+    const lefts = distinct(rows.map((cells) => cells[column].left));
+    expect(lefts, `column ${column} left edges: ${lefts.join(", ")}`).toHaveLength(1);
+    const rights = distinct(rows.map((cells) => cells[column].right));
+    expect(rights, `column ${column} right edges: ${rights.join(", ")}`).toHaveLength(1);
+  }
+
+  // The time reads right to left — "21h ago" and "7d ago" have to end together.
+  const timeRights = distinct(rows.filter((cells) => cells.length === 4).map((cells) => cells[3].right));
+  expect(timeRights, `time right edges: ${timeRights.join(", ")}`).toHaveLength(1);
+
+  // The three columns are in the order the operator reads them, and each one
+  // holds what it says it does.
+  const [name, description, status] = rows[0];
+  expect(name.right).toBeLessThan(description.left);
+  expect(description.right).toBeLessThan(status.left);
+  expect(name.text).toContain("Feature pipeline");
+  expect(description.text).toContain("A feature request goes from spec");
+  expect(status.text).toContain("Manual run blocked");
+
+  // And the dots the eye actually tracks down the page start on one pixel.
+  const dotLefts = await page.evaluate(() =>
+    [...document.querySelectorAll('[data-testid="workflow-list-row"] .rounded-full')].map((dot) =>
+      Math.round(dot.getBoundingClientRect().left),
+    ),
+  );
+  expect(dotLefts.length).toBeGreaterThan(5);
+  expect(distinct(dotLefts), `dot left edges: ${distinct(dotLefts).join(", ")}`).toHaveLength(1);
+});
+
+test("the description is the column that yields when the list narrows", async ({ page }) => {
+  await page.setViewportSize({ width: 700, height: 900 });
+  await openList(page);
+
+  const rows = await cellEdges(page);
+  // Three cells now: the description is `display: none`, so it is not a grid
+  // item at all and the name takes the space it left.
+  expect(distinct(rows.map((cells) => cells.length)).sort()).toEqual([2, 3]);
+
+  const [name, status] = rows[0];
+  expect(name.text).toContain("Feature pipeline");
+  expect(status.text).toContain("Manual run blocked");
+  expect(rows.some((cells) => cells.some((cell) => cell.text.includes("A feature request goes")))).toBe(false);
+
+  // Still aligned — a narrow list is not an excuse for a ragged one.
+  for (const column of [0, 1]) {
+    const lefts = distinct(rows.map((cells) => cells[column].left));
+    expect(lefts, `column ${column} left edges: ${lefts.join(", ")}`).toHaveLength(1);
+  }
+});

--- a/frontend/test/unit/workflow-run-summary-line.test.ts
+++ b/frontend/test/unit/workflow-run-summary-line.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeliveryReport, WorkflowRunOutcome } from "@/api/workflows";
+import { runSummaryLine, runTone } from "@/views/workflows/run-health";
+
+/**
+ * The workflow list's status column, as a string (issue #1136).
+ *
+ * The column is a fixed 13rem — that is what puts the state dots in a vertical
+ * line down the page — so everything the card says beside its dot has to fit in
+ * one truncating sentence instead of a row of badges that cannot shrink. These
+ * pin what that sentence is allowed to lose and what it must never repeat.
+ */
+
+/** A settled manual run with nothing wrong with it. */
+function run(over: Partial<WorkflowRunOutcome> = {}): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    workflowId: "feature_pipeline",
+    scheduled: false,
+    runId: "run-1",
+    deliveries: [],
+    pendingApprovals: [],
+    ...over,
+  };
+}
+
+/** One delivery row. `status` is widened because `pending` reaches the console
+ * from the host before this union names it — see `PENDING_STATUS`. */
+function delivery(status: string, kind: string): DeliveryReport {
+  return { node: "publish", kind, status: status as DeliveryReport["status"], detail: "", reason: "" };
+}
+
+/** The line as the row builds it: `runTone`'s label, and its failed node. */
+function line(r: WorkflowRunOutcome, failedNode?: string | null): string {
+  return runSummaryLine(r, runTone(r).label, failedNode);
+}
+
+describe("runSummaryLine", () => {
+  it("names who started the run, and how it went", () => {
+    expect(line(run())).toBe("Manual run ok");
+    expect(line(run({ scheduled: true }))).toBe("Scheduled run ok");
+  });
+
+  it("names the node a failed run stopped at", () => {
+    expect(line(run({ error: "boom" }), "draft")).toBe(
+      "Manual run failed at “draft”",
+    );
+  });
+
+  it("carries a failure with no known node without an empty quote", () => {
+    expect(line(run({ error: "boom" }), null)).toBe("Manual run failed");
+  });
+
+  // The whole reason this is a function and not a template in the row: the
+  // naive join reads "not delivered · 2 not delivered", because `runTone`
+  // already reports the undelivered reports AS the state.
+  it("brackets the count when the state is the thing being counted", () => {
+    const r = run({
+      deliveries: [
+        delivery("failed", "email"),
+        delivery("failed", "slack"),
+      ],
+    });
+    expect(runTone(r).label).toBe("not delivered");
+    expect(line(r)).toBe("Manual run not delivered (2)");
+  });
+
+  it("brackets a waiting-approval count the same way", () => {
+    const r = run({ deliveries: [delivery("pending", "email")] });
+    expect(runTone(r).label).toBe("awaiting approval");
+    expect(line(r)).toBe("Manual run awaiting approval (1)");
+  });
+
+  // A failure outranks both delivery readings in `runTone`, so here the counts
+  // are facts the state does NOT carry — and they get spelled out.
+  it("spells the counts out when the state is something else", () => {
+    const r = run({
+      error: "boom",
+      deliveries: [
+        delivery("failed", "email"),
+        delivery("pending", "slack"),
+      ],
+    });
+    expect(line(r, "draft")).toBe(
+      "Manual run failed at “draft” · 1 not delivered · 1 awaiting approval",
+    );
+  });
+
+  it("says nothing about deliveries that landed", () => {
+    const r = run({
+      deliveries: [
+        delivery("sent", "email"),
+        delivery("sent", "slack"),
+      ],
+    });
+    expect(line(r)).toBe("Manual run ok");
+  });
+});


### PR DESCRIPTION
## Summary

In List mode the workflow index had three columns and not one shared vertical edge between them. Every row laid itself out with `justify-between`, so each row sized its own cells: the descriptions were pushed right and their left edge zigzagged by a couple of hundred pixels from row to row, the status cell floated so the state dots never formed a line, and "No recent runs" landed somewhere different again.

The row is a CSS grid now, with the column widths issue #1136 approved:

| Column | Track | Alignment |
| --- | --- | --- |
| Name (+ the `in source` badge that qualifies it) | `17.5rem` fixed | left, truncate, `title` |
| Description | `minmax(0, 1fr)` | **left**, single-line truncate, `title` |
| Status (dot + reading) | `13rem` fixed | left *within its column*, so the dots form a line |
| Relative time | `4.5rem` fixed | right, so "21h ago" and "7d ago" end together |

Fixed lengths rather than `auto` is the whole fix: a row is its own element, so a grid drawn there is a grid of **one** row and `auto`/`fr` tracks are measured against that row's own content — exactly the per-row sizing that produced the ragged edge. The single `1fr` is the description, and it is the same width on every row because everything around it is.

**Narrow viewports — the description yields.** Below `@3xl` (48rem of *list* width) the three fixed tracks plus a readable description stop fitting, and the description would truncate to a word or two; it is dropped there and the name takes the space. A **container** query rather than a viewport breakpoint, because the tab sits beside a sidebar — a viewport breakpoint drops the description while there is still room and keeps it past the point where there isn't. `hidden` rather than a conditional render, so a `display: none` cell simply stops being a grid item and the remaining three fall into the three-track template with no second code path.

**The status column is one sentence** instead of a label plus badges. A badge cannot truncate — a "2 not delivered" pill beside the label in a 13rem column leaves the label four characters, two pills leave it none — so `runSummaryLine` folds the counts into prose that truncates from the right, dropping the count before the state, with the full string on a `title`. Nothing is lost against the card: `runTone` already reports an undelivered report and a waiting approval *as* the state, so the badge only added the number. When the state already names the condition the count goes in brackets beside it (`Manual run awaiting approval (1)`) rather than repeating the words (`awaiting approval · 1 awaiting approval`).

Cards mode is untouched, and so is the toolbar above the list (#1135 owns it).

## Verified in a browser

Against a real host (`companies/agentic_software_company`) seeded with 14 workflows over its own API — names from "AJ" to "Incident postmortem drafting service", descriptions from "Bump." to a full sentence, and one with none. The company-wide run page was intercepted to supply the state mix a host with no inference source can never journal (blocked, failed, running, stopped, not-delivered, awaiting-approval, and three workflows with no runs at all).

Measured across all 14 rows, light and dark:

| Viewport | Name | Description | Status | Time |
| --- | --- | --- | --- | --- |
| 1440 | 245→525 | 537→1107 | 1119→1327 | 1339→1411 |
| 1100 | 245→525 | 537→767 | 779→987 | 999→1071 |
| 820 | 245→487 | *(dropped)* | 499→707 | 719→791 |

One left edge and one right edge per column, on every row, at every width.

## Tests

- `frontend/test/e2e/workflow-list-columns.spec.ts` — twelve stubbed workflows of varied description length and nine runs in a spread of states; asserts one distinct left and right edge per column, one right edge for the time column, and one left edge for the state dots. A second test asserts the description is the column that disappears when the list narrows, and that the rest stay aligned. Geometry is the assertion because geometry is the defect — a spec reading the rendered text passes against the broken build. **Confirmed failing on `main`'s layout** ("column 0 right edges: 701, 751, 779, 743, 739, 669, 736, 738, 658").
- `frontend/test/unit/workflow-run-summary-line.test.ts` — seven cases pinning what the status sentence says and what it must not repeat.

## Commands run

```
cd frontend
npm run typecheck            # clean
npm run typecheck:unit       # clean
npm run typecheck:e2e        # clean
npm test                     # 116 files, 1127 tests passing
npx playwright test workflow-list-columns workflow-selection-persists \
    workflow-live-list workflow-edit-delete workflow-create-affordance   # 19 passed
scripts/ci/assert-design-tokens.sh   # clean
```

Closes #1136
