### PR TITLE
fix(workflows): the output node stops reading ok on a run whose report was dropped, and three skip reasons get ruled on (#981)

### DIFF
--- a/docs/modules/server/run-verdict.md
+++ b/docs/modules/server/run-verdict.md
@@ -101,17 +101,79 @@ The orchestrator's `run_workflow` tool summary
 `DeliveryReason` and never `detail` — the closed set is the log-safe half of the
 pair (issue #248), and a summary rides wherever the model's turn rides.
 
-## Not in scope
+## What counts as undelivered
 
-**What counts as undelivered is unchanged**: any row that is neither `sent` nor
-`pending`, exactly as the console's badge, the scheduler's log line and the SSE
-toast have always counted it. Three reasons that land on `skipped` arguably do
-not belong in that count — `already-delivered`, `no-destination-configured` and
-`dry-run` each describe a report that was never owed to an address — but
-reclassifying them moves the badge and the verdict apart unless every surface
-moves together. That is its own change; this one moved the ladder to the host
-without moving the rungs.
+A report is undelivered when it **did not reach a destination and will not
+without a change**. `crate::ports::is_undelivered` is the one rung, and every
+surface stands on it: the verdict above, the scheduler's alert number, the
+sidecar's and the orchestrator's run summaries, the console's "N not delivered"
+badge, the SSE toast, and the per-node marker the console paints on the `output`
+node itself.
+
+`sent` landed. `pending` is a report parked for an operator's approval, counted
+by `awaiting_count` instead — counting it here would score a working approvals
+queue as a failure. `denied` and `failed` always count.
+
+`skipped` is the interesting one, because the delivery path writes it for three
+genuinely different situations. The axis that separates them is **whether the
+report's fate is accounted for** (issue #981):
+
+| reason | counts? | why |
+| --- | --- | --- |
+| `already-delivered` | no | an earlier run in this approval lineage **sent it** (issue #438). Approving a gate re-runs the graph from the trigger, so every upstream `output` node is reached again; the report is at its destination. |
+| `dry-run` | no | a test run (issue #542). Nothing was attempted, on purpose, in a mode the operator chose. |
+| `no-destination-configured` | **yes** | the report was produced and then **lost**, with nothing accounting for it (issue #925). |
+
+The third is the deliberate non-move, and it is the reason the other two could
+move at all. That row exists precisely so "the author routed nothing on purpose"
+and "the author never configured a destination" stop being the same observation;
+excusing it here would restore the silence issues #947 and #963 were filed
+about. The earlier framing — that all three "describe a report that was never
+owed to an address" — reads the wrong axis: a report with nowhere to go was owed
+to nobody *because the graph is wrong*, which is the finding, not the excuse.
+
+The match on `DeliveryStatus` is exhaustive and only the `skipped` arm reads a
+reason, so a new status cannot be added without classifying it. A row carrying
+`unspecified` — the only reachable value on a `WorkflowRunFinished` journaled
+before issue #248 added the field — counts, which is the safe direction.
+
+## The node cell answers a different question
+
+`nodes[].status` stays `ok | error | blocked` and a delivery failure still does
+not move it. The node cell answers **"did the engine run this step?"**, and the
+honest answer for a dropped report is yes: delivery is post-engine, the node ran,
+its work is valid, and the fix is a destination or a runtime wiring.
+
+Issue #981's second report was that the console then showed `ok` on the output
+node of a run reading `undelivered` — two readings contradicting each other on
+one screen. The resolution is **not** a fourth status word:
+
+* `frontend/src/views/workflows/graph.ts`'s `nodeStateFrom` fail-safes any status
+  it does not recognise to `error`, so a new word would make every console
+  predating it paint a node that ran perfectly as failed;
+* one field would then answer two questions decided by two subsystems at two
+  different times — the collapse issues #383 and #881 each had to undo once.
+
+Instead the node cell stops being alone. `DeliveryReport.node` carries the
+`output` node's id, so the console joins the delivery rows to the nodes locally —
+**no new wire field, and no third notion of "this run did not fully work"**. Three
+surfaces render the join beside the node's own state, each explicitly labelled so
+the two facts read as different questions rather than as a contradiction:
+
+* the canvas node keeps its green ring and `DONE` badge and gains a
+  `report not delivered` strip (and a tooltip that says "This step ran. Its
+  report did not go out.");
+* the run drawer's **Steps** row keeps its `ok` badge and gains a
+  `not delivered` badge beside it;
+* the history panel's node chip keeps its green dot and gains a red
+  `not delivered` segment.
+
+`undeliveredNodes` in `frontend/src/views/workflows/run-health.ts` is that join,
+folding the same `isUndelivered` the counts use.
+
+## Not in scope
 
 The SSE `workflow_run_finished` frame carries no verdict. It already reads the
 delivery rows correctly and toasts an undelivered report, so nothing there
-scores a dropped report green.
+scores a dropped report green — it now toasts through the shared predicate, so a
+test run no longer warns that a report it never attempted "didn't go out".

--- a/frontend/src/components/workflow-node.tsx
+++ b/frontend/src/components/workflow-node.tsx
@@ -71,12 +71,18 @@ export function WorkflowNode({ data, selected }: NodeProps) {
             )}
             // "running" is now reported by the engine (issue #382), not a
             // derived frontier — the node really is executing when this shows.
+            // Issue #981: the last arm used to say "This node finished." on a
+            // node whose report was refused, which is true and reads as a
+            // promise it cannot make. It now says what it is actually a verdict
+            // on, and the strip below says the rest.
             title={
               runState === "running"
                 ? "This node is executing now."
                 : runState === "error"
                   ? "This node failed."
-                  : "This node finished."
+                  : d.reportUndelivered
+                    ? "This step ran. Its report did not go out."
+                    : "This node finished."
             }
           >
             {RUN_STATE_LABEL[runState]}
@@ -91,6 +97,22 @@ export function WorkflowNode({ data, selected }: NodeProps) {
           </span>
         )}
       </div>
+      {/* Issue #981. The complaint was a run reading `undelivered` whose output
+          node painted DONE, green, and said nothing else — so the truth lived
+          only in a banner somewhere off the canvas. The ring and the badge above
+          are unchanged, because they answer whether the STEP ran and it did;
+          this answers what became of its report, in its own words, on the same
+          card. Read together they are two facts, not a contradiction. */}
+      {d.reportUndelivered && (
+        <div
+          className="flex items-center gap-1.5 rounded-b-[10px] border-t border-status-failed/40 bg-status-failed-soft px-3 py-1 text-3xs font-medium text-[var(--status-failed-text)]"
+          data-testid="workflow-node-undelivered"
+          title="This step ran. Its report did not go out — open the run in History for the reason."
+        >
+          <span className="size-1.5 shrink-0 rounded-full bg-status-failed" />
+          report not delivered
+        </div>
+      )}
       <Handle
         type="source"
         position={Position.Right}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -7,6 +7,9 @@ import type {
   WorkflowBlockedNode,
   WorkflowRunApprovalRow,
 } from "@/api/workflows";
+// Issue #981: the one definition of "this report did not go out", shared with
+// the run drawer, the history rows and the host itself.
+import { undeliveredCount } from "@/views/workflows/run-health";
 
 /**
  * One attention item off the company → operator SSE feed (issue #66). Mirrors
@@ -890,21 +893,15 @@ export function handleEvent(
         });
         break;
       }
-      // `pending` is not a failure: it is a report parked for approval, and
-      // toasting it red would send the operator hunting for a bug that isn't
-      // there. Excluded from the count that speaks up.
+      // Issue #981: the shared rung, so this toast, the run's dot, the drawer's
+      // badge and the host's own verdict cannot disagree about a single row. The
+      // filter it replaces fired "1 report didn't go out" on every test run — a
+      // `dry-run` row is a report nothing attempted, on purpose.
       //
-      // Compared through a widened `string` because `pending` joins
-      // `DeliveryStatus` in issue #227 — a literal would be a no-overlap type
-      // error against today's union, and the host can already send a status
-      // this console's type doesn't name yet.
-      const pendingStatus: string = "pending";
       // `deliveries` is host-controlled and may be absent on an event shape this
       // console's types don't name yet (see note above) — default to empty so a
       // missing field can never throw and blank the subscriber.
-      const undelivered = (event.deliveries ?? []).filter(
-        (d) => d.status !== "sent" && d.status !== pendingStatus,
-      ).length;
+      const undelivered = undeliveredCount(event.deliveries ?? []);
       if (undelivered > 0) {
         toast.warning(
           `${undelivered} report${undelivered === 1 ? "" : "s"} didn't go out`,

--- a/frontend/src/lib/workflow-sample.ts
+++ b/frontend/src/lib/workflow-sample.ts
@@ -21,6 +21,22 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   runState?: NodeRunState;
   /** Wall-clock duration of the node's execution, once it has finished. */
   elapsedMs?: number;
+  /**
+   * Whether the report this `output` node produced did NOT go out (issue #981).
+   *
+   * A field of its own rather than a fourth {@link NodeRunState}, because it is
+   * not the same question. `runState` is the engine's verdict on the step, and
+   * for a dropped report the honest answer is `ok`: delivery is post-engine, the
+   * node ran, and its work stands. Widening the run-state union would have made
+   * one ring colour encode two subsystems' verdicts — and, since
+   * `nodeStateFrom()` fail-safes an unrecognised status to `error`, would have
+   * made every console predating this paint a node that ran perfectly as failed.
+   *
+   * So the card carries both: the green ring and `DONE` for the step, and a
+   * labelled strip for the report. Absent on every node of a run that delivered
+   * what it routed, which is the resting case.
+   */
+  reportUndelivered?: boolean;
 }
 
 /**

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -98,6 +98,9 @@ import { RunFailurePanel } from "@/views/workflows/RunFailurePanel";
 import { RunResultPanel } from "@/views/workflows/RunResultPanel";
 import { CanvasShell } from "@/views/workflows/CanvasShell";
 import { approvalsForRun } from "@/views/workflows/run-approvals";
+// Issue #981: which nodes produced a report that never went out, so the canvas
+// card can say so beside the DONE badge instead of leaving it to a banner.
+import { undeliveredNodes } from "@/views/workflows/run-health";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 import { type NodeOutputView, nodeOutputFor } from "@/views/workflows/run-output";
 
@@ -112,6 +115,11 @@ const EMPTY_FAILED: Record<string, string> = {};
 /** A stable empty default for `runEvents`, so an omitted prop does not hand the
  * fold a fresh array identity on every render. */
 const EMPTY_RUN_EVENTS: CompanyStreamEvent[] = [];
+
+/** A stable empty set for the canvas's undelivered-node marks (issue #981), so
+ * the common case — a run that delivered what it routed — hands `layout` the
+ * same identity every render and does not re-lay the graph out. */
+const EMPTY_UNDELIVERED: Set<string> = new Set();
 
 /** `decodeURIComponent` that survives a hand-edited address bar. A lone `%`
  * makes it throw, and a malformed hash must not take the whole view down —
@@ -1746,13 +1754,27 @@ export function WorkflowsView({
     if (overlayRun) return elapsedFromRun(overlayRun);
     return liveRun?.elapsed ?? {};
   }, [overlayRun, liveRun]);
+  // Issue #981, in the same priority order. The live SSE fold carries no
+  // delivery rows — delivery happens after the engine returns, so they arrive
+  // with the settled body — and correctly contributes nothing here. The
+  // just-finished manual run DOES have them, and is the case the issue was
+  // filed about: an operator presses Run, watches the output node land on DONE,
+  // and the report is gone. It is matched on `runId` so a stale result cannot
+  // mark up a different run's canvas.
+  const paintedUndelivered = useMemo<Set<string>>(() => {
+    if (overlayRun) return undeliveredNodes(overlayRun.deliveries);
+    if (result && (!liveRun || liveRun.runId === result.runId)) {
+      return undeliveredNodes(result.deliveries ?? []);
+    }
+    return EMPTY_UNDELIVERED;
+  }, [overlayRun, result, liveRun]);
 
   const { nodes, edges } = useMemo(
     () =>
       graph
-        ? layout(graph, paintedStates, paintedElapsed)
+        ? layout(graph, paintedStates, paintedElapsed, paintedUndelivered)
         : { nodes: [], edges: [] },
-    [graph, paintedStates, paintedElapsed],
+    [graph, paintedStates, paintedElapsed, paintedUndelivered],
   );
 
   const selected = workflows.find((w) => w.id === selectedId) ?? null;

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -30,6 +30,7 @@ import {
   runDuration,
   runTone,
   undeliveredCount,
+  undeliveredNodes,
 } from "./run-health";
 
 /** Badge styling per delivery outcome. A report that did NOT go out must not
@@ -52,9 +53,11 @@ export function DeliveryRows({ deliveries }: { deliveries: DeliveryReport[] }) {
   // broken — badging it red alongside a transport failure would send them
   // hunting for a bug when the fix is a click in Approvals.
   const pending = deliveries.filter((d) => d.status === "pending").length;
-  const undelivered = deliveries.filter(
-    (d) => d.status !== "sent" && d.status !== "pending",
-  ).length;
+  // Issue #981: the shared rung, not a fourth transcription of it. The filter
+  // this replaces badged every test run "1 not delivered" — a `dry-run` row is
+  // a report nothing attempted, on purpose — and said the same of a gate
+  // continuation whose report an earlier run had already sent.
+  const undelivered = undeliveredCount(deliveries);
   return (
     <div className="mb-3 space-y-1.5 rounded-lg border bg-background/40 p-2">
       <div className="flex items-center gap-2">
@@ -304,6 +307,12 @@ function RunHistoryRow({
 }) {
   const tone = runTone(run);
   const nodes = run.nodes ?? [];
+  // Issue #981: which of those nodes produced a report that never went out.
+  // Joined off `DeliveryReport.node` — the same rows the delivery block below
+  // renders — so the chip and the block cannot disagree, and so the node the
+  // operator clicks into stops claiming a clean run this row calls
+  // `not delivered`.
+  const droppedNodes = undeliveredNodes(run.deliveries);
   // Issue #881 / #880: read once, so the chip, the badge and the terminal line
   // below cannot disagree about whether this run stopped for a person.
   const blocked = run.blockedNodes ?? [];
@@ -402,7 +411,11 @@ function RunHistoryRow({
           data-testid="workflow-run-nodes"
         >
           {nodes.map((node) => (
-            <RunNodeChip key={`${node.nodeId}-${node.elapsedMs}`} node={node} />
+            <RunNodeChip
+              key={`${node.nodeId}-${node.elapsedMs}`}
+              node={node}
+              undelivered={droppedNodes.has(node.nodeId)}
+            />
           ))}
         </div>
       )}
@@ -609,8 +622,23 @@ function RunHistoryRow({
   );
 }
 
-/** One node's outcome in a history row: its id, how it went, how long it took. */
-function RunNodeChip({ node }: { node: WorkflowRunNode }) {
+/** One node's outcome in a history row: its id, how it went, how long it took —
+ * and, since issue #981, whether the report it produced actually went out.
+ *
+ * The two are separate facts and the chip states them separately. `node.status`
+ * answers "did the engine run this step?", and for a dropped report the honest
+ * answer is `ok`: delivery happens after the engine returns, so the node really
+ * did run and its work stands. What was wrong was that the chip said only that,
+ * beside a run the same panel scored `undelivered`. So the green dot stays and a
+ * second, labelled segment carries the delivery — nothing here is re-tinted to
+ * mean something it does not. */
+function RunNodeChip({
+  node,
+  undelivered,
+}: {
+  node: WorkflowRunNode;
+  undelivered: boolean;
+}) {
   // Issue #881: three tones, not two. A blocked step is neither green nor red —
   // painting it red sends an operator hunting for a bug when the fix is a click
   // in Approvals, and painting it green is the lie the issue was filed about.
@@ -643,6 +671,16 @@ function RunNodeChip({ node }: { node: WorkflowRunNode }) {
           ? `${node.elapsedMs}ms`
           : `${(node.elapsedMs / 1000).toFixed(1)}s`}
       </span>
+      {undelivered && (
+        <span
+          className="flex items-center gap-1 border-l border-status-failed/40 pl-1.5 text-[var(--status-failed-text)]"
+          data-testid="workflow-run-node-undelivered"
+          title="This step ran. Its report did not go out — see Report delivery below."
+        >
+          <span className="size-1.5 rounded-full bg-status-failed" />
+          not delivered
+        </span>
+      )}
     </span>
   );
 }

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -28,6 +28,9 @@ import { DeliveryRows } from "./RunHistoryPanel";
 import { type NodeResult, parseRunNodes } from "./run-output";
 // Issue #1002: which of the company's parked cards this run is held on.
 import { blockingApprovals, runApprovals, type RunApproval } from "./run-approvals";
+// Issue #981: the one rung for "this report did not go out", shared with the
+// history rows, the run dot, the SSE toast and the host itself.
+import { undeliveredCount, undeliveredNodes } from "./run-health";
 
 /** Stable empty defaults, so an omitted prop cannot churn the card's props. */
 const EMPTY_APPROVALS: ApprovalSummary[] = [];
@@ -126,9 +129,13 @@ export function RunResultPanel({
   const pendingDeliveryCount = deliveries.filter(
     (d) => d.status === "pending",
   ).length;
-  const undeliveredCount = deliveries.filter(
-    (d) => d.status !== "sent" && d.status !== "pending",
-  ).length;
+  // Issue #981: the shared predicate. The local filter this replaces counted a
+  // `dry-run` row, so the panel that exists to make a TEST run readable told the
+  // operator their test had failed to deliver every single time.
+  const droppedReports = undeliveredCount(deliveries);
+  // Which nodes those rows belong to, so the Steps trail can say it beside the
+  // step instead of leaving the delivery block to say it alone.
+  const droppedNodes = undeliveredNodes(deliveries);
   // Issue #542: a test run. The header says so plainly, and the delivery rows
   // (already `skipped`) read as "would have gone to …" rather than as failures.
   const isDry = result.dryRun === true;
@@ -180,12 +187,12 @@ export function RunResultPanel({
               {pendingDeliveryCount === 1 ? "" : "s"} awaiting approval
             </Badge>
           )}
-          {undeliveredCount > 0 && (
+          {droppedReports > 0 && (
             <Badge
               variant="outline"
               className="border-status-failed/40 bg-status-failed-soft"
             >
-              {undeliveredCount} report{undeliveredCount === 1 ? "" : "s"} not
+              {droppedReports} report{droppedReports === 1 ? "" : "s"} not
               delivered
             </Badge>
           )}
@@ -300,7 +307,11 @@ export function RunResultPanel({
             this is the only place a test run's step-by-step trail appears, since
             the canvas paints no optimistic frontier for it. */}
         {nodeTimeline.length > 0 && (
-          <NodeTimeline nodes={nodeTimeline} graph={graph} />
+          <NodeTimeline
+            nodes={nodeTimeline}
+            graph={graph}
+            undelivered={droppedNodes}
+          />
         )}
 
         {nodeResults && nodeResults.length > 0 ? (
@@ -567,9 +578,12 @@ function NodeResultCard({ node }: { node: NodeResult }) {
 function NodeTimeline({
   nodes,
   graph,
+  undelivered,
 }: {
   nodes: WorkflowRunNode[];
   graph: WorkflowGraph | null;
+  /** The nodes whose report did not go out (issue #981). */
+  undelivered: Set<string>;
 }) {
   const nameById = new Map(graph?.nodes.map((n) => [n.id, n.name]) ?? []);
   return (
@@ -602,6 +616,23 @@ function NodeTimeline({
             <span className="text-2xs text-muted-foreground">
               {n.elapsedMs} ms
             </span>
+            {/* Issue #981. A SECOND badge rather than a different first one:
+                `n.status` answers "did the engine run this step?", and for a
+                dropped report the honest answer is `ok` — delivery happens after
+                the engine returns, so the node ran and its work stands. What was
+                wrong was that this row said only that, next to a run the drawer
+                above scored `not delivered`. Two labelled badges state two facts;
+                one re-tinted badge would just move the ambiguity. */}
+            {undelivered.has(n.nodeId) && (
+              <Badge
+                variant="outline"
+                className="h-4 px-1.5 text-3xs font-normal border-status-failed/40 bg-status-failed-soft"
+                data-testid="workflow-run-step-undelivered"
+                title="This step ran. Its report did not go out — see Report delivery above."
+              >
+                not delivered
+              </Badge>
+            )}
           </div>
           {/* Issue #1014: the engine's own broken-wiring list for this node —
               every config binding that resolved to null, by its config path.

--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -392,11 +392,18 @@ export function failedNodeOf(run: WorkflowRunOutcome): string | null {
  *
  * `runStates` / `elapsed` (issue #371) tint each node with what the run on
  * screen did. Both default to empty, which is the resting canvas — identical to
- * how it rendered before #371. */
+ * how it rendered before #371.
+ *
+ * `undelivered` (issue #981) is the set of `output` nodes whose report did not
+ * go out. Deliberately a THIRD argument rather than another `NodeRunState`: it
+ * is a different subsystem's verdict, taken after the engine returned, and a
+ * node in it is normally also in `runStates` as `ok` — both are true and the
+ * card renders both. See {@link undeliveredNodes} in `run-health.ts`. */
 export function layout(
   graph: WorkflowGraph,
   runStates: Record<string, NodeRunState> = {},
   elapsed: Record<string, number> = {},
+  undelivered: Set<string> = new Set(),
 ): { nodes: Node<WorkflowNodeData>[]; edges: Edge[] } {
   const depth = new Map<string, number>(graph.nodes.map((n) => [n.id, 0]));
   for (let i = 0; i < graph.nodes.length; i++) {
@@ -430,6 +437,9 @@ export function layout(
         color: meta.color,
         runState: runStates[n.id],
         elapsedMs: elapsed[n.id],
+        // `undefined` rather than `false` when it delivered fine, so a resting
+        // node's data is byte-for-byte what it was before this existed.
+        reportUndelivered: undelivered.has(n.id) || undefined,
       },
     };
   });

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -41,7 +41,10 @@ const SKIPPED_STATUS: string = "skipped";
  * added the row to make visible; excusing it restores the silence issues #947
  * and #963 were filed about. See docs/modules/server/run-verdict.md.
  */
-const ACCOUNTED_FOR_REASONS: readonly string[] = ["already-delivered", "dry-run"];
+const ACCOUNTED_FOR_REASONS: readonly string[] = [
+  "already-delivered",
+  "dry-run",
+];
 
 /**
  * Whether THIS one report did not reach a destination and will not without a

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -24,14 +24,69 @@ import type {
  */
 const PENDING_STATUS: string = "pending";
 
+/** The `skipped` delivery status, widened for the same reason as
+ * {@link PENDING_STATUS}: the host owns this union and may grow it. */
+const SKIPPED_STATUS: string = "skipped";
+
+/**
+ * The two `skipped` reasons that do NOT count as a lost report (issue #981).
+ *
+ * `already-delivered` — an earlier run in this approval lineage sent it (issue
+ * #438); approving a gate re-runs the graph from the trigger, so every upstream
+ * `output` node is reached again and the report is already at its destination.
+ * `dry-run` — a test run (issue #542) attempted nothing, on purpose.
+ *
+ * `no-destination-configured` is deliberately NOT here. That report was produced
+ * and then lost with nothing accounting for it, which is exactly what issue #925
+ * added the row to make visible; excusing it restores the silence issues #947
+ * and #963 were filed about. See docs/modules/server/run-verdict.md.
+ */
+const ACCOUNTED_FOR_REASONS: readonly string[] = ["already-delivered", "dry-run"];
+
+/**
+ * Whether THIS one report did not reach a destination and will not without a
+ * change — the host's `is_undelivered`, mirrored (issue #981).
+ *
+ * Every count and every marker below folds this, so the run's dot, the drawer's
+ * badge, the toast and the per-node marker cannot disagree about a single row.
+ *
+ * `reason` is optional on the type: a host predating issue #248 sends no reason
+ * at all. An absent one **counts**, which is the safe direction — an unreadable
+ * reason must not excuse a report from the number an operator acts on.
+ */
+export function isUndelivered(d: DeliveryReport): boolean {
+  if (d.status === "sent" || d.status === PENDING_STATUS) return false;
+  // Only a skip can be accounted for. A `failed` or `denied` row is a report
+  // that was attempted and did not work, whatever it claims about why.
+  if (d.status !== SKIPPED_STATUS) return true;
+  return !ACCOUNTED_FOR_REASONS.includes(d.reason ?? "");
+}
+
 /** Reports that did NOT reach their destination **and will not without a
- * change** — the number worth acting on. `pending` is excluded on purpose: it
- * is a report parked for an operator's approval, so counting it here would
- * badge a working approvals queue as a failure. */
+ * change** — the number worth acting on. A fold of {@link isUndelivered}. */
 export function undeliveredCount(deliveries: DeliveryReport[]): number {
-  return deliveries.filter(
-    (d) => d.status !== "sent" && d.status !== PENDING_STATUS,
-  ).length;
+  return deliveries.filter(isUndelivered).length;
+}
+
+/**
+ * The `output` nodes whose report did not go out (issue #981).
+ *
+ * The join that lets the console answer TWO questions about one node without
+ * conflating them. `nodes[].status` says whether the engine ran the step — for a
+ * dropped report the honest answer is `ok`, because delivery happens after the
+ * engine returns — and this says whether its report reached anybody. Rendering
+ * only the first is what put a green `DONE` on the output node of a run the same
+ * screen called `undelivered`.
+ *
+ * Local, off `DeliveryReport.node` (the `output` node's id, on every delivery
+ * row the host writes), so this needs **no new wire field** and adds no third
+ * notion of "this run did not fully work" beyond the verdict itself.
+ *
+ * Takes the rows rather than a run: the settled `WorkflowRunResult` and the
+ * history's `WorkflowRunOutcome` are different shapes that both carry them.
+ */
+export function undeliveredNodes(deliveries: DeliveryReport[]): Set<string> {
+  return new Set(deliveries.filter(isUndelivered).map((d) => d.node));
 }
 
 /** Reports waiting on an operator's verdict rather than on a fix. */

--- a/frontend/test/unit/qa-harness.test.ts
+++ b/frontend/test/unit/qa-harness.test.ts
@@ -88,6 +88,10 @@ function loadHarness(fetchImpl?: (path: string, init?: { method?: string }) => P
       runVerdict: (run: unknown) => string;
       undeliveredCount: (d: DeliveryReport[]) => number;
       isUndelivered: (d: DeliveryReport) => boolean;
+      checkDeliveries: (
+        rows: { check: string; verdict: string; value: string }[],
+        runs: unknown[],
+      ) => void;
       pendingCount: (d: DeliveryReport[]) => number;
       awaitingCount: (run: unknown) => number;
       isBlocked: (run: unknown) => boolean;
@@ -445,6 +449,48 @@ describe("runVerdict agrees with the console's runTone", () => {
         consoleIsUndelivered(row),
       );
     }
+  });
+
+  /**
+   * The `workflow-deliveries` row is what an operator running the harness
+   * actually reads, and it owned a NINTH copy of the filter. A company whose
+   * most recent runs were **test** runs — the safest thing an operator can do —
+   * scored a red FAIL for a delivery path that is working perfectly.
+   */
+  it("does not fail the delivery check on accounted-for skips", () => {
+    const { checkDeliveries } = loadHarness()._internals;
+    const rows: { check: string; verdict: string; value: string }[] = [];
+    checkDeliveries(rows, [
+      {
+        workflowId: "digest",
+        deliveries: [
+          delivery("skipped", "dry-run"),
+          delivery("skipped", "already-delivered"),
+          delivery("sent", "channel-posted"),
+        ],
+      },
+    ]);
+    const r = rows.find((x) => x.check === "workflow-deliveries");
+    expect(r?.verdict).toBe("PASS");
+    expect(r?.value).toContain("0/3 reports dropped");
+  });
+
+  it("still fails it for a report that was produced and lost", () => {
+    const { checkDeliveries } = loadHarness()._internals;
+    const rows: { check: string; verdict: string; value: string }[] = [];
+    checkDeliveries(rows, [
+      {
+        workflowId: "digest",
+        deliveries: [
+          delivery("failed", "channel-not-wired"),
+          // The deliberate non-move (issue #925).
+          delivery("skipped", "no-destination-configured"),
+        ],
+      },
+    ]);
+    const r = rows.find((x) => x.check === "workflow-deliveries");
+    expect(r?.verdict).toBe("FAIL");
+    expect(r?.value).toContain("2/2 reports dropped");
   });
 
   it("reports an unknown run as unknown rather than ok", () => {

--- a/frontend/test/unit/qa-harness.test.ts
+++ b/frontend/test/unit/qa-harness.test.ts
@@ -27,7 +27,11 @@ import { fileURLToPath } from "node:url";
 import { createContext, runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 
-import { runTone, verdictOf } from "@/views/workflows/run-health";
+import {
+  isUndelivered as consoleIsUndelivered,
+  runTone,
+  verdictOf,
+} from "@/views/workflows/run-health";
 import type {
   DeliveryReport,
   WorkflowBlockedNode,
@@ -83,6 +87,7 @@ function loadHarness(fetchImpl?: (path: string, init?: { method?: string }) => P
     _internals: {
       runVerdict: (run: unknown) => string;
       undeliveredCount: (d: DeliveryReport[]) => number;
+      isUndelivered: (d: DeliveryReport) => boolean;
       pendingCount: (d: DeliveryReport[]) => number;
       awaitingCount: (run: unknown) => number;
       isBlocked: (run: unknown) => boolean;
@@ -108,8 +113,11 @@ function run(overrides: Partial<WorkflowRunOutcome>): WorkflowRunOutcome {
   } as WorkflowRunOutcome;
 }
 
-function delivery(status: DeliveryReport["status"]): DeliveryReport {
-  return { node: "report", kind: "channel", target: "operator", status, detail: "" };
+function delivery(
+  status: DeliveryReport["status"],
+  reason?: string,
+): DeliveryReport {
+  return { node: "report", kind: "channel", target: "operator", status, detail: "", reason };
 }
 
 /** The console's label for a run, mapped to the harness's verdict word. */
@@ -392,6 +400,51 @@ describe("runVerdict agrees with the console's runTone", () => {
     ];
     expect(undeliveredCount(deliveries)).toBe(2);
     expect(pendingCount(deliveries)).toBe(1);
+  });
+
+  /**
+   * Issue #981's second half. The harness is pasted against whatever host is in
+   * front of the operator, so its fallback has to move rung-for-rung with the
+   * host's `is_undelivered` and the console's `isUndelivered` — otherwise the
+   * three readings of the same rows diverge exactly where nobody is checking.
+   */
+  it("excuses the same two skipped reasons the console and the host excuse", () => {
+    const { isUndelivered, undeliveredCount } = loadHarness()._internals;
+    expect(isUndelivered(delivery("skipped", "dry-run"))).toBe(false);
+    expect(isUndelivered(delivery("skipped", "already-delivered"))).toBe(false);
+    // The deliberate non-move: this report was produced and then lost.
+    expect(isUndelivered(delivery("skipped", "no-destination-configured"))).toBe(
+      true,
+    );
+    // A host predating issue #248 records no reason; an unreadable one counts.
+    expect(isUndelivered(delivery("skipped"))).toBe(true);
+    // The exemptions are scoped to a skip.
+    expect(isUndelivered(delivery("failed", "dry-run"))).toBe(true);
+    expect(
+      undeliveredCount([
+        delivery("skipped", "dry-run"),
+        delivery("skipped", "already-delivered"),
+        delivery("skipped", "no-destination-configured"),
+      ]),
+    ).toBe(1);
+  });
+
+  it("agrees with the console's isUndelivered on every reason", () => {
+    const { isUndelivered } = loadHarness()._internals;
+    for (const row of [
+      delivery("sent", "channel-posted"),
+      delivery("pending", "parked-for-approval"),
+      delivery("skipped", "dry-run"),
+      delivery("skipped", "already-delivered"),
+      delivery("skipped", "no-destination-configured"),
+      delivery("skipped", "recipient-not-established"),
+      delivery("denied", "email-not-granted"),
+      delivery("failed", "channel-not-wired"),
+    ]) {
+      expect(isUndelivered(row), `${row.status}/${row.reason}`).toBe(
+        consoleIsUndelivered(row),
+      );
+    }
   });
 
   it("reports an unknown run as unknown rather than ok", () => {

--- a/frontend/test/unit/workflow-run-node-delivery.test.ts
+++ b/frontend/test/unit/workflow-run-node-delivery.test.ts
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  DeliveryReport,
+  WorkflowGraph,
+  WorkflowRunOutcome,
+  WorkflowRunResult,
+} from "@/api/workflows";
+import { layout } from "@/views/workflows/graph";
+import {
+  isUndelivered,
+  undeliveredCount,
+  undeliveredNodes,
+} from "@/views/workflows/run-health";
+import { RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
+import { RunResultPanel } from "@/views/workflows/RunResultPanel";
+
+/**
+ * Issue #981, the half PR #1165 left open: a run whose report was dropped reads
+ * `undelivered` at the run level, and the node the operator clicks into still
+ * claimed `ok` — two readings contradicting each other on one screen.
+ *
+ * The fix is NOT a fourth node status. `nodes[].status` answers "did the engine
+ * run this step?" and for a dropped report the honest answer is `ok`: delivery
+ * is post-engine, the node ran, its work stands. So the node cell stops being
+ * ALONE — every surface that renders a node renders the delivery beside it,
+ * explicitly labelled. These tests pin BOTH halves: the `ok` that must not move,
+ * and the delivery marker that must appear next to it.
+ *
+ * They also pin the second half of the issue: two `skipped` reasons stop
+ * counting as undelivered, and the third deliberately does not.
+ */
+
+function delivery(over: Partial<DeliveryReport> = {}): DeliveryReport {
+  return {
+    node: "report",
+    kind: "channel",
+    target: "engineering",
+    status: "failed",
+    detail: "the destination channel is not wired on this runtime",
+    reason: "channel-not-wired",
+    ...over,
+  };
+}
+
+const DROPPED = delivery();
+const DRY = delivery({ status: "skipped", reason: "dry-run" });
+const AGAIN = delivery({ status: "skipped", reason: "already-delivered" });
+const NOWHERE = delivery({
+  status: "skipped",
+  kind: "none",
+  target: undefined,
+  reason: "no-destination-configured",
+});
+
+describe("what counts as a report that did not go out", () => {
+  it("excuses a test run — nothing was attempted, on purpose", () => {
+    expect(isUndelivered(DRY)).toBe(false);
+    expect(undeliveredCount([DRY])).toBe(0);
+    expect(undeliveredNodes([DRY]).size).toBe(0);
+  });
+
+  it("excuses a report an earlier run in the lineage already sent", () => {
+    expect(isUndelivered(AGAIN)).toBe(false);
+    expect(undeliveredCount([AGAIN])).toBe(0);
+  });
+
+  // The deliberate NON-move, and the reason the other two could move at all:
+  // this report was produced and then lost, with nothing accounting for it.
+  // Issue #925 added the row so that case stops being indistinguishable from a
+  // graph that routed nothing on purpose.
+  it("still counts an output node with nowhere to send", () => {
+    expect(isUndelivered(NOWHERE)).toBe(true);
+    expect(undeliveredCount([NOWHERE])).toBe(1);
+  });
+
+  it("counts a row whose reason the host never recorded", () => {
+    // A host predating issue #248 sends no `reason` at all. An unreadable
+    // reason must not excuse a report from the number an operator acts on.
+    expect(isUndelivered(delivery({ status: "skipped", reason: undefined }))).toBe(
+      true,
+    );
+  });
+
+  it("scopes the two exemptions to `skipped`", () => {
+    for (const status of ["failed", "denied"] as const) {
+      expect(isUndelivered(delivery({ status, reason: "dry-run" }))).toBe(true);
+      expect(
+        isUndelivered(delivery({ status, reason: "already-delivered" })),
+      ).toBe(true);
+    }
+  });
+
+  it("never counts a sent or a parked report, whatever its reason", () => {
+    expect(isUndelivered(delivery({ status: "sent", reason: "channel-posted" }))).toBe(
+      false,
+    );
+    expect(
+      isUndelivered(delivery({ status: "pending", reason: "parked-for-approval" })),
+    ).toBe(false);
+  });
+
+  it("joins the dropped rows to the nodes that produced them", () => {
+    const nodes = undeliveredNodes([
+      DROPPED,
+      delivery({ node: "second", status: "sent", reason: "channel-posted" }),
+      delivery({ node: "third", status: "skipped", reason: "dry-run" }),
+    ]);
+    expect([...nodes]).toEqual(["report"]);
+  });
+});
+
+const GRAPH: WorkflowGraph = {
+  id: "digest",
+  name: "Digest",
+  nodes: [
+    { id: "draft", kind: "agent", name: "Draft" },
+    { id: "report", kind: "output", name: "Report" },
+  ],
+  edges: [{ from: "draft", to: "report" }],
+};
+
+describe("the canvas card", () => {
+  it("marks the dropped node and nothing else, without touching its run state", () => {
+    const { nodes } = layout(
+      GRAPH,
+      { draft: "ok", report: "ok" },
+      { draft: 120, report: 0 },
+      undeliveredNodes([DROPPED]),
+    );
+    const byId = new Map(nodes.map((n) => [n.id, n.data]));
+    // The step ran, and the card still says so.
+    expect(byId.get("report")?.runState).toBe("ok");
+    expect(byId.get("report")?.reportUndelivered).toBe(true);
+    // A node with no dropped report is byte-for-byte what it was before.
+    expect(byId.get("draft")?.reportUndelivered).toBeUndefined();
+  });
+
+  it("marks nothing for a test run", () => {
+    const { nodes } = layout(GRAPH, { report: "ok" }, {}, undeliveredNodes([DRY]));
+    expect(
+      nodes.every((n) => n.data.reportUndelivered === undefined),
+    ).toBe(true);
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const RUN: WorkflowRunOutcome = {
+  seq: 1,
+  atMillis: 1_700_000_000_000,
+  workflowId: "digest",
+  scheduled: false,
+  runId: "run-1",
+  deliveries: [DROPPED],
+  pendingApprovals: [],
+  verdict: "undelivered",
+  nodes: [
+    { nodeId: "draft", status: "ok", elapsedMs: 120 },
+    { nodeId: "report", status: "ok", elapsedMs: 0 },
+  ],
+};
+
+describe("the history panel's node chips", () => {
+  it("keeps the node's `ok` AND says the report did not go out", () => {
+    act(() => {
+      root.render(
+        createElement(RunHistoryPanel, { runs: [RUN], graph: GRAPH }),
+      );
+    });
+    // The fact that must NOT have moved: the engine ran both nodes.
+    expect(
+      container.querySelectorAll('[data-testid="workflow-run-node-ok"]'),
+    ).toHaveLength(2);
+    expect(
+      container.querySelector('[data-testid="workflow-run-node-error"]'),
+    ).toBeNull();
+    // The fact that was missing: exactly one of them lost its report.
+    const marks = container.querySelectorAll(
+      '[data-testid="workflow-run-node-undelivered"]',
+    );
+    expect(marks).toHaveLength(1);
+    expect(marks[0]?.textContent).toContain("not delivered");
+  });
+
+  it("marks no chip when the run delivered what it routed", () => {
+    act(() => {
+      root.render(
+        createElement(RunHistoryPanel, {
+          runs: [
+            {
+              ...RUN,
+              verdict: "ok",
+              deliveries: [delivery({ status: "sent", reason: "channel-posted" })],
+            },
+          ],
+          graph: GRAPH,
+        }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="workflow-run-node-undelivered"]'),
+    ).toBeNull();
+  });
+});
+
+const RESULT: WorkflowRunResult = {
+  output: {},
+  pendingApprovals: [],
+  runId: "run-1",
+  deliveries: [DROPPED],
+  nodes: [
+    { nodeId: "draft", status: "ok", elapsedMs: 120 },
+    { nodeId: "report", status: "ok", elapsedMs: 0 },
+  ],
+};
+
+describe("the run drawer's Steps trail", () => {
+  it("badges the dropped step beside its `ok`, not instead of it", () => {
+    act(() => {
+      root.render(
+        createElement(RunResultPanel, {
+          result: RESULT,
+          graph: GRAPH,
+          request: "",
+          onClose: () => {},
+        }),
+      );
+    });
+    const timeline = container.querySelector(
+      '[data-testid="workflow-run-node-timeline"]',
+    );
+    expect(timeline?.textContent).toContain("ok");
+    const marks = container.querySelectorAll(
+      '[data-testid="workflow-run-step-undelivered"]',
+    );
+    expect(marks).toHaveLength(1);
+  });
+
+  it("badges nothing on a test run, whose rows were never attempted", () => {
+    act(() => {
+      root.render(
+        createElement(RunResultPanel, {
+          result: { ...RESULT, dryRun: true, deliveries: [DRY] },
+          graph: GRAPH,
+          request: "",
+          onClose: () => {},
+        }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="workflow-run-step-undelivered"]'),
+    ).toBeNull();
+  });
+});

--- a/frontend/test/unit/workflow-run-node-delivery.test.ts
+++ b/frontend/test/unit/workflow-run-node-delivery.test.ts
@@ -117,6 +117,7 @@ describe("what counts as a report that did not go out", () => {
 const GRAPH: WorkflowGraph = {
   id: "digest",
   name: "Digest",
+  version: "v1",
   nodes: [
     { id: "draft", kind: "agent", name: "Draft" },
     { id: "report", kind: "output", name: "Report" },
@@ -184,7 +185,14 @@ describe("the history panel's node chips", () => {
   it("keeps the node's `ok` AND says the report did not go out", () => {
     act(() => {
       root.render(
-        createElement(RunHistoryPanel, { runs: [RUN], graph: GRAPH }),
+        createElement(RunHistoryPanel, {
+          runs: [RUN],
+          graph: GRAPH,
+          workflowName: "Digest",
+          onClose: () => {},
+          selectedRunSeq: null,
+          onSelectRun: () => {},
+        }),
       );
     });
     // The fact that must NOT have moved: the engine ran both nodes.
@@ -210,10 +218,16 @@ describe("the history panel's node chips", () => {
             {
               ...RUN,
               verdict: "ok",
-              deliveries: [delivery({ status: "sent", reason: "channel-posted" })],
+              deliveries: [
+                delivery({ status: "sent", reason: "channel-posted" }),
+              ],
             },
           ],
           graph: GRAPH,
+          workflowName: "Digest",
+          onClose: () => {},
+          selectedRunSeq: null,
+          onSelectRun: () => {},
         }),
       );
     });

--- a/qa/oc-qa.js
+++ b/qa/oc-qa.js
@@ -830,7 +830,13 @@
     }
     const all = runs.flatMap((r) => (r.deliveries || []).map((d) => ({ run: r, d })));
     const attempted = runs.filter((r) => (r.deliveries || []).length > 0);
-    const dropped = all.filter(({ d }) => d.status !== "sent" && d.status !== "pending");
+    // Issue #981: the shared predicate, not a fourth transcription of it inside
+    // this file. The status-only filter this replaces FAILED the whole check on
+    // a `skipped`/`dry-run` row (a test run attempted nothing, on purpose) and
+    // on a `skipped`/`already-delivered` one (an earlier run in the approval
+    // lineage sent it) — so a company whose most recent runs were tests scored
+    // a red row for a delivery path that is working.
+    const dropped = all.filter(({ d }) => isUndelivered(d));
     const reasons = [...new Set(dropped.map(({ d }) => d.reason || d.status))];
     rows.push(
       row(
@@ -1327,6 +1333,7 @@
       runVerdict,
       undeliveredCount,
       isUndelivered,
+      checkDeliveries,
       pendingCount,
       awaitingCount,
       isBlocked,

--- a/qa/oc-qa.js
+++ b/qa/oc-qa.js
@@ -229,9 +229,30 @@
    * Reports that did not land **and will not without a change**. `pending` is
    * excluded on purpose: it is a report parked for an operator's approval, so
    * counting it here would score a working approvals queue as a failure.
+   *
+   * Two `skipped` reasons are excluded too (issue #981), matching the host's
+   * `is_undelivered` and the console's `isUndelivered`: `already-delivered` (an
+   * earlier run in this approval lineage sent it, issue #438) and `dry-run` (a
+   * test run attempted nothing, on purpose, issue #542). Both describe a report
+   * whose fate is accounted for.
+   *
+   * `no-destination-configured` is deliberately NOT excluded: that report was
+   * produced and then lost, with nothing accounting for it, which is exactly
+   * what issue #925 added the row to make visible.
+   *
+   * An absent `reason` — a host predating issue #248 — counts, which is the
+   * safe direction for a harness that is pasted against whatever host is in
+   * front of the operator.
    */
   function undeliveredCount(deliveries) {
-    return (deliveries || []).filter((d) => d.status !== "sent" && d.status !== "pending").length;
+    return (deliveries || []).filter(isUndelivered).length;
+  }
+
+  /** Whether one delivery row is a report that did not go out. */
+  function isUndelivered(d) {
+    if (d.status === "sent" || d.status === "pending") return false;
+    if (d.status !== "skipped") return true;
+    return d.reason !== "already-delivered" && d.reason !== "dry-run";
   }
 
   /** Reports waiting on an operator's verdict rather than on a fix. */
@@ -1305,6 +1326,7 @@
     _internals: {
       runVerdict,
       undeliveredCount,
+      isUndelivered,
       pendingCount,
       awaitingCount,
       isBlocked,

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -14,7 +14,6 @@ use crate::ports::types::{
     ChunkAddr, CompanyEvent, ContextChunk, ContextOp, ContextOpResult, Effect, EffectGroup,
     LedgerEntry, OutboundMessage, Verdict,
 };
-use crate::ports::workflow_runner::DeliveryStatus;
 
 use super::wire::{EffectFrame, Role, WireEvent};
 
@@ -383,10 +382,15 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
                     format!("{how} run of workflow {workflow_id} was stopped by an operator")
                 }
                 None => {
-                    let undelivered = deliveries
-                        .iter()
-                        .filter(|d| !matches!(d.status, DeliveryStatus::Sent))
-                        .count();
+                    // Issue #981: `crate::ports::is_undelivered`, not a fourth
+                    // transcription of the rule. The local filter this replaces
+                    // counted anything that was not `Sent` — which folded in
+                    // `Pending`, so a report parked for an operator's approval
+                    // was reported to the sidecar as "1 not delivered, 1 pending
+                    // approval" on the same line: the same row, counted twice,
+                    // once as a loss it is not. It also counted a test run's
+                    // rows and a continuation's already-sent ones.
+                    let undelivered = crate::ports::undelivered_count(deliveries);
                     format!(
                         "{how} run of workflow {workflow_id} finished — {} report(s) routed, \
                          {undelivered} not delivered, {} pending approval",
@@ -673,7 +677,7 @@ pub(crate) fn payload_bool(value: &Value, key: &str) -> Option<bool> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ports::workflow_runner::{DeliveryReason, DeliveryReport};
+    use crate::ports::workflow_runner::{DeliveryReason, DeliveryReport, DeliveryStatus};
 
     /// A recipient address for fixtures. `.invalid` is reserved by RFC 2606 and
     /// can never resolve, so a fixture that escapes names nobody.

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -735,6 +735,58 @@ mod test {
         assert_eq!(wired.kind, "workflow.run");
     }
 
+    /// **Issue #981: a parked report is not a lost one, and must be counted
+    /// once.**
+    ///
+    /// This projection folded anything that was not `sent`, so a report waiting
+    /// in the approvals queue was reported to the sidecar on one line as both
+    /// "1 not delivered" *and* "1 pending approval" — the same row, counted
+    /// twice, once as a loss it is not. A test run's rows and an approval-gate
+    /// continuation's already-sent ones landed in the same bucket for the same
+    /// reason. All three now fold `crate::ports::undelivered_count`, the one
+    /// rung the host's verdict and the console stand on.
+    #[test]
+    fn a_parked_or_accounted_for_report_is_not_wired_out_as_undelivered() {
+        let event = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: None,
+            deliveries: vec![
+                DeliveryReport {
+                    node: "owner_summary".to_string(),
+                    kind: "email".to_string(),
+                    target: Some(RECIPIENT.to_string()),
+                    status: DeliveryStatus::Pending,
+                    detail: "waiting in Approvals".to_string(),
+                    reason: DeliveryReason::ParkedForApproval,
+                },
+                DeliveryReport {
+                    node: "digest".to_string(),
+                    kind: "channel".to_string(),
+                    target: Some("engineering".to_string()),
+                    status: DeliveryStatus::Skipped,
+                    detail: "already delivered by an earlier run".to_string(),
+                    reason: DeliveryReason::AlreadyDelivered,
+                },
+            ],
+            pending_approvals: vec!["owner_summary".to_string()],
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
+        };
+
+        let wired = wire_event(8, &event);
+
+        assert!(wired.body.contains("0 not delivered"), "{}", wired.body);
+        assert!(wired.body.contains("1 pending approval"), "{}", wired.body);
+        // The rows themselves are still counted as routed — nothing is hidden,
+        // only classified.
+        assert!(wired.body.contains("2 report(s) routed"), "{}", wired.body);
+    }
+
     /// **Issue #383: a stopped run must not wire out as a finished one.**
     ///
     /// A cancelled run carries `cancelled: true` and **no error**, so the arm

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1784,10 +1784,12 @@ fn summarize_event(event: &CompanyEvent) -> String {
                 // invite it to act on work an operator deliberately stopped.
                 None if *cancelled => format!("{how} workflow run stopped: {workflow_id}"),
                 None => {
-                    let undelivered = deliveries
-                        .iter()
-                        .filter(|d| !matches!(d.status, crate::ports::DeliveryStatus::Sent))
-                        .count();
+                    // Issue #981: the shared rung, not a local one. As in the
+                    // sidecar's projection, the filter this replaces counted
+                    // `Pending` — a report waiting on a human read to the
+                    // orchestrator as one that had been lost, and it would act
+                    // on that.
+                    let undelivered = crate::ports::undelivered_count(deliveries);
                     format!(
                         "{how} workflow run finished: {workflow_id} ({undelivered} not delivered)"
                     )
@@ -3915,12 +3917,7 @@ fn summarize_run(
     let undelivered: Vec<&crate::ports::DeliveryReport> = run
         .deliveries
         .iter()
-        .filter(|d| {
-            !matches!(
-                d.status,
-                crate::ports::DeliveryStatus::Sent | crate::ports::DeliveryStatus::Pending
-            )
-        })
+        .filter(|d| crate::ports::is_undelivered(d))
         .collect();
     if !undelivered.is_empty() {
         md.push_str(&format!(

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -9158,6 +9158,54 @@ name = "Morning"
         };
         let md = summarize_run(&file, &parked, "run-parked", RunOutputStored::Stored);
         assert!(!md.contains("did NOT reach a destination"), "{md}");
+
+        // Issue #981, the second half. This paragraph's own prose is the
+        // argument: it says the report "did not go out, and it will not without
+        // a change". Neither is true of a test run, which attempted nothing on
+        // purpose, nor of a continuation whose report an earlier run in the
+        // lineage already sent — so telling the model to "fix the destination"
+        // for either would send it at a graph that is behaving as designed.
+        for reason in [
+            crate::ports::DeliveryReason::DryRun,
+            crate::ports::DeliveryReason::AlreadyDelivered,
+        ] {
+            let accounted = WorkflowRun {
+                deliveries: vec![crate::ports::DeliveryReport {
+                    node: "worker".into(),
+                    kind: "channel".into(),
+                    target: Some("engineering".into()),
+                    status: crate::ports::DeliveryStatus::Skipped,
+                    detail: "nothing was sent".into(),
+                    reason,
+                }],
+                ..dropped.clone()
+            };
+            let md = summarize_run(&file, &accounted, "run-skip", RunOutputStored::Stored);
+            assert!(
+                !md.contains("did NOT reach a destination"),
+                "{reason:?}: {md}"
+            );
+        }
+
+        // The deliberate non-move: an `output` node with nowhere to send DID
+        // lose its report, and the model is exactly the reader that should be
+        // told (issues #925 / #947 / #963).
+        let nowhere = WorkflowRun {
+            deliveries: vec![crate::ports::DeliveryReport {
+                node: "worker".into(),
+                kind: "none".into(),
+                target: None,
+                status: crate::ports::DeliveryStatus::Skipped,
+                detail: "this output node has no destination".into(),
+                reason: crate::ports::DeliveryReason::NoDestinationConfigured,
+            }],
+            ..dropped.clone()
+        };
+        let md = summarize_run(&file, &nowhere, "run-nowhere", RunOutputStored::Stored);
+        assert!(
+            md.contains("1 report(s) did NOT reach a destination"),
+            "{md}"
+        );
     }
 
     /// T3: a successful run populates the cache and the tool's JSON payload

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -88,7 +88,7 @@ pub use workflow_runner::{
     WorkflowRunBoardRow, WorkflowRunContext, WorkflowRunNodeRow, WorkflowRunner,
 };
 pub use workflow_verdict::{
-    RunVerdictFacts, WorkflowRunVerdict, awaiting_count, undelivered_count,
+    RunVerdictFacts, WorkflowRunVerdict, awaiting_count, is_undelivered, undelivered_count,
 };
 pub use workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 

--- a/src/ports/workflow_verdict.rs
+++ b/src/ports/workflow_verdict.rs
@@ -48,7 +48,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::ports::workflow_runner::{DeliveryReport, DeliveryStatus};
+use crate::ports::workflow_runner::{DeliveryReason, DeliveryReport, DeliveryStatus};
 
 /// What a workflow run adds up to, as a closed set (issue #981).
 ///
@@ -192,28 +192,67 @@ impl RunVerdictFacts<'_> {
     }
 }
 
-/// Reports that did **not** reach their destination and will not without a
-/// change — the count worth acting on.
+/// Whether **this one report** did not reach a destination and will not without
+/// a change (issue #981).
 ///
-/// `pending` is excluded on purpose: it is a report parked for an operator's
-/// approval, so counting it here would score a working approvals queue as a
-/// failure. It is counted by [`awaiting_count`] instead.
+/// The single rung every surface stands on: the verdict below, the scheduler's
+/// alert number, the sidecar's and the orchestrator's summaries, the console's
+/// "N not delivered" badge, the SSE toast, and — since this exists — the
+/// per-node delivery marker the console paints on the `output` node itself.
+/// Written once here because a rung that only some readers honour is worse than
+/// no rung at all.
 ///
-/// Read off [`DeliveryStatus`] rather than off
-/// [`DeliveryReason`](crate::ports::DeliveryReason), which keeps this identical
-/// to the reading every existing surface already performs — the console's
-/// "N not delivered" badge, the scheduler's log line, the SSE toast. Three of
-/// the reasons that land on [`Skipped`](DeliveryStatus::Skipped) arguably do not
-/// belong in this count at all (`already-delivered`, `no-destination-configured`
-/// and `dry-run` each describe a report that was never owed to an address), but
-/// reclassifying them would move the badge and the verdict apart unless every
-/// surface moved together. That is its own change; this one moves the *ladder*
-/// to the host without moving the rungs.
+/// # Status alone is not the reading
+///
+/// `sent` obviously did land and `pending` is a report parked for an operator's
+/// approval — counting the latter here would score a working approvals queue as
+/// a failure, so it is counted by [`awaiting_count`] instead.
+///
+/// The interesting half is [`Skipped`](DeliveryStatus::Skipped), which the
+/// delivery path writes for three genuinely different situations. The axis that
+/// separates them is **whether the report's fate is accounted for**, not whether
+/// it "was owed to an address":
+///
+/// * [`AlreadyDelivered`](DeliveryReason::AlreadyDelivered) — an earlier run in
+///   this approval lineage **sent it** (issue #438). Approving a gate re-runs the
+///   graph from the trigger, so every upstream `output` node is reached a second
+///   time; the report is at its destination and re-counting it as lost would
+///   paint every resumed gate red.
+/// * [`DryRun`](DeliveryReason::DryRun) — a test run (issue #542). Nothing was
+///   attempted, on purpose, in a mode the operator chose. Counting it made the
+///   *only* safe way to try a graph report a failure every single time.
+/// * [`NoDestinationConfigured`](DeliveryReason::NoDestinationConfigured) — the
+///   report was **produced and then lost**, with nothing accounting for it
+///   (issue #925). This row exists precisely so that "the author routed nothing
+///   on purpose" and "the author never configured a destination" stop being the
+///   same observation; excusing it here would restore the silence issues #947
+///   and #963 were filed about. **It counts.**
+///
+/// The match on [`DeliveryStatus`] is exhaustive and only the `Skipped` arm
+/// reads a reason, so a new delivery status cannot be added without classifying
+/// it, and a hypothetical `failed`/`dry-run` pair still counts.
+///
+/// A row carrying [`Unspecified`](DeliveryReason::Unspecified) — the only
+/// reachable value on a `WorkflowRunFinished` journaled before issue #248 added
+/// the field — counts, which is the safe direction: an unreadable reason must
+/// not excuse a report from the number an operator acts on.
+pub fn is_undelivered(report: &DeliveryReport) -> bool {
+    match report.status {
+        DeliveryStatus::Sent | DeliveryStatus::Pending => false,
+        DeliveryStatus::Skipped => !matches!(
+            report.reason,
+            DeliveryReason::AlreadyDelivered | DeliveryReason::DryRun
+        ),
+        DeliveryStatus::Denied | DeliveryStatus::Failed => true,
+    }
+}
+
+/// How many of a run's reports did **not** reach their destination and will not
+/// without a change — the count worth acting on.
+///
+/// A fold of [`is_undelivered`], which is where the reasoning lives.
 pub fn undelivered_count(deliveries: &[DeliveryReport]) -> usize {
-    deliveries
-        .iter()
-        .filter(|d| !matches!(d.status, DeliveryStatus::Sent | DeliveryStatus::Pending))
-        .count()
+    deliveries.iter().filter(|d| is_undelivered(d)).count()
 }
 
 /// Everything about a run that is waiting on a person: the gates it paused at
@@ -454,6 +493,109 @@ mod test {
             );
             assert_eq!(verdict.as_str(), token);
             assert_eq!(verdict.to_string(), token);
+        }
+    }
+
+    /// Issue #981, the second half: a **test run** attempted nothing, on
+    /// purpose, so its rows are not reports that went missing.
+    ///
+    /// This was a live false positive, not a theoretical one — `deliver_outputs_dry`
+    /// writes one `skipped`/`dry-run` row per routed `output` node, so before
+    /// this every single test run of a graph with a destination scored
+    /// `undelivered` and the console badged the safest thing an operator can do
+    /// as a failure.
+    #[test]
+    fn a_dry_run_is_not_undelivered() {
+        let dry = [row(DeliveryStatus::Skipped, DeliveryReason::DryRun)];
+        assert!(!is_undelivered(&dry[0]));
+        assert_eq!(undelivered_count(&dry), 0);
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                deliveries: &dry,
+                ..clean()
+            }),
+            WorkflowRunVerdict::Ok
+        );
+    }
+
+    /// Issue #438: approving a gate re-runs the graph from the trigger, so an
+    /// `output` node upstream of the gate is reached a second time and
+    /// deliberately not sent again. The report is at its destination; the
+    /// continuation is not a run that lost one.
+    #[test]
+    fn an_already_delivered_report_is_not_undelivered() {
+        let again = [row(
+            DeliveryStatus::Skipped,
+            DeliveryReason::AlreadyDelivered,
+        )];
+        assert!(!is_undelivered(&again[0]));
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                deliveries: &again,
+                ..clean()
+            }),
+            WorkflowRunVerdict::Ok
+        );
+    }
+
+    /// The deliberate **non**-move, and the reason the other two could move at
+    /// all: an `output` node with nowhere to send produced a report and lost it,
+    /// with nothing accounting for it. Issue #925 added the row precisely so
+    /// that case stops being indistinguishable from a graph that routed nothing
+    /// on purpose; excusing it here restores the silence issues #947 and #963
+    /// were filed about.
+    #[test]
+    fn an_output_node_with_no_destination_is_still_undelivered() {
+        let nowhere = [row(
+            DeliveryStatus::Skipped,
+            DeliveryReason::NoDestinationConfigured,
+        )];
+        assert!(is_undelivered(&nowhere[0]));
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                deliveries: &nowhere,
+                ..clean()
+            }),
+            WorkflowRunVerdict::Undelivered
+        );
+    }
+
+    /// A row journaled before issue #248 added `reason` deserializes as
+    /// `Unspecified`, and an unreadable reason must not excuse a report from the
+    /// number an operator acts on.
+    #[test]
+    fn a_skipped_row_with_no_recorded_reason_still_counts() {
+        let old = [row(DeliveryStatus::Skipped, DeliveryReason::Unspecified)];
+        assert!(is_undelivered(&old[0]));
+    }
+
+    /// Only the `skipped` arm reads a reason. A `failed` row is a report that
+    /// was attempted and did not work, whatever it claims about why — so the
+    /// two exemptions cannot leak onto a status that means something broke.
+    #[test]
+    fn the_exemptions_are_scoped_to_skipped() {
+        for status in [DeliveryStatus::Failed, DeliveryStatus::Denied] {
+            for reason in [DeliveryReason::DryRun, DeliveryReason::AlreadyDelivered] {
+                assert!(
+                    is_undelivered(&row(status, reason)),
+                    "{status:?}/{reason:?} is not a skip"
+                );
+            }
+        }
+    }
+
+    /// `sent` and `pending` are excused by **status**, so no reason can pull
+    /// them into the count either.
+    #[test]
+    fn sent_and_pending_are_never_undelivered() {
+        for status in [DeliveryStatus::Sent, DeliveryStatus::Pending] {
+            for reason in [
+                DeliveryReason::ChannelPosted,
+                DeliveryReason::ParkedForApproval,
+                DeliveryReason::NoDestinationConfigured,
+            ] {
+                assert!(!is_undelivered(&row(status, reason)));
+            }
         }
     }
 }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1558,6 +1558,38 @@ to = "done"
     /// that escapes into a log or a PR body names nobody.
     const RECIPIENT: &str = "recipient@example.invalid";
 
+    /// Issue #981: `skipped` is no longer the same question as "did not go
+    /// out". Two of its reasons describe a report whose fate is accounted for —
+    /// an earlier run in the approval lineage sent it (issue #438), or a test
+    /// run attempted nothing on purpose (issue #542) — so they sit in the
+    /// `skipped` breakdown and out of the number an operator alerts on.
+    #[test]
+    fn an_accounted_for_skip_is_counted_but_not_alerted_on() {
+        let counts = DeliveryCounts::of(&[
+            reported(
+                "a",
+                DeliveryStatus::Skipped,
+                DeliveryReason::AlreadyDelivered,
+                "",
+            ),
+            reported("b", DeliveryStatus::Skipped, DeliveryReason::DryRun, ""),
+        ]);
+        assert_eq!(counts.skipped, 2, "the breakdown still sees them");
+        assert_eq!(counts.undelivered(), 0, "but nothing here needs a fix");
+
+        // The deliberate non-move: an `output` node with nowhere to send
+        // produced a report and lost it, which is what issue #925 added the row
+        // to make visible.
+        let nowhere = DeliveryCounts::of(&[reported(
+            "c",
+            DeliveryStatus::Skipped,
+            DeliveryReason::NoDestinationConfigured,
+            "",
+        )]);
+        assert_eq!(nowhere.skipped, 1);
+        assert_eq!(nowhere.undelivered(), 1);
+    }
+
     /// The fold behind the summary line counts each status separately, because
     /// "policy refused to send" and "something broke" are different problems.
     #[test]

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -83,7 +83,7 @@ use tokio::task::JoinHandle;
 
 use crate::company::{WorkflowFile, list_workflows_union};
 use crate::ports::types::CompanyId;
-use crate::ports::{DeliveryReport, DeliveryStatus, WorkflowRunContext};
+use crate::ports::{DeliveryReport, DeliveryStatus, WorkflowRunContext, is_undelivered};
 use crate::runtime::CompanyRegistry;
 use crate::runtime::WorkflowSpawn;
 use crate::runtime::cron::{CivilTime, CronExpr};
@@ -115,6 +115,21 @@ struct DeliveryCounts {
     skipped: usize,
     denied: usize,
     failed: usize,
+    /// Reports that did NOT reach their destination **and never will without a
+    /// change** — the number worth alerting on.
+    ///
+    /// A field rather than `skipped + denied + failed`, because that sum stopped
+    /// being the definition (issue #981): `skipped` also covers a report an
+    /// earlier run in the approval lineage already sent and a test run that
+    /// deliberately attempted nothing, and neither is a report that went
+    /// missing. [`is_undelivered`] is the one rung every surface stands on, so
+    /// this counts through it and the four per-status numbers stay exactly what
+    /// they are — a breakdown for the log line, not a classification.
+    ///
+    /// `pending` is excluded there for its own reason: it is awaiting a verdict,
+    /// not a fix, and folding it in would page someone for a queue that is
+    /// working as designed. It gets its own count on the summary line.
+    undelivered: usize,
 }
 
 impl DeliveryCounts {
@@ -128,18 +143,16 @@ impl DeliveryCounts {
                 DeliveryStatus::Denied => counts.denied += 1,
                 DeliveryStatus::Failed => counts.failed += 1,
             }
+            if is_undelivered(report) {
+                counts.undelivered += 1;
+            }
         }
         counts
     }
 
-    /// Reports that did NOT reach their destination **and never will without a
-    /// change** — the number worth alerting on.
-    ///
-    /// `pending` is deliberately excluded: it is awaiting a verdict, not a fix,
-    /// and folding it in here would page someone for a queue that is working as
-    /// designed. It gets its own count on the summary line.
+    /// See [`DeliveryCounts::undelivered`].
     fn undelivered(&self) -> usize {
-        self.skipped + self.denied + self.failed
+        self.undelivered
     }
 }
 
@@ -917,6 +930,16 @@ fn spawn_scheduled_run(
                         );
                         continue;
                     }
+                    // Issue #981: a row whose fate is accounted for is not a
+                    // problem to warn about. An approval-gate continuation
+                    // deliberately does not re-send a report an earlier run in
+                    // its lineage already delivered (issue #438), and warning
+                    // once a minute about a graph behaving exactly as designed
+                    // is how a real refusal gets scrolled past. The `skipped=`
+                    // number on the summary line below still carries it.
+                    if !is_undelivered(report) {
+                        continue;
+                    }
                     tracing::warn!(
                         %company,
                         workflow = %workflow_id,
@@ -1555,6 +1578,7 @@ to = "done"
                 skipped: 1,
                 denied: 1,
                 failed: 1,
+                undelivered: 3,
             }
         );
         // A parked report awaits a verdict, not a fix: it must NOT inflate the

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -8338,6 +8338,46 @@ label = "ok"
         /// not go out. The exact shape issue #981 caught reading green.
         struct DroppedReportRunner;
 
+        /// A runner whose only delivery row is a **dry run**'s (issue #542): the
+        /// report was routed as far as its destination and deliberately not
+        /// dispatched. The row shape a real `deliver_outputs_dry` writes.
+        struct DryRunRunner;
+
+        #[async_trait::async_trait]
+        impl WorkflowRunner for DryRunRunner {
+            async fn run(
+                &self,
+                _company: &CompanyId,
+                _workflow: &crate::company::WorkflowFile,
+                _input: serde_json::Value,
+                _ctx: &WorkflowRunContext,
+            ) -> crate::Result<WorkflowRun> {
+                Ok(WorkflowRun {
+                    output: serde_json::json!({ "run": {}, "nodes": {} }),
+                    pending_approvals: Vec::new(),
+                    deliveries: vec![crate::ports::DeliveryReport {
+                        node: "done".to_string(),
+                        kind: "channel".to_string(),
+                        target: Some("engineering".to_string()),
+                        status: crate::ports::DeliveryStatus::Skipped,
+                        detail: "this was a test run — nothing was sent".to_string(),
+                        reason: crate::ports::DeliveryReason::DryRun,
+                    }],
+                    cancelled: false,
+                    nodes: vec![crate::ports::WorkflowRunNodeRow {
+                        node_id: "done".to_string(),
+                        status: crate::ports::types::WorkflowNodeStatus::Ok,
+                        elapsed_ms: 3,
+                        diagnostics: Vec::new(),
+                    }],
+                    notices: Vec::new(),
+                    board: Vec::new(),
+                    blocked_nodes: Vec::new(),
+                    approvals: Vec::new(),
+                })
+            }
+        }
+
         #[async_trait::async_trait]
         impl WorkflowRunner for DroppedReportRunner {
             async fn run(
@@ -8492,6 +8532,31 @@ label = "ok"
                 body["deliveries"][0]["reason"], "channel-not-wired",
                 "{body}"
             );
+        }
+
+        /// Issue #981, the second half: a **test run** is not a run that lost
+        /// its report.
+        ///
+        /// `deliver_outputs_dry` writes one `skipped`/`dry-run` row per routed
+        /// `output` node, so before this every single test run of a graph with
+        /// a destination answered `undelivered` — the console badged the safest
+        /// thing an operator can do as a failure, every time. The rows stay on
+        /// the body: they are what say *where* the report would have gone.
+        #[tokio::test]
+        async fn a_test_run_is_not_a_run_that_lost_its_report() {
+            let home_dir = home();
+            let app = company_with_runner(home_dir.path(), Arc::new(DryRunRunner)).await;
+
+            let response = app
+                .oneshot(run_request(serde_json::json!({})))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = json_body(response).await;
+
+            assert_eq!(body["verdict"], "ok", "{body}");
+            assert_eq!(body["deliveries"][0]["reason"], "dry-run", "{body}");
+            assert_eq!(body["deliveries"][0]["status"], "skipped", "{body}");
         }
 
         /// The other direction, which is the one that must not regress: a run

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -8542,19 +8542,25 @@ label = "ok"
         /// a destination answered `undelivered` — the console badged the safest
         /// thing an operator can do as a failure, every time. The rows stay on
         /// the body: they are what say *where* the report would have gone.
+        ///
+        /// Asked for as a **real dry run** (`dry_run: true`) and the `dryRun`
+        /// discriminator asserted alongside the verdict, so this cannot pass on
+        /// a run that was not one — a stub runner returning a `dry-run` row is
+        /// only half the claim.
         #[tokio::test]
         async fn a_test_run_is_not_a_run_that_lost_its_report() {
             let home_dir = home();
             let app = company_with_runner(home_dir.path(), Arc::new(DryRunRunner)).await;
 
             let response = app
-                .oneshot(run_request(serde_json::json!({})))
+                .oneshot(run_request(serde_json::json!({ "dry_run": true })))
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             let body = json_body(response).await;
 
             assert_eq!(body["verdict"], "ok", "{body}");
+            assert_eq!(body["dryRun"], serde_json::json!(true), "{body}");
             assert_eq!(body["deliveries"][0]["reason"], "dry-run", "{body}");
             assert_eq!(body["deliveries"][0]["status"], "skipped", "{body}");
         }


### PR DESCRIPTION
## Summary

**Part 3 of #981**, and the two things PR #1165 named as left when it deliberately said *"Part of"* rather than *"Closes"*:

1. `nodes[].status` still read `ok` on the output node of a run whose delivery was dropped. The run-level `verdict` said `undelivered`; the node the operator clicked into still claimed success. Two readings contradicting each other on one screen — literally half of what @oxoxDev originally reported.
2. Three `skipped` delivery reasons — `already-delivered`, `no-destination-configured`, `dry-run` — arguably did not belong in the undelivered set. Documented as out of scope in `docs/modules/server/run-verdict.md`.

Both judgements were asked for explicitly rather than assumed, so both are argued below. **Nothing new is added to the three existing notions of "this run did not fully work"** (#981's `verdict`, #1051/#1008's `partial`, #1081's settle) — the second half is a *narrowing* of one predicate that already existed, and the first half adds no wire field at all.

---

## (1) Which fact is the node cell answering?

**It answers "did the engine run this step?", and it keeps saying `ok`. What changes is that it stops being the only thing on the cell.**

A node that ran fine is not a failed node. Delivery is host-side and *post-engine* (`src/workflows/delivery.rs`): by the time a destination is refused, the graph has returned, the node's work is valid and durable, and the fix is a destination or a runtime wiring. The issue sets this as a constraint in its own words — *"a failed delivery must not populate the run's `error` or flip `nodes[].status`"* — and #1165 held to it.

**So why not a fourth status word (`"undelivered"` on `WorkflowRunNode.status`)?** I looked at it properly, because it is the obvious move:

- `frontend/src/views/workflows/graph.ts`'s `nodeStateFrom()` **fail-safes any status it does not recognise to `error`**. A new word would make every console predating this paint a node that ran perfectly as *failed* — strictly worse than the bug, and on the surface where a wrong red dot costs most.
- It would make one field answer two questions, decided by two subsystems at two different times. That collapse is what #383 and #881 each had to undo once already, one surface over.
- `WorkflowRunNode.status` is a closed union on the wire (`"ok" | "error" | "blocked"`), read by `qa/oc-qa.js` and both drawers. Widening it is a compat break for a fact that has a lossless home already.

**But `ok` alone is exactly the bug being reported.** So the resolution is that the node cell stops being alone: every surface that renders a node now renders the *delivery* beside it, explicitly labelled, so the two facts read as two answers rather than as a contradiction.

| surface | before | after |
| --- | --- | --- |
| canvas card | green ring, `DONE`, nothing else | green ring, `DONE`, **plus** a red `report not delivered` strip; the `DONE` tooltip now reads *"This step ran. Its report did not go out."* |
| run drawer → Steps | `ok  Report  0 ms` | `ok  Report  0 ms  ‹not delivered›` — a **second** badge, the `ok` untouched |
| history → node chips | `● report 0ms` | `● report 0ms │ ● not delivered` — the green dot stays |

The join is local: `DeliveryReport.node` has always carried the `output` node's id on every arm of `delivery.rs`, so `undeliveredNodes()` in `run-health.ts` folds the same rows the delivery block already renders. **No new wire field, no new host-derived concept.** The machine reader that folds `nodes[].status` was already answered by #1165's `verdict`; adding a per-node derived field for the same fact would have been the third overlapping notion the issue forbids.

## (2) Are those three reasons genuinely not-undelivered? Two are. One is not.

The old doc grouped them as *"a report that was never owed to an address"*. That is the wrong axis, and reading it that way is how the third one nearly got excused. The right axis is **whether the report's fate is accounted for**:

| reason | ruling | why |
| --- | --- | --- |
| `dry-run` (#542) | **out** | Nothing was attempted, on purpose, in a mode the operator chose. This was a **live** false positive, not a theoretical one: `deliver_outputs_dry` writes one `skipped`/`dry-run` row per routed `output` node, so *every* test run of a graph with a destination scored `undelivered`, badged "1 not delivered", toasted "1 report didn't go out", and painted a red dot. The safest thing an operator can do reported itself as a failure, every single time. |
| `already-delivered` (#438) | **out** | The report **was sent** — by an earlier run in this approval lineage. Approving a gate re-runs the graph from the trigger, so every upstream `output` node is reached again and deliberately not re-sent. It is at its destination; counting it as lost paints every resumed gate red. |
| `no-destination-configured` (#925) | **stays in** | This report was **produced and then lost**, with nothing accounting for it. |

The third is the deliberate non-move, and it is the reason the other two could move at all. That row exists *precisely* so that "the author routed nothing on purpose" and "the author never configured a destination" stop being the same observation — before #925 both looked like an empty `deliveries` list and a summary reading *"Finished — this run routed no reports."* An output node with nowhere to send is #963/#947's complaint verbatim, and calling it delivered is how it stayed invisible. Excusing it here would have restored exactly that silence while looking like tidying.

Two structural guarantees came with it: the match on `DeliveryStatus` is **exhaustive** and only the `skipped` arm reads a reason, so a new delivery status cannot be added without classifying it, and a hypothetical `failed`/`dry-run` pair still counts. And an `unspecified` reason — the only reachable value on a `WorkflowRunFinished` journaled before #248 added the field — **counts**, which is the safe direction.

### Moving the rungs meant moving every surface, which is the real size of this change

#1165 declined this because "reclassifying them moves the badge and the verdict apart unless every surface moves together". That was right, and it is why this PR is not three lines. There were **seven** transcriptions of "did this report go out"; there is now one, `crate::ports::is_undelivered`, and one mirror each in TS and in the QA harness (which is pasted against whatever host is in front of the operator, so it keeps its own copy by design).

Two of those seven **already disagreed with the canonical reading**, and consolidating found it: `src/brain/medulla/effects.rs` and `src/harness/orchestrator.rs` filtered on `!= Sent` only, so a report *parked for an operator's approval* read to the inference sidecar and to the orchestrator as one that had been **lost**. The sidecar's sentence then said `1 not delivered, 1 pending approval` about a single row — counted twice, once as a loss it is not. That fix is a behaviour change beyond the issue's letter; it is named here rather than slipped in, and it is the price of having one predicate instead of seven.

## Judged against #1051's `partial` and #1081's settle, before adding anything

- **#1051 / #1008's `partial`** is a flag on `WorkflowRunOutputRecord` (`src/ports/run_output.rs:119`) meaning *this output snapshot is incomplete because the run broke mid-graph*. It is about one artifact's completeness. Disjoint from both halves here, and neither is derivable from the other.
- **#1081's settle** rewrites `running`, `error`, `seq` and `atMillis` on a row it finds dead. Nothing in this PR is stored, so nothing new has to be settled alongside them — the verdict pass still runs after the fold, unmoved.
- So: **no fourth concept.** Half (1) adds a *rendering* of a join that was already on the wire; half (2) *narrows* a predicate that already existed. `WorkflowRunVerdict` remains the only word for how a run reads.

## Files

| file | what |
| --- | --- |
| `src/ports/workflow_verdict.rs` | `is_undelivered` — the one rung, exhaustive over `DeliveryStatus`; `undelivered_count` folds it. +6 unit tests |
| `src/ports/mod.rs` | exports it |
| `src/runtime/workflow_scheduler.rs` | `DeliveryCounts.undelivered` is a counted field, not `skipped + denied + failed`; the per-report `warn!` skips an accounted-for row |
| `src/brain/medulla/effects.rs`, `src/harness/orchestrator.rs` (×2) | the local filters replaced by the shared one |
| `src/server/ops/workflows.rs` | route test: a dry run answers `ok` with its rows intact |
| `frontend/src/views/workflows/run-health.ts` | `isUndelivered`, `undeliveredNodes`; `undeliveredCount` folds them |
| `frontend/src/lib/workflow-sample.ts`, `components/workflow-node.tsx` | `reportUndelivered` on the node data + the canvas strip |
| `frontend/src/views/workflows/graph.ts` | `layout()` takes the undelivered set as a 4th arg |
| `frontend/src/views/WorkflowsView.tsx` | `paintedUndelivered`, in the same priority order as the states — overlay run, else the just-settled manual result matched on `runId` |
| `RunHistoryPanel.tsx`, `RunResultPanel.tsx`, `hooks/use-events.ts` | the chips, the Steps badges, and three inline filters folded into the shared count |
| `qa/oc-qa.js` | mirrors the reason exemption; `isUndelivered` exposed on `_internals` |
| `docs/modules/server/run-verdict.md` | the accounted-for axis, the ruling table, and why the node cell answers a different question |

## Tests

**The two facts that must NOT move** are asserted in the same tests as the new ones, so a future change cannot satisfy one by breaking the other: `a_run_whose_report_was_dropped_does_not_answer_as_a_clean_run` still pins `nodes[0].status == "ok"`, no `error`, no `cancelled`; and the console test asserts **two** `workflow-run-node-ok` chips *and* exactly one `workflow-run-node-undelivered` mark on the same row.

- Rust: dry-run / already-delivered are not undelivered; **no-destination-configured still is** (the deliberate non-move, pinned in four places — the ladder, the scheduler, the orchestrator summary, and the console); exemptions scoped to `skipped`; `unspecified` counts; `sent`/`pending` never count whatever their reason. Route: a dry run answers `verdict: "ok"` with its `skipped`/`dry-run` rows on the body. Scheduler: an accounted-for skip stays in the `skipped` breakdown and leaves `undelivered()`. Sidecar: `0 not delivered, 1 pending approval` for a parked row (was `1, 1`). Orchestrator: the "fix the destination" paragraph fires for a lost report and not for a test run or a continuation.
- Frontend, new `workflow-run-node-delivery.test.ts` (13): the predicate on every reason; `layout()` marks the dropped node and *only* it, without touching its `runState`; the history chip and the Steps row each render both facts; neither marks anything on a test run.
- `qa-harness.test.ts` gains a case asserting the harness's fallback and the console's `isUndelivered` agree **row for row on all eight reasons** — the drift this PR exists to prevent.

## Commands run locally

Re-run on the merged tree. `upstream/main` moved twice while this was open and both were merged in; the second brought #1172/#1182, which touch `src/ports/mod.rs` — the one file this PR and they both edit. Clean merge, export intact, and the whole gate set re-run below on the merged result rather than on the tree the work was done on.

```
cargo fmt --all -- --check                                                  # clean
cargo clippy --all-targets --features openhuman,tinycortex -- -D warnings   # exit 0, no warnings
cargo test --features openhuman,tinycortex                                  # 4639 + 11 + 1 + 2 + 11 + 2 passed, 0 failed
scripts/ci/assert-feature-lanes.sh                                          # 30 features, 0 owed a lane
cd frontend && npm run typecheck                                            # clean
cd frontend && npm test                                                     # 133 files, 1304 tests passed
cd frontend && npm run typecheck:unit                                       # clean — this one, not `typecheck`, is
cd frontend && npm run typecheck:e2e                                        #   what catches a missing prop under test/
cd frontend && npm run build                                                # clean
scripts/ci/assert-md-line-cap.sh                                            # every file <= 500 lines
```

No new Cargo feature, so no new lane row; every new test runs in the default lane.

## Behaviour changes

- **A test run no longer reports itself as a failed delivery.** Its verdict is `ok`, its badge and toast are gone, its node marks are gone. The `skipped`/`dry-run` rows stay on the body — they are what say *where* the report would have gone.
- **An approval-gate continuation no longer reports its already-sent report as lost.**
- **An `output` node with no destination is unchanged** — still `undelivered`, still marked on the node.
- **A parked report is counted once**, not as both a loss and a pending approval, in the sidecar projection and the orchestrator's insight line.
- The scheduler's `undelivered=` number drops for dry and resumed runs; anyone alerting on it sees fewer pages, with no change in behaviour.
- The console gains a delivery marker on the node in three places. Nothing existing changes colour, word, or `data-testid`.

## Verified in a browser

Local host on `OPENCOMPANY_DATA_DIR=/tmp/oc981data` (no `--home`), console on `:8363` with `OC_API_TARGET=http://127.0.0.1:8399`. A workflow `dropped_report_demo` (`trigger → output`) with two runs in its journal — one refused with `channel-not-wired`, one a `dry-run` — driven through the console in light and dark.

**The host, before the console sees it** (`GET …/workflows/runs`), which is both halves in two lines:

```
run-drop-981 -> undelivered | nodes: [(start, ok), (report, ok)] | deliveries: [(failed, channel-not-wired)]
run-dry-981  -> ok          | nodes: [(start, ok), (report, ok)] | deliveries: [(skipped, dry-run)]
```

The dry run reads `ok`; before this it read `undelivered`. The dropped run still reads `undelivered` and **its nodes still read `ok`** — nothing about the engine's verdict moved.

**On screen**, @oxoxDev's exact repro, now carrying the truth on the node itself:

- **Canvas** — the `Report` card shows `DONE` in the green badge *and* a red `● report not delivered` strip across its foot. Two labelled facts on one card. Dark mode picks up the themed `--status-failed-*` tokens; both legible.
- **History row** — `● start 4ms` `● report 0ms │ ● not delivered`: the node's own dot stays green, the delivery segment is red and says which fact it is.
- **The dry run's row, two rows down** — `● start 4ms` `● report 0ms`, green dot, and its "Report delivery" block carries **no** "1 not delivered" badge. Before this it was red on both.

Counted by the driver on the rendered DOM: `workflow-run-node-ok` ×4 (every node of both runs — unchanged), `workflow-run-node-undelivered` ×1, `workflow-node-undelivered` ×1. Exactly the dropped run's output node, and nothing else.

The run drawer's Steps badge (`workflow-run-step-undelivered`) is covered by unit tests rather than by this pass — it needs a synchronous run, which needs an inference provider this host has none of.

---

## Does this close #981?

**Yes — both things #1165 named as left are done, and nothing else was found open.** I re-walked @graycyrus's audit table from the issue: every row is now fixed (#995, #1083, #1097 for part 1; #1165 plus this for part 2). @oxoxDev's `smoke1` repro — the output node painting `DONE`, `0 ms`, green while only a banner carried the truth — now has the truth on the node, in the Steps panel, and on the history chip.

Closes #981.

One thing worth flagging separately rather than folding in: **#1046** is the same undeliverable destination accepted on a `*/5` schedule, where neither the banner nor the history row has a reader. That is its own issue and stays open.


---

# Also closes #1181 — teammate avatars reach the Company surfaces

Folded in rather than sent as a follow-up, since it edits the exact tiles this
PR was already rewriting.

The Company cards and the teammate detail header drew `initials()` over a
`TEAM_TONES` background — chat's visual language minus the mascot — so a
teammate had a face in a DM and two letters on the page that is *about* them.
Both now render the shared `Avatar`, at **44px** (card) and **56px** (detail
header), comfortably above the ~24px floor `markOnly` exists to respect.

## The seed — the issue's premise is inverted, and following it literally would have caused the bug it warns about

The issue says `Member` "already carries a computed `avatar` field for exactly
this — pass that through", on the understanding that chat is id-seeded.

**Chat is not id-seeded.** No `Avatar` call site in the console passes the
`avatar` prop — not `ChannelRail`, `MembersPane`, `MessageRow`, `ThreadPanel` or
`MessageTimeline`. Every one falls through to `avatarFor(name)`. And
`TeamMember.avatar` (`avatarFor(dto.id || name)`) is rendered by **nothing**
today — it is a dead field.

The two seeds disagree for every realistic roster row:

| teammate | id-seeded (`TeamMember.avatar`) | name-seeded (what chat renders) |
|---|---|---|
| `backend_engineer` | violet | **indigo** |
| `security_engineer` | ember | **rose** |
| `designer` | green | **graphite** |
| `product_manager` | rose | **blue** |
| `researcher` | clay | **indigo** |

8 of 8 sampled rows differ. So passing `TeamMember.avatar` on the Company
surfaces — the literal instruction — would have given every teammate one face on
their card and a different one in their DM: precisely the "two different mascots,
harder to notice because each screen looks internally consistent" failure the
issue is written to prevent.

**So these surfaces pass no `avatar` prop**, landing on the same fallback chat
uses. Every surface agrees today, which is the property that actually matters.

## Proof the seed is right

Not "a screenshot shows a mascot" — the same **file**, scraped from the live DOM
of three surfaces against a real host:

| teammate | Company card | detail header | chat member pane |
|---|---|---|---|
| Backend Engineer | `blob-indigo.webp` | `blob-indigo.webp` | `blob-indigo.webp` |
| Security Engineer | `blob-rose.webp` | `blob-rose.webp` | `blob-rose.webp` |
| Designer | `blob-graphite.webp` | `blob-graphite.webp` | `blob-graphite.webp` |
| Researcher | `blob-indigo.webp` | `blob-indigo.webp` | `blob-indigo.webp` |

**All three surfaces serve the identical mascot for the same teammate.**
Re-screenshotted light and dark: every card carries its blob, and the detail
header that read **SE** now shows the rose mascot matching Security Engineer's
DM.

## The org chart is deliberately untouched

The issue lists it as a third surface showing letters. It does not: `OrgChartView`
draws **no avatar tile at all** — seats are text rows with a crown for the lead,
and "Not on a desk" are `text-xs` chips. Adding an avatar there is new visual
design rather than a fix, and at chip height it would be exactly the smudge the
size rule exists to prevent. Left alone, and said so rather than invented.

## Component location — filed, not done

`components/ui/avatar.tsx` already exists (the Base UI primitive). Moving
`views/chat/Avatar.tsx` to `components/avatar.tsx` would put two different
components named `Avatar` side by side under `components/`, which is a worse
import path than the one being fixed, and naming it properly is its own decision.
Filed rather than bundled — #1185, which also carries the id-seed migration.

## Guards added

* `test/unit/teammate-avatar-seed.test.ts` (3) — pins both seeds and asserts they
  are different faces, so nobody can "tidy" the Company surfaces into passing
  `TeamMember.avatar` without moving chat in the same change.
* `test/e2e/company-cards.spec.ts` — `#1181 the card and the detail header wear
  the same mascot` asserts the two `img` `src`s are the **same file**, not merely
  that both render a mascot.

Suites after the change: `npm test` 1278 passing; full Playwright **180 passed,
21 skipped, 0 failed**; typechecks and design tokens clean.
