### PR TITLE
fix(harness): drop the CycleRequest fields #1182 removed from the spend-halt fixture

### DIFF
--- a/src/harness/spend_halt_turn_test.rs
+++ b/src/harness/spend_halt_turn_test.rs
@@ -376,9 +376,6 @@ fn chat(text: &str) -> CycleRequest {
             deliverable: None,
         }],
         event_seqs: Vec::new(),
-        compressed_history: Vec::new(),
-        roster: Vec::new(),
-        context_index: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Closes #1197

## Summary

`main` did not compile its **gated test targets**, so the `Rust (openhuman, tinycortex)` lane was failing on every open PR for a reason unrelated to its diff.

Three lines deleted from one test fixture.

## Problem

```
$ cargo check --locked --features openhuman,tinycortex --tests
error[E0560]: struct `ports::types::CycleRequest` has no field named `compressed_history`
   --> src/harness/spend_halt_turn_test.rs:379:9
error[E0560]: struct `ports::types::CycleRequest` has no field named `roster`
   --> src/harness/spend_halt_turn_test.rs:380:9
error[E0560]: struct `ports::types::CycleRequest` has no field named `context_index`
   --> src/harness/spend_halt_turn_test.rs:381:9
error: could not compile `opencompany` (lib test) due to 3 previous errors
```

A semantic merge conflict between two PRs that were each green:

| | |
|---|---|
| **#1134** | added `src/harness/spend_halt_turn_test.rs`, whose `CycleRequest` literal sets the three fields |
| **#1182** (`c778c33e`) | removed those three fields, merged 1h20m later |

Neither lane could have caught it: #1182's ran against a main without this file, #1134's against a struct that still had the fields.

## Solution

**I checked the direction before assuming the fixture was the wrong half.** `c778c33e` is explicit, and it is a fix rather than an oversight:

> `compressed_history`, `context_index` and `roster` were populated on every cycle and read by no Brain implementation. Populating the first two cost a recent_traces read plus an unbounded `ContextStore::list` scan per cycle for a Vec that was dropped; the index grows with every turn a company has ever run.

So the removal stays and the fixture moves. Three supporting checks:

1. **No other consumer.** Across `src/`, the only `CycleRequest`-field uses of these names are the three lines here. The remaining `compressed_history` hit is #1182's own doc note at `ports/types.rs:2001` recording the removal — correct, and untouched. Other `context_index` / `roster` hits are unrelated (`context_index_jsonl` store paths, manifest rosters).
2. **Nothing asserts on them.** All three were `Vec::new()`; they were required fields, not fixture inputs. Deleting them changes nothing the test pins.
3. **It matches its sibling.** `cap_turn_test.rs` — the test this one was modelled on — already carries exactly this 4-field form, since #1182 updated it. The two literals are now the same shape again.

## Verification

Run on this branch, with the submodules initialised:

| command | before | after |
|---|---|---|
| `cargo check --locked --features openhuman,tinycortex --tests` | **exit 101** — the three `E0560`s above | **exit 0** |
| `cargo check --locked --features openhuman,tinycortex --lib` | exit 0 | exit 0 |
| `cargo fmt --all -- --check` | — | exit 0 |
| `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` | — | exit 0 |
| `cargo test --locked --features openhuman,tinycortex --lib spend_halt` | — | **10 passed, 0 failed** |

I reproduced the red on a pristine checkout of `upstream/main` before touching anything, so the before column is measured rather than quoted from the issue.

**Note the `--lib` row.** It is green in both columns — a struct-field change breaks struct *literals*, which live in test fixtures, so a lib-only check is blind to this entire class. That is why this reached main, and it is why the `--tests` row is the one that matters.

The 10 spend-halt tests still pass, so this restores compilation without weakening what #1134 was written to assert.

## API Or Behavior Changes

**None.** Test-fixture only; no production code, no public type, no lockfile change.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran the gated form CI uses, `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`: clean.
- [x] `cargo build --all-targets` — ran `cargo check --locked --features openhuman,tinycortex --tests` instead, which is both the failing command and the one the gated lane compiles: exit 0. `Cargo.lock` is unchanged.
- [x] `cargo test` — ran the affected target, `cargo test --locked --features openhuman,tinycortex --lib spend_halt`: **10 passed, 0 failed**.

### No new test, deliberately

The assertion here is the compiler, and the gated lane already runs it — a test asserting "this struct literal type-checks" is what `cargo check --tests` is. What would have caught this class is a gated `--tests` compile **on push to main** rather than only on PRs; #1197 raises that as a follow-up thought, and I have deliberately not bundled it into this fix.

## Documentation

None needed. #1182's note at `ports/types.rs:2001` already documents why the fields are gone, and it stays as written.
