### PR TITLE
fix(workflows): stop a run claiming it waits on an approval the queue no longer holds (#1143)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -369,6 +369,19 @@ export interface WorkflowBlockedNode {
    * operator at Approvals would send them to an empty page. Absent when zero.
    */
   unparkable?: number;
+  /**
+   * How many of `approvalIds` the host no longer holds (issue #1143).
+   *
+   * The same end state as `unparkable`, reached later: the card was opened, so
+   * the run recorded an id for it, but the question did not survive and the
+   * queue has nothing to decide. Pointing the operator at Approvals for these
+   * sends them to an empty page — which is the dead end #1143 was filed for.
+   *
+   * Computed by the host on each read of run history rather than stored, so it
+   * reflects the queue as it is now. Absent when zero, which is every healthy
+   * run.
+   */
+  stranded?: number;
 }
 
 /** What became of one gated tool call a run tried to park (issue #880). */

--- a/frontend/src/views/workflows/BlockedNodeApprovals.tsx
+++ b/frontend/src/views/workflows/BlockedNodeApprovals.tsx
@@ -67,26 +67,49 @@ export function BlockedNodeApprovals({
     >
       {shown.map((b) => {
         const approvalIds = b.approvalIds ?? [];
+        const stranded = b.stranded ?? 0;
         return (
           <li key={b.nodeId}>
             <span className="font-medium">“{b.nodeId}”</span>
             {b.tools.length > 0 && <> gated {b.tools.join(", ")}</>}
-            {approvalIds.length > 0 && (
-              <>
-                {" — decide in Approvals: "}
-                {approvalIds.map((id, i) => (
-                  <span key={id}>
-                    {i > 0 && ", "}
-                    <a
-                      href={APPROVALS_ROUTE}
-                      className="underline underline-offset-2 hover:text-foreground"
-                      data-testid="workflow-blocked-approval-link"
-                    >
-                      {toolFor.get(id) ?? "this call"}
-                    </a>
-                  </span>
-                ))}
-              </>
+            {approvalIds.length > 0 && stranded >= approvalIds.length ? (
+              // Every card this node opened is gone from the queue (#1143), so
+              // there is nothing to link to. Sending the operator to an empty
+              // Approvals page and calling it an action is the defect itself —
+              // the honest line says the run cannot be continued and why.
+              <span data-testid="workflow-blocked-approval-stranded">
+                {" — "}
+                {approvalIds.length === 1
+                  ? "its approval is no longer in the queue"
+                  : "none of its approvals are in the queue any more"}
+                , so this run cannot be continued. Re-run the workflow.
+              </span>
+            ) : (
+              approvalIds.length > 0 && (
+                <>
+                  {" — decide in Approvals: "}
+                  {approvalIds.map((id, i) => (
+                    <span key={id}>
+                      {i > 0 && ", "}
+                      <a
+                        href={APPROVALS_ROUTE}
+                        className="underline underline-offset-2 hover:text-foreground"
+                        data-testid="workflow-blocked-approval-link"
+                      >
+                        {toolFor.get(id) ?? "this call"}
+                      </a>
+                    </span>
+                  ))}
+                  {stranded > 0 && (
+                    // Partly stranded: the surviving cards are still worth
+                    // linking, but the count would otherwise overstate what the
+                    // operator can actually act on.
+                    <span data-testid="workflow-blocked-approval-partly-stranded">
+                      {` (${stranded} more no longer in the queue)`}
+                    </span>
+                  )}
+                </>
+              )
             )}
           </li>
         );

--- a/frontend/test/unit/workflow-run-approval-links.test.ts
+++ b/frontend/test/unit/workflow-run-approval-links.test.ts
@@ -204,3 +204,64 @@ describe("the synchronous run result panel", () => {
     for (const a of links) expect(a.getAttribute("href")).toBe("#/approvals");
   });
 });
+
+/**
+ * Issue #1143: when the queue no longer holds a blocked node's cards, the drawer
+ * must stop offering them as a decision.
+ *
+ * The dead end this closes, observed on a staging tenant: the drawer rendered
+ * "decide in Approvals: shell, curl", the operator followed a link, and the
+ * Approvals page said "All clear". The run's `approvalIds` is a receipt and is
+ * right to be immutable — what was missing was reading it against the live
+ * queue, which the host now does and reports as `stranded`.
+ *
+ * Both tests fail on the code before it: `stranded` was not rendered, so the
+ * links were painted regardless.
+ */
+describe("a blocked run whose approvals the queue no longer holds", () => {
+  it("says the run cannot be continued instead of linking to an empty queue", async () => {
+    await renderHistory(
+      blockedOutcome({
+        blockedNodes: [
+          {
+            nodeId: "spec",
+            tools: ["publish_artifact", "web_search"],
+            approvalIds: ["appr-1", "appr-2"],
+            stranded: 2,
+          },
+        ],
+      }),
+    );
+    expect(
+      container.querySelectorAll('[data-testid="workflow-blocked-approval-link"]'),
+    ).toHaveLength(0);
+    const line = container.querySelector(
+      '[data-testid="workflow-blocked-approval-stranded"]',
+    );
+    expect(line?.textContent).toContain("cannot be continued");
+    expect(container.textContent).not.toContain("decide in Approvals");
+  });
+
+  it("keeps linking the cards that survive, and counts the ones that did not", async () => {
+    await renderHistory(
+      blockedOutcome({
+        blockedNodes: [
+          {
+            nodeId: "spec",
+            tools: ["publish_artifact", "web_search"],
+            approvalIds: ["appr-1", "appr-2"],
+            stranded: 1,
+          },
+        ],
+      }),
+    );
+    expect(
+      container.querySelectorAll('[data-testid="workflow-blocked-approval-link"]'),
+    ).toHaveLength(2);
+    expect(
+      container.querySelector(
+        '[data-testid="workflow-blocked-approval-partly-stranded"]',
+      )?.textContent,
+    ).toContain("1 more no longer in the queue");
+  });
+});

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -7657,6 +7657,7 @@ name = "Morning"
                 tools: vec!["publish_artifact".to_string()],
                 approval_ids: vec!["appr-1".to_string()],
                 unparkable: 0,
+                stranded: 0,
             }],
             approvals: vec![
                 crate::ports::WorkflowRunApprovalRow {

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -218,6 +218,27 @@ pub struct WorkflowBlockedNode {
     /// zero, which is the ordinary case.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub unparkable: usize,
+    /// How many of this node's [`approval_ids`](Self::approval_ids) the journal
+    /// no longer holds (issue #1143).
+    ///
+    /// **Computed on the read, never journaled.** Every writer leaves this zero
+    /// and it is skipped when zero, so a run's durable row is byte-for-byte what
+    /// it was; `list_runs` fills it in by asking the journal which of the ids
+    /// this node parked are still parked. It has to be derived rather than
+    /// stored for the same reason the sibling `WorkflowRun::approvals` receipt
+    /// is named for what was parked rather than what is outstanding: a stored
+    /// count of "still waiting" is a fresh lie the moment the queue moves.
+    ///
+    /// Semantically this is [`unparkable`](Self::unparkable) arrived at late.
+    /// Both mean the operator will never be asked and re-running is the only way
+    /// forward — the difference is only *when* that became true. A park is
+    /// unparkable at run time because the gate refused it; it is stranded
+    /// afterwards because the question did not survive (the park record is
+    /// `Durability::Process`, and the "the agent re-parks on its next attempt"
+    /// tolerance that justifies it does not hold for a run that already halted —
+    /// see #1145).
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub stranded: usize,
 }
 
 /// `skip_serializing_if` predicate for a count that is almost always zero.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -7292,6 +7292,7 @@ mode = "full"
                 tools: vec!["publish_artifact".into()],
                 approval_ids: vec!["appr-1".into()],
                 unparkable: 0,
+                stranded: 0,
             }],
             approvals: vec![crate::ports::WorkflowRunApprovalRow {
                 node_id: Some("spec".into()),

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2961,6 +2961,45 @@ async fn list_runs(
     // caller was asking about all along.
     runs.reverse();
     runs.truncate(limit);
+
+    // Issue #1143. A blocked node's `approval_ids` is a receipt of what the run
+    // parked, and a receipt cannot go stale — but the *question* it points at
+    // can. `ApprovalParked` is journaled at `Durability::Process` on the stated
+    // reasoning that losing it is harmless because "the agent parks it again on
+    // its next attempt". That holds for a chat turn, which retries; it is false
+    // for a workflow run, which halted at the blocked node and never re-enters
+    // the gate. So a run that outlived its own approvals goes on reporting that
+    // it waits on cards the queue does not have, and the drawer's "decide in
+    // Approvals" links land on an empty page. #1145 carries the durability
+    // decision; this reconciliation deliberately does not pre-empt it.
+    //
+    // Done HERE, on the read, for the same reason `relabel_blocked` above
+    // relabels rather than rewriting the durable node rows: the journal records
+    // what happened and is not edited to reflect what is true now. After the
+    // truncate, so the join costs one journal snapshot and covers only the rows
+    // actually being returned — and skipped entirely when no returned run
+    // parked anything, which is nearly every read.
+    if runs
+        .iter()
+        .any(|r| r.blocked_nodes.iter().any(|b| !b.approval_ids.is_empty()))
+    {
+        let live: std::collections::HashSet<String> = company
+            .runtime
+            .pending_approvals()
+            .into_iter()
+            .map(|a| a.id.as_ref().to_string())
+            .collect();
+        for run in &mut runs {
+            for blocked in &mut run.blocked_nodes {
+                blocked.stranded = blocked
+                    .approval_ids
+                    .iter()
+                    .filter(|id| !live.contains(id.as_str()))
+                    .count();
+            }
+        }
+    }
+
     Ok(Json(runs))
 }
 
@@ -3633,6 +3672,7 @@ mod tests {
                 tools: vec!["publish_artifact".into()],
                 approval_ids: vec!["appr-1".into()],
                 unparkable: 0,
+                stranded: 0,
             }],
             approvals: vec![crate::ports::WorkflowRunApprovalRow {
                 node_id: Some("spec".into()),
@@ -3692,6 +3732,7 @@ mod tests {
                 tools: vec!["publish_artifact".into()],
                 approval_ids: Vec::new(),
                 unparkable: 2,
+                stranded: 0,
             }],
             approvals: vec![crate::ports::WorkflowRunApprovalRow {
                 node_id: Some("spec".into()),
@@ -5666,6 +5707,7 @@ mod tests {
                             tools: vec!["publish_artifact".to_string()],
                             approval_ids: vec!["appr-1".to_string()],
                             unparkable: 0,
+                            stranded: 0,
                         }],
                         approvals: vec![crate::ports::WorkflowRunApprovalRow {
                             node_id: Some("spec".to_string()),
@@ -5694,6 +5736,147 @@ mod tests {
             assert_eq!(
                 rows[0]["nodes"][0]["status"], "blocked",
                 "the node chip must agree with the run's terminal reading: {body}"
+            );
+        }
+
+        /// Issue #1143. The run's receipt names a card the queue no longer
+        /// holds, so the history says so instead of offering it as a decision.
+        ///
+        /// This is the observed dead end: the drawer rendered "decide in
+        /// Approvals" links for `appr-gone`, the operator followed one, and
+        /// Approvals said "All clear". The run's `approvalIds` is a receipt and
+        /// is right to be immutable; what was missing is anything that reads it
+        /// against the live queue. Nothing is parked in this fixture, so the id
+        /// is stranded.
+        #[tokio::test]
+        async fn run_history_marks_a_blocked_approval_the_queue_no_longer_holds() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "digest", "run-s", false).await;
+            let runtime = state.registry().get(&id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: "digest".to_string(),
+                        scheduled: true,
+                        run_id: Some("run-s".to_string()),
+                        deliveries: Vec::new(),
+                        pending_approvals: vec!["spec".to_string()],
+                        error: None,
+                        cancelled: false,
+                        notices: Vec::new(),
+                        board: Vec::new(),
+                        blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                            node_id: "spec".to_string(),
+                            tools: vec!["shell".to_string()],
+                            approval_ids: vec!["appr-gone".to_string()],
+                            unparkable: 0,
+                            stranded: 0,
+                        }],
+                        approvals: Vec::new(),
+                    },
+                )
+                .await
+                .expect("append");
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(
+                body[0]["blockedNodes"][0]["stranded"], 1,
+                "an approval id the journal no longer holds must read as stranded, \
+                 or the drawer goes on linking to an empty queue: {body}"
+            );
+        }
+
+        /// The other direction, and the reason the test above proves anything.
+        ///
+        /// A field that marked *every* run stranded would satisfy the assertion
+        /// above and be worse than no field at all — it would retire live work.
+        /// Here the approval is genuinely parked, on both halves the runtime
+        /// reads (the gate's map and the journal), so `stranded` stays zero and
+        /// is skipped off the wire entirely.
+        #[tokio::test]
+        async fn run_history_leaves_a_live_approval_decidable() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            let runtime = state.registry().get(&id).expect("registered");
+
+            let effect = crate::ports::types::Effect {
+                kind: "filing.submit".into(),
+                group: crate::ports::types::EffectGroup::Sign,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::Value::Null,
+                agent: None,
+                run_id: Some("run-live".to_string()),
+            };
+            let approval_id = runtime
+                .approvals
+                .park(runtime.id(), effect.clone())
+                .await
+                .expect("park");
+            runtime
+                .journal()
+                .record_parked(
+                    &approval_id,
+                    &effect,
+                    crate::ports::now_millis(),
+                    crate::runtime::journal::TaskLink::Unlinked,
+                    crate::runtime::journal::ApprovalConversation {
+                        thread: None,
+                        parent: None,
+                    },
+                    None,
+                )
+                .await
+                .expect("record");
+
+            journal_start(&state, &id, "digest", "run-live", false).await;
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: "digest".to_string(),
+                        scheduled: true,
+                        run_id: Some("run-live".to_string()),
+                        deliveries: Vec::new(),
+                        pending_approvals: vec!["spec".to_string()],
+                        error: None,
+                        cancelled: false,
+                        notices: Vec::new(),
+                        board: Vec::new(),
+                        blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                            node_id: "spec".to_string(),
+                            tools: vec!["shell".to_string()],
+                            approval_ids: vec![approval_id.as_ref().to_string()],
+                            unparkable: 0,
+                            stranded: 0,
+                        }],
+                        approvals: Vec::new(),
+                    },
+                )
+                .await
+                .expect("append");
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert!(
+                body[0]["blockedNodes"][0].get("stranded").is_none(),
+                "a parked approval is still decidable, so nothing may be marked \
+                 stranded: {body}"
             );
         }
 

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -678,6 +678,7 @@ mod pure {
             tools: vec!["publish_artifact".to_string()],
             approval_ids: vec!["appr-1".to_string(), "appr-2".to_string()],
             unparkable: 0,
+            stranded: 0,
         });
         assert!(notice.contains("parked 2 approvals"), "{notice}");
         assert!(
@@ -700,6 +701,7 @@ mod pure {
             tools: vec!["publish_artifact".to_string()],
             approval_ids: Vec::new(),
             unparkable: 1,
+            stranded: 0,
         });
         assert!(
             notice.contains("could not be queued for approval"),

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1243,6 +1243,7 @@ impl AgentRunner for HarnessAgentRunner {
                 tools: parked.tools.clone(),
                 approval_ids: parked.approval_ids.clone(),
                 unparkable: parked.unparkable,
+                stranded: 0,
             });
             return Err(EngineError::Capability(blocked_diagnosis(
                 node_id.as_deref(),

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -2206,6 +2206,7 @@ to = "done"
             tools: vec!["shell".to_string()],
             approval_ids: vec!["appr-1".to_string()],
             unparkable: 0,
+            stranded: 0,
         }];
         // No node row reported `Error` at all — a setup/validation failure the
         // engine raised before any node ran, for instance.
@@ -2226,6 +2227,7 @@ to = "done"
             tools: vec!["shell".to_string()],
             approval_ids: vec!["appr-1".to_string()],
             unparkable: 0,
+            stranded: 0,
         }];
         let nodes = vec![crate::ports::WorkflowRunNodeRow {
             node_id: "work".to_string(),
@@ -2245,6 +2247,7 @@ to = "done"
             tools: vec!["shell".to_string()],
             approval_ids: vec!["appr-1".to_string()],
             unparkable: 0,
+            stranded: 0,
         }];
         let nodes = vec![
             crate::ports::WorkflowRunNodeRow {
@@ -2429,6 +2432,7 @@ to = "boom"
             tools: vec!["shell".to_string()],
             approval_ids: Vec::new(),
             unparkable: 0,
+            stranded: 0,
         };
 
         let capture = serde_json::json!({


### PR DESCRIPTION
## Summary

Part of #1143 — the first of its two halves. **Deliberately not `Closes`**: #1143 stays open until the durability half (#1145) also lands, so a closed issue never stands over a live defect.

Four workflow runs on the `smoke1` staging tenant are parked awaiting approval and cannot ever be released. The approvals queue is empty, so there is nothing to approve; the runs keep their `pendingApprovals` forever, and everything downstream of each one never ran.

The dead end, as an operator walks it: the run drawer says *"This run parked 3 approvals. **Approve them in Approvals** and this run continues on its own"*, then *"'backend' gated shell, curl — decide in Approvals: shell, curl, curl"* with those words as links (#1094, merged this week). Clicking one lands on Approvals, which says **"All clear — Nothing is waiting on you."**

**Root cause.** `ApprovalParked` is journaled at `Durability::Process`, and the code states the reasoning:

```rust
// Losing a park loses the *question*: the approval vanishes and the
// agent parks it again on its next attempt. Nothing external fired.
```

"Nothing external fired" is true and is the property that matters for safety. The second clause is not: a **chat turn** does re-park, and a **workflow run** does not — it halted at the blocked node and nothing re-enters the gate. So the run's durable `pending_approvals` outlives the question it refers to, and the two halves of the state diverge permanently.

**What this PR does, and does not do.** It stops the lie. A blocked node now carries `stranded` — how many of its `approvalIds` the journal no longer holds — computed on the read, and the drawer stops offering those cards as a decision.

It does **not** change any durability guarantee. Whether a workflow-gating park should survive what an effect commit already survives is #1145, filed as a sub-issue of #1143 and deliberately left open. Recording that split explicitly, because the pair could otherwise read as a suppression: this PR makes a live defect visible and honest, and is not a substitute for fixing it.

`stranded` is semantically `unparkable` arrived at late — both mean the operator will never be asked and re-running is the only way forward. Reusing that concept rather than inventing a new one is why the console change is small.

Ruled out while narrowing: **not #726** (closed 2026-08-12, and `StorageHandles::journal` is non-optional precisely to stop an fs fallback — three of the four runs parked after it closed); **not TTL expiry** (`DEFAULT_TTL_MILLIS` is 7 days, three parked within 24 hours); **not `approval_visibility`** (it redacts fields, never drops a row).

## API Or Behavior Changes

- **New optional field** `blockedNodes[].stranded` on run history and run results. Computed per read, never journaled — every writer leaves it zero, and it is skipped when zero, so a healthy run's payload is byte-for-byte unchanged and a client that ignores it behaves exactly as before.
- **Console copy changes on a stranded run only.** All cards gone → "…its approval is no longer in the queue, so this run cannot be continued. Re-run the workflow." Some gone → the surviving cards stay linked, with a count of the ones that are not, so the line never overstates what is actionable.
- **No durable record is rewritten.** The reconciliation sits beside `relabel_blocked`, which already relabels on the read for the same reason: the journal records what happened and is not edited to reflect what is true now.
- **The four stuck runs stay stuck.** Nothing here recovers them; they stop claiming to be actionable.

## Tests

- `run_history_marks_a_blocked_approval_the_queue_no_longer_holds` — a receipt naming a card the journal does not hold reports `stranded: 1`.
- `run_history_leaves_a_live_approval_decidable` — **the test that makes the first one mean anything.** A field that marked every run stranded would satisfy the positive case and be worse than no field at all, so this parks a real approval on both halves the runtime reads (the gate's map and the journal) and pins that `stranded` stays absent.
- Two console render tests in the existing `workflow-run-approval-links.test.ts` (#1014's render half): no links plus the "cannot be continued" line when all cards are gone; links preserved plus a count when only some are.

Gates, all green locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` (exit 0; the one warning is the pre-existing unused `whisper-rs-sys` patch)
- [x] `cargo test --locked --lib server::ops::workflows` — 104 passed; `--lib workflows::` — 106 passed
- [x] `npm run typecheck`, `typecheck:unit`, `typecheck:e2e` — all three projects
- [x] `npx vitest run test/unit/workflow-run-approval-links.test.ts` — 7 passed
- [x] `npm run build`

## Documentation

No docs change. The reasoning lives beside the code — on the `stranded` field, on the reconciliation in `list_runs`, and in the TypeScript type — which is where the next person to touch this will be reading. #1145 carries the durability argument.

