### PR TITLE
fix(copilot): name the node an Apply was refused on (#836)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,7 @@ import {
   type ReadMarker,
   type ReadStateResponse,
   type ApiErrorBody,
+  type WorkflowProblem,
   type AppSpec,
   type ApprovalSummary,
   type CapabilityStatusDto,
@@ -967,9 +968,40 @@ function parseJson(text: string): unknown {
 function errorEnvelope(text: string): ApiErrorBody | undefined {
   const parsed = parseJson(text);
   if (typeof parsed !== "object" || parsed === null) return undefined;
-  const { error, code } = parsed as Record<string, unknown>;
+  const { error, code, problems } = parsed as Record<string, unknown>;
   if (typeof error !== "string" || typeof code !== "string") return undefined;
-  return { error, code };
+  const breakdown = workflowProblems(problems);
+  return breakdown ? { error, code, problems: breakdown } : { error, code };
+}
+
+/**
+ * The `problems` array off an envelope, or `undefined` when there is not one.
+ *
+ * Held to the same strictness as the envelope itself, for the same reason: this
+ * is rendered to operators, so an entry is kept only when it carries a real
+ * `message`. Entries are filtered rather than the whole array rejected — a host
+ * that grows a new problem shape should cost the operator that one line, not
+ * the entire breakdown — and an array that filters down to nothing returns
+ * `undefined` so a caller cannot mistake "every entry was junk" for "the host
+ * refused with an empty list".
+ *
+ * `node_id` and `field` are dropped unless they are strings, keeping a
+ * malformed locator from reaching the UI as `[object Object]`.
+ */
+function workflowProblems(value: unknown): WorkflowProblem[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const kept: WorkflowProblem[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const { node_id, field, message } = entry as Record<string, unknown>;
+    if (typeof message !== "string" || !message.trim()) continue;
+    kept.push({
+      ...(typeof node_id === "string" ? { node_id } : {}),
+      ...(typeof field === "string" ? { field } : {}),
+      message,
+    });
+  }
+  return kept.length ? kept : undefined;
 }
 
 /**
@@ -1012,6 +1044,11 @@ function httpError(res: TransportResponse, text: string): ApiError {
     envelope?.error ?? statusMessage(res),
     envelope !== undefined,
   );
+  // Issue #836: the host has sent this breakdown since #1016 and the console
+  // dropped it here, so a refused graph read as one flat sentence with no node
+  // named. Carried, not rendered here — what a surface does with it is the
+  // surface's call.
+  if (envelope?.problems) err.problems = envelope.problems;
   // Not discarded, just not rendered. A proxy error page is the only clue to
   // which hop gave up, which is worth keeping for a bug report even though it
   // is worthless as prose.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1241,10 +1241,40 @@ export interface FinancesDto {
   transactions: TransactionDto[];
 }
 
-/** Error envelope shape: `{ error, code }`. */
+/**
+ * One structured problem with a workflow graph the host refused (issue #1016).
+ *
+ * Field names are the **wire** names, not the console's usual camelCase. The
+ * host serialises `WorkflowProblem` with serde's defaults (`src/error.rs`), so
+ * the key really is `node_id`; renaming it here to match house style would
+ * compile, type-check, and silently read `undefined` at runtime for every
+ * problem — the failure this shape exists to prevent.
+ *
+ * Both locators are optional because a problem need not have one: a graph-level
+ * refusal (an inescapable cycle) names several nodes at once and owns neither.
+ * `message` is the only field always present, and it is prosumer language ready
+ * to render.
+ */
+export interface WorkflowProblem {
+  /** The node at fault, or the dangling endpoint for an edge problem. */
+  node_id?: string;
+  /** The config path at fault (`config.url`, `workflow_id`, `from`). */
+  field?: string;
+  /** The human-readable problem. */
+  message: string;
+}
+
+/**
+ * Error envelope shape: `{ error, code }`, plus `problems` on a refusal that
+ * has them.
+ *
+ * `problems` is additive and scoped to `workflow_invalid` on the host side, so
+ * it is absent from every other error and must stay optional here.
+ */
 export interface ApiErrorBody {
   error: string;
   code: string;
+  problems?: WorkflowProblem[];
 }
 
 export class ApiError extends Error {
@@ -1261,6 +1291,23 @@ export class ApiError extends Error {
    * that may sit in state for the life of the view.
    */
   detail?: string;
+
+  /**
+   * The per-node, per-field breakdown behind `message`, when the host sent one
+   * (issue #836).
+   *
+   * The host already computes this and puts it on the wire; before this field
+   * existed the console parsed the envelope's `error` and `code` and dropped
+   * `problems` on the floor, so an operator was told *that* a graph was refused
+   * and never *which node*. `message` remains the flattened sentence and stays
+   * the fallback — a renderer may show this list instead, never in addition to
+   * nothing.
+   *
+   * Absent for every error that is not a workflow refusal, and absent (rather
+   * than empty) when the host sent no array, so `problems?.length` distinguishes
+   * "no breakdown offered" from "a breakdown with nothing in it".
+   */
+  problems?: WorkflowProblem[];
 
   constructor(
     public status: number,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1277,6 +1277,30 @@ export interface ApiErrorBody {
   problems?: WorkflowProblem[];
 }
 
+/**
+ * The "where" of a {@link WorkflowProblem}, or `undefined` when it names no
+ * location at all.
+ *
+ * A function rather than a conditional inside the card's JSX, because the three
+ * shapes are the whole of this feature's correctness and the console has no
+ * component-test harness to catch a mistake in markup. Extracted after review
+ * caught the field-only case being dropped: the first version keyed the whole
+ * locator on `node_id`, so a problem carrying `field` and no node rendered its
+ * message with no indication of where it came from — and nothing could have
+ * failed, because there was nothing to call.
+ *
+ * All three shapes are real. The host builds a node+field problem through
+ * `WorkflowProblem::node_field`, which stores `node_id` only when it is
+ * non-blank — so a blank node id with a real field emits exactly the field-only
+ * shape — and a graph-level refusal (an inescapable cycle) carries neither.
+ */
+export function workflowProblemLocator(problem: WorkflowProblem): string | undefined {
+  const parts = [problem.node_id, problem.field].filter(
+    (part): part is string => typeof part === "string" && part.trim() !== "",
+  );
+  return parts.length ? parts.join(" · ") : undefined;
+}
+
 export class ApiError extends Error {
   /**
    * The raw response body, kept only when it was **not** the host's envelope

--- a/frontend/src/views/workflows/CopilotPanel.tsx
+++ b/frontend/src/views/workflows/CopilotPanel.tsx
@@ -33,7 +33,7 @@ import { Bot, Loader2, Send } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { getInferenceStatus, type CognitionPath } from "@/api/inference";
-import { ApiError } from "@/api/types";
+import { ApiError, type WorkflowProblem } from "@/api/types";
 import {
   listWorkflowToolSlugs,
   updateWorkflow,
@@ -82,6 +82,8 @@ interface Review {
   state: ProposalState;
   /** The host's refusal of an apply, when one came back. */
   error?: string;
+  /** The per-node breakdown behind {@link error}, when the host sent one (#836). */
+  errorProblems?: WorkflowProblem[];
 }
 
 export function CopilotPanel({
@@ -342,7 +344,12 @@ export function CopilotPanel({
     async (messageId: string, proposal: WorkflowProposal) => {
       setReviews((prev) => ({
         ...prev,
-        [messageId]: { ...prev[messageId], state: "applying", error: undefined },
+        [messageId]: {
+          ...prev[messageId],
+          state: "applying",
+          error: undefined,
+          errorProblems: undefined,
+        },
       }));
       try {
         const saved = await updateWorkflow(
@@ -354,7 +361,12 @@ export function CopilotPanel({
         );
         setReviews((prev) => ({
           ...prev,
-          [messageId]: { ...prev[messageId], state: "applied", error: undefined },
+          [messageId]: {
+            ...prev[messageId],
+            state: "applied",
+            error: undefined,
+            errorProblems: undefined,
+          },
         }));
         onApplied(saved);
       } catch (e) {
@@ -366,9 +378,17 @@ export function CopilotPanel({
             : "The change could not be applied.";
         // Back to `pending`, not to a dead end: the diff stays on screen and the
         // operator can dismiss it or retry after reloading.
+        // Issue #836: the host names the node and field it refused on; before
+        // this the console kept only the flattened sentence.
+        const problems = e instanceof ApiError ? e.problems : undefined;
         setReviews((prev) => ({
           ...prev,
-          [messageId]: { ...prev[messageId], state: "pending", error: message },
+          [messageId]: {
+            ...prev[messageId],
+            state: "pending",
+            error: message,
+            errorProblems: problems,
+          },
         }));
         if (conflict && e instanceof ApiError) onConflict?.(e.message);
       }
@@ -380,7 +400,12 @@ export function CopilotPanel({
   const dismiss = useCallback((messageId: string) => {
     setReviews((prev) => ({
       ...prev,
-      [messageId]: { ...prev[messageId], state: "dismissed", error: undefined },
+      [messageId]: {
+        ...prev[messageId],
+        state: "dismissed",
+        error: undefined,
+        errorProblems: undefined,
+      },
     }));
   }, []);
 
@@ -642,6 +667,7 @@ export function CopilotPanel({
                     state={reviews[m.id].state}
                     blocked={blockedReason(m.id, reviews[m.id])}
                     error={reviews[m.id].error}
+                    problems={reviews[m.id].errorProblems}
                     onApply={() => void apply(m.id, reviews[m.id].proposal!)}
                     onDismiss={() => dismiss(m.id)}
                   />

--- a/frontend/src/views/workflows/ProposalCard.tsx
+++ b/frontend/src/views/workflows/ProposalCard.tsx
@@ -13,7 +13,7 @@
 
 import { AlertTriangle, Check, Loader2, X } from "lucide-react";
 
-import type { WorkflowProblem } from "@/api/types";
+import { type WorkflowProblem, workflowProblemLocator } from "@/api/types";
 import type { GraphDiff } from "@/api/workflow-proposal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -101,18 +101,15 @@ export function ProposalCard({
                 render-only and never reordered, so index is stable here. */}
             {problems && problems.length > 0 && (
               <ul className="mt-1 space-y-0.5" data-testid="workflow-proposal-problems">
-                {problems.map((problem, i) => (
-                  <li key={i}>
-                    {problem.node_id && (
-                      <span className="font-medium">
-                        {problem.node_id}
-                        {problem.field ? ` · ${problem.field}` : ""}
-                        {" — "}
-                      </span>
-                    )}
-                    {problem.message}
-                  </li>
-                ))}
+                {problems.map((problem, i) => {
+                  const locator = workflowProblemLocator(problem);
+                  return (
+                    <li key={i}>
+                      {locator && <span className="font-medium">{locator} — </span>}
+                      {problem.message}
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </AlertDescription>

--- a/frontend/src/views/workflows/ProposalCard.tsx
+++ b/frontend/src/views/workflows/ProposalCard.tsx
@@ -13,6 +13,7 @@
 
 import { AlertTriangle, Check, Loader2, X } from "lucide-react";
 
+import type { WorkflowProblem } from "@/api/types";
 import type { GraphDiff } from "@/api/workflow-proposal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -35,6 +36,17 @@ interface Props {
   blocked?: string;
   /** The host's refusal, when an Apply was attempted and came back rejected. */
   error?: string;
+  /**
+   * The per-node breakdown behind {@link error}, when the host sent one
+   * (issue #836).
+   *
+   * Rendered under the sentence rather than instead of it: the sentence is what
+   * the host chose to say, and the list is where it happened. An operator whose
+   * proposal touched one node reads the same thing twice and loses nothing; an
+   * operator whose proposal broke three nodes gets the three node ids that
+   * sentence had flattened together.
+   */
+  problems?: WorkflowProblem[];
   onApply: () => void;
   onDismiss: () => void;
 }
@@ -45,6 +57,7 @@ export function ProposalCard({
   state,
   blocked,
   error,
+  problems,
   onApply,
   onDismiss,
 }: Props) {
@@ -80,7 +93,29 @@ export function ProposalCard({
       {error && (
         <Alert variant="destructive" className="mt-2 py-1.5">
           <AlertTriangle className="size-3" />
-          <AlertDescription className="text-2xs leading-snug">{error}</AlertDescription>
+          <AlertDescription className="text-2xs leading-snug">
+            {error}
+            {/* Issue #836: the node and field the host named, when it named
+                any. Keyed by index because a problem carries no id of its own
+                and the same node can legitimately raise two — the list is
+                render-only and never reordered, so index is stable here. */}
+            {problems && problems.length > 0 && (
+              <ul className="mt-1 space-y-0.5" data-testid="workflow-proposal-problems">
+                {problems.map((problem, i) => (
+                  <li key={i}>
+                    {problem.node_id && (
+                      <span className="font-medium">
+                        {problem.node_id}
+                        {problem.field ? ` · ${problem.field}` : ""}
+                        {" — "}
+                      </span>
+                    )}
+                    {problem.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </AlertDescription>
         </Alert>
       )}
 

--- a/frontend/test/unit/workflow-invalid-problems.test.ts
+++ b/frontend/test/unit/workflow-invalid-problems.test.ts
@@ -7,7 +7,7 @@ import type {
   TransportRequest,
   TransportResponse,
 } from "@/api/transport";
-import { ApiError } from "@/api/types";
+import { ApiError, workflowProblemLocator } from "@/api/types";
 
 /**
  * The `problems` breakdown survives the wire (issue #836).
@@ -20,11 +20,12 @@ import { ApiError } from "@/api/types";
  * being the surface where that hurts, because the operator did not author the
  * change and has nothing to reread.
  *
- * These pin the parse, not the rendering. There is no component-test harness in
- * this project (no `@testing-library/react` anywhere under `test/`), so what
- * `ProposalCard` does with the array is guarded by the compiler and by reading.
- * Said out loud rather than implied: the transport is covered here, the markup
- * is not.
+ * These pin the parse, and — since review found a bug in the half that had none
+ * — the locator each problem renders. There is still no component-test harness
+ * in this project (no `@testing-library/react` anywhere under `test/`), so the
+ * markup that *places* that locator is guarded by the compiler and by reading.
+ * Said out loud rather than implied: the transport and the locator are covered
+ * here, the JSX around them is not.
  */
 
 /** Answers with whatever the test staged, so no `fetch` is involved. */
@@ -124,5 +125,44 @@ describe("a refused workflow graph carries its per-node problems", () => {
     expect(wrongShape.problems).toBeUndefined();
     // The envelope itself still parsed, so the operator keeps the sentence.
     expect(wrongShape.code).toBe("workflow_invalid");
+  });
+});
+
+/**
+ * Where a problem says it happened — the half that had no test and was wrong.
+ *
+ * Review caught the field-only shape rendering as a bare message: the locator
+ * was keyed on `node_id`, so a problem carrying a field and no node lost the one
+ * piece of information this feature exists to surface. It could not have been
+ * caught by a test, because the logic lived inside JSX in a project with no
+ * component-test harness. Pulling it into a function is the fix for that, not
+ * only for the bug.
+ */
+describe("a problem's locator", () => {
+  it("joins the node and the field when it has both", () => {
+    expect(workflowProblemLocator({ node_id: "greet", field: "config.url", message: "m" })).toBe(
+      "greet · config.url",
+    );
+  });
+
+  it("names the node alone when there is no field", () => {
+    expect(workflowProblemLocator({ node_id: "greet", message: "m" })).toBe("greet");
+  });
+
+  /** The regression: reachable whenever the host stores a blank node id. */
+  it("names the field alone when there is no node", () => {
+    expect(workflowProblemLocator({ field: "config.url", message: "m" })).toBe("config.url");
+  });
+
+  it("has nothing to say about a graph-level problem", () => {
+    expect(workflowProblemLocator({ message: "the graph has an inescapable cycle." })).toBeUndefined();
+  });
+
+  /** A blank string is not a locator; it would render a dangling separator. */
+  it("ignores blank parts rather than rendering an empty locator", () => {
+    expect(workflowProblemLocator({ node_id: "  ", field: "", message: "m" })).toBeUndefined();
+    expect(workflowProblemLocator({ node_id: "  ", field: "config.url", message: "m" })).toBe(
+      "config.url",
+    );
   });
 });

--- a/frontend/test/unit/workflow-invalid-problems.test.ts
+++ b/frontend/test/unit/workflow-invalid-problems.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenCompanyClient } from "@/api/client";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { ApiError } from "@/api/types";
+
+/**
+ * The `problems` breakdown survives the wire (issue #836).
+ *
+ * The host has answered a refused workflow graph with
+ * `{error, code: "workflow_invalid", problems: [...]}` since #1016, each entry
+ * naming the node and config field at fault. The console parsed `error` and
+ * `code` and dropped `problems` on the floor, so an operator was told *that*
+ * the graph was refused and never *which node* — the copilot's Apply button
+ * being the surface where that hurts, because the operator did not author the
+ * change and has nothing to reread.
+ *
+ * These pin the parse, not the rendering. There is no component-test harness in
+ * this project (no `@testing-library/react` anywhere under `test/`), so what
+ * `ProposalCard` does with the array is guarded by the compiler and by reading.
+ * Said out loud rather than implied: the transport is covered here, the markup
+ * is not.
+ */
+
+/** Answers with whatever the test staged, so no `fetch` is involved. */
+class StubTransport implements Transport {
+  constructor(private readonly staged: Partial<TransportResponse>) {}
+
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    return {
+      status: this.staged.status ?? 200,
+      statusText: this.staged.statusText ?? "",
+      url: this.staged.url ?? req.url,
+      text: this.staged.text ?? "",
+      header: this.staged.header ?? (() => null),
+    };
+  }
+
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+/** The `ApiError` a refused call threw, typed so assertions need no casts. */
+async function refusal(body: unknown, status = 400): Promise<ApiError> {
+  const client = new OpenCompanyClient(
+    { baseUrl: "", company: null, operatorToken: null, sessionHeader: null },
+    new StubTransport({ status, text: JSON.stringify(body) }),
+  );
+  try {
+    await client.get("/api/v1/company/workflows/x");
+  } catch (error) {
+    return error as ApiError;
+  }
+  throw new Error("expected the call to reject");
+}
+
+const invalid = (problems: unknown) => ({
+  error: "greet has a bad url.",
+  code: "workflow_invalid",
+  problems,
+});
+
+describe("a refused workflow graph carries its per-node problems", () => {
+  it("keeps the node and field the host named", async () => {
+    const err = await refusal(
+      invalid([
+        { node_id: "greet", field: "config.url", message: "greet has a bad url." },
+        { node_id: "post", field: "config.set", message: "post sets an unknown key." },
+      ]),
+    );
+
+    expect(err.code).toBe("workflow_invalid");
+    expect(err.problems).toEqual([
+      { node_id: "greet", field: "config.url", message: "greet has a bad url." },
+      { node_id: "post", field: "config.set", message: "post sets an unknown key." },
+    ]);
+    // The flat sentence stays the fallback; the breakdown is additive.
+    expect(err.message).toBe("greet has a bad url.");
+  });
+
+  it("keeps a graph-level problem that owns no node or field", async () => {
+    const err = await refusal(invalid([{ message: "the graph has an inescapable cycle." }]));
+    expect(err.problems).toEqual([{ message: "the graph has an inescapable cycle." }]);
+  });
+
+  it("drops an entry with no readable message rather than rendering junk", async () => {
+    const err = await refusal(
+      invalid([
+        { node_id: "greet", message: "greet has a bad url." },
+        { node_id: "post", message: "   " },
+        { node_id: "other" },
+        "not an object",
+        null,
+      ]),
+    );
+    expect(err.problems).toEqual([{ node_id: "greet", message: "greet has a bad url." }]);
+  });
+
+  it("drops a locator that is not a string, keeping the message", async () => {
+    const err = await refusal(invalid([{ node_id: 7, field: {}, message: "something is wrong." }]));
+    expect(err.problems).toEqual([{ message: "something is wrong." }]);
+  });
+
+  /**
+   * "Every entry was junk" must not read as "a breakdown with nothing in it" —
+   * a renderer branching on `problems` would otherwise open an empty list.
+   */
+  it("reports no breakdown at all when nothing survives the filter", async () => {
+    const err = await refusal(invalid([{ node_id: "greet" }, 42]));
+    expect(err.problems).toBeUndefined();
+  });
+
+  it("reports no breakdown when the key is absent or not an array", async () => {
+    const absent = await refusal({ error: "nope.", code: "company_not_found" }, 404);
+    expect(absent.problems).toBeUndefined();
+
+    const wrongShape = await refusal(invalid({ greet: "bad url" }));
+    expect(wrongShape.problems).toBeUndefined();
+    // The envelope itself still parsed, so the operator keeps the sentence.
+    expect(wrongShape.code).toBe("workflow_invalid");
+  });
+});


### PR DESCRIPTION
## Summary

The copilot's Apply refused a change and said only what HTTP said. The host had
been naming the exact node and field all along — the console threw it away.

`GET`/`PUT` on a workflow graph has answered a refusal with
`{error, code: "workflow_invalid", problems: [...]}` since #1016, each entry
carrying the node id and config field at fault. The console's envelope parser
destructured `{error, code}` and dropped the rest, so an operator was told
*that* the graph was refused and never *which node*.

That hurts most at the copilot's Apply button, which is where this was reported:
the operator did not author the change, so there is no field to reread and
nothing to inspect — the proposal is the copilot's, and the refusal was the only
information they were going to get.

**Console-only. No host change, no route change, no new field on the wire.**

## API Or Behavior Changes

**No wire change.** Nothing new is sent or served; this reads a key the host has
emitted since #1016.

**Behaviour.** A refused Apply now lists each problem under the host's sentence,
prefixed with the node it belongs to and the field when there is one. A refusal
that carries no breakdown renders exactly as before.

`ApiError` gains an optional `problems`. It is absent — not empty — when the
host sent none, so a reader can tell "no breakdown offered" from "a breakdown
with nothing in it".

Note on the two halves of #838's sibling report: the *first* defect it describes
(the copilot proposing a `channel` destination with no target, which the editor
structurally refuses) was already closed by the save-time destination validation
in #981/#1046. What remained was the unreadable refusal, and that is what this
PR fixes.

## Tests

- [x] `npm run typecheck` — clean.
- [x] `npm run typecheck:unit` — clean. (`typecheck` alone skips test directories.)
- [x] `npm run typecheck:e2e` — clean.
- [x] `npx vitest run` — **116 files, 1126 tests, 0 failed.** Run from `frontend/`;
      from the repo root vitest sweeps the vendored trees.
- [x] `npm run build` — clean.
- N/A: `cargo` gates — no Rust file is touched by this branch.

### Six new cases, and what they actually prove

`frontend/test/unit/workflow-invalid-problems.test.ts` pins the parse: the
node+field pair survives; a graph-level problem that owns neither survives; an
entry with no readable message is dropped rather than rendered as junk; a
non-string locator is dropped while its message is kept; an array that filters
to empty reports no breakdown at all; and an absent or wrong-shaped key leaves
the envelope itself intact.

**Reverting the one-line attach in `httpError` turns four of the six red.** The
other two expect `undefined` and pass either way — they guard the filter against
a future regression rather than proving this feature, and are counted as
neither.

### What is NOT proven, stated rather than claimed as coverage

**The markup has no test.** There is no `@testing-library/react` anywhere under
`test/`, so this project has no component-test harness and `ProposalCard`'s
rendering of the list is guarded by the compiler and by reading. Adding a render
harness is a larger change than this fix warrants; naming the gap is cheaper
than implying it is closed.

## Documentation

No spec change — no route, type or contract moved. The reasoning lives at the
code it governs: the `WorkflowProblem` type carries why its keys are snake_case
(the host serialises with serde's defaults, so renaming `node_id` to the
console's usual camelCase would compile, type-check, and read `undefined` at
runtime for every problem), and `ProposalCard` carries why the breakdown renders
under the host's sentence rather than instead of it.

Closes #836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow proposal errors now display detailed, per-node and graph-level validation problems.
  * Problem locations are shown clearly when available, while invalid or incomplete details are filtered out.
  * Problem details are cleared when proposals are applied, dismissed, or retried.
  * The main error message remains visible even when no valid problem details are available.

* **Tests**
  * Added coverage for valid, invalid, missing, and graph-level workflow problem details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->