### PR TITLE
fix(ci): report tenant rollout truth

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -227,14 +227,101 @@ jobs:
                 echo "  ${ns}/${name} -> ${IMAGE}"
                 kubectl -n "${ns}" set image "statefulset/${name}" "opencompany=${IMAGE}"
               done
-            # Report where each tenant actually landed rather than assuming the
-            # patch took: a tenant scaled to zero has no pod to roll, so
-            # `rollout status` would block forever on it.
-            kubectl get statefulset -A -l app=opencompany \
-              -o 'custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[?(@.name=="opencompany")].image'
           else
             echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to move them."
           fi
+
+          # Report the image a pod actually landed on rather than the desired
+          # StatefulSet template. An idle tenant deliberately has no pod, so it
+          # is reported without asking rollout status to wait forever. A tenant
+          # with replicas must either become ready or make this deploy fail.
+          echo "Tenant landed-state report (pod status, not StatefulSet spec):"
+          printf '%-24s %-24s %-8s %-90s %s\n' NS NAME STATE IMAGE DETAIL
+          tenant_failed=no
+          append_failure_detail() {
+            if [ -n "${failure_detail}" ]; then
+              failure_detail="${failure_detail}; "
+            fi
+            failure_detail="${failure_detail}$1"
+          }
+          tenant_rows=$(kubectl get statefulset -A -l app=opencompany \
+            -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.replicas}{"\n"}{end}')
+          while IFS=$'\t' read -r ns name replicas; do
+            [ -n "${ns}" ] || continue
+
+            if [ "${replicas}" = "0" ]; then
+              printf '%-24s %-24s %-8s %-90s %s\n' "${ns}" "${name}" idle - 'scaled to zero'
+              continue
+            fi
+
+            rollout_error=''
+            if ! rollout_output=$(kubectl -n "${ns}" rollout status "statefulset/${name}" --timeout=180s 2>&1); then
+              rollout_error=$(printf '%s' "${rollout_output}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g')
+            fi
+
+            if ! pod_json=$(kubectl -n "${ns}" get pod -l app=opencompany -o json 2>&1); then
+              printf '%-24s %-24s %-8s %-90s %s\n' \
+                "${ns}" "${name}" failed - "could not read pod status: ${pod_json}"
+              tenant_failed=yes
+              continue
+            fi
+
+            pod_status=$(printf '%s' "${pod_json}" | jq -r --arg statefulset "${name}" '
+              [.items[]
+               | select(any(.metadata.ownerReferences[]?;
+                   .kind == "StatefulSet" and .name == $statefulset))]
+              | if length == 0 then
+                  "-\t-\t-\tno pod"
+                else
+                  . as $pods
+                  | [
+                      ($pods | map(.metadata.name) | join(",")),
+                      ($pods | map(.status.phase // "Unknown") | unique | join(",")),
+                      ([ $pods[] | .status.containerStatuses[]?
+                         | select(.name == "opencompany") | .image ] | unique | join(",")),
+                      ([ $pods[] | (
+                           .status.containerStatuses[]?.state.waiting.reason,
+                           .status.containerStatuses[]?.state.terminated.reason,
+                           .status.initContainerStatuses[]?.state.waiting.reason,
+                           .status.initContainerStatuses[]?.state.terminated.reason
+                         ) ]
+                       | map(select(. != null and . != "")) | unique | join(","))
+                    ] | @tsv
+                end')
+            IFS=$'\t' read -r pod_name pod_phase pod_image pod_reason <<< "${pod_status}"
+
+            failure_detail=''
+            if [ -n "${rollout_error}" ]; then
+              append_failure_detail "rollout timed out or failed: ${rollout_error}"
+            fi
+            if [ "${pod_name}" = - ]; then
+              append_failure_detail 'no pod belongs to this StatefulSet'
+            else
+              if [ "${pod_phase}" != Running ]; then
+                append_failure_detail "pod ${pod_name} phase ${pod_phase}"
+              fi
+              if [ -n "${pod_reason}" ]; then
+                append_failure_detail "pod ${pod_name}: ${pod_reason}"
+              fi
+              if [ "${REFRESH_ALL}" = true ] && [ "${pod_image}" != "${IMAGE}" ]; then
+                append_failure_detail 'pod did not land on the requested image'
+              fi
+            fi
+
+            if [ -n "${failure_detail}" ]; then
+              printf '%-24s %-24s %-8s %-90s %s\n' \
+                "${ns}" "${name}" failed "${pod_image:--}" "${failure_detail}"
+              tenant_failed=yes
+            else
+              printf '%-24s %-24s %-8s %-90s %s\n' \
+                "${ns}" "${name}" ok "${pod_image:--}" "pod ${pod_name} is Running"
+            fi
+          done <<< "${tenant_rows}"
+
+          [ "${tenant_failed}" = no ] || {
+            echo 'ERROR: one or more non-idle tenants did not land successfully.' >&2
+            exit 1
+          }
 
           kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
             -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE")]}OCM_TENANT_IMAGE={.value}{"\n"}{end}'


### PR DESCRIPTION
## Summary

Replace the post-deploy StatefulSet template-image table with a per-tenant landed-state table based on pod status.

It reports `idle` for zero-replica tenants, `ok` only for Running tenant pods, and `failed` with pod/rollout diagnostics for active tenants that did not land. `Closes #823`.

## API Or Behavior Changes

No public API changes. A staging refresh now waits at most 180 seconds per non-idle tenant StatefulSet, reads `.status.containerStatuses[].image` rather than the desired pod spec, and fails on rollout timeout, absent/non-Running pods, ImagePullBackOff/ErrImagePull/CrashLoopBackOff reasons, or a requested image that did not land. The default `refresh_all_tenants=false` path reports a healthy older landed image without failing.

The live k3s path is intentionally unverified until the next staging deploy.

## Tests

- Extracted the remote shell block and ran `shellcheck -s bash -`.
- Parsed `.github/workflows/deploy-staging.yml` with Ruby YAML.
- Dry-ran the workflow’s exact StatefulSet JSONPath against saved local fixture JSON through a local mock Kubernetes API: `tenant-idle/opencompany/0`, `tenant-ok/opencompany/1`, and `tenant-backoff/opencompany/1`.
- Exercised the report against matching pod-status fixture JSON: zero replicas produced `idle`; a Running pod with the status image produced `ok`; ImagePullBackOff plus a bounded rollout timeout produced `failed` and a non-zero result.
- Verified that `refresh_all_tenants=false` permits a healthy pod on an older landed image.

- [x] N/A — workflow-only change; `cargo fmt --all -- --check` does not apply.
- [x] N/A — workflow-only change; `cargo clippy --all-targets -- -D warnings` does not apply.
- [x] N/A — workflow-only change; `cargo build --all-targets` does not apply.
- [x] N/A — workflow-only change; `cargo test` does not apply.

## Documentation

No documentation update needed: the workflow comments document the changed deployment reporting and bounded idle-tenant behavior.