### PR TITLE
Withhold the add-teammate confirmation when the read-back fails

### DIFF
--- a/frontend/src/lib/member-feedback.ts
+++ b/frontend/src/lib/member-feedback.ts
@@ -44,6 +44,41 @@ export type AddMemberOutcome =
   /** Nothing was created. `message` is the host's refusal where there is one. */
   | { kind: "failed"; message: string };
 
+/**
+ * One step of the add that did not land.
+ *
+ * A single add can miss in more than one way at once — the inbox refused *and*
+ * the refetch that was meant to substantiate the whole thing failed — and
+ * picking one to report would drop a failure the operator has to act on. So the
+ * views collect what missed and `addOutcome` builds the sentence.
+ */
+export interface MissedStep {
+  /** Completes "Added Ada, but …" — no leading capital, no trailing stop. */
+  what: string;
+  /** What the operator can do about it, as a whole sentence. */
+  fix?: string;
+}
+
+/**
+ * A clean add, or the honest version of one.
+ *
+ * Empty `missed` is the only thing that earns a plain success. In particular a
+ * refetch that failed belongs in here rather than being ignored: the console
+ * cannot see the record it is about to congratulate itself on, and on the Team
+ * roster the failed read actively *replaces* the roster with the starter team,
+ * so "Added Ada." would sit above a list Ada is not in.
+ */
+export function addOutcome(name: string, missed: MissedStep[]): AddMemberOutcome {
+  if (missed.length === 0) return { kind: "added", name };
+  const fixes = missed.map((m) => m.fix).filter(Boolean);
+  return {
+    kind: "partial",
+    name,
+    missed: `${missed.map((m) => m.what).join(", and ")}.`,
+    fix: fixes.length ? fixes.join(" ") : undefined,
+  };
+}
+
 /** A toast, decided but not yet raised — the testable half of the answer. */
 export interface AddMemberMessage {
   level: "success" | "warning" | "error";

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -29,7 +29,12 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { emptyDraft, type AgentDraft, type AgentFieldKey } from "@/lib/agent";
-import { addMemberFailure, reportAddMember } from "@/lib/member-feedback";
+import {
+  addMemberFailure,
+  addOutcome,
+  reportAddMember,
+  type MissedStep,
+} from "@/lib/member-feedback";
 import {
   fromDto,
   initials,
@@ -154,7 +159,16 @@ export function TeamView({
     }
   }
 
-  const boot = useCallback(async () => {
+  /**
+   * Re-read the roster. Answers whether it landed.
+   *
+   * The catch below is right to show nobody, and wrong to stay silent about
+   * after a write we know the host took: a failed read here does not leave a
+   * stale list, it empties the one the operator is about to be congratulated
+   * over. `addMember` is the only caller that looks at the answer; the effects
+   * and the Back handler still fire and forget.
+   */
+  const boot = useCallback(async (): Promise<boolean> => {
     try {
       const roster = await client.listTeam(company);
       if (roster.length) {
@@ -172,6 +186,7 @@ export function TeamView({
         setFromHost(false);
         setHostEmpty(true);
       }
+      return true;
     } catch {
       // The roster read failed, so we never learned who is on this company.
       // Show nobody rather than a fabricated team: an operator cannot tell an
@@ -180,6 +195,7 @@ export function TeamView({
       setMembers([]);
       setFromHost(false);
       setHostEmpty(false);
+      return false;
     } finally {
       setLoad("ready");
     }
@@ -289,33 +305,33 @@ export function TeamView({
       return;
     }
 
+    const missed: MissedStep[] = [];
     // Enable the inbox against the host's real agent id *before* refetching, so
     // the reloaded roster already reports the toggle as on.
-    let inboxMissed = false;
     if (fields.inbox) {
       try {
         await setInboxEnabled(client, company, created.id, true);
       } catch {
-        inboxMissed = true;
+        missed.push({
+          what: "their inbox couldn't be switched on",
+          fix: "Turn it on from their actions menu.",
+        });
       }
     }
     // Persisted on the host — refetch so the card reflects the real record
     // (id, merge order, inbox state) rather than a locally-guessed one.
-    await boot();
+    if (!(await boot())) {
+      missed.push({
+        what: "the roster couldn't be read back",
+        fix: "The roster below is empty because that read failed, not because your company is — reload to see them.",
+      });
+    }
     setAddOpen(false);
-    // Announced after the refetch, not on the response: the roster the operator
-    // is looking at is the one being claimed about, so a read that contradicted
-    // the write would contradict the toast too rather than follow it.
-    reportAddMember(
-      inboxMissed
-        ? {
-            kind: "partial",
-            name: fields.name,
-            missed: "their inbox couldn't be switched on.",
-            fix: "Turn it on from their actions menu.",
-          }
-        : { kind: "added", name: fields.name },
-    );
+    // Announced after the refetch, not on the response, and only as a clean add
+    // when that refetch actually landed: the roster the operator is looking at
+    // is the one being claimed about, so a read that could not confirm the
+    // write must not be toasted over as though it had.
+    reportAddMember(addOutcome(fields.name, missed));
   }
 
   async function removeMember(member: TeamMember) {

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -48,9 +48,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   addMemberFailure,
+  addOutcome,
   NO_TEAM_WRITE_PLANE,
   reportAddMember,
   type AddMemberOutcome,
+  type MissedStep,
 } from "@/lib/member-feedback";
 import {
   addableTo,
@@ -134,7 +136,16 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
   const [focusMark, setFocusMark] = useState<string | null>(null);
   const chartRef = useRef<HTMLDivElement | null>(null);
 
-  const boot = useCallback(async () => {
+  /**
+   * Re-read the whole chart. Answers whether it landed.
+   *
+   * A read superseded by a newer one counts as landed: another `boot` owns the
+   * screen and will settle it, so reporting a reload failure for it would warn
+   * about a chart nobody is looking at. Only the catch is a real miss, and
+   * `addMember` is the only caller that asks — everything else fires and
+   * forgets, which is why this reports rather than rejects.
+   */
+  const boot = useCallback(async (): Promise<boolean> => {
     const mine = ++gen.current;
     try {
       // Desks are the only required half — they are the chart. The roster and
@@ -156,7 +167,7 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
           .catch(() => [] as OrgPerson[]),
         client.status(company).catch(() => null),
       ]);
-      if (mine !== gen.current) return;
+      if (mine !== gen.current) return true;
       // Cleared here rather than at the top of the write that triggered this
       // read: since #1099 the banner belongs to the load alone, so a chart that
       // loads is the only thing that can retire the message saying it did not.
@@ -170,14 +181,16 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
         ),
       );
       setLoad("ready");
+      return true;
     } catch (e) {
-      if (mine !== gen.current) return;
+      if (mine !== gen.current) return true;
       // A failed `/desks` is a real error, not an empty company. Inventing an
       // empty chart here would tell the operator their desks are gone.
       setError(
         e instanceof Error ? e.message : "Could not load the org chart.",
       );
       setLoad("error");
+      return false;
     }
   }, [client, company]);
 
@@ -305,6 +318,9 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
     // `boot()`, so a refetch that contradicts the write contradicts the message
     // too rather than arriving a beat behind it.
     let outcome: AddMemberOutcome;
+    // Every step of the ask that did not land, in the order the operator met
+    // them. Empty is the only thing that earns "Added <name>.".
+    const missed: MissedStep[] = [];
     try {
       let created: TeamMemberDto;
       try {
@@ -328,7 +344,6 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
         }
         throw e;
       }
-      outcome = { kind: "added", name: fields.name };
       if (deskId) {
         try {
           await client.addDeskMember(deskId, created.id, company);
@@ -336,15 +351,22 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
           // Created but unplaced — a real half-landing, and the operator has
           // to know which half, because the fix is on the chart in front of
           // them rather than in the dialog they just closed.
-          outcome = {
-            kind: "partial",
-            name: fields.name,
-            missed: `they couldn't be added to that desk: ${e instanceof Error ? e.message : "unknown error"}`,
-            fix: "They're on the roster — drag them onto the desk from here.",
-          };
+          missed.push({
+            what: `they couldn't be added to that desk: ${e instanceof Error ? e.message : "unknown error"}`,
+            fix: "They're on the roster — drag them onto the desk from the chart.",
+          });
         }
       }
-      await boot();
+      if (!(await boot())) {
+        // The chart is on its error state behind this toast. Congratulating the
+        // operator over a banner saying the chart could not be loaded is the
+        // contradiction #1099 set out to remove, not one to add.
+        missed.push({
+          what: "the chart couldn't be read back",
+          fix: "Retry to see where they landed.",
+        });
+      }
+      outcome = addOutcome(fields.name, missed);
       setAddMemberOpen(false);
     } catch (e) {
       setAddMemberOpen(false);

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -76,6 +76,15 @@ let teamWriteAvailable = true;
  */
 let deskAddAvailable = true;
 
+/**
+ * Makes `GET .../desks` fail from the moment a teammate is created, so the
+ * create-landed-then-read-back-failed case is reachable. The write still
+ * succeeds — that is the point: the host has the teammate and the console
+ * cannot see them.
+ */
+let desksReadFailsAfterCreate = false;
+let desksReadable = true;
+
 /** The host's desks, as this stub holds them. Mutated by the write routes. */
 let desks: Desk[] = [];
 
@@ -84,6 +93,8 @@ function reset() {
   roster = [...ROSTER];
   teamWriteAvailable = true;
   deskAddAvailable = true;
+  desksReadFailsAfterCreate = false;
+  desksReadable = true;
   desks = [
     {
       id: "engineering",
@@ -216,6 +227,7 @@ async function mockApi(page: Page) {
         desks = [...desks, created];
         return json(created, 201);
       }
+      if (!desksReadable) return json({ error: "unavailable" }, 500);
       return json(desks);
     }
 
@@ -234,6 +246,7 @@ async function mockApi(page: Page) {
       };
       roster = [...roster, created];
       writes.push({ method, path, body });
+      if (desksReadFailsAfterCreate) desksReadable = false;
       return json(created, 201);
     }
     if (path.endsWith("/team")) return json(roster);
@@ -563,6 +576,39 @@ test("#1099 a teammate added from the company page is confirmed by name", async 
   // through sonner's own type attribute so the two cannot be confused by
   // wording alone.
   await expect(toasts(page).first()).toHaveAttribute("data-type", "success");
+});
+
+test("#1099 a teammate the chart cannot read back is not confirmed as added", async ({
+  page,
+}) => {
+  // The host takes the teammate and then the chart's own read fails. `boot`
+  // swallows that — it has to, the chart has an error state and a Retry — so
+  // without the check the console toasted "Added Grace Murray." over a banner
+  // saying the chart could not be loaded.
+  desksReadFailsAfterCreate = true;
+  await mockApi(page);
+  await openChart(page);
+
+  await page.getByRole("button", { name: "New teammate" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name").fill("Grace Murray");
+  await dialog.getByLabel("Role").fill("Compiler");
+  await dialog.getByRole("button", { name: "Add teammate" }).click();
+
+  const notice = toasts(page).first();
+  await expect(notice).toContainText("Added Grace Murray, but");
+  await expect(notice).toContainText("chart couldn't be read back");
+  await expect(notice).toHaveAttribute("data-type", "warning");
+  // The teeth: nothing anywhere claims the clean add. `Added Grace Murray.`
+  // with a full stop is the exact string the success arm produces.
+  await expect(page.getByText("Added Grace Murray.", { exact: true })).toHaveCount(0);
+  // And the write really did land, so this is the honest half-landing rather
+  // than a failure being reported as one.
+  expect(
+    writes.find(
+      (write) => write.method === "POST" && write.path.endsWith("/team"),
+    ),
+  ).toBeTruthy();
 });
 
 test("#311 the lead can be changed from the chart and survives a reload", async ({

--- a/frontend/test/unit/member-feedback.test.ts
+++ b/frontend/test/unit/member-feedback.test.ts
@@ -18,9 +18,8 @@ vi.mock("sonner", () => {
   return { toast };
 });
 
-const { addMemberFailure, addMemberMessage, reportAddMember } = await import(
-  "@/lib/member-feedback"
-);
+const { addMemberFailure, addMemberMessage, addOutcome, reportAddMember } =
+  await import("@/lib/member-feedback");
 
 /**
  * Issue #1099: adding a teammate said nothing at all, and the three surfaces
@@ -78,6 +77,62 @@ describe("addMemberMessage", () => {
       level: "error",
       title: "Name already taken.",
     });
+  });
+});
+
+/**
+ * A refetch that failed is a missed step, not a detail (review of #1099).
+ *
+ * Both `boot()`s swallow their own errors — `TeamView`'s goes further and
+ * empties the roster — so before this the console could POST a teammate, fail
+ * to read them back, and toast "Added Ada." over a list Ada was not in. The
+ * refetch is what the toast's timing was justified by, so it has to be able to
+ * withhold the confirmation it was supposed to substantiate.
+ */
+describe("addOutcome", () => {
+  it("is a clean add only when nothing missed", () => {
+    expect(addOutcome("Ada", [])).toEqual({ kind: "added", name: "Ada" });
+  });
+
+  it("withholds the confirmation when the read-back failed", () => {
+    const outcome = addOutcome("Ada", [
+      { what: "the roster couldn't be read back", fix: "Reload to see them." },
+    ]);
+    expect(outcome.kind).toBe("partial");
+    expect(addMemberMessage(outcome)).toEqual({
+      level: "warning",
+      title: "Added Ada, but the roster couldn't be read back.",
+      description: "Reload to see them.",
+    });
+  });
+
+  it("reports every miss, rather than picking one", () => {
+    // The inbox refusing and the read-back failing are different follow-ups
+    // and the operator owes both; dropping either is how one goes unnoticed.
+    const msg = addMemberMessage(
+      addOutcome("Ada", [
+        { what: "their inbox couldn't be switched on", fix: "Turn it on from their actions menu." },
+        { what: "the roster couldn't be read back", fix: "Reload to see them." },
+      ]),
+    );
+    expect(msg.title).toBe(
+      "Added Ada, but their inbox couldn't be switched on, and the roster couldn't be read back.",
+    );
+    expect(msg.description).toBe(
+      "Turn it on from their actions menu. Reload to see them.",
+    );
+  });
+
+  it("carries no description when no step offered a follow-up", () => {
+    expect(addOutcome("Ada", [{ what: "something slipped" }]).kind).toBe("partial");
+    expect(addMemberMessage(addOutcome("Ada", [{ what: "something slipped" }])).description).toBeUndefined();
+  });
+
+  it("never reaches toast.success for a failed read-back", () => {
+    for (const fn of Object.values(toasts)) fn.mockClear();
+    reportAddMember(addOutcome("Ada", [{ what: "the roster couldn't be read back" }]));
+    expect(toasts.success).not.toHaveBeenCalled();
+    expect(toasts.warning).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Follow-up to #1114 (issue #1099), which merged before this review fix could be
pushed to it. Same subject, one defect.

## The defect

#1114 justified toasting *after* `boot()` rather than on the POST response, with
this comment:

> a read that contradicted the write would contradict the toast too rather than
> follow it.

That was false. Both `boot()`s catch their own errors and resolve normally, so
`await boot()` told the caller nothing and the toast fired either way:

- **`TeamView`** — the catch sets `setMembers([])`. A failed `listTeam` after a successful POST therefore does not leave a stale list, it empties the one the operator is about to be congratulated over, so `Added Ada.` appeared above a roster Ada was not in.
- **`OrgChartView`** — the catch sets `load="error"`, so the confirmation landed directly beside the banner reading "The org chart could not be loaded."

`ChatView` is unaffected and untouched: its `addMember` never refetches, it
patches state from the POST response, so there is no read to fail.

## The fix

Both `boot()`s now answer whether the read landed, and a failed read joins the
inbox and desk failures as a missed step feeding a new `addOutcome()` — a plain
success only when nothing missed.

Two decisions worth stating:

- **Report, don't reject.** Every other call site is a fire-and-forget `void boot()` in an effect or the Retry button; rejecting would turn those into unhandled rejections. A read superseded by the generation guard counts as landed — another `boot` owns the screen, so warning about it would warn about a chart nobody is looking at.
- **Every miss is named, not one picked.** The inbox refusing and the read-back failing are different follow-ups and the operator owes both.

**Not done, deliberately:** the review also suggested holding the dialog open
until the reload succeeds. I did not. The teammate exists on the host at that
point, so leaving the form open invites a duplicate person — worse, and less
reversible, than a chart the operator has to Retry.

## Tests

- New e2e `#1099 a teammate the chart cannot read back is not confirmed as added` — the stub's `GET .../desks` fails from the moment the create lands, so the write succeeds and the read does not. Asserts the warning, and that `Added Grace Murray.` (the exact string the success arm emits) appears nowhere. **Verified red against current `main`** — "element(s) not found" for the warning — and green here.
- 5 new unit cases on `addOutcome`, including that a failed read-back never reaches `toast.success`, and that two simultaneous misses are both reported.

`TeamView`'s wiring is covered at the unit level only: there is no mocked
`TeamView` e2e in the suite, and the live-host team specs deliberately create no
teammates.

## Rebase note

Cherry-picked onto current `main`, which moved under this: `starterTeam()` is
gone (`56bb7589`), so one comment and one follow-up string were rewritten to
describe the empty-roster behaviour that replaced it rather than the fabricated
one, and the new spec was moved onto the dialog's renamed **Add teammate**
button. Conflict was one line in `boot`'s catch; nothing from `main` was
reverted.

## Commands run

- `tsc -b --noEmit`, `tsc -p tsconfig.unit.json`, `tsc -p tsconfig.e2e.json` — clean
- `vitest run` — 126 files, 1233 tests, all pass
- `playwright test test/e2e/org-tree.spec.ts` against a dev-server `PW_BASE_URL` — 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved member- and teammate-add feedback when follow-up steps fail.
  - Warnings now identify incomplete actions, including failed inbox setup or roster/chart refreshes.
  - Clean success messages are shown only when the updated roster or chart is confirmed.

- **Tests**
  - Added coverage for multiple failed steps, missing follow-up guidance, and failed chart read-backs.
  - Added end-to-end validation that completed writes still display an appropriate warning when refreshing the chart fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->