### PR TITLE
memory: stop loading compressed history and the whole context index on every cycle

### DIFF
--- a/docs/spec/company-brain/README.md
+++ b/docs/spec/company-brain/README.md
@@ -17,7 +17,7 @@ CompanyBrain
 ├── identity   CompanyId (ULID), Ed25519 keypair, tiny.place @handle, Agent Card
 ├── charter    name, output, mission, human_role, policies (mutable at runtime)
 ├── roster     teammates: id, role, description, tier hint, tool grants, budgets
-├── memory     compressed cycle traces (~20:1 working memory) + task results
+├── memory     compressed cycle traces + task results
 ├── context    addressable chunks (the RLM environment: put/list/peek/search)
 ├── world      event log (append-only), ledger, open tasks, approval queue
 └── feedback   inbox of feedback items + links to filed GitHub issues

--- a/docs/spec/company-brain/memory.md
+++ b/docs/spec/company-brain/memory.md
@@ -6,7 +6,7 @@ What a company remembers, where it lives, and the Operator's rights over it.
 
 | Kind | Written by | Retention |
 | --- | --- | --- |
-| Compressed cycle traces (~20:1 working memory) | every cycle | rolling window feeds cycles; older traces retained until evicted |
+| Compressed cycle traces | every cycle | written and exported; **not** summarized, **not** read back into a cycle, **not** evicted (issue #1175) |
 | Task results (delegated work products) | cycles | durable |
 | Context chunks (documents, research, transcripts the brain filed) | cycles, imports | durable, content-addressed |
 | Customers, engagements, decisions, outcomes | cycles (as structured task results / context) | durable |
@@ -57,11 +57,27 @@ DB-agnosticism applies to memory exactly as to every other store.
 
 ## Compounding
 
-Each cycle loads recent traces, so decisions and outcomes bias future work —
-this is the mechanism behind "memory compounds" in the
+**Intended**: each cycle loads recent traces, so decisions and outcomes bias
+future work — the mechanism behind "memory compounds" in the
 [vision](../vision/README.md). Eviction (`evict` with an `EvictionPolicy`)
 keeps the working window bounded; evicted traces are archived, not deleted,
 until retention policy or the Operator says otherwise.
+
+**Today** (issue #1175), one narrower path does the compounding and the rest is
+not wired:
+
+- Before each turn the harness retrieves the top-5 prior task outcomes matching
+  the incoming message from the `ContextStore` and injects them as text, then
+  stores the turn's outcome back (`src/harness/memory_loop.rs`). This is the
+  only live recall a company has.
+- Traces are written every cycle and read by nothing. `CycleRequest` used to
+  carry them; no `Brain` consumed the field, so it was removed rather than left
+  looking functional.
+- `evict` is implemented on every backend and called from no production path,
+  so the trace window is unbounded. `ContextStore` has no delete verb at all,
+  so the chunk store only grows — which is also why deleting an operator fact
+  leaves its `ContextStore` mirror agent-recallable
+  (`src/server/ops/memory.rs`), against the Delete right below.
 
 ## Operator rights (normative)
 

--- a/docs/spec/glossary.md
+++ b/docs/spec/glossary.md
@@ -40,7 +40,7 @@ Medulla vocabulary is adopted unchanged where it appears; see
 | Medulla term | Meaning here |
 | --- | --- |
 | **Tier** | A named cognition class (`orchestrator`, `reasoning`, `frontend`, `compress`, `subconscious`). The client only names a tier; the TinyHumans backend maps tier → model SKU. OpenCompany never selects models. |
-| **Compressed history** | ~20:1 summaries of cycle traces — the Company's working memory, persisted through `MemoryStore`. |
+| **Compressed trace** | One record per cycle, persisted through `MemoryStore`. Named for the ~20:1 working memory it is meant to become; today the `summary` is a constant string, nothing summarizes it, and no cycle reads it back (issue #1175). |
 | **World-state diff** | Append-only notes about the world uploaded between cycles (`POST /orchestration/v1/world-diff`). |
 | **Steering** | A directive synthesized by the subconscious tick that biases future cycles. |
 | **Device tool** | A tool the client registers over Socket.IO that the hosted brain calls back into (`orch:tool_call` → `orch:tool_result`). |

--- a/docs/spec/runtime/ports-cognition.md
+++ b/docs/spec/runtime/ports-cognition.md
@@ -71,8 +71,13 @@ projected call is parked as-is so the operator can see and resolve it. Passing
 it back through `emit_effect` would re-decide it against the coarser
 `ApprovalGate` taxonomy and quietly drop it (issue #172).
 
-`CycleRequest` carries `{cycle_id, company_id, events, compressed_history,
-roster, context_index}`; `CycleResult` carries channel responses, new
+`CycleRequest` carries `{cycle_id, company_id, events, event_seqs}`. It also
+carried `compressed_history`, `roster` and `context_index` until issue #1175:
+no `Brain` read any of the three, and populating the first two cost a
+`recent_traces` read plus an unbounded `ContextStore::list` scan on every
+cycle. A cycle therefore carries **no working memory** — see
+[company-brain/memory.md](../company-brain/memory.md) for what does the
+compounding instead. `CycleResult` carries channel responses, new
 compressed traces, ledger deltas, and `token_usage` — tokens **and** cost, which
 `CycleRunner` meters onto the [`UsageMeter`](ports-console.md#usagemeter) +
 ledger for every path that is not

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -173,9 +173,6 @@ mod test {
             company_id: CompanyId::new("acme"),
             events,
             event_seqs: Vec::new(),
-            compressed_history: Vec::new(),
-            roster: Vec::new(),
-            context_index: Vec::new(),
         }
     }
 

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -115,9 +115,6 @@ fn operator_request() -> CycleRequest {
             deliverable: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -114,9 +114,6 @@ fn operator_request() -> CycleRequest {
             deliverable: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -3206,9 +3206,6 @@ description = "Runs Acme."
             company_id: CompanyId::new("acme"),
             events,
             event_seqs: Vec::new(),
-            compressed_history: Vec::new(),
-            roster: Vec::new(),
-            context_index: Vec::new(),
         }
     }
 
@@ -6987,9 +6984,6 @@ members = ["eng1", "eng2"]
             company_id: CompanyId::new("acme"),
             events,
             event_seqs: Vec::new(),
-            compressed_history: Vec::new(),
-            roster: vec!["ceo".to_string()],
-            context_index: Vec::new(),
         }
     }
 

--- a/src/harness/cap_publish_test.rs
+++ b/src/harness/cap_publish_test.rs
@@ -361,9 +361,6 @@ fn chat(text: &str) -> CycleRequest {
             deliverable: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 

--- a/src/harness/cap_turn_test.rs
+++ b/src/harness/cap_turn_test.rs
@@ -363,9 +363,6 @@ fn chat(text: &str) -> CycleRequest {
             deliverable: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -438,9 +438,6 @@ fn dispatch_run(task_id: &str, run_id: Option<&str>) -> CycleRequest {
             run_id: run_id.map(str::to_string),
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 
@@ -1190,9 +1187,6 @@ fn chat(text: &str) -> CycleRequest {
             deliverable: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -345,9 +345,6 @@ fn dispatch(task_id: &str) -> CycleRequest {
             run_id: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1996,6 +1996,26 @@ impl TokenUsage {
 }
 
 /// Everything the brain needs to run one cycle.
+///
+/// **A cycle carries no working memory.** The struct once also carried
+/// `compressed_history` (32 recent [`CompressedTrace`]s) and `context_index`
+/// (every [`ChunkMeta`] in the company, unbounded), loaded from the
+/// [`MemoryStore`](crate::ports::MemoryStore) and
+/// [`ContextStore`](crate::ports::ContextStore) on every cycle — and read by no
+/// [`Brain`](crate::ports::Brain) implementation. Two facts made them dead
+/// rather than merely unused: no summariser exists anywhere in the crate, so a
+/// trace's `summary` is a constant string like `harness cycle handled 3
+/// event(s)`, and no brain ever consulted either field. A `roster` field was
+/// dead on the same terms; every brain re-derives the roster from the company
+/// record. Issue #1175 removed all three, so the cycle stops paying an
+/// unbounded full scan per turn for a `Vec` it drops.
+///
+/// The one live recall path is elsewhere and is untouched by this: before each
+/// turn `HarnessPool::run` retrieves the top-5 prior task outcomes from the
+/// `ContextStore` and injects them as text (`src/harness/memory_loop.rs`, under
+/// the `openhuman` feature). Traces are still *written* every cycle
+/// (they travel with the export bundle); nothing reads them back. Do not
+/// re-add a field here until something consumes it.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CycleRequest {
     /// Unique id for this cycle.
@@ -2011,12 +2031,6 @@ pub struct CycleRequest {
     /// idempotent `POST /events` on the durable log seq.
     #[serde(default)]
     pub event_seqs: Vec<EventSeq>,
-    /// Compressed traces of prior cycles.
-    pub compressed_history: Vec<CompressedTrace>,
-    /// The company roster (agent ids).
-    pub roster: Vec<String>,
-    /// The context index available to the brain.
-    pub context_index: Vec<ChunkMeta>,
 }
 
 /// The brain's output from one cycle.

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2906,7 +2906,7 @@ mod test {
         assert!(!task_names_a_card(&[], "019ff728-abcd"));
     }
     use std::sync::Arc;
-    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::company::CompanyManifest;
     use crate::company::runtime::CompanyMail;
@@ -2914,13 +2914,16 @@ mod test {
     use crate::ports::ChannelAdapter;
     use crate::ports::brain::Brain;
     use crate::ports::types::{
-        ActorKind, CompressedTrace, CycleResult, EffectGroup, EventSeq, ReplyTo, TokenUsage,
+        ActorKind, ChunkAddr, ChunkHit, ChunkMeta, CompressedTrace, ContextChunk, CycleResult,
+        EffectGroup, EventSeq, EvictionPolicy, ReplyTo, TaskResult, TokenUsage,
     };
+    use crate::ports::{ContextStore, MemoryStore};
     use crate::runtime::RuntimeBuilder;
     use crate::runtime::channel::OperatorChannel;
     use crate::server::ops::mailer::RecordingMailSender;
     use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
     use crate::store::paths::Bundle;
+    use crate::store::{FsContextStore, FsMemoryStore};
 
     fn tmp_home() -> tempfile::TempDir {
         tempfile::Builder::new()
@@ -3490,6 +3493,142 @@ mod test {
         }])
         .await
         .expect("an unknown run id is a bookkeeping miss, not a cycle failure");
+    }
+
+    /// A [`MemoryStore`] that counts the calls a cycle makes, delegating the
+    /// work to a real fs store so the runtime behaves normally around it.
+    struct CountingMemory {
+        inner: FsMemoryStore,
+        reads: AtomicUsize,
+        writes: AtomicUsize,
+    }
+
+    impl CountingMemory {
+        fn new(inner: FsMemoryStore) -> Self {
+            Self {
+                inner,
+                reads: AtomicUsize::new(0),
+                writes: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MemoryStore for CountingMemory {
+        async fn save_trace(&self, id: &CompanyId, trace: CompressedTrace) -> Result<()> {
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            self.inner.save_trace(id, trace).await
+        }
+
+        async fn recent_traces(
+            &self,
+            id: &CompanyId,
+            limit: usize,
+        ) -> Result<Vec<CompressedTrace>> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            self.inner.recent_traces(id, limit).await
+        }
+
+        async fn save_task_result(&self, id: &CompanyId, result: TaskResult) -> Result<()> {
+            self.inner.save_task_result(id, result).await
+        }
+
+        async fn evict(&self, id: &CompanyId, policy: EvictionPolicy) -> Result<u64> {
+            self.inner.evict(id, policy).await
+        }
+    }
+
+    /// The [`ContextStore`] half of the same instrument.
+    struct CountingContext {
+        inner: FsContextStore,
+        lists: AtomicUsize,
+    }
+
+    impl CountingContext {
+        fn new(inner: FsContextStore) -> Self {
+            Self {
+                inner,
+                lists: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ContextStore for CountingContext {
+        async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
+            self.inner.put(id, chunk).await
+        }
+
+        async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
+            self.lists.fetch_add(1, Ordering::SeqCst);
+            self.inner.list(id, prefix).await
+        }
+
+        async fn peek(
+            &self,
+            id: &CompanyId,
+            addr: &ChunkAddr,
+            range: Option<std::ops::Range<usize>>,
+        ) -> Result<String> {
+            self.inner.peek(id, addr, range).await
+        }
+
+        async fn search(&self, id: &CompanyId, query: &str, limit: usize) -> Result<Vec<ChunkHit>> {
+            self.inner.search(id, query, limit).await
+        }
+    }
+
+    /// Issue #1175: a cycle used to load 32 recent traces *and the whole context
+    /// index* (`list(company, "")` — no prefix, no limit) into `CycleRequest`,
+    /// where no brain read either. Both reads are gone, and the context one was
+    /// the expensive half: it grew with every turn the company had ever run.
+    ///
+    /// The trace *write* deliberately stayed — traces travel with the export
+    /// bundle — so this asserts the save as well. Without that half, a later
+    /// "nothing reads traces, delete the write" would pass silently.
+    #[tokio::test]
+    async fn a_cycle_reads_neither_recent_traces_nor_the_context_index() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let memory = Arc::new(CountingMemory::new(FsMemoryStore::new(home.clone())));
+        let context = Arc::new(CountingContext::new(FsContextStore::new(home.clone())));
+        let rt = RuntimeBuilder::new(home, manifest("full"))
+            .with_memory(memory.clone())
+            .with_context(context.clone())
+            .build()
+            .await
+            .unwrap();
+
+        // Boot is not what this test is about; only what one cycle costs.
+        memory.reads.store(0, Ordering::SeqCst);
+        memory.writes.store(0, Ordering::SeqCst);
+        context.lists.store(0, Ordering::SeqCst);
+
+        rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
+            text: "hi".into(),
+            by: None,
+            chat: None,
+            deliverable: None,
+        }])
+        .await
+        .unwrap();
+
+        assert_eq!(
+            memory.reads.load(Ordering::SeqCst),
+            0,
+            "a cycle must not read traces back: no brain consumes them"
+        );
+        assert_eq!(
+            context.lists.load(Ordering::SeqCst),
+            0,
+            "a cycle must not scan the context index: no brain consumes it"
+        );
+        assert_eq!(
+            memory.writes.load(Ordering::SeqCst),
+            1,
+            "the trace write is not dead code — it feeds the export bundle"
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -49,9 +49,6 @@ use crate::runtime::journal::{ApprovalConversation, ExecutedEffect, TaskLink};
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 
-/// How many recent traces to load into a cycle's compressed history.
-const HISTORY_LIMIT: usize = 32;
-
 /// The `Effect::kind` for an outbound email send. Shared between where the
 /// effect is built (`CycleHostImpl::send_email`, and the workflow delivery path
 /// in [`crate::workflows::delivery`]) and where it is executed
@@ -415,23 +412,15 @@ impl<'a> CycleRunner<'a> {
             );
         }
 
-        // 3. Load — history, context index, roster.
-        let compressed_history = self
-            .rt
-            .memory
-            .recent_traces(&company, HISTORY_LIMIT)
-            .await?;
-        let context_index = self.rt.context.list(&company, "").await?;
+        // 3. Load — the company record, and nothing else.
+        //
+        // Issue #1175: this step used to also read 32 recent traces and the
+        // *entire* context index (`list(&company, "")` — no prefix, no limit, so
+        // a full scan that grows with every turn the company has ever run) into
+        // `CycleRequest`. No brain read either one. Both loads are gone; see the
+        // note on [`CycleRequest`] for why the fields went with them. Traces are
+        // still written below — only the read was dead.
         let record = self.rt.store.load(&company).await?;
-        let roster = match &record {
-            Some(record) => record
-                .manifest
-                .agents
-                .iter()
-                .map(|agent| agent.id.clone())
-                .collect(),
-            None => Vec::new(),
-        };
 
         // Issue #176 (handed-task awareness): when an operator message is
         // addressed to a desk/agent that already has open work handed to it,
@@ -464,9 +453,6 @@ impl<'a> CycleRunner<'a> {
             company_id: company.clone(),
             events,
             event_seqs,
-            compressed_history,
-            roster,
-            context_index,
         };
 
         // 4. Think + 5. Gate — the host services callbacks and gates effects.


### PR DESCRIPTION
Closes the cheapest item on #1175.

## What

`CycleRunner::run_locked` loaded two stores on every cycle and handed the results to the brain in `CycleRequest`. No `Brain` implementation read either field:

```rust
let compressed_history = self.rt.memory.recent_traces(&company, HISTORY_LIMIT).await?;  // 32 traces
let context_index = self.rt.context.list(&company, "").await?;                          // every chunk, no limit
```

The second is the expensive one: `list(company, "")` has no prefix and no `LIMIT` on any backend (`src/store/fs.rs` reads the whole `context/index.jsonl`; sqlite and mongo full-scan the company's rows), and the index grows one row per completed agent turn, per brain `ContextOp::Put`, and per operator fact. A long-lived company paid a linearly growing scan on every cycle to build a `Vec` that was dropped.

`roster` was dead on the same terms — no `req.roster` read exists anywhere; every brain re-derives the roster from the company record. It cost nothing (the record is loaded a line later regardless), but a field nothing reads is a field that misleads.

All three are removed. The two loads are gone.

## What is not in this PR

Deliberately narrow. `#1175` also covers unbounded trace growth (`evict` is implemented on every backend and called from nothing but store tests) and the missing `ContextStore::delete` (which is why deleting an operator fact leaves its mirror agent-recallable). Neither is touched here, and neither is a memory architecture — that is the third item on the issue and its own piece of work.

Trace **writes** stay (`cycle.rs`, `save_trace`): traces travel with the export bundle. Only the read was dead.

## Why remove the fields rather than just stop populating them

A field populated with data no consumer reads is a worse seam than no field — it reads to the next author as working. The replacement is a doc block on `CycleRequest` that says plainly that a cycle carries no working memory, why (no summariser exists; a trace `summary` is a constant string like `harness cycle handled 3 event(s)`), what does the compounding instead (the harness retrieve→inject loop, `src/harness/memory_loop.rs`), and not to re-add a field until something consumes it.

## Test

`a_cycle_reads_neither_recent_traces_nor_the_context_index` (`src/runtime/cycle.rs`) wraps the fs memory and context stores in counting decorators via `RuntimeBuilder::with_memory` / `with_context`, runs one cycle, and asserts:

- `recent_traces` called 0 times
- `ContextStore::list` called 0 times
- `save_trace` called **once** — this half is what makes it a regression test rather than a deletion test: a later "nothing reads traces, delete the write" cannot pass silently.

No new file under `tests/`, so no CI lane or `feature-lanes.txt` row is needed; it rides the existing `Rust (openhuman, tinycortex)` job.

## Docs

Corrected the five places that describe the ~20:1 compressed working memory as a thing that exists: `docs/spec/glossary.md`, `docs/spec/company-brain/memory.md` (the "What is remembered" table and the whole Compounding section, now split into Intended vs Today), `docs/spec/company-brain/README.md`, `docs/spec/runtime/ports-cognition.md`. Left `docs/spec/integrations/medulla.md` alone — its ~20:1 claim is about the hosted backend, not this crate.

## Commands run

```
cargo fmt --all -- --check
cargo clippy --all-targets --features openhuman,tinycortex -- -D warnings
cargo test --features openhuman,tinycortex
```

## Behavior change

Brains lose three request fields none of them read. No route, event, or stored shape changes; `CycleRequest` is never serialized onto a wire.
