### PR TITLE
console: stop collapsing the sidebar the operator left open

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -40,7 +40,6 @@ import {
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import { HostSwitcher } from "@/components/host-switcher";
 import {
-  AutoCollapse,
   RESTING_ROW,
   SidebarCollapseToggle,
   SidebarControls,
@@ -1298,7 +1297,6 @@ export function AppShell({
         aria-label="Toggle sidebar"
         className="fixed bottom-4 left-4 z-50 md:hidden"
       />
-      <AutoCollapse view={view} />
       <Sidebar collapsible="icon">
         <SidebarHeader>
           {/* Which host, and how every host is doing. It sits above the collapse

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import { Building2, MessageSquareWarning, PanelLeft } from "lucide-react";
 
 import type { CompanyStatus } from "@/api/types";
@@ -227,31 +226,3 @@ export function SidebarCollapseToggle() {
   );
 }
 
-/**
- * Collapse the app's sidebar when entering a view that carries a nav of its
- * own — Chat's channel rail, Settings' sub-page rail. Two full-width sidebars
- * side by side leaves the actual content squeezed into what is left.
- *
- * It only ever collapses. Re-expanding on the way out would undo a collapse
- * the operator chose for themselves, so leaving is their move to make.
- *
- * It fires once per arrival, tracked in a ref. `setOpen` is rebuilt whenever
- * the sidebar's own open state changes, so an effect keyed on its identity
- * would re-collapse the instant you expanded — pinning you shut for as long as
- * you stayed on the view.
- */
-export function AutoCollapse({ view }: { view: View }) {
-  const { setOpen } = useSidebar();
-  const acted = useRef<View | null>(null);
-
-  useEffect(() => {
-    if (acted.current === view) return;
-    acted.current = view;
-    if (NESTED_NAV_VIEWS.has(view)) setOpen(false);
-  }, [view, setOpen]);
-
-  return null;
-}
-
-/** The views that bring their own sidebar. */
-const NESTED_NAV_VIEWS = new Set<View>(["chat", "settings"]);


### PR DESCRIPTION
Closes #1173.

Entering **Chat** or **Settings** collapsed the app sidebar. Now it stays in whatever state the operator left it, governed by the sidebar's own persisted `sidebar_state`.

## What was removed, and what it was for

`AutoCollapse` (`sidebar-controls.tsx`) with `NESTED_NAV_VIEWS = { chat, settings }`. Its reasoning was sound as far as it went — both views bring a rail of their own, and *"two full-width sidebars side by side leaves the actual content squeezed into what is left"*.

It was also carefully built: it only ever collapsed, never re-expanded, because re-expanding *"would undo a collapse the operator chose for themselves"*, and it fired once per arrival via a ref, since an effect keyed on `setOpen`'s identity would re-collapse the instant you expanded and pin you shut.

**But all that care went into not fighting the operator on the way out, while it still overrode them on the way in.** If you pin the sidebar open, arriving at Chat closes it, and there is no way to express "I want it open here" — the next visit closes it again.

The squeeze is real, but it is a layout problem and deserves a layout answer: a narrower nested rail, or a middle column that shrinks first. Closing someone's chrome for them is a workaround that costs them control over their own window.

## Verification

`npm run typecheck` clean · `typecheck:unit` 0 errors · `npm test` **1268 passed across 130 files**.

Two follow-on unused-import errors came with the removal (`TS6192` on the whole import line, then the `react` import that only `AutoCollapse` used). Both are cleaned up here — `tsc -b` is the first step of every console CI lane, so an unused binding fails Console, Console (advisory), Desktop and both E2E lanes together.

## Not verified

I have not driven Chat and Settings at a narrow width with the sidebar open. If the content genuinely becomes unusable there, that is the case this component existed to prevent and the layout fix should follow — worth a reviewer's eye.