### PR TITLE
console: an inset, centred app frame with the colour on the outer surface

### DIFF
--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -78,9 +78,32 @@ is the primitive and the theme picks a set.
 | `3` | `#E8E8F2` | `#131317` | Icon circles |
 | `4` | `#DADAE5` | `#161719` | Card stroke · dividers |
 | `active` | `#ECE9FC` | `#1E1E28` | The nav row you are standing on |
+| `ground` | `#EBE7F7` | `#15131B` | The surface the app frame sits on |
 
-Declared as `--surface-light-*` and `--surface-dark-*`. Every value is the
-brand guide's, unchanged.
+Declared as `--surface-light-*` and `--surface-dark-*`. Every value except
+`ground` is the brand guide's, unchanged.
+
+`ground` is the one rung that is not inside the app (issue #1178). The console
+is inset from the window, and this is what shows around it. Two things make it
+different from the six above:
+
+- **It is the most chromatic neutral in the system** (chroma 0.017–0.022
+  against 0.004–0.026 for the rest, at hue 296.5° rather than the ladder's
+  285–286°). It carries no text, no stroke and no control, so nothing on it can
+  be harmed by a tint — and a grey there reads as an empty margin rather than
+  as a ground the app is standing on. The ~10° warmer hue is what separates it
+  from "another panel". A genuinely warm ground would put a second hue family
+  into a palette that owns one, and would go muddy exactly where it meets the
+  cool greys — at the frame's edge, the one place this colour is ever seen
+  against another.
+- **The two themes take opposite sides of their canvas.** Light sits a step
+  *below* it (L 0.936 against 0.978), so the app stays the brightest thing on
+  screen. Dark sits a step *above* it (L 0.193 against 0.140), because there is
+  no rung left below near-black — darker is `#000`, and at that lightness the
+  chroma is invisible. It is also what makes the frame's shadow work: a shadow
+  needs something to fall on. The rule that surfaces climb toward the viewer
+  governs panels stacked *inside* the app; the window ground is not in that
+  stack.
 
 ### Ink levels
 
@@ -130,15 +153,40 @@ Layer 2. These are what components use.
 | `--secondary` | rung `3` | rung `active` | Secondary button fill |
 | `--surface-icon` | rung `3` | rung `3` | Ground behind an icon circle |
 | `--accent` | rung `active` | rung `active` | Hover/rest tint under rows |
-| `--sidebar` | rung `1` | rung `1` | Nav column |
+| `--sidebar` | rung `2` | rung `1` | Nav column |
 | `--sidebar-accent` | rung `active` | rung `active` | Active nav row background |
 | `--border` | rung `4` | rung `4` | The hairline |
 | `--input` | rung `4` | rung `active` | Field borders, stronger rules |
 | `--ring` | `brand-500` | `brand-400` | Focus |
+| `--app-ground` | rung `ground` | rung `ground` | Outside the app frame |
+| `--app-frame-edge` | rung `4` | rung `bg` | The frame's own hairline |
 
 Light surfaces climb *toward* the viewer with lightness (canvas `#F7F7FC` →
 card white), and dark does the same (`#08090B` → `#0C0D0F` → `#161719`). A card
 lifts off the page before any shadow is applied.
+
+**The ladder runs from the window inward, and it has to be monotonic.** With a
+ground outside the frame there are four surfaces between the window edge and a
+card, and if they do not step in one direction the frame reads as three
+unrelated greys rather than as an app sitting on a desk:
+
+```
+light   ground #EBE7F7 → sidebar #F1F1F8 → canvas #F7F7FC → card #FFFFFF
+dark    ground #15131B → sidebar #0C0D0F → canvas #08090B → card #0C0D0F
+```
+
+Dark already ran in that order. Light did not: `--sidebar` was rung 1, pure
+white, one step *above* the canvas it sits beside — while the stylesheet's own
+comment on the line claimed it was "slightly recessed from the canvas so the
+working area is the brightest thing on screen". Issue #1178 moved it to rung 2,
+which is what that sentence meant.
+
+`--app-frame-edge` is `--border` in light and the *canvas* value in dark, which
+looks inconsistent and is not. In dark the ground is lighter than the app, so
+rung 4 (`#161719`) sits between the two and reads as a third surface wedged into
+the seam. The canvas value disappears against the content it borders and stays a
+dark line against the ground and the sidebar — a raised edge on a dark screen is
+an absence of light, not a stroke.
 
 Dark borders were translucent white, so one value could read against the
 canvas, the card and the popover at once. The guide names the stroke outright —

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -209,6 +209,11 @@ zero below `lg` (1024px):
 | `--app-frame-radius` | 14px | 14px | 0 |
 | `--app-frame-border` | 1px | 1px | 0 |
 
+The breakpoint is `lg` and not `md`: `md` is where the sidebar becomes an
+overlay sheet, so a frame surviving down to it would be a border around a single
+column. `lg` is where the inset starts to cost — 24px out of a 779px working
+column at 1024, 4.6% of a 523px one at 768.
+
 **Inset on three sides, flush to the bottom.** Vertical space is the scarcest
 thing in this app — chat's composer, the ledgers board and the workflows canvas
 all want every pixel of height — so only one inset comes out of `100svh`, and

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -189,6 +189,48 @@ Never nest a modal inside a modal.
 
 ---
 
+## App frame
+
+Not a primitive but a shape the whole console takes, so it is stated once here
+rather than rediscovered per view (issue #1178). `SidebarProvider` renders two
+boxes:
+
+| Box | `data-slot` | What it is |
+| --- | --- | --- |
+| Ground | `sidebar-ground` | `100svh`, painted `bg-app-ground`. Holds nothing. |
+| Frame | `sidebar-wrapper` | The console: one edge, one radius, one shadow. |
+
+Three geometry tokens drive it, all declared at `:root` in `index.css` and all
+zero below `lg` (1024px):
+
+| Token | ≥ `lg` | ≥ `2xl` | Below `lg` |
+| --- | --- | --- | --- |
+| `--app-frame-inset` | 12px | 18px | 0 |
+| `--app-frame-radius` | 14px | 14px | 0 |
+| `--app-frame-border` | 1px | 1px | 0 |
+
+**Inset on three sides, flush to the bottom.** Vertical space is the scarcest
+thing in this app — chat's composer, the ledgers board and the workflows canvas
+all want every pixel of height — so only one inset comes out of `100svh`, and
+only the two top corners are rounded.
+
+**All three collapse together.** A radius kept at zero inset rounds the corners
+against the window edge and lets the ground show through as two stray tinted
+notches; a border kept there draws a hairline down the outside of the screen.
+Below `lg` there is no frame, not a flattened one.
+
+**Nothing inside may use a viewport unit for height.** The frame is one inset
+shorter than the window, and the shell clips rather than scrolls, so an `h-svh`
+box loses its bottom edge with no scrollbar to say so. Use `flex-1 min-h-0`.
+
+The desktop sidebar is `absolute` against the frame, not `fixed` against the
+window — that is what keeps it inside. Making the frame a containing block for
+`fixed` instead (a `transform`, or `contain: paint`) would have recaptured
+every other fixed descendant with it. `test/e2e/app-frame.spec.ts` pins the
+geometry.
+
+---
+
 ## Scrollbars
 
 Native scrollbars are themed once, globally, in `index.css` — nothing opts in

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1300,7 +1300,7 @@ export function AppShell({
      * collapses to edge-to-edge, and for what the ground's tint is in each
      * theme.
      */
-    <SidebarProvider className="overflow-hidden rounded-t-[calc(var(--radius)*1.4)] border border-app-frame-edge border-b-0 shadow-frame">
+    <SidebarProvider className="overflow-hidden rounded-t-[var(--app-frame-radius)] border-app-frame-edge [border-width:var(--app-frame-border)] border-b-0 shadow-frame">
       {/* Mobile turns the sidebar into a sheet, so its own collapse control is
           not mounted while it is closed. Keep the way back fixed to the
           viewport and below the page controls rather than competing with a

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1288,7 +1288,19 @@ export function AppShell({
   });
 
   return (
-    <SidebarProvider className="h-svh overflow-hidden">
+    /*
+     * The app frame (issue #1178). `SidebarProvider` renders two boxes: the
+     * tinted ground that fills the window, and the console inset inside it.
+     * These classes describe the console — the ground's geometry belongs to
+     * the frame itself and is stated in `ui/sidebar.tsx`.
+     *
+     * `rounded-t-*` and no bottom edge: the frame is inset on three sides and
+     * flush to the bottom of the window. See the note beside
+     * `--app-frame-inset` in `index.css` for why, for where the frame
+     * collapses to edge-to-edge, and for what the ground's tint is in each
+     * theme.
+     */
+    <SidebarProvider className="overflow-hidden rounded-t-[calc(var(--radius)*1.4)] border border-app-frame-edge border-b-0 shadow-frame">
       {/* Mobile turns the sidebar into a sheet, so its own collapse control is
           not mounted while it is closed. Keep the way back fixed to the
           viewport and below the page controls rather than competing with a

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -130,8 +130,30 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
+      {/*
+        Two boxes, not one (issue #1178).
+
+        THE GROUND fills the window and carries the colour. It holds nothing:
+        no text, no control, no stroke — it exists so the console has a surface
+        to sit on and so status colour has somewhere to live that is not the
+        content. `p-… pb-0` insets the console on three sides and leaves it
+        flush to the bottom; `--app-frame-inset` is 0 below `lg`, which is how
+        the frame collapses to edge-to-edge on a narrow viewport without a
+        second set of classes here. `h-svh` with `box-sizing: border-box`
+        keeps the pair exactly one viewport tall at every inset, so nothing
+        below can grow a document scrollbar.
+
+        THE FRAME is the console: one object, one edge, one radius, holding
+        the sidebar and the working column together instead of letting each
+        meet the window on its own. `relative`, because the desktop sidebar
+        positions against it — see the note on `sidebar-container` below.
+
+        `className` lands on the frame, because the frame is the box that
+        looks like something. `style` and the rest of the props stay on the
+        ground so `--sidebar-width` reaches both.
+      */}
       <div
-        data-slot="sidebar-wrapper"
+        data-slot="sidebar-ground"
         style={
           {
             "--sidebar-width": SIDEBAR_WIDTH,
@@ -139,13 +161,18 @@ function SidebarProvider({
             ...style,
           } as React.CSSProperties
         }
-        className={cn(
-          "group/sidebar-wrapper flex h-svh min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
-          className
-        )}
+        className="h-svh bg-app-ground p-[var(--app-frame-inset)] pb-0"
         {...props}
       >
-        {children}
+        <div
+          data-slot="sidebar-wrapper"
+          className={cn(
+            "group/sidebar-wrapper relative flex h-full w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+        >
+          {children}
+        </div>
       </div>
     </SidebarContext.Provider>
   )
@@ -232,16 +259,20 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          // `left: 0`, and nothing stands to the left of it any more.
+          // `left: 0`, and nothing stands to the left of it any more. It used
+          // to be offset by `--oc-rail-inset` because the connection rail
+          // occupied the first 56px of the window and pinning this to 0 slid
+          // the whole sidebar underneath it — every icon and the first
+          // characters of every label clipped. Issue #1142 replaced that rail
+          // with a switcher in this sidebar's own header, so the offset has
+          // nothing left to clear.
           //
-          // This container is `fixed`, so it positions against the VIEWPORT
-          // rather than the column it is written inside. It used to be offset
-          // by `--oc-rail-inset` because the connection rail occupied the first
-          // 56px of the window and pinning this to 0 slid the whole sidebar
-          // underneath it — every icon and the first characters of every label
-          // clipped. Issue #1142 replaced that rail with a switcher in this
-          // sidebar's own header, so the offset has nothing left to clear.
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          // `absolute`, and `h-full` rather than `h-svh`: this box is measured
+          // against the `relative` frame wrapper above, NOT the window. It was
+          // `fixed`/`h-svh` until issue #1178 inset the console from the window
+          // edge, at which point "0" and "the left edge of the app" stopped
+          // being the same number and this column stood outside the frame.
+          "absolute inset-y-0 z-10 hidden h-full w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,6 +96,41 @@
     --surface-dark-active: oklch(0.2396 0.019 284.87); /* #1E1E28 */
 
     /*
+     * Ground — the surface the app frame sits on (issue #1178).
+     *
+     * A seventh rung, and the only one that is not inside the app: the
+     * console is inset from the window edge, and this is what shows around
+     * it. It is deliberately the most chromatic neutral in the system,
+     * because it is the one surface that carries no text, no stroke and no
+     * control — nothing on it can be harmed by a tint, and a grey there
+     * reads as an empty margin rather than as a ground the app is standing
+     * on.
+     *
+     * Hue 296.5° in both themes: ~10° warmer than the 285–286° the neutral
+     * ladder runs at, which is what separates it from "another panel" and
+     * gets it as close to the reference's warm paper as a palette that owns
+     * one hue can honestly go. A genuinely warm ground (amber, 70–90°) would
+     * put a second hue family into the console and go muddy exactly where it
+     * meets the cool greys — at the frame's edge, which is the one place
+     * this colour is ever seen against another.
+     *
+     * The two themes take OPPOSITE sides of their canvas, and that is not an
+     * oversight:
+     *
+     *   light  L 0.936 — a step BELOW the canvas (0.978). The app is the
+     *          brightest thing on screen, as the surface ladder intends.
+     *   dark   L 0.193 — a step ABOVE the canvas (0.140). There is no rung
+     *          left below near-black: darker is #000, and at that lightness
+     *          chroma is invisible, so "the ground" would read as nothing at
+     *          all. Lighter is also what makes the drop shadow work — a
+     *          shadow needs something to fall on. The rule that surfaces
+     *          climb toward the viewer governs panels stacked INSIDE the
+     *          app; the window ground is not in that stack.
+     */
+    --surface-light-ground: oklch(0.9364 0.0221 296.5); /* #EBE7F7 */
+    --surface-dark-ground: oklch(0.193 0.017 296.5); /* #15131B */
+
+    /*
      * Ink — the five text levels, stated per theme.
      *
      * `primary` and the light `secondary` are the guide's values. The rest are
@@ -169,6 +204,13 @@
     --background: var(--surface-light-bg);
     --foreground: var(--ink-light-primary);
     --card: var(--surface-light-1);
+
+    /* The app frame (issue #1178). `--app-ground` is what shows around the
+       inset console; `--app-frame-edge` is the hairline that closes it.
+       In light the edge is the card stroke — the same rung every other
+       raised surface is outlined with. */
+    --app-ground: var(--surface-light-ground);
+    --app-frame-edge: var(--surface-light-4);
     --card-foreground: var(--ink-light-primary);
     --popover: var(--surface-light-1);
     --popover-foreground: var(--ink-light-primary);
@@ -294,9 +336,26 @@
     --chart-4: var(--amber-mark);
     --chart-5: var(--pink-mark);
 
-    /* Sidebar. Slightly recessed from the canvas so the working area is
-       the brightest thing on screen. */
-    --sidebar: var(--surface-light-1);
+    /* Sidebar — rung 2, not rung 1 (issue #1178).
+     *
+     * This line has always CLAIMED the sidebar is "slightly recessed from the
+     * canvas so the working area is the brightest thing on screen"; at rung 1
+     * (#FFFFFF) it was the brightest thing on screen instead, one step ABOVE
+     * the canvas it sits beside.
+     *
+     * Nothing depended on that until the app gained a ground to sit on. Now
+     * there is a ladder running from the window inward, and it has to be
+     * monotonic or the frame reads as three unrelated greys:
+     *
+     *   light   ground #EBE7F7 → sidebar #F1F1F8 → canvas #F7F7FC → card #FFF
+     *   dark    ground #15131B → sidebar #0C0D0F → canvas #08090B → card #0C0D0F
+     *
+     * Dark already ran in the right order — its sidebar is rung 1 and its
+     * canvas is `bg`, one step further from the ground. Light is the theme
+     * that was inverted, and this is the one value that fixes it. The working
+     * column becomes the brightest surface, which is what the sentence above
+     * meant all along. */
+    --sidebar: var(--surface-light-2);
     --sidebar-foreground: var(--ink-light-primary);
     --sidebar-primary: var(--brand-500);
     --sidebar-primary-foreground: var(--surface-light-1);
@@ -329,6 +388,14 @@
        surface. Not a substitute for the focus ring — an addition to it. */
     --shadow-brand: 0 2px 8px -2px color-mix(in oklab, var(--brand-500) 32%, transparent);
 
+    /* The app frame's lift (issue #1178). Its own step rather than `--shadow-md`
+       because this is the largest object on screen and the only one lit from
+       three sides: the frame is flush to the bottom of the window, so the
+       shadow must spread sideways and stay shallow downward, where there is
+       no gap left for it to fall into. */
+    --shadow-frame: 0 2px 6px -3px hsl(var(--shadow-color) / 0.1),
+        0 10px 32px -12px hsl(var(--shadow-color) / 0.22);
+
     /*
      * Third-party brand colours.
      *
@@ -357,6 +424,15 @@
     --background: var(--surface-dark-bg);
     --foreground: var(--ink-dark-primary);
     --card: var(--surface-dark-1);
+
+    /* The frame's edge is NOT `--border` here. The ground is lighter than the
+       app in dark, so rung 4 (#161719) sits between the two and reads as a
+       third surface wedged into the seam. The canvas value instead: it
+       disappears against the content it borders and stays a dark line against
+       the ground and the sidebar — which is how a raised edge reads on a dark
+       screen, as an absence of light rather than a stroke. */
+    --app-ground: var(--surface-dark-ground);
+    --app-frame-edge: var(--surface-dark-bg);
     --card-foreground: var(--ink-dark-primary);
     /* Rung 3, not rung 4. `--border` is rung 4, and a popover painted rung 4
        renders its own edge in its own fill — the dialog loses its outline
@@ -463,6 +539,14 @@
     --shadow-xl: 0 8px 16px -8px hsl(var(--shadow-color) / 0.55),
         0 24px 56px -12px hsl(var(--shadow-color) / 0.6), inset 0 1px 0 0 oklch(1 0 0 / 7%);
     --shadow-brand: 0 2px 12px -2px color-mix(in oklab, var(--brand-400) 40%, transparent);
+
+    /* Heavier than light mode's, and no inset highlight. The ground is
+       LIGHTER than the app here, so for once in dark mode there is something
+       for a shadow to fall on — it is the shadow, not a lit top edge, that
+       separates the frame from what surrounds it. Every other dark elevation
+       token has the opposite problem and adds the highlight instead. */
+    --shadow-frame: 0 2px 6px -3px hsl(var(--shadow-color) / 0.5),
+        0 12px 36px -12px hsl(var(--shadow-color) / 0.75);
 }
 
 /* ============================================================================
@@ -504,6 +588,11 @@
     --color-input: var(--input);
     --color-ring: var(--ring);
     --color-surface-icon: var(--surface-icon);
+
+    /* The app frame (issue #1178) — the ground it sits on and the hairline
+       that closes it. Two call sites, both in `app-shell.tsx`. */
+    --color-app-ground: var(--app-ground);
+    --color-app-frame-edge: var(--app-frame-edge);
 
     /* The five-level text hierarchy, as `text-ink-*`. Named `ink` rather than
        `text` because `--text-*` is Tailwind's font-size namespace in this same
@@ -579,6 +668,7 @@
     --shadow-lg: var(--shadow-lg);
     --shadow-xl: var(--shadow-xl);
     --shadow-brand: var(--shadow-brand);
+    --shadow-frame: var(--shadow-frame);
 
     --radius-sm: calc(var(--radius) * 0.6);
     --radius-md: calc(var(--radius) * 0.8);
@@ -648,6 +738,59 @@
     --duration-fast: 120ms;
     --duration-base: 180ms;
     --duration-slow: 260ms;
+}
+
+/* ============================================================================
+ * The app frame (issue #1178).
+ *
+ * The console is inset from the window on three sides and flush to the bottom.
+ * Three sides, not four, and that is the load-bearing decision:
+ *
+ *   - Vertical space is the scarcest thing in this app. Chat's composer, the
+ *     ledgers board and the workflows canvas all want every pixel of height,
+ *     and a bottom gutter costs each of them twice — once for the gap and once
+ *     for the corner radius above it.
+ *   - A card that meets the bottom edge still reads as an object, because the
+ *     three edges that ARE inset are the three the eye tracks. Slack and the
+ *     macOS sidebar apps the reference is drawn from do the same thing.
+ *   - It keeps the arithmetic honest: only ONE inset comes out of `100svh`,
+ *     so a full-height scroller loses 12px, not 24px.
+ *
+ * Declared at `:root` rather than in `@theme` for the same reason the
+ * durations above are: `--app-frame-*` is not a namespace Tailwind emits, so
+ * a `@theme` entry would define nothing at runtime. Components read them
+ * through arbitrary values (`p-[var(--app-frame-inset)]`), which is a token
+ * reference, not an arbitrary value in the sense the design-token guard
+ * means.
+ *
+ * WHERE THE FRAME COLLAPSES: below `lg` (1024px) the inset is zero and the
+ * console runs edge to edge. Not `md` (768px), where the sidebar becomes an
+ * overlay sheet — by then the frame is a border around a single column and
+ * has been useless for a while. 1024 is where it starts to *cost*: with the
+ * sidebar expanded (13.5rem) a 12px inset leaves a 779px working column at
+ * 1024 and 523px at 768, and below `lg` the console has already begun
+ * stacking its secondary rails (chat's channel rail, settings' nav), so the
+ * content column is doing more work per pixel exactly as the frame starts
+ * taking them.
+ * ========================================================================== */
+
+:root {
+    --app-frame-inset: 0px;
+}
+
+@media (min-width: 64rem) {
+    :root {
+        --app-frame-inset: 0.75rem; /* 12px */
+    }
+}
+
+/* On a display wide enough that the frame is no longer competing with the
+   content for width, the gutter grows — this is the width at which the
+   surround stops being a detail and starts being the point. */
+@media (min-width: 96rem) {
+    :root {
+        --app-frame-inset: 1.125rem; /* 18px */
+    }
 }
 
 /* ============================================================================

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -776,11 +776,20 @@
 
 :root {
     --app-frame-inset: 0px;
+    --app-frame-radius: 0px;
+    --app-frame-border: 0px;
 }
 
+/* All three collapse together, and they have to: a frame that keeps its
+   radius at zero inset rounds its corners against the window edge and lets
+   the ground show through as two stray tinted notches, and a frame that keeps
+   its border draws a hairline down the outside of the screen. Below `lg`
+   there is no frame — not a flattened one. */
 @media (min-width: 64rem) {
     :root {
         --app-frame-inset: 0.75rem; /* 12px */
+        --app-frame-radius: calc(var(--radius) * 1.4); /* = radius-xl, 14px */
+        --app-frame-border: 1px;
     }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -204,6 +204,9 @@
     --background: var(--surface-light-bg);
     --foreground: var(--ink-light-primary);
     --card: var(--surface-light-1);
+    --card-foreground: var(--ink-light-primary);
+    --popover: var(--surface-light-1);
+    --popover-foreground: var(--ink-light-primary);
 
     /* The app frame (issue #1178). `--app-ground` is what shows around the
        inset console; `--app-frame-edge` is the hairline that closes it.
@@ -211,9 +214,6 @@
        raised surface is outlined with. */
     --app-ground: var(--surface-light-ground);
     --app-frame-edge: var(--surface-light-4);
-    --card-foreground: var(--ink-light-primary);
-    --popover: var(--surface-light-1);
-    --popover-foreground: var(--ink-light-primary);
 
     /* Interaction. `primary` is the brand: the button you press, the link
        you follow, the series that leads a chart. */
@@ -424,6 +424,13 @@
     --background: var(--surface-dark-bg);
     --foreground: var(--ink-dark-primary);
     --card: var(--surface-dark-1);
+    --card-foreground: var(--ink-dark-primary);
+    /* Rung 3, not rung 4. `--border` is rung 4, and a popover painted rung 4
+       renders its own edge in its own fill — the dialog loses its outline
+       entirely. Rung 3 keeps the popover above the card (rung 1) and leaves
+       the stroke a step to read against. */
+    --popover: var(--surface-dark-3);
+    --popover-foreground: var(--ink-dark-primary);
 
     /* The frame's edge is NOT `--border` here. The ground is lighter than the
        app in dark, so rung 4 (#161719) sits between the two and reads as a
@@ -433,13 +440,6 @@
        screen, as an absence of light rather than a stroke. */
     --app-ground: var(--surface-dark-ground);
     --app-frame-edge: var(--surface-dark-bg);
-    --card-foreground: var(--ink-dark-primary);
-    /* Rung 3, not rung 4. `--border` is rung 4, and a popover painted rung 4
-       renders its own edge in its own fill — the dialog loses its outline
-       entirely. Rung 3 keeps the popover above the card (rung 1) and leaves
-       the stroke a step to read against. */
-    --popover: var(--surface-dark-3);
-    --popover-foreground: var(--ink-dark-primary);
 
     /* Brand-500 is too dense to read as ink on near-black; 400 is the
        working accent in dark mode. Filled brand buttons keep 500 with
@@ -764,14 +764,19 @@
  * means.
  *
  * WHERE THE FRAME COLLAPSES: below `lg` (1024px) the inset is zero and the
- * console runs edge to edge. Not `md` (768px), where the sidebar becomes an
- * overlay sheet — by then the frame is a border around a single column and
- * has been useless for a while. 1024 is where it starts to *cost*: with the
- * sidebar expanded (13.5rem) a 12px inset leaves a 779px working column at
- * 1024 and 523px at 768, and below `lg` the console has already begun
- * stacking its secondary rails (chat's channel rail, settings' nav), so the
- * content column is doing more work per pixel exactly as the frame starts
- * taking them.
+ * console runs edge to edge.
+ *
+ * `md` (768px) is the obvious candidate and it is the wrong one. That is where
+ * the sidebar becomes an overlay sheet, so a frame that survived down to it
+ * would be a border drawn around a single column — useless, and useless for
+ * the whole 768–1024 band on the way there.
+ *
+ * 1024 is where the inset starts to *cost* instead of give. With the sidebar
+ * expanded (13.5rem) the working column is 779px at 1024 and 523px at 768; the
+ * frame's 24px is 3% of the first and 4.6% of the second, taken from a column
+ * that by then is the only one left. Turning the frame off at `lg` means it is
+ * never on while the console is already short of width — which is the whole
+ * argument for having a breakpoint at all.
  * ========================================================================== */
 
 :root {

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -185,10 +185,14 @@ export function Overview({ client, company }: Props) {
   const memoryGraph = useMemo(() => buildMemoryGraph(sources.memories), [sources.memories]);
 
   return (
-    // The whole viewport: the shell hides its top bar for this view, so there
-    // is nothing above to subtract.
+    // The whole working column: the shell hides its top bar for this view, so
+    // there is nothing above to subtract. `flex-1` rather than `h-svh` — the
+    // app frame is inset from the top of the window (issue #1178), so a
+    // viewport-tall box overflows its slot by exactly the frame's inset and
+    // the shell's `overflow-hidden` clips the bottom of the graph off with no
+    // scrollbar to say so.
     <div
-      className="oc-kg relative h-svh min-h-0 w-full min-w-0 overflow-hidden"
+      className="oc-kg relative min-h-0 w-full min-w-0 flex-1 overflow-hidden"
       // The guided tour's Overview stop anchors here. It used to spotlight the
       // quick-action row this page had before it became the graph; the graph is
       // the page now, so the graph is what gets spotlighted.

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -203,6 +203,10 @@ const BRAND_STEPS = [
 ] as const;
 
 const SURFACE_TOKENS = [
+  // Furthest back first, which is also the order the eye meets them: the
+  // ground is outside the app frame, the canvas is the working column, and
+  // a card is the closest thing to the operator (issue #1178).
+  { name: "app-ground", cls: "bg-app-ground" },
   { name: "background", cls: "bg-background" },
   { name: "card", cls: "bg-card" },
   { name: "popover", cls: "bg-popover" },

--- a/frontend/test/e2e/app-frame.spec.ts
+++ b/frontend/test/e2e/app-frame.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Issue #1178: the console is an object inset inside the window, not a
+ * wallpaper that runs to its edges.
+ *
+ * **Geometry is the assertion.** The frame is three numbers and a breakpoint —
+ * an inset on three sides, a radius, and a border, all of which collapse to
+ * zero below `lg` — and every one of them is a thing a stylesheet edit can
+ * silently take away while the console still renders perfectly well. Reading
+ * the class names back would pass against a build where the media query never
+ * matched.
+ *
+ * Two failure modes this pins that are not obvious from a screenshot:
+ *
+ *   1. **The frame growing the document.** The ground is `100svh` with the
+ *      inset as padding, so `border-box` keeps the pair exactly one viewport
+ *      tall. Move that padding to the wrong box and the page becomes
+ *      `100svh + inset` — a document scrollbar down the side of an app that
+ *      is not supposed to scroll, and 12px of the console below the fold.
+ *   2. **A view that still thinks it owns the viewport.** `Overview` sized
+ *      itself `h-svh`, which now overflows its slot by exactly the inset and
+ *      gets clipped by the shell's `overflow-hidden` — no scrollbar, just a
+ *      graph with its bottom edge missing. Any view that reaches for a
+ *      viewport unit again fails here.
+ *
+ * The narrow case is the other half of the design and not a formality: below
+ * `lg` the frame is gone entirely, not flattened. A radius kept at zero inset
+ * rounds the corners against the window edge and lets the ground show through
+ * as two stray tinted notches; a border kept there draws a hairline down the
+ * outside of the screen.
+ */
+
+/** Dismisses the first-run tour before it can cover the app. */
+async function skipTour(page: Page) {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+}
+
+type Frame = {
+  ground: { x: number; y: number; width: number; height: number };
+  frame: { x: number; y: number; width: number; height: number };
+  radius: number;
+  borderTop: number;
+  borderBottom: number;
+  documentOverflowY: number;
+  documentOverflowX: number;
+};
+
+/** Measures the frame as the browser resolved it, not as the classes read. */
+async function measure(page: Page): Promise<Frame> {
+  return page.evaluate(() => {
+    const ground = document.querySelector("[data-slot=sidebar-ground]")!;
+    const frame = document.querySelector("[data-slot=sidebar-wrapper]")!;
+    const style = getComputedStyle(frame);
+    const box = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return { x: r.x, y: r.y, width: r.width, height: r.height };
+    };
+    const root = document.documentElement;
+    return {
+      ground: box(ground),
+      frame: box(frame),
+      radius: parseFloat(style.borderTopLeftRadius),
+      borderTop: parseFloat(style.borderTopWidth),
+      borderBottom: parseFloat(style.borderBottomWidth),
+      documentOverflowY: root.scrollHeight - root.clientHeight,
+      documentOverflowX: root.scrollWidth - root.clientWidth,
+    };
+  });
+}
+
+test("at a desktop width the console is inset on three sides and flush to the bottom", async ({
+  page,
+}) => {
+  await skipTour(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/overview");
+  await expect(page.locator("[data-slot=sidebar-wrapper]")).toBeVisible();
+
+  const m = await measure(page);
+
+  // The ground is the window. Nothing shows behind it and nothing scrolls.
+  expect(m.ground.width, "the ground fills the window").toBe(1440);
+  expect(m.ground.height, "the ground is exactly one viewport tall").toBe(900);
+  expect(m.documentOverflowY, "the frame must not grow the document").toBe(0);
+  expect(m.documentOverflowX, "the frame must not grow the document").toBe(0);
+
+  // Three sides inset by the same amount, and the fourth flush — the whole
+  // point of the shape. Vertical space is the scarcest thing in this app, so
+  // only ONE inset comes out of the height.
+  const inset = m.frame.x;
+  expect(inset, "the console is inset from the window").toBeGreaterThan(0);
+  expect(m.frame.y, "the top inset matches the side inset").toBe(inset);
+  expect(
+    m.ground.width - (m.frame.x + m.frame.width),
+    "the right inset matches the left",
+  ).toBe(inset);
+  expect(
+    m.frame.y + m.frame.height,
+    "the console runs to the bottom of the window",
+  ).toBe(m.ground.height);
+
+  // A card, not a rectangle: rounded at the two corners that are inset, and
+  // closed with an edge on the three sides that are.
+  expect(m.radius, "the inset corners are rounded").toBeGreaterThan(0);
+  expect(m.borderTop, "the inset sides carry an edge").toBeGreaterThan(0);
+  expect(m.borderBottom, "the flush side does not").toBe(0);
+});
+
+test("below lg the frame collapses to edge-to-edge rather than shrinking", async ({
+  page,
+}) => {
+  await skipTour(page);
+  // 1023: one pixel under the `lg` breakpoint the frame appears at. A width
+  // where the console still shows its full desktop sidebar, so the frame's
+  // absence here is a decision rather than a side effect of the mobile sheet.
+  await page.setViewportSize({ width: 1023, height: 800 });
+  await page.goto("/#/overview");
+  await expect(page.locator("[data-slot=sidebar-wrapper]")).toBeVisible();
+
+  const m = await measure(page);
+
+  expect(m.frame.x, "no left inset").toBe(0);
+  expect(m.frame.y, "no top inset").toBe(0);
+  expect(m.frame.width, "the console spans the window").toBe(m.ground.width);
+  expect(m.frame.height, "and its full height").toBe(m.ground.height);
+  // Not merely a thinner frame: a radius here would round the corners against
+  // the window edge, and a border would ride the outside of the screen.
+  expect(m.radius, "no radius at the window edge").toBe(0);
+  expect(m.borderTop, "no edge at the window edge").toBe(0);
+});
+
+test("the frame appears exactly at lg, and every view fits inside it", async ({ page }) => {
+  await skipTour(page);
+  await page.setViewportSize({ width: 1024, height: 800 });
+  await page.goto("/#/overview");
+  await expect(page.locator("[data-slot=sidebar-wrapper]")).toBeVisible();
+  expect((await measure(page)).frame.x, "the frame is on at lg").toBeGreaterThan(0);
+
+  // Issue #1178's regression: `Overview` sized itself to the viewport, so it
+  // overflowed its slot by the frame's inset and the shell clipped the bottom
+  // of the graph with no scrollbar to say so. Checked on the Overview because
+  // it is the one view that had a viewport unit, and it is still the widest
+  // and tallest thing the console draws.
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const m = await measure(page);
+  const graph = (await page.locator("[data-tour=overview-graph]").boundingBox())!;
+  expect(
+    graph.y + graph.height,
+    "the Overview must end at the frame's bottom, not past it",
+  ).toBeLessThanOrEqual(m.frame.y + m.frame.height + 1);
+  expect(
+    graph.x + graph.width,
+    "and inside its right edge",
+  ).toBeLessThanOrEqual(m.frame.x + m.frame.width + 1);
+});

--- a/frontend/test/e2e/app-frame.spec.ts
+++ b/frontend/test/e2e/app-frame.spec.ts
@@ -29,6 +29,12 @@ import { expect, test, type Page } from "@playwright/test";
  * rounds the corners against the window edge and lets the ground show through
  * as two stray tinted notches; a border kept there draws a hairline down the
  * outside of the screen.
+ *
+ * Both sidebar states matter now. Issue #1176 removed the auto-collapse, so
+ * the console stays in whatever state the operator left it — the frame has to
+ * hold with a 13.5rem column and with a 3rem icon rail, and the rail is the
+ * harder case because it is the narrow strip that has to keep reading as part
+ * of the app rather than as more of the ground.
  */
 
 /** Dismisses the first-run tour before it can cover the app. */
@@ -158,4 +164,39 @@ test("the frame appears exactly at lg, and every view fits inside it", async ({ 
     graph.x + graph.width,
     "and inside its right edge",
   ).toBeLessThanOrEqual(m.frame.x + m.frame.width + 1);
+});
+
+test("the frame holds with the sidebar collapsed to its icon rail", async ({ page }) => {
+  await skipTour(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/overview");
+  await expect(page.locator("[data-slot=sidebar-wrapper]")).toBeVisible();
+
+  const before = await measure(page);
+  await page.getByRole("button", { name: "Collapse", exact: true }).click();
+  // The width transition is 200ms; wait past it rather than racing the box.
+  await expect(page.locator("[data-slot=sidebar]")).toHaveAttribute(
+    "data-state",
+    "collapsed",
+  );
+  await page.waitForTimeout(400);
+
+  const after = await measure(page);
+  // The frame is the app's outline and belongs to the window, not to the
+  // sidebar. Collapsing a column inside it must not move it.
+  expect(after.frame, "collapsing the sidebar does not move the frame").toEqual(
+    before.frame,
+  );
+
+  // The icon rail is still the first thing inside the frame, and it is still
+  // inside — a rail that slipped to x=0 would be sitting on the ground.
+  const rail = (await page.locator("[data-slot=sidebar-container]").boundingBox())!;
+  expect(rail.x - after.frame.x, "the rail starts at the app's left edge").toBeLessThanOrEqual(
+    1,
+  );
+  expect(rail.width, "and it is the icon rail, not the full column").toBeLessThan(80);
+  expect(
+    rail.y + rail.height,
+    "the rail runs to the frame's flush bottom",
+  ).toBeGreaterThanOrEqual(after.frame.y + after.frame.height - 1);
 });

--- a/frontend/test/e2e/sidebar-host-switcher.spec.ts
+++ b/frontend/test/e2e/sidebar-host-switcher.spec.ts
@@ -7,8 +7,15 @@ import { expect, test } from "@playwright/test";
  * edge, and a `position: fixed` sidebar that had to be offset by 56px or it
  * slid underneath and clipped every nav label — "Company" read as "mpany".
  * Issue #1142 removed the rail and moved the choice into the sidebar's own
- * header, so the offset is gone and the assertion inverts: the sidebar now
- * starts at the left edge of the window, and nothing stands in front of it.
+ * header, so the offset went away and nothing stands in front of the sidebar.
+ *
+ * Issue #1178 then moved the line the sidebar starts on. The console is inset
+ * inside an app frame on a tinted ground, so "the left edge of the window" and
+ * "the left edge of the app" are no longer the same number, and pinning the
+ * sidebar to x=0 would now be pinning it OUTSIDE the frame — the exact bug
+ * this spec exists to catch, one frame further out. So the assertion is
+ * restated against the frame rather than the window: the sidebar starts where
+ * the app starts, and the app starts inset from the window.
  *
  * What carries over is why the spec exists at all. The broken state needed two
  * connections, and nothing else in the suite creates them — a design-system
@@ -31,7 +38,7 @@ test.beforeEach(async ({ page }) => {
 /** Must match `companies/e2e_harness/company.toml`'s `[users] admins`. */
 const ADMIN_EMAIL = "harness-e2e@tinyhumans.ai";
 
-test("the sidebar owns the left edge, and its header switches hosts", async ({
+test("the sidebar owns the frame's left edge, and its header switches hosts", async ({
   page,
   baseURL,
 }) => {
@@ -81,11 +88,32 @@ test("the sidebar owns the left edge, and its header switches hosts", async ({
   // Nothing stands to the left of the sidebar any more.
   await expect(page.getByTestId("connection-rail")).toHaveCount(0);
 
+  // The app frame, and the ground it sits on (issue #1178). The default
+  // Playwright viewport is 1280 wide, which is past the `lg` breakpoint the
+  // frame appears at, so the inset here is a real number rather than zero.
+  const ground = page.locator("[data-slot=sidebar-ground]");
+  const frame = page.locator("[data-slot=sidebar-wrapper]");
+  const groundBox = (await ground.boundingBox())!;
+  const frameBox = (await frame.boundingBox())!;
+  expect(
+    frameBox.x,
+    "the console is inset from the window, not flush against it",
+  ).toBeGreaterThan(groundBox.x);
+
   const sidebar = page.locator("[data-slot=sidebar-container]");
   await expect(sidebar).toBeVisible();
   const sidebarBox = await sidebar.boundingBox();
   expect(sidebarBox, "sidebar should have a box").not.toBeNull();
-  expect(sidebarBox!.x, "the sidebar starts at the left edge of the window").toBe(0);
+  // Inside the frame's 1px edge and nothing further: the sidebar is the first
+  // thing in the app, and the app's own border is all that precedes it.
+  expect(
+    sidebarBox!.x - frameBox.x,
+    "the sidebar starts at the left edge of the app, inside its border",
+  ).toBeLessThanOrEqual(1);
+  expect(
+    sidebarBox!.x,
+    "and the app's left edge is not the window's",
+  ).toBeGreaterThanOrEqual(frameBox.x);
 
   // And the labels are actually on screen rather than clipped — the symptom a
   // reader would report, asserted separately from the cause so a future change


### PR DESCRIPTION
Closes #1178.

The console stops being a wallpaper and becomes an object. A tinted ground fills
the window; the app sits inset inside it as one rounded card holding the sidebar
and the working column together, instead of each of them meeting the window on
its own.

Draft, because the direction is the thing to judge. The rough edges are named at
the bottom rather than left for you to find.

## The shape: inset on three sides, flush to the bottom

The issue asked for "breathing room on top, left and right", and I took that
literally rather than as shorthand for a margin. Three reasons:

- **Vertical space is the scarcest thing here.** Chat's composer, the ledgers
  board and the workflows canvas all want every pixel of height, and a bottom
  gutter costs each of them twice — once for the gap and once for the corner
  radius above it. Only one inset comes out of `100svh`, not two.
- **A card that meets the bottom edge still reads as an object.** The three
  edges that *are* inset are the three the eye tracks. It is what Slack and the
  macOS sidebar apps the reference is drawn from do.
- **On the desktop it is free.** A macOS window rounds its own bottom corners,
  so the OS supplies the radius our card deliberately does not draw.

| Token | ≥ `lg` | ≥ `2xl` | Below `lg` |
| --- | --- | --- | --- |
| `--app-frame-inset` | 12px | 18px | 0 |
| `--app-frame-radius` | 14px | 14px | 0 |
| `--app-frame-border` | 1px | 1px | 0 |

All three collapse together, and that mattered: my first pass kept the radius at
zero inset and the corners rounded *against the window edge*, letting the ground
show through as two stray tinted notches. Below `lg` there is no frame — not a
flattened one.

## Where the colour lives

One new rung on the surface ladder, `ground`, and it is the only rung that is not
inside the app.

| | Light | Dark |
| --- | --- | --- |
| `--app-ground` | `#EBE7F7` (L 0.936, C 0.022) | `#15131B` (L 0.193, C 0.017) |
| `--app-frame-edge` | rung `4` `#DADAE5` | rung `bg` `#08090B` |

**It is the most chromatic neutral in the system, on purpose.** It is the one
surface that carries no text, no stroke and no control, so nothing on it can be
harmed by a tint — and a grey there reads as an empty margin rather than as a
ground the app is standing on. Hue 296.5° in both themes, ~10° warmer than the
neutral ladder's 285–286°.

**On "warm paper": I went as warm as this palette honestly goes, and no
further.** A genuinely warm ground (amber, 70–90°) would put a second hue family
into a console that owns exactly one, and it would go muddy precisely where it
meets the cool greys — at the frame's edge, which is the only place this colour
is ever seen against another. So the ground takes the brand's own hue, pushed
warm within the family and dropped to near-neutral chroma. It reads as tinted
paper rather than as violet.

**The two themes take opposite sides of their canvas, and that is the real
decision.** Light sits a step *below* the canvas (0.936 vs 0.978), so the app
stays the brightest thing on screen. Dark sits a step *above* it (0.193 vs
0.140), because there is no rung left below near-black: darker is `#000`, and at
that lightness the chroma is invisible, so "the ground" would read as nothing at
all — the "lighter black" the issue warned about, in its other form. Going up
also gives the shadow something to fall on, which is the first time in dark mode
this system has had that. The rule that surfaces climb toward the viewer governs
panels stacked *inside* the app; the window ground is not in that stack.

`--app-frame-edge` is `--border` in light but the *canvas* value in dark. In dark
the ground is lighter than the app, so rung 4 (`#161719`) sits between the two
and reads as a third surface wedged into the seam; the canvas value disappears
against the content it borders and stays a dark line against the ground and the
sidebar. A raised edge on a dark screen is an absence of light, not a stroke.

## The judgement call you may want to veto: `--sidebar` moves to rung 2

Light mode's sidebar was rung 1, pure white — one step *above* the canvas beside
it — while the stylesheet's own comment on that line claimed it was "slightly
recessed from the canvas so the working area is the brightest thing on screen".

Nothing depended on the contradiction until the app gained a ground. Now there is
a ladder running from the window inward and it has to be monotonic, or the frame
reads as three unrelated greys rather than as an app sitting on a desk:

```
light   ground #EBE7F7 → sidebar #F1F1F8 → canvas #F7F7FC → card #FFFFFF
dark    ground #15131B → sidebar #0C0D0F → canvas #08090B → card #0C0D0F
```

Dark already ran in the right order. Light is the theme that was inverted, and
one value fixes it. It is also the half of the reference that the frame alone
does not deliver — "the main column is a near-white panel set inside the tint".

**No contrast regression is possible**, because rung 2 sits *between* two grounds
the ink ramp was already tuned against:

| Ground | primary | secondary | tertiary | hint | muted |
| --- | --- | --- | --- | --- | --- |
| canvas `#F7F7FC` | 18.44 | 9.04 | 7.38 | 6.09 | 5.05 |
| **sidebar `#F1F1F8`** | **17.51** | **8.58** | **7.01** | **5.79** | **4.79** |
| active `#ECE9FC` (documented worst case) | 16.53 | 8.10 | 6.62 | 5.46 | 4.52 |

This is one line and fully reversible. Say the word and it goes back.

## The breakpoint: `lg` (1024px)

`md` (768px) is the obvious candidate and it is the wrong one: that is where the
sidebar becomes an overlay sheet, so a frame surviving down to it would be a
border drawn around a single column — useless, and useless for the whole
768–1024 band on the way there.

1024 is where the inset starts to *cost* instead of give. With the sidebar
expanded (13.5rem) the working column is 779px at 1024 and 523px at 768; the
frame's 24px is 3% of the first and 4.6% of the second, taken from a column that
by then is the only one left. Turning it off at `lg` means the frame is never on
while the console is already short of width — which is the whole argument for
having a breakpoint at all.

## Scroll containers

The shell was already a pure flex chain rooted at one `h-svh`, so most surfaces
absorbed a shorter viewport for free. Two things needed doing, and one thing
needed checking:

- **The sidebar was `position: fixed` against the *viewport*.** That is what an
  inset frame cannot have — 0 and "the left edge of the app" stopped being the
  same number, and the column stood outside the frame. It is now `absolute`
  against the frame. I deliberately did *not* make the frame a containing block
  for `fixed` (a `transform` or `contain: paint` would do it): that recaptures
  every other fixed descendant with it — toasts, the tour overlay, any dialog
  that is not portalled — and clips them to the frame.
- **`Overview` sized itself `h-svh`** and was the only view that did. It
  overflowed its slot by exactly the inset and the shell's `overflow-hidden`
  clipped the bottom of the graph off with no scrollbar to say so. Now
  `flex-1 min-h-0`, and pinned by a test.
- **Checked and unchanged:** the ledgers board (scrolled to its far right,
  including #1121's collapsing columns), the workflows canvas with the run
  rail open, chat's timeline, settings' nav, and the workspace tree. At 1440 in
  both themes I walked the DOM for any element whose box escapes the frame —
  the only hits are the frame's own ancestors. `documentScrollWidth/Height`
  overflow is 0 at every width from 768 to 1600.

## The desktop shell — partially verified, and I will say where it stops

I built and launched the real Tauri window rather than reasoning from the config
alone. What I could confirm:

- The window is 1280×900 with `minWidth: 960`, and the accessibility tree
  reports the webview at the full window size with the traffic lights at the top.
- `decorations` and `titleBarStyle` are both unset, so the default is a standard
  visible title bar and the webview does **not** extend under it. Structurally
  there is one system separator, then 12px of ground, then our 1px hairline —
  a gap between two lines, which is not a double border.
- At the default 1280 the frame is on; at the 960 minimum it collapses to
  edge-to-edge. Screenshots of both are below.

**What I could not test: the actual pixels.** Screen recording is denied in this
environment (`screencapture` fails with "could not create image from display"),
so I could not photograph the boundary between the native title bar and the
frame. The specific thing I am unsure about is stated in the rough edges below.

## Screenshots

In the scratchpad, not the repo:
`/private/tmp/claude-504/.../scratchpad/wt5-1178/shots/`

Taken on the merged head. `upstream/main` moved twice under this branch and both
moves touched the chrome I was designing against — **#1176** removed the
auto-collapse (so the sidebar now stays wherever the operator left it), **#1174**
put the host switcher in the sidebar header, and **#1172** took Pages out of the
nav. Every shot below is after all three.

**40 shots: 5 views × 2 themes × 2 widths × 2 sidebar states.**
`f-<view>-<theme>-<width>[-collapsed].png`

Views: `overview`, `chat`, `workflows`, `ledgers`, `settings`.
Widths: `1440` (frame on) and `820` (frame off).
Sidebar: expanded (no suffix) and `-collapsed` (the 3rem icon rail).

What each one is for:

- **Overview** — the knowledge graph, which is the only full-bleed view and the
  one that had `h-svh`. Its legend sits flush to the frame's bottom edge; if the
  clipping regression came back this is where you would see it.
- **Chat** — three columns inside one frame (shell nav, channel rail, timeline),
  composer flush to the bottom. This is where the step from the ground into the
  work reads most clearly: tinted ground → rung-2 sidebar → near-white rail →
  canvas.
- **Workflows** — a workflow open with the run-history rail showing. Rail and
  canvas both run the full height of the frame; the canvas keeps ~880px beside
  the rail at 1440, well over the 640px floor `workflow-run-history-rail.spec.ts`
  pins. At 820 the rail correctly falls back to a strip under the canvas.
- **Ledgers** — the board. Also `f-board-end-<theme>.png`, scrolled to its far
  right, where Done is a full column ending inside the frame's inner edge rather
  than against the window's.
- **Settings → General** — the densest column arithmetic in the console: shell
  nav, settings nav, and content, all inside the frame.

At **820** every one of these is edge to edge — no ground, no radius, no border.
The frame is gone, not thinned.

Detail and shell shots:

- `d-tl-light.png` / `d-tl-dark.png` — the top-left corner at 3×, where the
  radius, the hairline and the ground → sidebar → canvas step are all legible.
- `f-workspace-light.png` / `-dark.png` — the workspace tree.
- `f-tauri-default-1280.png`, `f-tauri-min-960.png` — the frame at Tauri's
  default window width and at its minimum, i.e. either side of the breakpoint.
- `ov-tour.png`, `ov-dialog.png` — the first-run tour and a dialog, both
  portalled, both still centred on the window and above the frame.

## What I am unsure about

1. **The macOS title-bar boundary, in light mode.** The light ground `#EBE7F7`
   is close in lightness to the macOS light title bar. The 12px band may read as
   part of the window chrome rather than as the app's ground, which would make
   the console look like it simply starts lower. I could not photograph this.
   If it lands badly, the fix is one value, not a redesign.
2. **12px may be too quiet.** At 1440 the ground is present but modest. I chose
   restraint over a band you cannot miss, on the grounds that this is chrome and
   not content — but this is exactly the sort of thing to have an opinion about
   from the screenshots.
3. **The active nav row is softer in light mode.** `--sidebar-accent` (`#ECE9FC`)
   against rung 2 rather than white is a smaller step in the fill. The brand-hued
   label (6.90:1) still carries it, but if the row reads weak, bumping
   `--sidebar-accent` toward `--brand-100` is the follow-up.
4. **The ReactFlow minimap** sits at the bottom-right of the workflows canvas and
   its lower edge is close to the frame's. It looks the same as it did before
   this change, so I have left it, but it is the one control that lives where the
   frame's flush bottom edge is.
5. **The collapsed sidebar is the weakest case in light mode, and #1176 made it
   a state people stay in.** The icon rail is 3rem wide and painted rung 2
   (`#F1F1F8`) against a ground of `#EBE7F7` — 0.024 apart in lightness, which
   reads fine across a 13.5rem column and has very little area to register in
   across a 48px strip. Compare `f-overview-light-1440.png` with
   `f-overview-light-1440-collapsed.png`: in the second the console arguably
   reads as starting at the canvas rather than at the rail.

   **Dark does not have this problem** — there the ground is *lighter* than the
   app, so the collapsed rail is the darker of the two and separates cleanly
   (`f-workflows-dark-1440-collapsed.png`). If light needs fixing, the honest
   fix is to open the gap between the ground and rung 2 rather than to
   special-case the rail, and that is a one-value change to
   `--surface-light-ground`.

Taken on the merged head, after `upstream/main` moved under me — #1176 landed
while I was working, so the sidebar no longer auto-collapses on Chat and these
shots show it expanded.

## Commands run

```
frontend: npm run typecheck · typecheck:unit · typecheck:e2e · npm test (130 files, 1268 tests)
          npm run build
          npx playwright test app-frame sidebar-host-switcher board-drag board-columns \
              workflow-list-columns workflow-run-history-rail tour-popover-in-viewport \
              sidebar-toggle-reachable
root:     scripts/ci/assert-design-tokens.sh · scripts/ci/assert-md-line-cap.sh
tauri:    cargo build (src-tauri) and launched the window
```

### Tests updated, and why

- **`sidebar-host-switcher.spec.ts`** — asserted `sidebar.x === 0`. That was the
  right assertion when the window edge and the app edge were the same line; now
  it would pin the sidebar *outside* the frame, which is the exact bug the spec
  exists to catch, one frame further out. Restated against the frame: the app is
  inset from the window, and the sidebar starts at the app's left edge inside its
  1px border. **Tighter, not looser** — it now checks two facts where it checked
  one, and it reads the frame's real box rather than a magic 13.
- **`app-frame.spec.ts`** — new, four cases. Pins the three insets and the flush
  bottom, the collapse at `lg` (1023 vs 1024), that the frame never grows the
  document, that no view overflows it, and — because #1176 landed mid-branch —
  that collapsing the sidebar to its icon rail does not move the frame or let
  the rail slip onto the ground. Geometry is the assertion because geometry is
  what a stylesheet edit can silently take away while the console still renders
  fine.

Everything else passed unchanged: `board-drag`, `board-columns`,
`workflow-list-columns`, `workflow-run-history-rail`,
`tour-popover-in-viewport`, `sidebar-toggle-reachable`.
