### PR TITLE
fix(orchestration): ground a teammate by the name the roster prints (#1162)

### DIFF
--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -310,7 +310,12 @@ pub enum Delegation {
     /// [`desk_lead`](crate::runtime::delegation_tools::desk_lead) — which is the
     /// whole of what D1 was missing.
     DelegateToTeammate {
-        /// The teammate's roster id, already validated at the tool boundary.
+        /// The teammate's **canonical** roster id, resolved and validated at
+        /// the tool boundary (#1162 — before it, this carried the key exactly
+        /// as the model typed it, and the drain had to resolve it a second
+        /// time). The one exception is the fail-open path, where the record
+        /// could not be read at all: nothing was refused there and nothing was
+        /// canonicalised, so the drain resolves it with the same resolver.
         teammate: String,
         /// The instruction handed to that teammate.
         instruction: String,
@@ -1485,21 +1490,43 @@ impl Tool for QueryCompanyTool {
         // Team roster: manifest agents plus operator-added overlay teammates
         // (the ones `add_agent` persists), so a freshly added teammate is
         // visible on the next query instead of looking unpersisted.
-        let mut roster: Vec<(String, String)> = Vec::new();
+        //
+        // **Every row leads with the id**, because this column is the one the
+        // orchestrator's brief and `delegate_to_teammate`'s own description
+        // send the model to for a hand-off target. An overlay teammate used to
+        // be listed under `overlay.name` while a manifest agent was listed
+        // under `agent.id` — two namespaces rendered identically, and since
+        // `mint_agent_id` slugs the display name (`"Dana Designer"` →
+        // `dana_designer`) the name was a token the delegation tools could not
+        // ground. The model did exactly what it was told and was refused
+        // (issue #1162). The display name follows as a label, in the shape
+        // `workflow_build::roster_line` (#813) already uses for the roster it
+        // shows the same model, so the two surfaces cannot drift apart.
+        let mut roster: Vec<(String, Option<String>, String)> = Vec::new();
         if let Some(record) = &record {
             for agent in &record.manifest.agents {
-                roster.push((agent.id.clone(), agent.role.clone()));
+                // A manifest `[[agent]]` has no display name; its role is its
+                // label.
+                roster.push((agent.id.clone(), None, agent.role.clone()));
             }
             for overlay in &record.overlay_agents {
-                roster.push((overlay.name.clone(), overlay.role.clone()));
+                roster.push((
+                    overlay.id.clone(),
+                    Some(overlay.name.clone()).filter(|n| !n.trim().is_empty()),
+                    overlay.role.clone(),
+                ));
             }
         }
         md.push_str("\n## Team\n");
         if roster.is_empty() {
             md.push_str("_Roster unavailable._\n");
         } else {
-            for (id, role) in &roster {
-                md.push_str(&format!("- **{}** — {}\n", id, role.trim()));
+            for (id, name, role) in &roster {
+                md.push_str(&format!("- **{}** — {}", id, role.trim()));
+                if let Some(name) = name {
+                    md.push_str(&format!(" (known as {})", name.trim()));
+                }
+                md.push('\n');
             }
         }
 
@@ -1935,10 +1962,26 @@ pub struct MemberScope {
 }
 
 /// What one read of the company record decided about a hand-off target: the
-/// refusal to return, if any, and the depth bound in force.
+/// refusal to return, if any, the canonical id it resolved to, and the depth
+/// bound in force.
 struct Grounding {
     /// The refusal to hand back to the model, or `None` when the target is good.
     refusal: Option<String>,
+    /// The **canonical roster id** the key resolved to, when it resolved to one
+    /// (issue #1162).
+    ///
+    /// What makes grounding at the tool boundary mean anything: the queued
+    /// delegation carries this rather than the string the model typed, so the
+    /// drain has nothing left to decide. Without it the tool could accept a
+    /// display name, answer "Handed to …", and then have the drain fail to
+    /// resolve the very key the tool just approved — a refusal traded for a
+    /// silent drop.
+    ///
+    /// `None` on the fail-open path (the record could not be read, so there was
+    /// nothing to resolve against) and for [`DelegateToDeskTool`], whose target
+    /// is a desk: `desk_lead` and `resolve_desk_id` already accept a desk by id
+    /// **or** name at both ends, so that path has no namespace to close.
+    target: Option<String>,
     /// `[tools].max_delegation_depth`, or its default. Read from the same record
     /// load as the refusal so a single store round-trip decides both.
     max_depth: usize,
@@ -2017,7 +2060,14 @@ impl DelegateToDeskTool {
                     )
                 })
         });
-        Grounding { refusal, max_depth }
+        Grounding {
+            refusal,
+            // A desk key needs no canonicalising: `resolve_desk_id` and
+            // `desk_lead` both accept a desk by id or name, at the tool
+            // boundary and again at the drain.
+            target: None,
+            max_depth,
+        }
     }
 
     /// What a hand-off grounds to when the record behind the grounding could
@@ -2044,6 +2094,7 @@ impl DelegateToDeskTool {
                  yourself.",
                 member = scope.member
             )),
+            target: None,
             max_depth: usize::from(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
         }
     }
@@ -2054,6 +2105,10 @@ impl Grounding {
     fn open() -> Self {
         Self {
             refusal: None,
+            // Nothing was read, so there is nothing to canonicalise: the key
+            // goes to the queue as the model wrote it, and the drain does the
+            // resolve instead (#1162).
+            target: None,
             max_depth: usize::from(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
         }
     }
@@ -2250,7 +2305,16 @@ impl DelegateToTeammateTool {
                 teammate,
             )
         });
-        Grounding { refusal, max_depth }
+        // Resolved from the same record read that decided the refusal, so the
+        // id queued below is the id the refusal was (or was not) written about.
+        // Pure over `record`, so it agrees with `reject_teammate_target`'s own
+        // resolve by construction.
+        let target = record.resolve_teammate_key(teammate).agent();
+        Grounding {
+            refusal,
+            target,
+            max_depth,
+        }
     }
 
     /// The member/orchestrator split for an unreadable record — see
@@ -2266,6 +2330,7 @@ impl DelegateToTeammateTool {
                  out yourself.",
                 member = scope.member
             )),
+            target: None,
             max_depth: usize::from(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
         }
     }
@@ -2306,10 +2371,21 @@ impl Tool for DelegateToTeammateTool {
             return Ok(ToolResult::error(refusal));
         }
 
-        let effect = format!("nothing was handed to {teammate}");
+        // Queue the **canonical id**, not the key as typed (issue #1162). The
+        // grounding above is the only place the roster is read before the turn
+        // ends, so whatever goes into the queue is what the drain must be able
+        // to deliver to. A display name accepted here and re-resolved there
+        // would turn a refusal the model can retry into a hand-off that is
+        // answered "Handed to …" and then quietly never runs.
+        //
+        // Falls back to the key on the fail-open path — the record could not be
+        // read, so nothing was resolved and nothing was refused either; the
+        // drain resolves it with the same resolver.
+        let target = grounding.target.unwrap_or_else(|| teammate.clone());
+        let effect = format!("nothing was handed to {target}");
         match self.queue.push_within_cap(
             Delegation::DelegateToTeammate {
-                teammate: teammate.clone(),
+                teammate: target.clone(),
                 instruction,
             },
             MAX_DELEGATIONS_PER_TURN,
@@ -2325,9 +2401,15 @@ impl Tool for DelegateToTeammateTool {
                 )));
             }
         }
-        Ok(ToolResult::success(format!(
-            "Handed to {teammate}. They will answer this turn."
-        )))
+        // Both strings when they differ: the model asked for a person by the
+        // name it read, and the id is the token it should write next time.
+        Ok(ToolResult::success(
+            if target.eq_ignore_ascii_case(&teammate) {
+                format!("Handed to {target}. They will answer this turn.")
+            } else {
+                format!("Handed to {teammate} (`{target}`). They will answer this turn.")
+            },
+        ))
     }
 }
 
@@ -6190,6 +6272,85 @@ members = ["legal_counsel"]
         assert!(refused.is_error, "{}", refused.output_for_llm(true));
     }
 
+    /// Issue #1162, the other half of the fix: a hand-off written with a
+    /// teammate's **display name** is accepted, and what reaches the queue is
+    /// the **canonical id**.
+    ///
+    /// Queueing the key as typed is what would make a name-accepting refusal
+    /// worse than the refusal it replaced — the tool would answer "Handed to
+    /// …" and the drain, which resolves independently, would find nothing to
+    /// deliver to. The reply names both strings so the model learns the id.
+    #[tokio::test]
+    async fn a_teammate_named_by_display_name_is_queued_under_its_id() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let mut record = peers_record(&company);
+        record.overlay_agents.push(OverlayAgent {
+            id: "dana_designer".to_string(),
+            name: "Dana Designer".to_string(),
+            role: "Designer".to_string(),
+            description: None,
+            tools: Vec::new(),
+        });
+        let store = Arc::new(MemStore::seeded(record)) as Arc<dyn CompanyStore>;
+        let tool = DelegateToTeammateTool::new(queue.clone(), company, store);
+
+        let result = tool
+            .execute(json!({ "teammate": "Dana Designer", "instruction": "draw it" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.output_for_llm(true));
+        let reply = result.output_for_llm(true);
+        assert!(
+            reply.contains("Dana Designer") && reply.contains("dana_designer"),
+            "the reply must name the person and teach the id: {reply}"
+        );
+        assert_eq!(
+            queue.drain(MAX_DELEGATIONS_PER_TURN),
+            vec![Delegation::DelegateToTeammate {
+                teammate: "dana_designer".to_string(),
+                instruction: "draw it".to_string(),
+            }],
+            "the queue must carry the canonical id, not the key as typed"
+        );
+    }
+
+    /// A display name two teammates answer to is refused rather than routed to
+    /// whichever was added first, and the refusal carries the ids to retry
+    /// with — the collision is the operator's to resolve, and the model cannot
+    /// do it without being told the alternatives (issue #1162).
+    #[tokio::test]
+    async fn a_display_name_two_teammates_share_is_refused_with_their_ids() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let mut record = peers_record(&company);
+        for id in ["dana_designer", "dana_designer_2"] {
+            record.overlay_agents.push(OverlayAgent {
+                id: id.to_string(),
+                name: "Dana Designer".to_string(),
+                role: "Designer".to_string(),
+                description: None,
+                tools: Vec::new(),
+            });
+        }
+        let store = Arc::new(MemStore::seeded(record)) as Arc<dyn CompanyStore>;
+        let tool = DelegateToTeammateTool::new(queue.clone(), company, store);
+
+        let result = tool
+            .execute(json!({ "teammate": "Dana Designer", "instruction": "draw it" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "{}", result.output_for_llm(true));
+        let refusal = result.output_for_llm(true);
+        assert!(
+            refusal.contains("dana_designer") && refusal.contains("dana_designer_2"),
+            "the refusal must name both ids: {refusal}"
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
     /// Both arguments are required, and neither may be blank — a hand-off with
     /// no instruction is a turn run on nothing.
     #[tokio::test]
@@ -6788,6 +6949,61 @@ name = "Morning"
         assert!(
             out.contains("Fact Fetcher"),
             "overlay teammate name missing: {out}"
+        );
+    }
+
+    /// Issue #1162: the Team column is the one the orchestrator is told to take
+    /// a hand-off target from, so every row must lead with a token the
+    /// delegation tools can ground. An overlay teammate was listed under its
+    /// **display name** while a manifest agent was listed under its **id** —
+    /// two namespaces rendered identically, and `mint_agent_id` guarantees the
+    /// name is not the id.
+    ///
+    /// The two halves are pinned together deliberately: the assertion is not
+    /// "the line contains `dana_designer`" but "the token the line prints
+    /// resolves", so a render that drifts from the resolver fails here rather
+    /// than in production.
+    #[tokio::test]
+    async fn query_company_lists_a_teammate_under_the_id_delegation_grounds() {
+        let mut record = seeded_record(&CompanyId::new("acme"));
+        let id = record.mint_agent_id("Dana Designer");
+        assert_eq!(id, "dana_designer", "the id and the name must differ");
+        record.overlay_agents.push(OverlayAgent {
+            id: id.clone(),
+            name: "Dana Designer".to_string(),
+            role: "Designer".to_string(),
+            description: None,
+            tools: Vec::new(),
+        });
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::seeded(record.clone()));
+
+        let out = QueryCompanyTool::new(CompanyId::new("acme"), None, None, None, Some(store))
+            .execute(json!({}))
+            .await
+            .expect("execute")
+            .output_for_llm(true);
+
+        let line = out
+            .lines()
+            .find(|line| line.contains("Designer"))
+            .unwrap_or_else(|| panic!("no teammate line: {out}"));
+        assert!(
+            line.contains(&id),
+            "the row must lead with the groundable id: {line}"
+        );
+        assert!(
+            line.contains("known as Dana Designer"),
+            "the display name must survive as a label: {line}"
+        );
+        // The token the roster prints is the token delegation accepts.
+        let printed = line
+            .split("**")
+            .nth(1)
+            .unwrap_or_else(|| panic!("no bold token: {line}"));
+        assert_eq!(
+            record.resolve_teammate_key(printed),
+            crate::ports::types::TeammateResolution::Agent(id),
+            "the roster printed a token delegation cannot ground: {line}"
         );
     }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -3064,6 +3064,41 @@ pub struct CompanyRecord {
     pub setup: Option<crate::company::setup::SetupAnswers>,
 }
 
+/// What a teammate key an operator or a model typed resolves to on a company's
+/// roster (issue #1162).
+///
+/// The three answers a caller has to tell apart. A key that names nothing is a
+/// different fact from a key that names two people: the first is a typo or an
+/// invention, the second is a collision the operator created and can only fix
+/// by renaming or by using an id. Collapsing them — or silently taking the
+/// first match — is the misrouting [`CompanyRecord::overlay_agent_ids_by_name`]
+/// exists to end.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TeammateResolution {
+    /// Exactly one teammate. Carries the **canonical roster id**, never the key
+    /// as typed, so every consumer downstream is working in one namespace.
+    Agent(String),
+    /// Names no teammate at all.
+    Unknown,
+    /// Names more than one operator-added teammate, because they share a
+    /// display name. Carries every colliding id so a refusal can name them.
+    Ambiguous(Vec<String>),
+}
+
+impl TeammateResolution {
+    /// The canonical id when the key named exactly one teammate.
+    ///
+    /// For the callers that have nothing useful to say about the other two
+    /// answers — a cycle guard has no target to compare, a drain has nothing to
+    /// deliver to — and where the caller ahead of them has already refused.
+    pub fn agent(self) -> Option<String> {
+        match self {
+            Self::Agent(id) => Some(id),
+            Self::Unknown | Self::Ambiguous(_) => None,
+        }
+    }
+}
+
 impl CompanyRecord {
     /// The effective member ids of a desk: the desk's declared members first
     /// (from the manifest `[[group_chat]]` or, for an operator-created desk, the
@@ -3353,6 +3388,54 @@ impl CompanyRecord {
             .filter(|a| a.name.eq_ignore_ascii_case(name_key))
             .map(|a| a.id.clone())
             .collect()
+    }
+
+    /// Resolves a teammate key the way every surface that takes one should:
+    /// **id first, then an operator-added teammate's display name** (issue
+    /// #1162).
+    ///
+    /// The single place the two halves of the roster's namespace are joined.
+    /// [`Self::resolve_roster_agent_id`] is deliberately id-only and
+    /// [`Self::overlay_agent_ids_by_name`] deliberately name-only; every caller
+    /// that wants "who did the human mean" needs both, in this order, and
+    /// before #1162 only the board's assignee field had them. `query_company`
+    /// printed an overlay teammate under its display name while
+    /// `delegate_to_teammate` grounded ids alone, so the orchestrator read a
+    /// name off the roster it was told was authoritative and was refused.
+    ///
+    /// **Ids win.** Trying the id namespace first is what stops a display name
+    /// shadowing a real id: a teammate mischievously (or accidentally) named
+    /// `"engineer"` can never intercept work meant for the manifest agent
+    /// `engineer`. That ordering is a guarantee, not an optimisation — it is
+    /// why this is one method rather than a convention each caller re-applies.
+    ///
+    /// **Manifest agents are not matched by role**, only by id. Two teammates
+    /// may legitimately share a role, so role-matching belongs to the surfaces
+    /// that can ask a human which one they meant — the workflow authoring
+    /// resolver does it deliberately, and stays separate for that reason.
+    ///
+    /// **Desks are not in scope here.** A caller that accepts a desk *and* a
+    /// teammate — [`assignee::resolve`] is the one — must try
+    /// [`Self::resolve_desk_id`] itself, first: a desk whose id matches a
+    /// teammate id keeps routing as a desk. Folding desks in here would teach
+    /// `delegate_to_teammate` to accept them, contradicting its own "that is a
+    /// desk, not a teammate" refusal.
+    ///
+    /// [`assignee::resolve`]: crate::runtime::assignee::resolve
+    pub fn resolve_teammate_key(&self, key: &str) -> TeammateResolution {
+        let key = key.trim();
+        if key.is_empty() {
+            return TeammateResolution::Unknown;
+        }
+        if let Some(id) = self.resolve_roster_agent_id(key) {
+            return TeammateResolution::Agent(id);
+        }
+        let mut by_name = self.overlay_agent_ids_by_name(key);
+        match by_name.len() {
+            0 => TeammateResolution::Unknown,
+            1 => TeammateResolution::Agent(by_name.remove(0)),
+            _ => TeammateResolution::Ambiguous(by_name),
+        }
     }
 
     /// This teammate's operator-set budget override, if one exists.
@@ -4935,6 +5018,95 @@ mod test {
         assert_eq!(record.mint_agent_id("Agents"), "agents_2");
         assert_eq!(record.mint_agent_id("desks"), "desks_2");
         assert_eq!(RESERVED_AGENT_IDS, ["operator", "Agents", "Desks"]);
+    }
+
+    /// Issue #1162: the resolve every surface that takes a teammate key runs.
+    /// An id resolves, an overlay teammate's **display name** resolves to the
+    /// id it was minted under, and a key that is nobody resolves to nothing.
+    #[test]
+    fn resolve_teammate_key_takes_an_id_or_a_display_name() {
+        let manifest = "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n";
+        let mut record = desk_record(manifest, Vec::new());
+        record.overlay_agents.push(OverlayAgent {
+            id: "dana_designer".into(),
+            name: "Dana Designer".into(),
+            role: "Designer".into(),
+            description: None,
+            tools: Vec::new(),
+        });
+
+        assert_eq!(
+            record.resolve_teammate_key("ceo"),
+            TeammateResolution::Agent("ceo".into())
+        );
+        assert_eq!(
+            record.resolve_teammate_key("dana_designer"),
+            TeammateResolution::Agent("dana_designer".into())
+        );
+        // The case #1162 is about: the name `query_company` prints, grounding
+        // to the id the delegation tools accept.
+        assert_eq!(
+            record.resolve_teammate_key("Dana Designer"),
+            TeammateResolution::Agent("dana_designer".into())
+        );
+        assert_eq!(
+            record.resolve_teammate_key("  dana designer  "),
+            TeammateResolution::Agent("dana_designer".into())
+        );
+        assert_eq!(
+            record.resolve_teammate_key("ghost"),
+            TeammateResolution::Unknown
+        );
+        assert_eq!(
+            record.resolve_teammate_key("   "),
+            TeammateResolution::Unknown
+        );
+    }
+
+    /// Ids win. A teammate whose **display name** is another teammate's id can
+    /// never intercept work meant for that id — the ordering is the guarantee
+    /// that makes one shared resolver safe to use everywhere.
+    #[test]
+    fn resolve_teammate_key_never_lets_a_name_shadow_an_id() {
+        let manifest = "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n";
+        let mut record = desk_record(manifest, Vec::new());
+        record.overlay_agents.push(OverlayAgent {
+            id: "impostor".into(),
+            name: "ceo".into(),
+            role: "Growth".into(),
+            description: None,
+            tools: Vec::new(),
+        });
+        assert_eq!(
+            record.resolve_teammate_key("ceo"),
+            TeammateResolution::Agent("ceo".into())
+        );
+    }
+
+    /// Two teammates answering to one display name is a collision the operator
+    /// created, and it is reported as one: every colliding id comes back, so a
+    /// caller can name them instead of silently taking the first.
+    #[test]
+    fn resolve_teammate_key_reports_a_name_two_teammates_answer_to() {
+        let mut record = desk_record("[company]\nname = \"Acme\"\n", Vec::new());
+        for id in ["dana_designer", "dana_designer_2"] {
+            record.overlay_agents.push(OverlayAgent {
+                id: id.into(),
+                name: "Dana Designer".into(),
+                role: "Designer".into(),
+                description: None,
+                tools: Vec::new(),
+            });
+        }
+        assert_eq!(
+            record.resolve_teammate_key("dana designer"),
+            TeammateResolution::Ambiguous(vec!["dana_designer".into(), "dana_designer_2".into()])
+        );
+        // Either id still resolves on its own — the collision is in the name.
+        assert_eq!(
+            record.resolve_teammate_key("dana_designer_2"),
+            TeammateResolution::Agent("dana_designer_2".into())
+        );
     }
 
     /// Whatever is minted is a legal roster id, suffix included — the same

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -20,7 +20,7 @@
 //! four cases **distinct** — [`AssigneeResolution`] — so a caller can give the
 //! blank card to the orchestrator and still refuse the invalid one.
 
-use crate::ports::types::CompanyRecord;
+use crate::ports::types::{CompanyRecord, TeammateResolution};
 use crate::runtime::delegation_tools::desk_lead;
 
 /// What a card's `assignee` string names on the company roster.
@@ -169,9 +169,18 @@ pub fn dm_key(chat: &str) -> Option<&str> {
 /// [`responder_for`](crate::harness) — a desk whose id happens to match a
 /// teammate id keeps routing as a desk, exactly as it does for an operator
 /// message addressed to that chat. A teammate id is then matched
-/// case-insensitively ([`CompanyRecord::resolve_roster_agent_id`]), because
-/// unlike a desk key it is typed by hand and `resolve_desk_id` was already
+/// case-insensitively, then an operator-added teammate's display name — both
+/// halves through [`CompanyRecord::resolve_teammate_key`], because unlike a
+/// desk key a teammate key is typed by hand and `resolve_desk_id` was already
 /// forgiving about case.
+///
+/// The name arm used to live here. #1162 moved it onto the record, where the
+/// delegation path could reach it too: the same string an operator types into
+/// an Assignee field is the string a model reads off `query_company`'s roster,
+/// and having one of them resolve while the other refused is how #1162
+/// happened. The rationale for trying names at all — teammates added before
+/// #686 keep generated ids forever, and an id never follows a rename — is
+/// documented on that method.
 pub fn resolve(record: &CompanyRecord, assignee: &str) -> AssigneeResolution {
     let key = assignee.trim();
     if key.is_empty() {
@@ -183,27 +192,17 @@ pub fn resolve(record: &CompanyRecord, assignee: &str) -> AssigneeResolution {
             None => AssigneeResolution::EmptyDesk(desk),
         };
     }
-    if let Some(id) = record.resolve_roster_agent_id(key) {
-        return AssigneeResolution::Agent(id);
-    }
-    // Then operator-added teammates by display name. Tried only after the id
-    // namespace so a display name can never shadow a real id. `ops::team` used
-    // to mint these with `id: generate_id()`, making the name the only string
-    // the operator ever saw — matching ids alone left every teammate they added
-    // unassignable on a free-text Assignee field (#214 review). Since #686 the
-    // id is a readable slug, so the typical new teammate now resolves on the
-    // line above; this arm still earns its keep for the two cases a slug does
-    // not cover — teammates added before #686, which keep their generated ids
-    // forever, and any teammate renamed since (the id is minted once and never
-    // follows a rename, so the current display name may be the *only* string
-    // the operator recognises).
-    let by_name = record.overlay_agent_ids_by_name(key);
-    match by_name.len() {
-        0 => AssigneeResolution::Unknown(key.to_string()),
-        1 => AssigneeResolution::Agent(by_name.into_iter().next().expect("one match")),
-        count => AssigneeResolution::AmbiguousTeammate {
+    // Then the teammate namespace: id first, then an operator-added teammate's
+    // display name. Both halves, in that order, live on
+    // `CompanyRecord::resolve_teammate_key` — this was the only surface that
+    // had them until #1162 gave the delegation path the same resolve, and the
+    // two must not be able to disagree about who a name means.
+    match record.resolve_teammate_key(key) {
+        TeammateResolution::Agent(id) => AssigneeResolution::Agent(id),
+        TeammateResolution::Unknown => AssigneeResolution::Unknown(key.to_string()),
+        TeammateResolution::Ambiguous(ids) => AssigneeResolution::AmbiguousTeammate {
             raw: key.to_string(),
-            count,
+            count: ids.len(),
         },
     }
 }

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -109,7 +109,7 @@ use crate::runtime::delegation_tools;
 ///
 /// The two hand-off delegations differ only in how they get here — a desk key
 /// through [`desk_lead`], a roster id straight through
-/// [`CompanyRecord::resolve_roster_agent_id`] — and this is the type that makes
+/// [`CompanyRecord::resolve_teammate_key`] — and this is the type that makes
 /// that the *only* difference. A hand-off's card, its steer registration, its
 /// depth bound and its relayed reply are properties of handing work over, not
 /// of the namespace the target was named in.
@@ -1398,11 +1398,19 @@ impl<'a> DelegationRunner<'a> {
             let lead = match &delegation {
                 Delegation::DelegateToDesk { desk, .. } => desk_lead(self.record, desk),
                 // Issue #884: resolved directly, with no desk in between — which
-                // is the point. `resolve_roster_agent_id` is pure over the same
+                // is the point. `resolve_teammate_key` is pure over the same
                 // record, so the second resolution inside `run_delegation`
                 // yields the same member, exactly as `desk_lead` does above.
+                //
+                // It grounds the display-name half of the roster too (#1162).
+                // The tool now queues the canonical id, so on the ordinary path
+                // this is the identity — but `ground` fails open for the
+                // orchestrator when the record cannot be read, and that path
+                // queues the key exactly as the model wrote it. Resolving the
+                // same way here is what stops a name that reached the queue
+                // from being dropped at the drain.
                 Delegation::DelegateToTeammate { teammate, .. } => {
-                    self.record.resolve_roster_agent_id(teammate)
+                    self.record.resolve_teammate_key(teammate).agent()
                 }
                 _ => None,
             };
@@ -2281,11 +2289,15 @@ impl<'a> DelegationRunner<'a> {
                 teammate,
                 instruction,
             } => {
-                let Some(member) = self.record.resolve_roster_agent_id(&teammate) else {
+                let Some(member) = self.record.resolve_teammate_key(&teammate).agent() else {
                     // The mirror of the desk arm's warning, and reachable for the
                     // same narrow reason: the tool grounds the target before
                     // queuing, so this is a teammate removed from the roster
-                    // between the call and the drain.
+                    // between the call and the drain — or one named on the
+                    // fail-open path, which queues the key ungrounded. Resolved
+                    // with the same id-then-name resolve the tool boundary used
+                    // (#1162), so a display name cannot be accepted there and
+                    // silently dropped here.
                     tracing::warn!(
                         company = %self.company,
                         teammate = %teammate,

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -40,7 +40,7 @@
 use serde_json::{Value, json};
 
 use crate::brain::medulla::wire::ToolManifestEntry;
-use crate::ports::types::CompanyRecord;
+use crate::ports::types::{CompanyRecord, TeammateResolution};
 
 /// The `spawn_task` tool name — open a tracked task card on the board.
 pub const SPAWN_TASK_TOOL: &str = "spawn_task";
@@ -254,7 +254,7 @@ cannot be used. Answer directly instead."
     // A teammate's id is the most common invented target (the orchestrator
     // reaches for the person it has in mind rather than the desk they sit on),
     // so name the mistake instead of only listing the alternatives.
-    let Some(agent) = record.resolve_roster_agent_id(key) else {
+    let Some(agent) = record.resolve_teammate_key(key).agent() else {
         return format!(
             "There is no \"{key}\" desk. Valid desk ids: {list}. Call `delegate_to_desk` again \
 with one of those ids."
@@ -395,6 +395,9 @@ fn chain_trail(chain: &[String]) -> String {
 /// * **Not a teammate** — `key` resolves to no roster agent. When it names a
 ///   *desk* the message says so and points at [`DELEGATE_TO_DESK_TOOL`], the
 ///   mirror of [`unknown_desk_message`]'s teammate arm.
+/// * **More than one teammate** — `key` is a display name two operator-added
+///   teammates answer to. Real, but not routable; the refusal names the
+///   colliding ids so the model can pick one (issue #1162).
 /// * **Yourself** — the target is the caller. Its turn is the one running.
 /// * **Out of reach** — a real teammate the caller may not hand work to: not on
 ///   a desk with them, and not on any desk their
@@ -409,8 +412,14 @@ pub fn reject_teammate_target(
     allowed: &[String],
     key: &str,
 ) -> Option<String> {
-    let Some(target) = record.resolve_roster_agent_id(key) else {
-        return Some(unknown_teammate_message(record, caller, allowed, key));
+    let target = match record.resolve_teammate_key(key) {
+        TeammateResolution::Agent(id) => id,
+        TeammateResolution::Unknown => {
+            return Some(unknown_teammate_message(record, caller, allowed, key));
+        }
+        TeammateResolution::Ambiguous(ids) => {
+            return Some(ambiguous_teammate_message(key, ids));
+        }
     };
     let caller = caller?;
     if target == caller {
@@ -468,6 +477,23 @@ work to. Do the work yourself, or say what you cannot do."
     }
 }
 
+/// The refusal for a `delegate_to_teammate` target that names **more than one**
+/// teammate (issue #1162).
+///
+/// Grounding a display name gave this case somewhere to happen: two
+/// operator-added teammates may carry the same name, and their ids are what
+/// tell them apart. Taking the first would be the misrouting
+/// [`CompanyRecord::overlay_agent_ids_by_name`] exists to end, and the plain
+/// "there is no such teammate" message would be a lie about a teammate that
+/// demonstrably exists — so the collision is named, with the ids to retry with.
+fn ambiguous_teammate_message(key: &str, ids: Vec<String>) -> String {
+    let list = agent_list(ids).unwrap_or_else(|| "-".to_string());
+    format!(
+        "\"{key}\" is the name of more than one teammate here, so it does not say who to hand \
+this to. Call `{DELEGATE_TO_TEAMMATE_TOOL}` again with one of their ids: {list}."
+    )
+}
+
 /// Why a **teammate** hand-off would close a loop rather than make progress — or
 /// `None` when the target is a step forward (issue #884).
 ///
@@ -483,7 +509,10 @@ pub fn reject_teammate_cycle_target(
     chain: &[String],
     key: &str,
 ) -> Option<String> {
-    let target = record.resolve_roster_agent_id(key)?;
+    // The same id-then-name resolve the refusal above grounds with (#1162): a
+    // hand-off written as a display name has to reach this guard as the id it
+    // means, or A→B→A spelled with a name would slip past the chain check.
+    let target = record.resolve_teammate_key(key).agent()?;
     let scoped = teammate_scope_key(&target);
     if !chain.iter().any(|entry| entry == &scoped) {
         return None;


### PR DESCRIPTION
## Summary

Closes #1162.

`query_company` built its `## Team` column from two namespaces and rendered them identically — manifest agents under `agent.id`, operator-added teammates under `overlay.name`. Since `mint_agent_id` slugs the display name (`"Dana Designer"` → `dana_designer`) and never re-mints, those two strings differ for essentially every teammate an operator adds, while every grounding site on the delegation path matched **ids only**. The orchestrator's brief (`orchestrator.rs:257`) and `delegate_to_teammate`'s own description both send the model to exactly that column for a hand-off target — so it did what it was told and was refused, then either retried or answered the work itself.

Four changes, and the third is what makes the first two safe:

1. **Every Team row leads with the id**, with the display name following as `(known as …)`. That is the shape `workflow_build::roster_line` (#813) already uses for the roster shown to the same model, so the two surfaces cannot drift apart.

2. **`CompanyRecord::resolve_teammate_key` is the id-then-name resolve, in one place.** Ids are tried first, so a display name can never shadow a real id. `assignee::resolve` — which was the only surface that had both halves — now delegates to it rather than carrying its own copy, and the delegation path grounds through it at `reject_teammate_target`, `reject_teammate_cycle_target`, `unknown_desk_message`'s teammate hint, and both drain sites. Desks are deliberately *not* folded in: `assignee::resolve` still tries `resolve_desk_id` itself, first, so `delegate_to_teammate` does not learn to accept desk ids and contradict its own "that's a desk, not a teammate" refusal. `workflow_build::resolve_agent_ids` also stays separate — it matches on **role** too, which is right for a surface that can ask a human which teammate they meant and wrong for this one, since roles legitimately collide.

3. **`delegate_to_teammate` queues the canonical id**, not the key as typed. This is the trap the issue does not mention: the tool queued the raw `required_str` argument and the drain re-resolved it independently (`delegation.rs:1405`, `:2284`). Teaching only the refusal to accept display names would let a name past the tool boundary, answer *"Handed to … They will answer this turn."*, and then fail at the drain — trading a refusal the model can retry for a drop (a `warn!` on the chat path, an undeliverable card on the dispatched-card path). A half-fix here is worse than no fix. The drain still resolves the same way, because `ground()` fails open for the orchestrator when the record cannot be read at all, and that path queues the key ungrounded.

4. **A display name two teammates answer to is refused with their ids** rather than routed to whichever was added first. Grounding names gave this case somewhere to happen, and `AmbiguousTeammate` had no message at the delegation boundary.

### Not in scope

Two adjacent gaps this deliberately does not touch, both worth their own issue if wanted:

- Hosted tenants get no `delegate_to_teammate` at all (`delegation_manifest_entries`, #884), so this is a harness-path fix.
- A **desk-member** caller is still refused for lack of desk co-membership even with the correct id — neither `add_agent` nor `ops::team` seats a new teammate on a desk. Only the orchestrator escapes it, via the `caller?` short-circuit.

## API Or Behavior Changes

- `query_company`'s `## Team` lines change shape: `- **dana_designer** — Designer (known as Dana Designer)`. Manifest agents are unchanged (they have no display name). The `"team"` count in the JSON payload is unchanged.
- `delegate_to_teammate` now **accepts** an operator-added teammate's display name, and its success reply names both strings when they differ: `Handed to Dana Designer (`dana_designer`).`
- The queued `Delegation::DelegateToTeammate.teammate` is now the canonical id on every grounded path.
- New public API: `CompanyRecord::resolve_teammate_key` and `TeammateResolution`. Nothing was removed — `resolve_roster_agent_id` and `overlay_agent_ids_by_name` keep their contracts and are what the new method is built from.

## Tests

Six added: three on the resolver (id, display name, and that a name cannot shadow an id / a shared name is reported as a collision), one pinning the roster render **to the resolver** — the assertion is that the token the line prints resolves, not that it contains a literal, so a render that drifts from grounding fails here — and two at the tool boundary (a name queues the id; a shared name is refused with both ids).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests --features openhuman -- -D warnings`
- [x] `cargo check --lib --tests --features openhuman`
- [x] `cargo test --lib --features openhuman` — 4484 passed, 0 failed, 3 ignored

## Documentation

No doc pages cover this surface. The rationale lives in doc comments: why ids win, why desks and the role-matching workflow resolver stay separate, and why the queued payload must be canonical.

---

<sub>Root-caused with a medulla `issue-rca-panel` run — one Claude session against the code, three independent verifiers (evidence / refutation / fix critique). The synthesis is [on the issue](https://github.com/tinyhumansai/opencompany/issues/1162#issuecomment-5344927001); points 3 and 4 and the two out-of-scope gaps came out of that review rather than the original report.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPB2GtVGHcJy2bEf4BNzpT
