### PR TITLE
fix(chat): give host-authored notices an author that is honestly not an agent (#966)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -381,6 +381,28 @@ pub struct CompanyRuntime {
     pub(crate) mcp: Option<Arc<crate::harness::mcp::McpRuntime>>,
 }
 
+/// The event the runtime appends when a continuation could not be picked back
+/// up (issue #469, defect 4).
+///
+/// Named so its **author** can be asserted (issue #966). This site writes the
+/// `AgentReply` directly rather than going through `OutboundMessage`, so it does
+/// not get the `agent` field's fallback and has to name the author itself. It
+/// used to store `OPERATOR_CHANNEL`, which made a correct system row
+/// indistinguishable on disk from a reply whose author the pre-#885 defect
+/// overwrote.
+fn continuation_failure_notice(thread: String, parent: Option<EventSeq>) -> CompanyEvent {
+    CompanyEvent::AgentReply {
+        parent,
+        chat_id: thread,
+        agent_id: crate::ports::SYSTEM_AUTHOR.to_string(),
+        text: "Your approval was recorded, but the agent could not pick the work back up. \
+               Nothing was half-done — approving again is safe and will retry it."
+            .to_string(),
+        steps: Vec::new(),
+        task_id: None,
+    }
+}
+
 impl CompanyRuntime {
     /// Assembles a runtime from its ports. Most callers use
     /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) instead.
@@ -1916,20 +1938,7 @@ impl CompanyRuntime {
         let parent = self.resolvable_parent(conversation.parent, &thread).await;
         if let Err(err) = self
             .events
-            .append(
-                &self.id,
-                CompanyEvent::AgentReply {
-                    parent,
-                    chat_id: thread,
-                    agent_id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
-                    text: "Your approval was recorded, but the agent could not pick the work \
-                           back up. Nothing was half-done — approving again is safe and will \
-                           retry it."
-                        .to_string(),
-                    steps: Vec::new(),
-                    task_id: None,
-                },
-            )
+            .append(&self.id, continuation_failure_notice(thread, parent))
             .await
         {
             tracing::warn!(
@@ -2726,7 +2735,10 @@ impl std::fmt::Debug for CompanyRuntime {
 
 #[cfg(test)]
 mod tests {
-    use super::{emergency_from_load, task_enters_in_progress, task_enters_planning};
+    use super::{
+        CompanyEvent, continuation_failure_notice, emergency_from_load, task_enters_in_progress,
+        task_enters_planning,
+    };
 
     /// Issue #880: which parked approvals name a workflow run, and which must
     /// not.
@@ -3773,6 +3785,34 @@ mod tests {
             rt.resolvable_parent(Some(roots[0]), "desk-ops").await,
             None,
             "and the General desk is not a named one",
+        );
+    }
+
+    /// Issue #966: the failed-continuation report is authored by the runtime.
+    ///
+    /// This site appends the `AgentReply` itself, so it never sees
+    /// `OutboundMessage::agent` or its `channel` fallback — it has to name the
+    /// author, and it used to name `OPERATOR_CHANNEL`. That made a correct
+    /// system row byte-identical on disk to a reply the pre-#885 defect had
+    /// damaged, which is the finding recorded on #966.
+    #[test]
+    fn a_failed_continuation_report_is_authored_by_the_runtime_not_the_operator() {
+        let event = continuation_failure_notice("desk-general".to_string(), None);
+        let CompanyEvent::AgentReply {
+            agent_id, chat_id, ..
+        } = event
+        else {
+            panic!("the notice must stay an AgentReply — the console renders it from that arm");
+        };
+        assert_eq!(agent_id, crate::ports::SYSTEM_AUTHOR);
+        assert_ne!(
+            agent_id,
+            crate::runtime::channel::OPERATOR_CHANNEL,
+            "a notice must not store the author a destination-overwrite produces"
+        );
+        assert_eq!(
+            chat_id, "desk-general",
+            "it still lands in the thread it answers"
         );
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -208,6 +208,30 @@ pub struct HarnessBrain {
 ///
 /// No card, by construction: a confined turn has no `spawn_task` to call, and
 /// the chat handler does not open one from a copilot message either.
+/// A bubble the **runtime** wrote, not an agent (issue #966).
+///
+/// Two sites emit these on the operator channel: the approval-overflow notice
+/// and the cycle's `"Acknowledged."` fallback. Both used to leave the author
+/// unset, so the journal writer's `channel` fallback stamped `"operator"` — and
+/// that made a *correct* system row byte-identical on disk to a reply whose
+/// author the pre-#885 defect had overwritten. No reader could tell them apart,
+/// which is the finding recorded on #966.
+///
+/// Named rather than inlined for the same reason [`confined_bubble`] is: the
+/// author is the load-bearing field, and a free function is what lets it be
+/// asserted without standing up a cycle.
+fn system_notice(text: String) -> OutboundMessage {
+    OutboundMessage {
+        message_id: None,
+        task_id: None,
+        channel: "operator".to_string(),
+        agent: Some(crate::ports::SYSTEM_AUTHOR.to_string()),
+        text,
+        steps: Vec::new(),
+        reply_to: None,
+    }
+}
+
 fn confined_bubble(outcome: crate::harness::TurnOutcome) -> OutboundMessage {
     OutboundMessage {
         message_id: None,
@@ -2987,28 +3011,12 @@ impl HarnessBrain {
         // the agent was cut off — and because a turn whose only outcome was
         // overflow has no reply to append to.
         if let Some(notice) = self.park_approval_requests(host).await? {
-            channel_responses.push(OutboundMessage {
-                message_id: None,
-                task_id: None,
-                channel: "operator".to_string(),
-                agent: None,
-                text: notice,
-                steps: Vec::new(),
-                reply_to: None,
-            });
+            channel_responses.push(system_notice(notice));
         }
 
         // The runtime requires at least one channel response per cycle.
         if channel_responses.is_empty() {
-            channel_responses.push(OutboundMessage {
-                message_id: None,
-                task_id: None,
-                channel: "operator".to_string(),
-                agent: None,
-                text: "Acknowledged.".to_string(),
-                steps: Vec::new(),
-                reply_to: None,
-            });
+            channel_responses.push(system_notice("Acknowledged.".to_string()));
         }
 
         let trace = CompressedTrace::now(
@@ -8801,6 +8809,25 @@ members = ["eng1", "eng2"]
             bubble.agent.as_deref(),
             Some(bubble.channel.as_str()),
             "author and destination must not be the same value — that conflation is issue #885"
+        );
+    }
+
+    /// Issue #966: a bubble the runtime wrote names a non-agent author.
+    ///
+    /// Asserts it is not `"operator"` specifically, rather than only that it
+    /// equals the constant. The whole defect is that a host-authored notice and
+    /// a reply whose author was overwritten stored the *same* value, so a test
+    /// that checked equality alone would still pass if `SYSTEM_AUTHOR` were ever
+    /// redefined to the channel name.
+    #[test]
+    fn a_host_authored_notice_is_not_authored_by_the_operator_channel() {
+        let bubble = system_notice("Acknowledged.".to_string());
+        assert_eq!(bubble.channel, "operator", "the destination is unchanged");
+        assert_eq!(bubble.agent.as_deref(), Some(crate::ports::SYSTEM_AUTHOR));
+        assert_ne!(
+            bubble.agent.as_deref(),
+            Some("operator"),
+            "a notice must not store the author a destination-overwrite produces"
         );
     }
 }

--- a/src/ports/ids.rs
+++ b/src/ports/ids.rs
@@ -51,6 +51,26 @@ pub fn generate_id() -> String {
     format!("{millis:012x}-{counter:012x}")
 }
 
+/// The author a **host-authored notice** is journaled under (issue #966).
+///
+/// Not an agent, and deliberately not a destination either. Three sites emit
+/// prose the runtime wrote itself — an approval-overflow notice, the
+/// `"Acknowledged."` cycle fallback, and a failed-continuation report — and each
+/// used to land as an ordinary `AgentReply` carrying `"operator"` in the author
+/// field. That made them **byte-identical to a reply whose author was
+/// overwritten** by the pre-#885 defect, so no reader could tell a correct
+/// system row from a damaged agent row.
+///
+/// The value matches the literal `MessageView::project` already uses for the
+/// `DeskTaskCompleted` marker, which is what routes it to the console's centred
+/// system pill rather than a company bubble — so nothing on the read side has to
+/// learn a new word.
+///
+/// **Forward-only.** Notices already journaled keep `"operator"` and stay
+/// indistinguishable, permanently: the distinguishing information was never
+/// written down, and nothing recovers it after the fact.
+pub const SYSTEM_AUTHOR: &str = "system";
+
 /// The agent id a confined turn runs under (issue #416).
 ///
 /// Deliberately **not** a roster id: it names no teammate, carries no manifest

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -51,7 +51,9 @@ pub use context::ContextStore;
 pub use economy::AgentEconomy;
 pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_prune};
 pub use facts::{FactKind, FactRecord, FactStore};
-pub use ids::{AGENT_SLUG_FALLBACK, CONFINED_AGENT_ID, agent_slug, generate_id, now_millis};
+pub use ids::{
+    AGENT_SLUG_FALLBACK, CONFINED_AGENT_ID, SYSTEM_AUTHOR, agent_slug, generate_id, now_millis,
+};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use journal::{Durability, JournalStore};
 pub use ledgers::LedgerStore;

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -430,8 +430,8 @@ impl MessageView {
                 task_id, column, ..
             } => MessageView {
                 id,
-                channel: "system".to_string(),
-                author: "system".to_string(),
+                channel: crate::ports::SYSTEM_AUTHOR.to_string(),
+                author: crate::ports::SYSTEM_AUTHOR.to_string(),
                 text: dispatch_marker_text(&column),
                 at_millis,
                 mine: false,
@@ -443,8 +443,8 @@ impl MessageView {
             // `owns` never admits other variants into a history.
             other => MessageView {
                 id,
-                channel: "system".to_string(),
-                author: "system".to_string(),
+                channel: crate::ports::SYSTEM_AUTHOR.to_string(),
+                author: crate::ports::SYSTEM_AUTHOR.to_string(),
                 text: format!("{other:?}"),
                 at_millis,
                 mine: false,
@@ -533,7 +533,15 @@ impl AttributionAudit {
 /// bound; in practice that notice is rare enough not to move it.
 /// Whether a stored `agent_id` names an author we can actually resolve.
 ///
-/// The roster, **plus the confined copilot** (issue #966). `CONFINED_AGENT_ID`
+/// The roster, **plus two ids that are truthful authors without being teammates**.
+///
+/// [`SYSTEM_AUTHOR`](crate::ports::SYSTEM_AUTHOR) (issue #966) is the runtime
+/// speaking for itself — an approval-overflow notice, the `"Acknowledged."`
+/// fallback, a failed-continuation report. Those rows are *correct*, so counting
+/// them as damage would inflate the one figure in #965 that has to be
+/// trustworthy, and would caption a legitimate system message as unattributable.
+///
+/// `CONFINED_AGENT_ID`
 /// is deliberately not a roster id — it names no teammate, carries no manifest
 /// grants and cannot be addressed — but a copilot turn genuinely authored its
 /// reply, so the id is a truthful author rather than a destination that leaked
@@ -546,6 +554,7 @@ impl AttributionAudit {
 /// which rows are unknown.
 pub fn is_known_author(agent_id: &str, record: &CompanyRecord) -> bool {
     agent_id == crate::ports::CONFINED_AGENT_ID
+        || agent_id == crate::ports::SYSTEM_AUTHOR
         || record.resolve_roster_agent_id(agent_id).is_some()
 }
 
@@ -1262,6 +1271,37 @@ mod test {
                 template_provenance: None,
                 setup: None,
             }
+        }
+
+        /// Issue #966. The runtime speaking for itself is a *correct* row, not
+        /// damage. Counting it would inflate the blast-radius figure on a company
+        /// doing nothing wrong, and would caption a legitimate system message as
+        /// something nobody can attribute.
+        #[test]
+        fn a_host_authored_notice_is_a_known_author_not_an_affected_row() {
+            let record = record();
+            let mut audit = AttributionAudit::default();
+            audit.fold(
+                &[reply(1, crate::ports::SYSTEM_AUTHOR), reply(2, "engineer")],
+                |agent_id| is_known_author(agent_id, &record),
+            );
+            assert_eq!(audit.replies, 2);
+            assert_eq!(audit.affected, 0);
+        }
+
+        /// The whole point of the reserved id: a notice and a damaged reply used
+        /// to be the same bytes. This pins that they are now different ones, so
+        /// the distinction a marker would rely on actually exists in the data.
+        #[test]
+        fn a_notice_and_an_overwritten_reply_are_no_longer_the_same_author() {
+            let record = record();
+            assert_ne!(
+                crate::ports::SYSTEM_AUTHOR,
+                "operator",
+                "a notice must not share the author a destination-overwrite produces"
+            );
+            assert!(is_known_author(crate::ports::SYSTEM_AUTHOR, &record));
+            assert!(!is_known_author("operator", &record));
         }
 
         /// Issue #966. A copilot turn genuinely authored its reply, so the id it


### PR DESCRIPTION
## Summary

Host-authored desk notices (an approval-overflow warning, the runtime's `"Acknowledged."`) were journaled as ordinary `AgentReply`s carrying `"operator"` in the author field — byte-identical to the pre-#885 damaged agent rows #966 is about. That made a legitimate, known-author system message indistinguishable from a reply whose author was overwritten. This gives the runtime a truthful author of its own so the two stop colliding.

## Problem

#885 fixed the agent-reply write path forward-only, but the runtime's own messages still went out as `AgentReply` with a destination string (`"operator"`) where the author belongs. So on the read side there was no way to tell "the runtime said this" (a known, legitimate author) from "an agent said this and the author was lost" (a pre-#885 damaged row) — both rendered as a confident, wrong teammate name.

## Solution

- Introduce a reserved `SYSTEM_AUTHOR` (`"system"`) — the id the runtime speaks under when it authors a notice for itself. Host notices are now journaled under it instead of borrowing `"operator"`.
- Project those rows as a system message (a system pill, not a company/teammate bubble), so nothing downstream has to re-derive the author.
- Treat `SYSTEM_AUTHOR` as a *known, truthful* author that is explicitly **not** a teammate (`is_known_author`), so it is never mistaken for a roster member or counted as one — while a genuinely damaged pre-#885 agent row remains identifiable as the separate, unrecoverable case #966 describes.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features openhuman,tinycortex --all-targets`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex --lib` — `server::chat_history` (26), `company::runtime` (22), `ports::ids` (6), `harness::brain` (98)

New test `a_host_authored_notice_is_a_known_author_not_an_affected_row` pins the separation: a `SYSTEM_AUTHOR` notice and a damaged reply are no longer conflated.

## Impact

Backend + projection only; no schema migration. Host notices now render honestly as the runtime speaking for itself, and the damaged-row case #966 flags is cleanly separable from a legitimate system author — the prerequisite for rendering pre-#885 authors as "unknown" rather than a confident wrong name.

## Related

Part of #966 (the honest-author foundation; builds on the forward-only #885). Closes the host-notice half — a runtime notice is no longer misfiled as an operator reply.