### PR TITLE
board: name the remedy the operator's own build actually has

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -944,13 +944,34 @@ impl CompanyRuntime {
             .inert_board_reported
             .swap(true, std::sync::atomic::Ordering::Relaxed)
         {
+            // The remedy is per build, because there are two different causes
+            // and only one of them is "nobody called `with_harness`" (issue
+            // #1059 review). `RuntimeBuilder::with_harness` is itself
+            // `#[cfg(feature = "openhuman")]`, so in a default-feature build
+            // naming it sends the operator looking for a method that is not
+            // compiled into their binary — and that build is not hypothetical:
+            // `Dockerfile`'s `ARG FEATURES=""` ships it as a first-class
+            // configuration, and Cargo.toml describes the default as offline
+            // and echo-brained. There the thing that would actually help is to
+            // rebuild with the feature.
+            //
+            // Only the remedy is split. The symptom stays one literal shared by
+            // both builds, so the half that describes what happened cannot
+            // drift between them while the half that says what to do about it
+            // is the only thing the cfg decides.
+            #[cfg(feature = "openhuman")]
+            const REMEDY: &str = "Wire one with `RuntimeBuilder::with_harness(...)` (see \
+                 `src/bin/opencompany.rs`), or move the card by hand.";
+            #[cfg(not(feature = "openhuman"))]
+            const REMEDY: &str = "This binary was built without the `openhuman` feature, so it \
+                 has no harness to wire — rebuild with `--features openhuman` (the `FEATURES` \
+                 build arg in `Dockerfile`), or move the card by hand.";
             tracing::warn!(
                 company = %self.id,
                 task = %task.id,
                 "[board] a card was dispatched but this runtime has no agent pool, so nothing \
-                 will work it: the card stays in `in_progress` with no attempt row. Wire one with \
-                 `RuntimeBuilder::with_harness(...)` (see `src/bin/opencompany.rs`), or move the \
-                 card by hand. Reported once per runtime."
+                 will work it: the card stays in `in_progress` with no attempt row. {REMEDY} \
+                 Reported once per runtime."
             );
         }
         let _ = task;

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4060,6 +4060,13 @@ mod test {
     /// The second dispatch pins the latch. An inert board with fifty cards has
     /// one problem, not fifty, and a per-card warning is the kind of noise that
     /// gets a useful line filtered out.
+    ///
+    /// The remedy is asserted per build (issue #1059 review). "No agent pool"
+    /// has two causes with two different fixes — nobody called `with_harness`,
+    /// or the binary was built without the feature that compiles it — and a
+    /// message naming the wrong one is a dead end dressed as help. Each arm
+    /// pins the other's remedy *absent* as well as its own present, so a
+    /// message that hedged by carrying both would fail here.
     #[tokio::test]
     async fn an_inert_board_says_it_cannot_dispatch_once() {
         use std::sync::{Arc as StdArc, Mutex as StdMutex};
@@ -4176,10 +4183,38 @@ mod test {
             text.contains("no agent pool"),
             "an inert board must say why nothing will work the card: {text:?}"
         );
-        assert!(
-            text.contains("with_harness"),
-            "the warning must name the fix, not just the symptom: {text:?}"
-        );
+        // The remedy has to be the one that helps THIS build, and asserting
+        // its presence is only half of that (issue #1059 review). A message
+        // carrying both remedies would satisfy every "contains" assertion while
+        // still telling a default-build operator to call a method that is not
+        // in their binary — so each arm also pins the other's absence, which is
+        // what makes this prove the split rather than tolerate it.
+        #[cfg(feature = "openhuman")]
+        {
+            assert!(
+                text.contains("with_harness"),
+                "a build WITH the feature must name the call that wires a pool: {text:?}"
+            );
+            assert!(
+                !text.contains("--features openhuman"),
+                "the feature is already on; telling this operator to rebuild with it is \
+                 a remedy for a problem they do not have: {text:?}"
+            );
+        }
+        #[cfg(not(feature = "openhuman"))]
+        {
+            assert!(
+                text.contains("--features openhuman"),
+                "a default-feature build has no harness to wire, so rebuilding with the \
+                 feature is the only thing that helps: {text:?}"
+            );
+            assert!(
+                !text.contains("with_harness"),
+                "`RuntimeBuilder::with_harness` is itself `#[cfg(feature = \"openhuman\")]`, \
+                 so naming it here sends the operator after a method that is not compiled \
+                 into their binary: {text:?}"
+            );
+        }
         assert_eq!(
             text.matches("no agent pool").count(),
             1,


### PR DESCRIPTION
## Summary

The inert-board warning added by #1059 names a remedy the operator's build may not have. Raised by @oxoxDev in review on #1084, and merged before it was addressed, so it has been live on `main` since `c83de73c`:

> The warn block isn't cfg-gated, but `RuntimeBuilder::with_harness` is — `#[cfg(feature = "openhuman")]` at `runtime/builder.rs:941`. So a host built without `openhuman` tells the operator *"Wire one with `RuntimeBuilder::with_harness(...)`"* about a method that isn't compiled into their binary.

Re-verified against `upstream/main` before writing anything, rather than trusting the issue:

* `src/runtime/builder.rs:941-942` — `#[cfg(feature = "openhuman")] pub fn with_harness(...)`
* `src/company/runtime.rs:~950` — the `tracing::warn!` is **not** gated and names it
* `Dockerfile:7` — `ARG FEATURES=""`

`dispatch_task` itself is not gated either (only the early-return arms inside it are), so the warning genuinely executes in a default build.

## Two causes, two remedies

| Cause | What actually helps |
| --- | --- |
| Feature on, nobody called `with_harness` | wire one — the existing text |
| Binary built without `openhuman` | rebuild with `--features openhuman` |

Only the first was ever printed, so the build most likely to meet the warning was the one it could not help. Not re-argued here: the rebuttal was made on #1084 and @oxoxDev answered it — *"the feature being off is a separate cause with a separate fix, and that's the one the message gets wrong."*

## What changed

**Only the remedy sentence is split.** The symptom stays one literal shared by both builds, so the half that describes what happened cannot drift between them while the half that says what to do about it is the only thing the `cfg` decides.

```rust
#[cfg(feature = "openhuman")]
const REMEDY: &str = "Wire one with `RuntimeBuilder::with_harness(...)` …";
#[cfg(not(feature = "openhuman"))]
const REMEDY: &str = "This binary was built without the `openhuman` feature, so it has no \
     harness to wire — rebuild with `--features openhuman` (the `FEATURES` build arg in \
     `Dockerfile`), or move the card by hand.";
```

The latch, the level, the fields and the symptom text are untouched.

## The test had to move with it, and that is not incidental

`an_inert_board_says_it_cannot_dispatch_once` asserted `text.contains("with_harness")`, and its module is `#[cfg(test)]` with **no feature gate** — so it runs in the default build and would have failed on the corrected message. Split with it, and each arm now pins the **other** remedy *absent* as well as its own present.

That second half is the load-bearing one: without it, a message that hedged by carrying both strings would satisfy every `contains()` and still hand a default-build operator a dead end.

## API Or Behavior Changes

None. One log line's wording, in one build configuration. No API, no signature, no wire change.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A as a separate run: the change is a `const` and a `format!` capture inside an existing block, and both builds were compiled through `cargo check --tests` below. Flagging honestly rather than ticking a command I did not run.
- [x] `cargo build --all-targets` — N/A as a separate run; covered by the `check --tests` compiles in both feature sets, which build every test target.
- [x] `cargo test` — the affected test, run in **both** builds, because the whole point is that the message differs by build:
  - default features → `an_inert_board_says_it_cannot_dispatch_once ... ok`
  - `--features openhuman,tinycortex` → `an_inert_board_says_it_cannot_dispatch_once ... ok`

Compiles, both feature sets, `--lib` **and** `--tests`:

| Command | Result |
| --- | --- |
| `cargo check --locked --tests` (default) | exit 0 |
| `cargo check --locked --features openhuman,tinycortex --lib` | exit 0 |
| `cargo check --locked --features openhuman,tinycortex --tests` | exit 0 † |

† **`main` currently fails that command for an unrelated reason** — #1197, `CycleRequest has no field named compressed_history` in `src/harness/spend_halt_turn_test.rs`, from #1134 and #1182 colliding semantically. #1197 had not landed when this was verified, so I applied its three-line deletion **locally, for verification only, and reverted it before committing**. This branch does **not** carry that fix; its diff is two files. Once #1197 merges, the gated lane here should be green on its own.

### Prove-red

Reverting `runtime.rs` to main's unconditional message while keeping the new test fails it in the default build (exit 101), and the panic prints the defect verbatim:

```
a default-feature build has no harness to wire, so rebuilding with the feature is the
only thing that helps: "… WARN … [board] a card was dispatched but this runtime has no
agent pool … Wire one with `RuntimeBuilder::with_harness(...)` …"
```

Stated plainly: the **gated** arm is a regression guard, not a mutation proof of this bug. Main's message already satisfies it, which is correct — the defect only ever existed in the default build. It exists so a future "fix" that swaps the message wholesale cannot silently take the right remedy away from the build that does have `with_harness`.

## Documentation

No spec doc changes. The reasoning — two causes, why only the remedy is split, and why each test arm pins the other's absence — is recorded at both sites.

Closes #1198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated no-harness dispatch warnings to provide build-specific remediation guidance.
  * OpenHuman builds now recommend connecting a harness.
  * Default builds now explain that the feature is unavailable and recommend rebuilding with the `openhuman` option.
  * Preserved the existing warning behavior and one-time reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->