### PR TITLE
fix(templates): give 17 company templates a desk their pipeline report can reach (#963)

### DIFF
--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Accounting Firm"
 output = "Books, taxes, payroll, and forecasts"
 human_role = "Sign-off on filings"
 
+# The close-review desk keeps the people who reconcile, file, and substantiate the books together.
+[[group_chat]]
+id = "close-review"
+name = "Close review desk"
+description = "Coordinate the month-end close package before operator sign-off."
+members = ["bookkeeper", "tax_preparer", "audit_prep"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -9,7 +9,7 @@ human_role = "Sign-off on filings"
 
 # The close-review desk keeps the people who reconcile, file, and substantiate the books together.
 [[group_chat]]
-id = "close-review"
+id = "close_review"
 name = "Close review desk"
 description = "Coordinate the month-end close package before operator sign-off."
 members = ["bookkeeper", "tax_preparer", "audit_prep"]

--- a/companies/agentic_accounting_firm/workflows/month_end_close.toml
+++ b/companies/agentic_accounting_firm/workflows/month_end_close.toml
@@ -55,6 +55,10 @@ id = "review"
 kind = "output"
 name = "Park for sign-off"
 summary = "Send the close package to the operator."
+# The close-review desk owns the package that needs filing approval.
+[node.destination]
+kind = "channel"
+target = "close-review"
 
 [[edge]]
 from = "close"

--- a/companies/agentic_accounting_firm/workflows/month_end_close.toml
+++ b/companies/agentic_accounting_firm/workflows/month_end_close.toml
@@ -58,7 +58,7 @@ summary = "Send the close package to the operator."
 # The close-review desk owns the package that needs filing approval.
 [node.destination]
 kind = "channel"
-target = "close-review"
+target = "close_review"
 
 [[edge]]
 from = "close"

--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -24,6 +24,13 @@ human_role = "Executive workshops"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
+# The engagement-delivery desk aligns the recommendation, client deck, and implementation plan.
+[[group_chat]]
+id = "engagement-delivery"
+name = "Engagement delivery desk"
+description = "Coordinate the client-ready strategy and implementation materials."
+members = ["strategist", "deck_builder", "implementation_planner"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -26,7 +26,7 @@ allow = ["*", "media", "composio", "search"]
 
 # The engagement-delivery desk aligns the recommendation, client deck, and implementation plan.
 [[group_chat]]
-id = "engagement-delivery"
+id = "engagement_delivery"
 name = "Engagement delivery desk"
 description = "Coordinate the client-ready strategy and implementation materials."
 members = ["strategist", "deck_builder", "implementation_planner"]

--- a/companies/agentic_consultation_firm/workflows/engagement_pipeline.toml
+++ b/companies/agentic_consultation_firm/workflows/engagement_pipeline.toml
@@ -79,7 +79,7 @@ summary = "Hand the deck and plan to the operator."
 # The engagement-delivery desk keeps the workshop materials together for review.
 [node.destination]
 kind = "channel"
-target = "engagement-delivery"
+target = "engagement_delivery"
 
 [[edge]]
 from = "brief"

--- a/companies/agentic_consultation_firm/workflows/engagement_pipeline.toml
+++ b/companies/agentic_consultation_firm/workflows/engagement_pipeline.toml
@@ -76,6 +76,10 @@ id = "done"
 kind = "output"
 name = "Deliver to workshop"
 summary = "Hand the deck and plan to the operator."
+# The engagement-delivery desk keeps the workshop materials together for review.
+[node.destination]
+kind = "channel"
+target = "engagement-delivery"
 
 [[edge]]
 from = "brief"

--- a/companies/agentic_customer_support/company.toml
+++ b/companies/agentic_customer_support/company.toml
@@ -9,7 +9,7 @@ human_role = "Escalation and policy"
 
 # The support-operations desk owns customer outcomes and the guidance that supports them.
 [[group_chat]]
-id = "support-operations"
+id = "support_operations"
 name = "Support operations desk"
 description = "Coordinate ticket resolution, escalations, and support documentation."
 members = ["support_agent", "escalation_manager", "docs_writer"]

--- a/companies/agentic_customer_support/company.toml
+++ b/companies/agentic_customer_support/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Customer Support Company"
 output = "Resolved tickets and current documentation"
 human_role = "Escalation and policy"
 
+# The support-operations desk owns customer outcomes and the guidance that supports them.
+[[group_chat]]
+id = "support-operations"
+name = "Support operations desk"
+description = "Coordinate ticket resolution, escalations, and support documentation."
+members = ["support_agent", "escalation_manager", "docs_writer"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_customer_support/workflows/ticket_pipeline.toml
+++ b/companies/agentic_customer_support/workflows/ticket_pipeline.toml
@@ -74,7 +74,7 @@ summary = "Close the ticket and report back."
 # The support-operations desk owns the resolution record and any follow-up.
 [node.destination]
 kind = "channel"
-target = "support-operations"
+target = "support_operations"
 
 [[edge]]
 from = "ticket"

--- a/companies/agentic_customer_support/workflows/ticket_pipeline.toml
+++ b/companies/agentic_customer_support/workflows/ticket_pipeline.toml
@@ -71,6 +71,10 @@ id = "done"
 kind = "output"
 name = "Close and report"
 summary = "Close the ticket and report back."
+# The support-operations desk owns the resolution record and any follow-up.
+[node.destination]
+kind = "channel"
+target = "support-operations"
 
 [[edge]]
 from = "ticket"

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -26,7 +26,7 @@ allow = ["*", "media", "composio", "search"]
 
 # The creative-direction desk brings research, brand, and product-design decisions to one review.
 [[group_chat]]
-id = "creative-direction"
+id = "creative_direction"
 name = "Creative direction desk"
 description = "Coordinate the design system before creative sign-off."
 members = ["user_researcher", "brand_designer", "ui_designer"]

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -24,6 +24,13 @@ human_role = "Creative direction sign-off"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
+# The creative-direction desk brings research, brand, and product-design decisions to one review.
+[[group_chat]]
+id = "creative-direction"
+name = "Creative direction desk"
+description = "Coordinate the design system before creative sign-off."
+members = ["user_researcher", "brand_designer", "ui_designer"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_design_studio/workflows/design_pipeline.toml
+++ b/companies/agentic_design_studio/workflows/design_pipeline.toml
@@ -65,7 +65,7 @@ summary = "Hand the system to the operator for sign-off."
 # The creative-direction desk gathers the system for the operator's design review.
 [node.destination]
 kind = "channel"
-target = "creative-direction"
+target = "creative_direction"
 
 [[edge]]
 from = "brief"

--- a/companies/agentic_design_studio/workflows/design_pipeline.toml
+++ b/companies/agentic_design_studio/workflows/design_pipeline.toml
@@ -62,6 +62,10 @@ id = "done"
 kind = "output"
 name = "Deliver for direction"
 summary = "Hand the system to the operator for sign-off."
+# The creative-direction desk gathers the system for the operator's design review.
+[node.destination]
+kind = "channel"
+target = "creative-direction"
 
 [[edge]]
 from = "brief"

--- a/companies/agentic_enterprise_sales/company.toml
+++ b/companies/agentic_enterprise_sales/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Enterprise Sales Organization"
 output = "Qualified pipeline and proposals"
 human_role = "Closing strategic accounts"
 
+# The deal desk brings the proposal, contract, and follow-up owners together for account decisions.
+[[group_chat]]
+id = "deal-desk"
+name = "Deal desk"
+description = "Coordinate strategic account proposals, contracts, and next steps."
+members = ["proposal_writer", "contract_generator", "follow_up_agent"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_enterprise_sales/company.toml
+++ b/companies/agentic_enterprise_sales/company.toml
@@ -9,7 +9,7 @@ human_role = "Closing strategic accounts"
 
 # The deal desk brings the proposal, contract, and follow-up owners together for account decisions.
 [[group_chat]]
-id = "deal-desk"
+id = "deal_desk"
 name = "Deal desk"
 description = "Coordinate strategic account proposals, contracts, and next steps."
 members = ["proposal_writer", "contract_generator", "follow_up_agent"]

--- a/companies/agentic_enterprise_sales/workflows/sales_pipeline.toml
+++ b/companies/agentic_enterprise_sales/workflows/sales_pipeline.toml
@@ -72,7 +72,7 @@ summary = "Report pipeline state and the ask."
 # The deal desk coordinates the account materials behind the closing decision.
 [node.destination]
 kind = "channel"
-target = "deal-desk"
+target = "deal_desk"
 
 [[edge]]
 from = "lead"

--- a/companies/agentic_enterprise_sales/workflows/sales_pipeline.toml
+++ b/companies/agentic_enterprise_sales/workflows/sales_pipeline.toml
@@ -69,6 +69,10 @@ id = "done"
 kind = "output"
 name = "Report to operator"
 summary = "Report pipeline state and the ask."
+# The deal desk coordinates the account materials behind the closing decision.
+[node.destination]
+kind = "channel"
+target = "deal-desk"
 
 [[edge]]
 from = "lead"

--- a/companies/agentic_game_business/company.toml
+++ b/companies/agentic_game_business/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Game Business"
 output = "LiveOps, user acquisition, and monetization for a live game"
 human_role = "Monetization and growth strategy"
 
+# The liveops desk coordinates the event decisions that affect revenue and the player community.
+[[group_chat]]
+id = "liveops"
+name = "LiveOps desk"
+description = "Coordinate live events, monetization, and community communications."
+members = ["liveops_manager", "monetization_designer", "community_manager"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_game_business/workflows/liveops_pipeline.toml
+++ b/companies/agentic_game_business/workflows/liveops_pipeline.toml
@@ -69,6 +69,10 @@ id = "done"
 kind = "output"
 name = "Launch and report"
 summary = "Go live behind approval and report back."
+# The liveops desk owns the release decision and its player-facing follow-through.
+[node.destination]
+kind = "channel"
+target = "liveops"
 
 [[edge]]
 from = "cadence"

--- a/companies/agentic_game_studio/company.toml
+++ b/companies/agentic_game_studio/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Game Studio"
 output = "Shippable games"
 human_role = "Creative and design direction"
 
+# The release desk joins the build, quality, and launch owners before a game ships.
+[[group_chat]]
+id = "release"
+name = "Release desk"
+description = "Coordinate game quality, release readiness, and launch marketing."
+members = ["gameplay_engineer", "qa_tester", "marketer"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_game_studio/workflows/game_build_pipeline.toml
+++ b/companies/agentic_game_studio/workflows/game_build_pipeline.toml
@@ -82,6 +82,10 @@ id = "done"
 kind = "output"
 name = "Ship and report"
 summary = "Release behind approval and report back."
+# The release desk needs the build, quality result, and launch plan before shipping.
+[node.destination]
+kind = "channel"
+target = "release"
 
 [[edge]]
 from = "concept"

--- a/companies/agentic_influencer_business/company.toml
+++ b/companies/agentic_influencer_business/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Influencer Business"
 output = "A creator brand that never sleeps"
 human_role = "Occasional appearance or AI avatar"
 
+# The content desk keeps creation, publishing, and community response aligned around each release.
+[[group_chat]]
+id = "content"
+name = "Content desk"
+description = "Coordinate published content, audience response, and performance learnings."
+members = ["scriptwriter", "publisher", "community_manager"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_influencer_business/workflows/content_pipeline.toml
+++ b/companies/agentic_influencer_business/workflows/content_pipeline.toml
@@ -83,6 +83,10 @@ id = "done"
 kind = "output"
 name = "Report back"
 summary = "Summarize performance and learnings."
+# The content desk turns the published piece and audience response into the next decision.
+[node.destination]
+kind = "channel"
+target = "content"
 
 [[edge]]
 from = "cadence"

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -26,7 +26,7 @@ allow = ["*", "media", "composio", "search"]
 
 # The matter-review desk aligns research, drafting, and compliance before legal approval.
 [[group_chat]]
-id = "matter-review"
+id = "matter_review"
 name = "Matter review desk"
 description = "Coordinate legal research, draft review, and compliance checks."
 members = ["legal_researcher", "contract_drafter", "compliance_agent"]

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -24,6 +24,13 @@ human_role = "Approving filings"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
+# The matter-review desk aligns research, drafting, and compliance before legal approval.
+[[group_chat]]
+id = "matter-review"
+name = "Matter review desk"
+description = "Coordinate legal research, draft review, and compliance checks."
+members = ["legal_researcher", "contract_drafter", "compliance_agent"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_law_firm/workflows/matter_pipeline.toml
+++ b/companies/agentic_law_firm/workflows/matter_pipeline.toml
@@ -55,6 +55,10 @@ id = "review"
 kind = "output"
 name = "Park for approval"
 summary = "Send the draft to the operator for sign-off."
+# The matter-review desk holds the research, draft, and compliance result for approval.
+[node.destination]
+kind = "channel"
+target = "matter-review"
 
 [[edge]]
 from = "intake"

--- a/companies/agentic_law_firm/workflows/matter_pipeline.toml
+++ b/companies/agentic_law_firm/workflows/matter_pipeline.toml
@@ -58,7 +58,7 @@ summary = "Send the draft to the operator for sign-off."
 # The matter-review desk holds the research, draft, and compliance result for approval.
 [node.destination]
 kind = "channel"
-target = "matter-review"
+target = "matter_review"
 
 [[edge]]
 from = "intake"

--- a/companies/agentic_media_company/company.toml
+++ b/companies/agentic_media_company/company.toml
@@ -24,6 +24,13 @@ human_role = "Editorial standards"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
+# The newsroom desk pairs the reported story with its verification and publication owners.
+[[group_chat]]
+id = "newsroom"
+name = "Newsroom desk"
+description = "Coordinate story verification, editorial delivery, and publication."
+members = ["source_verifier", "writer", "publisher"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_media_company/workflows/newsroom_pipeline.toml
+++ b/companies/agentic_media_company/workflows/newsroom_pipeline.toml
@@ -83,6 +83,10 @@ id = "done"
 kind = "output"
 name = "Report back"
 summary = "Report what ran and how it did."
+# The newsroom desk owns the verified story and its publication outcome.
+[node.destination]
+kind = "channel"
+target = "newsroom"
 
 [[edge]]
 from = "tip"

--- a/companies/agentic_pharma_startup/company.toml
+++ b/companies/agentic_pharma_startup/company.toml
@@ -9,7 +9,7 @@ human_role = "Laboratory work"
 
 # The research-review desk pairs candidate evidence with the trial plan before lab work begins.
 [[group_chat]]
-id = "research-review"
+id = "research_review"
 name = "Research review desk"
 description = "Coordinate candidate evidence and trial planning for laboratory review."
 members = ["molecule_discovery", "simulation_agent", "trial_planner"]

--- a/companies/agentic_pharma_startup/company.toml
+++ b/companies/agentic_pharma_startup/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Pharma Startup"
 output = "Candidate molecules and trial plans"
 human_role = "Laboratory work"
 
+# The research-review desk pairs candidate evidence with the trial plan before lab work begins.
+[[group_chat]]
+id = "research-review"
+name = "Research review desk"
+description = "Coordinate candidate evidence and trial planning for laboratory review."
+members = ["molecule_discovery", "simulation_agent", "trial_planner"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_pharma_startup/workflows/discovery_pipeline.toml
+++ b/companies/agentic_pharma_startup/workflows/discovery_pipeline.toml
@@ -55,6 +55,10 @@ id = "done"
 kind = "output"
 name = "Hand to the lab"
 summary = "Report candidates and plan to the operator."
+# The research-review desk assembles the candidate evidence and trial plan for lab review.
+[node.destination]
+kind = "channel"
+target = "research-review"
 
 [[edge]]
 from = "target"

--- a/companies/agentic_pharma_startup/workflows/discovery_pipeline.toml
+++ b/companies/agentic_pharma_startup/workflows/discovery_pipeline.toml
@@ -58,7 +58,7 @@ summary = "Report candidates and plan to the operator."
 # The research-review desk assembles the candidate evidence and trial plan for lab review.
 [node.destination]
 kind = "channel"
-target = "research-review"
+target = "research_review"
 
 [[edge]]
 from = "target"

--- a/companies/agentic_realestate_company/company.toml
+++ b/companies/agentic_realestate_company/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Real Estate Company"
 output = "Underwritten deals and managed properties"
 human_role = "Purchase approvals"
 
+# The investment committee reviews the deal, underwriting, and rehabilitation plan together.
+[[group_chat]]
+id = "investment-committee"
+name = "Investment committee"
+description = "Coordinate acquisition diligence, underwriting, and property plans."
+members = ["property_scout", "deal_underwriter", "contractor_coordinator"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_realestate_company/company.toml
+++ b/companies/agentic_realestate_company/company.toml
@@ -9,7 +9,7 @@ human_role = "Purchase approvals"
 
 # The investment committee reviews the deal, underwriting, and rehabilitation plan together.
 [[group_chat]]
-id = "investment-committee"
+id = "investment_committee"
 name = "Investment committee"
 description = "Coordinate acquisition diligence, underwriting, and property plans."
 members = ["property_scout", "deal_underwriter", "contractor_coordinator"]

--- a/companies/agentic_realestate_company/workflows/acquisition_pipeline.toml
+++ b/companies/agentic_realestate_company/workflows/acquisition_pipeline.toml
@@ -62,6 +62,10 @@ id = "done"
 kind = "output"
 name = "Purchase approval"
 summary = "Send the deal to the operator to approve."
+# The investment committee reviews the acquisition case before the purchase decision.
+[node.destination]
+kind = "channel"
+target = "investment-committee"
 
 [[edge]]
 from = "lead"

--- a/companies/agentic_realestate_company/workflows/acquisition_pipeline.toml
+++ b/companies/agentic_realestate_company/workflows/acquisition_pipeline.toml
@@ -65,7 +65,7 @@ summary = "Send the deal to the operator to approve."
 # The investment committee reviews the acquisition case before the purchase decision.
 [node.destination]
 kind = "channel"
-target = "investment-committee"
+target = "investment_committee"
 
 [[edge]]
 from = "lead"

--- a/companies/agentic_recruiting_company/company.toml
+++ b/companies/agentic_recruiting_company/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Recruiting Company"
 output = "Sourced, screened, and scheduled candidates"
 human_role = "Final hiring decisions"
 
+# The hiring desk keeps sourcing, interviews, and offer preparation connected for final decisions.
+[[group_chat]]
+id = "hiring"
+name = "Hiring desk"
+description = "Coordinate candidate assessment, interview feedback, and offers."
+members = ["candidate_sourcer", "interviewer", "offer_generator"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_recruiting_company/workflows/hiring_pipeline.toml
+++ b/companies/agentic_recruiting_company/workflows/hiring_pipeline.toml
@@ -69,6 +69,10 @@ id = "done"
 kind = "output"
 name = "Report to operator"
 summary = "Report advances, passes, and the offer."
+# The hiring desk holds the candidate record and offer for the final decision.
+[node.destination]
+kind = "channel"
+target = "hiring"
 
 [[edge]]
 from = "role"

--- a/companies/agentic_venture_capital/company.toml
+++ b/companies/agentic_venture_capital/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Venture Capital Firm"
 output = "Investment memos and a managed portfolio"
 human_role = "Investment decisions"
 
+# The investment committee brings market, deck, and technical diligence into one recommendation.
+[[group_chat]]
+id = "investment-committee"
+name = "Investment committee"
+description = "Coordinate diligence findings before an investment decision."
+members = ["market_sizer", "deck_evaluator", "code_analyst"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_venture_capital/company.toml
+++ b/companies/agentic_venture_capital/company.toml
@@ -9,7 +9,7 @@ human_role = "Investment decisions"
 
 # The investment committee brings market, deck, and technical diligence into one recommendation.
 [[group_chat]]
-id = "investment-committee"
+id = "investment_committee"
 name = "Investment committee"
 description = "Coordinate diligence findings before an investment decision."
 members = ["market_sizer", "deck_evaluator", "code_analyst"]

--- a/companies/agentic_venture_capital/workflows/diligence_pipeline.toml
+++ b/companies/agentic_venture_capital/workflows/diligence_pipeline.toml
@@ -72,7 +72,7 @@ summary = "Deliver the memo and recommendation."
 # The investment committee turns the diligence evidence into the investment decision.
 [node.destination]
 kind = "channel"
-target = "investment-committee"
+target = "investment_committee"
 
 [[edge]]
 from = "inbound"

--- a/companies/agentic_venture_capital/workflows/diligence_pipeline.toml
+++ b/companies/agentic_venture_capital/workflows/diligence_pipeline.toml
@@ -69,6 +69,10 @@ id = "done"
 kind = "output"
 name = "Investment memo"
 summary = "Deliver the memo and recommendation."
+# The investment committee turns the diligence evidence into the investment decision.
+[node.destination]
+kind = "channel"
+target = "investment-committee"
 
 [[edge]]
 from = "inbound"

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -9,7 +9,7 @@ human_role = "Capital allocation and major strategic decisions"
 
 # The venture-launch desk keeps the founding, product, and market owners aligned on the new company.
 [[group_chat]]
-id = "venture-launch"
+id = "venture_launch"
 name = "Venture launch desk"
 description = "Coordinate venture launch readiness and the next strategic decision."
 members = ["founder", "engineer", "marketer"]

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -7,6 +7,13 @@ name = "Agentic Venture Studio"
 output = "A portfolio of startups"
 human_role = "Capital allocation and major strategic decisions"
 
+# The venture-launch desk keeps the founding, product, and market owners aligned on the new company.
+[[group_chat]]
+id = "venture-launch"
+name = "Venture launch desk"
+description = "Coordinate venture launch readiness and the next strategic decision."
+members = ["founder", "engineer", "marketer"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_venture_studio/workflows/venture_launch_pipeline.toml
+++ b/companies/agentic_venture_studio/workflows/venture_launch_pipeline.toml
@@ -90,6 +90,10 @@ id = "done"
 kind = "output"
 name = "Report to operator"
 summary = "Report the launch and the ask."
+# The venture-launch desk coordinates the operational result behind the strategic ask.
+[node.destination]
+kind = "channel"
+target = "venture-launch"
 
 [[edge]]
 from = "idea"

--- a/companies/agentic_venture_studio/workflows/venture_launch_pipeline.toml
+++ b/companies/agentic_venture_studio/workflows/venture_launch_pipeline.toml
@@ -93,7 +93,7 @@ summary = "Report the launch and the ask."
 # The venture-launch desk coordinates the operational result behind the strategic ask.
 [node.destination]
 kind = "channel"
-target = "venture-launch"
+target = "venture_launch"
 
 [[edge]]
 from = "idea"

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -61,7 +61,7 @@ skills = [
 
 # The opportunity-review desk validates the weekly signal synthesis before it reaches the operator.
 [[group_chat]]
-id = "opportunity-review"
+id = "opportunity_review"
 name = "Opportunity review desk"
 description = "Coordinate signal evidence, opportunity ranking, and the weekly brief."
 members = ["signal_scout", "opportunity_analyst", "research_agent"]

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -59,6 +59,13 @@ skills = [
   { id = "opportunity.brief", price_usd = "49.00", description = "A ranked, evidence-backed weekly opportunity brief for a chosen market." },
 ]
 
+# The opportunity-review desk validates the weekly signal synthesis before it reaches the operator.
+[[group_chat]]
+id = "opportunity-review"
+name = "Opportunity review desk"
+description = "Coordinate signal evidence, opportunity ranking, and the weekly brief."
+members = ["signal_scout", "opportunity_analyst", "research_agent"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/signals_opportunity_studio/workflows/opportunity_pipeline.toml
+++ b/companies/signals_opportunity_studio/workflows/opportunity_pipeline.toml
@@ -48,6 +48,10 @@ id = "brief"
 kind = "output"
 name = "Ranked brief"
 summary = "Deliver the ranked brief to the operator."
+# The opportunity-review desk validates the evidence and ranking before the operator sees it.
+[node.destination]
+kind = "channel"
+target = "opportunity-review"
 
 [[edge]]
 from = "cadence"

--- a/companies/signals_opportunity_studio/workflows/opportunity_pipeline.toml
+++ b/companies/signals_opportunity_studio/workflows/opportunity_pipeline.toml
@@ -51,7 +51,7 @@ summary = "Deliver the ranked brief to the operator."
 # The opportunity-review desk validates the evidence and ranking before the operator sees it.
 [node.destination]
 kind = "channel"
-target = "opportunity-review"
+target = "opportunity_review"
 
 [[edge]]
 from = "cadence"

--- a/companies/startup_accelerator/company.toml
+++ b/companies/startup_accelerator/company.toml
@@ -9,7 +9,7 @@ human_role = "Investment and demo-day decisions"
 
 # The cohort-review desk brings admissions, mentorship, and investor readiness into one decision.
 [[group_chat]]
-id = "cohort-review"
+id = "cohort_review"
 name = "Cohort review desk"
 description = "Coordinate cohort outcomes and decisions for the accelerator operator."
 members = ["application_screener", "mentor_matcher", "investor_liaison"]

--- a/companies/startup_accelerator/company.toml
+++ b/companies/startup_accelerator/company.toml
@@ -7,6 +7,13 @@ name = "Startup Accelerator"
 output = "A funded, mentored startup cohort"
 human_role = "Investment and demo-day decisions"
 
+# The cohort-review desk brings admissions, mentorship, and investor readiness into one decision.
+[[group_chat]]
+id = "cohort-review"
+name = "Cohort review desk"
+description = "Coordinate cohort outcomes and decisions for the accelerator operator."
+members = ["application_screener", "mentor_matcher", "investor_liaison"]
+
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/startup_accelerator/workflows/cohort_pipeline.toml
+++ b/companies/startup_accelerator/workflows/cohort_pipeline.toml
@@ -83,6 +83,10 @@ id = "done"
 kind = "output"
 name = "Report to operator"
 summary = "Report cohort outcomes and the ask."
+# The cohort-review desk gathers the decisions that need accelerator operator review.
+[node.destination]
+kind = "channel"
+target = "cohort-review"
 
 [[edge]]
 from = "open"

--- a/companies/startup_accelerator/workflows/cohort_pipeline.toml
+++ b/companies/startup_accelerator/workflows/cohort_pipeline.toml
@@ -86,7 +86,7 @@ summary = "Report cohort outcomes and the ask."
 # The cohort-review desk gathers the decisions that need accelerator operator review.
 [node.destination]
 kind = "channel"
-target = "cohort-review"
+target = "cohort_review"
 
 [[edge]]
 from = "open"

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -602,9 +602,9 @@ fn the_marketing_campaign_preset_is_runnable() {
     assert_eq!(node("publish").config["agent_ref"], "copywriter");
 }
 
-/// Every seeded `output` node either names a destination its own manifest can
-/// resolve, or names none at all — and the ones that name none are exactly the
-/// templates that declare no desk (issue #947).
+/// Every seeded `output` node names a destination its own manifest can resolve,
+/// except the research lab, which deliberately proves that workflows can
+/// coordinate without desks (issue #963).
 ///
 /// Two failures this catches, and they are opposite:
 ///
@@ -614,38 +614,17 @@ fn the_marketing_campaign_preset_is_runnable() {
 ///     that manifest does not declare parses fine, ships, and fails at run time
 ///     on a freshly provisioned tenant — which is the class of bug #947 is about,
 ///     one step further along.
-///  2. **A desk-bearing template that quietly loses its destination.** The
-///     allowlist below is the 18 templates that declare no desk and therefore
-///     have nothing to address. It is an allowlist rather than a `!is_empty()`
-///     check so that removing a destination from one of the three that *can*
-///     deliver fails here instead of passing as "well, some have none".
+///  2. **A template that quietly loses its destination.** All shipped
+///     templates except the research lab now declare a desk for their terminal
+///     output. The single exception is named below so removing any other
+///     destination fails rather than passing as "well, some have none".
 ///
-/// The 18 are tracked in #963: they need desks before they can have
-/// destinations, which is a content judgement per company rather than a stanza,
-/// and `agentic_research_lab` declares no desk deliberately.
+/// `agentic_research_lab` explains in its own manifest why it has no desk: its
+/// workflow is the proving ground for collapsing desk coordination into the
+/// graph itself.
 #[test]
 fn every_seeded_output_destination_resolves_against_its_own_manifest() {
-    /// Templates with an `output` node and no desk to deliver it to (#963).
-    const NO_DESK_YET: &[&str] = &[
-        "agentic_accounting_firm",
-        "agentic_consultation_firm",
-        "agentic_customer_support",
-        "agentic_design_studio",
-        "agentic_enterprise_sales",
-        "agentic_game_business",
-        "agentic_game_studio",
-        "agentic_influencer_business",
-        "agentic_law_firm",
-        "agentic_media_company",
-        "agentic_pharma_startup",
-        "agentic_realestate_company",
-        "agentic_recruiting_company",
-        "agentic_research_lab",
-        "agentic_venture_capital",
-        "agentic_venture_studio",
-        "signals_opportunity_studio",
-        "startup_accelerator",
-    ];
+    const DESKLESS_WORKFLOW_TEMPLATE: &str = "agentic_research_lab";
 
     let mut checked = 0;
     let mut with_destination = 0;
@@ -682,17 +661,15 @@ fn every_seeded_output_destination_resolves_against_its_own_manifest() {
                 checked += 1;
                 let Some(destination) = node.destination.as_ref() else {
                     assert!(
-                        NO_DESK_YET.contains(&company.as_str()),
+                        company == DESKLESS_WORKFLOW_TEMPLATE,
                         "{label} has an output node with no destination, so a run of it \
-                         delivers nothing. Give it a destination, or — if this template \
-                         declares no desk to deliver to — add it to `NO_DESK_YET` and to \
-                         issue #963."
+                         delivers nothing. Give it a channel destination backed by a \
+                         manifest desk. The research lab is the only intentional exception."
                     );
                     assert!(
                         desks.is_empty(),
-                        "{label} is listed in `NO_DESK_YET` but its manifest declares \
-                         desks {desks:?}, so it has somewhere to deliver. Give its output \
-                         node a destination and drop it from the list."
+                        "{label} is the deskless-workflow exception but its manifest \
+                         declares desks {desks:?}. Give its output node a destination."
                     );
                     continue;
                 };
@@ -721,7 +698,8 @@ fn every_seeded_output_destination_resolves_against_its_own_manifest() {
         "the seeded output-node count changed; this test and #963's list describe 21"
     );
     assert_eq!(
-        with_destination, 3,
-        "exactly the three desk-bearing templates carry a destination today"
+        with_destination, 20,
+        "every seeded output except the research lab's deliberate deskless workflow \
+         carries a destination"
     );
 }


### PR DESCRIPTION
## Summary

17 shipped company templates each declared one workflow with an `output` node and **no `[[group_chat]]` desk**, so every run of them dropped its report unseen. Split out of #947, which fixed the three templates that already had desks.

Each of the 17 gains one desk in `company.toml` and a `[node.destination]` on its terminal `output` node pointing at it, following the `agentic_marketing_agency` pattern #947 established. Desk membership is drawn from that company's own roster, and the desk chosen is the one the report actually belongs to rather than a stanza repeated 17 times.

**`agentic_research_lab` is deliberately excluded.** Its manifest declares no desks on purpose and says why — `docs/spec/runtime/orchestration/delegation.md` collapses desks into workflows, and that company is the proving ground for it. Adding a desk there would contradict a documented design decision, so it stays as it is and becomes the test's single named exception.

## API Or Behavior Changes

None in code. Template content only: 17 `company.toml` files gain a `[[group_chat]]`, 17 workflow files gain a `[node.destination]`. A freshly provisioned tenant from any of these templates now delivers its pipeline report instead of discarding it.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked --features openhuman,tinycortex --lib company::content_test` — 13 passed, 0 failed

`every_seeded_output_destination_resolves_against_its_own_manifest` gets **stricter**, which is the point:

- The `NO_DESK_YET` allowlist of 18 templates collapses to one named constant, `DESKLESS_WORKFLOW_TEMPLATE = "agentic_research_lab"`. An allowlist that long could absorb a regression silently; a single exception cannot.
- `with_destination` goes from `3` to `20`, so removing a destination from any template except the research lab now fails here rather than passing as "well, some have none".
- The paired assertion still holds in both directions: a template with no destination must declare no desks, and a destination must resolve against its own manifest.

Desk ids and members were checked against each company's `agents/` roster — the test resolves a destination against the manifest, so a wrong desk id or a member that is not on the roster fails rather than shipping.

## Documentation

None needed. The desk choice for each company is explained in a comment above its `[node.destination]`, the way the marketing template does it — these templates are read as examples, so the reasoning is part of the content.

Closes #963
