### PR TITLE
feat(approvals): let a workflow hold a standing permission (#1098)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2369,7 +2369,14 @@ impl CompanyRuntime {
                 // is offered on exactly the call the card itself is showing —
                 // which matters for `composio_execute`, where the same tool is
                 // grantable reading a repository and not grantable sending mail.
-                broadly_grantable: p.effect.agent.is_some() && p.effect.may_be_granted_standing(),
+                // Issue #1098 replaced "is there a teammate" with "is there a
+                // subject": a gate has no teammate but names the workflow it
+                // belongs to, and that workflow can hold a permission. Decided by
+                // the same `subject_of` the resolve route's 400 and the mint use,
+                // so the control the card offers and the answer a resolve gets
+                // cannot disagree.
+                broadly_grantable: crate::runtime::grants::subject_of(&p.effect).is_some()
+                    && p.effect.may_be_granted_standing(),
                 // Always false here. Whether a *reader* may see the contents is
                 // a property of who is asking, and this projection is
                 // deliberately principal-free (issue #618) — the redaction

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -7232,6 +7232,7 @@ members = ["eng1", "eng2"]
             .grant_standing(crate::runtime::grants::StandingGrant {
                 id: crate::runtime::grants::GrantId::new("g1"),
                 agent: "ceo".into(),
+                workflow: None,
                 tool: "workspace_write".into(),
                 granted_by: crate::ports::types::Actor {
                     kind: crate::ports::types::ActorKind::User,

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -135,7 +135,7 @@ use crate::metering::{usd_spent_by_agent, utc_day_start_millis};
 use crate::policy::CallPath;
 use crate::ports::UsageMeter;
 use crate::ports::types::{CompanyId, Effect, EffectGroup};
-use crate::runtime::grants::{GrantSet, GrantedCall};
+use crate::runtime::grants::{GrantSet, GrantSubject, GrantedCall};
 
 /// The name openhuman knows this policy by, and the name it stamps into the
 /// refusal it hands the model when a call is gated
@@ -643,6 +643,14 @@ impl ApprovalRequestQueue {
     /// The runtime mints and sweeps grants and the policy redeems them, so both
     /// sides must share one set. The builder creates the [`GrantSet`] first
     /// (it is feature-independent, unlike this queue) and hands it in here.
+    ///
+    /// The workflow gate pass uses it for a second reason (issue #1098): it
+    /// needs the company's real grants but must **not** share `inner`, because
+    /// `ApprovalPolicy::check` pushes its projected effect there and the shared
+    /// queue is drained by `park_gated_calls` and the chat cycle — either of
+    /// which would park a second, tool-call-shaped card for a decision the gate
+    /// card already covers. A fresh `inner` with the real `grants` is exactly
+    /// what this gives, and is why the two halves are separately owned.
     pub fn with_grants(grants: GrantSet) -> Self {
         Self {
             inner: Arc::default(),
@@ -753,6 +761,17 @@ pub struct ApprovalPolicy {
     /// projected before: no agent, so no grant, so the runtime executes it
     /// natively. Only `build_roster` sets it.
     agent: Option<String>,
+    /// Which authored workflow this policy instance is gating (issue #1098),
+    /// read by the standing-permission arm and by nothing else.
+    ///
+    /// `None` everywhere except the workflow gate pass, so no other construction
+    /// site changes behaviour. Set alongside — never instead of — the absent
+    /// [`agent`](Self::agent): a gate still projects an effect with no teammate
+    /// on it, because there is none. This names the subject a *standing*
+    /// permission may be matched against, and nothing else; see
+    /// [`with_workflow`](Self::with_workflow) for why the single-use arm stays
+    /// shut.
+    workflow: Option<String>,
     /// Which of the two paths the calls this instance judges arrive on (issue
     /// #674), read by the per-call judgement arm and by nothing else.
     ///
@@ -799,6 +818,7 @@ impl ApprovalPolicy {
             budget_usd_daily,
             requests: ApprovalRequestQueue::default(),
             agent: None,
+            workflow: None,
             spend: None,
             no_meter_warned: AtomicBool::new(false),
             // The strict path by default — see `for_authored_workflow_nodes`.
@@ -827,6 +847,29 @@ impl ApprovalPolicy {
     /// effect knows whose tool call it came from (issue #243).
     pub fn with_agent(mut self, agent: impl Into<String>) -> Self {
         self.agent = Some(agent.into());
+        self
+    }
+
+    /// Binds this policy to the authored workflow whose nodes it is gating, so a
+    /// standing permission the operator gave that workflow can be matched (issue
+    /// #1098).
+    ///
+    /// **This opens exactly one arm.** `standing_grant_allows` gains a subject
+    /// to match on; [`consume_grant`](Self::consume_grant) is untouched and
+    /// still short-circuits on the absent agent, so no single-use grant can ever
+    /// be minted or redeemed on this path. That asymmetry is the whole safety
+    /// argument and it is not an oversight: a `GrantedCall` is redeemed by
+    /// re-dispatching *the agent that asked*, and on a workflow path nobody
+    /// asked — such a grant could never be redeemed, would expire on its TTL,
+    /// and would tell the operator "the agent did not act" about a call no agent
+    /// made. See [`crate::workflows::gate`], which records that reasoning and
+    /// whose `agent: None` this deliberately does **not** undo.
+    ///
+    /// A standing permission has the opposite lifecycle and so is not covered by
+    /// that argument: nothing redeems it, it is matched at the gate before the
+    /// call and the call then proceeds in place.
+    pub fn with_workflow(mut self, workflow_id: impl Into<String>) -> Self {
+        self.workflow = Some(workflow_id.into());
         self
     }
 
@@ -923,6 +966,13 @@ impl ApprovalPolicy {
     /// and the developer have no way to tell a re-worded argument from a bug in
     /// the grant machinery.
     fn consume_grant(&self, tool: &str, args: &serde_json::Value) -> Option<GrantedCall> {
+        // Agent-only, permanently. Do NOT extend this to the workflow subject
+        // #1098 added to `standing_grant_allows` — the asymmetry is deliberate.
+        // A `GrantedCall` is redeemed by re-dispatching the agent that asked;
+        // on a workflow path nobody asked, so one minted here could never be
+        // redeemed, would expire on its TTL, and would tell the operator "the
+        // agent did not act" about a call no agent made. `crate::workflows::gate`
+        // records the full reasoning.
         let agent = self.agent.as_deref()?;
         let grants = self.requests.grants();
         if let Some(grant) = grants.consume(agent, tool, args) {
@@ -976,8 +1026,20 @@ impl ApprovalPolicy {
     ///   refuses it. A grant replayed from a line written before the field
     ///   existed is unscoped and behaves exactly as it did.
     fn standing_grant_allows(&self, tool: &str, args: &serde_json::Value) -> bool {
-        let Some(agent) = self.agent.as_deref() else {
-            return false;
+        // Issue #1098: an agent when one is installed, else the authored
+        // workflow this instance is gating. Neither means no subject to match a
+        // permission against, which is every construction site that has set
+        // up neither and is why they are unaffected.
+        let subject = match (self.agent.as_deref(), self.workflow.as_deref()) {
+            (Some(agent), _) => GrantSubject::Agent(agent.to_string()),
+            (None, Some(workflow)) => GrantSubject::Workflow(workflow.to_string()),
+            (None, None) => return false,
+        };
+        // Built only where a log line actually needs it — this runs on every
+        // gated tool call, and the two refusal paths below are the cold ones.
+        let holder = || match &subject {
+            GrantSubject::Agent(agent) => format!("agent '{agent}'"),
+            GrantSubject::Workflow(workflow) => format!("workflow '{workflow}'"),
         };
         if Self::is_priced_call(tool, args, Self::amount_usd(args)) {
             return false;
@@ -987,8 +1049,9 @@ impl ApprovalPolicy {
             .is_grantable()
         {
             log::debug!(
-                "[approval] tool '{tool}' holds a standing grant for agent '{agent}' but this \
-                 call is not grantable on its own arguments; parking it"
+                "[approval] tool '{tool}' holds a standing grant for {} but this \
+                 call is not grantable on its own arguments; parking it",
+                holder()
             );
             return false;
         }
@@ -998,7 +1061,7 @@ impl ApprovalPolicy {
         // a grant that never matches its own tool.
         let scope = crate::policy::consequence::standing_scope_of(tool, args);
         let Some(grant) = self.requests.grants().match_standing(
-            agent,
+            &subject,
             tool,
             scope.as_deref(),
             crate::ports::now_millis(),
@@ -1006,9 +1069,10 @@ impl ApprovalPolicy {
             return false;
         };
         log::debug!(
-            "[approval] tool '{tool}' allowed by standing grant {} for agent '{agent}' \
+            "[approval] tool '{tool}' allowed by standing grant {} for {} \
              (expires at {})",
             grant.id,
+            holder(),
             grant.expires_at_millis
         );
         true
@@ -3860,6 +3924,7 @@ mod tests {
         crate::runtime::grants::StandingGrant {
             id: crate::runtime::grants::GrantId::new("g1"),
             agent: agent.to_string(),
+            workflow: None,
             tool: tool.to_string(),
             granted_by: crate::ports::types::Actor {
                 kind: crate::ports::types::ActorKind::User,

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -2899,6 +2899,7 @@ mod tests {
         let grant = StandingGrant {
             id: GrantId::new("g610"),
             agent: "ops".to_string(),
+            workflow: None,
             tool: COMPOSIO_EXECUTE.to_string(),
             granted_by: crate::ports::types::Actor {
                 kind: crate::ports::types::ActorKind::User,

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1834,8 +1834,27 @@ impl Effect {
     /// every Composio action under one name, so the same tool is grantable when
     /// it is listing a repository's pull requests and per-call when it is
     /// sending mail.
+    ///
+    /// ## A workflow gate is asked about the call it is stopping (issue #1098)
+    ///
+    /// A gate's `kind` is the wrapper `workflow.approve`, so asking about it
+    /// classifies a name the declaration table has never heard of and returns
+    /// the undeclared fallback — the classifier never sees the `web_fetch` on
+    /// the card. That is a second, independent reason a workflow card is not
+    /// grantable today, on top of its `agent: None`, and fixing only the
+    /// principal would leave this one refusing every gate.
+    ///
+    /// [`gate_inner_call`](crate::runtime::workflow_resume::gate_inner_call)
+    /// reads the tool and arguments issue #846 already writes onto the payload,
+    /// so what is classified is what the card showed. Every other effect takes
+    /// the branch below unchanged, which is what keeps the agent path answering
+    /// exactly as it did.
     pub fn may_be_granted_standing(&self) -> bool {
-        crate::policy::consequence_of(&self.kind, &self.payload)
+        let (kind, payload) = match crate::runtime::workflow_resume::gate_inner_call(self) {
+            Some((tool, args)) => (tool, args),
+            None => (self.kind.as_str(), &self.payload),
+        };
+        crate::policy::consequence_of(kind, payload)
             .standing
             .is_grantable()
     }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -44,7 +44,7 @@ use crate::runtime::delegation_tools::{
     DELEGATE_TO_DESK_TOOL, DelegateArgs, SPAWN_TASK_TOOL, SpawnTaskArgs, desk_lead,
     unknown_desk_message,
 };
-use crate::runtime::grants::{GrantId, GrantScope, GrantedCall, StandingGrant};
+use crate::runtime::grants::{GrantId, GrantScope, GrantSubject, GrantedCall, StandingGrant};
 use crate::runtime::journal::{ApprovalConversation, ExecutedEffect, TaskLink};
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
@@ -962,9 +962,13 @@ approval.]"
         let Some(effect) = self.rt.approval_gate.parked_effect(id) else {
             return Ok(());
         };
-        if effect.agent.is_none() {
+        // Issue #1098: a teammate, or the authored workflow a gate belongs to.
+        // Neither means the runtime itself is performing this, and there is
+        // genuinely nothing to hold a permission — the refusal below is the same
+        // one it always was, now stated about a subject rather than an agent.
+        if crate::runtime::grants::subject_of(&effect).is_none() {
             return Err(OpenCompanyError::InvalidRequest(format!(
-                "'{}' is performed by the runtime itself, so there is no teammate's tool use to \
+                "'{}' is performed by the runtime itself, so there is nobody's tool use to \
                  grant; approve it once instead",
                 effect.kind
             )));
@@ -986,6 +990,20 @@ approval.]"
         by: Actor,
         scope: GrantScope,
     ) -> Result<()> {
+        // Issue #1098: a gate carries no teammate but can still hold a standing
+        // permission for its workflow, so that case is taken before the native
+        // fall-through below. Only for `GrantScope::Tool` — a `Once` approval of
+        // a gate is still performed natively, because the single-use grant this
+        // would otherwise mint has nobody to redeem it (see `crate::workflows::gate`).
+        if effect.agent.is_none()
+            && let GrantScope::Tool { expires_at_millis } = scope
+            && let Some(subject @ GrantSubject::Workflow(_)) =
+                crate::runtime::grants::subject_of(&effect)
+        {
+            return self
+                .mint_standing_grant(id, subject, effect, by, expires_at_millis)
+                .await;
+        }
         let Some(agent) = effect.agent.clone() else {
             let key = format!("approval:{id}");
             // The card that asked for this sign-off (issue #351). It is not
@@ -1003,8 +1021,14 @@ approval.]"
         match scope {
             GrantScope::Once => self.mint_grant(id, agent, effect).await,
             GrantScope::Tool { expires_at_millis } => {
-                self.mint_standing_grant(id, agent, effect, by, expires_at_millis)
-                    .await
+                self.mint_standing_grant(
+                    id,
+                    GrantSubject::Agent(agent),
+                    effect,
+                    by,
+                    expires_at_millis,
+                )
+                .await
             }
         }
     }
@@ -1024,7 +1048,7 @@ approval.]"
     async fn mint_standing_grant(
         &self,
         id: &ApprovalId,
-        agent: String,
+        subject: GrantSubject,
         effect: Effect,
         by: Actor,
         expires_at_millis: u64,
@@ -1034,12 +1058,33 @@ approval.]"
             .journal
             .approval_conversation(id)
             .unwrap_or_default();
+        // Issue #1098: a gate's `kind` is the `workflow.approve` wrapper, so the
+        // tool and arguments the permission is *about* are the inner call issue
+        // #846 wrote onto the payload — the same call the card showed. Every
+        // other effect is its own call and answers `None` here.
+        let (tool, args) = crate::runtime::workflow_resume::gate_inner_call(&effect)
+            .map(|(tool, args)| (tool.to_string(), args.clone()))
+            .unwrap_or_else(|| (effect.kind.clone(), effect.payload.clone()));
+        // Issue #457: which slice of the tool the card was actually about, read
+        // off the **parked effect's own payload** — the arguments the operator
+        // was shown — rather than re-derived from anything live, so the grant
+        // records the sentence they consented to. `None` for every tool whose
+        // name is the whole of what it can do.
+        //
+        // Computed here rather than inline in the literal below, which would
+        // borrow `tool` after the field above has moved it.
+        let scope = crate::policy::consequence::standing_scope_of(&tool, &args);
+        let (agent, workflow) = match subject {
+            GrantSubject::Agent(agent) => (agent, None),
+            GrantSubject::Workflow(workflow) => (String::new(), Some(workflow)),
+        };
         let grant = StandingGrant {
             id: GrantId::generate(),
             agent,
+            workflow,
             // The tool, and nothing about the arguments. A standing grant has no
             // `args` field to copy them into — that is the type's whole point.
-            tool: effect.kind.clone(),
+            tool,
             granted_by: by,
             approval_id: id.clone(),
             at_millis: now_millis(),
@@ -1053,19 +1098,19 @@ approval.]"
             // Issue #796: the task this call was parked from, carried so a
             // standing grant can reclaim the task's checkout across parks.
             origin_task: self.approval_work_key(id),
-            // Issue #457: which slice of the tool the card was actually about.
-            // Read off the **parked effect's own payload** — the arguments the
-            // operator was shown — rather than re-derived from anything live, so
-            // the grant records the sentence they consented to. `None` for every
-            // tool whose name is the whole of what it can do.
-            scope: crate::policy::consequence::standing_scope_of(&effect.kind, &effect.payload),
+            // Derived from the same `(tool, args)` the grant records, which for
+            // a gate is the inner call rather than the wrapper — read with the
+            // same function the live side uses, so the two cannot drift into a
+            // permission that never matches its own call.
+            scope,
         };
         self.rt.journal.record_standing_granted(&grant).await?;
         tracing::debug!(
             approval_id = %id,
             grant_id = %grant.id,
-            tool = %effect.kind,
+            tool = %grant.tool,
             agent = %grant.agent,
+            workflow = ?grant.workflow,
             expires_at_millis,
             "[approval] minted a standing grant; this tool will not ask again until it expires"
         );

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -250,7 +250,77 @@ pub enum GrantScope {
     },
 }
 
-/// A standing permission: one tool, one teammate, until a deadline (issue #374).
+/// Who may spend a standing permission (issue #1098).
+///
+/// Two kinds, and the second is the whole of that issue. A scheduled workflow
+/// re-asked the same question on every run because a permission could only name
+/// a teammate, and a graph that is simply running has none — so the case whose
+/// calls were *pre-declared by an operator* was the one case standing permission
+/// could not cover, while an agent choosing its arguments at run time could hold
+/// one.
+///
+/// # Why a workflow and not one of its nodes
+///
+/// The operator consented to a host, and a second call to that host from the
+/// same job is the same proposition they already agreed to. Keying on the node
+/// would re-park it — the workflow-shaped version of slug-exactness, which
+/// [`StandingGrant::scope`] records was rejected for Composio because it "would
+/// re-park every new action and make the grant worth nothing".
+///
+/// The cost is stated rather than hidden: for the six tools that are grantable
+/// with no scope at all (`file_write`, `edit`, `apply_patch`, `csv_export`,
+/// `memory_store`, `publish_artifact`) nothing narrows a workflow permission, so
+/// a node added inside the window inherits it. Three things bound that, and are
+/// why it is the accepted trade: `shell` and `http_request` are
+/// [`Standing::PerCall`](crate::policy::Standing) and never persist at all, the
+/// ceiling is seven days, and a permission is per-tool — "may write files" never
+/// implies "may publish". Narrowing this later means adding a node id to the
+/// workflow variant, and nothing else.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GrantSubject {
+    /// A roster teammate. Every permission minted before issue #1098.
+    Agent(String),
+    /// One authored workflow, by the stable id its file declares — not the run
+    /// id, which is fresh on every firing and would make each permission die
+    /// with the run that minted it.
+    Workflow(String),
+}
+
+impl GrantSubject {
+    /// A teammate subject from anything string-like.
+    pub fn agent(id: impl Into<String>) -> Self {
+        Self::Agent(id.into())
+    }
+
+    /// A workflow subject from anything string-like.
+    pub fn workflow(id: impl Into<String>) -> Self {
+        Self::Workflow(id.into())
+    }
+}
+
+/// Who could hold a standing permission for `effect`, or `None` when nobody
+/// could (issue #1098).
+///
+/// **The one place this is decided.** Three surfaces ask it — the card's
+/// `broadly_grantable` flag, the resolve route's 400, and the mint — and all
+/// three must agree or an operator is offered a control that then refuses them,
+/// which is the drift issue #444 exists to prevent.
+///
+/// A teammate wins when there is one. A gate has no teammate but does name the
+/// workflow it belongs to, and that is the subject issue #1098 added. `None` is
+/// every other native effect — something the runtime performs itself, where
+/// there is no tool use to hand over and approving once is the only honest
+/// answer.
+pub fn subject_of(effect: &crate::ports::types::Effect) -> Option<GrantSubject> {
+    if let Some(agent) = effect.agent.as_deref() {
+        return Some(GrantSubject::Agent(agent.to_string()));
+    }
+    crate::runtime::workflow_resume::gate_workflow_id(effect)
+        .map(|workflow| GrantSubject::Workflow(workflow.to_string()))
+}
+
+/// A standing permission: one tool, one subject, until a deadline (issues #374,
+/// #1098).
 ///
 /// Deliberately **not** a variant of [`GrantedCall`]. See the module docs: no
 /// `args` and a non-optional expiry are the two properties that make this type
@@ -260,7 +330,21 @@ pub struct StandingGrant {
     /// This grant's id — what a revoke addresses.
     pub id: GrantId,
     /// The roster agent allowed to redeem it. Nobody else matches.
+    ///
+    /// Empty on a workflow permission, which names its subject in
+    /// [`workflow`](Self::workflow) instead. Read
+    /// [`subject`](Self::subject) rather than this field — matching on a bare
+    /// agent string would let an empty one collide.
+    #[serde(default)]
     pub agent: String,
+    /// The authored workflow allowed to redeem it (issue #1098).
+    ///
+    /// `None` on every teammate permission, and on any journal line written
+    /// before this field existed — both of which are agent permissions and
+    /// resolve through [`agent`](Self::agent), so a replayed line reproduces
+    /// today's behaviour exactly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
     /// The tool it admits, with any arguments.
     pub tool: String,
     /// Who granted it. Journaled so "who opened this up" is answerable later.
@@ -353,6 +437,20 @@ pub struct StandingGrant {
 }
 
 impl StandingGrant {
+    /// Who may spend this permission (issue #1098).
+    ///
+    /// The one place the two subject fields are reconciled, so no caller has to
+    /// decide what an empty [`agent`](Self::agent) means. A line carrying
+    /// [`workflow`](Self::workflow) is a workflow permission; everything else —
+    /// including every line written before that field existed — is an agent
+    /// permission, which is what makes replay a no-op.
+    pub fn subject(&self) -> GrantSubject {
+        match self.workflow.as_deref() {
+            Some(workflow) => GrantSubject::Workflow(workflow.to_string()),
+            None => GrantSubject::Agent(self.agent.clone()),
+        }
+    }
+
     /// Whether this grant admits a call whose live scope is `scope` (issue
     /// #457).
     ///
@@ -599,7 +697,7 @@ impl GrantSet {
             .insert(grant.id.clone(), grant);
     }
 
-    /// Matches an unexpired standing grant for `(agent, tool, scope)`
+    /// Matches an unexpired standing grant for `(subject, tool, scope)`
     /// **without** removing it — that is the whole difference from
     /// [`consume`](Self::consume).
     ///
@@ -622,9 +720,13 @@ impl GrantSet {
     /// most recent intent is the more permissive one they are living with, and
     /// picking arbitrarily out of a `HashMap` would make redemption depend on
     /// hash order.
+    /// `subject` rather than a bare agent string (issue #1098): a workflow
+    /// permission carries an empty [`StandingGrant::agent`], so a `&str`
+    /// parameter would let one match on emptiness. The enum makes the two kinds
+    /// of subject impossible to confuse at the call site.
     pub fn match_standing(
         &self,
-        agent: &str,
+        subject: &GrantSubject,
         tool: &str,
         scope: Option<&str>,
         now_millis: u64,
@@ -634,7 +736,7 @@ impl GrantSet {
             .standing
             .values()
             .filter(|g| {
-                g.agent == agent
+                &g.subject() == subject
                     && g.tool == tool
                     && g.admits_scope(scope)
                     && g.is_live_at(now_millis)
@@ -968,6 +1070,7 @@ mod test {
         StandingGrant {
             id: GrantId::new(id),
             agent: agent.to_string(),
+            workflow: None,
             tool: tool.to_string(),
             granted_by: operator(),
             approval_id: ApprovalId::new(format!("approval-{id}")),
@@ -978,6 +1081,118 @@ mod test {
             origin_task: None,
             scope: None,
         }
+    }
+
+    /// A permission held by a workflow rather than a teammate (issue #1098).
+    fn standing_workflow(
+        id: &str,
+        workflow: &str,
+        tool: &str,
+        scope: Option<&str>,
+        expires_at_millis: u64,
+    ) -> StandingGrant {
+        StandingGrant {
+            agent: String::new(),
+            workflow: Some(workflow.to_string()),
+            scope: scope.map(str::to_string),
+            ..standing(id, "", tool, expires_at_millis)
+        }
+    }
+
+    /// The two subject fields reconcile in exactly one place, and a line with no
+    /// `workflow` is an agent permission — which is what makes every journal line
+    /// written before issue #1098 replay unchanged.
+    #[test]
+    fn subject_reads_a_workflow_line_as_a_workflow_and_everything_else_as_an_agent() {
+        assert_eq!(
+            standing("g1", "maya", "web_fetch", 9_999).subject(),
+            GrantSubject::agent("maya")
+        );
+        assert_eq!(
+            standing_workflow("g2", "sports_blog", "web_fetch", None, 9_999).subject(),
+            GrantSubject::workflow("sports_blog")
+        );
+    }
+
+    /// A journal line written before the field existed carries no `workflow` key
+    /// at all. It must deserialize, and it must replay as the agent permission it
+    /// was — not as a workflow one keyed on an empty string.
+    #[test]
+    fn a_pre_1098_journal_line_replays_as_an_agent_permission() {
+        let line = r#"{
+            "id": "g-old",
+            "agent": "maya",
+            "tool": "web_fetch",
+            "granted_by": { "kind": "user", "id": "user-1" },
+            "approval_id": "approval-old",
+            "at_millis": 1000,
+            "expires_at_millis": 9999
+        }"#;
+        let replayed: StandingGrant =
+            serde_json::from_str(line).expect("a pre-#1098 line still deserializes");
+        assert_eq!(replayed.workflow, None);
+        assert_eq!(replayed.subject(), GrantSubject::agent("maya"));
+
+        let set = GrantSet::default();
+        set.grant_standing(replayed);
+        assert!(
+            set.match_standing(&GrantSubject::agent("maya"), "web_fetch", None, 2_000)
+                .is_some(),
+            "a replayed line must still admit the calls it always admitted"
+        );
+    }
+
+    /// The two subjects are separate namespaces. A workflow named like a teammate
+    /// must not spend that teammate's permission, in either direction.
+    #[test]
+    fn an_agent_and_a_workflow_of_the_same_name_do_not_share_a_permission() {
+        let set = GrantSet::default();
+        set.grant_standing(standing("g1", "digest", "web_fetch", 9_999));
+
+        assert!(
+            set.match_standing(&GrantSubject::workflow("digest"), "web_fetch", None, 2_000)
+                .is_none(),
+            "a workflow must not spend a teammate's permission"
+        );
+
+        let set = GrantSet::default();
+        set.grant_standing(standing_workflow("g2", "digest", "web_fetch", None, 9_999));
+        assert!(
+            set.match_standing(&GrantSubject::agent("digest"), "web_fetch", None, 2_000)
+                .is_none(),
+            "a teammate must not spend a workflow's permission"
+        );
+    }
+
+    /// The scope machinery is subject-agnostic: a workflow permission narrows by
+    /// host on exactly the terms a teammate's does.
+    #[test]
+    fn a_workflow_permission_is_narrowed_by_its_host_like_any_other() {
+        let set = GrantSet::default();
+        set.grant_standing(standing_workflow(
+            "g1",
+            "sports_blog",
+            "web_fetch",
+            Some("https://www.bbc.co.uk"),
+            9_999,
+        ));
+        let subject = GrantSubject::workflow("sports_blog");
+
+        assert!(
+            set.match_standing(&subject, "web_fetch", Some("https://www.bbc.co.uk"), 2_000)
+                .is_some(),
+            "the host it was granted for keeps passing"
+        );
+        assert!(
+            set.match_standing(&subject, "web_fetch", Some("https://www.espn.com"), 2_000)
+                .is_none(),
+            "a repointed host re-parks — scope equality is the invalidation"
+        );
+        assert!(
+            set.match_standing(&subject, "web_fetch", None, 2_000)
+                .is_none(),
+            "a call whose host cannot be read is refused by a scoped permission"
+        );
     }
 
     /// A grant confined to one Composio toolkit (issue #457).
@@ -1001,10 +1216,16 @@ mod test {
         let set = GrantSet::default();
         set.grant_standing(standing("g1", "ops", "shell", 10_000));
 
-        assert!(set.match_standing("ops", "shell", None, 2_000).is_some());
+        assert!(
+            set.match_standing(&GrantSubject::agent("ops"), "shell", None, 2_000)
+                .is_some()
+        );
         // Matching does not depend on arguments at all — there are none to
         // depend on. Two different calls, same admission.
-        assert!(set.match_standing("ops", "shell", None, 9_999).is_some());
+        assert!(
+            set.match_standing(&GrantSubject::agent("ops"), "shell", None, 9_999)
+                .is_some()
+        );
         assert_eq!(
             set.standing_count(),
             1,
@@ -1012,8 +1233,14 @@ mod test {
         );
 
         // The deadline instant itself is already past.
-        assert!(set.match_standing("ops", "shell", None, 10_000).is_none());
-        assert!(set.match_standing("ops", "shell", None, 10_001).is_none());
+        assert!(
+            set.match_standing(&GrantSubject::agent("ops"), "shell", None, 10_000)
+                .is_none()
+        );
+        assert!(
+            set.match_standing(&GrantSubject::agent("ops"), "shell", None, 10_001)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1022,12 +1249,12 @@ mod test {
         set.grant_standing(standing("g1", "ops", "shell", 10_000));
 
         assert!(
-            set.match_standing("marketing", "shell", None, 2_000)
+            set.match_standing(&GrantSubject::agent("marketing"), "shell", None, 2_000)
                 .is_none(),
             "another teammate is not who the operator granted"
         );
         assert!(
-            set.match_standing("ops", "workspace_write", None, 2_000)
+            set.match_standing(&GrantSubject::agent("ops"), "workspace_write", None, 2_000)
                 .is_none(),
             "another tool is not what the operator granted"
         );
@@ -1044,13 +1271,23 @@ mod test {
         set.grant_standing(scoped("g1", "ops", "composio_execute", "github", 10_000));
 
         assert!(
-            set.match_standing("ops", "composio_execute", Some("github"), 2_000)
-                .is_some(),
+            set.match_standing(
+                &GrantSubject::agent("ops"),
+                "composio_execute",
+                Some("github"),
+                2_000
+            )
+            .is_some(),
             "a second GitHub read is the sentence the operator agreed to"
         );
         assert!(
-            set.match_standing("ops", "composio_execute", Some("gmail"), 2_000)
-                .is_none(),
+            set.match_standing(
+                &GrantSubject::agent("ops"),
+                "composio_execute",
+                Some("gmail"),
+                2_000
+            )
+            .is_none(),
             "'read from GitHub' is not consent to read a mailbox"
         );
     }
@@ -1065,7 +1302,7 @@ mod test {
         set.grant_standing(scoped("g1", "ops", "composio_execute", "github", 10_000));
 
         assert!(
-            set.match_standing("ops", "composio_execute", None, 2_000)
+            set.match_standing(&GrantSubject::agent("ops"), "composio_execute", None, 2_000)
                 .is_none()
         );
     }
@@ -1098,19 +1335,29 @@ mod test {
         // whatever the live call resolves to.
         for live in [Some("github"), Some("gmail"), None] {
             assert!(
-                set.match_standing("ops", "composio_execute", live, 2_000)
+                set.match_standing(&GrantSubject::agent("ops"), "composio_execute", live, 2_000)
                     .is_some(),
                 "an unscoped grant must keep admitting: {live:?}"
             );
         }
         // …and the boundaries it always had still hold.
         assert!(
-            set.match_standing("marketing", "composio_execute", Some("github"), 2_000)
-                .is_none()
+            set.match_standing(
+                &GrantSubject::agent("marketing"),
+                "composio_execute",
+                Some("github"),
+                2_000
+            )
+            .is_none()
         );
         assert!(
-            set.match_standing("ops", "composio_execute", Some("github"), 10_000)
-                .is_none()
+            set.match_standing(
+                &GrantSubject::agent("ops"),
+                "composio_execute",
+                Some("github"),
+                10_000
+            )
+            .is_none()
         );
     }
 
@@ -1135,11 +1382,17 @@ mod test {
     fn revoking_a_standing_grant_stops_it_matching() {
         let set = GrantSet::default();
         set.grant_standing(standing("g1", "ops", "shell", 10_000));
-        assert!(set.match_standing("ops", "shell", None, 2_000).is_some());
+        assert!(
+            set.match_standing(&GrantSubject::agent("ops"), "shell", None, 2_000)
+                .is_some()
+        );
 
         let revoked = set.revoke_standing(&GrantId::new("g1")).expect("was live");
         assert_eq!(revoked.tool, "shell");
-        assert!(set.match_standing("ops", "shell", None, 2_000).is_none());
+        assert!(
+            set.match_standing(&GrantSubject::agent("ops"), "shell", None, 2_000)
+                .is_none()
+        );
         assert_eq!(set.standing_count(), 0);
         assert!(
             set.revoke_standing(&GrantId::new("g1")).is_none(),
@@ -1179,7 +1432,7 @@ mod test {
         assert_eq!(expired[0].id, GrantId::new("old"));
         assert_eq!(set.standing_count(), 1);
         assert!(
-            set.match_standing("ops", "workspace_write", None, 10_000)
+            set.match_standing(&GrantSubject::agent("ops"), "workspace_write", None, 10_000)
                 .is_some()
         );
     }
@@ -1191,7 +1444,7 @@ mod test {
         set.grant_standing(standing("long", "ops", "shell", 50_000));
 
         let matched = set
-            .match_standing("ops", "shell", None, 1_000)
+            .match_standing(&GrantSubject::agent("ops"), "shell", None, 1_000)
             .expect("matches");
         assert_eq!(matched.id, GrantId::new("long"));
     }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -2969,6 +2969,7 @@ mod test {
         StandingGrant {
             id: GrantId::new(id),
             agent: "ops".into(),
+            workflow: None,
             tool: tool.into(),
             granted_by: Actor {
                 kind: crate::ports::types::ActorKind::User,

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -506,6 +506,68 @@ pub fn gate_node_id(effect: &Effect) -> Option<&str> {
         .filter(|node| !node.trim().is_empty())
 }
 
+/// The workflow a parked [`WORKFLOW_APPROVE_KIND`] effect belongs to, or `None`
+/// for any other effect (issue #1098).
+///
+/// The subject half of a workflow standing permission, read off the payload the
+/// park already writes. Kind-checked for the same reason [`gate_node_id`] is: a
+/// non-gate effect carrying a `workflow_id` must not be mistaken for one.
+pub fn gate_workflow_id(effect: &Effect) -> Option<&str> {
+    if effect.kind != WORKFLOW_APPROVE_KIND {
+        return None;
+    }
+    effect
+        .payload
+        .get(PAYLOAD_WORKFLOW_ID)
+        .and_then(Value::as_str)
+        .filter(|workflow| !workflow.trim().is_empty())
+}
+
+/// The call a parked [`WORKFLOW_APPROVE_KIND`] effect is stopping — `(tool,
+/// args)` — or `None` for any other effect, and for a gate whose call the host
+/// could not classify (issue #1098).
+///
+/// # Why this exists
+///
+/// A gate's [`kind`](Effect::kind) is the wrapper `workflow.approve`, not the
+/// tool the node is about to call. Anything that classifies an effect by asking
+/// [`consequence_of`](crate::policy::consequence_of) about its `kind` therefore
+/// asks about a name the declaration table has never heard of, and gets the
+/// undeclared fallback rather than an answer about the real call. That is
+/// correct as a default — an unknown name must fail closed — but it means the
+/// classifier never sees the `web_fetch` the operator is actually looking at.
+///
+/// The call itself is already on the payload: issue #846 wrote
+/// [`PAYLOAD_TOOL`] / [`PAYLOAD_ARGS`] so a workflow card could say *which*
+/// call it is stopping instead of naming a node id. This reads the same two
+/// keys back, so the thing classified is the thing the card showed.
+///
+/// # Absent arguments are `Null`, not an error
+///
+/// [`PAYLOAD_ARGS`] is written only when the node had arguments to write, so a
+/// tool present with no args is an ordinary shape rather than a broken one. It
+/// answers `Value::Null`, which every argument-aware classifier reads as "no
+/// argument I can place" and resolves in the cautious direction — a `web_fetch`
+/// with no readable host is [`Standing::PerCall`](crate::policy::Standing), not
+/// an unscoped permission. Node arguments may also still be unresolved
+/// `=`-expressions at gate time, which lands in the same place for the same
+/// reason.
+pub fn gate_inner_call(effect: &Effect) -> Option<(&str, &Value)> {
+    if effect.kind != WORKFLOW_APPROVE_KIND {
+        return None;
+    }
+    let tool = effect
+        .payload
+        .get(PAYLOAD_TOOL)
+        .and_then(Value::as_str)
+        .filter(|tool| !tool.trim().is_empty())?;
+    // `'static` rather than `&Value::Null`: the return borrows from `effect`, so
+    // a reference to a temporary would not outlive the call.
+    static NO_ARGS: Value = Value::Null;
+    let args = effect.payload.get(PAYLOAD_ARGS).unwrap_or(&NO_ARGS);
+    Some((tool, args))
+}
+
 /// The ledger a gate parked on this run should carry: what the run just
 /// delivered, unioned with what its own trigger input already listed.
 ///
@@ -1275,6 +1337,136 @@ mod tests {
 
     fn effect(workflow: &str, node: &str, input: Value) -> Effect {
         gate_effect(workflow, node, &input, "run-1", &[], &[], None)
+    }
+
+    /// A gate whose call the host classified — the shape issue #846 writes and
+    /// issue #1098 reads back.
+    fn gate_with_call(tool: &str, args: &Value) -> Effect {
+        gate_effect(
+            "sports_blog",
+            "fetch_bbc",
+            &json!({}),
+            "run-1",
+            &[],
+            &[],
+            Some(GateCall {
+                tool,
+                reason: None,
+                args: Some(args),
+                target: None,
+            }),
+        )
+    }
+
+    #[test]
+    fn gate_inner_call_reads_the_call_the_card_shows() {
+        let args = json!({ "url": "https://www.bbc.co.uk/sport" });
+        let gate = gate_with_call("web_fetch", &args);
+
+        let (tool, read_back) = gate_inner_call(&gate).expect("a classified gate names its call");
+        assert_eq!(tool, "web_fetch");
+        assert_eq!(read_back, &args);
+    }
+
+    /// The wrapper is what a naive classifier sees, and it is not the call. This
+    /// is the whole reason the projection exists.
+    #[test]
+    fn gate_inner_call_is_not_the_effect_kind() {
+        let gate = gate_with_call("web_fetch", &json!({ "url": "https://www.bbc.co.uk" }));
+        assert_eq!(gate.kind, WORKFLOW_APPROVE_KIND);
+        assert_eq!(
+            gate_inner_call(&gate).map(|(tool, _)| tool),
+            Some("web_fetch")
+        );
+    }
+
+    /// A gate the host could not classify has no inner call to offer, and must
+    /// not invent one — it stays per-call, as it always did.
+    #[test]
+    fn gate_inner_call_is_none_when_the_call_was_never_named() {
+        let bare = effect("sports_blog", "fetch_bbc", json!({}));
+        assert!(gate_inner_call(&bare).is_none());
+    }
+
+    /// `args` is written only when the node had some, so tool-without-args is an
+    /// ordinary shape. It answers `Null`, which every argument-aware classifier
+    /// resolves in the cautious direction.
+    #[test]
+    fn gate_inner_call_answers_null_for_a_call_with_no_arguments() {
+        let gate = gate_effect(
+            "sports_blog",
+            "fetch_bbc",
+            &json!({}),
+            "run-1",
+            &[],
+            &[],
+            Some(GateCall {
+                tool: "web_fetch",
+                reason: None,
+                args: None,
+                target: None,
+            }),
+        );
+        assert_eq!(gate_inner_call(&gate), Some(("web_fetch", &Value::Null)));
+    }
+
+    /// Kind-checked for the same reason [`gate_node_id`] is: a teammate's own
+    /// `web_fetch` effect carries a tool name too, and must not be read as a
+    /// gate.
+    #[test]
+    fn gate_inner_call_ignores_a_non_gate_effect() {
+        let mut agent_call = gate_with_call("web_fetch", &json!({ "url": "https://x.test" }));
+        agent_call.kind = "web_fetch".to_string();
+        assert!(gate_inner_call(&agent_call).is_none());
+    }
+
+    /// The second half of why a job card was never grantable, independent of its
+    /// `agent: None`. Classifying the wrapper asks about `workflow.approve`, an
+    /// undeclared name that fails closed; classifying the inner call asks about
+    /// the `web_fetch` the operator is looking at.
+    #[test]
+    fn a_gate_is_classified_by_the_call_it_stops_not_by_its_wrapper() {
+        let gate = gate_with_call(
+            crate::policy::consequence::WEB_FETCH,
+            &json!({ "url": "https://www.bbc.co.uk/sport" }),
+        );
+
+        assert!(
+            !crate::policy::consequence_of(&gate.kind, &gate.payload)
+                .standing
+                .is_grantable(),
+            "the wrapper kind is undeclared and must keep failing closed on its own"
+        );
+        assert!(
+            gate.may_be_granted_standing(),
+            "a BBC fetch is ScopedGrantable, and that is the call the card shows"
+        );
+    }
+
+    /// A gate stopping a per-call tool stays per-call. Reading the inner call
+    /// must widen nothing on its own — the classifier still decides.
+    #[test]
+    fn a_gate_stopping_a_per_call_tool_is_still_not_grantable() {
+        let gate = gate_with_call("shell", &json!({ "command": "echo hi" }));
+        assert!(!gate.may_be_granted_standing());
+    }
+
+    /// No readable host means no scope, and `ScopedGrantable` falls back to
+    /// per-call rather than minting a permission that would admit everything.
+    #[test]
+    fn a_gate_whose_url_names_no_host_is_still_not_grantable() {
+        let gate = gate_with_call(crate::policy::consequence::WEB_FETCH, &json!({}));
+        assert!(!gate.may_be_granted_standing());
+    }
+
+    #[test]
+    fn gate_workflow_id_names_the_permission_subject() {
+        let gate = effect("sports_blog", "fetch_bbc", json!({}));
+        assert_eq!(gate_workflow_id(&gate), Some("sports_blog"));
+
+        let mut not_a_gate = gate.clone();
+        not_a_gate.kind = "web_fetch".to_string();
+        assert!(gate_workflow_id(&not_a_gate).is_none());
     }
 
     /// A delivery row with `status`, as `deliver_outputs` would have returned it.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -7731,6 +7731,7 @@ mode = "full"
             .grant_standing(crate::runtime::grants::StandingGrant {
                 id: crate::runtime::grants::GrantId::new("g1"),
                 agent: "ops".into(),
+                workflow: None,
                 tool: "workspace_write".into(),
                 granted_by: Actor {
                     kind: ActorKind::User,

--- a/src/workflows/caps/resolver.rs
+++ b/src/workflows/caps/resolver.rs
@@ -137,6 +137,9 @@ impl StoreWorkflowResolver {
             &self.company,
             child_id,
             &audit.run_id,
+            // Issue #1098: the audit reports calls never offered for approval at
+            // all, so it deliberately does not consult standing permissions.
+            None,
         )
         .await;
 

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -53,6 +53,16 @@
 //! TTL and the operator would be told the agent did not act, about a call no
 //! agent ever made.
 //!
+//! That argument is about the **single-use** grant and only it, which is why
+//! issue #1098 could open the standing arm without touching this one. A
+//! [`StandingGrant`](crate::runtime::grants::StandingGrant) is never redeemed by
+//! anybody: it is matched at the gate, before the call, and the call then
+//! proceeds in place. Nothing has to be re-dispatched, so "nothing would ever
+//! redeem it" is not a property of it. `consume_grant` therefore stays closed on
+//! this path permanently and
+//! [`standing_grant_allows`](crate::harness::policy::ApprovalPolicy) does not —
+//! the asymmetry is the safety argument, not an oversight to tidy up.
+//!
 //! And the seam says so itself. [`ToolInvoker::invoke`](tinyflows::caps::ToolInvoker)
 //! receives `(slug, args, conn)` — no node id, no run state. It cannot name the
 //! node on a card, and on a continuation it could not recognise a call the
@@ -95,15 +105,22 @@
 //!
 //! # Deliberate deviations, stated rather than quietly satisfied
 //!
-//! * **Standing grants cannot apply "identically on both paths"** (a criterion
-//!   in #460's body). A standing grant is scoped to a teammate
-//!   ([`admits_scope`](crate::runtime::grants::StandingGrant::admits_scope)) and
-//!   a `tool_call` node has no teammate — it acts as the company. This module
-//!   therefore matches grants against a synthetic `workflow:{id}` principal,
-//!   which nothing mints for today, so the answer is always **fail-closed**: a
-//!   teammate's standing grant does not open a workflow node's gate. Widening
-//!   that is a consent decision for the maintainer, not one to make by
-//!   defaulting.
+//! * **Standing grants now apply on this path too** (issue #1098). #460 left
+//!   this fail-closed and named the reason: a standing grant was scoped to a
+//!   teammate, a `tool_call` node has none, and *"widening that is a consent
+//!   decision for the maintainer, not one to make by defaulting."* #1098 is that
+//!   decision taken. The workflow is now a real grant subject
+//!   ([`GrantSubject::Workflow`](crate::runtime::grants::GrantSubject)), so a
+//!   permission the operator gave *this workflow* opens its gates until the
+//!   deadline — which is what stops a scheduled run re-asking the same question
+//!   every time it fires.
+//!
+//!   Three things did **not** widen with it. A *teammate's* grant still does not
+//!   open a workflow node's gate: the two subjects are separate namespaces and a
+//!   workflow named like a teammate matches nothing of theirs. The permission is
+//!   still refused unless the call is grantable on its own arguments, so
+//!   `shell` and `http_request` keep asking every run. And the **single-use**
+//!   arm is untouched — see the note below.
 //! * **A `Deny` verdict is not enforced here.** Under `readonly`,
 //!   [`ApprovalPolicy::check`] denies external effects outright. Honouring that
 //!   would be a *new refusal* on a path that runs today, i.e. exactly the
@@ -131,8 +148,9 @@ use oh::agent::tool_policy::{ToolCallContext, ToolPolicy, ToolPolicyDecision, To
 use openhuman_core::openhuman as oh;
 
 use crate::company::Policy;
-use crate::harness::policy::ApprovalPolicy;
+use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::runtime::grants::GrantSet;
 
 /// The tool name an `http_request` node's call is classified as (issue #614).
 ///
@@ -237,6 +255,7 @@ pub(crate) async fn apply_policy_gates(
     record: &CompanyRecord,
     workflow_id: &str,
     run_id: &str,
+    grants: &GrantSet,
 ) -> Vec<GatedCall> {
     let gated = policy_gates(
         graph,
@@ -244,6 +263,7 @@ pub(crate) async fn apply_policy_gates(
         &record.id,
         workflow_id,
         run_id,
+        Some(grants),
     )
     .await;
 
@@ -272,18 +292,47 @@ pub(crate) async fn apply_policy_gates(
 /// what it found, so an operator reviewing what was approved is not left with a
 /// hole they cannot account for. One classifier, so the audit line and the gate
 /// can never disagree about the same call.
+///
+/// `grants` is the company's live permission set (issue #1098). `Some` on the
+/// gate path, so a standing permission the operator gave this workflow is
+/// honoured and the node does not park again. **`None` on the #617 audit line**,
+/// deliberately: that line discloses calls this run never offered for approval
+/// at all, and a permission is about not asking *again*. Passing the set there
+/// would suppress a disclosure on the grounds that a *different* question had
+/// once been answered. The two can only differ by the audit naming a call the
+/// gate would have let through, which over-discloses — the safe direction for a
+/// line that reports rather than enforces.
 pub(crate) async fn policy_gates(
     graph: &WorkflowGraph,
     company_policy: &Policy,
     company: &CompanyId,
     workflow_id: &str,
     run_id: &str,
+    grants: Option<&GrantSet>,
 ) -> Vec<GatedCall> {
     // The manifest's `[policy]` verbatim — same mode, same `always_approve`,
     // same `auto_approve_under_usd` the roster runs under. No per-agent budget:
     // a workflow node is not a teammate, and the company-wide ceiling is
     // enforced elsewhere.
-    let policy = ApprovalPolicy::new(company_policy, None).for_authored_workflow_nodes();
+    //
+    // Issue #1098: bound to the workflow, so the standing-permission arm has a
+    // subject to match on. Built **once** for the whole graph rather than per
+    // node — the subject is the workflow, and every node of it spends the same
+    // permission. The agent stays unbound, so the single-use arm stays closed.
+    //
+    // The queue is private-but-grant-sharing for the reason the module note
+    // gives: `check` pushes its projected effect onto `requests`, and a shared
+    // queue would have `park_gated_calls` or the chat cycle drain it into a
+    // second, tool-call-shaped card for a decision this pass already carded.
+    // The grants half must still be the company's real one or the permission is
+    // invisible to the pass that has to honour it.
+    let policy = ApprovalPolicy::new(company_policy, None)
+        .for_authored_workflow_nodes()
+        .with_workflow(workflow_id);
+    let policy = match grants {
+        Some(grants) => policy.with_requests(ApprovalRequestQueue::with_grants(grants.clone())),
+        None => policy,
+    };
     let mut gated = Vec::new();
 
     for node in &graph.nodes {
@@ -656,7 +705,14 @@ description = "Runs Acme."
     #[tokio::test]
     async fn a_consequential_call_gates_under_supervised() {
         let mut g = graph(vec![tool_node("run-it", "shell")]);
-        let gated = apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(gate_ids(&g), ["run-it"]);
         assert_eq!(gated.len(), 1);
@@ -676,7 +732,14 @@ description = "Runs Acme."
     async fn full_autonomy_leaves_the_graph_untouched() {
         let before = graph(vec![tool_node("run-it", "shell")]);
         let mut after = before.clone();
-        let gated = apply_policy_gates(&mut after, &company("full", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut after,
+            &company("full", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert!(gated.is_empty());
         assert_eq!(after.nodes[0].config, before.nodes[0].config);
@@ -699,7 +762,14 @@ description = "Runs Acme."
         node.config = json!({ "slug": "shell", "args": { "command": "=previous.output" } });
         let mut g = graph(vec![node]);
 
-        let gated = apply_policy_gates(&mut g, &company("full", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("full", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(gate_ids(&g), vec!["run-it"]);
         assert_eq!(gated.len(), 1, "{gated:?}");
@@ -725,7 +795,14 @@ description = "Runs Acme."
         node.config = json!({ "method": "POST", "url": "=item.endpoint" });
         let mut g = graph(vec![node]);
 
-        let gated = apply_policy_gates(&mut g, &company("full", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("full", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(gated.len(), 1, "{gated:?}");
         assert_eq!(
@@ -753,7 +830,14 @@ description = "Runs Acme."
             tool_node("read", "file_read"),
             tool_node("search", "web_search"),
         ]);
-        let gated = apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert!(gated.is_empty(), "{gated:?}");
         assert!(gate_ids(&g).is_empty());
@@ -811,8 +895,14 @@ description = "Runs Acme."
     #[tokio::test]
     async fn always_approve_gates_a_call_the_tier_would_allow() {
         let mut g = graph(vec![tool_node("search", "web_search")]);
-        let gated =
-            apply_policy_gates(&mut g, &company("full", &["web_search"]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("full", &["web_search"]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(gate_ids(&g), ["search"]);
         assert!(gated[0].reason.contains("always-approve"), "{gated:?}");
@@ -826,7 +916,14 @@ description = "Runs Acme."
         node.config = json!({ "slug": "shell", "requires_approval": false });
         let mut g = graph(vec![node]);
 
-        apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(g.nodes[0].config["requires_approval"], json!(true));
     }
@@ -846,7 +943,14 @@ description = "Runs Acme."
         transform.kind = NodeKind::Transform;
         let mut g = graph(vec![agent, transform]);
 
-        let gated = apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert!(gated.is_empty(), "{gated:?}");
         assert!(gate_ids(&g).is_empty());
@@ -864,7 +968,14 @@ description = "Runs Acme."
             json!({ "method": "post", "url": "https://api.example.com/v1/pay?token=s3cret" });
         let mut g = graph(vec![node]);
 
-        let gated = apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(gate_ids(&g), ["fetch"]);
         assert_eq!(gated[0].slug, "http_request");
@@ -887,7 +998,14 @@ description = "Runs Acme."
         let before = node.config.clone();
         let mut g = graph(vec![node]);
 
-        let gated = apply_policy_gates(&mut g, &company("full", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("full", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert!(gated.is_empty(), "{gated:?}");
         assert_eq!(g.nodes[0].config, before);
@@ -906,7 +1024,14 @@ description = "Runs Acme."
         node.config = json!({ "method": "GET", "url": "=item.endpoint" });
         let mut g = graph(vec![node]);
 
-        let gated = apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert_eq!(gate_ids(&g), ["fetch"]);
         let target = gated[0].target.as_deref().expect("the absence is stated");
@@ -983,7 +1108,14 @@ description = "Runs Acme."
         node.config = json!({});
         let mut g = graph(vec![node]);
 
-        let gated = apply_policy_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+        let gated = apply_policy_gates(
+            &mut g,
+            &company("supervised", &[]),
+            "wf",
+            "run-1",
+            &GrantSet::default(),
+        )
+        .await;
 
         assert!(gated.is_empty());
         assert!(gate_ids(&g).is_empty());

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -56,6 +56,10 @@ mod parallel_gate_fanout_test;
 pub mod replay;
 pub mod runner;
 pub mod translate;
+/// Issue #1098: a scheduled workflow granted a standing permission stops
+/// re-asking on every run — two runs, because a single-run test cannot see it.
+#[cfg(test)]
+mod workflow_standing_grant_test;
 
 pub use caps::{HarnessAgentRunner, build_capabilities};
 pub use delivery::{DeliveryParking, WorkflowDeliveryDeps, deliver_outputs, deliver_outputs_dry};

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -262,7 +262,18 @@ async fn run_workflow_inner(
     let gated = if ctx.dry_run {
         Vec::new()
     } else {
-        super::gate::apply_policy_gates(&mut graph, record, &workflow.id, &ctx.run_id).await
+        super::gate::apply_policy_gates(
+            &mut graph,
+            record,
+            &workflow.id,
+            &ctx.run_id,
+            // Issue #1098: the company's live permission set, so a workflow the
+            // operator granted standing permission does not park again. Reached
+            // through the queue the rest of the approval round-trip already
+            // travels on, so nothing new threads through the runner.
+            &deps.approval_requests.grants(),
+        )
+        .await
     };
     // Issue #846: a node whose call already left the building in an earlier run
     // of this lineage replays its recorded result instead of calling again.

--- a/src/workflows/workflow_standing_grant_test.rs
+++ b/src/workflows/workflow_standing_grant_test.rs
@@ -1,0 +1,678 @@
+//! Issue #1098 — a scheduled workflow stops re-asking the same question on
+//! every run, once its operator has granted it a standing permission.
+//!
+//! # The defect, and why nothing already in the suite caught it
+//!
+//! Every part worked alone. `web_fetch` has been [`ScopedGrantable`] since
+//! #673, the console has offered a duration picker since #374, and the gate
+//! pass has parked `tool_call` nodes since #460. But a standing permission could
+//! only ever name a *teammate*, and a scheduled graph has none — so the one
+//! caller whose calls an operator had **pre-declared in a graph** was the one
+//! caller that could not hold a permission, while an agent choosing its
+//! arguments at run time could.
+//!
+//! Net for a three-fetch daily job: three identical cards, every morning,
+//! forever. The harm is not the clicks. An operator trained to approve twenty
+//! meaningless cards approves the meaningful one the same way.
+//!
+//! Two things had to change together, and a test below pins each:
+//!
+//! * the **subject** — a permission may now name a workflow
+//!   ([`GrantSubject::Workflow`]), not only a teammate;
+//! * the **classifier** — a gate's `kind` is the `workflow.approve` wrapper, so
+//!   asking about it returned the undeclared fallback and the `web_fetch` on the
+//!   card was never seen. Fixing only the subject would have left every gate
+//!   refused for that second, unrelated reason.
+//!
+//! # What this drives
+//!
+//! Nothing is stubbed on the path under test, on the same terms as
+//! [`super::parallel_gate_fanout_test`]: a real graph, the real engine through
+//! [`HarnessWorkflowRunner`](super::runner::HarnessWorkflowRunner), the real
+//! `ApprovalPolicy` gate, a real on-disk journal, and a real [`CompanyRuntime`]
+//! resolving through `resolve_approval_spawned` — the same call the console's
+//! Approvals route makes when the operator picks a duration.
+//!
+//! **Two runs, not one.** Every claim here is about the *second* run, and a
+//! single-run test cannot see any of it. The first run establishes the cards; the
+//! second is the assertion.
+//!
+//! # The hosts never resolve, deliberately
+//!
+//! The three nodes fetch `*.invalid` — reserved by RFC 2606 and guaranteed never
+//! to resolve. That is itself an assertion: these tests are about whether a node
+//! was **stopped**, and a suite that reached the real internet to prove it would
+//! be measuring something else. A permission that works lets the node run, the
+//! fetch then fails on DNS, and the run settles without a card — which is exactly
+//! the distinction being drawn, because a *gated* node leaves a card behind.
+//!
+//! [`ScopedGrantable`]: crate::policy::Standing::ScopedGrantable
+//! [`GrantSubject::Workflow`]: crate::runtime::grants::GrantSubject::Workflow
+//! [`CompanyRuntime`]: crate::company::runtime::CompanyRuntime
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::ports::WorkflowRunContext;
+use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyRecord, Verdict};
+use crate::runtime::RuntimeBuilder;
+use crate::runtime::grants::GrantScope;
+use crate::runtime::workflow_resume::{PAYLOAD_NODE_ID, WORKFLOW_APPROVE_KIND};
+
+/// The reported shape, minimised: a daily digest fanning out to three fetches
+/// over three distinct hosts, converging on one output node.
+///
+/// Three *different* hosts rather than three paths on one, because the host is
+/// what a permission is scoped to. One host would mint one permission covering
+/// all three nodes and the run-2 assertion would pass without the subject change
+/// having done anything.
+const DIGEST_TOML: &str = r#"
+id = "sports_digest"
+name = "Sports digest"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "fetch_bbc"
+kind = "tool_call"
+name = "Fetch BBC"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://bbc.invalid/sport"
+[[node]]
+id = "fetch_espn"
+kind = "tool_call"
+name = "Fetch ESPN"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://espn.invalid/nfl"
+[[node]]
+id = "fetch_guardian"
+kind = "tool_call"
+name = "Fetch Guardian"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://guardian.invalid/football"
+[[node]]
+id = "rank"
+kind = "output"
+name = "Rank"
+[[edge]]
+from = "start"
+to = "fetch_bbc"
+[[edge]]
+from = "start"
+to = "fetch_espn"
+[[edge]]
+from = "start"
+to = "fetch_guardian"
+[[edge]]
+from = "fetch_bbc"
+to = "rank"
+[[edge]]
+from = "fetch_espn"
+to = "rank"
+[[edge]]
+from = "fetch_guardian"
+to = "rank"
+"#;
+
+/// The same graph with one node repointed at a fourth host, for the
+/// scope-invalidation test.
+const DIGEST_REPOINTED_TOML: &str = r#"
+id = "sports_digest"
+name = "Sports digest"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "fetch_bbc"
+kind = "tool_call"
+name = "Fetch BBC"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://bbc.invalid/sport"
+[[node]]
+id = "fetch_espn"
+kind = "tool_call"
+name = "Fetch ESPN"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://espn.invalid/nfl"
+[[node]]
+id = "fetch_guardian"
+kind = "tool_call"
+name = "Fetch Guardian"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://sky.invalid/football"
+[[node]]
+id = "rank"
+kind = "output"
+name = "Rank"
+[[edge]]
+from = "start"
+to = "fetch_bbc"
+[[edge]]
+from = "start"
+to = "fetch_espn"
+[[edge]]
+from = "start"
+to = "fetch_guardian"
+[[edge]]
+from = "fetch_bbc"
+to = "rank"
+[[edge]]
+from = "fetch_espn"
+to = "rank"
+[[edge]]
+from = "fetch_guardian"
+to = "rank"
+"#;
+
+/// The same graph plus a fourth node on an **already-approved** host, for the
+/// Q1 decision (the subject is the workflow, not the node).
+const DIGEST_EXTRA_NODE_TOML: &str = r#"
+id = "sports_digest"
+name = "Sports digest"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "fetch_bbc"
+kind = "tool_call"
+name = "Fetch BBC"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://bbc.invalid/sport"
+[[node]]
+id = "fetch_bbc_weather"
+kind = "tool_call"
+name = "Fetch BBC weather"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://bbc.invalid/weather"
+[[node]]
+id = "fetch_espn"
+kind = "tool_call"
+name = "Fetch ESPN"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://espn.invalid/nfl"
+[[node]]
+id = "fetch_guardian"
+kind = "tool_call"
+name = "Fetch Guardian"
+on_error = "continue"
+[node.config]
+slug = "web_fetch"
+[node.config.args]
+url = "https://guardian.invalid/football"
+[[node]]
+id = "rank"
+kind = "output"
+name = "Rank"
+[[edge]]
+from = "start"
+to = "fetch_bbc"
+[[edge]]
+from = "start"
+to = "fetch_bbc_weather"
+[[edge]]
+from = "start"
+to = "fetch_espn"
+[[edge]]
+from = "start"
+to = "fetch_guardian"
+[[edge]]
+from = "fetch_bbc"
+to = "rank"
+[[edge]]
+from = "fetch_bbc_weather"
+to = "rank"
+[[edge]]
+from = "fetch_espn"
+to = "rank"
+[[edge]]
+from = "fetch_guardian"
+to = "rank"
+"#;
+
+/// A graph whose one gated node calls a tool that is `PerCall` forever.
+const SHELL_TOML: &str = r#"
+id = "sports_digest"
+name = "Sports digest"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "run_it"
+kind = "tool_call"
+name = "Run it"
+[node.config]
+slug = "shell"
+[node.config.args]
+command = "echo hi"
+[[node]]
+id = "rank"
+kind = "output"
+name = "Rank"
+[[edge]]
+from = "start"
+to = "run_it"
+[[edge]]
+from = "run_it"
+to = "rank"
+"#;
+
+const FETCHES: [&str; 3] = ["fetch_bbc", "fetch_espn", "fetch_guardian"];
+
+/// A week, the ceiling a console duration picker offers.
+const A_WEEK_MILLIS: u64 = 7 * 24 * 60 * 60 * 1000;
+
+/// A company that grants the `web` namespace and gates it, under `full`
+/// autonomy.
+///
+/// `full` with `always_approve`, on [`super::parallel_gate_fanout_test`]'s
+/// reasoning: it is the stronger claim (the call is stopped whatever the tier)
+/// and it keeps exec-security out of the way, so the only thing that can stop
+/// the call is the gate. It also makes the run-2 assertion sharper — the
+/// standing arm sits **above** `always_approve` in `ApprovalPolicy::check`, so a
+/// silent second run is the permission winning against an explicit fence, not a
+/// tier quietly letting the call through.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+always_approve = ["web_fetch", "shell"]
+
+[tools]
+allow = ["web", "shell"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        manifest: manifest(),
+        ..super::gated_tool_turn_test::record()
+    }
+}
+
+fn operator() -> Actor {
+    Actor {
+        kind: ActorKind::Operator,
+        id: "owner".into(),
+    }
+}
+
+/// A home whose `workflows/` directory holds `graph`, so a continuation's loader
+/// finds it exactly as the console run route would.
+fn seed_home(graph: &str) -> tempfile::TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("opencompany-standing-")
+        .tempdir()
+        .expect("tempdir");
+    let workflows = dir.path().join("workflows");
+    std::fs::create_dir_all(&workflows).expect("workflows dir");
+    std::fs::write(workflows.join("sports_digest.toml"), graph).expect("seed graph");
+    dir
+}
+
+/// Rewrites the seeded graph, standing in for an operator editing it between
+/// runs.
+fn reseed(home: &std::path::Path, graph: &str) {
+    std::fs::write(home.join("workflows").join("sports_digest.toml"), graph).expect("reseed graph");
+}
+
+/// A runtime wired to the **real** workflow runner, parking into its own gate,
+/// journal and continuation queues.
+///
+/// The parking bundle is rebuilt over the runtime's own handles for the reason
+/// [`super::parallel_gate_fanout_test`] gives: a card has to land in the queue
+/// the runtime resolves from, or every assertion here is vacuous.
+async fn runtime(home: &std::path::Path) -> Arc<crate::company::runtime::CompanyRuntime> {
+    let mut rt = RuntimeBuilder::new(home.to_path_buf(), manifest())
+        .with_seed_dir(home.to_path_buf())
+        .build()
+        .await
+        .expect("runtime builds");
+
+    // A base URL nothing calls: this graph has no agent node, so no model is
+    // reached. A dead address is the assertion.
+    let (mut deps, _unused) =
+        super::gated_tool_turn_test::deps("http://127.0.0.1:1/unused".to_string(), home);
+    // Issue #243/#1098: the runtime mints permissions into `rt.grants` and the
+    // gate pass reads them back off the deps queue, so the two must be one set —
+    // exactly what `RuntimeBuilder` wires in production. The `gated_tool_turn_test`
+    // fixture defaults to its own, which would make every assertion here vacuous.
+    deps.approval_requests =
+        crate::harness::policy::ApprovalRequestQueue::with_grants(rt.grants.clone());
+    let delivery = deps.delivery.as_mut().expect("the fixture wires delivery");
+    delivery.parking = Some(super::delivery::DeliveryParking {
+        approvals: rt.approvals.clone(),
+        journal: rt.journal().clone(),
+        continuations: rt.continuations.clone(),
+        gates: rt.workflow_gates().clone(),
+        blocked_nodes: rt.blocked_nodes().clone(),
+    });
+
+    let pool = Arc::new(crate::harness::HarnessPool::new());
+    pool.ensure(&record(), &deps).await.expect("roster builds");
+    rt.set_workflow_runner(Arc::new(super::runner::HarnessWorkflowRunner::new(
+        pool,
+        deps,
+        record(),
+    )));
+    Arc::new(rt)
+}
+
+/// Fires the graph through the runtime's own runner — the path both the console
+/// run route and the scheduler take — and answers which nodes it paused on.
+async fn fire(rt: &Arc<crate::company::runtime::CompanyRuntime>, graph: &str) -> Vec<String> {
+    let file = parse_workflow(graph).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let runner = rt.workflow_runner().cloned().expect("a runner is wired");
+    // A run whose granted nodes executed and then failed DNS is a *failed run*
+    // carrying a partial — and its `pending_approvals` is exactly the claim
+    // under test. Unwrapping would throw that away and read the DNS failure as
+    // a test failure, when it is the designed outcome of a permission working.
+    match runner
+        .run(rt.id(), &file, json!({ "topic": "sports" }), &ctx)
+        .await
+    {
+        Ok(run) => sorted(run.pending_approvals),
+        Err(crate::error::OpenCompanyError::WorkflowRunFailed { partial, .. }) => {
+            sorted(partial.pending_approvals)
+        }
+        Err(other) => panic!("the run failed for a reason this test does not model: {other}"),
+    }
+}
+
+fn sorted(mut items: Vec<String>) -> Vec<String> {
+    items.sort();
+    items
+}
+
+/// The gate cards currently on the Approvals page, as `(id, node)`.
+fn gate_cards(rt: &Arc<crate::company::runtime::CompanyRuntime>) -> Vec<(ApprovalId, String)> {
+    rt.journal()
+        .pending()
+        .into_iter()
+        .filter(|entry| entry.effect.kind == WORKFLOW_APPROVE_KIND)
+        .map(|entry| {
+            let node = entry.effect.payload[PAYLOAD_NODE_ID]
+                .as_str()
+                .expect("a gate card names its node")
+                .to_string();
+            (entry.id, node)
+        })
+        .collect()
+}
+
+/// Approves every open gate card with a standing permission lasting
+/// `expires_in_millis`, the way the console does when an operator picks a
+/// duration.
+async fn grant_every_open_card(
+    rt: &Arc<crate::company::runtime::CompanyRuntime>,
+    expires_in_millis: u64,
+) {
+    for (id, _node) in gate_cards(rt) {
+        rt.resolve_approval_spawned(
+            &id,
+            Verdict::Approve,
+            operator(),
+            GrantScope::Tool {
+                expires_at_millis: crate::ports::now_millis() + expires_in_millis,
+            },
+        )
+        .await
+        .expect("a gate card accepts a standing permission");
+    }
+    settle().await;
+}
+
+/// The continuation is spawned rather than awaited (#380's drop safety), so a
+/// test that asserted immediately would race it. Bounded, so a genuine failure
+/// fails rather than hangs.
+async fn settle() {
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+}
+
+/// **The headline.** Run one parks three cards; the operator grants each a
+/// week; run two parks **nothing**.
+///
+/// Asserted as equalities rather than bounds, because the defect is that the
+/// second number was three.
+#[tokio::test]
+async fn a_granted_workflow_does_not_ask_again_on_the_next_run() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    let first = fire(&rt, DIGEST_TOML).await;
+    assert_eq!(
+        first,
+        FETCHES.map(str::to_string).to_vec(),
+        "the cold run must pause on all three fetches"
+    );
+    assert_eq!(gate_cards(&rt).len(), 3, "one card per gated fetch");
+
+    grant_every_open_card(&rt, A_WEEK_MILLIS).await;
+
+    let second = fire(&rt, DIGEST_TOML).await;
+    assert!(
+        second.is_empty(),
+        "the next run must not ask again — it paused on {second:?}"
+    );
+    assert_eq!(
+        gate_cards(&rt).len(),
+        0,
+        "and it must leave no new card behind"
+    );
+}
+
+/// Scope equality **is** the invalidation. Repointing one node at a fourth host
+/// makes that node ask again, and leaves its siblings quiet — no separate
+/// change-detection machinery, and no all-or-nothing revocation.
+#[tokio::test]
+async fn a_repointed_host_asks_again_while_its_siblings_stay_quiet() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, DIGEST_TOML).await.len(), 3);
+    grant_every_open_card(&rt, A_WEEK_MILLIS).await;
+
+    reseed(home.path(), DIGEST_REPOINTED_TOML);
+    let second = fire(&rt, DIGEST_REPOINTED_TOML).await;
+
+    assert_eq!(
+        second,
+        vec!["fetch_guardian".to_string()],
+        "only the repointed node asks again"
+    );
+}
+
+/// The Q1 decision, made executable: the subject is the **workflow**, so a node
+/// added later on an already-approved host does not re-ask.
+///
+/// This is the deliberate consequence of not keying on the node, and the reason
+/// it is deliberate is the Composio toolkit scope: the operator consented to a
+/// host, and re-parking a second call to that host is the workflow-shaped
+/// version of the slug-exactness #457 rejected. Asserted rather than left
+/// implicit, so that a future change to node-level keying has to come here and
+/// argue with it.
+#[tokio::test]
+async fn a_node_added_on_an_already_approved_host_does_not_ask() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, DIGEST_TOML).await.len(), 3);
+    grant_every_open_card(&rt, A_WEEK_MILLIS).await;
+
+    reseed(home.path(), DIGEST_EXTRA_NODE_TOML);
+    let second = fire(&rt, DIGEST_EXTRA_NODE_TOML).await;
+
+    assert!(
+        second.is_empty(),
+        "a fourth node on an approved host rides the same permission — got {second:?}"
+    );
+}
+
+/// A permission is bounded, and the bound is enforced. Granted for a
+/// millisecond, it is gone by the next run.
+#[tokio::test]
+async fn an_expired_permission_asks_again() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, DIGEST_TOML).await.len(), 3);
+    // `settle()` inside the grant helper is two orders of magnitude longer than
+    // this, so the permission is certainly past its deadline by the second run.
+    grant_every_open_card(&rt, 1).await;
+
+    let second = fire(&rt, DIGEST_TOML).await;
+    assert_eq!(
+        second,
+        FETCHES.map(str::to_string).to_vec(),
+        "an expired permission admits nothing"
+    );
+}
+
+/// `shell` is `Standing::PerCall` and stays that way. A workflow subject does
+/// not widen *what* may be granted — only *who* may hold a grant.
+#[tokio::test]
+async fn a_per_call_tool_is_refused_a_workflow_permission() {
+    let home = seed_home(SHELL_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, SHELL_TOML).await, vec!["run_it".to_string()]);
+    let (id, _node) = gate_cards(&rt).into_iter().next().expect("one card");
+
+    let refused = rt
+        .resolve_approval_spawned(
+            &id,
+            Verdict::Approve,
+            operator(),
+            GrantScope::Tool {
+                expires_at_millis: crate::ports::now_millis() + A_WEEK_MILLIS,
+            },
+        )
+        .await;
+
+    assert!(
+        refused.is_err(),
+        "a per-call tool must refuse a standing permission even on a workflow gate"
+    );
+}
+
+/// The invariant `crate::workflows::gate` exists to protect: **no single-use
+/// grant is ever minted on this path**, whatever the operator picks.
+///
+/// A `GrantedCall` is redeemed by re-dispatching the agent that asked, and on a
+/// workflow path nobody asked — one minted here would expire on its TTL and tell
+/// the operator "the agent did not act" about a call no agent made. Issue #1098
+/// opened the standing arm and this asserts it left the other one shut.
+#[tokio::test]
+async fn no_single_use_grant_is_minted_for_a_workflow_gate() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, DIGEST_TOML).await.len(), 3);
+    grant_every_open_card(&rt, A_WEEK_MILLIS).await;
+
+    assert_eq!(
+        rt.grants.live_count(),
+        0,
+        "approving a gate must mint no single-use grant"
+    );
+    assert_eq!(
+        rt.grants.standing_count(),
+        3,
+        "it mints one standing permission per card instead"
+    );
+}
+
+/// A permission is scoped to the workflow that holds it. Another workflow of the
+/// company, fetching the identical host, is a different subject and asks for
+/// itself.
+#[tokio::test]
+async fn another_workflow_on_the_same_host_still_asks() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, DIGEST_TOML).await.len(), 3);
+    grant_every_open_card(&rt, A_WEEK_MILLIS).await;
+
+    // The same three fetches, under a different workflow id.
+    let other = DIGEST_TOML.replacen("id = \"sports_digest\"", "id = \"other_digest\"", 1);
+    std::fs::write(
+        home.path().join("workflows").join("other_digest.toml"),
+        &other,
+    )
+    .expect("seed the second graph");
+
+    let second = fire(&rt, &other).await;
+    assert_eq!(
+        second,
+        FETCHES.map(str::to_string).to_vec(),
+        "a permission held by one workflow must not open another's gates"
+    );
+}
+
+/// Sanity on the fixture itself: without a permission the second run asks again,
+/// so every silence asserted above is the permission's doing and not something
+/// about firing the same graph twice.
+#[tokio::test]
+async fn without_a_permission_the_second_run_asks_again() {
+    let home = seed_home(DIGEST_TOML);
+    let rt = runtime(home.path()).await;
+
+    assert_eq!(fire(&rt, DIGEST_TOML).await.len(), 3);
+    for (id, _node) in gate_cards(&rt) {
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("a plain approve is recorded");
+    }
+    settle().await;
+
+    let second = fire(&rt, DIGEST_TOML).await;
+    assert_eq!(
+        second,
+        FETCHES.map(str::to_string).to_vec(),
+        "approving once buys one run — this is the behaviour #1098 changes"
+    );
+}

--- a/src/workflows/workflow_standing_grant_test.rs
+++ b/src/workflows/workflow_standing_grant_test.rs
@@ -597,6 +597,25 @@ async fn a_per_call_tool_is_refused_a_workflow_permission() {
         refused.is_err(),
         "a per-call tool must refuse a standing permission even on a workflow gate"
     );
+
+    // An `Err` return says only what the resolver *answered*. `resolve_approval`
+    // checks grantability before it touches anything precisely so "a bad request
+    // changes nothing at all" — the approval stays parked, no verdict is
+    // journaled, and the operator can approve it once instead. That invariant was
+    // asserted only by a comment; these three pin it, so a future reordering that
+    // minted first and refused second fails here rather than silently opening
+    // `shell` for a week.
+    assert_eq!(
+        rt.grants.standing_count(),
+        0,
+        "a refused request must mint no standing permission"
+    );
+    assert_eq!(rt.grants.live_count(), 0, "and no single-use grant either");
+    assert_eq!(
+        gate_cards(&rt).len(),
+        1,
+        "the card must still be there to decide again"
+    );
 }
 
 /// The invariant `crate::workflows::gate` exists to protect: **no single-use


### PR DESCRIPTION
## Summary

A scheduled workflow re-asks the same approval on every run, forever. `daily-sports-news-blog` parks `fetch_bbc` / `fetch_espn` / `fetch_guardian` each time it fires; approving buys exactly that run.

The gap is narrower than "we have no standing permissions" — nearly all the machinery exists. `web_fetch` has been `ScopedGrantable` since #673, the console has had a duration picker since #374, and expiry, host scoping, the grant list and the revoke route are all built. But a permission could only name a **teammate**, and a graph that is simply running has none. So the one caller whose calls an operator had *pre-declared in a graph* was the one caller that could not hold a permission, while an agent choosing its arguments at run time could.

This makes the workflow a grant subject. `GrantSubject` is `Agent | Workflow`, and `match_standing` keys on it.

**#460 left room for exactly this.** From `gate.rs`'s own module doc:

> This module therefore matches grants against a synthetic `workflow:{id}` principal, which nothing mints for today, so the answer is always fail-closed… **Widening that is a consent decision for the maintainer, not one to make by defaulting.**

The design call is recorded on #1098 (Q1–Q3 answered) — worth reading first; this PR implements it.

### Two blockers, not one

Besides `agent: None`, a gate's `kind` is the `workflow.approve` wrapper, so `consequence_of` returned the undeclared fallback and never saw the `web_fetch` the operator was looking at. Fixing only the subject would have left every gate refused for an unrelated reason. `gate_inner_call` reads the tool and args #846 already writes onto the payload, so what is classified is what the card showed.

### What deliberately did not widen

- **`consume_grant` stays closed on this path, permanently.** A `GrantedCall` is redeemed by re-dispatching the agent that asked; here nobody asked, so one minted would expire on its TTL and tell the operator "the agent did not act" about a call no agent made. A `StandingGrant` is never redeemed — it is matched at the gate and the call proceeds in place — which is why only that arm opens. The asymmetry is the safety argument, and both `gate.rs` and `consume_grant` now carry a note saying so.
- **A teammate's permission still does not open a workflow's gate**, in either direction — separate namespaces.
- **`Standing::PerCall` is untouched.** `shell` and `http_request` keep asking every run.
- **`is_priced_call` still short-circuits above the grant**, so a metered call never holds a permission.
- **Seven-day ceiling, mandatory expiry, 400-not-clamp** — unchanged.
- **`run_id` is not in the match key.** A permission that died with the run that minted it would be the reported bug wearing a new field.

### Subject is the workflow, not the node

The operator consented to a host, and re-parking a second call to that host is the workflow-shaped version of the slug-exactness #457 rejected ("would re-park every new action and make the grant worth nothing").

Stated plainly: for the six tools grantable with no scope (`file_write`, `edit`, `apply_patch`, `csv_export`, `memory_store`, `publish_artifact`) nothing narrows a workflow permission, so a node added mid-window inherits it. Bounded by `shell`/`http_request` never persisting, the seven-day ceiling, and permissions being per-tool. If that trade is judged wrong, adding a node id to `GrantSubject::Workflow` is one field.

## API Or Behavior Changes

- A `workflow.approve` card whose inner call is grantable now offers a duration, where it previously offered only "approve once" and 400'd on a scope. `broadly_grantable`, the resolve route's refusal and the mint all decide through one `subject_of`, so the control offered and the answer given cannot disagree (#444).
- `StandingGrant` gains `workflow: Option<String>`, additive and `#[serde(default)]`. A journal line written before this replays as the agent permission it was — pinned by a test that deserializes a literal pre-change line.
- `GrantSet::match_standing` takes `&GrantSubject` rather than `&str`. Internal; a workflow permission carries an empty `agent`, and a `&str` parameter would let one match on emptiness.
- The #617 audit line passes `None` for grants deliberately: it reports calls never offered for approval *at all*, and a permission is about not asking *again*.
- No console change in this PR — a workflow permission renders with an empty holder name in the standing-permissions list until the label lands. Noted below.

## Tests

New `src/workflows/workflow_standing_grant_test.rs` — two runs, at the altitude `parallel_gate_fanout_test` uses, because every unit below already passes individually and it is the composition that was wrong. Real graph, real engine, real `ApprovalPolicy`, real journal, resolving through `resolve_approval_spawned`. Hosts are `*.invalid` so nothing reaches the network; that is itself an assertion.

- `a_granted_workflow_does_not_ask_again_on_the_next_run` — **the headline**: run one parks three, each granted a week, run two parks zero
- `a_repointed_host_asks_again_while_its_siblings_stay_quiet` — scope equality is the invalidation
- `a_node_added_on_an_already_approved_host_does_not_ask` — the subject decision, asserted so a future move to node-keying has to argue with it
- `an_expired_permission_asks_again`
- `a_per_call_tool_is_refused_a_workflow_permission`
- `no_single_use_grant_is_minted_for_a_workflow_gate` — 0 single-use, 3 standing
- `another_workflow_on_the_same_host_still_asks`
- `without_a_permission_the_second_run_asks_again` — control, so every silence above is the permission's doing

Plus unit coverage for the projection (including that the wrapper kind still fails closed on its own) and the subject (replay, namespace separation, host narrowing).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features openhuman -- -D warnings`
- [x] `cargo check --lib` and `cargo check --all-targets --features openhuman`
- [x] `cargo test --lib --features openhuman` — 4499 passed, 0 failed

## Documentation

`gate.rs`'s module doc is updated where it is now wrong: the "standing grants cannot apply identically on both paths" deviation becomes a record of the decision taken and what did *not* widen with it, and the "card could not be honoured" paragraph now says it is an argument about the single-use grant alone. `with_grants` documents the gate's second reason for needing it.

## Follow-ups, not in this PR

- **Console label.** `grantHeadline` still speaks a teammate name; a workflow permission needs to read "the sports-blog job may fetch bbc.invalid until Friday". Small and self-contained.
- **#1085 composition.** Auto-continue for a blocked agent node should be strictly simpler when a node is never gated, but I have not traced it.
- **`admits_scope` dormancy.** Documented dormant for Composio (#610); this makes it load-bearing. Covered for `web_fetch` by the repointed-host test, not for Composio.

Closes #1098


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standing permissions for workflows, allowing approved actions to proceed without repeated approval prompts.
  * Workflow permissions are isolated by workflow and respect tool scope, host scope, and expiration.
  * Existing agent-based standing permissions continue to work, including previously recorded grants.
  * Added support for scheduled workflows to reuse valid standing permissions across runs.

* **Bug Fixes**
  * Corrected approval classification for workflow-gated actions.
  * Single-use permissions remain limited to one-time execution and are not reused as standing permissions.
  * Invalid, expired, or out-of-scope workflow permissions continue to require approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->