### PR TITLE
console: take Pages out of the sidebar nav

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  AppWindow,
+  // AppWindow,  // re-add with the Pages nav entry below
   FolderClosed,
   LayoutDashboard,
   type LucideIcon,
@@ -156,7 +156,12 @@ const NAV: NavItem[] = [
   // Agent-authored internal dashboard pages, rendered in a sandboxed iframe
   // (docs/spec/runtime/pages.md). Placed beside Workflows: both are the
   // "something an agent built" surfaces, as opposed to the fixed views above.
-  { view: "pages", label: "Pages", icon: AppWindow },
+  // Pages is deliberately not offered in the nav. The view and its `#/pages`
+  // route stay live, so an address or an existing link still resolves — this
+  // is the same treatment `feedback`, `inbox`, `memory`, `finances`,
+  // `conversation` and `team` already get. Do not "fix" the omission by
+  // adding it back.
+  // { view: "pages", label: "Pages", icon: AppWindow },
   { view: "settings", label: "Settings", icon: Settings2 },
 ];
 


### PR DESCRIPTION
Closes #1171.

`Pages` is no longer offered in the sidebar. **Commented, not deleted** — `PagesView` and the `#/pages` route stay intact, so an address or an existing link still resolves, and restoring the entry is one line.

That matches how this console already treats views it does not advertise: `feedback`, `inbox`, `memory`, `finances`, `conversation` and `team` are all routable and absent from the nav list. A comment says it is deliberate, so the next reader does not "fix" the omission by adding it back.

## The import goes with it

Removing the entry leaves `AppWindow` unused, which fails `tsc -b` with `TS6133` — and `tsc -b` is the first step of `npm run build`, which **Console, Console (advisory), Desktop and both E2E lanes each run before doing anything**. Exactly one unused binding took all five lanes down earlier today on an unrelated PR. So the import is commented alongside the entry it belongs to.

## Verification

`npm run typecheck` clean · `npm run typecheck:unit` 0 errors · `npm test` **1268 passed**.

`test/unit/pages-view-bridge.test.ts` exercises the view rather than the nav entry, so it is unaffected and still passes.