### PR TITLE
journal: make a workflow gate's park survive what its resume assumes

### DIFF
--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -366,6 +366,57 @@ impl JournalRecord {
             Self::GrantConsumed { .. } => Durability::Host,
             // Losing a park loses the *question*: the approval vanishes and the
             // agent parks it again on its next attempt. Nothing external fired.
+            //
+            // **Except for a workflow gate, which has no next attempt (issue
+            // #1145).** The re-park reasoning above is a property of the
+            // *caller*, not of the record, and it was generalised to a caller
+            // that has none. A chat turn re-enters its gate and mints a new
+            // approval, so the cost of the loss is one extra question — the
+            // tolerance is exactly right there, and that is where the volume is.
+            // A workflow run does not: `workflow_resume` turns on the fact that
+            // "resume is a re-run, because a paused run is settled" — the engine
+            // returned, the future completed, and nothing is holding a
+            // continuation. So the parked effect is not a record *of* the
+            // continuation, it **is** the continuation, carrying the whole
+            // trigger input, and `WorkflowGateQueue::rearm` rebuilds the live
+            // gate set at recovery from exactly these still-parked lines. Lose
+            // the line and the run keeps a durable `pending_approvals` naming a
+            // question that exists nowhere: no card to decide, no re-park
+            // coming, and the whole downstream of that pipeline held behind it.
+            //
+            // Not a new guarantee so much as the one this crate already claims
+            // in two other places and did not deliver — `workflow_resume`'s
+            // "restart durability … a host that dies between the park and the
+            // approval loses nothing", and `CompanyCycle::park`'s "survives a
+            // restart with its original `ApprovalId`". Both hold for a *process*
+            // restart and fail for the host death the first one names, because
+            // `Process` is page-cache-resident by definition. The flush is the
+            // same trade `GrantConsumed` accepted four arms up: one flush on a
+            // record written at operator-decision scale.
+            //
+            // **Deliberately NOT extended to an agent node's gated tool call**,
+            // though those park inside a workflow run too and strand it just as
+            // badly. Flushing them would buy nothing: their continuation needs
+            // the workflow id and trigger input, which the tool-call effect does
+            // not carry, so `BlockedNodeQueue` stashes them **in memory** and
+            // — unlike the gate queue — does not rehydrate from the journal at
+            // all (`blocked_nodes`, stated there as the #899 Stage-1 boundary).
+            // A durable record whose continuation died with the process is a
+            // flush that changes nothing, and it would read as a fix. Making
+            // that path survive is #899 Stage 2.
+            //
+            // Keyed on the effect kind rather than on `run_id`, which cannot do
+            // this job: `run_id` is stamped with a *task attempt* id at the
+            // dispatch boundary and with a *workflow run* id by `gate_effect`,
+            // so `is_some()` also selects card runs and blocked-node parks —
+            // the two cases this must not widen to. `WORKFLOW_APPROVE_KIND` is
+            // minted in exactly one place, for exactly the parks whose loss
+            // strands a run nothing will re-enter.
+            Self::ApprovalParked { effect, .. }
+                if effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND =>
+            {
+                Durability::Host
+            }
             Self::ApprovalParked { .. } => Durability::Process,
             // Bookkeeping after the decision. A ghost approval that is approved
             // a second time cannot duplicate the effect, because the effect's
@@ -1769,14 +1820,22 @@ impl RuntimeJournal {
     /// [`JournalRecord::durability`], and this is the single choke point that
     /// passes that decision to the sink:
     ///
-    /// * The three [`Durability::Host`] kinds — `EffectExecuted`,
+    /// * The three unconditional [`Durability::Host`] kinds — `EffectExecuted`,
     ///   `GrantConsumed` and `StandingGrantRevoked` — are on stable storage
     ///   before this returns. So the at-most-once contract holds against
     ///   **losing the machine** for precisely the records whose loss would
     ///   repeat an external action, and a failed flush fails the append — which
     ///   aborts `execute_effect_once` before `perform_effect` and so cannot
     ///   produce the duplicate it is guarding against.
-    /// * The other ten are [`Durability::Process`]: killing the process cannot
+    /// * `ApprovalParked` is [`Durability::Host`] **for a workflow gate only**
+    ///   (issue #1145), and `Process` for every other park. It is the one kind
+    ///   whose level is decided by its contents rather than by its tag, because
+    ///   the reasoning behind `Process` is a property of the caller: a chat turn
+    ///   re-enters its gate and re-parks, a paused workflow run has already
+    ///   settled and never will. For that run the parked effect *is* the
+    ///   continuation, so its loss strands the run permanently rather than
+    ///   costing a second question.
+    /// * The other nine are [`Durability::Process`]: killing the process cannot
     ///   lose them, a host crash can. That is the decision, not a gap left open.
     ///   Losing any of them makes the runtime **re-ask** — an approval is parked
     ///   again, an operator is prompted again, a cycle bracket reads as
@@ -3610,6 +3669,12 @@ mod test {
     /// across the line: flipping `EffectExecuted` to `Process` compiles, passes
     /// every other test in this file, and silently gives up the one guarantee
     /// the journal exists for. This is the test that notices.
+    ///
+    /// `every_record_kind`'s `ApprovalParked` sample carries an ordinary effect,
+    /// so it belongs on the `Process` side here. Its workflow-gate arm is the
+    /// one kind whose level depends on contents rather than tag, and it is
+    /// pinned separately below (issue #1145) — deliberately not by loosening
+    /// this list, which is the assertion that would have stopped noticing.
     #[test]
     fn host_durable_kinds_are_exactly_the_three_that_could_repeat_an_action() {
         let all = every_record_kind();
@@ -3637,6 +3702,55 @@ mod test {
              widening it taxes the hot path, narrowing it lets an effect duplicate \
              or a spent grant re-arm"
         );
+    }
+
+    /// One `ApprovalParked` line, built from the given effect kind.
+    fn parked_with_kind(kind: &str) -> JournalRecord {
+        let mut effect = effect();
+        effect.kind = kind.to_string();
+        JournalRecord::ApprovalParked {
+            id: ApprovalId::new("a"),
+            effect,
+            at_millis: 1,
+            task: Some(TaskLink::Unlinked),
+            thread: None,
+            parent: None,
+            cycle: None,
+        }
+    }
+
+    /// **Issue #1145.** A workflow gate's park is host-durable; every other park
+    /// is not.
+    ///
+    /// Both arms in one test because the assertion *is* the distinction. The
+    /// `Host` half alone would pass if every park were flushed — taxing the
+    /// journal's approval path to fix one caller — and the `Process` half alone
+    /// would pass on the code this replaces.
+    ///
+    /// Why the gate is different: a paused workflow run is *settled*, not
+    /// suspended, so nothing re-enters the gate and the parked effect is the
+    /// run's only continuation. A chat turn re-parks on its next attempt, which
+    /// is why its park stays `Process` — and why the volume this record is
+    /// written at is untouched.
+    #[test]
+    fn only_a_workflow_gate_park_is_host_durable() {
+        assert_eq!(
+            parked_with_kind(crate::runtime::WORKFLOW_APPROVE_KIND).durability(),
+            Durability::Host,
+            "a workflow gate's park is the run's only continuation — losing it \
+             strands the run behind a question that exists nowhere, and nothing \
+             re-parks it"
+        );
+
+        // The callers that do re-park, and the volume this record is written at.
+        for kind in ["shell", "http.request", "message.send", "composio_execute"] {
+            assert_eq!(
+                parked_with_kind(kind).durability(),
+                Durability::Process,
+                "{kind} parks are re-asked on the next attempt; flushing them \
+                 taxes the approval path for a question that comes back on its own"
+            );
+        }
     }
 
     /// **Issue #392**: a host-durable record's append really does take the


### PR DESCRIPTION
## Summary

`ApprovalParked` is written at `Durability::Process` on the reasoning stated in the code:

```rust
// Losing a park loses the *question*: the approval vanishes and the
// agent parks it again on its next attempt. Nothing external fired.
```

"Nothing external fired" is true and is the safety property. The re-park clause is a property of the **caller**, not of the record, and it was generalised to a caller that has no next attempt.

A **chat turn** does re-park — it re-enters the gate and mints a new approval, so the loss costs one extra question. The tolerance is exactly right there, and that is where the volume is. A **paused workflow run** does not.

This makes a workflow gate's park `Durability::Host`. Every other park is untouched.

## Why the workflow path cannot re-park — verified, not assumed

`workflow_resume`'s module docs state it as the fact its whole design turns on:

> **Resume is a re-run, because a paused run is settled.** A paused tinyflows run is **not suspended**. Nothing holds a task, a connection, or a continuation — the engine returns, the future completes, and the run is over.

So the parked effect is not a record *of* the continuation, it **is** the continuation — it carries the whole trigger input — and `WorkflowGateQueue::rearm` rebuilds the live gate set at recovery from exactly these still-parked lines. Lose the line and the run keeps a durable `pending_approvals` naming a question that exists nowhere: no card to decide, no re-park coming, and the whole downstream of that pipeline held behind it.

## This is less a new guarantee than one the crate already claims twice

`workflow_resume.rs`, listing what its design gets for free:

> **restart durability.** The parked effect carries the whole input, so a host that dies between the park and the approval **loses nothing**: journal replay rehydrates the card and approving it still resumes.

`CompanyCycle::park`, on the single write path into the queue:

> a parked effect is journaled exactly one way and **survives a restart** with its original `ApprovalId` regardless of who decided it.

Both hold for a *process* restart and fail for the host death the first one names, because `Process` is page-cache-resident by definition. So this is an internal inconsistency being closed, not a fresh durability policy being proposed.

## What is deliberately NOT included, and why it would have been a false fix

**An agent node's gated tool call.** Those park inside a workflow run too, and strand it just as badly — they are the `shell`, `curl`, `curl` in #1143's `feature_pipeline`. Flushing them would buy **nothing**. Their continuation needs the workflow id and the trigger input, which the tool-call effect does not carry, so `BlockedNodeQueue` stashes them **in memory** and — unlike the gate queue — does not rehydrate from the journal at all. `blocked_nodes.rs` says so itself:

> A restart in the middle of a blocked node therefore comes back with the `ContinuationQueue` counter re-armed but the stash empty […] That is a strictly worse restart story than the gate path's, and it is the Stage-1 boundary — the durable-card version is Stage 2 territory.

A durable record whose continuation died with the process is a flush that changes nothing, and it would read as a fix. That path is #899 Stage 2.

**This also rules out the discriminator that first looks obvious.** `Effect.run_id` cannot do the job: it is stamped with a *task attempt* id at the dispatch boundary and with a *workflow run* id by `gate_effect`, so `run_id.is_some()` would select card runs and blocked-node parks — the two cases this must not widen to. `WORKFLOW_APPROVE_KIND` is minted in exactly one place, for exactly the parks whose loss strands a run nothing will re-enter.

## The trade, priced

One flush on a record written at operator-decision scale, on the one effect kind a human is about to be asked about — the identical trade `GrantConsumed` accepted four arms up the same `match`, with the same reasoning written out. The host-durable set goes from three unconditional kinds to three plus one conditional arm; the other nine, and every non-workflow park, stay `Process`.

## One honesty note on the blast radius

`Durability::Process` survives a *process* restart, and on the mongodb backend it is an acknowledged insert, which survives a tenant container replacement too. The loss window is a host death on the fs backend, or a primary loss without `j:true` on mongodb. The durability gap is real and worth closing on its own terms — but I would not assume it is the proximate cause of all four stuck runs in #1143 without a separate look at that tenant's backend. This makes the failure impossible; it does not by itself prove what happened on `smoke1`.

Recommendation and full reasoning were [posted on #1145](https://github.com/tinyhumansai/opencompany/issues/1145#issuecomment-5343538738) before any code was written, as the issue asked.

## API Or Behavior Changes

No API change and no wire/schema change — `ApprovalParked`'s shape is untouched, so every line already on disk replays identically. The behaviour change is one `sync_data` / `synchronous=FULL` / `j:true` write on workflow-gate parks only.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — both ways: default features (the bare `Rust` lane's command) exit 0, and `--locked --no-deps --features openhuman,tinycortex --all-targets` exit 0.
- [x] `cargo build --all-targets` — `--locked --features openhuman,tinycortex --all-targets`, exit 0.
- [x] `cargo test` — both configurations: `--locked --features openhuman,tinycortex --tests` → **4518 passed, 0 failed, 3 ignored** (+26 across integration targets); `cargo test --locked` (default features) → **2980 passed, 0 failed**.

`only_a_workflow_gate_park_is_host_durable` pins **both arms in one test**, because the assertion *is* the distinction: the `Host` half alone would pass if every park were flushed — taxing the approval path to fix one caller — and the `Process` half alone passes on the code this replaces.

**Prove-red:** reverting the new arm fails it with *"a workflow gate's park is the run's only continuation — losing it strands the run behind a question that exists nowhere, and nothing re-parks it"* (exit 101).

The existing #392 guard `host_durable_kinds_are_exactly_the_three_that_could_repeat_an_action` is kept **unloosened** — its fixture's `ApprovalParked` carries an ordinary effect and stays on the `Process` side, so the policy pin that exists to notice a kind moving across the line still notices. The new conditional arm is pinned separately rather than by widening that list, which is the assertion that would otherwise have stopped noticing.

## Documentation

`append`'s durability contract updated — it enumerated "the three `Host` kinds" and "the other ten", which this change makes stale. Now states the three unconditional kinds, the one conditional arm and why it is decided by contents rather than tag, and the other nine.

Closes #1145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow gate approvals now remain available across host restarts.
  * Other parked approvals retain their existing process-lifetime behavior.

* **Documentation**
  * Clarified durability expectations for workflow gates, chat approvals, tool approvals, and other approval types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->