### PR TITLE
console: name each host in the switcher, and say which one is broken

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -174,7 +174,18 @@ function Console() {
       // Hosts added in a previous session come back first, so the bootstrap add
       // below finds its own profile already registered and reuses that entry
       // rather than creating a duplicate row for one host.
-      restoreConnections();
+      //
+      // Told which same-origin console this load is, so the rows a *previous*
+      // one left behind stay out of the switcher. A link carrying `?company=`
+      // writes its own profile at the same (empty) address, so restoring every
+      // one of them put an identical row in the menu for every company ever
+      // opened here — issue #1167. Only when the bootstrap is same-origin: a
+      // console pointed elsewhere with `?api=` claims nothing about what lives
+      // at its own origin.
+      restoreConnections(
+        undefined,
+        config.baseUrl === "" ? { defaultCompany: config.company } : undefined,
+      );
       // `null` in the desktop, which has no host at its own origin and never
       // will — see `isAddressableBaseUrl`. Adding one anyway is what made the
       // packaged app open on a connection that could not work and select it,

--- a/frontend/src/components/host-switcher.tsx
+++ b/frontend/src/components/host-switcher.tsx
@@ -57,7 +57,14 @@ import { hostShortcutLabel, useHosts } from "@/connections/HostsContext";
 import type { Connection, ConnectionStatus } from "@/connections/types";
 import { cn } from "@/lib/utils";
 
-/** How a connection's state reads, and what colour says so. */
+/**
+ * How a connection's state reads, and what colour says so.
+ *
+ * The `label` is the load-bearing half and the dot is the shorthand, not the
+ * other way round: a row that is anything but `live` prints its state (issue
+ * #1167), because hue alone tells an operator that *something* differs without
+ * saying what, and tells someone who cannot separate amber from green nothing.
+ */
 const STATUS_COPY: Record<ConnectionStatus, { label: string; dot: string }> = {
   connecting: { label: "Connecting…", dot: "bg-muted-foreground/50" },
   live: { label: "Connected", dot: "bg-status-done" },
@@ -257,7 +264,23 @@ export function HostSwitcher({ variant = "sidebar", companyName }: Props) {
               <span className={cn("flex-1 truncate", connection.id === selected && "font-medium")}>
                 {connection.label}
               </span>
-              <span className="sr-only">{status.label}</span>
+              {connection.status === "live" ? (
+                // Nothing to say out loud on a host that is simply working, so
+                // the state stays where a screen reader can still reach it.
+                <span className="sr-only">{status.label}</span>
+              ) : (
+                // In words, not in hue (issue #1167). A colour is no help to
+                // anyone who cannot tell these two apart, and even where it is
+                // read correctly "amber" does not say *what* is wrong —
+                // leaving an operator to discover an unreachable host by
+                // landing on its failure. This is the row telling them first.
+                <span
+                  data-testid={`host-row-state-${connection.id}`}
+                  className="shrink-0 text-xs text-muted-foreground"
+                >
+                  {status.label}
+                </span>
+              )}
               {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
               {connection.id === selected && <Check className="size-4 shrink-0" />}
             </DropdownMenuItem>

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -204,7 +204,7 @@ export function addConnection(input: AddConnection): ConnectionId {
   const id = remembered?.id ?? mintId();
   const connection: Connection = {
     id,
-    label: input.label ?? remembered?.label ?? hostLabel(baseUrl),
+    label: input.label ?? rememberedLabel(remembered) ?? hostLabel(baseUrl),
     baseUrl,
     defaultCompany,
     credential: input.credential ?? { kind: "cookie" },
@@ -312,13 +312,31 @@ function sameCredential(a: Credential, b: Credential): boolean {
   return true;
 }
 
-export function restoreConnections(transport?: Transport): ConnectionId[] {
+/**
+ * The same-origin console this page load *is*.
+ *
+ * Passed by `App` when the bootstrap host is the origin serving the bundle,
+ * which is every ordinary web deployment. Absent in the desktop, where a
+ * same-origin profile is unreachable and dropped outright by
+ * {@link keepIfReachable}, and in a console pointed elsewhere with `?api=`,
+ * which makes no claim about what lives at its own origin.
+ */
+export interface SameOriginConsole {
+  /** What `?company=` names on this load; `null` for the alias form. */
+  defaultCompany: string | null;
+}
+
+export function restoreConnections(
+  transport?: Transport,
+  sameOrigin?: SameOriginConsole,
+): ConnectionId[] {
   return readProfiles()
     .filter(keepIfReachable)
+    .filter((profile) => isThisConsole(profile, sameOrigin))
     .map((profile) =>
       addConnection({
         baseUrl: profile.baseUrl,
-        label: profile.label,
+        label: rememberedLabel(profile),
         defaultCompany: profile.defaultCompany,
         credential: profile.credential,
         identity: profile.instanceId ? { instanceId: profile.instanceId } : undefined,
@@ -345,6 +363,38 @@ function keepIfReachable(profile: ConnectionProfile): boolean {
   if (isAddressableBaseUrl(profile.baseUrl)) return true;
   forgetProfile(profile.id);
   return false;
+}
+
+/**
+ * Whether a same-origin profile is *this* page load's console, or a past one.
+ *
+ * The second half of issue #1167, and the reason the duplicate row existed at
+ * all. Profiles are keyed on `(baseUrl, defaultCompany)` — deliberately, so
+ * `?company=a` and `?company=b` keep their view state apart (`findProfile`) —
+ * but the empty base url is one host, whichever company a link named. So every
+ * distinct `?company=` ever opened against this origin left a durable profile
+ * behind, and this function is what used to bring all of them back: one row per
+ * company ever visited, all at the same address, all with the same name, and
+ * nothing that ever expired them.
+ *
+ * They are not extra hosts. A connection already carries every company its host
+ * serves, and `switchCompany` moves between them *inside* one console
+ * (`ConnectionConsole.tsx`) — so a second row for the same origin offers an
+ * operator a choice that changes nothing but which of two identical rows is
+ * ticked.
+ *
+ * Skipped rather than forgotten, which is the distinction `retireConnection`
+ * exists for: the profile stays, so opening `?company=b` again lands on the
+ * same connection id and the same scoped state (`scopedKey`) rather than a
+ * freshly minted one.
+ */
+function isThisConsole(
+  profile: ConnectionProfile,
+  sameOrigin: SameOriginConsole | undefined,
+): boolean {
+  if (sameOrigin === undefined) return true;
+  if (profile.baseUrl !== "") return true;
+  return profile.defaultCompany === sameOrigin.defaultCompany;
 }
 
 /** Where a host running inside this application is, and who it is. */
@@ -773,12 +823,58 @@ function labelOf(id: ConnectionId): string {
   return getConnection(id)?.label ?? id;
 }
 
-/** A readable name for a host before it has told us its own. */
+/**
+ * The name every same-origin connection used to carry, and no longer earns.
+ *
+ * Kept as a constant because two things still need to recognise it: the
+ * fallback below, for a runtime with no address to read, and
+ * {@link rememberedLabel}, which has to spot it in a profile written before
+ * issue #1167 and re-derive rather than restore it.
+ */
+export const SAME_ORIGIN_LABEL = "This host";
+
+/**
+ * A readable name for a host before it has told us its own.
+ *
+ * A same-origin host has no url of its own to read, and naming it by a constant
+ * is the whole of issue #1167: *every* such connection came out with the same
+ * name, so a console holding two offered an operator two identical rows in the
+ * host switcher with nothing but the hue of a status dot between them — the
+ * failure `adoptLocalHosts` above was written to end, resurfacing somewhere a
+ * position and a hover title no longer make up for it.
+ *
+ * The origin serving this page is what the connection actually addresses, so it
+ * is both distinguishing and honest. "This host" is only ever true of one row,
+ * and survives here solely for a runtime with no location to read — Node, under
+ * the unit tests — where a label is still required and there is nothing better.
+ */
 export function hostLabel(baseUrl: string): string {
-  if (!baseUrl) return "This host";
+  if (!baseUrl) return sameOriginLabel();
   try {
     return new URL(baseUrl).host;
   } catch {
     return baseUrl;
   }
+}
+
+function sameOriginLabel(): string {
+  const host = typeof window === "undefined" ? "" : (window.location?.host ?? "");
+  return host || SAME_ORIGIN_LABEL;
+}
+
+/**
+ * The remembered name for a host, or `undefined` when it is not worth keeping.
+ *
+ * Installs are durable, so dropping the constant from {@link hostLabel} does
+ * nothing on its own: every console that has already run wrote "This host" into
+ * `oc.connections.v1`, and a remembered label outranks a derived one — so the
+ * indistinguishable name would outlive the fix on exactly the machines that
+ * reported it. A profile still carrying it is therefore treated as carrying
+ * none. Only the same-origin row is treated this way; a host someone typed is
+ * named by its address and could never have been given this label.
+ */
+function rememberedLabel(profile: ConnectionProfile | undefined): string | undefined {
+  if (!profile) return undefined;
+  if (profile.baseUrl === "" && profile.label === SAME_ORIGIN_LABEL) return undefined;
+  return profile.label;
 }

--- a/frontend/test/e2e/connection-degrade.spec.ts
+++ b/frontend/test/e2e/connection-degrade.spec.ts
@@ -30,6 +30,15 @@ import { openHostMenu } from "./host-switcher";
 /** A port nothing is listening on, so the second connection is always down. */
 const DEAD_HOST = "http://127.0.0.1:9";
 
+/** The tour modal covers the board and swallows clicks. */
+async function silenceTour(page: Page) {
+  await page.addInitScript(() => {
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
+    }
+  });
+}
+
 /**
  * Seeds a second host into the connection store before the app boots.
  *
@@ -39,11 +48,8 @@ const DEAD_HOST = "http://127.0.0.1:9";
  * shell is where adding hosts becomes a first-class flow).
  */
 async function seedSecondHost(page: Page) {
+  await silenceTour(page);
   await page.addInitScript((dead) => {
-    // The tour modal covers the board and swallows clicks.
-    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
-      window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
-    }
     window.localStorage.setItem(
       "oc.connections.v1",
       JSON.stringify([
@@ -98,6 +104,14 @@ test("a host that is down reddens its own row and leaves the others working", as
   await expect(page.getByTestId("host-row-conn-dead")).toHaveAttribute("data-status", "down", {
     timeout: 30_000,
   });
+  // And it says so in words, not only in the colour of its dot. An operator
+  // who cannot separate amber from green — or who can, and still does not know
+  // *what* amber means here — otherwise learns the host is gone by switching
+  // to it and landing on its failure (issue #1167).
+  await expect(page.getByTestId("host-row-state-conn-dead")).toHaveText("Unreachable");
+  // The working row stays quiet: a state printed beside every host is a state
+  // beside none of them.
+  await expect(page.getByTestId("host-row-state-conn-primary")).toHaveCount(0);
   await page.keyboard.press("Escape");
 
   // THE assertion. The working host's console is rendered, not a full-screen
@@ -161,4 +175,54 @@ test("the number row switches hosts, and leaves the browser alone past the last 
   await page.keyboard.press(`${mod}+1`);
   await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1);
   await expect(page.getByTestId("connection-error")).toHaveCount(0);
+});
+
+/**
+ * The naming half of issue #1167, and the state that produced the screenshot.
+ *
+ * The same-origin host is the one with no url of its own to read, and it used
+ * to be named by a constant — so a console holding it beside anything else
+ * unnamed offered two rows reading "This host", one live and one not, with only
+ * a dot colour between them. Nothing is seeded for it here on purpose: the
+ * point is what the console calls a host it was told nothing about.
+ */
+test("names the host it was told nothing about by the address it answers on", async ({
+  page,
+  baseURL,
+}) => {
+  const origin = new URL(baseURL ?? "http://127.0.0.1:8080").host;
+  await silenceTour(page);
+  await page.addInitScript((dead) => {
+    window.localStorage.setItem(
+      "oc.connections.v1",
+      JSON.stringify([
+        // A second host, and nothing about the bootstrap one — which is exactly
+        // the arrangement an ordinary console reaches by adding a host.
+        {
+          id: "conn-unnamed-dead",
+          baseUrl: dead,
+          label: "Offline host",
+          defaultCompany: null,
+          credential: { kind: "cookie" },
+        },
+      ]),
+    );
+  }, DEAD_HOST);
+
+  await page.goto("/#/ledgers/tasks");
+  await openHostMenu(page);
+
+  const rows = await page.getByRole("menuitem").allInnerTexts();
+  // Every menu item but the trailing "Add a host", down to its first line: a
+  // row also carries its state and its shortcut, and a shortcut differs on
+  // every row — comparing whole rows would call two identical names distinct.
+  const names = rows
+    .filter((text) => !text.includes("Add a host"))
+    .map((text) => text.split("\n")[0].trim());
+  expect(names.length).toBe(2);
+  expect(new Set(names).size, `two hosts must not read alike: ${JSON.stringify(names)}`).toBe(2);
+  // Addressable, so it distinguishes — and distinct from every other row, which
+  // a constant could never promise.
+  expect(names.some((name) => name.includes(origin))).toBe(true);
+  expect(names.some((name) => name.includes("This host"))).toBe(false);
 });

--- a/frontend/test/unit/connection-registry.test.ts
+++ b/frontend/test/unit/connection-registry.test.ts
@@ -111,8 +111,122 @@ describe("registering a host", () => {
     expect(getConnection(addConnection({ baseUrl: "https://acme.test:9000" }))?.label).toBe(
       "acme.test:9000",
     );
-    // Same-origin, which is how the web build is configured.
-    expect(getConnection(addConnection({ baseUrl: "" }))?.label).toBe("This host");
+    // Same-origin, which is how the web build is configured. Named by the
+    // origin serving the page rather than by a constant: issue #1167, where two
+    // such rows in the host switcher came out with identical names and only a
+    // dot colour between them.
+    expect(getConnection(addConnection({ baseUrl: "" }))?.label).toBe(window.location.host);
+    expect(window.location.host).not.toBe("");
+  });
+
+  it("re-derives the name a version before #1167 wrote down", () => {
+    // The durability half. Every console that has already run wrote "This host"
+    // into `oc.connections.v1`, and a remembered label outranks a derived one —
+    // so without this the indistinguishable name outlives the fix on exactly
+    // the machines that reported it.
+    window.localStorage.setItem(
+      "oc.connections.v1",
+      JSON.stringify([
+        {
+          id: "conn-legacy-origin",
+          baseUrl: "",
+          label: "This host",
+          defaultCompany: null,
+          credential: { kind: "cookie" },
+        },
+      ]),
+    );
+
+    const [id] = restoreConnections();
+
+    expect(id).toBe("conn-legacy-origin");
+    expect(getConnection(id)?.label).toBe(window.location.host);
+    // And written back, so the next load reads the new name rather than
+    // re-deriving it forever.
+    expect(findProfile("", null)?.label).toBe(window.location.host);
+  });
+
+  it("keeps a name an operator's host reported for itself", () => {
+    // The rule only reaches the constant. A host that named itself, or one
+    // someone typed an address for, is untouched.
+    window.localStorage.setItem(
+      "oc.connections.v1",
+      JSON.stringify([
+        {
+          id: "conn-named",
+          baseUrl: "",
+          label: "Acme",
+          defaultCompany: null,
+          credential: { kind: "cookie" },
+        },
+      ]),
+    );
+
+    expect(getConnection(restoreConnections()[0])?.label).toBe("Acme");
+  });
+});
+
+/**
+ * One same-origin row, not one per company ever opened here (issue #1167).
+ *
+ * Profiles are keyed on `(baseUrl, defaultCompany)`, so a link carrying
+ * `?company=` writes a second durable profile at the *same* (empty) address.
+ * Restoring all of them put an identical row in the host switcher for every
+ * company ever visited — same host, same name, nothing that expired them.
+ */
+describe("the same-origin console", () => {
+  const profiles = [
+    {
+      id: "conn-origin-alias",
+      baseUrl: "",
+      label: "This host",
+      defaultCompany: null,
+      credential: { kind: "cookie" },
+    },
+    {
+      id: "conn-origin-acme",
+      baseUrl: "",
+      label: "This host",
+      defaultCompany: "acme",
+      credential: { kind: "cookie" },
+    },
+    {
+      id: "conn-remote",
+      baseUrl: "https://remote.test",
+      label: "Remote",
+      defaultCompany: null,
+      credential: { kind: "cookie" },
+    },
+  ];
+
+  beforeEach(() => {
+    window.localStorage.setItem("oc.connections.v1", JSON.stringify(profiles));
+  });
+
+  it("restores only the one this page load is, plus every other host", () => {
+    expect(restoreConnections(undefined, { defaultCompany: "acme" })).toEqual([
+      "conn-origin-acme",
+      "conn-remote",
+    ]);
+  });
+
+  it("keeps the profile it skipped, so its scoped state survives", () => {
+    restoreConnections(undefined, { defaultCompany: "acme" });
+
+    // Skipped, not forgotten — the distinction `retireConnection` exists for.
+    // Opening `?company=` again must land on the same connection id, because
+    // every browser-local key is named after it (`scopedKey`).
+    expect(findProfile("", null)?.id).toBe("conn-origin-alias");
+  });
+
+  it("restores every remembered host when the bootstrap is not same-origin", () => {
+    // A desktop, or a console pointed elsewhere with `?api=`: neither makes any
+    // claim about what lives at its own origin, so nothing is filtered.
+    expect(restoreConnections()).toEqual([
+      "conn-origin-alias",
+      "conn-origin-acme",
+      "conn-remote",
+    ]);
   });
 });
 
@@ -488,7 +602,7 @@ describe("a same-origin profile", () => {
     resetConnections();
 
     expect(restoreConnections()).toEqual([id]);
-    expect(getConnection(id)?.label).toBe("This host");
+    expect(getConnection(id)?.label).toBe(window.location.host);
   });
 });
 


### PR DESCRIPTION
Closes #1167.

Every host in the sidebar switcher read **"This host"**, so a console holding
two offered two identical rows with nothing but a dot colour between them.

## What I found about the duplicate

The `#615` identity matching (`adoptLocalHosts` / `thisHost`) is **not**
regressed. It is embedded-host-only, it matches on `instance_id`, and an
embedded connection is labelled `EMBEDDED_LABEL` ("This computer") — never
"This host". So the duplicate in the screenshot cannot have come from there.

It is a real accumulation, by a different route. Profiles are keyed on
`(baseUrl, defaultCompany)` — deliberately, so `?company=a` and `?company=b`
keep their view state apart — but the *empty* base url is one host whichever
company a link named. So every distinct `?company=` ever opened against this
origin left a durable same-origin profile behind, `restoreConnections` brought
all of them back on every load, and nothing ever expired them: one row per
company ever visited, same address, same name.

They are not extra hosts. A connection already carries every company its host
serves and `switchCompany` moves between them *inside* one console
(`ConnectionConsole.tsx`), so a second row for the same origin is a choice that
changes nothing. Reproduced in a browser before touching anything — a seeded
`?company=other-co` profile gives exactly the reported menu, two "This host"
rows, one live.

## The fix

1. **A name that distinguishes.** `hostLabel("")` returns the origin the page
   is served from instead of a constant. The constant survives only for a
   runtime with no location to read (Node, under the unit tests) — and, because
   installs are durable and a remembered label outranks a derived one, a profile
   still carrying the old constant is treated as carrying none and re-derived,
   so the fix reaches the machines that reported it.
2. **The condition in words.** A menu row that is not `live` prints its state
   ("Unreachable", "Sign-in needed", …) beside the name. `live` keeps the
   `sr-only` text, so a state printed beside every host is not a state beside
   none of them. Colour is no longer the only carrier.
3. **The duplicate.** `restoreConnections` is told which same-origin console
   this page load is, and skips same-origin profiles belonging to a different
   one. **Skipped, not forgotten** — the `retireConnection` precedent: the
   profile stays, so opening that `?company=` again lands on the same connection
   id and the same scoped state rather than a freshly minted one. Applied only
   when the bootstrap *is* same-origin; a desktop (which drops these outright)
   and an `?api=` console are unchanged.

## Verified in a browser, two hosts, one stopped

Two real hosts (`OPENCOMPANY_DATA_DIR` each): 8361 live, 8362 started then
stopped so a row is genuinely unreachable; console over the dev server proxying
to 8361; seeded with what a pre-fix console would have written — a legacy
"This host" same-origin profile, a second same-origin profile from a
`?company=other-co` visit, and the 8362 host. Menu screenshotted open, light
and dark.

| | before | after |
|---|---|---|
| rows | `This host` ⌘1 · `This host` ⌘2 · `127.0.0.1:8362` ⌘3 | `localhost:5199` ⌘1 · `127.0.0.1:8362` ⌘2 |
| `data-host-count` | 3 | 2 |
| the dead row says | nothing (a red dot) | `Unreachable` |
| trigger subtitle | `This host` | `localhost:5199` |
| storage | 3 profiles | 3 profiles — the skipped one is kept, the legacy label rewritten |

## Commands run

- `npm run typecheck`, `typecheck:unit`, `typecheck:e2e`
- `npm test` — 1273 passed
- `npx playwright test connection-degrade sidebar-host-switcher` — 5 passed
- `npx playwright test desktop-connections desktop-first-run-signin desktop-embedded-identity desktop-local-instances` — 12 passed

## Behaviour changes

- A same-origin connection's label is now `location.host` rather than
  "This host"; profiles carrying the old constant are rewritten on first load.
- A same-origin profile for a company this page load is not addressing no
  longer produces a row. Its profile — and everything scoped to its id — is
  untouched.
