### PR TITLE
feat(tasks): ask who owns a card instead of picking one (#1106)

### DIFF
--- a/docs/spec/runtime/planning.md
+++ b/docs/spec/runtime/planning.md
@@ -47,6 +47,7 @@ plan and proposes a graph for review. This document is only the planning half.
 |---|---|---|
 | planned, nothing blocking, a valid assignee | `in_progress` | the plan; the dispatch edge fires |
 | planned, a hard prerequisite missing (or no valid assignee) | `todo` | the plan **and** the named gap |
+| planned, but **more than one** teammate could own it | `todo` | the plan **and** the candidates, with a reason each |
 | the pass failed (model error, timeout, unparseable output) | `todo` | the reason only — **no** plan |
 
 A failed pass writes no partial brief on purpose. A plan half-produced by a
@@ -178,6 +179,45 @@ chose. The operator's routing decision is not the planner's to overrule; a
 proposal is still recorded on the brief either way, so the suggestion is visible
 without being applied. A proposal the roster does not recognise is dropped
 rather than shown.
+
+### Ambiguous ownership (issue #1106)
+
+The pass answers with **candidates**, not a single name: every teammate or desk
+that could genuinely take the card, best first, capped at three. What happens
+next is a function of how many survive resolution — and of nothing else. Who
+authored a teammate's profile does not enter into it, and neither does which of
+the four roster sources it came from.
+
+| Resolved candidates | Card assigned? | Outcome |
+|---|---|---|
+| any number | yes | dispatches — an assignee a person set is never second-guessed |
+| 0 | no | `todo`, with the existing "nobody on the roster" reason |
+| 1 | no | applied as `proposedAssignee`, dispatches — the pre-#1106 behaviour |
+| 2 or 3 | no | `todo`, **candidates on the brief**, nothing assigned |
+
+Two or more is a question, not a proposal, so `proposedAssignee` stays empty and
+`assigneeCandidates` carries the list instead — the two are never both set. The
+console renders the candidates as a chooser and one click assigns, through the
+same `PATCH …/tasks/{id}` the reassign row uses.
+
+**The dedup is load-bearing.** Candidates are deduplicated by their *canonical*
+id, not by the string the model wrote, and only then counted. A model that names
+one teammate twice — by id and again by display name, or in two casings —
+resolves to one key both times, and without the dedup that card would park
+asking a person to choose between a teammate and itself.
+
+**No fuzzy matching**, here or anywhere below it: candidates go through the same
+exact-match `runtime::assignee::resolve` the write boundary uses, so anything the
+roster does not carry is dropped rather than approximated. The model proposes;
+the host only enforces that each name is real. That is the same split the
+workflow copilot's grounding takes.
+
+**Why ask rather than pick.** A roster has four sources — the global baseline,
+the company blueprint, the console's `POST …/team`, and the orchestrator's own
+`add_agent` — and only one of them is the operator. Descriptions are thinnest
+exactly where two roles overlap most, and a card's owner may have been added by
+an agent the operator never configured. Recording a pick for them to correct
+assumes they would recognise a wrong one; asking does not.
 
 ---
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -168,7 +168,30 @@ export interface TaskPlan {
    * had no assignee — a plan never reassigns work a person routed.
    */
   proposedAssignee?: string;
+  /**
+   * The teammates that plausibly fit, when more than one did (issue #1106).
+   *
+   * Non-empty means the pass **declined to choose** and the card is waiting on
+   * a person — it is never populated alongside `proposedAssignee`, which is set
+   * only when exactly one candidate resolved. Absent on every plan written
+   * before #1106, and on every unambiguous plan written since.
+   */
+  assigneeCandidates?: AssigneeCandidate[];
   plannedAtMillis: number;
+}
+
+/**
+ * One teammate the planner thinks could take a card, and why (issue #1106).
+ *
+ * `id` is canonical — the host resolves it against the roster before storing
+ * it, and drops anything the roster does not carry, so every candidate rendered
+ * is one the assignee write boundary will accept.
+ */
+export interface AssigneeCandidate {
+  /** A teammate id, or a desk id. Submitted verbatim, never resolved here. */
+  id: string;
+  /** One line on why this one fits. Model prose, shown to a person deciding. */
+  reason: string;
 }
 
 /** A board card as the host returns it. */

--- a/frontend/src/views/CreateTaskDialog.tsx
+++ b/frontend/src/views/CreateTaskDialog.tsx
@@ -43,6 +43,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useBoardColumns } from "@/hooks/use-board-columns";
 import { ADD_TASK_COLUMN, labelFor } from "@/lib/board-columns";
+import { AssigneeSelect } from "./AssigneeSelect";
 
 
 /** How long a derived title may run before the full prompt moves to the note. */
@@ -70,6 +71,40 @@ export function derivePromptCard(prompt: string): { title: string; note?: string
 }
 
 /**
+ * Builds the `POST …/tasks` body from what the dialog collected, or `null` when
+ * there is no title to create from.
+ *
+ * Extracted for the same reason {@link derivePromptCard} is: the rule worth
+ * pinning is what the dialog *omits*. Both optional fields are sent only when
+ * they differ from the host's own default — `"once"` and unassigned are sent as
+ * nothing rather than as `"once"` and `""` — so a card created without touching
+ * either control posts the body it posted before those controls existed. That is
+ * what keeps `column`'s deliberate absence (issue #301) meaningful: the server's
+ * intake default decides where the card lands, and nothing here widens the body
+ * far enough to start deciding for it.
+ */
+export function newTaskBody({
+  prompt,
+  deliverable,
+  assignee,
+}: {
+  prompt: string;
+  deliverable: TaskDeliverable;
+  /** The wire value: `""` (unassigned), a desk id, or a teammate id. */
+  assignee: string;
+}): CreateTask | null {
+  const { title, note } = derivePromptCard(prompt);
+  if (!title) return null;
+  const body: CreateTask = { title, note };
+  if (deliverable === "workflow") body.deliverable = "workflow";
+  // Issue #1106. Sent verbatim — a desk stays a desk, exactly as
+  // `AssigneeSelect` submits it; resolving one to its lead is the host's call
+  // and only for the surfaces that are allowed to make it.
+  if (assignee) body.assignee = assignee;
+  return body;
+}
+
+/**
  * The once-vs-workflow options, in review order (issue #580). Shared by the
  * create dialog here and the edit dialog, so the two pickers can never offer a
  * different vocabulary than the wire's {@link TaskDeliverable}.
@@ -86,19 +121,29 @@ export const DELIVERABLE_OPTIONS: { value: TaskDeliverable; label: string; hint:
 /**
  * New work enters the board through one prompt box (issue #301).
  *
- * Title/Note/Priority/Assignee used to be collected up front. They are not gone,
- * only moved: priority and assignee default on the host (`medium`, unassigned →
- * orchestrator) and are edited on the card afterwards, where #278 put the
- * picker. `column` is omitted on purpose so the *server's* intake default
- * decides where the card lands — the same spend gate the transcript's "Add to
- * board" relies on, keeping the human drag into In progress the only thing that
- * spends an agent turn.
+ * Title/Note/Priority used to be collected up front. They are not gone, only
+ * moved: priority defaults on the host (`medium`) and is edited on the card
+ * afterwards, where #278 put the picker. `column` is omitted on purpose so the
+ * *server's* intake default decides where the card lands — the same spend gate
+ * the transcript's "Add to board" relies on, keeping the human drag into In
+ * progress the only thing that spends an agent turn.
  *
- * The one field it does collect beyond the prompt is the deliverable (issue
- * #580): once versus workflow is a decision about *what kind of thing* the card
- * produces, not a default the host can pick, so the operator states it here. It
- * still lands in To-do like any card — the builder pass fires only on the drag
- * into In progress.
+ * Two fields are collected beyond the prompt.
+ *
+ * The **deliverable** (issue #580): once versus workflow is a decision about
+ * *what kind of thing* the card produces, not a default the host can pick, so
+ * the operator states it here. It still lands in To-do like any card — the
+ * builder pass fires only on the drag into In progress.
+ *
+ * The **owner** (issue #1106). Assignee was moved out by #301 on the reasoning
+ * that the host defaults it and the card edits it. What that missed is what the
+ * host's default actually is: an unassigned card is routed by a planning pass
+ * that picks from the roster, and when two teammates plausibly fit it picked one
+ * with nothing recorded about the other. Offering the picker here is the
+ * *pre-empt* for that — an operator who knows the owner states it once and never
+ * meets the ambiguity prompt #1106 adds. It defaults to unassigned, so a quick
+ * card is exactly as quick as before and today's routing stays the default
+ * rather than becoming a choice forced on every card.
  */
 export function CreateTaskDialog({
   open,
@@ -115,6 +160,9 @@ export function CreateTaskDialog({
 }) {
   const [prompt, setPrompt] = useState("");
   const [deliverable, setDeliverable] = useState<TaskDeliverable>("once");
+  // The wire value, verbatim: `""` (unassigned), a desk id, or a teammate id.
+  // `AssigneeSelect` never resolves a desk to its lead, and neither does this.
+  const [assignee, setAssignee] = useState("");
   const [busy, setBusy] = useState(false);
   // Above the `!open` return, and it has to be: every hook runs on every
   // render or none do. Reading the columns *below* it made this component call
@@ -127,21 +175,17 @@ export function CreateTaskDialog({
     if (open) {
       setPrompt("");
       setDeliverable("once");
+      setAssignee("");
     }
   }, [open]);
 
   if (!open) return null;
 
   async function create() {
-    const { title, note } = derivePromptCard(prompt);
-    if (!title) return;
+    const body = newTaskBody({ prompt, deliverable, assignee });
+    if (!body) return;
     setBusy(true);
     try {
-      const body: CreateTask = { title, note };
-      // Only `"workflow"` reaches the wire; `"once"` is the host default and is
-      // sent as nothing, so a one-off card's body is byte-identical to a
-      // pre-#580 one.
-      if (deliverable === "workflow") body.deliverable = "workflow";
       const created = await createTask(client, company, body);
       onCreated(created);
       toast.success("Task created.");
@@ -196,6 +240,22 @@ export function CreateTaskDialog({
           </Select>
           <p className="text-2xs text-muted-foreground">
             {DELIVERABLE_OPTIONS.find((o) => o.value === deliverable)?.hint}
+          </p>
+        </div>
+
+        <div className="grid gap-1.5">
+          <Label htmlFor="new-assignee">Owner</Label>
+          <AssigneeSelect
+            id="new-assignee"
+            client={client}
+            company={company}
+            value={assignee}
+            onChange={setAssignee}
+            disabled={busy}
+          />
+          <p className="text-2xs text-muted-foreground">
+            Leave unassigned and the card is routed for you. If more than one
+            teammate fits, it waits and asks rather than picking one.
           </p>
         </div>
 

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -622,7 +622,28 @@ export function TaskDetailView({
 
               {detail.task.plan && (
                 <TabsContent value="plan" className="mt-4">
-                  <TaskPlanBrief plan={detail.task.plan} />
+                  <TaskPlanBrief
+                    plan={detail.task.plan}
+                    // Issue #1106: answering the brief's ownership question is
+                    // the same write the reassign row makes, through the same
+                    // route — so the host validates the pick against the roster
+                    // once, for both, and a candidate the planner named cannot
+                    // reach the card by a path that skips that check.
+                    onPick={async (id) => {
+                      try {
+                        const saved = await patchTask(client, company, detail.task.id, {
+                          assignee: id,
+                        });
+                        onSaved(saved);
+                        await load();
+                        toast.success(`Assigned to ${id}.`);
+                      } catch (e) {
+                        toast.error(
+                          e instanceof Error ? e.message : "could not assign the task",
+                        );
+                      }
+                    }}
+                  />
                 </TabsContent>
               )}
 
@@ -1046,12 +1067,14 @@ function ControlBar({
 
       {reassigning && (
         <div className="mt-2 flex items-center gap-2">
-          {/* Issue #263: the same roster picker the edit dialog uses. Since
-              #301 this is the *only* place a card gets an assignee — the create
-              box asks for a prompt and nothing else, so the host's default
-              (unassigned → orchestrator) stands until somebody picks here.
-              Unassigned is a row here rather than an empty field, so handing the
-              card back to the orchestrator is something you can see and choose. */}
+          {/* Issue #263: the same roster picker the edit dialog uses, and since
+              #1106 the same one the create dialog offers up front. This is the
+              row that can reach the *whole* roster after the fact — the create
+              dialog pre-empts, and the plan brief's candidate list narrows to
+              what the planner named, so a card that needs anyone else is
+              reassigned here. Unassigned is a row rather than an empty field, so
+              handing the card back to the orchestrator is something you can see
+              and choose. */}
           <AssigneeSelect
             client={client}
             company={company}

--- a/frontend/src/views/TaskPlanBrief.tsx
+++ b/frontend/src/views/TaskPlanBrief.tsx
@@ -12,24 +12,36 @@
 // gap is one somebody has to act on, and burying that under a numbered list of
 // steps would make the useful case the slow one.
 //
-// Everything here is read-only. The console never posts a plan — the host's
+// The plan itself is read-only. The console never posts a plan — the host's
 // create body has no field for one — so a verdict cannot be forged from a
 // browser, and nothing in this file needs to guard against that.
+//
+// One thing here does write, and it writes the *card*, not the plan: when a pass
+// declined to choose an owner (issue #1106) the brief renders the candidates it
+// named and hands a pick back through `onPick`, which the detail screen turns
+// into the same `PATCH …/tasks/{id} {assignee}` its reassign row already sends.
+// The rule the read-only note was protecting is intact — nothing here can author
+// a prerequisite verdict — and the write goes through the one boundary that
+// validates an assignee against the roster.
 
+import { useState } from "react";
 import {
   AlertTriangle,
   CircleHelp,
   ClipboardCheck,
   Clock,
   HelpCircle,
+  Loader2,
   ShieldAlert,
   TriangleAlert,
+  Users,
   XCircle,
   CheckCircle2,
   type LucideIcon,
 } from "lucide-react";
 
 import type { PrereqStatus, Prerequisite, TaskPlan } from "@/api/tasks";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 /**
@@ -90,10 +102,24 @@ export function tallyPrerequisites(plan: TaskPlan): {
 }
 
 /** The whole brief: what the plan is, what it needs, and how it will be judged. */
-export function TaskPlanBrief({ plan }: { plan: TaskPlan }) {
+export function TaskPlanBrief({
+  plan,
+  onPick,
+}: {
+  plan: TaskPlan;
+  /**
+   * Receives a candidate's id when the operator answers the ownership question
+   * (issue #1106). Omitted on any surface that cannot write the card — the
+   * candidates then render as a read-only record of what the pass declined to
+   * decide, which is still the runner-up that used to be lost.
+   */
+  onPick?: (id: string) => void | Promise<void>;
+}) {
   return (
     <div className="flex flex-col gap-5" data-testid="task-plan-brief">
       <Headline plan={plan} />
+
+      <OwnerChoice plan={plan} onPick={onPick} />
 
       {plan.description && (
         <p className="text-sm leading-relaxed text-foreground/90">{plan.description}</p>
@@ -241,6 +267,101 @@ function Headline({ plan }: { plan: TaskPlan }) {
           </span>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * The ownership question, when the pass declined to answer it (issue #1106).
+ *
+ * Rendered above the description and below only the headline, because a card
+ * sitting in To-do with an unanswered question is not waiting on anything in the
+ * plan — it is waiting on the person reading it, and burying that under the
+ * brief would make the actionable case the one you have to scroll for. It is the
+ * same reasoning that puts blockers above steps.
+ *
+ * Each row carries its reason. A bare pair of ids would hand the operator back
+ * the judgement the planner already made and ask them to re-derive it; the line
+ * beside each name is what lets them answer without opening two agent pages.
+ *
+ * Nothing is pre-selected and there is no default button. A highlighted "best"
+ * option would be the silent pick this issue exists to remove, wearing a
+ * suggestion's clothes.
+ */
+function OwnerChoice({
+  plan,
+  onPick,
+}: {
+  plan: TaskPlan;
+  onPick?: (id: string) => void | Promise<void>;
+}) {
+  const [picking, setPicking] = useState<string | null>(null);
+  const candidates = plan.assigneeCandidates ?? [];
+  if (candidates.length === 0) return null;
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-lg border border-status-blocked/30 bg-status-blocked-soft px-3 py-2.5"
+      data-testid="plan-owner-choice"
+    >
+      <div className="flex items-start gap-2">
+        <Users className="mt-0.5 size-4 shrink-0 text-status-blocked-text" />
+        <p className="min-w-0 text-sm leading-relaxed">
+          <span className="font-medium">Who owns this?</span>{" "}
+          <span className="text-muted-foreground">
+            More than one teammate could take it, so it is waiting on you rather
+            than being handed to whichever one the plan named first.
+          </span>
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-1.5">
+        {candidates.map((candidate) => (
+          <li
+            key={candidate.id}
+            className="flex items-start gap-2 rounded-md bg-background/60 px-2.5 py-2"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">{candidate.id}</p>
+              {candidate.reason && (
+                <p className="mt-0.5 text-sm leading-relaxed text-muted-foreground">
+                  {candidate.reason}
+                </p>
+              )}
+            </div>
+            {onPick && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 shrink-0"
+                disabled={picking !== null}
+                onClick={() => {
+                  setPicking(candidate.id);
+                  // The screen reloads the card on success and surfaces its own
+                  // failure toast; either way this component is about to be
+                  // re-rendered from fresh data, so the only state it owns is
+                  // "a click is in flight".
+                  void Promise.resolve(onPick(candidate.id)).finally(() =>
+                    setPicking(null),
+                  );
+                }}
+              >
+                {picking === candidate.id && (
+                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                )}
+                Assign
+              </Button>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {onPick && (
+        <p className="text-2xs text-muted-foreground">
+          Someone else can take it too — the reassign row on this card offers the
+          whole roster.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/test/e2e/assignee-picker.spec.ts
+++ b/frontend/test/e2e/assignee-picker.spec.ts
@@ -3,11 +3,13 @@ import { expect, test, type Page, type Request } from "@playwright/test";
 /**
  * Issue #263 — the task assignee is picked from the company roster, not typed.
  *
- * Issue #301 moved *where*: the create box asks for a prompt and nothing else,
- * so a new card is always unassigned (the host hands it to the orchestrator)
- * and the picker lives on the card's own edit surface. These tests therefore
- * exercise the picker through Edit / Reassign rather than through create — the
- * invariant under test is unchanged, only the screen it is reached from.
+ * Issue #301 moved *where*: the create box asked for a prompt and nothing else,
+ * so the picker lived on the card's own edit surface. Issue #1106 gave the
+ * create dialog a picker again — defaulting to unassigned, so a card created
+ * without touching it is still unassigned by construction and the host still
+ * hands it to the orchestrator. These tests therefore keep exercising the picker
+ * through Edit / Reassign: that is the surface that reaches the whole roster,
+ * and the invariant under test is unchanged either way.
  *
  * These run against a live host serving the built console, with the
  * `e2e_harness` company: desks `engineering` / `content` and manifest agents
@@ -160,9 +162,12 @@ test("a card can be assigned to a teammate, and created for nobody at all", asyn
   await dismissTour(page);
   await expect(card(page, forWriter)).toContainText("writer", { timeout: 15_000 });
 
-  // Issue #301: the prompt box collects no assignee, so a card created on the
-  // board is unassigned by construction — the host hands it to the
-  // orchestrator. This is the default the create surface now relies on.
+  // Issue #301, as amended by #1106: the create dialog now *offers* an owner,
+  // but defaults to unassigned and omits the field entirely when it is not
+  // touched — so a card created by filling only the prompt is still unassigned
+  // by construction and the host still hands it to the orchestrator. This
+  // asserts that default, which is what keeps adding the picker a no-op for
+  // anyone who does not use it.
   const forNobody = `e2e unassigned card ${Date.now()}`;
   await createViaPromptBox(page, forNobody);
 

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -144,12 +144,23 @@ test("new work enters through one prompt box and lands in To-do", async ({ page,
   await addTask.click();
   await expect(page.getByRole("heading", { name: "New task" })).toBeVisible();
 
-  // One field. Title / Note / Priority / Assignee are gone from create — the
-  // host defaults the last two and the card's edit surface owns them (#278).
+  // Title / Note / Priority stay gone from create — the host defaults priority
+  // and the card's edit surface owns them (#278).
   await expect(page.locator("#new-prompt")).toBeVisible();
-  for (const gone of ["#new-title", "#new-note", "#new-assignee"]) {
+  for (const gone of ["#new-title", "#new-note", "#new-priority"]) {
     await expect(page.locator(gone)).toHaveCount(0);
   }
+
+  // Assignee came *back* in #1106, and is the one exception to "one field".
+  // #301 removed it on the reasoning that the host defaults it; what that missed
+  // is that the host's default is a planning pass which picks an owner, and picks
+  // one silently when two teammates fit. Offering it here is the pre-empt.
+  //
+  // The rule that keeps this from re-breaking what #301 fixed is the *default*,
+  // asserted below rather than the control's absence: an operator who ignores it
+  // types a prompt, hits Create, and gets exactly the unassigned card they got
+  // before — the field is omitted from the body entirely when untouched.
+  await expect(page.locator("#new-assignee")).toHaveCount(1);
 
   // A prompt longer than the title cap: the title is shortened and the full
   // text survives in the note, so nothing the operator typed is lost.
@@ -158,7 +169,7 @@ test("new work enters through one prompt box and lands in To-do", async ({ page,
   await page.locator("#new-prompt").fill(long);
   await page.getByRole("button", { name: "Create", exact: true }).click();
 
-  type Row = { title: string; note?: string; column: string };
+  type Row = { title: string; note?: string; column: string; assignee: string };
   const find = async (): Promise<Row | undefined> => {
     const rows = (await (await request.get(`${API}/tasks`)).json()) as Row[];
     return rows.find((r) => r.title.startsWith(marker));
@@ -170,6 +181,10 @@ test("new work enters through one prompt box and lands in To-do", async ({ page,
   expect(created.column).toBe("todo");
   expect(created.title.length).toBeLessThanOrEqual(81); // 80 + the ellipsis
   expect(created.note).toBe(long);
+  // The #1106 default, and the reason adding the control is a no-op for anyone
+  // who does not use it: the prompt was the only thing filled in, so the card is
+  // unassigned exactly as it was before the picker existed.
+  expect(created.assignee).toBe("");
 });
 
 /**

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -455,6 +455,51 @@ function isTriageRequest(messages) {
   return typeof textOf(first) === "string" && textOf(first).includes("You classify one message");
 }
 
+/**
+ * A planning pass (issue #337), recognised by its own system prompt.
+ *
+ * Like a triage classification, this is not an agent turn: the pass runs with no
+ * tools and expects one JSON object back. Before this arm existed a planning
+ * prompt fell through to the turn arms and came back as prose, which the host
+ * reads as an unparseable answer — so every card dragged into Planning in this
+ * lane settled as a failed pass.
+ */
+function isPlanningRequest(messages) {
+  const first = messages[0];
+  return (
+    typeof textOf(first) === "string" && textOf(first).includes("You are the planning desk")
+  );
+}
+
+/**
+ * The plan this lane answers every planning pass with (issue #1106).
+ *
+ * Deliberately **ambiguous**: it names two teammates the `e2e_harness` roster
+ * really carries, so the host resolves both and the card parks asking who owns
+ * it rather than dispatching. That is the whole behaviour under test, and it is
+ * unreachable from a fixture that names one.
+ *
+ * `prerequisites` is empty on purpose. A missing prerequisite parks the card
+ * too, by a different arm and with a different note — leaving one here would
+ * make a passing test unable to say which mechanism it had exercised.
+ */
+const AMBIGUOUS_PLAN = JSON.stringify({
+  description:
+    "Find what is being said about the topic and write up what matters, with links.",
+  steps: [
+    { title: "Gather the sources", detail: "Search and collect what is current." },
+    { title: "Write the digest", detail: "Summarise with links, newest first." },
+  ],
+  prerequisites: [],
+  risks: ["the sources may be thin on the day it runs"],
+  verification: "a digest exists with at least three linked sources",
+  scope: "the digest only; no publishing",
+  assigneeCandidates: [
+    { id: "engineer", reason: "already automates the collection side of this" },
+    { id: "writer", reason: "owns everything the company publishes in prose" },
+  ],
+});
+
 function chatCompletion(body) {
   const messages = Array.isArray(body?.messages) ? body.messages : [];
   const model = typeof body?.model === "string" ? body.model : "mock-brain";
@@ -479,6 +524,16 @@ function chatCompletion(body) {
   if (isTriageRequest(messages)) {
     process.stderr.write("[mock brain] triage classification (no directive consumed)\n");
     return completion(model, { role: "assistant", content: "chatter" }, "stop");
+  }
+
+  // Beside the triage arm and for the same reason: a planning pass is not an
+  // agent turn, so it must not reach the directive arms below — a card whose
+  // text happened to carry `__MOCK_TOOL_CALL__` would otherwise burn it here
+  // and leave the real turn with a plain reply, which is exactly the bug #678
+  // fixed for triage.
+  if (isPlanningRequest(messages)) {
+    process.stderr.write("[mock brain] planning pass (ambiguous plan, no directive consumed)\n");
+    return completion(model, { role: "assistant", content: AMBIGUOUS_PLAN }, "stop");
   }
 
   // Ahead of the directive arms, and only when the instruction is the LAST

--- a/frontend/test/unit/create-task-body.test.ts
+++ b/frontend/test/unit/create-task-body.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { derivePromptCard, newTaskBody } from "@/views/CreateTaskDialog";
+
+/**
+ * Issue #1106: the create dialog collects an owner.
+ *
+ * Assignee was moved out of this dialog by #301, on the reasoning that the host
+ * defaults it and the card edits it afterwards. What that missed is what the
+ * default *does*: an unassigned card is routed by a planning pass that picks
+ * from the roster, and when two teammates plausibly fit it picked one with
+ * nothing recorded about the other. Collecting it here is the pre-empt — an
+ * operator who already knows the owner never reaches that ambiguity.
+ *
+ * The rule these pin is what the body **omits**. Both optional controls are sent
+ * only when they differ from the host's default, so adding them cannot change
+ * what a card created without touching them posts.
+ */
+describe("newTaskBody", () => {
+  it("omits the owner entirely when the card is left unassigned", () => {
+    const body = newTaskBody({ prompt: "ship the thing", deliverable: "once", assignee: "" });
+    expect(body).not.toBeNull();
+    expect(body).not.toHaveProperty("assignee");
+  });
+
+  /**
+   * The load-bearing one: a card created without touching either new control
+   * must post what it posted before those controls existed. `column` is absent
+   * for the same reason it always was (#301) — the server's intake default is
+   * what keeps the human drag into In progress the only thing that spends.
+   */
+  it("posts the pre-#580/#1106 body when neither control is touched", () => {
+    expect(newTaskBody({ prompt: "ship the thing", deliverable: "once", assignee: "" })).toEqual({
+      title: "ship the thing",
+      note: undefined,
+    });
+  });
+
+  it("carries a chosen teammate verbatim", () => {
+    const body = newTaskBody({
+      prompt: "fetch trending tweets about agent harnesses",
+      deliverable: "once",
+      assignee: "devrel",
+    });
+    expect(body?.assignee).toBe("devrel");
+  });
+
+  /**
+   * A desk stays a desk. `AssigneeResolution::links_working_agent` is true only
+   * for `Unassigned | Agent(_)`, precisely so a card assigned to a desk is never
+   * silently rewritten to that desk's lead — so this body must not resolve one
+   * either, the same invariant `AssigneeSelect` holds.
+   */
+  it("carries a chosen desk verbatim, without resolving it to a lead", () => {
+    const body = newTaskBody({ prompt: "ship it", deliverable: "once", assignee: "engineering" });
+    expect(body?.assignee).toBe("engineering");
+  });
+
+  it("carries the owner alongside a workflow deliverable", () => {
+    const body = newTaskBody({ prompt: "ship it", deliverable: "workflow", assignee: "devrel" });
+    expect(body?.deliverable).toBe("workflow");
+    expect(body?.assignee).toBe("devrel");
+  });
+
+  it("refuses a prompt with no title to derive", () => {
+    expect(newTaskBody({ prompt: "   \n  ", deliverable: "once", assignee: "devrel" })).toBeNull();
+  });
+
+  /**
+   * The long-prompt split is #301's and is not re-specified here — this only
+   * pins that routing it through `newTaskBody` did not drop the note, since the
+   * operator's full text surviving on the card is what the planner reads.
+   */
+  it("keeps the full prompt on the note when the title was shortened", () => {
+    const prompt = `${"a".repeat(100)}\nsecond line`;
+    const body = newTaskBody({ prompt, deliverable: "once", assignee: "" });
+    expect(body?.note).toBe(prompt);
+    expect(body?.title).toBe(derivePromptCard(prompt).title);
+  });
+});

--- a/frontend/test/unit/plan-owner-choice.test.ts
+++ b/frontend/test/unit/plan-owner-choice.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TaskPlan } from "@/api/tasks";
+import { TaskPlanBrief } from "@/views/TaskPlanBrief";
+
+/**
+ * Issue #1106: a card whose planner could not separate two teammates asks,
+ * instead of picking one and recording nothing about the other.
+ *
+ * This suite is normally for pure functions, and this is the same earned
+ * exception `task-blocked-card.test.ts` takes: the claim only exists at the
+ * rendered brief. The resolver's rules (drop, dedup, cap) and the park itself
+ * are pinned in Rust, next to the code that enforces them. What no Rust test can
+ * reach is whether the operator is actually shown the runner-up *and its
+ * reason*, and whether one click answers — which is the whole acceptance.
+ */
+
+const PLANNED_AT = new Date("2026-03-02T10:00:00Z").getTime();
+
+function plan(overrides: Partial<TaskPlan> = {}): TaskPlan {
+  return {
+    description: "Fetch what is trending and summarise it.",
+    steps: [],
+    prerequisites: [],
+    risks: [],
+    verification: "the digest exists",
+    scope: "the digest only",
+    plannedAtMillis: PLANNED_AT,
+    ...overrides,
+  };
+}
+
+let host: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+function render(props: Parameters<typeof TaskPlanBrief>[0]) {
+  act(() => root.render(createElement(TaskPlanBrief, props)));
+}
+
+function assignButtons(): HTMLButtonElement[] {
+  return [...host.querySelectorAll("button")].filter((b) =>
+    (b.textContent ?? "").includes("Assign"),
+  ) as HTMLButtonElement[];
+}
+
+describe("the plan brief's ownership question", () => {
+  /**
+   * The unambiguous card is untouched. A plan with one proposal — or none —
+   * renders exactly what it rendered before this field existed, so the common
+   * case gains no new furniture.
+   */
+  it("renders nothing at all when the pass was not ambiguous", () => {
+    render({ plan: plan({ proposedAssignee: "devrel" }), onPick: () => {} });
+    expect(host.querySelector('[data-testid="plan-owner-choice"]')).toBeNull();
+    expect(assignButtons()).toHaveLength(0);
+  });
+
+  it("treats an absent candidate list the same as an empty one", () => {
+    render({ plan: plan({ assigneeCandidates: [] }), onPick: () => {} });
+    expect(host.querySelector('[data-testid="plan-owner-choice"]')).toBeNull();
+  });
+
+  /**
+   * The defect, inverted: both teammates are named, and each carries the reason
+   * it was named for. A bare pair of ids would hand back the judgement the
+   * planner already made.
+   */
+  it("shows every candidate with its reason", () => {
+    render({
+      plan: plan({
+        assigneeCandidates: [
+          { id: "devrel", reason: "talks to developers all day" },
+          { id: "social_manager", reason: "owns the company's social accounts" },
+        ],
+      }),
+      onPick: () => {},
+    });
+
+    const block = host.querySelector('[data-testid="plan-owner-choice"]');
+    expect(block).not.toBeNull();
+    const text = block?.textContent ?? "";
+    expect(text).toContain("devrel");
+    expect(text).toContain("talks to developers all day");
+    expect(text).toContain("social_manager");
+    expect(text).toContain("owns the company's social accounts");
+  });
+
+  /** One click answers, and it answers with that row's candidate. */
+  it("hands the picked candidate's id back on one click", async () => {
+    const onPick = vi.fn();
+    render({
+      plan: plan({
+        assigneeCandidates: [
+          { id: "devrel", reason: "first" },
+          { id: "social_manager", reason: "second" },
+        ],
+      }),
+      onPick,
+    });
+
+    const buttons = assignButtons();
+    expect(buttons).toHaveLength(2);
+    // Async, so the in-flight flag the handler clears on settle is flushed
+    // inside `act` rather than after the test has moved on.
+    await act(async () => {
+      buttons[1].click();
+    });
+
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith("social_manager");
+  });
+
+  /**
+   * No default and no highlighted "best" row: every candidate is offered on the
+   * same terms. A pre-selected first option would be the silent pick this issue
+   * removes, wearing a suggestion's clothes.
+   */
+  it("offers every candidate on equal terms, with none pre-selected", () => {
+    render({
+      plan: plan({
+        assigneeCandidates: [
+          { id: "devrel", reason: "first" },
+          { id: "social_manager", reason: "second" },
+        ],
+      }),
+      onPick: () => {},
+    });
+
+    const buttons = assignButtons();
+    expect(buttons).toHaveLength(2);
+    for (const button of buttons) {
+      expect(button.disabled).toBe(false);
+    }
+    expect(host.querySelector("[aria-selected='true']")).toBeNull();
+  });
+
+  /**
+   * A surface that cannot write the card still shows what the pass declined to
+   * decide. The runner-up being *recorded* is the acceptance criterion; being
+   * clickable is the convenience on top of it.
+   */
+  it("still records the candidates when no pick handler is wired", () => {
+    render({
+      plan: plan({
+        assigneeCandidates: [
+          { id: "devrel", reason: "first" },
+          { id: "social_manager", reason: "second" },
+        ],
+      }),
+    });
+
+    const text = host.querySelector('[data-testid="plan-owner-choice"]')?.textContent ?? "";
+    expect(text).toContain("devrel");
+    expect(text).toContain("social_manager");
+    expect(assignButtons()).toHaveLength(0);
+  });
+});

--- a/src/harness/planning.rs
+++ b/src/harness/planning.rs
@@ -747,7 +747,7 @@ impl Evidence {
         assignee::resolve(&self.record, key).canonical().is_some()
     }
 
-    /// The manifest teammate a resolved assignee ultimately routes work to, for
+    /// The roster teammate a resolved assignee ultimately routes work to, for
     /// the permission check.
     ///
     /// A **desk** resolves to its lead, deliberately: the lead is who actually
@@ -755,8 +755,17 @@ impl Evidence {
     /// work can happen. Checking "the desk" would be checking nothing.
     ///
     /// `None` — and therefore an honest `unknown` verdict — for a desk with no
-    /// lead yet, and for an overlay teammate, which carries no manifest `tools`
-    /// list to resolve grants from.
+    /// lead yet.
+    ///
+    /// It used to answer `None` for an overlay teammate too, on the grounds that
+    /// one carried no `tools` list to resolve grants from. That stopped being
+    /// true at issue #661 / L5, which gave [`OverlayAgent`] its own grant, and
+    /// [`gather_evidence`] now resolves it through the same
+    /// `agent_effective_grants` as a manifest agent. So a runtime teammate gets a
+    /// real permission verdict rather than a blanket `unknown` — the same answer
+    /// the roster builder would give, which is the point.
+    ///
+    /// [`OverlayAgent`]: crate::ports::types::OverlayAgent
     fn working_teammate(&self, key: &str) -> Option<&TeammateBrief> {
         let resolution = assignee::resolve(&self.record, key);
         let working = resolution.working_agent()?;
@@ -799,7 +808,29 @@ async fn gather_evidence(
         })?;
 
     let allow = record.manifest.tools.allow.clone();
-    let teammates: Vec<TeammateBrief> = record
+    // The roster the company actually runs, not the half of it the manifest
+    // declares (issue #1106, CodeRabbit on #1157).
+    //
+    // A teammate reaches the roster from four places — the global baseline, the
+    // company bundle, the console's `POST …/team`, and the orchestrator's own
+    // `add_agent` — and only the first two are manifest `[[agent]]` rows. Reading
+    // `manifest.agents` alone showed the planner a roster that
+    // `assignee::resolve` would happily accept names from and the planner had
+    // never been told about, so a runtime teammate could not be proposed, could
+    // not be named an assignee prerequisite, and — since #1106 — could not be one
+    // of the candidates a person is asked to choose between. That is exactly the
+    // case #1106 reports: no shipped bundle carries two teammates who overlap the
+    // way its DevRel/social pair does, so at least one of them was added here.
+    //
+    // Manifest first, then every overlay id the manifest does not already claim —
+    // the same precedence and the same skip rule `harness::build_roster` uses to
+    // materialise the live roster, so what the planner is shown is what will run.
+    //
+    // Grants resolve through the same `agent_effective_grants` as a manifest
+    // agent: an overlay's own `tools` list (issue #661 / L5), or the standard
+    // company-wide grant when it is empty, exactly as an omitted manifest `tools`
+    // line means.
+    let mut teammates: Vec<TeammateBrief> = record
         .manifest
         .agents
         .iter()
@@ -810,12 +841,44 @@ async fn gather_evidence(
             grants: crate::runtime::builder::agent_effective_grants(&allow, &a.tools),
         })
         .collect();
+    teammates.extend(
+        record
+            .overlay_agents
+            .iter()
+            .filter(|overlay| !record.manifest.agents.iter().any(|a| a.id == overlay.id))
+            .map(|overlay| TeammateBrief {
+                id: overlay.id.clone(),
+                role: overlay.role.clone(),
+                description: overlay.description.clone(),
+                grants: crate::runtime::builder::agent_effective_grants(&allow, &overlay.tools),
+            }),
+    );
 
+    // Every desk the company has, with the members it actually has.
+    //
+    // `effective_desk_members` rather than the manifest's declared list: it is
+    // the shared source of truth the REST `list_desks` handler and the harness
+    // `desk_lead` resolver both read, so it carries operator-added members and
+    // the operator's ordering — and ordering is load-bearing here, because the
+    // first member is the desk's lead and the lead is who a desk assignment
+    // actually routes work to.
     let desks: Vec<(String, Vec<String>)> = record
         .manifest
         .group_chats
         .iter()
-        .map(|g| (g.id.clone(), g.members.clone()))
+        .map(|g| g.id.clone())
+        .chain(record.overlay_desks.iter().map(|d| d.id.clone()))
+        .fold(Vec::new(), |mut acc: Vec<String>, id| {
+            if !acc.contains(&id) {
+                acc.push(id);
+            }
+            acc
+        })
+        .into_iter()
+        .map(|id| {
+            let members = record.effective_desk_members(&id);
+            (id, members)
+        })
         .collect();
 
     // The SAME projection `GET …/connections` builds (issue #316 already made
@@ -1268,7 +1331,10 @@ fn evidence_prompt(e: &Evidence) -> String {
 
     out.push_str("\n## Roster\n");
     if e.teammates.is_empty() {
-        out.push_str("- (no teammates on the manifest roster)\n");
+        // "the roster", not "the manifest roster": since #1106 this list is the
+        // effective roster, so an empty one means the company has nobody at all
+        // rather than nobody *declared*.
+        out.push_str("- (no teammates on the roster)\n");
     }
     for t in &e.teammates {
         let grants = if t.grants.is_empty() {

--- a/src/harness/planning.rs
+++ b/src/harness/planning.rs
@@ -360,7 +360,20 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
         [only] => Some(only.id.clone()),
         _ => None,
     };
-    let ambiguous = candidates.len() > 1;
+    // Resolved *before* the brief is built, because whether this card carries an
+    // ownership question is part of the brief. A card with a usable owner has no
+    // question to persist: it dispatches, and a candidate list stored beside a
+    // teammate who is already doing the work is one the console would render as
+    // an unanswered "Who owns this?" — with live Assign buttons — on a card
+    // nobody was ever asked about.
+    //
+    // The validity filter is part of that: a card still naming a teammate who
+    // has since left the roster has no usable owner, so it is ambiguous like any
+    // other unowned card rather than being answered with "the plan did not name
+    // a teammate who could take it", which would be false.
+    let assignee = settled_assignee(&evidence.card_assignee, proposed.clone())
+        .filter(|a| evidence.assignee_is_valid(a));
+    let ambiguous = assignee.is_none() && candidates.len() > 1;
     let plan = TaskPlan {
         description: cap(&draft.description, MAX_PROSE_CHARS),
         steps: draft
@@ -394,23 +407,15 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
         planned_at_millis: now_millis(),
     };
 
-    // The validity filter is hoisted out of the `let else` below so the
-    // ambiguity arm can see through it. A card still carrying a teammate who has
-    // since left the roster has no usable owner, so it is the ambiguity arm's
-    // business too — leaving it to the arm below would answer a card that named
-    // two perfectly good candidates with "the plan did not name a teammate who
-    // could take it".
-    let assignee = settled_assignee(&evidence.card_assignee, proposed)
-        .filter(|a| evidence.assignee_is_valid(a));
     // Issue #1106: park rather than pick, when the card has no usable owner and
     // the pass named more than one teammate who could take it.
     //
-    // Gated on `assignee.is_none()` deliberately — an assignee a person set is
-    // never second-guessed, so a card with a valid owner dispatches even when the
-    // planner could name three others who would also have fitted. That is the
-    // same precedence the proposal already had; this only adds a case to the
+    // `ambiguous` already carries `assignee.is_none()` — an assignee a person set
+    // is never second-guessed, so a card with a valid owner dispatches even when
+    // the planner could name three others who would also have fitted. That is
+    // the same precedence the proposal already had; this only adds a case to the
     // branch that had nothing to say.
-    if assignee.is_none() && ambiguous {
+    if ambiguous {
         settle_blocked(
             &runtime,
             &task_id,

--- a/src/harness/planning.rs
+++ b/src/harness/planning.rs
@@ -94,8 +94,8 @@ use crate::harness::build::{grants_cover, model_for_tier};
 use crate::harness::provider::HarnessModel;
 use crate::ports::now_millis;
 use crate::ports::tasks::{
-    COLUMN_IN_PROGRESS, COLUMN_PLANNING, COLUMN_TODO, PlanStep, PrereqKind, PrereqStatus,
-    Prerequisite, TaskPlan, TaskRecord,
+    AssigneeCandidate, COLUMN_IN_PROGRESS, COLUMN_PLANNING, COLUMN_TODO, PlanStep, PrereqKind,
+    PrereqStatus, Prerequisite, TaskPlan, TaskRecord,
 };
 use crate::ports::types::{CompanyRecord, TokenUsage};
 use crate::runtime::advance::{SYSTEM_ATTRIBUTION, append_result};
@@ -127,6 +127,13 @@ const MAX_OUTPUT_TOKENS: u32 = 4_000;
 const MAX_STEPS: usize = 12;
 const MAX_PREREQUISITES: usize = 12;
 const MAX_RISKS: usize = 8;
+/// Cap on the teammates a pass may put in front of a person (issue #1106).
+///
+/// Deliberately much tighter than the caps above, because this one is not about
+/// rendering cost — it is the difference between a decision and a survey.
+/// Proposing three is a judgement; proposing nine is a refusal wearing a list,
+/// and it would park cards that today route correctly.
+const MAX_ASSIGNEE_CANDIDATES: usize = 3;
 /// Cap for the prose blocks (description, scope, verification), in codepoints.
 const MAX_PROSE_CHARS: usize = 2_000;
 /// Cap for a step's detail and a prerequisite's note, in codepoints.
@@ -344,7 +351,16 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
     record_usage(&runtime, &planner, &task_id, &usage).await;
 
     let prerequisites = verify_prerequisites(&runtime, &evidence, &draft.prerequisites).await;
-    let proposed = resolve_proposed_assignee(&evidence, draft.proposed_assignee.as_deref());
+    let candidates = resolve_assignee_candidates(&evidence, &draft.assignee_candidates);
+    // Issue #1106. One surviving candidate is a proposal and behaves exactly as
+    // it did before this change. Two or more is an open question, and a question
+    // is not something to answer by taking the first element — so nothing is
+    // proposed, and the candidates travel on the brief instead.
+    let proposed = match candidates.as_slice() {
+        [only] => Some(only.id.clone()),
+        _ => None,
+    };
+    let ambiguous = candidates.len() > 1;
     let plan = TaskPlan {
         description: cap(&draft.description, MAX_PROSE_CHARS),
         steps: draft
@@ -368,11 +384,45 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
         verification: cap(&draft.verification, MAX_PROSE_CHARS),
         scope: cap(&draft.scope, MAX_PROSE_CHARS),
         proposed_assignee: proposed.clone(),
+        // Only ever carried when the pass declined to choose. A one-candidate
+        // pass writes the pre-#1106 shape: a `proposedAssignee` and no list.
+        assignee_candidates: if ambiguous {
+            candidates.clone()
+        } else {
+            Vec::new()
+        },
         planned_at_millis: now_millis(),
     };
 
-    let assignee = settled_assignee(&evidence.card_assignee, proposed);
-    let Some(assignee) = assignee.filter(|a| evidence.assignee_is_valid(a)) else {
+    // The validity filter is hoisted out of the `let else` below so the
+    // ambiguity arm can see through it. A card still carrying a teammate who has
+    // since left the roster has no usable owner, so it is the ambiguity arm's
+    // business too — leaving it to the arm below would answer a card that named
+    // two perfectly good candidates with "the plan did not name a teammate who
+    // could take it".
+    let assignee = settled_assignee(&evidence.card_assignee, proposed)
+        .filter(|a| evidence.assignee_is_valid(a));
+    // Issue #1106: park rather than pick, when the card has no usable owner and
+    // the pass named more than one teammate who could take it.
+    //
+    // Gated on `assignee.is_none()` deliberately — an assignee a person set is
+    // never second-guessed, so a card with a valid owner dispatches even when the
+    // planner could name three others who would also have fitted. That is the
+    // same precedence the proposal already had; this only adds a case to the
+    // branch that had nothing to say.
+    if assignee.is_none() && ambiguous {
+        settle_blocked(
+            &runtime,
+            &task_id,
+            token,
+            plan,
+            None,
+            &ambiguity_reason(&candidates),
+        )
+        .await;
+        return;
+    }
+    let Some(assignee) = assignee else {
         settle_blocked(
             &runtime,
             &task_id,
@@ -972,7 +1022,20 @@ struct PlanDraft {
     #[serde(default)]
     scope: String,
     #[serde(default)]
-    proposed_assignee: Option<String>,
+    assignee_candidates: Vec<CandidateDraft>,
+}
+
+/// One assignee candidate as the model named it (issue #1106).
+///
+/// `id` is whatever the model wrote — it is resolved against the roster, and
+/// dropped if the roster does not carry it, before anything is persisted.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CandidateDraft {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    reason: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1148,8 +1211,20 @@ fn system_prompt() -> String {
          \x20 \"risks\": [\"what could go wrong\"],\n\
          \x20 \"verification\": \"how a person will know it worked\",\n\
          \x20 \"scope\": \"what is in scope, and explicitly what is not\",\n\
-         \x20 \"proposedAssignee\": \"a teammate or desk id from the roster, or null\"\n\
+         \x20 \"assigneeCandidates\": [{{ \"id\": \"a teammate or desk id from the roster\", \
+         \"reason\": \"one line on why this one fits\" }}]\n\
          }}\n\n\
+         Rules for assigneeCandidates:\n\
+         - Name every teammate or desk that could genuinely take this card, best first, at most \
+         {MAX_ASSIGNEE_CANDIDATES}. One is the normal answer.\n\
+         - Name a second only when you would not be able to defend picking the first over it. Two \
+         entries means \"a person should choose\", and a person is asked — so a list padded with a \
+         teammate you do not actually rate costs them a decision they did not need to make.\n\
+         - Return an empty list when nobody on the roster fits. Do not invent an id to fill it.\n\
+         - `id` must be an id from the roster below, copied exactly. Anything the roster does not \
+         carry is dropped, so a near-miss spelling is the same as saying nothing.\n\
+         - The reason is read by a person deciding between the entries. Say what makes THIS one \
+         fit, not what the task is.\n\n\
          Rules for prerequisites, which matter more than anything else here:\n\
          - List ONLY what the work genuinely cannot proceed without. Every entry you add can stop \
          this card from starting, so a speculative one costs a person a round trip.\n\
@@ -1661,22 +1736,82 @@ fn verify_assignee(e: &Evidence, name: &str) -> (PrereqStatus, String) {
     }
 }
 
-/// Canonicalises the model's proposed assignee, or drops it.
+/// Canonicalises the assignee candidates the model named, dropping what the
+/// roster does not carry (issue #1106).
 ///
-/// The plan may only ever *offer* a name; whether it is used at all is decided
-/// by [`run_planning_pass`], which applies it only to a card nobody has
-/// assigned. A name the roster does not recognise is dropped here rather than
-/// written onto the brief, so the console never shows a proposal that could not
-/// be acted on.
-fn resolve_proposed_assignee(evidence: &Evidence, proposed: Option<&str>) -> Option<String> {
-    let raw = proposed?.trim();
-    if raw.is_empty() {
-        return None;
+/// The plan may only ever *offer* names; what is done with them is decided by
+/// [`run_planning_pass`], which applies a candidate only to a card nobody has
+/// assigned and only when exactly one survives this function. A name the roster
+/// does not recognise is dropped here rather than written onto the brief, so the
+/// console never shows a pick that the write boundary would then refuse.
+///
+/// # Why the dedup is load-bearing
+///
+/// Candidates are deduplicated by their **canonical** id, not by what the model
+/// wrote. A model that names the same teammate twice — `"DevRel"` and
+/// `"devrel"`, or a teammate by display name and again by id — resolves to one
+/// key both times, and without this that card would park asking a person to
+/// choose between a teammate and itself. Dedup before the count is taken is what
+/// makes "two candidates" mean two teammates.
+///
+/// The first spelling of a duplicate keeps its reason: the model was told to
+/// order these best-first, so the earlier line is the one it stood behind.
+///
+/// No fuzzy matching, here or anywhere below: [`assignee::resolve`] is the same
+/// exact-match resolver the write boundary uses, so a candidate this accepts is
+/// one a person can actually be handed.
+fn resolve_assignee_candidates(
+    evidence: &Evidence,
+    drafts: &[CandidateDraft],
+) -> Vec<AssigneeCandidate> {
+    let mut out: Vec<AssigneeCandidate> = Vec::new();
+    for draft in drafts {
+        let raw = draft.id.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let Some(id) = assignee::resolve(&evidence.record, raw)
+            .canonical()
+            .filter(|c| !c.is_empty())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        if out.iter().any(|existing| existing.id == id) {
+            continue;
+        }
+        out.push(AssigneeCandidate {
+            id,
+            reason: cap(draft.reason.trim(), MAX_LABEL_CHARS),
+        });
+        if out.len() == MAX_ASSIGNEE_CANDIDATES {
+            break;
+        }
     }
-    assignee::resolve(&evidence.record, raw)
-        .canonical()
-        .filter(|c| !c.is_empty())
-        .map(str::to_string)
+    out
+}
+
+/// The note line a card parks with when the pass declined to choose.
+///
+/// Rendered in the same shape as the blocked-on-prerequisites reason — a
+/// sentence, then one bullet per item — because both are the card telling a
+/// person what it is waiting on, and reading two different layouts for that
+/// would be gratuitous.
+fn ambiguity_reason(candidates: &[AssigneeCandidate]) -> String {
+    let lines: Vec<String> = candidates
+        .iter()
+        .map(|c| {
+            if c.reason.is_empty() {
+                format!("- `{}`", c.id)
+            } else {
+                format!("- `{}` — {}", c.id, c.reason)
+            }
+        })
+        .collect();
+    format!(
+        "planned, but more than one teammate could take it — pick who owns it:\n{}",
+        lines.join("\n")
+    )
 }
 
 #[cfg(test)]

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -1453,6 +1453,22 @@ async fn an_operator_assigned_card_dispatches_even_when_the_plan_is_ambiguous() 
     let after = read(&runtime, "t-21").await;
     assert_eq!(after.column, COLUMN_IN_PROGRESS, "it still dispatches");
     assert_eq!(after.assignee, "sam");
+
+    // And it carries NO ownership question. The console renders any non-empty
+    // candidate list as an unanswered "Who owns this?" with live Assign buttons,
+    // so persisting one here would put that question on a card whose owner a
+    // person had already chosen and whose work is already running — asking about
+    // a decision that was never open. Caught by CodeRabbit on #1157: the first
+    // version of this test asserted the column and the assignee and stopped
+    // there, which is exactly the half that was wrong.
+    assert!(
+        after
+            .plan
+            .expect("the brief is still written")
+            .assignee_candidates
+            .is_empty(),
+        "an owned card has no ownership question to persist"
+    );
 }
 
 /// One candidate is unchanged behaviour: it is applied, recorded as the

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -1606,6 +1606,123 @@ async fn a_stale_assignee_does_not_shield_the_card_from_the_question() {
     );
 }
 
+/// Seeds an overlay teammate onto the stored record, the way the console's
+/// `POST …/team` route and the orchestrator's `add_agent` tool both do.
+async fn add_overlay_agent(runtime: &Arc<CompanyRuntime>, id: &str, role: &str, description: &str) {
+    let mut record = runtime
+        .store()
+        .load(runtime.id())
+        .await
+        .expect("load")
+        .expect("record");
+    record
+        .overlay_agents
+        .push(crate::ports::types::OverlayAgent {
+            id: id.to_string(),
+            name: id.to_string(),
+            role: role.to_string(),
+            description: Some(description.to_string()),
+            tools: Vec::new(),
+        });
+    runtime.store().save(&record).await.expect("save");
+}
+
+/// The planner is shown the roster the company actually runs, not the half of
+/// it the manifest declares (CodeRabbit on #1157).
+///
+/// A teammate reaches the roster from four places and only two of them are
+/// manifest rows. `assignee::resolve` has always accepted the other two, so a
+/// runtime teammate was a name the host would honour and the planner had never
+/// heard of — it could not be proposed, and since #1106 could not be one of the
+/// candidates a person is asked to choose between.
+#[tokio::test]
+async fn the_prompt_carries_runtime_teammates_and_desks_not_just_manifest_ones() {
+    let model = ScriptedModel::replying(CLEAN_PLAN);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    add_overlay_agent(
+        &runtime,
+        "social_manager",
+        "Social Media Manager",
+        "Runs the accounts",
+    )
+    .await;
+
+    let mut record = runtime.store().load(runtime.id()).await.unwrap().unwrap();
+    record.overlay_desks.push(crate::ports::types::OverlayDesk {
+        id: "growth".to_string(),
+        name: "Growth".to_string(),
+        description: None,
+        members: vec!["social_manager".to_string()],
+    });
+    runtime.store().save(&record).await.unwrap();
+
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-27", ""))
+        .await
+        .unwrap();
+    run_planning_pass(Arc::clone(&runtime), "t-27".to_string()).await;
+
+    let prompt = model.last_prompt();
+    assert!(
+        prompt.contains("`social_manager`"),
+        "an operator- or orchestrator-added teammate is on the roster the planner reads:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("Social Media Manager"),
+        "with its role, which is what the model judges fit from:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("desk `growth`"),
+        "and an operator-created desk is a nominatable target too:\n{prompt}"
+    );
+    // Still there, unchanged — this widens the roster, it does not replace it.
+    assert!(prompt.contains("`maya`"), "{prompt}");
+}
+
+/// The case #1106 actually reports: two teammates who overlap, where one of them
+/// was added at runtime. No shipped bundle carries such a pair, so this is the
+/// shape the real defect had — and before the roster widened, the runtime half
+/// could not be named at all.
+#[tokio::test]
+async fn a_manifest_teammate_and_a_runtime_one_can_be_the_ambiguous_pair() {
+    let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+        "verification":"v","scope":"s","assigneeCandidates":[
+          {"id":"maya","reason":"writes the company's prose"},
+          {"id":"social_manager","reason":"owns the accounts it would be posted to"}]}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    add_overlay_agent(
+        &runtime,
+        "social_manager",
+        "Social Media Manager",
+        "Runs the accounts",
+    )
+    .await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-28", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-28".to_string()).await;
+
+    let after = read(&runtime, "t-28").await;
+    assert_eq!(after.column, COLUMN_TODO, "it parks rather than picking");
+    assert_eq!(after.assignee, "");
+    let ids: Vec<String> = after
+        .plan
+        .expect("plan")
+        .assignee_candidates
+        .into_iter()
+        .map(|c| c.id)
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["maya".to_string(), "social_manager".to_string()],
+        "the runtime teammate survives resolution exactly like the manifest one"
+    );
+}
+
 /// Direct unit coverage of the resolver's caps and drops, so the rules hold
 /// independently of what any one scripted model happens to emit.
 #[test]

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -300,7 +300,7 @@ const CLEAN_PLAN: &str = r#"```json
   "risks": ["the tag may not exist yet"],
   "verification": "the entry is in the file and reads correctly",
   "scope": "the changelog only",
-  "proposedAssignee": "maya"
+  "assigneeCandidates": [{"id": "maya", "reason": "writes everything the company ships"}]
 }
 ```"#;
 
@@ -314,7 +314,8 @@ const CLEAN_PLAN: &str = r#"```json
 fn a_fenced_or_narrated_answer_still_parses() {
     let fenced = parse_draft(CLEAN_PLAN).expect("a fenced answer parses");
     assert_eq!(fenced.steps.len(), 1);
-    assert_eq!(fenced.proposed_assignee.as_deref(), Some("maya"));
+    assert_eq!(fenced.assignee_candidates.len(), 1);
+    assert_eq!(fenced.assignee_candidates[0].id, "maya");
 
     let narrated = parse_draft(
         "Sure! Here is the plan:\n{\"description\":\"do it\",\"steps\":[]}\nLet me know.",
@@ -1166,6 +1167,7 @@ async fn an_operator_move_mid_pass_discards_the_pass() {
             verification: "v".to_string(),
             scope: "s".to_string(),
             proposed_assignee: None,
+            assignee_candidates: Vec::new(),
             planned_at_millis: 0,
         },
         "maya".to_string(),
@@ -1347,7 +1349,8 @@ async fn a_re_plan_does_not_erase_what_an_earlier_attempt_produced() {
 #[tokio::test]
 async fn a_card_with_no_valid_assignee_cannot_dispatch() {
     let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
-        "verification":"v","scope":"s","proposedAssignee":"someone-who-left"}"#;
+        "verification":"v","scope":"s",
+        "assigneeCandidates":[{"id":"someone-who-left","reason":"used to own this"}]}"#;
     let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
     runtime
         .tasks()
@@ -1365,6 +1368,263 @@ async fn a_card_with_no_valid_assignee_cannot_dispatch() {
         "a proposal the roster does not recognise is dropped rather than shown"
     );
     assert!(after.note.unwrap().contains("nobody on the roster"));
+}
+
+// ---------------------------------------------------------------------------
+// Ambiguous ownership (issue #1106)
+// ---------------------------------------------------------------------------
+
+/// A model answer naming both roster teammates, each with a reason.
+const AMBIGUOUS_PLAN: &str = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+    "verification":"v","scope":"s","assigneeCandidates":[
+      {"id":"maya","reason":"owns the words"},
+      {"id":"sam","reason":"owns the tooling that publishes them"}]}"#;
+
+/// The defect: two teammates could take the card, so one was picked and the
+/// operator was never told there had been a choice.
+///
+/// The card now parks instead — in To-do, with the brief and both candidates on
+/// it, and nobody assigned. `settle_blocked` is the same disposition a card with
+/// *no* valid candidate already took; this only widens what reaches it.
+#[tokio::test]
+async fn two_plausible_teammates_park_the_card_instead_of_picking_one() {
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(AMBIGUOUS_PLAN)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-20", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-20".to_string()).await;
+
+    let after = read(&runtime, "t-20").await;
+    assert_eq!(
+        after.column, COLUMN_TODO,
+        "an open choice waits for a person rather than dispatching"
+    );
+    assert_eq!(
+        after.assignee, "",
+        "nobody is picked — the whole point is that the host did not choose"
+    );
+
+    let plan = after.plan.expect("the brief is still written");
+    assert!(
+        plan.proposed_assignee.is_none(),
+        "two candidates is a question, not a proposal"
+    );
+    let ids: Vec<&str> = plan
+        .assignee_candidates
+        .iter()
+        .map(|c| c.id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["maya", "sam"], "both survive, in the order given");
+
+    // The runner-up is recorded *with its reason* — a bare pair of ids would ask
+    // the operator to re-derive the judgement the planner already made.
+    let note = after.note.expect("the card says what it is waiting on");
+    assert!(
+        note.contains("more than one teammate could take it"),
+        "{note}"
+    );
+    assert!(note.contains("owns the words"), "{note}");
+    assert!(
+        note.contains("owns the tooling that publishes them"),
+        "{note}"
+    );
+}
+
+/// An assignee a person chose is never second-guessed, even when the planner
+/// could name others who would also have fitted.
+///
+/// This is the precedence `settled_assignee` already gave a proposal, and the
+/// ambiguity arm is deliberately gated behind it: an operator who has already
+/// answered the question must not be asked it again.
+#[tokio::test]
+async fn an_operator_assigned_card_dispatches_even_when_the_plan_is_ambiguous() {
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(AMBIGUOUS_PLAN)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-21", "sam"))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-21".to_string()).await;
+
+    let after = read(&runtime, "t-21").await;
+    assert_eq!(after.column, COLUMN_IN_PROGRESS, "it still dispatches");
+    assert_eq!(after.assignee, "sam");
+}
+
+/// One candidate is unchanged behaviour: it is applied, recorded as the
+/// proposal, and the card dispatches. The pre-#1106 shape.
+#[tokio::test]
+async fn a_single_candidate_still_fills_a_blank_assignee_and_dispatches() {
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(CLEAN_PLAN)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-22", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-22".to_string()).await;
+
+    let after = read(&runtime, "t-22").await;
+    assert_eq!(after.assignee, "maya");
+    assert_eq!(after.column, COLUMN_IN_PROGRESS);
+    let plan = after.plan.expect("plan");
+    assert_eq!(plan.proposed_assignee.as_deref(), Some("maya"));
+    assert!(
+        plan.assignee_candidates.is_empty(),
+        "a card that was not ambiguous carries no candidate list, so the console \
+         renders it exactly as it did before this field existed"
+    );
+}
+
+/// The dedup is what makes "two candidates" mean two *teammates*.
+///
+/// A model that names one teammate twice — by id and again by display name, or
+/// in two casings — resolves to one canonical key both times. Without the dedup
+/// this card would park asking a person to choose between `maya` and `maya`.
+#[tokio::test]
+async fn one_teammate_named_twice_is_not_an_ambiguity() {
+    let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+        "verification":"v","scope":"s","assigneeCandidates":[
+          {"id":"maya","reason":"first spelling"},
+          {"id":"MAYA","reason":"second spelling of the same teammate"}]}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-23", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-23".to_string()).await;
+
+    let after = read(&runtime, "t-23").await;
+    assert_eq!(
+        after.column, COLUMN_IN_PROGRESS,
+        "one teammate spelled two ways is one candidate, so it dispatches"
+    );
+    assert_eq!(after.assignee, "maya");
+    assert_eq!(
+        after.plan.expect("plan").proposed_assignee.as_deref(),
+        Some("maya"),
+        "and the first spelling is the one kept"
+    );
+}
+
+/// A name the roster does not carry is dropped, so it cannot manufacture an
+/// ambiguity out of one real teammate and one hallucinated id.
+#[tokio::test]
+async fn an_unrecognised_candidate_is_dropped_rather_than_counted() {
+    let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+        "verification":"v","scope":"s","assigneeCandidates":[
+          {"id":"maya","reason":"real"},
+          {"id":"someone-who-left","reason":"not on the roster"}]}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-24", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-24".to_string()).await;
+
+    let after = read(&runtime, "t-24").await;
+    assert_eq!(
+        after.column, COLUMN_IN_PROGRESS,
+        "one real candidate remains, so there is nothing to ask about"
+    );
+    assert_eq!(after.assignee, "maya");
+}
+
+/// A desk is a legitimate candidate and stays a desk — it is the delegation
+/// address space the board already assigns to, and `AssigneeResolution` keeps a
+/// desk assignment from being rewritten to its lead.
+#[tokio::test]
+async fn a_desk_is_a_candidate_and_is_not_resolved_to_its_lead() {
+    let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+        "verification":"v","scope":"s","assigneeCandidates":[
+          {"id":"studio","reason":"the desk that owns published work"}]}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-25", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-25".to_string()).await;
+
+    let after = read(&runtime, "t-25").await;
+    assert_eq!(
+        after.assignee, "studio",
+        "the desk is assigned, not `maya` who leads it"
+    );
+}
+
+/// A card still carrying a teammate who has since left the roster has no usable
+/// owner, so it reaches the ambiguity arm rather than the "nobody could take it"
+/// one — which would be a false statement about a plan that named two.
+#[tokio::test]
+async fn a_stale_assignee_does_not_shield_the_card_from_the_question() {
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(AMBIGUOUS_PLAN)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-26", "someone-who-left"))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-26".to_string()).await;
+
+    let after = read(&runtime, "t-26").await;
+    assert_eq!(after.column, COLUMN_TODO);
+    let note = after.note.expect("a reason");
+    assert!(
+        note.contains("more than one teammate could take it"),
+        "the card asks the real question rather than claiming the plan named nobody: {note}"
+    );
+    assert_eq!(
+        after.plan.expect("plan").assignee_candidates.len(),
+        2,
+        "and both candidates are on the brief to answer it with"
+    );
+}
+
+/// Direct unit coverage of the resolver's caps and drops, so the rules hold
+/// independently of what any one scripted model happens to emit.
+#[test]
+fn the_candidate_resolver_caps_drops_and_dedups() {
+    let evidence = evidence();
+    let draft = |id: &str, reason: &str| CandidateDraft {
+        id: id.to_string(),
+        reason: reason.to_string(),
+    };
+
+    // Blank and unrecognised ids are dropped; a real one survives.
+    let resolved = resolve_assignee_candidates(
+        &evidence,
+        &[
+            draft("", "blank"),
+            draft("nobody_here", "unreal"),
+            draft("sam", "real"),
+        ],
+    );
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].id, "sam");
+    assert_eq!(resolved[0].reason, "real");
+
+    // Never more than the cap, however many the model names.
+    let many: Vec<CandidateDraft> = ["maya", "sam", "studio", "empty_desk"]
+        .iter()
+        .map(|id| draft(id, "fits"))
+        .collect();
+    assert_eq!(
+        resolve_assignee_candidates(&evidence, &many).len(),
+        MAX_ASSIGNEE_CANDIDATES
+    );
+
+    // An empty answer is an empty list, not a fabricated candidate.
+    assert!(resolve_assignee_candidates(&evidence, &[]).is_empty());
 }
 
 /// The prompt carries names and booleans, and nothing else. This is the check

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -469,10 +469,51 @@ pub struct TaskPlan {
     /// The teammate the planner would hand it to. Applied to the card **only**
     /// when the card had no assignee and this names a real one — a plan never
     /// reassigns work a person already assigned.
+    ///
+    /// Set only when the pass resolved **exactly one** candidate (issue #1106).
+    /// Two or more is an open choice, not a proposal, and lands in
+    /// [`assignee_candidates`](Self::assignee_candidates) instead — the two are
+    /// never both populated.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proposed_assignee: Option<String>,
+    /// The teammates that plausibly fit, when more than one did (issue #1106).
+    ///
+    /// Non-empty means the pass **declined to choose** and the card is waiting
+    /// on a person: an unassigned card whose planner named two teammates who
+    /// could each take it is not a card with a proposal, it is a card with a
+    /// question. Empty is every other case — the card was already assigned, or
+    /// exactly one candidate resolved (see
+    /// [`proposed_assignee`](Self::proposed_assignee)), or none did.
+    ///
+    /// Additive on the wire like every field above it, so a board holding
+    /// pre-#1106 plans reads back unchanged: those carry a `proposedAssignee`
+    /// and no candidates, which is exactly the shape a one-candidate pass writes
+    /// today.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub assignee_candidates: Vec<AssigneeCandidate>,
     /// When the pass that produced this brief finished.
     pub planned_at_millis: u64,
+}
+
+/// One teammate the planner thinks could take a card, and why (issue #1106).
+///
+/// The reason is the whole point. A bare list of two ids asks an operator to
+/// re-derive the judgement the planner already made; the line beside each is
+/// what lets them answer without opening two agent pages.
+///
+/// `id` is **canonical** — resolved against the roster by the host before it is
+/// stored, never the raw string the model emitted. A candidate the roster does
+/// not recognise is dropped rather than shown, for the same reason
+/// `proposed_assignee` drops one: the console must not offer a pick that the
+/// write boundary would then refuse.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssigneeCandidate {
+    /// The canonical roster key: a teammate id, or a desk id.
+    pub id: String,
+    /// One line on why this one fits. Model prose, shown to a person who is
+    /// about to decide; nothing dispatches off it.
+    pub reason: String,
 }
 
 /// One metered planning pass attributed to a task.
@@ -1280,6 +1321,7 @@ mod test {
             verification: "the PR exists and CI is green".to_string(),
             scope: "the changelog only; no code changes".to_string(),
             proposed_assignee: Some("maya".to_string()),
+            assignee_candidates: Vec::new(),
             planned_at_millis: 42,
         }
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1211,6 +1211,20 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
             verification: "the notes are live".to_string(),
             scope: "the notes only".to_string(),
             proposed_assignee: Some("maya".to_string()),
+            // Issue #1106. Populated here even though a real plan never carries
+            // both this and `proposed_assignee` — this fixture's job is to make
+            // a silently-dropped field fail, and a field left empty would
+            // round-trip through a backend that drops it entirely.
+            assignee_candidates: vec![
+                crate::ports::tasks::AssigneeCandidate {
+                    id: "maya".to_string(),
+                    reason: "writes the release notes today".to_string(),
+                },
+                crate::ports::tasks::AssigneeCandidate {
+                    id: "devrel".to_string(),
+                    reason: "owns everything that ships to developers".to_string(),
+                },
+            ],
             planned_at_millis: 1_234,
         }),
         ..task("t-planned", "planning", 9)


### PR DESCRIPTION
## Summary

Closes #1106.

Creating a task offered no choice of who does it, and when nobody chose, the host picked silently — even when two teammates plausibly fit. The reported case: *fetch trending tweets about "agent harness"*, in a company with both a DevRel agent and a Social Media Manager. One got it. The operator was never asked, and nothing recorded that there had been a choice.

Two gaps, addressed in four commits.

**The create dialog collects an owner.** `AssigneeSelect` already existed and `POST …/tasks` already accepted `assignee`; only the create surface never offered it, so setting an owner meant create → open → edit. It defaults to unassigned and is **omitted from the body when untouched**, so a card created without using it posts exactly what it posted before.

**The planning pass asks instead of picking.** The pass now answers with *candidates* rather than one name, and what happens next is a function of how many survive resolution and nothing else:

| Resolved candidates | Card assigned? | Outcome |
|---|---|---|
| any | yes | dispatches — an owner a person set is never second-guessed |
| 0 | no | `todo`, existing "nobody on the roster" reason |
| 1 | no | applied as `proposedAssignee`, dispatches — **unchanged** behaviour |
| 2 or 3 | no | `todo`, candidates on the brief, nothing assigned |

The console renders those candidates as *"Who owns this?"* with the planner's one-line reason for each, and one click assigns through the same `PATCH …/tasks/{id}` the reassign row already uses.

### Why ask rather than propose-and-correct

The alternative — pick, then record the runner-up for the operator to fix — assumes they would recognise a wrong pick. A roster has four sources (the global baseline, the company blueprint, the console's `POST …/team`, and the orchestrator's own `add_agent`) and only one of them is the operator. No shipped bundle carries both a DevRel agent and a Social Media Manager, so in the reported case at least one of the overlapping pair was created at runtime — possibly by an agent, with a description no human wrote. `OverlayAgent::description` is an `Option`; it can be absent entirely. So the descriptions are thinnest exactly where the ambiguity is worst.

### Three things worth a reviewer's eye

**It reuses `settle_blocked`, which the zero-candidate case already reached.** This widens a condition rather than adding a disposition — which is why the change is small. The cost: ambiguity, "no valid assignee" and "prerequisites missing" now all land in To-do, distinguishable only by the note. If ambiguity should be its own board state, that is a larger change than this and I would rather hear it now.

**The dedup is by canonical id and happens before the count.** A model naming one teammate twice — by id and again by display name, or in two casings — resolves to one key both times. Without it, that card parks asking a person to choose between a teammate and itself.

**The validity filter is hoisted out of the `let else`.** A card still carrying a teammate who has since left the roster has no usable owner, so it reaches the ambiguity arm. Left alone it would have answered a card that named two good candidates with "the plan did not name a teammate who could take it" — false.

**No fuzzy matching.** Candidates go through the same exact-match `runtime::assignee::resolve` the write boundary uses. The model proposes; the host only enforces that each name is real — the same split the workflow copilot's grounding takes.

## API Or Behavior Changes

- `TaskPlan` gains `assigneeCandidates: AssigneeCandidate[]` (`{id, reason}`). Additive on the wire (`serde(default)` + skip-if-empty), so no stored board migrates on any of the three backends. Added to the store conformance fixture, which exists to fail on a dropped field.
- `proposedAssignee` is now set **only** when exactly one candidate resolved. It and `assigneeCandidates` are never both populated. A one-candidate pass writes the pre-#1106 shape exactly.
- The planner's response schema replaces `proposedAssignee` with `assigneeCandidates`, capped at 3.
- `POST …/tasks` is unchanged — it already accepted `assignee`.
- Console: the create dialog gains an Owner row; the plan brief gains the chooser. Both render as before when the field is absent.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`

All four run on the rebased base with `--features openhuman`: **4486 passed, 0 failed**, clippy clean, build clean.

Frontend: `pnpm typecheck`, `pnpm typecheck:e2e`, `pnpm test` — **128 files / 1241 tests**, all green.

8 new Rust tests cover the park, operator precedence, the single-candidate path, the dedup, the unrecognised-candidate drop, a desk candidate staying a desk, the stale-assignee edge, and the resolver's caps. 13 new frontend tests cover the body-omission rule and the chooser's render and callback.

**Also driven end to end in a browser** against a real host (`--features openhuman,tinycortex,mcp`, real store, real planning pass, scripted model only): an unassigned card dragged into Planning parked in To-do with both candidates and their reasons; one click assigned `writer` and persisted. The mock brain logged exactly **1** planning pass across the flow, confirming that answering the question dispatches on the existing brief rather than paying for a second pass.

## Documentation

`docs/spec/runtime/planning.md` — new exit row, the disposition table above, and the dedup / no-fuzzy-matching rules.

---

### Notes for the reviewer

**One commit here is not about #1106.** `main` did not pass `pnpm typecheck`:

```
src/lib/team.ts(207,10): error TS6133: 'member' is declared but its value is never read.
```

Verified as pre-existing by checking out pure `upstream/main` detached and running it there. `starterTeam()` was deliberately deleted in #1057 and its tombstone comment explains why, but `member()` — the factory that existed only to build its twelve invented rows — was left behind, arriving on main with `48a21af8`. `b31158d8` removes it, along with the docblock that still described the starter team in the present tense directly above the comment recording its deletion. It is its own commit and can be cherry-picked out, but the frontend lane is red without it.

**Unproven, and worth watching after deploy:** no real model has yet been asked to produce `assigneeCandidates`. The scripted brain returns what it was told to. The risk is not under-reporting but *padding* — a model returning two out of helpfulness when one clearly wins would park cards that route correctly today. The prompt states the rule ("name a second only when you would not be able to defend picking the first over it") and the cap is 3, but that is a prompt, not an enforcement. If it pads in practice, the rule needs tightening before this is relied on.
