### PR TITLE
fix(app): attach a stranded note to the test it describes

### DIFF
--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1204,6 +1204,10 @@ mod tests {
     }
 
     /// A host with nothing to open is the only one the wizard is for.
+    ///
+    /// The registered-company half of this lives in `server::setup::test`,
+    /// beside the helper that can build a real runtime:
+    /// `spec_reports_setup_complete_once_a_company_is_registered`.
     #[test]
     fn spec_reports_setup_incomplete_for_an_empty_unstamped_host() {
         let spec = AppState::new(AppConfig::default()).spec();
@@ -1213,10 +1217,6 @@ mod tests {
             "no stamp and no companies is exactly the first-run case"
         );
     }
-
-    /// The registered-company half of this lives in `server::setup::test`,
-    /// beside the helper that can build a real runtime:
-    /// `spec_reports_setup_complete_once_a_company_is_registered`.
 
     #[cfg(feature = "mcp")]
     #[test]


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets --no-deps --features openhuman,mcp,telegram -- -D warnings` fails on `src/app/types.rs` with `empty_line_after_doc_comments`. This fixes it, but not the way the lint suggests.

The stranded comment reads:

> The registered-company half of this lives in `server::setup::test`, beside the helper that can build a real runtime: `spec_reports_setup_complete_once_a_company_is_registered`.

That describes `spec_reports_setup_incomplete_for_an_empty_unstamped_host`, the test **above** it — the "incomplete" half whose counterpart lives elsewhere. The item **below** it is `parked_oauth_flow_is_single_use`, an MCP OAuth test with no relation to setup completeness.

So the one-line fix the lint nudges you toward — close the blank line — would have silenced it by making the note that OAuth test's documentation, planting a false cross-reference for the next reader. Moved onto the test it actually describes instead.

## API Or Behavior Changes

None. Comment placement only, inside a `#[cfg(test)]` module.

## Tests

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --no-deps --features openhuman,mcp,telegram -- -D warnings` — now clean; fails on `main` without this

## Documentation

None needed.

## Why CI never caught it

The lint site is `#[cfg(feature = "mcp")]`, and the gated lane runs `--features openhuman,tinycortex`. The test is never compiled there, so the lint never fires in CI while being red for anyone building locally with `mcp` — an instance of the known full-feature gap, where no lane builds the `openhuman,mcp,telegram` combination.

Worth deciding separately whether a lane should cover that combination. This PR only clears the existing breakage.

## Related

Found while running local gates for #1186. Independent of it — cut from a clean `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified test comments documenting setup-completion coverage.
  * Removed a duplicate comment related to the MCP OAuth test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->