### PR TITLE
Give host-authored notices an author that is honestly not an agent

### DIFF
--- a/frontend/test/unit/chat-system-notice.test.ts
+++ b/frontend/test/unit/chat-system-notice.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatHistoryMessageDto } from "@/api/types";
+import { fromHistory } from "@/lib/chat";
+
+/**
+ * Issue #966 — the console half of the host-authored notice.
+ *
+ * Three sites emit prose the runtime wrote itself: an approval-overflow notice,
+ * the `"Acknowledged."` cycle fallback, and a failed-continuation report. They
+ * used to journal under `"operator"`, which made a correct system row identical
+ * on disk to a reply whose author the pre-#885 defect had overwritten. The host
+ * now journals them under `SYSTEM_AUTHOR`, and this file pins what that buys on
+ * the surface a reader actually looks at.
+ *
+ * **What is and is not covered here.** The `author === "system"` branch itself
+ * predates this issue (#377 added it for the dispatch marker), so these are not
+ * a regression guard for the host-side change — the marker tests already cover
+ * that branch, and they only ever exercise it through a row carrying a card.
+ * What was untested is this shape: a system-authored row with **no** `taskId`,
+ * which is what all three notices are. Together with the host-side assertion
+ * that `SYSTEM_AUTHOR` is literally `"system"`, this is the coupling that keeps
+ * the two halves spelled the same.
+ */
+
+const AT = 1_700_000_000_000;
+
+/** A notice as the host now journals it: authored by the runtime, no card. */
+function notice(over: Partial<ChatHistoryMessageDto> = {}): ChatHistoryMessageDto {
+  return {
+    id: "512",
+    channel: "system",
+    author: "system",
+    text: "Acknowledged.",
+    atMillis: AT,
+    mine: false,
+    ...over,
+  };
+}
+
+describe("a host-authored notice", () => {
+  it("renders as a centred pill, not as the company speaking", () => {
+    const [line] = fromHistory([notice()]);
+
+    expect(line.from).toBe("system");
+    expect(line.text).toBe("Acknowledged.");
+  });
+
+  /**
+   * The notices carry no card. The marker tests only ever drive the system
+   * branch through a row that has one, so this is the shape they leave open.
+   */
+  it("carries no card chip", () => {
+    expect(fromHistory([notice()])[0].taskId).toBeUndefined();
+  });
+
+  /** All three notices, including the one that bypasses `OutboundMessage`. */
+  it("reads the same for the failed-continuation report", () => {
+    const [line] = fromHistory([
+      notice({
+        id: "513",
+        text: "Your approval was recorded, but the agent could not pick the work back up.",
+      }),
+    ]);
+
+    expect(line.from).toBe("system");
+  });
+});
+
+describe("a notice journaled before the fix", () => {
+  /**
+   * The forward-only boundary, stated as a test rather than only in prose.
+   *
+   * A row already on disk keeps `"operator"` and is indistinguishable from a
+   * reply whose author was overwritten, so it still reads as the company. That
+   * is not a defect this change can repair — the distinguishing information was
+   * never written down — and pinning it here keeps the limit visible to anyone
+   * who later wonders why old transcripts still look wrong.
+   */
+  it("still reads as a company bubble, which no fix can undo", () => {
+    const [line] = fromHistory([notice({ channel: "operator", author: "operator" })]);
+
+    expect(line.from).toBe("company");
+  });
+});

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -384,6 +384,28 @@ pub struct CompanyRuntime {
     pub(crate) mcp: Option<Arc<crate::harness::mcp::McpRuntime>>,
 }
 
+/// The event the runtime appends when a continuation could not be picked back
+/// up (issue #469, defect 4).
+///
+/// Named so its **author** can be asserted (issue #966). This site writes the
+/// `AgentReply` directly rather than going through `OutboundMessage`, so it does
+/// not get the `agent` field's fallback and has to name the author itself. It
+/// used to store `OPERATOR_CHANNEL`, which made a correct system row
+/// indistinguishable on disk from a reply whose author the pre-#885 defect
+/// overwrote.
+fn continuation_failure_notice(thread: String, parent: Option<EventSeq>) -> CompanyEvent {
+    CompanyEvent::AgentReply {
+        parent,
+        chat_id: thread,
+        agent_id: crate::ports::SYSTEM_AUTHOR.to_string(),
+        text: "Your approval was recorded, but the agent could not pick the work back up. \
+               Nothing was half-done — approving again is safe and will retry it."
+            .to_string(),
+        steps: Vec::new(),
+        task_id: None,
+    }
+}
+
 impl CompanyRuntime {
     /// Assembles a runtime from its ports. Most callers use
     /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) instead.
@@ -1996,20 +2018,7 @@ impl CompanyRuntime {
         let parent = self.resolvable_parent(conversation.parent, &thread).await;
         if let Err(err) = self
             .events
-            .append(
-                &self.id,
-                CompanyEvent::AgentReply {
-                    parent,
-                    chat_id: thread,
-                    agent_id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
-                    text: "Your approval was recorded, but the agent could not pick the work \
-                           back up. Nothing was half-done — approving again is safe and will \
-                           retry it."
-                        .to_string(),
-                    steps: Vec::new(),
-                    task_id: None,
-                },
-            )
+            .append(&self.id, continuation_failure_notice(thread, parent))
             .await
         {
             tracing::warn!(
@@ -2806,7 +2815,10 @@ impl std::fmt::Debug for CompanyRuntime {
 
 #[cfg(test)]
 mod tests {
-    use super::{emergency_from_load, task_enters_in_progress, task_enters_planning};
+    use super::{
+        CompanyEvent, continuation_failure_notice, emergency_from_load, task_enters_in_progress,
+        task_enters_planning,
+    };
 
     /// Issue #880: which parked approvals name a workflow run, and which must
     /// not.
@@ -3916,6 +3928,34 @@ mod tests {
             rt.resolvable_parent(Some(roots[0]), "desk-ops").await,
             None,
             "and the General desk is not a named one",
+        );
+    }
+
+    /// Issue #966: the failed-continuation report is authored by the runtime.
+    ///
+    /// This site appends the `AgentReply` itself, so it never sees
+    /// `OutboundMessage::agent` or its `channel` fallback — it has to name the
+    /// author, and it used to name `OPERATOR_CHANNEL`. That made a correct
+    /// system row byte-identical on disk to a reply the pre-#885 defect had
+    /// damaged, which is the finding recorded on #966.
+    #[test]
+    fn a_failed_continuation_report_is_authored_by_the_runtime_not_the_operator() {
+        let event = continuation_failure_notice("desk-general".to_string(), None);
+        let CompanyEvent::AgentReply {
+            agent_id, chat_id, ..
+        } = event
+        else {
+            panic!("the notice must stay an AgentReply — the console renders it from that arm");
+        };
+        assert_eq!(agent_id, crate::ports::SYSTEM_AUTHOR);
+        assert_ne!(
+            agent_id,
+            crate::runtime::channel::OPERATOR_CHANNEL,
+            "a notice must not store the author a destination-overwrite produces"
+        );
+        assert_eq!(
+            chat_id, "desk-general",
+            "it still lands in the thread it answers"
         );
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -230,23 +230,6 @@ pub struct HarnessBrain {
     runs: Option<Arc<dyn crate::ports::RunStore>>,
 }
 
-/// The single bubble a workflow-copilot turn returns (issues #416, #966).
-///
-/// Named rather than inlined because its **author** is the load-bearing field
-/// and it was wrong. #885 taught the main operator bubble to carry its
-/// responder and left this branch on `None`, so a genuine copilot reply kept
-/// journaling as `agent_id: "operator"` — the #885 defect still happening, not
-/// history needing a label. A function is what lets that be asserted without
-/// standing up a scripted model endpoint and a whole harness pool.
-///
-/// `CONFINED_AGENT_ID` is deliberately not a roster id (see [`confine`]): it
-/// names no teammate and cannot be addressed. That makes it a **truthful**
-/// author rather than a resolvable one, which is why
-/// `chat_history::is_known_author` has to know it — otherwise this row trades
-/// one wrong answer for a permanent false positive in the attribution audit.
-///
-/// No card, by construction: a confined turn has no `spawn_task` to call, and
-/// the chat handler does not open one from a copilot message either.
 /// A bubble the **runtime** wrote, not an agent (issue #966).
 ///
 /// Two sites emit these on the operator channel: the approval-overflow notice
@@ -271,6 +254,23 @@ fn system_notice(text: String) -> OutboundMessage {
     }
 }
 
+/// The single bubble a workflow-copilot turn returns (issues #416, #966).
+///
+/// Named rather than inlined because its **author** is the load-bearing field
+/// and it was wrong. #885 taught the main operator bubble to carry its
+/// responder and left this branch on `None`, so a genuine copilot reply kept
+/// journaling as `agent_id: "operator"` — the #885 defect still happening, not
+/// history needing a label. A function is what lets that be asserted without
+/// standing up a scripted model endpoint and a whole harness pool.
+///
+/// `CONFINED_AGENT_ID` is deliberately not a roster id (see [`confine`]): it
+/// names no teammate and cannot be addressed. That makes it a **truthful**
+/// author rather than a resolvable one, which is why
+/// `chat_history::is_known_author` has to know it — otherwise this row trades
+/// one wrong answer for a permanent false positive in the attribution audit.
+///
+/// No card, by construction: a confined turn has no `spawn_task` to call, and
+/// the chat handler does not open one from a copilot message either.
 fn confined_bubble(outcome: crate::harness::TurnOutcome) -> OutboundMessage {
     OutboundMessage {
         message_id: None,

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -247,6 +247,30 @@ pub struct HarnessBrain {
 ///
 /// No card, by construction: a confined turn has no `spawn_task` to call, and
 /// the chat handler does not open one from a copilot message either.
+/// A bubble the **runtime** wrote, not an agent (issue #966).
+///
+/// Two sites emit these on the operator channel: the approval-overflow notice
+/// and the cycle's `"Acknowledged."` fallback. Both used to leave the author
+/// unset, so the journal writer's `channel` fallback stamped `"operator"` — and
+/// that made a *correct* system row byte-identical on disk to a reply whose
+/// author the pre-#885 defect had overwritten. No reader could tell them apart,
+/// which is the finding recorded on #966.
+///
+/// Named rather than inlined for the same reason [`confined_bubble`] is: the
+/// author is the load-bearing field, and a free function is what lets it be
+/// asserted without standing up a cycle.
+fn system_notice(text: String) -> OutboundMessage {
+    OutboundMessage {
+        message_id: None,
+        task_id: None,
+        channel: "operator".to_string(),
+        agent: Some(crate::ports::SYSTEM_AUTHOR.to_string()),
+        text,
+        steps: Vec::new(),
+        reply_to: None,
+    }
+}
+
 fn confined_bubble(outcome: crate::harness::TurnOutcome) -> OutboundMessage {
     OutboundMessage {
         message_id: None,
@@ -3062,28 +3086,12 @@ impl HarnessBrain {
         // the agent was cut off — and because a turn whose only outcome was
         // overflow has no reply to append to.
         if let Some(notice) = self.park_approval_requests(host).await? {
-            channel_responses.push(OutboundMessage {
-                message_id: None,
-                task_id: None,
-                channel: "operator".to_string(),
-                agent: None,
-                text: notice,
-                steps: Vec::new(),
-                reply_to: None,
-            });
+            channel_responses.push(system_notice(notice));
         }
 
         // The runtime requires at least one channel response per cycle.
         if channel_responses.is_empty() {
-            channel_responses.push(OutboundMessage {
-                message_id: None,
-                task_id: None,
-                channel: "operator".to_string(),
-                agent: None,
-                text: "Acknowledged.".to_string(),
-                steps: Vec::new(),
-                reply_to: None,
-            });
+            channel_responses.push(system_notice("Acknowledged.".to_string()));
         }
 
         let trace = CompressedTrace::now(
@@ -8871,6 +8879,25 @@ members = ["eng1", "eng2"]
             bubble.agent.as_deref(),
             Some(bubble.channel.as_str()),
             "author and destination must not be the same value — that conflation is issue #885"
+        );
+    }
+
+    /// Issue #966: a bubble the runtime wrote names a non-agent author.
+    ///
+    /// Asserts it is not `"operator"` specifically, rather than only that it
+    /// equals the constant. The whole defect is that a host-authored notice and
+    /// a reply whose author was overwritten stored the *same* value, so a test
+    /// that checked equality alone would still pass if `SYSTEM_AUTHOR` were ever
+    /// redefined to the channel name.
+    #[test]
+    fn a_host_authored_notice_is_not_authored_by_the_operator_channel() {
+        let bubble = system_notice("Acknowledged.".to_string());
+        assert_eq!(bubble.channel, "operator", "the destination is unchanged");
+        assert_eq!(bubble.agent.as_deref(), Some(crate::ports::SYSTEM_AUTHOR));
+        assert_ne!(
+            bubble.agent.as_deref(),
+            Some("operator"),
+            "a notice must not store the author a destination-overwrite produces"
         );
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -3342,6 +3342,16 @@ description = "Runs Acme."
             .expect("cycle runs");
         assert_eq!(result.channel_responses.len(), 1);
         assert_eq!(result.channel_responses[0].text, "Acknowledged.");
+        // Issue #966, asserted here rather than only on `system_notice`: this
+        // drives the real cycle, so it pins that the fallback *calls* the
+        // constructor. Asserting the constructor alone leaves the call site free
+        // to go back to an inline bubble with no author, which is the shape that
+        // caused the defect.
+        assert_eq!(
+            result.channel_responses[0].agent.as_deref(),
+            Some(crate::ports::SYSTEM_AUTHOR),
+            "the runtime's own fallback is authored by the runtime, not by its destination"
+        );
     }
 
     #[test]

--- a/src/ports/ids.rs
+++ b/src/ports/ids.rs
@@ -51,6 +51,26 @@ pub fn generate_id() -> String {
     format!("{millis:012x}-{counter:012x}")
 }
 
+/// The author a **host-authored notice** is journaled under (issue #966).
+///
+/// Not an agent, and deliberately not a destination either. Three sites emit
+/// prose the runtime wrote itself — an approval-overflow notice, the
+/// `"Acknowledged."` cycle fallback, and a failed-continuation report — and each
+/// used to land as an ordinary `AgentReply` carrying `"operator"` in the author
+/// field. That made them **byte-identical to a reply whose author was
+/// overwritten** by the pre-#885 defect, so no reader could tell a correct
+/// system row from a damaged agent row.
+///
+/// The value matches the literal `MessageView::project` already uses for the
+/// `DeskTaskCompleted` marker, which is what routes it to the console's centred
+/// system pill rather than a company bubble — so nothing on the read side has to
+/// learn a new word.
+///
+/// **Forward-only.** Notices already journaled keep `"operator"` and stay
+/// indistinguishable, permanently: the distinguishing information was never
+/// written down, and nothing recovers it after the fact.
+pub const SYSTEM_AUTHOR: &str = "system";
+
 /// The agent id a confined turn runs under (issue #416).
 ///
 /// Deliberately **not** a roster id: it names no teammate, carries no manifest

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -51,7 +51,9 @@ pub use context::ContextStore;
 pub use economy::AgentEconomy;
 pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_prune};
 pub use facts::{FactKind, FactRecord, FactStore};
-pub use ids::{AGENT_SLUG_FALLBACK, CONFINED_AGENT_ID, agent_slug, generate_id, now_millis};
+pub use ids::{
+    AGENT_SLUG_FALLBACK, CONFINED_AGENT_ID, SYSTEM_AUTHOR, agent_slug, generate_id, now_millis,
+};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use journal::{Durability, JournalStore};
 pub use ledgers::LedgerStore;

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2945,17 +2945,26 @@ impl OverlayBlob {
 }
 
 /// Ids [`CompanyRecord::mint_agent_id`] will never hand to a teammate, however
-/// free the roster leaves them: the always-present operator channel and the two
-/// workspace system roots.
+/// free the roster leaves them: the always-present operator channel, the two
+/// workspace system roots, and the author the runtime speaks under.
 ///
 /// Held as references to the real constants rather than re-typed literals, so a
-/// rename of any of the three moves this list with it instead of quietly
+/// rename of any of the four moves this list with it instead of quietly
 /// unreserving a name. Compared case-insensitively, which is why `Agents` and
 /// `Desks` cover a minted (always-lowercase) `agents` / `desks`.
-pub const RESERVED_AGENT_IDS: [&str; 3] = [
+///
+/// [`SYSTEM_AUTHOR`](crate::ports::SYSTEM_AUTHOR) earns its place for the same
+/// reason `OPERATOR_CHANNEL` does, and issue #966 is why it was noticed: it
+/// reaches the console's centred system pill **by value**, so a teammate minted
+/// onto it would render as the host. `"system"` is an ordinary legal slug —
+/// `agent_slug("System")` produces it — which is what separates it from
+/// [`CONFINED_AGENT_ID`](crate::ports::CONFINED_AGENT_ID), unmintable by
+/// construction because slugs never emit a hyphen.
+pub const RESERVED_AGENT_IDS: [&str; 4] = [
     crate::runtime::OPERATOR_CHANNEL,
     crate::company::workspace_scaffold::AGENTS_ROOT,
     crate::company::workspace_scaffold::DESKS_ROOT,
+    crate::ports::SYSTEM_AUTHOR,
 ];
 
 /// A durable company record: charter/roster (manifest) plus ledger and
@@ -5050,7 +5059,38 @@ mod test {
         assert_eq!(record.mint_agent_id("Operator"), "operator_2");
         assert_eq!(record.mint_agent_id("Agents"), "agents_2");
         assert_eq!(record.mint_agent_id("desks"), "desks_2");
-        assert_eq!(RESERVED_AGENT_IDS, ["operator", "Agents", "Desks"]);
+        assert_eq!(record.mint_agent_id("System"), "system_2");
+        assert_eq!(
+            RESERVED_AGENT_IDS,
+            ["operator", "Agents", "Desks", "system"]
+        );
+    }
+
+    /// Issue #966: the host's own author is not a name a teammate can be given.
+    ///
+    /// `SYSTEM_AUTHOR` reaches the console's centred system pill by value —
+    /// `MessageView` projects an `AgentReply`'s `agent_id` straight into
+    /// `author`, and the console keys on the string. A teammate holding that id
+    /// would therefore render *as the host*, which is a worse confusion than the
+    /// one this issue set out to fix, and the value it replaces (`"operator"`)
+    /// was already reserved.
+    ///
+    /// Its sibling `CONFINED_AGENT_ID` needs no entry here: `agent_slug` emits
+    /// only lowercase alphanumerics and underscores, so `"workflow-copilot"` is
+    /// unmintable by construction. `"system"` is an ordinary legal slug.
+    #[test]
+    fn mint_agent_id_never_returns_the_host_author() {
+        let record = desk_record("[company]\nname = \"Acme\"\n", Vec::new());
+        assert_eq!(
+            agent_slug("System"),
+            crate::ports::SYSTEM_AUTHOR,
+            "the guard is needed precisely because this is a legal slug"
+        );
+        assert_ne!(
+            record.mint_agent_id("System"),
+            crate::ports::SYSTEM_AUTHOR,
+            "a teammate must never be minted onto the id the runtime speaks under"
+        );
     }
 
     /// Issue #1162: the resolve every surface that takes a teammate key runs.

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -430,8 +430,8 @@ impl MessageView {
                 task_id, column, ..
             } => MessageView {
                 id,
-                channel: "system".to_string(),
-                author: "system".to_string(),
+                channel: crate::ports::SYSTEM_AUTHOR.to_string(),
+                author: crate::ports::SYSTEM_AUTHOR.to_string(),
                 text: dispatch_marker_text(&column),
                 at_millis,
                 mine: false,
@@ -443,8 +443,8 @@ impl MessageView {
             // `owns` never admits other variants into a history.
             other => MessageView {
                 id,
-                channel: "system".to_string(),
-                author: "system".to_string(),
+                channel: crate::ports::SYSTEM_AUTHOR.to_string(),
+                author: crate::ports::SYSTEM_AUTHOR.to_string(),
                 text: format!("{other:?}"),
                 at_millis,
                 mine: false,
@@ -533,7 +533,15 @@ impl AttributionAudit {
 /// bound; in practice that notice is rare enough not to move it.
 /// Whether a stored `agent_id` names an author we can actually resolve.
 ///
-/// The roster, **plus the confined copilot** (issue #966). `CONFINED_AGENT_ID`
+/// The roster, **plus two ids that are truthful authors without being teammates**.
+///
+/// [`SYSTEM_AUTHOR`](crate::ports::SYSTEM_AUTHOR) (issue #966) is the runtime
+/// speaking for itself — an approval-overflow notice, the `"Acknowledged."`
+/// fallback, a failed-continuation report. Those rows are *correct*, so counting
+/// them as damage would inflate the one figure in #965 that has to be
+/// trustworthy, and would caption a legitimate system message as unattributable.
+///
+/// `CONFINED_AGENT_ID`
 /// is deliberately not a roster id — it names no teammate, carries no manifest
 /// grants and cannot be addressed — but a copilot turn genuinely authored its
 /// reply, so the id is a truthful author rather than a destination that leaked
@@ -546,6 +554,7 @@ impl AttributionAudit {
 /// which rows are unknown.
 pub fn is_known_author(agent_id: &str, record: &CompanyRecord) -> bool {
     agent_id == crate::ports::CONFINED_AGENT_ID
+        || agent_id == crate::ports::SYSTEM_AUTHOR
         || record.resolve_roster_agent_id(agent_id).is_some()
 }
 
@@ -1262,6 +1271,37 @@ mod test {
                 template_provenance: None,
                 setup: None,
             }
+        }
+
+        /// Issue #966. The runtime speaking for itself is a *correct* row, not
+        /// damage. Counting it would inflate the blast-radius figure on a company
+        /// doing nothing wrong, and would caption a legitimate system message as
+        /// something nobody can attribute.
+        #[test]
+        fn a_host_authored_notice_is_a_known_author_not_an_affected_row() {
+            let record = record();
+            let mut audit = AttributionAudit::default();
+            audit.fold(
+                &[reply(1, crate::ports::SYSTEM_AUTHOR), reply(2, "engineer")],
+                |agent_id| is_known_author(agent_id, &record),
+            );
+            assert_eq!(audit.replies, 2);
+            assert_eq!(audit.affected, 0);
+        }
+
+        /// The whole point of the reserved id: a notice and a damaged reply used
+        /// to be the same bytes. This pins that they are now different ones, so
+        /// the distinction a marker would rely on actually exists in the data.
+        #[test]
+        fn a_notice_and_an_overwritten_reply_are_no_longer_the_same_author() {
+            let record = record();
+            assert_ne!(
+                crate::ports::SYSTEM_AUTHOR,
+                "operator",
+                "a notice must not share the author a destination-overwrite produces"
+            );
+            assert!(is_known_author(crate::ports::SYSTEM_AUTHOR, &record));
+            assert!(!is_known_author("operator", &record));
         }
 
         /// Issue #966. A copilot turn genuinely authored its reply, so the id it

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -461,6 +461,22 @@ impl MessageView {
 ///
 /// Reported rather than repaired. See [`channel_attributed_replies`] for why a
 /// repair is not available.
+///
+/// # The figure is not comparable across the #966 cutover
+///
+/// Host-authored notices — the approval-overflow line, the `"Acknowledged."`
+/// fallback, the failed-continuation report — used to journal under the
+/// operator channel, so every one already on disk is counted here as damage.
+/// Since #966 they journal under [`SYSTEM_AUTHOR`](crate::ports::SYSTEM_AUTHOR)
+/// and are not counted, because they are correct rows and inflating this number
+/// with them would make the one figure that has to be trustworthy the least
+/// trustworthy one.
+///
+/// The consequence is a step in the series that nothing on the wire labels: a
+/// company's `affected` can fall without a single row being repaired, purely
+/// because it stopped minting new false positives. Read a decline across that
+/// boundary as "the bleeding stopped", never as "history got better" — no row
+/// counted here has ever become attributable, and none can.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct AttributionAudit {
     /// Every `AgentReply` inspected.
@@ -1287,6 +1303,27 @@ mod test {
             );
             assert_eq!(audit.replies, 2);
             assert_eq!(audit.affected, 0);
+        }
+
+        /// Issue #966. The console reaches the centred system pill by comparing
+        /// the projected author against a literal `"system"`
+        /// (`frontend/src/lib/chat.ts`), and `MessageView` projects an
+        /// `AgentReply`'s `agent_id` straight into that field. So the *value* is
+        /// the contract with the console, not merely the constant's identity.
+        ///
+        /// Redefining `SYSTEM_AUTHOR` to anything else keeps every other test
+        /// here green and silently returns these three notices to rendering as
+        /// company bubbles — the exact appearance this change exists to end.
+        /// Two copies of one literal is the same coupling
+        /// `dispatch_marker_text` already carries with that file, and it is
+        /// deliberate for the same reason.
+        #[test]
+        fn the_notice_author_is_the_literal_the_console_keys_on() {
+            assert_eq!(
+                crate::ports::SYSTEM_AUTHOR,
+                "system",
+                "frontend/src/lib/chat.ts renders `author === \"system\"` as the centred pill"
+            );
         }
 
         /// The whole point of the reserved id: a notice and a damaged reply used

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -8003,6 +8003,24 @@ mode = "full"
             .collect()
     }
 
+    /// The authors of every journaled `AgentReply`, in order (issue #966).
+    ///
+    /// Separate from [`agent_replies`] because that one folds the author away.
+    async fn agent_reply_authors(runtime: &Arc<CompanyRuntime>) -> Vec<String> {
+        use crate::ports::types::EventSeq;
+        runtime
+            .events()
+            .read_from(runtime.id(), EventSeq::new(0), 10_000)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|s| match s.event {
+                CompanyEvent::AgentReply { agent_id, .. } => Some(agent_id),
+                _ => None,
+            })
+            .collect()
+    }
+
     fn approve_detached(id: &ApprovalId) -> Request<Body> {
         resolve_request(id, serde_json::json!({"verdict":"approve","detach":true}))
     }
@@ -8317,6 +8335,18 @@ mode = "full"
         assert!(
             replies[0].contains("approving again is safe"),
             "the notice has to say what to do about it, got {replies:?}"
+        );
+        // Issue #966, asserted on the journaled row rather than on the
+        // constructor: this drives the real approve path, so it pins that
+        // `announce_continuation_failure` *calls* the named notice. Asserting
+        // the constructor alone leaves the call site free to go back to an
+        // inline `AgentReply` authored by the operator channel — a correct
+        // system row byte-identical to one the pre-#885 defect damaged.
+        let authors = agent_reply_authors(&c.runtime).await;
+        assert_eq!(
+            authors,
+            vec![crate::ports::SYSTEM_AUTHOR.to_string()],
+            "the runtime authored this notice, so it must not be stored under its destination"
         );
     }
 }


### PR DESCRIPTION
## Summary

**This is a recovery, not a new change.** PR #1060 built exactly this fix, was reviewed, approved by `tinysweeper` and CI-green — and never reached `main`. It was opened with `baseRefName: fix/966-confined-turn-author`, a branch whose own PR (#1040) had already landed, and was "merged" into that dead branch on 2026-08-19 05:16 UTC. It reads as merged on the PR list and on the issue timeline, and **none of its five files changed on `main`**.

Verified by symbol rather than by the merged badge, since a merged PR whose base was a feature branch looks exactly like one that landed:

- `git merge-base --is-ancestor a9b4e472 upstream/main` → **NO** (the merge `1830ab61` likewise)
- `grep -rn SYSTEM_AUTHOR src/` on `main` → nothing
- `src/server/chat_history.rs:547` `is_known_author` → still only `CONFINED_AGENT_ID` + roster
- `src/company/runtime.rs:1898` → still `agent_id: OPERATOR_CHANNEL`

Commit **`a9b4e472`** is re-raised here as `1a9ad8a4`, cherry-picked onto current `main` with an identical diffstat, so it can be diffed against the reviewed original. **Full credit to that commit — the content is unchanged and was already reviewed; only its destination was wrong.** This is not a duplicate of #1060; #1060 changed nothing on `main`.

### What the fix does

Three sites journal prose the runtime wrote itself — the approval-overflow notice, the `"Acknowledged."` cycle fallback, and the failed-continuation report — as an ordinary `AgentReply` carrying `"operator"` in the author field. That made a **correct** system row byte-identical on disk to a reply whose author the pre-#885 defect overwrote, which is why a reader-side marker was not buildable: no stored field separated them.

`SYSTEM_AUTHOR` is a reserved id in the ungated `ports::ids`, carried on the `OutboundMessage.agent` field #885 added, set at the three sites, and admitted by `is_known_author` so the attribution audit does not count three correct rows as damage. No new event variant, no schema change, no reader change.

### Two things I changed on top of the recovered commit

**`685041ed` — a doc comment on the wrong function.** The recovered commit inserted `system_notice` between `confined_bubble`'s doc comment and its `fn`, so all seventeen lines about the workflow-copilot turn attached to `system_notice` and `confined_bubble` was left undocumented. Kept as its own commit so `1a9ad8a4` stays byte-identical to `a9b4e472`.

**`bcaae55a` — the tests did not guard the fix.** `a9b4e472`'s message records that an earlier version of its tests was vacuous and that naming the constructors fixed it. It fixed half. The tests pin what the constructors *build*; nothing forced the production paths to *call* them. Reverting each site with the message text left byte-identical, so only the author moved:

| Reverted | Result before `bcaae55a` |
|---|---|
| `is_known_author` admission | fails — guarded |
| `system_notice` body | fails — guarded |
| `continuation_failure_notice` body | fails — guarded |
| `"Acknowledged."` **call site** → inline `agent: None` | **4441 passed, 0 failed** |
| continuation-failure **call site** → inline `OPERATOR_CHANNEL` | **4441 passed, 0 failed** |
| approval-overflow **call site** → inline `agent: None` | **4441 passed, 0 failed** |

The journal is the whole subject of this issue, so an unpinned journal path is the gap worth closing. Both new assertions go on tests that already drive the real path rather than on new fixtures: `no_events_still_acknowledges` runs a real cycle, and `a_failed_continuation_tells_the_operator` goes through the HTTP approve and reads the journaled row. Each now fails on its call-site revert — `left: None / right: Some("system")` and `left: ["operator"] / right: ["system"]`.

**One site is still unpinned, stated rather than papered over:** the approval-overflow call site. Reaching it through a cycle needs a gated tool call, a scripted model and a parking host — a far larger fixture than the two above. Its constructor is guarded; its call site is not.

### Deliberately out of scope

The issue has a second half — how to present pre-cutover rows — which the research notes leave as a product decision (their own lean is option 2, "mark as legacy", with option 1 now costing more than the issue body assumed because the affected set provably contains correct system rows). Nothing here decides that. What this does is make every row journaled *after* it cleanly separable, so whichever presentation wins can be applied without slandering a system row.

Forward-only, and permanently so: notices already journaled keep `"operator"` and stay indistinguishable. The distinguishing information was never written down.

## API Or Behavior Changes

**Two wire-visible changes, both on the same three notice rows.**

**1. The author, and with it the rendering.** Those three notices move from rendering as a company bubble to rendering as a centred system pill. `MessageView::project` already maps an `AgentReply`'s `agent_id` into `author`, and `SYSTEM_AUTHOR`'s value matches the literal the projection already uses for the `DeskTaskCompleted` marker — so the console reaches its existing system rendering with no reader change.

**2. `MessageView.channel`, which the first draft of this body did not mention** (caught in review). The `AgentReply` projection arm derives `channel` from `agent_id`, so these three rows also go `channel: "operator"` → `channel: "system"`. That is consistent with the pill rendering and no consumer keys on it, but it is a second field changing shape, not a side effect of the first. Holding `channel` at its old value would mean special-casing the projection for three rows — trading an accurate wire field for a cosmetic one — so it is left to follow the author.

No new event variant, no schema change, no route change. `GET {scope}/chat/attribution-audit` stops counting post-fix system notices as damage, which is a correction to that figure rather than a change of contract — and `AttributionAudit`'s doc now states that the figure is **not comparable across the cutover**: a company's `affected` can fall without a single row being repaired, purely because it stopped minting new false positives.

**`SYSTEM_AUTHOR` is a reserved agent id.** `RESERVED_AGENT_IDS` grows from three entries to four, so `mint_agent_id` will never hand `system` to a teammate. Without that, the id was mintable (`agent_slug("System")` produces it) and a teammate holding it would have rendered as the host — a worse confusion than the one this fixes, given the value it replaces was already reserved.

## Tests

- [x] `cargo fmt --all -- --check` — PASS.
- [x] `cargo clippy --all-targets -- -D warnings` — PASS at default features, and as CI's gated form `--no-deps --features openhuman,tinycortex --all-targets`. Default features matter here: `ports::ids` is ungated on purpose, or `chat_history` would not compile without the harness features.
- [x] `cargo build --all-targets` — N/A as a separate step; covered by the clippy and test runs above, which compile every target in both feature sets.
- [x] `cargo test` — **4441 passed / 0 failed** gated (`--features openhuman,tinycortex --lib`) and **2919 passed / 0 failed** at default features.

Every new assertion was proven by reverting its fix and showing it fails, then restoring — the table above records which reverts failed nothing before `bcaae55a`, and the one site that still fails nothing.

## Documentation

The reasoning sits at the seams it governs: `SYSTEM_AUTHOR`'s doc says why it is neither an agent nor a destination and that it is forward-only; `is_known_author`'s doc says why counting these rows would inflate the one figure in #965 that has to be trustworthy; `system_notice` and `continuation_failure_notice` each say why they are named rather than inlined. The full discriminator table — every field that fails to separate a notice from a damaged reply — is recorded on the issue.

No `docs/` change: no route, launcher behaviour or `tiny*` integration changes.

Closes #966



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime-generated notices are now clearly identified as system messages.
  - Failed-continuation, approval-limit, and empty-cycle notices use consistent system attribution.
  - System notices remain directed to the appropriate conversation thread.

- **Bug Fixes**
  - System notices no longer appear as company-authored messages or task cards.
  - Legacy operator-authored notices continue to display correctly.
  - Host-authored notices are excluded from affected-message attribution counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->