### PR TITLE
fix(chat): draw the teammate's avatar in a DM header

### DIFF
--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, CircleDot, Hash, Lock, SquarePen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
-import type { Channel, ChannelSection } from "./model";
+import { dmFace, type Channel, type ChannelSection } from "./model";
 
 /**
  * What an unread badge actually claims (issue #364).
@@ -178,8 +178,9 @@ function ChannelRow({
 
 function ChannelIcon({ channel }: { channel: Channel }) {
   if (channel.kind === "dm") {
-    return channel.member ? (
-      <Avatar name={channel.name} tone={channel.tone} className="size-5 text-3xs" />
+    const face = dmFace(channel);
+    return face ? (
+      <Avatar {...face} className="size-5 text-3xs" />
     ) : (
       <CircleDot className="size-4 shrink-0" aria-hidden />
     );

--- a/frontend/src/views/chat/ChatHeader.tsx
+++ b/frontend/src/views/chat/ChatHeader.tsx
@@ -3,7 +3,8 @@ import { Check, CircleDot, Copy, Hash, Lock, PanelLeft, Users } from "lucide-rea
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { channelTitle, type Channel } from "./model";
+import { Avatar } from "./Avatar";
+import { channelTitle, dmFace, type Channel } from "./model";
 
 interface Props {
   channel: Channel;
@@ -18,10 +19,10 @@ interface Props {
 /**
  * The bar above a channel's timeline.
  *
- * It is deliberately thin — a kind icon, the name, and the purpose in the
- * tooltip — with the two things you actually reach for on the right: the
- * member pane and a copy of the channel name. The copy button only appears on
- * hover so the title reads clean at rest.
+ * It is deliberately thin — a kind mark (the teammate's avatar on a DM), the
+ * name, and the purpose in the tooltip — with the two things you actually
+ * reach for on the right: the member pane and a copy of the channel name. The
+ * copy button only appears on hover so the title reads clean at rest.
  */
 export function ChatHeader({
   channel,
@@ -98,9 +99,27 @@ export function ChatHeader({
   );
 }
 
+/**
+ * What sits to the left of the title: a channel's kind, or a DM's teammate.
+ *
+ * A channel has no face, so `#` and `Lock` are the honest marks for one. A DM
+ * has exactly one person on the other end, and drawing a glyph for them while
+ * the rail row a few pixels away drew their mascot gave one teammate two faces
+ * on one screen (issue #1170). Both now seed off [`dmFace`], so they cannot
+ * disagree about who you are talking to.
+ *
+ * `size-6` — 24px — rather than the rail's 20px: this header has the room, and
+ * 24px is the floor `Avatar`'s `markOnly` draws for a mascot being legible
+ * rather than a smudge, so the drawing is worth rendering at all here.
+ */
 function KindIcon({ channel }: { channel: Channel }) {
   const cls = "size-4 shrink-0 text-muted-foreground";
-  if (channel.kind === "dm") return <CircleDot className={cls} aria-hidden />;
+  if (channel.kind === "dm") {
+    const face = dmFace(channel);
+    // A DM with no roster entry behind it has nobody to draw — the rail falls
+    // back to the same glyph rather than inventing a face for a stranger.
+    return face ? <Avatar {...face} className="size-6" /> : <CircleDot className={cls} aria-hidden />;
+  }
   if (channel.private) return <Lock className={cls} aria-hidden />;
   return <Hash className={cls} aria-hidden />;
 }

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -162,3 +162,15 @@ first row carries the avatar and the author, and continuation rows leave the
 gutter empty and reveal their timestamp there on hover. A run also breaks on a
 day boundary, and on any row that has replies — a summary row between two lines
 that read as one utterance is worse than an extra avatar.
+
+## One face per teammate
+
+`Avatar` hashes its mascot out of the `name` it is given, so every surface that
+draws the same person must hand it the same string. A DM is where that bites:
+the rail row and `ChatHeader` sit on screen together, and seeding them
+differently would put two faces on one teammate — worse than the generic glyph
+the header drew before issue #1170. Both go through `dmFace(channel)` in
+`model.ts`; a channel and a DM with no roster entry get `null` there and wear a
+glyph (`#`, `Lock`, `CircleDot`) instead, because neither has one person behind
+it. The header draws its tile at 24px, the floor below which `Avatar`'s
+`markOnly` says a mascot is a smudge and the bare tone tile is the honest mark.

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -297,6 +297,24 @@ export function channelTitle(channel: Channel): string {
 }
 
 /**
+ * The face a DM wears — the `Avatar` seed for the teammate on the other end —
+ * or `null` for anything that has no face: a channel, and a DM with no roster
+ * entry behind it (both of those wear a glyph instead).
+ *
+ * One function rather than the same two props written out at each call site,
+ * because the rail row and the header sit on screen together and `Avatar`
+ * derives its mascot from the `name` it is handed. A call site that seeded on
+ * anything else — the teammate's id, its role — would draw a *different* face
+ * for the same person a few pixels away, which is worse than the generic glyph
+ * the header used to show (issue #1170). Deriving both from here is what makes
+ * that drift impossible rather than merely unlikely.
+ */
+export function dmFace(channel: Channel): { name: string; tone?: string } | null {
+  if (channel.kind !== "dm" || !channel.member) return null;
+  return { name: channel.name, tone: channel.tone };
+}
+
+/**
  * Whether this chat target's composer offers "Do it once" / "Build me the
  * workflow" (issues #580, #845).
  *

--- a/frontend/test/unit/chat-dm-face.test.ts
+++ b/frontend/test/unit/chat-dm-face.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { avatarFor } from "@/lib/team";
+import type { TeamMember } from "@/lib/team";
+import { buildChannels, dmFace, type Channel } from "@/views/chat/model";
+
+/**
+ * The seed a DM's avatar is drawn from (issue #1170).
+ *
+ * The failure this guards is silent and only visible side by side: the rail row
+ * and the chat header both draw the teammate on the other end of a DM, and
+ * `Avatar` hashes its mascot out of the `name` it is handed. Seed the two from
+ * different fields — the name in one place, the id or the role in the other —
+ * and one person wears two faces on one screen, which is worse than the generic
+ * glyph the header used to draw. Nothing throws, nothing fails to render, and
+ * no type objects.
+ *
+ * So this pins the seed itself rather than a rendered tile: both call sites go
+ * through `dmFace`, and `dmFace` promises the teammate's own name.
+ */
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
+  return {
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    avatar: "green",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  };
+}
+
+function dmFor(m: TeamMember): Channel {
+  const dms = buildChannels([m], []).find((s) => s.id === "dms");
+  expect(dms?.channels).toHaveLength(1);
+  return dms!.channels[0];
+}
+
+describe("dmFace", () => {
+  it("hands back the teammate's own name and tone, so every caller seeds alike", () => {
+    const ada = member({ id: "agent_ada", name: "Ada", tone: "violet" });
+    expect(dmFace(dmFor(ada))).toEqual({ name: "Ada", tone: "violet" });
+  });
+
+  it("resolves to one mascot for one teammate", () => {
+    // What the rail row and the header each end up drawing. They call the same
+    // function, so the only way these can differ is a change to `dmFace` — the
+    // point of routing both through it.
+    const face = dmFace(dmFor(member({ id: "agent_backend", name: "Backend Engineer" })));
+    expect(face).not.toBeNull();
+    expect(avatarFor(face!.name)).toBe(avatarFor("Backend Engineer"));
+  });
+
+  it("does not seed on the id, which would give the rail and the roster row different faces", () => {
+    // A guard against the plausible-looking "fix" of seeding on the stable id:
+    // it is stable, but it is not what `Avatar` hashes when a caller passes only
+    // a name, and these two ids hash to different mascots than the name does.
+    const face = dmFace(dmFor(member({ id: "agent_ada", name: "Ada" })));
+    expect(face!.name).not.toBe("agent_ada");
+  });
+
+  it("has no face for a channel — a desk line has no one person behind it", () => {
+    const desks = buildChannels([], [{ id: "d1", channel: "front-desk", name: "Front desk", blurb: "" }]);
+    const channel = desks.find((s) => s.id === "channels")!.channels[0];
+    expect(channel.kind).toBe("channel");
+    expect(dmFace(channel)).toBeNull();
+  });
+
+  it("has no face for a DM with no roster entry behind it", () => {
+    // Both call sites fall back to a glyph here rather than inventing a mascot
+    // for a teammate the roster cannot name.
+    const orphan: Channel = { id: "dm:gone", name: "Gone", kind: "dm", purpose: "" };
+    expect(dmFace(orphan)).toBeNull();
+  });
+
+  it("gives a private channel no face either — the lock still speaks for it", () => {
+    const locked: Channel = { id: "c1", name: "ops", kind: "channel", purpose: "", private: true };
+    expect(dmFace(locked)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

A DM showed the teammate twice with two different faces: the rail row drew their
mascot `Avatar`, and the header a few pixels away drew a generic `CircleDot`.
The header now draws the same mascot.

`#` for a channel and `Lock` for a private one are untouched — a channel has no
face, so a glyph is the honest mark for it.

## The seed, and why it is a shared helper

`Avatar` hashes its mascot out of the `name` it is handed. Seeding the header on
anything else — the teammate's id, its role — would have put *two different
mascots* on one person on one screen, which is worse than the glyph it replaced.
So the seed is not written out twice: both call sites go through one pure
`dmFace(channel)` in `views/chat/model.ts`, which returns `{ name, tone }` for a
DM with a roster entry and `null` for everything else (a channel, and a DM whose
teammate the roster cannot name — both keep their glyph). Drift is now
structurally impossible rather than merely watched for.

This deliberately seeds exactly the way the rail row already did — on the name.
`TeamMember.avatar` is id-seeded and currently rendered by nothing; using it here
would have made the header disagree with the rail. Unifying that properly is
#1185, and this PR stays out of its way.

Size: `size-6` (24px) rather than the rail's 20px. The header has the room, and
24px is the floor below which `Avatar`'s `markOnly` says a mascot is a smudge and
the bare tone tile is the honest fallback — so at 24px the drawing is worth
rendering.

## Verified in a browser

Host on `:8364` (`companies/agentic_software_company`), console on Vite, on the
merged tree at `ca5ed29`.

A screenshot showing *a* mascot would prove nothing — the seeds have to match. So
the check walks **every teammate in the roster**, opens their DM, and compares the
`src` of the header's `<img>` against the `src` of that same teammate's rail row:

```
MATCH  Backend Engineer      header=/avatars/blob-indigo.webp   row=/avatars/blob-indigo.webp    px=24/20
MATCH  Customer Support      header=/avatars/blob-blue.webp     row=/avatars/blob-blue.webp      px=24/20
MATCH  Designer              header=/avatars/blob-graphite.webp row=/avatars/blob-graphite.webp  px=24/20
MATCH  Developer Relations   header=/avatars/blob-green.webp    row=/avatars/blob-green.webp     px=24/20
MATCH  Documentation Writer  header=/avatars/blob-cloud.webp    row=/avatars/blob-cloud.webp     px=24/20
MATCH  Frontend Engineer     header=/avatars/blob-green.webp    row=/avatars/blob-green.webp     px=24/20
MATCH  Product Manager       header=/avatars/blob-blue.webp     row=/avatars/blob-blue.webp      px=24/20
MATCH  QA Engineer           header=/avatars/blob-ember.webp    row=/avatars/blob-ember.webp     px=24/20
MATCH  Security Engineer     header=/avatars/blob-rose.webp     row=/avatars/blob-rose.webp      px=24/20
MATCH  Operations            header=/avatars/blob-clay.webp     row=/avatars/blob-clay.webp      px=24/20
MATCH  Page Builder          header=/avatars/blob-ember.webp    row=/avatars/blob-ember.webp     px=24/20
MATCH  Researcher            header=/avatars/blob-indigo.webp   row=/avatars/blob-indigo.webp    px=24/20
MATCH  Writer                header=/avatars/blob-cloud.webp    row=/avatars/blob-cloud.webp     px=24/20

light: 13/13 match; 8 distinct mascots across the roster
dark:  13/13 match; 8 distinct mascots across the roster
```

**The two mascots are the same file, for every teammate, in both themes.** The
8-distinct count is there so this cannot pass by everyone collapsing onto one
face. A channel header is unchanged: it still reports `lucide-hash size-4` and no
`<img>`.

## Commands run

- `npm run typecheck`
- `npm run typecheck:unit`
- `npm test` — 133 files, 1293 tests, including the 6 new `dmFace` cases

## Follow-up filed separately

The header prints the DM's name and then the teammate's role after a divider, and
a teammate the host sends no display name for takes its role *as* its name
(`fromDto`: `dto.name?.trim() || dto.role`), so the bar reads "Backend Engineer │
Backend Engineer". Out of scope here — filed as #1180.

Closes #1170
