### PR TITLE
fix(bin): keep durable-append failure reports visible by default (#450)

### DIFF
--- a/docs/spec/runtime/workspace-layout.md
+++ b/docs/spec/runtime/workspace-layout.md
@@ -81,6 +81,44 @@ subdirectories, it can only fail on a genuinely broken mount or an explicitly
 misconfigured `OPENHUMAN_WORKSPACE`, so it cannot turn a healthy tenant into one
 that will not wake.
 
+#### Seeing an append failure that happens anyway (issue #450)
+
+Boot proving the root writable does not make the sink infallible — a volume can
+fill, go read-only or disappear under a running tenant. The vendored append
+worker no longer prints its one-line-per-event flood described above; since
+tinyagents `73e6f5d` it keeps a failure-run state machine and reports through
+`tracing` on the target `tinyagents::observability`. Only the **first** failure of
+a run is `error`. The three lines that say how bad it got are `warn`:
+
+| Line | Level | Says |
+|---|---|---|
+| `durable append failed; the observation is lost…` | `error` | a failure run started |
+| `…still failing after N consecutive observations` | `warn` | it is still going (rate-limited reminder) |
+| `durable append recovered; N observation(s) lost` | `warn` | it ended, and the cost |
+| `…never recovered before shutdown, N observation(s) lost` | `warn` | it outlived the process |
+
+The binary's default `EnvFilter` is `error` and nothing in the container images,
+compose files or deploy workflows sets `RUST_LOG`, so those three `warn` lines
+were dropped in every deployed tenant: an operator saw a degraded run begin and
+never learned that it continued, that it ended, or how many observations went
+missing. `DEFAULT_LOG_FILTER` in `src/bin/opencompany.rs` is therefore
+`error,tinyagents::observability=warn` — today's default plus that one target.
+`RUST_LOG`, when set, still replaces the whole thing. The desktop shell
+(`src-tauri/src/lib.rs`) names the same target for a sharper reason: its fallback
+has no global directive at all, so an unnamed target is dropped at every level
+including `error`.
+
+**Known limitation.** The worker's own subscriber-independent fallback,
+`AppendWorker::append_failures()` — a counter of appends attempted and rejected,
+documented there as "the only subscriber-free signal of durable-log loss" — is
+`pub(crate)` in tinyagents. OpenCompany cannot read it, and there is no other
+seam that exposes it: the worker is constructed inside OpenHuman's agent journal,
+which hands out no handle to it. So the log filter is the *whole* mechanism here,
+and a tenant whose operator overrides `RUST_LOG` with something that excludes
+`tinyagents::observability` has no second channel. Surfacing the count — as a
+health field, a metric, or simply a `pub` accessor — needs an upstream tinyagents
+change first; do not try to plumb it from this repo.
+
 ### Agent sandboxes (`<home>/harness`)
 
 The tree an agent's file tools actually act in hangs off the **home**, not off a

--- a/docs/spec/runtime/workspace-layout.md
+++ b/docs/spec/runtime/workspace-layout.md
@@ -103,7 +103,11 @@ were dropped in every deployed tenant: an operator saw a degraded run begin and
 never learned that it continued, that it ended, or how many observations went
 missing. `DEFAULT_LOG_FILTER` in `src/bin/opencompany.rs` is therefore
 `error,tinyagents::observability=warn` — today's default plus that one target.
-`RUST_LOG`, when set, still replaces the whole thing. The desktop shell
+`RUST_LOG`, when set, still replaces the whole thing — and is parsed *lossily*,
+carrying the same `error` default the binary had before this constant existed, so
+one unparseable directive drops itself rather than the operator's whole
+configuration, and an empty value still reports errors rather than silencing the
+binary outright. The desktop shell
 (`src-tauri/src/lib.rs`) names the same target for a sharper reason: its fallback
 has no global directive at all, so an unnamed target is dropped at every level
 including `error`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,10 +86,23 @@ fn dirs_next_data_dir() -> Option<PathBuf> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // The `tinyagents::observability` directive is the vendored durable-append
+    // writer's reporting target, and it has to be named explicitly here for a
+    // reason the host binary's filter does not share: this fallback carries no
+    // global directive at all, only per-target ones, so an unnamed target is
+    // dropped at *every* level — `error` included. Without this the writer's
+    // "still failing" reminders, its "recovered, N observation(s) lost" summary
+    // and its "never recovered before shutdown" summary are silent, and so is
+    // the first-failure `error` line. See `DEFAULT_LOG_FILTER` in
+    // `src/bin/opencompany.rs` for the full argument (issue #450). Latent while
+    // this crate does not enable the `openhuman` feature; a landmine for
+    // whoever does.
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "opencompany_desktop_lib=info,opencompany=info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                "opencompany_desktop_lib=info,opencompany=info,tinyagents::observability=warn"
+                    .into()
+            }),
         )
         .init();
 

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -953,6 +953,36 @@ const MAX_BLOCKING_THREADS: usize = openhuman_core::core::runtime::MAX_BLOCKING_
 #[cfg(not(feature = "openhuman"))]
 const MAX_BLOCKING_THREADS: usize = 512;
 
+/// The log filter used when `RUST_LOG` says nothing.
+///
+/// The bare `error` is exactly what `EnvFilter::from_default_env()` fell back to,
+/// so no target in this binary becomes chattier than it was. The one added
+/// directive is the exception the default cannot express, and it is not cosmetic.
+///
+/// `tinyagents::observability` is the target the vendored durable-append writer
+/// (`AppendWorker`, in
+/// `vendor/openhuman/vendor/tinyagents/src/harness/observability/worker.rs`)
+/// reports on — the writer behind the embedded runtime's durable agent journal.
+/// It reports only the *first* failure of a failure run at `error`; every line
+/// after that is `warn`:
+///
+/// - "still failing after N consecutive observations" — the run is ongoing,
+/// - "recovered; N observation(s) lost" — the run ended, and how much it cost,
+/// - "never recovered before shutdown, N observation(s) lost" — the run outlived
+///   the process.
+///
+/// Those `warn` lines are the only signal that the durable log is losing data and
+/// how much of it. Under a bare `error` filter an operator sees one line when a
+/// degraded run begins and then nothing — no reminder that it is still degraded,
+/// no recovery, no loss count — which is the visibility gap issue #450 is about.
+/// The writer's own subscriber-independent fallback, `AppendWorker::append_failures()`,
+/// is `pub(crate)` in tinyagents and cannot be read from here, so the subscriber
+/// is the only channel we have (see `docs/spec/runtime/workspace-layout.md`).
+///
+/// Setting `RUST_LOG` replaces this string wholesale — the operator keeps full
+/// control, and behaviour with `RUST_LOG` set is unchanged.
+const DEFAULT_LOG_FILTER: &str = "error,tinyagents::observability=warn";
+
 fn main() -> Result<()> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -964,7 +994,10 @@ fn main() -> Result<()> {
 
 async fn async_main() -> Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| DEFAULT_LOG_FILTER.into()),
+        )
         .init();
 
     match Cli::parse().command {
@@ -1738,5 +1771,86 @@ mod test {
             "path is the template basename, not the absolute host path"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Records the target and level of every event a subscriber was actually
+    /// asked to record, so a filter can be tested on behaviour rather than on
+    /// the contents of its own string.
+    #[derive(Clone)]
+    struct Captured(std::sync::Arc<std::sync::Mutex<Vec<(String, tracing::Level)>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Captured {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let meta = event.metadata();
+            self.0
+                .lock()
+                .expect("capture lock")
+                .push((meta.target().to_string(), *meta.level()));
+        }
+    }
+
+    #[test]
+    fn the_default_filter_passes_durable_append_warnings_and_still_drops_other_ones() {
+        // The point of `DEFAULT_LOG_FILTER` is the vendored append worker's
+        // warn-level reports — "still failing after N", "recovered, N lost",
+        // "never recovered before shutdown, N lost". They are the only account
+        // of how much of the durable agent journal was lost, and a bare `error`
+        // filter drops all three (issue #450).
+        //
+        // Asserted by running the filter, not by reading it: this builds the
+        // real `EnvFilter` from the real constant, installs it over a capturing
+        // layer exactly as `async_main` installs it over `fmt`, and emits the
+        // four events that matter. Revert the constant to `"error"` and the
+        // first assertion fails.
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(Captured(std::sync::Arc::clone(&captured)))
+            .with(tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER));
+
+        tracing::subscriber::with_default(subscriber, || {
+            // The worker's recovery summary — the line the operator needs.
+            tracing::warn!(
+                target: "tinyagents::observability",
+                sink = "journal",
+                lost = 3_u64,
+                "durable append recovered"
+            );
+            // An unrelated warning stays dropped: the default is still `error`
+            // for everything the exception does not name.
+            tracing::warn!(target: "opencompany::unrelated", "ordinary warning");
+            // And a real error still gets through, unchanged from before.
+            tracing::error!(target: "opencompany::unrelated", "ordinary error");
+            // The exception is scoped to `warn`, not opened wide.
+            tracing::info!(target: "tinyagents::observability", "chatter");
+        });
+
+        let events = captured.lock().expect("capture lock").clone();
+        let seen = |target: &str, level: tracing::Level| {
+            events.iter().any(|(t, l)| t == target && *l == level)
+        };
+
+        assert!(
+            seen("tinyagents::observability", tracing::Level::WARN),
+            "the durable-append recovery/reminder/shutdown reports must survive \
+             the default filter; captured {events:?}"
+        );
+        assert!(
+            !seen("opencompany::unrelated", tracing::Level::WARN),
+            "the exception is one target, not a global level bump; captured {events:?}"
+        );
+        assert!(
+            seen("opencompany::unrelated", tracing::Level::ERROR),
+            "errors kept passing exactly as they did before; captured {events:?}"
+        );
+        assert!(
+            !seen("tinyagents::observability", tracing::Level::INFO),
+            "the exception stops at `warn`; captured {events:?}"
+        );
     }
 }

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1908,4 +1908,38 @@ mod test {
             "the valid directive must survive the invalid one beside it; captured {events:?}"
         );
     }
+
+    /// `RUST_LOG=` — set, but empty — must not silence the binary.
+    ///
+    /// This is the sharper half of the same mistake as
+    /// `a_malformed_directive_does_not_discard_the_rest_of_rust_log`, and it is
+    /// worth its own test because it fails in the opposite direction from the
+    /// bug this file's constant exists to fix. `from_default_env` carries an
+    /// `ERROR` default directive; `try_from_default_env` carries none, so an
+    /// empty value parsed strictly yields a filter with no directives at all
+    /// and drops **everything** — errors included. That is worse than the
+    /// silence issue #450 is about, and it is reachable from an empty
+    /// environment variable in a compose file or a shell export.
+    #[test]
+    fn an_empty_rust_log_still_reports_errors() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(Captured(std::sync::Arc::clone(&captured)))
+            .with(log_filter(Some("")));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(target: "opencompany::anything", "something broke");
+        });
+
+        let events = captured.lock().expect("capture lock").clone();
+        assert!(
+            events
+                .iter()
+                .any(|(t, l)| t == "opencompany::anything" && *l == tracing::Level::ERROR),
+            "an empty RUST_LOG must keep the ERROR default, not silence the binary; \
+             captured {events:?}"
+        );
+    }
 }

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -992,12 +992,34 @@ fn main() -> Result<()> {
         .block_on(async_main())
 }
 
+/// The filter to install, given whatever `RUST_LOG` holds.
+///
+/// Split out from [`async_main`] and taking the variable as an argument so the
+/// choice can be tested without mutating process-global environment state,
+/// which no test can do without racing every other test in the binary.
+///
+/// `Some` — the operator set the variable, so it is parsed exactly the way it
+/// was before [`DEFAULT_LOG_FILTER`] existed: **lossily**. A single malformed
+/// directive drops itself and the valid ones around it still apply. Parsing it
+/// strictly and falling back on error would silently discard an operator's
+/// entire working configuration over one typo, which is a worse failure than
+/// the one this constant was added to fix.
+///
+/// `None` — the variable is unset, so [`DEFAULT_LOG_FILTER`] applies.
+fn log_filter(rust_log: Option<&str>) -> tracing_subscriber::EnvFilter {
+    // `EnvFilter::new` is `parse_lossy` over the same `ERROR` default directive
+    // that `from_default_env` uses, so passing the variable's value through it
+    // is exactly what the old code did with it — just reachable from a test.
+    match rust_log {
+        Some(directives) => tracing_subscriber::EnvFilter::new(directives),
+        None => tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER),
+    }
+}
+
 async fn async_main() -> Result<()> {
+    let rust_log = std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).ok();
     tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| DEFAULT_LOG_FILTER.into()),
-        )
+        .with_env_filter(log_filter(rust_log.as_deref()))
         .init();
 
     match Cli::parse().command {
@@ -1811,7 +1833,7 @@ mod test {
         let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::registry()
             .with(Captured(std::sync::Arc::clone(&captured)))
-            .with(tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER));
+            .with(log_filter(None));
 
         tracing::subscriber::with_default(subscriber, || {
             // The worker's recovery summary — the line the operator needs.
@@ -1851,6 +1873,39 @@ mod test {
         assert!(
             !seen("tinyagents::observability", tracing::Level::INFO),
             "the exception stops at `warn`; captured {events:?}"
+        );
+    }
+
+    /// A `RUST_LOG` the operator set is theirs, even when part of it is junk.
+    ///
+    /// `try_from_default_env` rejects the whole variable over one malformed
+    /// directive, so falling back to [`DEFAULT_LOG_FILTER`] on that error would
+    /// throw away every valid directive the operator wrote — turning a typo into
+    /// a silent, total loss of their logging configuration. [`log_filter`] parses
+    /// it lossily instead, which is what this binary did before the constant
+    /// existed. Flagged by review on PR #1186.
+    #[test]
+    fn a_malformed_directive_does_not_discard_the_rest_of_rust_log() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        // One good directive, one that cannot parse.
+        let subscriber = tracing_subscriber::registry()
+            .with(Captured(std::sync::Arc::clone(&captured)))
+            .with(log_filter(Some(
+                "opencompany::kept=info,@@@not a directive@@@",
+            )));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "opencompany::kept", "the operator asked for this");
+        });
+
+        let events = captured.lock().expect("capture lock").clone();
+        assert!(
+            events
+                .iter()
+                .any(|(t, l)| t == "opencompany::kept" && *l == tracing::Level::INFO),
+            "the valid directive must survive the invalid one beside it; captured {events:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The durable-append writer behind the embedded runtime's agent journal reports a failure run in four beats: the first failure at `error`, then a `warn` reminder every five minutes while it is still failing, a `warn` recovery summary naming how many observations were lost, and a `warn` on shutdown if the run never recovered. The server binary's default log filter was a bare `error`, so an operator saw the first line and then nothing — no reminder that the tenant was still degraded, no recovery, no loss count.

This names `tinyagents::observability` as the one exception to that default. Everything else is unchanged, and setting `RUST_LOG` still replaces the filter wholesale.

Issue #450 was filed against an older shape of this code, where the writer used a bare `eprintln!` and flooded the log with one identical line per queued item. That half is fixed upstream — tinyagents `73e6f5d` replaced it with a bounded, deduplicated reporter, reaching us via `vendor/openhuman` → `vendor/tinyagents`. But that commit moved every report off stderr onto `tracing`, and its own message flags the consequence: an embedder with no matching subscriber filter now sees nothing. #450's stated concern is the visibility rather than the write, so it is not closed until the reports reach someone. That is what this does.

## API Or Behavior Changes

Behaviour change, log output only, on the default path:

- With `RUST_LOG` **unset**: `tinyagents::observability` now emits at `warn` instead of `error`. Every other target keeps its previous `error` threshold.
- With `RUST_LOG` **set**: unchanged, byte for byte. No deploy or environment change is needed.

The desktop binary's fallback filter gets the same directive. That filter carries only per-target directives and no global one, so an unnamed target was dropped at *every* level there — including the first-failure `error`. Latent today, since that crate does not enable the `openhuman` feature, but it would fail silently for whoever turns it on.

**Known limitation, documented rather than worked around:** the writer's own subscriber-independent fallback, `AppendWorker::append_failures()`, is `pub(crate)` in tinyagents and cannot be read from this repo. The log filter is therefore the whole mechanism. Surfacing the counter needs an upstream change to tinyagents and should not be plumbed from here.

## Tests

A new test in `src/bin/opencompany.rs` builds the real `EnvFilter` from the real constant, installs it over a capturing layer the way `async_main` installs it over `fmt`, emits four events and asserts on which survived — it never inspects the constant's string. It pins all four directions: the observability `warn` passes, an unrelated `warn` is still dropped, an unrelated `error` still passes, and the exception stops at `warn` rather than opening the target wide.

Verified as a real gate rather than a green-by-construction one: reverting the constant to plain `"error"` fails the first assertion, and the captured vector in the failure message is the production symptom itself — the only surviving event is the unrelated error.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run with `--no-deps`; the vendored crates lint otherwise)
- [x] `cargo check --features openhuman,mcp,telegram` and `cargo check --all-features`
- [x] `cargo test --bin opencompany` — 11 passed, 0 failed

## Documentation

`docs/spec/runtime/workspace-layout.md` gains a subsection under the embedded-runtime root heading, which already describes this same writer and its earlier stderr flood. It records what changed, why the warn-level reports matter, and the `append_failures` limitation above.

## Related

Closes #450. Completes the last open child of #575, whose other three (#418, #392, #420) are already closed by merged work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime logging for durable append failures.
  * Append failure warnings now appear by default, including recovery and shutdown status.
  * Preserved existing filtering for unrelated warnings and informational messages.
  * Explicit `RUST_LOG` configurations continue to take precedence.
  * Malformed logging directives are ignored individually while valid settings remain active.
  * Empty `RUST_LOG` values retain the error baseline instead of disabling logging.

* **Documentation**
  * Documented append failure reporting behavior, log filtering, and the known limitation around displaying failure counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->