### PR TITLE
feat(chat): a "Just chatting" intent that withholds the card (#1152)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,7 +7,7 @@
 //     and calls use `/api/v1/companies/{id}/*`.
 
 import type { ConsoleConfig } from "../config";
-import type { TaskDeliverable } from "./tasks";
+import type { MessageIntent } from "./tasks";
 import { defaultTransport, needsCarriedSession } from "./transport";
 import type { StreamHandlers, Transport, TransportResponse } from "./transport";
 import {
@@ -423,20 +423,29 @@ export class OpenCompanyClient {
      */
     parent?: string | null,
     /**
-     * The once-vs-workflow choice for the card this line opens (issue #580).
-     * Only `"workflow"` reaches the wire: `"once"` (and the default) is sent as
-     * *nothing at all*, so an ordinary message keeps the exact body shape it had
-     * before #580 — the same omitted-field compatibility rule the deliverable
-     * field follows everywhere (see `CreateTask.deliverable`).
+     * What this message is for (issues #580, #845, #1152): `"once"` and
+     * `"workflow"` say what the card it opens produces, `"chat"` says it is not
+     * a request for work and no card should be opened for it.
+     *
+     * Everything except `"once"` reaches the wire; `"once"` and the default are
+     * sent as *nothing at all*. That is what keeps "Do it once" the default: an
+     * unmarked message posts the exact body shape it posted before any of these
+     * controls existed, so the host cannot tell one from a pre-#580 client —
+     * the same omitted-field compatibility rule the deliverable field follows
+     * everywhere (see `CreateTask.deliverable`).
+     *
+     * One key, not two. `"chat"` rides `deliverable` rather than arriving as a
+     * second `intent` field, so a body cannot claim "build me the workflow" and
+     * "just chatting" about the same message.
      */
-    deliverable?: TaskDeliverable,
+    intent?: MessageIntent,
   ): Promise<ChatResponse> {
-    const body: { text: string; chat?: string; parent?: string; deliverable?: TaskDeliverable } = {
+    const body: { text: string; chat?: string; parent?: string; deliverable?: MessageIntent } = {
       text,
     };
     if (chat) body.chat = chat;
     if (parent) body.parent = parent;
-    if (deliverable === "workflow") body.deliverable = deliverable;
+    if (intent && intent !== "once") body.deliverable = intent;
     return this.request<ChatResponse>("POST", `${this.scope(company)}/chat`, body);
   }
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -203,6 +203,24 @@ export interface AssigneeCandidate {
  */
 export type TaskDeliverable = "once" | "workflow";
 
+/**
+ * What the operator says one chat **message** is for (issue #1152).
+ *
+ * The two work words mean exactly what they mean on a card. `"chat"` is the
+ * operator saying this message is not a request for work at all — the composer's
+ * "Just chatting" — so no deterministic path opens a card for it.
+ *
+ * Deliberately **not** a widening of `TaskDeliverable`. That type is the card
+ * field, shared by `CreateTask`, `TaskPatch` and `TaskDto`, and a card can never
+ * *be* "not work": widening it would make `"chat"` assignable in every one of
+ * those positions and put the compiler on the wrong side of the invariant. This
+ * is message-scoped, and the host draws the same line (`MessageIntent` beside
+ * `TaskDeliverable` in `src/ports/types.rs`).
+ *
+ * Sent only when it is not the default — see `OpenCompanyClient.chat`.
+ */
+export type MessageIntent = "chat" | TaskDeliverable;
+
 /** A positive source-currency USD amount or an explicit role-redacted state. */
 export interface TaskCost {
   amountUsd?: number;

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -13,7 +13,7 @@ import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
-import type { TaskDeliverable } from "@/api/tasks";
+import type { MessageIntent } from "@/api/tasks";
 import { setInboxEnabled } from "@/api/inbox";
 import {
   ApiError,
@@ -624,7 +624,7 @@ export function ChatView({
    * cannot resolve — the row's own actions are disabled in that window, so this
    * is the belt to that brace.
    */
-  async function send(text: string, deliverable?: TaskDeliverable, parentId?: string) {
+  async function send(text: string, intent?: MessageIntent, parentId?: string) {
     if (sending) return;
     const target = active.id;
     const chatId = activeThreadId;
@@ -642,7 +642,7 @@ export function ChatView({
         company,
         chatId,
         toHostMessageId(parentId),
-        deliverable,
+        intent,
       );
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
@@ -905,11 +905,12 @@ export function ChatView({
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}
-              onSend={(text, deliverable) => void send(text, deliverable)}
-              // Channel *and* DM composers offer "do it once" vs "build me the
-              // workflow" (issues #580, #845) — see `offersDeliverableChoice`,
-              // which owns the rule. Only the thread and copilot composers below
-              // go without.
+              onSend={(text, intent) => void send(text, intent)}
+              // Channel *and* DM composers offer "just chatting" / "do it once" /
+              // "build me the workflow" (issues #580, #845, #1152) — see
+              // `offersDeliverableChoice`, which owns the rule and is unchanged:
+              // the new position inherits the same channel+DM gating. Only the
+              // thread and copilot composers below go without.
               deliverableChoice={offersDeliverableChoice(active.kind)}
             />
           </div>

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -13,23 +13,24 @@ import {
   Strikethrough,
 } from "lucide-react";
 
-import type { TaskDeliverable } from "@/api/tasks";
+import type { MessageIntent } from "@/api/tasks";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface Props {
   placeholder: string;
   disabled?: boolean;
-  onSend: (text: string, deliverable?: TaskDeliverable) => void;
+  onSend: (text: string, intent?: MessageIntent) => void;
   /** Compact form, for the narrower thread panel. */
   compact?: boolean;
   /**
-   * Show the once-vs-workflow control (issue #580), opt-in per composer.
+   * Show the what-is-this-message-for control (issues #580, #1152), opt-in per
+   * composer.
    *
    * The channel and DM composers ask for it — either can open a board card, so
-   * "do it once" versus "build me the workflow" belongs at both prompt boxes.
-   * The thread and copilot composers never carry it, so their `onSend` stays a
-   * plain `(text)` and their wire shape is unchanged.
+   * "just chatting" versus "do it once" versus "build me the workflow" belongs
+   * at both prompt boxes. The thread and copilot composers never carry it, so
+   * their `onSend` stays a plain `(text)` and their wire shape is unchanged.
    *
    * DMs were omitted when #580 landed (issue #845). Nothing downstream was
    * scoped to channels — the chat route reads `deliverable` off the payload
@@ -64,10 +65,15 @@ export function MessageComposer({
   deliverableChoice,
 }: Props) {
   const [draft, setDraft] = useState("");
-  // The once-vs-workflow choice for the NEXT line only. It resets to "once"
-  // after every send so a workflow request never silently carries into the
-  // ordinary message after it — each build is an explicit, per-line decision.
-  const [deliverable, setDeliverable] = useState<TaskDeliverable>("once");
+  // What the NEXT line is for, and only the next one. It resets to "once"
+  // after every send so neither a workflow request nor a "just chatting" mark
+  // silently carries into the message after it — each is an explicit, per-line
+  // decision.
+  //
+  // "once" is the initial value, and stays it (issue #1152): "Just chatting" is
+  // a third position, not the new default, so an unmarked message is
+  // byte-identical on the wire to one sent before this control existed.
+  const [intent, setIntent] = useState<MessageIntent>("once");
   // The formatting row is opt-in, behind the `Aa` toggle in the icon row. It
   // used to sit open above every composer, which spent the widest strip of the
   // dock on four buttons most lines never use.
@@ -78,8 +84,8 @@ export function MessageComposer({
     const text = draft.trim();
     if (!text || disabled) return;
     setDraft("");
-    onSend(text, deliverableChoice ? deliverable : undefined);
-    setDeliverable("once");
+    onSend(text, deliverableChoice ? intent : undefined);
+    setIntent("once");
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -168,10 +174,19 @@ export function MessageComposer({
             <div
               className="mr-1 flex items-center gap-0.5 rounded-lg border p-0.5"
               role="group"
-              aria-label="What this should produce"
+              // Issue #1152: the group no longer only asks what the message
+              // should *produce* — "Just chatting" produces nothing — so it asks
+              // what the message is for.
+              aria-label="What this message is for"
             >
               {(
                 [
+                  // "Just chatting" leads, because it is the position that
+                  // withholds: the operator reaches for it to stop something
+                  // happening, and a control you press to prevent an action
+                  // belongs before the ones that cause it. It is NOT pre-pressed
+                  // — "Do it once" stays the default.
+                  { value: "chat", label: "Just chatting" },
                   { value: "once", label: "Do it once" },
                   { value: "workflow", label: "Build me the workflow" },
                 ] as const
@@ -179,12 +194,12 @@ export function MessageComposer({
                 <button
                   key={option.value}
                   type="button"
-                  aria-pressed={deliverable === option.value}
-                  onClick={() => setDeliverable(option.value)}
+                  aria-pressed={intent === option.value}
+                  onClick={() => setIntent(option.value)}
                   data-testid={`composer-deliverable-${option.value}`}
                   className={cn(
                     "rounded-md px-2 py-1 text-2xs font-medium transition-colors",
-                    deliverable === option.value
+                    intent === option.value
                       ? "bg-primary text-primary-foreground"
                       : "text-muted-foreground hover:text-foreground",
                   )}

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -50,6 +50,7 @@ backend, and there is no per-channel routing on the host.
 | Threads | A reply posts its `parent` — the parent message's own id — and comes back under it. Both halves of the exchange hang off the row the thread opened from. |
 | Reactions | One durable row per person per emoji, so a chip says who reacted and whether one of them was you. `POST {scope}/chat/messages/{seq}/reactions` with an explicit `on`, which makes a retry idempotent. |
 | Message ids | A sent message comes back with the id it was journaled under (`messageId`), which is what a thread reply or a reaction names. Until the id lands the row's reply/react actions are disabled and say why. |
+| Message intent | The composer's three positions — "Just chatting" / "Do it once" / "Build me the workflow" — travel as `deliverable` on the message and are journaled with it. Only a non-default value is sent, so an unmarked line is byte-identical on the wire to a pre-#580 one. `chat` withholds the card the host would otherwise open by construction; it does **not** take the orchestrator's own `spawn_task` away, so it means "not automatically carded", not "never carded". |
 
 **Still console-local:**
 

--- a/frontend/test/unit/chat-deliverable-choice.test.ts
+++ b/frontend/test/unit/chat-deliverable-choice.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { OpenCompanyClient } from "@/api/client";
+import type { MessageIntent } from "@/api/tasks";
 import type { ChannelKind } from "@/views/chat/model";
 import { offersDeliverableChoice } from "@/views/chat/model";
 
@@ -34,5 +36,81 @@ describe("offersDeliverableChoice", () => {
     for (const kind of kinds) {
       expect(typeof offersDeliverableChoice(kind)).toBe("boolean");
     }
+  });
+});
+
+/**
+ * A client whose transport records the body of every request it is handed.
+ *
+ * The rule under test is what the console *omits*, and that is only observable
+ * on the wire — a fake `client.chat` would be asserting against a second copy of
+ * the rule rather than against the one that ships.
+ */
+function recordingClient() {
+  const bodies: Array<Record<string, unknown>> = [];
+  const transport = {
+    request: async (req: { method: string; url: string; body?: string }) => {
+      bodies.push(req.body === undefined ? {} : JSON.parse(req.body));
+      return {
+        status: 200,
+        statusText: "OK",
+        url: req.url,
+        text: JSON.stringify({ responses: [] }),
+        header: () => null,
+      };
+    },
+    subscribe: () => () => {},
+  };
+  const client = new OpenCompanyClient(
+    { baseUrl: "", company: "acme", operatorToken: "t0ken", sessionHeader: null },
+    transport as never,
+  );
+  return { client, bodies };
+}
+
+async function chatBody(intent?: MessageIntent) {
+  const { client, bodies } = recordingClient();
+  await client.chat("morning all", "acme", null, null, intent);
+  return bodies[0];
+}
+
+/**
+ * Issue #1152: the wire rule for the composer's third position.
+ *
+ * The operator could already override the classifier upward — "Build me the
+ * workflow" mints a card it declined — and had no way to override it downward.
+ * `"chat"` is that control, and these pin the only thing the console decides
+ * about it: which values reach the body.
+ *
+ * The omission half is the compatibility guarantee. "Do it once" is the default
+ * *because nothing is sent for it*, so an unmarked message posts a body
+ * byte-identical to one from a console that predates every one of these
+ * controls — which is what lets the host treat an absent field as "no choice"
+ * rather than having to tell two kinds of client apart.
+ */
+describe("client.chat — what the composer's choice puts on the wire", () => {
+  it("sends the new chat intent explicitly, under the existing key", async () => {
+    expect(await chatBody("chat")).toEqual({ text: "morning all", deliverable: "chat" });
+  });
+
+  it("omits the key entirely for `once` — the default is silence, not a value", async () => {
+    expect(await chatBody("once")).not.toHaveProperty("deliverable");
+  });
+
+  it("omits the key entirely when no choice was expressed", async () => {
+    expect(await chatBody(undefined)).toEqual({ text: "morning all" });
+  });
+
+  it("still sends `workflow`, unchanged from #580", async () => {
+    expect(await chatBody("workflow")).toEqual({ text: "morning all", deliverable: "workflow" });
+  });
+
+  /**
+   * One key, not two. A `{deliverable, intent}` pair would let a body claim
+   * "build me the workflow" and "just chatting" about the same message — the
+   * split brain #1035 closed, pointed the other way.
+   */
+  it("never puts a second intent field beside the deliverable", async () => {
+    expect(await chatBody("chat")).not.toHaveProperty("intent");
   });
 });

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2806,11 +2806,13 @@ impl HarnessBrain {
                     let record = self.record();
                     let turn = self
                         .delegation_runner(&run_turn, &record)
-                        // Issue #1035: the operator's own statement of what this
-                        // message is for. The REST handler already acts on it;
-                        // until now the runtime never saw it, so it could not
-                        // tell a message the handler had carded from one it had
-                        // not.
+                        // Issues #1035 / #1152: the operator's own statement of
+                        // what this message is for. The REST handler already
+                        // acts on it; until #1035 the runtime never saw it, so
+                        // it could not tell a message the handler had carded
+                        // from one it had not — and since #1152 it also carries
+                        // "this is not work", which the runtime has to honour or
+                        // the console's promise holds on one surface only.
                         .requested(*deliverable)
                         .handle_operator_message(&responder, text, chat_id)
                         .await?;

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -204,6 +204,77 @@ pub enum Verdict {
     Deny,
 }
 
+/// What the operator says one chat message is **for** (issue #1152).
+///
+/// # Why this is not a third `TaskDeliverable`
+///
+/// [`TaskDeliverable`](crate::ports::tasks::TaskDeliverable) answers a question
+/// about a **card**: once the work exists, does doing it produce a one-off
+/// result or a reusable workflow. This answers the question one step earlier —
+/// whether the message is a request for work at all. A card can never *be* "not
+/// work", so a third `TaskDeliverable` variant would be
+/// representable-but-invalid in every position that field is stored and read
+/// (`TaskRecord::deliverable`, the builder pass's dispatch check, the console's
+/// task edit dialog), and every one of those readers would owe a branch for a
+/// state that cannot occur.
+///
+/// [`deliverable`](Self::deliverable) returning `None` for [`Chat`](Self::Chat)
+/// is that same statement, made in the type: no card, therefore no deliverable
+/// to choose.
+///
+/// # The operator chooses; nothing guesses
+///
+/// Like `TaskDeliverable` (decision D2a of issue #580), this is only ever set
+/// from an explicit control a person pressed. Nothing reads a message and
+/// decides it "looks like chatter" — that judgement already exists one layer
+/// down, as the lexical triage (issue #267) and the model escalation (issue
+/// #984), and this is deliberately not a third one of those. It is the person's
+/// own statement about their own message, settled before any model runs.
+///
+/// Additive on the wire: the two work values are the exact `TaskDeliverable`
+/// words, so every `deliverable` value ever journaled on a
+/// [`CompanyEvent::OperatorMessage`] still deserializes, and a message that
+/// carried no choice still serializes with the field absent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageIntent {
+    /// Not a request for work — the composer's "Just chatting". No
+    /// deterministic path opens a card for this message.
+    Chat,
+    /// A request for work, done once. The historical default: identical in
+    /// behaviour, and on the wire, to a message that expressed no choice.
+    Once,
+    /// A request for work, built as a reusable workflow. The card it opens
+    /// routes through the builder pass.
+    Workflow,
+}
+
+impl MessageIntent {
+    /// The deliverable a card opened for this message carries, or `None` when
+    /// the operator said the message asks for no card at all.
+    pub fn deliverable(self) -> Option<crate::ports::tasks::TaskDeliverable> {
+        match self {
+            Self::Chat => None,
+            Self::Once => Some(crate::ports::tasks::TaskDeliverable::Once),
+            Self::Workflow => Some(crate::ports::tasks::TaskDeliverable::Workflow),
+        }
+    }
+
+    /// Whether the operator stated this message is not a request for work.
+    pub fn is_chat(self) -> bool {
+        matches!(self, Self::Chat)
+    }
+
+    /// The wire word, for a log line or a note a person reads.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::Once => "once",
+            Self::Workflow => "workflow",
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Events
 // ---------------------------------------------------------------------------
@@ -255,9 +326,10 @@ pub enum CompanyEvent {
         /// terms above, so no stored record migrates.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent: Option<EventSeq>,
-        /// The composer's once-vs-workflow choice for this message (issue #845),
-        /// as the operator set it — [`TaskDeliverable::Workflow`] when they
-        /// picked "Build me the workflow".
+        /// What the operator's composer said this message is **for** (issues
+        /// #845, #1152), as they set it — [`MessageIntent::Workflow`] when they
+        /// picked "Build me the workflow", [`MessageIntent::Chat`] when they
+        /// picked "Just chatting".
         ///
         /// Carried on the event because the cycle is the only place that holds
         /// both this fact and the turn about to answer, and without it the turn
@@ -269,12 +341,20 @@ pub enum CompanyEvent {
         /// [`CompanyRuntime::inject_workflow_builder_awareness`](crate::company::runtime::CompanyRuntime)
         /// reads this to tell the turn who owns the authoring.
         ///
+        /// Typed [`MessageIntent`] rather than
+        /// [`TaskDeliverable`](crate::ports::tasks::TaskDeliverable) since
+        /// #1152, because the operator can now say the message is not a request
+        /// for work at all — which is a statement about the *message*, not a
+        /// choice of what a card produces. The field keeps its name and its wire
+        /// key: one operator choice, one field, so `{"deliverable":"workflow"}`
+        /// and "just chatting" cannot both be asserted about one message.
+        ///
         /// `None` means the caller expressed no choice — every message journaled
         /// before this field existed, and every non-chat producer. Additive on
-        /// exactly the `by` / `chat` / `parent` terms above, so no stored record
-        /// migrates.
+        /// exactly the `by` / `chat` / `parent` terms above, and the two work
+        /// words are unchanged, so no stored record migrates.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        deliverable: Option<crate::ports::tasks::TaskDeliverable>,
+        deliverable: Option<MessageIntent>,
     },
     /// A turn was **accepted** for an operator message (issue #983) — the
     /// transcript line that says the company took the work on.
@@ -4346,6 +4426,141 @@ mod test {
         assert_eq!(
             serde_json::from_str::<CompanyEvent>(&json).unwrap(),
             attributed
+        );
+    }
+
+    /// The three intents are exactly the three wire words, and only those
+    /// (issue #1152).
+    ///
+    /// Pinned as literals because the console and the journal both write them:
+    /// a rename here silently stops matching every message already on disk.
+    #[test]
+    fn a_message_intent_round_trips_through_its_wire_word() {
+        for (intent, word) in [
+            (MessageIntent::Chat, "chat"),
+            (MessageIntent::Once, "once"),
+            (MessageIntent::Workflow, "workflow"),
+        ] {
+            let json = serde_json::to_string(&intent).unwrap();
+            assert_eq!(json, format!("\"{word}\""));
+            assert_eq!(
+                serde_json::from_str::<MessageIntent>(&json).unwrap(),
+                intent
+            );
+            assert_eq!(intent.as_str(), word);
+        }
+        assert!(
+            serde_json::from_str::<MessageIntent>(r#""build""#).is_err(),
+            "the set is closed: an unknown word is a 400, not a silent default"
+        );
+    }
+
+    /// "Just chatting" has no deliverable, and that is the whole point of the
+    /// type (issue #1152).
+    ///
+    /// A card can never *be* "not work", so the honest mapping from a `Chat`
+    /// message onto the card field is "there is no card" — `None` — rather than
+    /// a third `TaskDeliverable` variant every stored reader would owe a branch
+    /// for.
+    #[test]
+    fn only_a_work_intent_maps_onto_a_card_deliverable() {
+        use crate::ports::tasks::TaskDeliverable;
+
+        assert_eq!(MessageIntent::Chat.deliverable(), None);
+        assert_eq!(
+            MessageIntent::Once.deliverable(),
+            Some(TaskDeliverable::Once)
+        );
+        assert_eq!(
+            MessageIntent::Workflow.deliverable(),
+            Some(TaskDeliverable::Workflow)
+        );
+        assert!(MessageIntent::Chat.is_chat());
+        assert!(!MessageIntent::Once.is_chat());
+        assert!(!MessageIntent::Workflow.is_chat());
+    }
+
+    /// **No journaled record migrates** (issue #1152).
+    ///
+    /// Retyping `OperatorMessage::deliverable` from `TaskDeliverable` to
+    /// [`MessageIntent`] is only safe if every value already written under that
+    /// key still loads, and still writes back the same bytes. Getting this wrong
+    /// does not fail CI — it fails on somebody's event log, on whichever of the
+    /// three backends they run, the next time a company boots. So the claim is a
+    /// test rather than a sentence in a doc comment.
+    ///
+    /// The blobs are asserted verbatim in both directions: parsed to the value
+    /// the new type gives them, and re-serialized byte-for-byte back to what is
+    /// on disk.
+    #[test]
+    fn every_journaled_deliverable_value_still_loads_and_writes_back_identically() {
+        for (blob, expected) in [
+            (r#"{"kind":"OperatorMessage","text":"hi"}"#, None),
+            (
+                r#"{"kind":"OperatorMessage","text":"ship the landing page","deliverable":"once"}"#,
+                Some(MessageIntent::Once),
+            ),
+            (
+                r#"{"kind":"OperatorMessage","text":"build me a weekly report","deliverable":"workflow"}"#,
+                Some(MessageIntent::Workflow),
+            ),
+        ] {
+            let event: CompanyEvent = serde_json::from_str(blob).unwrap_or_else(|e| {
+                panic!("a stored line must still load: {blob} — {e}");
+            });
+            match &event {
+                CompanyEvent::OperatorMessage { deliverable, .. } => {
+                    assert_eq!(*deliverable, expected, "{blob}")
+                }
+                other => panic!("unexpected variant: {other:?}"),
+            }
+            assert_eq!(
+                serde_json::to_string(&event).unwrap(),
+                blob,
+                "a stored line must serialize back byte-for-byte"
+            );
+        }
+    }
+
+    /// The new word travels on the same key, and only when it was chosen
+    /// (issue #1152).
+    ///
+    /// The absent case is the compatibility half that matters most: "Do it
+    /// once" is not the default *because it is sent* — it is the default
+    /// because nothing is sent, so an unmarked message is byte-identical on the
+    /// wire to every message journaled before this control existed.
+    #[test]
+    fn a_chat_intent_journals_under_the_same_key_and_absence_stays_absent() {
+        let chatting = CompanyEvent::OperatorMessage {
+            text: "morning all".into(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: Some(MessageIntent::Chat),
+        };
+        assert_eq!(
+            serde_json::to_string(&chatting).unwrap(),
+            r#"{"kind":"OperatorMessage","text":"morning all","deliverable":"chat"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(
+                r#"{"kind":"OperatorMessage","text":"morning all","deliverable":"chat"}"#
+            )
+            .unwrap(),
+            chatting
+        );
+
+        let unmarked = CompanyEvent::OperatorMessage {
+            text: "morning all".into(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&unmarked).unwrap(),
+            r#"{"kind":"OperatorMessage","text":"morning all"}"#,
+            "no choice must still put nothing on the wire"
         );
     }
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -32,7 +32,8 @@ use crate::feedback::tool::SEND_EMAIL_TOOL;
 use crate::policy::gate::ResolveOutcome;
 use crate::ports::brain::{CycleHost, UsageMetering};
 use crate::ports::runs::{RunOutcome, RunStatus};
-use crate::ports::tasks::{COLUMN_TODO, TaskDeliverable, TaskRecord};
+use crate::ports::tasks::{COLUMN_TODO, TaskRecord};
+use crate::ports::types::MessageIntent;
 use crate::ports::types::{
     Actor, ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult,
     CycleRequest, Effect, EffectDisposition, EffectGroup, EventSeq, LedgerEntry, OutboundMessage,
@@ -810,7 +811,7 @@ working on):\n{}\n]",
         for event in events.iter_mut() {
             let CompanyEvent::OperatorMessage {
                 text,
-                deliverable: Some(TaskDeliverable::Workflow),
+                deliverable: Some(MessageIntent::Workflow),
                 ..
             } = event
             else {
@@ -2726,6 +2727,12 @@ mod test {
     /// desk agent answering the same message was telling the operator that it
     /// "cannot make it exist". The turn was right about its own toolset and
     /// wrong about the company, because nothing told it.
+    ///
+    /// The `chat` case is issue #1152's, and "nothing else does" is why it is
+    /// pinned here rather than assumed: a "Just chatting" message opens no card,
+    /// so there is no builder pass owning anything, so briefing the turn that a
+    /// build is under way would be telling it something untrue. The injection
+    /// matches `Workflow` exactly and this is what keeps it exact.
     #[test]
     fn only_a_workflow_message_gets_the_builder_briefing() {
         let msg = |deliverable| CompanyEvent::OperatorMessage {
@@ -2741,9 +2748,10 @@ mod test {
         };
 
         let mut events = vec![
-            msg(Some(TaskDeliverable::Workflow)),
-            msg(Some(TaskDeliverable::Once)),
+            msg(Some(MessageIntent::Workflow)),
+            msg(Some(MessageIntent::Once)),
             msg(None),
+            msg(Some(MessageIntent::Chat)),
             // A non-operator event must be left entirely alone.
             CompanyEvent::ScheduleFired {
                 cron: "0 6 * * 5".to_string(),
@@ -2764,14 +2772,18 @@ mod test {
             "{briefed}"
         );
 
-        for (i, label) in [(1, "once"), (2, "no choice")] {
+        for (i, label) in [(1, "once"), (2, "no choice"), (3, "chat")] {
             let text = text_of(&events[i]);
             assert_eq!(
                 text, "set up a weekly AEO audit",
                 "a `{label}` message must reach the brain exactly as typed"
             );
+            assert!(
+                !text.contains(BUILDER_ANNOTATION),
+                "a `{label}` message must carry no builder briefing: {text}"
+            );
         }
-        assert!(matches!(events[3], CompanyEvent::ScheduleFired { .. }));
+        assert!(matches!(events[4], CompanyEvent::ScheduleFired { .. }));
     }
 
     /// Issue #845, the wiring: the briefing actually reaches the brain.
@@ -2815,7 +2827,7 @@ mod test {
         };
 
         let workflow = rt
-            .run_cycle(vec![ask(Some(TaskDeliverable::Workflow))])
+            .run_cycle(vec![ask(Some(MessageIntent::Workflow))])
             .await
             .unwrap();
         let seen = workflow
@@ -2831,7 +2843,7 @@ mod test {
         // …and a one-off is handed through byte-for-byte, so the annotation is
         // not simply always on.
         let once = rt
-            .run_cycle(vec![ask(Some(TaskDeliverable::Once))])
+            .run_cycle(vec![ask(Some(MessageIntent::Once))])
             .await
             .unwrap();
         let seen_once = once

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -368,6 +368,22 @@ pub(crate) struct MessageContext {
     /// no escalation wired, an unparseable or slow verdict — leaves it `false`
     /// and behaves exactly as before.
     pub(crate) chatter: bool,
+    /// The **operator** said this message is not a request for work (issue
+    /// #1152) — they sent it under the composer's "Just chatting".
+    ///
+    /// A peer to [`chatter`](Self::chatter), never a reuse of it. That field is
+    /// documented as *the model's* verdict, set only where the lexical layer
+    /// abstained; this is a person's own statement about their own message,
+    /// settled before any model runs, and it holds whatever the triage read —
+    /// including a confident `Track`. Folding this into `chatter` would falsify
+    /// that doc, make the debug line attribute an operator's choice to a model
+    /// that was never asked, and put this change inside the field #984 owns.
+    ///
+    /// Subtractive only, like `chatter`: it stands the deterministic card paths
+    /// down and touches nothing else. The model's own board tools are NOT
+    /// narrowed — see [`open_work_card`](DelegationRunner::open_work_card) for
+    /// why, and what that means the label does and does not promise.
+    pub(crate) not_work: bool,
 }
 
 /// Whether a drain may run the hand-offs it finds, or must drop them.
@@ -506,9 +522,9 @@ pub(crate) struct DelegationRunner<'a> {
     /// turn, and for a dispatch whose run row could not be minted.
     run_sink: Option<Arc<RunTraceSink>>,
     /// What the operator's composer said this message is for, when they chose
-    /// (issue #1035). `None` for every path that is not an operator chat turn,
-    /// and for a message whose sender expressed no preference.
-    requested_deliverable: Option<crate::ports::tasks::TaskDeliverable>,
+    /// (issues #1035, #1152). `None` for every path that is not an operator chat
+    /// turn, and for a message whose sender expressed no preference.
+    requested_intent: Option<crate::ports::types::MessageIntent>,
     /// The cycle's approval queue, read (never written) to tell whether a turn
     /// this runner drove parked an approval (issue #465).
     ///
@@ -564,7 +580,7 @@ impl<'a> DelegationRunner<'a> {
             max_delegations,
             task: None,
             run_sink: None,
-            requested_deliverable: None,
+            requested_intent: None,
             approvals: None,
             workflow_run: None,
             workflow_refs: None,
@@ -613,7 +629,7 @@ impl<'a> DelegationRunner<'a> {
             run_sink: None,
             // A workflow run has no operator message and therefore no composer
             // choice; `None` is the only honest value here.
-            requested_deliverable: None,
+            requested_intent: None,
             approvals: None,
             workflow_run: Some(run),
             workflow_refs: None,
@@ -807,7 +823,7 @@ impl<'a> DelegationRunner<'a> {
     }
 
     /// Carries the operator's own statement of what this message is for
-    /// (issue #1035).
+    /// (issues #1035, #1152).
     ///
     /// A builder rather than a parameter on
     /// [`handle_operator_message`](Self::handle_operator_message) for the same
@@ -815,11 +831,8 @@ impl<'a> DelegationRunner<'a> {
     /// it is optional context about the turn, absent on every path that is not a
     /// person typing into the composer, and threading it as an argument would
     /// make a dozen test call sites restate `None` to say nothing.
-    pub(crate) fn requested(
-        mut self,
-        deliverable: Option<crate::ports::tasks::TaskDeliverable>,
-    ) -> Self {
-        self.requested_deliverable = deliverable;
+    pub(crate) fn requested(mut self, intent: Option<crate::ports::types::MessageIntent>) -> Self {
+        self.requested_intent = intent;
         self
     }
 
@@ -975,8 +988,8 @@ impl<'a> DelegationRunner<'a> {
         // handler had carded, and stand down the paths that were the only ones
         // left to open one. The two conditions travel together or the signal
         // lies.
-        let workflow_requested = self.requested_deliverable
-            == Some(crate::ports::tasks::TaskDeliverable::Workflow)
+        let workflow_requested = self.requested_intent
+            == Some(crate::ports::types::MessageIntent::Workflow)
             && !crate::company::copilot::is_copilot_thread(chat_id);
         // Issue #463: did the REST chat handler already card this message?
         //
@@ -987,13 +1000,33 @@ impl<'a> DelegationRunner<'a> {
         // message that went down that second road arrived here looking uncarded,
         // and the paths below opened a card beside the one it already had.
         let carded_by_handler = triage.title().is_some() || workflow_requested;
-        // Everything below that could open a card reads these two facts about
-        // the operator's message rather than re-deriving them from text that is
-        // no longer the operator's (issues #463, #267).
+        // Issue #1152: the mirror image of `workflow_requested` — the operator
+        // said this message is not a request for work at all.
+        //
+        // The REST handler honours it by opening no card. This is the other half
+        // of the same promise: the handler is not the only path that cards a
+        // chat message, so a handler-only fix would leave "Just chatting" true on
+        // an unaddressed message and false on a DM to a desk — which is worse
+        // than not shipping the control, because the label would be a promise
+        // the company keeps only sometimes.
+        //
+        // No `is_copilot_thread` term, unlike `workflow_requested` above. That
+        // one reproduces half of the handler's condition because it concludes
+        // "the handler already carded this", and on a copilot thread the handler
+        // deliberately did not. This concludes nothing about the handler — it
+        // reads the operator's own statement, which means the same thing on
+        // every thread.
+        let not_work = self
+            .requested_intent
+            .is_some_and(crate::ports::types::MessageIntent::is_chat);
+        // Everything below that could open a card reads these facts about the
+        // operator's message rather than re-deriving them from text that is no
+        // longer the operator's (issues #463, #267, #1152).
         let ctx = MessageContext {
             carded_by_handler,
             answering,
             chatter,
+            not_work,
         };
         // …and *which* card that is, when it is still on the board. Adopting it
         // is what carries "one message, one card" through the publish drain too:
@@ -1839,17 +1872,29 @@ impl<'a> DelegationRunner<'a> {
     /// that is about to run somebody's turn goes through here first, so there is
     /// no path on which work starts and the board stays empty.
     ///
-    /// Returns `None` — no card, nothing to settle — in exactly five cases:
+    /// Returns `None` — no card, nothing to settle — in exactly six cases:
     ///
     /// * **no task store wired**, the silent no-op every task path on this seam
     ///   takes;
     /// * **already inside a dispatched card** (`for_task`), which is the card;
     ///   opening a second one would double-count one piece of work;
+    /// * **the operator said this is not work** (`not_work`, issue #1152) — they
+    ///   sent the message under "Just chatting";
+    /// * **the model read this as conversation** (`chatter`, issue #984);
     /// * **the chat handler already carded this message** (`carded_by_handler`,
     ///   issue #463) — see [`handle_operator_message`](Self::handle_operator_message);
     /// * **nothing substantial was asked** — see [`is_trackable_work`]; this is
     ///   the carve-out that keeps a trivial question from minting a card;
     /// * the write failed, which propagates rather than returning `None`.
+    ///
+    /// # What `not_work` does NOT do (issue #1152)
+    ///
+    /// It stands down the paths that open a card **by construction**. The
+    /// orchestrator's own `spawn_task` tool is untouched: narrowing the board
+    /// tools would change which delegation-queue claim the turn runs under, and
+    /// "this is not a work request" is not a reason to take the company's tools
+    /// away mid-conversation. So it means the company will not *automatically*
+    /// card the message, not that a card can never appear.
     ///
     /// The write goes through the [`TaskStore`] port rather than
     /// `CompanyRuntime::upsert_task`, so landing the card straight in
@@ -1866,6 +1911,27 @@ impl<'a> DelegationRunner<'a> {
             return Ok(None);
         };
         if self.task.is_some() {
+            return Ok(None);
+        }
+        // Issue #1152: the operator said, on this message, that it is not a
+        // request for work. Nothing below gets a vote.
+        //
+        // **Above the `chatter` check on purpose.** When both are true they
+        // agree, so the order changes no outcome — but it changes what the log
+        // says happened, and the operator is the one who can be asked why. A
+        // line crediting the model for a stand-down a person asked for sends the
+        // next person debugging this to the escalation prompt instead of to the
+        // composer.
+        //
+        // One guard here rather than one per caller: all three card-opening
+        // paths funnel through this method, and #442's lesson is exactly that a
+        // stand-down placed in one caller leaves the others opening cards.
+        if ctx.not_work {
+            tracing::debug!(
+                company = %self.company,
+                assignee = %assignee,
+                "[delegation] not opening a card: the operator sent this message as chat, not work"
+            );
             return Ok(None);
         }
         // Issue #984: the model already read this as conversation, so no card.
@@ -4096,7 +4162,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         let turn = fx
             .runner(&turns)
-            .requested(Some(crate::ports::tasks::TaskDeliverable::Workflow))
+            .requested(Some(crate::ports::types::MessageIntent::Workflow))
             .handle_operator_message("engineer", residue, Some("eng_desk"))
             .await
             .expect("operator message handled");
@@ -4118,7 +4184,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     #[tokio::test]
     async fn the_same_message_without_a_composer_choice_still_cards() {
         let residue = "the pricing page copy, before Friday if you can";
-        for choice in [None, Some(crate::ports::tasks::TaskDeliverable::Once)] {
+        for choice in [None, Some(crate::ports::types::MessageIntent::Once)] {
             let fx = Fixture::new();
             let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
             fx.runner(&turns)
@@ -4149,7 +4215,7 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
         fx.runner(&turns)
-            .requested(Some(crate::ports::tasks::TaskDeliverable::Workflow))
+            .requested(Some(crate::ports::types::MessageIntent::Workflow))
             .handle_operator_message("engineer", residue, Some("workflow-copilot:weekly_report"))
             .await
             .expect("operator message handled");
@@ -4159,6 +4225,86 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             1,
             "the handler suppresses its override on a copilot thread, so this \
              message has no card yet and the runtime still owes one"
+        );
+    }
+
+    /// **Issue #1152, the direct path.** The operator said this message is not
+    /// work, so the runtime opens no card for it either.
+    ///
+    /// A handler-only fix would pass every REST test and still be wrong here.
+    /// The chat route is not the only thing that cards a chat message: this seam
+    /// opens one *by construction* whenever work is handed to an agent, and
+    /// [`is_trackable_work`]'s default is "everything is work". So "Just
+    /// chatting" would hold on an unaddressed message and fail on a message to a
+    /// desk — a label the company keeps only sometimes, which is worse than not
+    /// shipping the control.
+    ///
+    /// The fixture is the residue `the_same_message_without_a_composer_choice_still_cards`
+    /// drives, and that pairing is what makes this non-vacuous: the same words
+    /// with `None` and with `Once` open exactly one card there, so a run that
+    /// opens none here is the operator's statement doing the work rather than
+    /// the message being unremarkable.
+    #[tokio::test]
+    async fn a_message_the_operator_sent_as_chat_opens_no_direct_card() {
+        let residue = "the pricing page copy, before Friday if you can";
+        assert!(
+            crate::company::task_intent::triage_message_detailed(residue)
+                .triage
+                .title()
+                .is_none(),
+            "fixture must be a message the handler did NOT card on the triage, \
+             or `carded_by_handler` would suppress this path anyway"
+        );
+        assert!(
+            is_trackable_work(residue),
+            "and one the card detector would otherwise track, or this proves nothing"
+        );
+
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
+        let turn = fx
+            .runner(&turns)
+            .requested(Some(crate::ports::types::MessageIntent::Chat))
+            .handle_operator_message("engineer", residue, Some("eng_desk"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turn.reply, "noted",
+            "the message is still answered — withholding a card is not silence"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "a message the operator sent as chat opens no card"
+        );
+        assert_eq!(turn.spawned_task, None, "and nothing is linked to one");
+    }
+
+    /// **Issue #1152, and it outranks the model too.** A `Work` verdict from the
+    /// triage escalation does not resurrect the card.
+    ///
+    /// The two facts are peers, not a hierarchy the model sits on top of:
+    /// [`MessageContext::chatter`] is the model's reading of words it was shown,
+    /// and `not_work` is the author of those words saying what they meant. Where
+    /// they disagree the person wins. Without this, "Just chatting" would be
+    /// advisory on exactly the companies that wire an escalation — the ones
+    /// paying for a second opinion — and nothing would report the difference.
+    #[tokio::test]
+    async fn a_work_verdict_does_not_override_the_operators_own_statement() {
+        let residue = "the pricing page copy, before Friday if you can";
+        let fx = Fixture::new();
+        let escalation = ScriptedTriage::new(crate::harness::triage::TriageVerdict::Work);
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
+        fx.runner(&turns)
+            .with_triage(&escalation)
+            .requested(Some(crate::ports::types::MessageIntent::Chat))
+            .handle_operator_message("engineer", residue, Some("eng_desk"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            fx.cards().await.is_empty(),
+            "the operator's own statement outranks a `work` verdict about their words"
         );
     }
 
@@ -5543,6 +5689,81 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             "a work verdict leaves the hand-off card the abstention would have opened"
         );
         assert_eq!(cards[0].assignee, "engineer");
+    }
+
+    /// **Issue #1152, the second caller.** `open_work_card` has two callers, and
+    /// the direct-path test only drives one. This drives the hand-off: the
+    /// orchestrator queues `delegate_to_desk` on a message the operator sent as
+    /// chat.
+    ///
+    /// The shape mirrors `a_hand_off_of_a_message_the_model_calls_chatter_opens_no_card`
+    /// exactly, because the requirement is the same: **only the card** stands
+    /// down. Saying "I'm just chatting" must not silence the company — the
+    /// hand-off is not refused, the desk lead's turn really runs, and the
+    /// relayed answer still reaches the operator.
+    ///
+    /// The `staged()` assertion is the load-bearing one, and it is what pins the
+    /// scope this deliberately does not take: the turn's board tools are NOT
+    /// narrowed, so a card can still appear if the orchestrator explicitly
+    /// spawns one. "Just chatting" means the company will not *automatically*
+    /// card the message.
+    ///
+    /// Non-vacuous by the same pairing as the chatter test above it:
+    /// `the_same_hand_off_on_a_work_verdict_still_opens_its_card` opens a card
+    /// on these very words with no composer choice.
+    #[tokio::test]
+    async fn a_hand_off_of_a_message_the_operator_sent_as_chat_opens_no_card() {
+        let residue = "the deck looks good to me";
+        assert!(
+            is_trackable_work(residue),
+            "fixture must be one the card detector would otherwise track"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling(
+                    "asking engineering",
+                    vec![handoff("take a look at the deck")],
+                ),
+                Turn::reply("looks fine to me too"),
+                Turn::reply("engineering agrees the deck is fine"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .requested(Some(crate::ports::types::MessageIntent::Chat))
+            .handle_operator_message("chief", residue, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::Queued],
+            "a chat intent must NOT refuse the hand-off — it does not gate tools"
+        );
+        let calls = turns.calls();
+        assert_eq!(
+            calls.len(),
+            3,
+            "the orchestrator, the desk lead and the relay all ran: {calls:?}"
+        );
+        assert_eq!(
+            calls[1].0, "engineer",
+            "the desk lead really ran: {calls:?}"
+        );
+        assert_eq!(
+            turn.reply, "engineering agrees the deck is fine",
+            "and the operator still gets the relayed answer"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "but the hand-off card stands down: the operator said this is not work"
+        );
+        assert!(
+            turn.spawned_task.is_none(),
+            "and nothing is linked to a card"
+        );
     }
 
     /// The same hand-off on a message that is NOT a question still opens its

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1248,13 +1248,22 @@ struct ChatMessage {
     /// rather than a silently-dropped thread.
     #[serde(default)]
     parent: Option<String>,
-    /// Whether an actionable request in this message opens a one-off card or a
-    /// workflow card (issue #580). The operator chooses explicitly (decision
-    /// D2a); absent means `once`, so an ordinary chat request is unchanged. Only
-    /// consulted when the message actually carries a task intent — a greeting or
-    /// a question opens no card regardless.
+    /// What this message is **for** (issues #580, #1152) — whether an
+    /// actionable request opens a one-off card or a workflow card, or whether
+    /// the operator is saying it is not a request for work at all.
+    ///
+    /// The operator chooses explicitly (decision D2a); absent means `once`, so
+    /// an ordinary chat request is unchanged. `once` and `workflow` are only
+    /// consulted when the message actually carries a task intent — a greeting
+    /// or a question opens no card regardless; `chat` is consulted whatever the
+    /// triage said, because withholding is the whole point of it.
+    ///
+    /// **One field, one choice.** The `chat` word rides the existing
+    /// `deliverable` key rather than arriving as a second `intent` field, so a
+    /// body cannot assert "build me the workflow" and "just chatting" about the
+    /// same message — the split-brain #1035 closed, pointed the other way.
     #[serde(default)]
-    deliverable: Option<crate::ports::tasks::TaskDeliverable>,
+    deliverable: Option<crate::ports::types::MessageIntent>,
 }
 
 /// A chat or approval-resolution response: the company's channel replies.
@@ -1427,8 +1436,30 @@ async fn run_chat(
     // inside the `!confined` guard — a copilot thread still opens nothing,
     // because a message *about* a graph is not a request to build one.
     let workflow_requested =
-        !confined && message.deliverable == Some(crate::ports::tasks::TaskDeliverable::Workflow);
-    if let Some(title) = (!confined)
+        !confined && message.deliverable == Some(crate::ports::types::MessageIntent::Workflow);
+    // Issue #1152: and the other direction — the operator said this message is
+    // NOT a request for work ("Just chatting"), so no deterministic path may
+    // card it whatever the triage read in the words.
+    //
+    // The operator could already *mint* a card the classifier declined
+    // (`workflow_requested`, above) and could never *withhold* one. That
+    // asymmetry is the bug: a message the triage happens to read as `Track` —
+    // "we should probably rewrite the pricing page some day" — opened a card,
+    // assigned it to a desk, and there was no control anywhere that said
+    // otherwise. This is that control, and it is the same kind of evidence the
+    // override above is: a positive statement by the person who wrote the
+    // message, which is better than a lexical guess about it.
+    //
+    // **No `!confined` term, deliberately.** `workflow_requested` needs one
+    // because it *mints* a card, and minting one on a workflow copilot thread —
+    // a conversation ABOUT one graph — is exactly what #416 suppresses. This
+    // only ever *subtracts*, and on a copilot thread the branch below is already
+    // suppressed, so a `!confined` term here would be inert at best and would
+    // read as though the two were symmetrical.
+    let not_work = message
+        .deliverable
+        .is_some_and(crate::ports::types::MessageIntent::is_chat);
+    if let Some(title) = (!confined && !not_work)
         .then(|| crate::company::task_intent::triage_message(&message.text))
         .and_then(|triage| match triage {
             crate::company::task_intent::MessageTriage::Track(title) => Some(title),
@@ -1515,7 +1546,10 @@ async fn run_chat(
             // card through the builder pass when it reaches In Progress. Nothing
             // here infers the choice from the text (decision D2a).
             planning_attempts: Vec::new(),
-            deliverable: message.deliverable.unwrap_or_default(),
+            deliverable: message
+                .deliverable
+                .and_then(crate::ports::types::MessageIntent::deliverable)
+                .unwrap_or_default(),
             workflow_proposal: None,
             // Issue #983: the turn that opened it. A card raised from chat used
             // to be the *only* visible sign that a long turn was under way, and
@@ -3381,6 +3415,101 @@ mode = "full"
             tasks[0].title,
             crate::company::task_intent::to_title(text),
             "a bypassed card must be titled byte-for-byte as a tracked one"
+        );
+    }
+
+    /// Issue #1152: an explicit "Just chatting" **withholds** the card the
+    /// triage would otherwise have opened.
+    ///
+    /// The mirror of the test above, and the asymmetry it closes. Since #845 the
+    /// operator could override the classifier *upward* — mint a card it
+    /// declined — and there was no control anywhere that overrode it downward.
+    /// So a message the lexical layer reads as `Track` ("can you build the
+    /// landing page?" asked rhetorically, while thinking out loud) opened a
+    /// card, assigned it to a desk, and started a planning pass, and the only
+    /// recourse was to go to the board and delete it.
+    ///
+    /// The fixture's verdict is asserted `Track` **first**, in the strongest
+    /// direction available: the `chat` run is made before any other, on an empty
+    /// board, and the unmarked run right after it opens the card on the very
+    /// same words. So "zero cards" is the intent doing the work, not a message
+    /// the classifier was never going to card.
+    #[tokio::test]
+    async fn just_chatting_withholds_the_card_the_triage_would_have_opened() {
+        use crate::ports::tasks::TaskDeliverable;
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        // Work by construction — the request frame beats the interrogative, so
+        // the triage names a title and the card branch fires.
+        let text = "can you build the landing page?";
+        assert!(
+            matches!(
+                crate::company::task_intent::triage_message(text),
+                crate::company::task_intent::MessageTriage::Track(_)
+            ),
+            "fixture must be a message the handler cards, or this proves nothing"
+        );
+
+        let chat = |intent: Option<&str>| {
+            let body = match intent {
+                Some(i) => format!(
+                    r#"{{"text":{},"deliverable":"{i}"}}"#,
+                    serde_json::json!(text)
+                ),
+                None => format!(r#"{{"text":{}}}"#, serde_json::json!(text)),
+            };
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/chat")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap()
+        };
+
+        // `chat`: the operator's statement outranks the classifier's `Track`.
+        let r = app.clone().oneshot(chat(Some("chat"))).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK, "the message is still answered");
+        assert!(
+            runtime.tasks().list(&id).await.unwrap().is_empty(),
+            "a message sent as chat must open no card, whatever the triage read"
+        );
+
+        // The same words, unmarked: the card the run above withheld.
+        let r = app.clone().oneshot(chat(None)).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(
+            tasks.len(),
+            1,
+            "an unmarked message is unchanged — this is what the `chat` run withheld"
+        );
+        assert_eq!(tasks[0].deliverable, TaskDeliverable::Once);
+
+        // …and so are both work words, on the same words again.
+        let r = app.clone().oneshot(chat(Some("once"))).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        assert_eq!(
+            runtime.tasks().list(&id).await.unwrap().len(),
+            2,
+            "`once` is unchanged"
+        );
+
+        let r = app.oneshot(chat(Some("workflow"))).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 3, "`workflow` is unchanged");
+        assert!(
+            tasks
+                .iter()
+                .any(|t| t.deliverable == TaskDeliverable::Workflow),
+            "and still routes its card to the builder pass: {tasks:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

An operator could make the company open a card the classifier had declined, but never stop it opening one. `TaskDeliverable` has two values and both mean "do work", so there was no value on the wire meaning "this is not work". The classifier was the only thing that could withhold a card.

This adds a third composer position, **"Just chatting"**, and honours it in the chat route and the runtime.

The runtime seam already existed. `MessageContext.chatter` stands both deterministic card paths down — but it is the *model's* verdict, set only where the lexical layer abstained. What was missing was a way for the person who typed the message to assert the same thing.

## Problem

Concretely, before this change:

- `TaskDeliverable` is `Once | Workflow`. Both open a card.
- The console sent the field only for `workflow`, so choosing "Do it once" put nothing on the wire.
- So the operator's only lever was additive. `#1035` fixed the case where that lever fired twice; this is the half `#1035` named and deliberately left, because it needed a product decision first.

## Solution

**A separate `MessageIntent { Chat, Once, Workflow }`, not a third `TaskDeliverable` variant.** `TaskDeliverable` is a stored card field, editable later in the task dialog. A card can never *be* "not work", so a third variant would be representable-but-invalid in every persisted position. `MessageIntent::deliverable()` returns `Option<TaskDeliverable>`, and `Chat => None` is the type-level statement "no card, therefore no deliverable".

**It rides the existing `deliverable` key** — one operator choice, one field. A second field would make `{deliverable: "workflow", intent: "chat"}` representable and force identical reconciliation in two surfaces, which is precisely the split-brain `#1035` fixed.

**A peer field in the runtime, not a reuse of `chatter`.** `not_work` is a person's statement, settled before any model runs; `chatter` is the model's verdict. Folding them together would falsify `chatter`'s documented meaning and attribute an operator's choice to the model in the debug log. The guard sits above the `chatter` check in `open_work_card`, where all three card paths funnel.

**Wire compatibility:** `"chat"` is sent explicitly; `"once"` and no-choice send nothing, so an unmarked message is byte-identical to today's. "Do it once" stays pre-pressed, so nothing changes for anyone who does not touch the new control.

### Known limit — please read before approving

Only the **deterministic** card paths stand down. The orchestrator's own `spawn_task` tool is untouched, deliberately: narrowing board tools would change which delegation-queue claim the turn runs under, which this issue does not justify.

So "Just chatting" means the company will not *automatically* card the message — not that a card can never appear. If that reads as too weak a promise for the label, say so and the label is the cheap thing to change.

## Submission Checklist

- [x] `cargo check --features openhuman,mcp,telegram` and `cargo check --all-features`
- [x] `cargo fmt --check`
- [x] Touched-scope tests, re-run after rebasing onto current main: `ports::types` 97, `runtime::delegation` 80, `runtime::cycle` 76, `server::operator` 105, `harness::brain` 97 — all passing
- [x] Console: `npx vitest run` 131 files / 1283 tests, `typecheck` + `typecheck:unit` + `typecheck:e2e`, `npm run build`
- [ ] `cargo clippy --all-targets --no-deps -- -D warnings` — passes at the CI lane's feature set. With `mcp` added it fails on `src/app/types.rs` (`empty_line_after_doc_comments`), a file this branch does not touch; the site is `#[cfg(feature = "mcp")]` so the CI lane never compiles it. Pre-existing on main, reported separately rather than swept in here.
- [x] Manual UI verification — done, evidence in the thread below

## Impact

Behaviour is unchanged for every message that does not use the new control. An unmarked message is byte-identical on the wire, and no journaled record migrates: `OperatorMessage` blobs with no `deliverable` and with `"workflow"` both still parse and re-serialize identically, which is asserted by test rather than by comment.

## Tests

The behaviour tests were checked by mutation, not by reasoning. Disabling the two guards failed all four new behaviour tests; restoring them turned them green. Widening the builder-injection pattern turned the no-briefing assertion red. Reverting the console's wire rule failed exactly the one case that asserts `"chat"` reaches the body.

One assertion from the plan was **moved because it was vacuous where it was specified**: "outranks a `Track` triage" is already true in the runtime before this change, since `carded_by_handler` covers it — the test would have passed for the wrong reason. It now lives in the REST handler test, on a fixture whose triage verdict is asserted `Track`, where it is real. The runtime tests instead assert the two things that *are* real there: `not_work` beats `is_trackable_work`'s "everything is work" default, and it beats a model `Work` verdict from the triage escalation.

## Related

Closes #1152. Follows #1035, which threaded the signal and fixed the double-card. Part of #984 — this takes two bullets from its Fix list (the operator-side override), and deliberately leaves `chatter` and the "nothing pre-pressed" default alone, since both belong to that issue.
