### PR TITLE
fix(console): ration the knowledge graph's node labels

### DIFF
--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -30,6 +30,29 @@ Panning is an offset on top of whatever the camera is framing, not a separate
 mode: the shot still tracks its subject, just off-centre by the amount you
 dragged, and re-framing (selecting a node, opening the core) resets it.
 
+## Which nodes are named
+
+Labels are rationed, because the graph has more nodes than it has room for
+names (issue #1104).
+
+| When | Named |
+|---|---|
+| at rest | the company, every department, and the roster — agents and people |
+| hovering | the node under the pointer, and only that node |
+| in a focused tree | the node you clicked and its direct children — a pillar names its tasks, an agent names its tools |
+
+Selection always keeps its name, and everything else the pointer reaches keeps
+a `<title>`, so a native tooltip is the floor wherever a drawn label is
+suppressed. Tasks, workflow stages and tools are the numerous tiers, which is
+why they are bare until you point at one.
+
+Whatever that leaves is then decluttered: candidates are placed highest
+priority first and any label whose box overlaps one already placed is dropped
+rather than nudged. The pass measures in **screen px**, not graph units —
+labels hold one on-screen size at every camera depth (`fixedLabel` counter
+scales through `--kg-cam-k`), so zooming changes how far apart nodes are and
+never how wide a name is. `kg/label-plan.ts` holds both steps, pure.
+
 ## What is derived — read this before trusting the org chart
 
 **One thing, and it is not a ring.** Everything the graph draws is now a value
@@ -111,7 +134,8 @@ and who can sign in.
 
 `kg/` holds the graph itself — `model.ts` (the five-ring node/edge model),
 `adapter.ts` (our host's data, shaped into it), `tree-layout.ts` and
-`memory-core.ts` (pure layout and camera maths), and the `KnowledgeGraph` /
+`memory-core.ts` (pure layout and camera maths), `label-plan.ts` (which
+labels survive), and the `KnowledgeGraph` /
 `KnowledgeGraphFullscreen` / `KnowledgeDetail` components. `pulse.ts` holds
 the two board predicates the adapter needs. Theme tokens live under `.oc-kg`
 in `src/index.css`.

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -16,6 +16,7 @@ import { ClipboardList, Info, Milestone, Sparkles, User, UserRound, Users, Workf
 import { DERIVED_NOTICE } from './adapter';
 import { orderGraphDepartments, SELF_ID, toolSlugOf, type KGNode, type KGNodeKind, type KnowledgeGraph as KGData } from './model';
 import { branchPath, branchWidth, cyclicDeltaF, edgeArc, focusWheel, radialRestLayout, responsiveRingR, rotateAbout, shortestAngleDelta, treeLayout, wheelPoint, wheelStageGeom, wheelStageSpot, type RestLayoutResult, type TreeLayoutResult, type TreeNodePos } from './tree-layout';
+import { focusLabelIds, LABEL_PRIORITY, planLabels, type LabelCandidate } from './label-plan';
 import { rafThrottle } from './raf-throttle';
 import { buildToolWiki, isMcpSlug, prettifySlug } from './agent-wiki';
 import { cameraRect, lerpRect, memoryNodePos, pickRestTier, R_CORE, type MemoryGraph, type Rect } from './memory-core';
@@ -87,6 +88,11 @@ const EDGE_COLOR: Record<string, string> = {
 // for the on-canvas label; the full title lives in the hover tooltip + card.
 const shortLabel = (n: KGNode) =>
   n.kind === 'task' && n.label.length > 20 ? `${n.label.slice(0, 18).trimEnd()}…` : n.label;
+
+// On-screen label size per tier, in px. Quoted at rest and held there at every
+// camera depth by `fixedLabel`, which is why the declutter can measure in px.
+const labelFontPx = (kind: KGNodeKind): number =>
+  kind === 'self' || kind === 'team' ? 10 : kind === 'task' ? 8.5 : 9;
 
 // 'about how long ago' for the harness card's last-run line
 const agoLabel = (iso: string): string => {
@@ -257,6 +263,11 @@ export function KnowledgeGraph({
     startX: number; startY: number; originX: number; originY: number; moved: boolean;
   } | null>(null);
   const camRectRef = useRef<Rect>({ x: 0, y: 0, w: W, h: H });
+  // The camera's published zoom (`cur.w / W`), mirrored into state so the label
+  // declutter — which measures in screen px — re-runs when the zoom settles.
+  // The simulation may already be asleep by then, so its tick cannot carry this.
+  const [camK, setCamK] = useState(1);
+  const camKRef = useRef(1);
   const [, setTick] = useState(0);
 
   const agentById = useMemo(() => new Map(agents.map((a) => [`emp:${a.id}`, a])), [agents]);
@@ -970,6 +981,14 @@ export function KnowledgeGraph({
           svg.setAttribute('viewBox', `${cur.x} ${cur.y} ${cur.w} ${cur.h}`);
           // zoom factor for the constant-size label counter-scale
           svg.style.setProperty('--kg-cam-k', String(cur.w / W));
+        }
+        // Only the SCALE reaches the declutter: a pan shifts every label box by
+        // the same vector and cannot change which pairs overlap, so dragging
+        // the graph never costs a re-render here.
+        const k = cur.w / W;
+        if (Math.abs(k - camKRef.current) > 0.002) {
+          camKRef.current = k;
+          setCamK(k);
         }
       }
 
@@ -1757,6 +1776,93 @@ export function KnowledgeGraph({
     panRef.current = { x: 0, y: 0 };
   }, [focusId, selectedAgentId, selectedToolId, selectedTaskId, selectedHumanId, selectedMemoryId, coreExpanded]);
 
+  // ── what gets drawn per node, and which labels survive (issue #1104) ────────
+  // Radius and opacity are settled here rather than mid-render because the
+  // label declutter needs both: a label is only a candidate if its node is
+  // actually legible, and the label hangs off the node's radius.
+  const visuals = new Map<string, { r: number; opacity: number; dim: boolean; hidden: boolean }>();
+  for (const n of nodes) {
+    // inside the memory only the core + the pillar gateways stay visible
+    const dim = coreExpanded
+      ? n.kind !== 'self' && n.kind !== 'team'
+      : lit
+        ? !lit.has(n.id)
+        : false;
+    // tier radius + a connection-count bump for workers and tools, so
+    // heavily-wired nodes read heavier at a glance
+    const degree = (adjacency.get(n.id)?.size ?? 1) - 1;
+    const r = CAT[n.kind].r + (isWorker(n.kind) || n.kind === 'tool' ? Math.min(2.5, degree * 0.3) : 0);
+    // hierarchy brightness at rest; dimmed nodes drop to 0.15 on hover,
+    // in focus, ONLY the flanking pillar gateways stay visible beside
+    // the tree — nothing behind the pillar you are looking at —
+    // every other unfocused node rides the carousel fully hidden
+    // flanks show a PORTION of their department: the gateway
+    // reads at 0.6, its condensed cluster at a whisper — transparent so
+    // it never overbears the stage; everything further is fully hidden
+    const sectorTeam = n.kind === 'team' ? n.id : teamForFocus(n.id);
+    const inFlankSector = !!(sectorTeam && flankTeams?.has(sectorTeam));
+    const isFlank = !!flankTeams?.has(n.id);
+    visuals.set(n.id, {
+      r,
+      dim,
+      hidden: !!(dim && !coreExpanded && focusSet && !inFlankSector),
+      opacity: dim
+        ? coreExpanded
+          ? 0.06
+          : focusSet
+            ? isFlank
+              ? 0.6
+              : inFlankSector
+                ? 0.2
+                : 0
+            : 0.15
+        : TIER_OPACITY[n.kind],
+    });
+  }
+
+  // Who is worth naming. At rest that is the company, its departments and the
+  // roster — the agents and people complaint 1 in #1104 is about; the tasks,
+  // stages and tools below them are far more numerous and stay bare. In focus
+  // it is the node you clicked and its direct children, so a pillar names its
+  // tasks and an agent names its tools instead of the whole tree shouting at
+  // once. Hover names exactly one node — the chain still lights (that is what
+  // shows structure) but it no longer drags a crowd of labels with it.
+  const selectedOrgId = selectedAgentId ?? selectedHumanId ?? selectedTaskId ?? selectedToolId;
+  const focusChildren = focusTree ? focusLabelIds(focusTree.branches, focusId) : null;
+  const labelCandidates: LabelCandidate[] = [];
+  for (const n of nodes) {
+    const v = visuals.get(n.id)!;
+    // a node faded to a whisper has nothing to label, and a label there would
+    // still take a box from a node you can actually see
+    if (v.opacity < 0.3) continue;
+    let priority: number | null = null;
+    if (hoverId === n.id) priority = LABEL_PRIORITY.hovered;
+    else if (selectedOrgId === n.id) priority = LABEL_PRIORITY.selected;
+    else if (n.kind === 'self') priority = LABEL_PRIORITY.self;
+    else if (focusSet) {
+      if (n.id === focusId) priority = LABEL_PRIORITY.focused;
+      else if (n.id === focusTeamId) priority = LABEL_PRIORITY.team;
+      else if (focusChildren?.has(n.id)) priority = LABEL_PRIORITY.child;
+    } else if (n.kind === 'team') priority = LABEL_PRIORITY.team;
+    else if (isWorker(n.kind)) priority = LABEL_PRIORITY.worker;
+    if (priority === null) continue;
+    // inside a band, the busier node keeps its name
+    const degree = (adjacency.get(n.id)?.size ?? 1) - 1;
+    labelCandidates.push({
+      id: n.id,
+      text: shortLabel(n),
+      x: n.x,
+      y: n.y,
+      dy: v.r + 11 + (labelDy.get(n.id) ?? 0),
+      fontPx: labelFontPx(n.kind),
+      priority: priority + Math.min(degree, 50) / 100,
+    });
+  }
+  // `camK` (state) rather than the live ref: reading it here is what ties the
+  // declutter to the zoom, and `camK * W` is the camera width it was published
+  // from. x/y come off the ref — they only move every box by a shared vector.
+  const labelSet = planLabels(labelCandidates, { x: camRectRef.current.x, y: camRectRef.current.y, w: camK * W }, W);
+
   // ── the graph itself (reused inline + fullscreen) ───────────────────────────
   const graphInner = (
     <>
@@ -1968,42 +2074,10 @@ export function KnowledgeGraph({
         {nodes.map((n) => {
           const cat = CAT[n.kind];
           const color = nodeColor(n);
-          // inside the memory only the core + the pillar gateways stay visible
-          const dim = coreExpanded
-            ? n.kind !== 'self' && n.kind !== 'team'
-            : lit
-              ? !lit.has(n.id)
-              : false;
-          const inFocus = focusSet?.has(n.id) ?? false;
+          const { r, opacity: nodeOpacity, dim, hidden } = visuals.get(n.id)!;
           const selected = selectedAgentId === n.id || selectedToolId === n.id || selectedTaskId === n.id || selectedHumanId === n.id;
-          const showLabel = n.kind === 'self' || n.kind === 'team' || inFocus || (hoverId ? (lit?.has(n.id) ?? false) : false);
+          const showLabel = labelSet.has(n.id);
           const Icon = cat.Icon;
-          // tier radius + a connection-count bump for workers and tools, so
-          // heavily-wired nodes read heavier at a glance
-          const degree = (adjacency.get(n.id)?.size ?? 1) - 1;
-          const r = cat.r + (isWorker(n.kind) || n.kind === 'tool' ? Math.min(2.5, degree * 0.3) : 0);
-          // hierarchy brightness at rest; dimmed nodes drop to 0.15 on hover,
-          // in focus, ONLY the flanking pillar gateways stay visible beside
-          // the tree — nothing behind the pillar you are looking at —
-          // every other unfocused node rides the carousel fully hidden
-          // flanks show a PORTION of their department: the gateway
-          // reads at 0.6, its condensed cluster at a whisper — transparent so
-          // it never overbears the stage; everything further is fully hidden
-          const sectorTeam = n.kind === 'team' ? n.id : teamForFocus(n.id);
-          const inFlankSector = !!(sectorTeam && flankTeams?.has(sectorTeam));
-          const isFlank = !!flankTeams?.has(n.id);
-          const hidden = !!(dim && !coreExpanded && focusSet && !inFlankSector);
-          const nodeOpacity = dim
-            ? coreExpanded
-              ? 0.06
-              : focusSet
-                ? isFlank
-                  ? 0.6
-                  : inFlankSector
-                    ? 0.2
-                    : 0
-                : 0.15
-            : TIER_OPACITY[n.kind];
 
           // the company rendered as its memory: the Notes constellation of real
           // memory notes, folder-tinted, links as hairlines. Collapsed
@@ -2204,9 +2278,9 @@ export function KnowledgeGraph({
                   y={r + 11 + (labelDy.get(n.id) ?? 0)}
                   textAnchor="middle"
                   fontFamily="var(--font-mono)"
-                  fontWeight={n.kind === 'self' || n.kind === 'team' ? 600 : 400}
-                  fill={n.kind === 'team' ? color : 'var(--text-2)'}
-                  style={fixedLabel(n.kind === 'self' || n.kind === 'team' ? 10 : n.kind === 'task' ? 8.5 : 9)}
+                  fontWeight={n.kind === 'self' || n.kind === 'team' || hoverId === n.id ? 600 : 400}
+                  fill={hoverId === n.id ? 'var(--text)' : n.kind === 'team' ? color : 'var(--text-2)'}
+                  style={fixedLabel(labelFontPx(n.kind))}
                 >
                   {shortLabel(n)}
                 </text>

--- a/frontend/src/views/overview/kg/label-plan.ts
+++ b/frontend/src/views/overview/kg/label-plan.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Which node labels the knowledge graph actually draws (issue #1104).
+ *
+ * The graph used to decide this with one boolean: label `self` and `team`
+ * always, label *everything* the moment a pillar was focused. That rule failed
+ * at both ends — at rest every agent was an anonymous circle, and in focus a
+ * whole tree's worth of names turned on at once and smeared into each other.
+ *
+ * The replacement is two pure steps, both here:
+ *
+ * 1. the component nominates **candidates** with a priority (the roster at
+ *    rest, the focused node and its direct children in focus, plus whatever is
+ *    hovered or selected);
+ * 2. {@link planLabels} runs a greedy declutter over them — highest priority
+ *    placed first, and any later label whose box overlaps one already placed is
+ *    dropped. Every node keeps a `<title>`, so a dropped label still has a
+ *    native tooltip underneath it.
+ *
+ * ## Why the collision pass measures in SCREEN space
+ *
+ * Labels are deliberately a constant on-screen size at every camera depth: the
+ * camera publishes its zoom as `--kg-cam-k` and each font counter-scales
+ * through it. So zooming changes how far apart nodes are, never how wide a
+ * label is. Comparing boxes in graph units would therefore get the answer
+ * backwards at every depth but one — the same two labels overlap or not
+ * depending purely on the camera. {@link planLabels} projects each node through
+ * the camera first and measures in pixels.
+ *
+ * Only the camera's *scale* matters: a pan shifts every box by the same vector
+ * and cannot change which pairs overlap, so the caller only has to re-run this
+ * when the zoom changes.
+ */
+
+/** The live camera rect — the SVG's `viewBox`, in graph units. */
+export type LabelCamera = { x: number; y: number; w: number };
+
+export type LabelCandidate = {
+  id: string;
+  /** the text as rendered (already shortened, if the caller shortens it) */
+  text: string;
+  /** the node's centre, in graph units */
+  x: number;
+  y: number;
+  /** centre → label baseline, in graph units (radius + row stagger) */
+  dy: number;
+  /** the label's on-screen font size in px — constant at every camera depth */
+  fontPx: number;
+  /** higher wins a collision; ties break on the order given */
+  priority: number;
+};
+
+/**
+ * Label priorities, highest first. The bands are far enough apart that a
+ * caller can add a small tie-breaker (degree, say) without crossing a band.
+ */
+export const LABEL_PRIORITY = {
+  /** the node under the pointer — the one name the reader just asked for */
+  hovered: 1000,
+  /** whatever the detail panel is currently showing */
+  selected: 900,
+  /** the company at the core */
+  self: 800,
+  /** the node a focused tree is built around */
+  focused: 700,
+  /** a department: the trunk in focus, the whole ring at rest */
+  team: 600,
+  /** the focused node's direct children */
+  child: 500,
+  /** the roster — agents and people — named at rest */
+  worker: 400,
+} as const;
+
+/**
+ * Monospace advance width as a fraction of the font size. The labels are set in
+ * `var(--font-mono)` (Geist Mono), whose advance is 0.6em; every glyph is that
+ * wide, so a character count is an exact width rather than an estimate.
+ */
+const MONO_ADVANCE = 0.6;
+
+/**
+ * Horizontal breathing room around a label box, in px, so two survivors on the
+ * same row never quite touch. There is no vertical counterpart on purpose: the
+ * rows a label can sit on are already staggered by a fixed amount, and padding
+ * the box past its own line height turns that stagger into a collision and
+ * throws away a label that reads perfectly well.
+ */
+const LABEL_GAP_X = 3;
+
+export type LabelBox = { x0: number; y0: number; x1: number; y1: number };
+
+/**
+ * A candidate's label box in screen px, padded by {@link LABEL_GAP}.
+ * `scale` is px per graph unit (canvas width ÷ camera width).
+ */
+export function labelBoxPx(c: LabelCandidate, cam: LabelCamera, scale: number): LabelBox {
+  const cx = (c.x - cam.x) * scale;
+  // `dy` rides the graph, so it scales with the camera; the font does not.
+  const baseline = (c.y - cam.y) * scale + c.dy * scale;
+  const halfW = (c.text.length * MONO_ADVANCE * c.fontPx) / 2 + LABEL_GAP_X;
+  return {
+    x0: cx - halfW,
+    x1: cx + halfW,
+    // a baseline sits ~0.8em below the cap line and ~0.2em above the descender
+    y0: baseline - c.fontPx * 0.8,
+    y1: baseline + c.fontPx * 0.2,
+  };
+}
+
+const overlaps = (a: LabelBox, b: LabelBox): boolean =>
+  a.x0 < b.x1 && b.x0 < a.x1 && a.y0 < b.y1 && b.y0 < a.y1;
+
+/**
+ * The ids whose labels survive the declutter, measured in screen px.
+ *
+ * `canvasW` is the width the camera rect maps onto — the nominal SVG width, so
+ * the px here are the same px `fontPx` is quoted in. Candidates are placed
+ * highest priority first; a label that collides with one already placed is
+ * dropped rather than nudged, because nudging is what the old two-row stagger
+ * did and it only moved the pile-up.
+ */
+export function planLabels(
+  candidates: readonly LabelCandidate[],
+  cam: LabelCamera,
+  canvasW: number,
+): Set<string> {
+  const scale = cam.w > 0 ? canvasW / cam.w : 1;
+  const order = candidates.map((c, i) => ({ c, i }));
+  order.sort((a, b) => b.c.priority - a.c.priority || a.i - b.i);
+  const placed: LabelBox[] = [];
+  const kept = new Set<string>();
+  for (const { c } of order) {
+    const box = labelBoxPx(c, cam, scale);
+    if (placed.some((p) => overlaps(p, box))) continue;
+    placed.push(box);
+    kept.add(c.id);
+  }
+  return kept;
+}
+
+/**
+ * The focused node and its direct children in a focused tree — the only nodes
+ * guaranteed a label there. `branches` is the tree's edge list; a child is any
+ * branch whose source is the focused node.
+ *
+ * Focus follows what was clicked: a pillar names its tasks, an agent names its
+ * tools. Everything else in the tree is one hover (or one native tooltip) away.
+ */
+export function focusLabelIds(
+  branches: readonly { source: string; target: string }[],
+  focusId: string | null,
+): Set<string> {
+  const set = new Set<string>();
+  if (!focusId) return set;
+  set.add(focusId);
+  for (const b of branches) if (b.source === focusId) set.add(b.target);
+  return set;
+}

--- a/frontend/test/unit/overview-graph-labels.test.ts
+++ b/frontend/test/unit/overview-graph-labels.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  focusLabelIds,
+  LABEL_PRIORITY,
+  planLabels,
+  type LabelCandidate,
+} from "@/views/overview/kg/label-plan";
+
+/**
+ * The Overview graph's label declutter (issue #1104).
+ *
+ * The rule this replaced was one boolean, and it failed at both ends: at rest
+ * only the company and its departments were named, so every agent was an
+ * anonymous circle; the moment a pillar was focused, every node in the tree was
+ * named at once and the names smeared into each other.
+ *
+ * Two properties are worth guarding here, and neither is visible from a
+ * screenshot:
+ *
+ * 1. **Priority decides who survives a collision.** Silent failure: the label
+ *    you are pointing at loses to a sibling that happened to be nominated
+ *    first, and the graph looks like hover simply does nothing.
+ * 2. **The overlap is measured in SCREEN space.** Labels hold one on-screen
+ *    size at every camera depth (`fixedLabel` counter-scales through
+ *    `--kg-cam-k`), so graph units answer this question correctly at exactly
+ *    one zoom level and wrongly everywhere else — and wrongly in the direction
+ *    that matters, because zooming out is what packs nodes together. That
+ *    regression would restore the pile-up this issue is about while every unit
+ *    of the layout still looked right.
+ */
+
+const W = 880;
+
+const cand = (over: Partial<LabelCandidate> & { id: string }): LabelCandidate => ({
+  text: "AAAA",
+  x: 0,
+  y: 0,
+  dy: 20,
+  fontPx: 10,
+  priority: LABEL_PRIORITY.worker,
+  ...over,
+});
+
+describe("planLabels", () => {
+  it("drops the lower-priority label of a colliding pair", () => {
+    const kept = planLabels(
+      [
+        cand({ id: "quiet", x: 0, priority: LABEL_PRIORITY.worker }),
+        cand({ id: "hovered", x: 28, priority: LABEL_PRIORITY.hovered }),
+      ],
+      { x: 0, y: 0, w: W },
+      W,
+    );
+    expect([...kept]).toEqual(["hovered"]);
+  });
+
+  it("keeps both when the boxes clear each other", () => {
+    const kept = planLabels(
+      [
+        cand({ id: "left", x: 0, priority: LABEL_PRIORITY.worker }),
+        cand({ id: "right", x: 32, priority: LABEL_PRIORITY.hovered }),
+      ],
+      { x: 0, y: 0, w: W },
+      W,
+    );
+    expect(kept).toEqual(new Set(["left", "right"]));
+  });
+
+  it("measures in screen space, so zooming out drops a label the same graph gap kept", () => {
+    const pair = [
+      cand({ id: "left", x: 0, priority: LABEL_PRIORITY.hovered }),
+      cand({ id: "right", x: 32, priority: LABEL_PRIORITY.worker }),
+    ];
+    // camera width === canvas width: one graph unit is one px, both fit
+    expect(planLabels(pair, { x: 0, y: 0, w: W }, W)).toEqual(new Set(["left", "right"]));
+    // pulled back to half scale the nodes are 16px apart while the labels are
+    // still 24px wide — in graph units nothing changed at all
+    expect([...planLabels(pair, { x: 0, y: 0, w: W * 2 }, W)]).toEqual(["left"]);
+  });
+
+  it("panning the camera never changes the outcome", () => {
+    const pair = [
+      cand({ id: "left", x: 0, priority: LABEL_PRIORITY.hovered }),
+      cand({ id: "right", x: 32, priority: LABEL_PRIORITY.worker }),
+    ];
+    expect(planLabels(pair, { x: -400, y: 250, w: W }, W)).toEqual(
+      planLabels(pair, { x: 0, y: 0, w: W }, W),
+    );
+  });
+
+  it("collides on the rendered width, so a long name costs its neighbour", () => {
+    const neighbour = cand({ id: "neighbour", x: 100, priority: LABEL_PRIORITY.worker });
+    const short = cand({ id: "named", x: 0, text: "A", priority: LABEL_PRIORITY.hovered });
+    const long = { ...short, text: "A".repeat(40) };
+    expect(planLabels([short, neighbour], { x: 0, y: 0, w: W }, W)).toEqual(
+      new Set(["named", "neighbour"]),
+    );
+    expect([...planLabels([long, neighbour], { x: 0, y: 0, w: W }, W)]).toEqual(["named"]);
+  });
+
+  it("separates labels that share an x but sit on different rows", () => {
+    const stacked = [
+      cand({ id: "row-0", x: 0, dy: 20, priority: LABEL_PRIORITY.hovered }),
+      cand({ id: "row-1", x: 0, dy: 40, priority: LABEL_PRIORITY.worker }),
+    ];
+    expect(planLabels(stacked, { x: 0, y: 0, w: W }, W)).toEqual(new Set(["row-0", "row-1"]));
+  });
+});
+
+describe("focusLabelIds", () => {
+  const branches = [
+    { source: "self", target: "team" },
+    { source: "team", target: "task-a" },
+    { source: "team", target: "task-b" },
+    { source: "task-a", target: "worker" },
+    { source: "worker", target: "tool" },
+  ];
+
+  it("names the focused node and its direct children, and stops there", () => {
+    expect(focusLabelIds(branches, "team")).toEqual(new Set(["team", "task-a", "task-b"]));
+  });
+
+  it("follows what was clicked: an agent names its tools, not its pillar's tasks", () => {
+    expect(focusLabelIds(branches, "worker")).toEqual(new Set(["worker", "tool"]));
+  });
+
+  it("names nothing when nothing is focused", () => {
+    expect(focusLabelIds(branches, null).size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1104

## The rule

One boolean decided every label, and it failed at both ends:

```ts
const showLabel = n.kind === 'self' || n.kind === 'team' || inFocus ||
  (hoverId ? (lit?.has(n.id) ?? false) : false);
```

At rest only `self` and `team` were named, so every agent was an anonymous
circle. In focus `inFocus` is true for the whole tree at once, so the entire
cluster's labels turned on together and smeared. `labelDy`'s two-row stagger is
not collision avoidance — it assumes short labels and even spacing.

## What replaces it

`kg/label-plan.ts` (new, pure, unit-tested) holds two steps; the component
nominates candidates and reads back the survivors.

**1 — Who is nominated**

| When | Named |
|---|---|
| at rest | the company, every department, and the roster — agents and people |
| hovering | the node under the pointer, and only that node |
| in a focused tree | the node you clicked and its direct children |
| always | the selection |

Focus follows what was clicked: a pillar names its tasks, an agent names its
tools. Tasks, stages and tools are the numerous tiers and stay bare until you
point at one. A node faded below 0.3 opacity is never a candidate — a label
there would still take a box from a node you can actually see.

Hover no longer drives labels through `litFor()`. The chain still lights (that
is what shows structure); it just stops dragging a crowd of names with it.

**2 — The declutter**

Candidates are placed highest priority first; any label whose box overlaps one
already placed is dropped rather than nudged. Nudging is what the stagger did,
and it only moved the pile-up.

The pass measures in **screen px, not graph units**. Labels hold one on-screen
size at every camera depth (`fixedLabel` counter-scales through `--kg-cam-k`),
so zooming changes how far apart nodes are and never how wide a name is —
graph units would answer this correctly at exactly one zoom level and wrongly
everywhere else, wrongly in the direction that matters. `camK` mirrors the
camera's published zoom into state so the pass re-runs when the zoom settles;
only the *scale* reaches it, because a pan shifts every box by the same vector
and cannot change which pairs overlap.

The box is padded horizontally but not vertically, on purpose: padding past the
line height turns the existing two-row stagger into a collision and throws away
a label that reads perfectly well.

**`<title>`** was already on every node path (org nodes, the memory core, and
each memory note), so the native-tooltip floor the issue asks for is in place —
verified rather than duplicated.

## Verified in a browser

Host on `:8355` with `companies/agentic_software_company`, console on `:5195`,
Playwright, light and dark, plus four SOP cards created through the API so a
pillar has a non-degenerate tree.

Labels drawn, before → after:

| State | before | after |
|---|---|---|
| at rest | 4 (`This company` + 3 pillars) | 16 (+ all 12 agents and people) |
| hover one stage node at rest | 33 | 4 — the hovered node plus what stays lit |
| focus Engineering | 12, overlapping | 6 — the trunk and its 4 SOP tasks |
| focus + hover an agent | 12 | 7 — the same 6 plus the hovered agent |
| focus an agent | — | 7 — the agent and its 4 tools |

The before shot of a focused pillar shows the pile-up from the issue verbatim
(`Backend Engineer` / `Frontend Engineer` / `QA Engineer` printed on top of one
another); the after shot has none. The hovered label also reads at `--text` and
600 weight, so the name you asked for separates from the ambient roster instead
of joining it.

## Commands

```
npm run typecheck      # clean
npm run typecheck:unit # clean
npm test               # 116 files, 1129 tests
npm run build          # clean
```

`frontend/test/unit/overview-graph-labels.test.ts` adds 9 tests, including the
regression guard for the screen-space constraint: the same graph coordinates
keep both labels at `k = 1` and drop one at `k = 2`.

## Note on scope

Deeper tiers inside a focused tree (agents, tools, stages) are now named on
hover rather than always. That is the change that removes the pile-up; if
reviewers would rather they stayed nominated at a lower priority and let the
declutter decide, that is a one-line change to the candidate rule.
