### PR TITLE
fix(console): delete the orphaned `member` helper that fails typecheck and skips the Console lane

### DIFF
--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -204,22 +204,6 @@ function roleHash(role: string): string {
   return (hash >>> 0).toString(36);
 }
 
-function member(name: string, role: string, description: string): TeamMember {
-  return {
-    id: localMemberId(role),
-    name,
-    role,
-    description,
-    tone: toneFor(name),
-    avatar: avatarFor(name),
-    inboxEnabled: false,
-    // A console-invented teammate exists on no host, so it holds no grant and
-    // sits on no desk. Stated, not guessed.
-    effectiveTools: [],
-    desks: [],
-  };
-}
-
 /**
  * A generic starter team that fits any company; the operator edits from here.
  *
@@ -260,8 +244,8 @@ export function newMember(fields: { name: string; role: string; description: str
     tone: toneFor(memberId),
     avatar: avatarFor(memberId),
     inboxEnabled: false,
-    // Same as `member` above: nothing on a host has granted this teammate
-    // anything or seated it anywhere yet.
+    // Nothing on a host has granted this teammate anything or seated it
+    // anywhere yet, so both are stated empty rather than guessed.
     effectiveTools: [],
     desks: [],
   };


### PR DESCRIPTION
Closes #1156

## Summary

`frontend/src/lib/team.ts:207` declared `member(name, role, description)` and nothing called it, so `tsc -b` failed:

```
src/lib/team.ts(207,10): error TS6133: 'member' is declared but its value is never read.
```

`typecheck` is the **first** step of the Console job, so everything after it was `skipped`: `typecheck:e2e`, `typecheck:unit`, `npm test`, `build`, `build:pages-sdk`, the design-token assertion, the markdown line cap and both lockfile validations. **The console unit suite — 1228 tests — was not running in CI at all.**

## The judgement call: delete, or wire up a caller?

The issue asks whether #1126 meant to have a caller. **It did not, and there is no caller to restore.** The history is unambiguous once you look at the merge rather than the commits:

`member()` existed to build rows for `starterTeam()` — the fabricated twelve-agent roster ("Ops Lead", "Front Desk", "Product Lead", …). **`56bb7589` deleted both together**, and left a tombstone comment in this same file saying why: the invented teammates made every surface lie — the Team page offered budgets and inboxes for people the host had never heard of, Chat offered DMs whose first message went nowhere, the Overview graph drew a full org chart for a company with nobody in it.

So the helper's return came from the merge `48a21af8`, not from anyone's edit:

| | `function member(` | the "starterTeam used to live here" tombstone |
|---|---|---|
| parent 1 — `e19fc721` (`feat/teammate-avatars`) | **present** | absent |
| parent 2 — `e5652d8f` (`main`) | absent | **present** |
| merge — `48a21af8` | **present** | **present** |

Neither side is at fault alone. The avatar branch was cut before the removal, and `512baac5` only touched the function's *body* — adding `avatar: avatarFor(name)` so it still satisfied the widened `TeamMember`. `main` deleted its only caller. The two edits sat in different regions of the file, so git reported no conflict and kept both: the helper from one side, the deletion of its caller from the other. A textbook orphan-by-adjacency, and exactly why no reviewer saw it.

Restoring a caller would therefore mean reinstating `starterTeam()` — the thing the repo removed on purpose. `newMember()` already covers the legitimate path, and is deliberately keyed on **name** rather than role, because an operator adding a teammate by hand is naming a person; `member()` keyed on **role** precisely because that is what distinguished its fabricated rows. Deleting is completing `56bb7589`, not taking the smaller option.

One follow-on: `newMember()` documented itself as *"Same as `member` above"*, so that sentence is restated rather than left pointing at nothing.

## API Or Behavior Changes

**None.** `member` was module-private and unreachable — no export, no caller, no test. `toneFor` and `avatarFor` remain used (3 call sites each) and are untouched.

## Tests

- [x] `cargo fmt --all -- --check` — N/A: no Rust file is touched; the diff is one file under `frontend/src/lib/`.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust file is touched, so neither the default nor the `openhuman,tinycortex` lane has anything to lint here.
- [x] `cargo build --all-targets` — N/A: as above; `git diff --stat Cargo.lock` is empty and nothing outside `frontend/` changed.
- [x] `cargo test` — N/A: as above. **Ran instead, every Console step this was blocking:**

| step | result |
|---|---|
| `npm run typecheck` | clean (exit 0) |
| `npm run typecheck:e2e` | clean |
| `npm run typecheck:unit` | clean |
| `npm test` | **1228 passed, 126 files, 0 failed** |
| `./scripts/ci/assert-design-tokens.sh` | ✓ |
| `./scripts/ci/assert-md-line-cap.sh` | ✓ |

Running the suite mattered rather than being a formality: it had not executed in CI since the breakage, so "the typecheck passes now" would not have told anyone whether the lane actually goes green. It does.

Not run: `npm run build` and `build:pages-sdk` (per the local no-full-builds rule) and the two `pnpm --lockfile-only` validations — the latter are unaffected, since no manifest or lockfile is touched. CI settles those three.

### Proven, not assumed

There is no new unit test, and adding one would be theatre: the assertion "this function does not exist" is what `tsc`'s `noUnusedLocals` already makes, in the lane, on every PR. What I did instead is run the revert both ways:

| tree | `npm run typecheck` |
|---|---|
| with this fix | **exit 0** |
| helper restored (pristine `main`) | **exit 1** — `src/lib/team.ts(207,10): error TS6133`, the issue's error verbatim |

## Documentation

None needed. The tombstone comment in `team.ts` that explains why the fabricated roster was removed is already the documentation for this deletion, and it stays.

**Deliberately out of scope:** the JSDoc block above that tombstone still describes `starterTeam()` — "A generic starter team that fits any company" — a function that no longer exists. That one is **not** from this merge (both parents carry it, so it is `main`'s own pre-existing state), it fails nothing, and folding it in would widen a one-line lane fix into a tidy-up. Flagged here rather than silently swept in or silently ignored.
