### PR TITLE
fix(chat): stop a DM header printing the teammate's name twice

### DIFF
--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, CircleDot, Hash, Lock, SquarePen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
-import { dmFace, type Channel, type ChannelSection } from "./model";
+import { channelSubtitle, dmFace, type Channel, type ChannelSection } from "./model";
 
 /**
  * What an unread badge actually claims (issue #364).
@@ -148,7 +148,12 @@ function ChannelRow({
       type="button"
       onClick={() => onSelect(channel.id)}
       aria-current={active ? "page" : undefined}
-      title={channel.purpose}
+      // The row's own label is `channel.name`, so a tooltip that resolves to
+      // the same string is the header's issue-#1180 duplicate in a slower
+      // form: you hover for a second fact and get the one already under the
+      // cursor. No tooltip at all is the better answer, and `undefined` — not
+      // `""` — is what suppresses the native bubble.
+      title={channelSubtitle(channel) ?? undefined}
       className={cn(
         "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
         active

--- a/frontend/src/views/chat/ChatHeader.tsx
+++ b/frontend/src/views/chat/ChatHeader.tsx
@@ -4,7 +4,7 @@ import { Check, CircleDot, Copy, Hash, Lock, PanelLeft, Users } from "lucide-rea
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
-import { channelTitle, dmFace, type Channel } from "./model";
+import { channelSubtitle, channelTitle, dmFace, type Channel } from "./model";
 
 interface Props {
   channel: Channel;
@@ -20,9 +20,14 @@ interface Props {
  * The bar above a channel's timeline.
  *
  * It is deliberately thin — a kind mark (the teammate's avatar on a DM), the
- * name, and the purpose in the tooltip — with the two things you actually
- * reach for on the right: the member pane and a copy of the channel name. The
- * copy button only appears on hover so the title reads clean at rest.
+ * name, and a muted second line past the divider — with the two things you
+ * actually reach for on the right: the member pane and a copy of the channel
+ * name. The copy button only appears on hover so the title reads clean at rest.
+ *
+ * That second line is [`channelSubtitle`], which answers `null` when the only
+ * thing it could say is what the title already says. The whole `<span>` goes
+ * with it: it carries the `border-l` that draws the divider, so rendering it
+ * empty would leave a rule hanging beside the name with nothing after it.
  */
 export function ChatHeader({
   channel,
@@ -33,6 +38,7 @@ export function ChatHeader({
 }: Props) {
   const [copied, setCopied] = useState(false);
   const title = channelTitle(channel);
+  const subtitle = channelSubtitle(channel);
 
   async function copyName() {
     try {
@@ -62,7 +68,7 @@ export function ChatHeader({
         <KindIcon channel={channel} />
         <h1
           className="min-w-0 truncate text-base font-semibold tracking-tight"
-          title={channel.purpose}
+          title={subtitle ?? undefined}
         >
           {channel.name}
         </h1>
@@ -76,9 +82,11 @@ export function ChatHeader({
         >
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>
-        <span className="hidden min-w-0 truncate border-l pl-2 text-xs text-muted-foreground sm:block">
-          {channel.purpose}
-        </span>
+        {subtitle && (
+          <span className="hidden min-w-0 truncate border-l pl-2 text-xs text-muted-foreground sm:block">
+            {subtitle}
+          </span>
+        )}
       </div>
 
       <Button

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -9,7 +9,7 @@ import { Avatar } from "./Avatar";
 import { MessageRow } from "./MessageRow";
 import { StepTimeline } from "./StepTimeline";
 import { WorkingIndicator } from "./WorkingIndicator";
-import { channelTitle, type Channel, type TimelineItem } from "./model";
+import { channelSubtitle, channelTitle, type Channel, type TimelineItem } from "./model";
 
 interface Props {
   channel: Channel;
@@ -268,6 +268,14 @@ function ChannelIntro({
   loading: boolean;
   onAddPeople?: () => void;
 }) {
+  // Every branch below appends this to a sentence that has already named the
+  // channel, so it goes through the same guard the header does: without it the
+  // DM line read "…your direct message with Backend Engineer — backend
+  // engineer." for any teammate the host sends no name for (issue #1180). A
+  // `null` here drops the clause rather than the sentence — where you are is
+  // still worth saying, the tautology after it is not.
+  const subtitle = channelSubtitle(channel);
+
   return (
     <div className={cn("px-4 pb-3", empty ? "pt-16" : "pt-6")}>
       <Avatar
@@ -284,10 +292,14 @@ function ChannelIntro({
           and stays either way, so the pane still says where you are. */}
       <p className="mt-1 max-w-prose text-sm text-muted-foreground">
         {loading
-          ? sentence(channel.purpose)
+          ? subtitle
+            ? sentence(subtitle)
+            : ""
           : channel.kind === "dm"
-            ? `This is the start of your direct message with ${channel.name} — ${lower(channel.purpose)}.`
-            : `This is the very beginning of ${channelTitle(channel)}. ${sentence(channel.purpose)}`}
+            ? subtitle
+              ? `This is the start of your direct message with ${channel.name} — ${lower(subtitle)}.`
+              : `This is the start of your direct message with ${channel.name}.`
+            : `This is the very beginning of ${channelTitle(channel)}.${subtitle ? ` ${sentence(subtitle)}` : ""}`}
       </p>
       {/* The two openings a new channel actually has. Held back until the
           history has answered, for the same reason the sentence above is:

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -9,7 +9,7 @@ import { Avatar } from "./Avatar";
 import { MessageRow } from "./MessageRow";
 import { StepTimeline } from "./StepTimeline";
 import { WorkingIndicator } from "./WorkingIndicator";
-import { channelSubtitle, channelTitle, type Channel, type TimelineItem } from "./model";
+import { channelIntroSentence, channelTitle, type Channel, type TimelineItem } from "./model";
 
 interface Props {
   channel: Channel;
@@ -268,14 +268,6 @@ function ChannelIntro({
   loading: boolean;
   onAddPeople?: () => void;
 }) {
-  // Every branch below appends this to a sentence that has already named the
-  // channel, so it goes through the same guard the header does: without it the
-  // DM line read "…your direct message with Backend Engineer — backend
-  // engineer." for any teammate the host sends no name for (issue #1180). A
-  // `null` here drops the clause rather than the sentence — where you are is
-  // still worth saying, the tautology after it is not.
-  const subtitle = channelSubtitle(channel);
-
   return (
     <div className={cn("px-4 pb-3", empty ? "pt-16" : "pt-6")}>
       <Avatar
@@ -291,15 +283,7 @@ function ChannelIntro({
           conversation (issue #934). The identity block above is not a claim
           and stays either way, so the pane still says where you are. */}
       <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-        {loading
-          ? subtitle
-            ? sentence(subtitle)
-            : ""
-          : channel.kind === "dm"
-            ? subtitle
-              ? `This is the start of your direct message with ${channel.name} — ${lower(subtitle)}.`
-              : `This is the start of your direct message with ${channel.name}.`
-            : `This is the very beginning of ${channelTitle(channel)}.${subtitle ? ` ${sentence(subtitle)}` : ""}`}
+        {channelIntroSentence(channel, loading)}
       </p>
       {/* The two openings a new channel actually has. Held back until the
           history has answered, for the same reason the sentence above is:
@@ -447,13 +431,4 @@ function TypingRow({ channel }: { channel: Channel }) {
       <WorkingIndicator srLabel="Replying…" />
     </div>
   );
-}
-
-function lower(s: string): string {
-  return s.charAt(0).toLowerCase() + s.slice(1);
-}
-
-function sentence(s: string): string {
-  const t = s.trim();
-  return /[.!?]$/.test(t) ? t : `${t}.`;
 }

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -174,3 +174,23 @@ the header drew before issue #1170. Both go through `dmFace(channel)` in
 glyph (`#`, `Lock`, `CircleDot`) instead, because neither has one person behind
 it. The header draws its tile at 24px, the floor below which `Avatar`'s
 `markOnly` says a mascot is a smudge and the bare tone tile is the honest mark.
+
+## One name per teammate
+
+The header's title is `channel.name`; the muted slot past the divider is
+`channelSubtitle(channel)`. A DM's `purpose` is the teammate's **description**,
+falling back to their role — the field parallel to a desk's blurb, since both
+answer "what is this line for". It used to be the role alone, which is an
+identity field in a description slot, and `fromDto` resolves a teammate's name
+as `dto.name?.trim() || dto.role`: a company that declares roles and names
+nobody made the two slots one string, and every DM header in it read
+`Backend Engineer │ Backend Engineer` (issue #1180).
+
+So `channelSubtitle` returns `null` — not `""` — for a purpose that is empty or
+that only repeats the title, compared case- and whitespace-insensitively. The
+header drops the entire `<span>` when it does, divider included: the `border-l`
+lives on that element, so keeping it empty would leave a rule hanging beside the
+name. `ChannelRail`'s row tooltip and `MessageTimeline`'s conversation-intro
+clause read the same helper, for the same reason. The rule is kind-agnostic: a
+desk whose blurb just restates its slug is the identical non-fact under `#`, and
+a blurb that says something the slug does not is untouched.

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -159,7 +159,17 @@ export function buildChannels(members: TeamMember[], desks: Desk[] = defaultDesk
     id: dmChannelId(m),
     name: m.name,
     kind: "dm" as const,
-    purpose: m.role,
+    // The teammate's **description**, which is the field parallel to a desk's
+    // `blurb` above — both answer "what is this line for", and neither repeats
+    // what the title already said. This used to read `m.role`, an identity
+    // field in a description slot, and that is precisely what made the header
+    // say the same words twice (issue #1180): `fromDto` falls back
+    // `dto.name?.trim() || dto.role`, so a company that names roles rather than
+    // people has name === role, and the title and the slot after the divider
+    // resolved to one string. The role is still the fallback — for a teammate
+    // the host *did* name it is a real second fact — and {@link channelSubtitle}
+    // is what declines to render even that when it just echoes the title.
+    purpose: m.description.trim() || m.role,
     tone: m.tone,
     member: m,
   }));
@@ -294,6 +304,35 @@ export function channelMembers(channel: Channel, roster: TeamMember[]): TeamMemb
 /** How a channel is titled in the header and the rail. */
 export function channelTitle(channel: Channel): string {
   return channel.kind === "dm" ? channel.name : `#${channel.name}`;
+}
+
+/**
+ * The line that goes *beside* the title — the muted slot after the header's
+ * divider, the rail row's tooltip, the conversation intro's clause — or `null`
+ * when there is nothing to say that the title has not already said.
+ *
+ * `null` rather than the empty string, and a rule rather than a DM special
+ * case. A subtitle exists to add a second fact; one that repeats the first is
+ * not a hierarchy, it is the same word twice with two type styles, and the
+ * honest render of "nothing more to say" is nothing. Issue #1180 is what that
+ * looks like when it ships: every agent in a company that declares roles and no
+ * names read `Backend Engineer │ Backend Engineer` across the top of its DM.
+ *
+ * The comparison is case- and whitespace-insensitive because the duplicate is a
+ * duplicate to a reader either way — a manifest whose description restates the
+ * role in sentence case is the same non-fact as one that restates it verbatim.
+ *
+ * Kind-agnostic on purpose. A DM is where this bites today, but a desk whose
+ * blurb is just its own name is the identical duplicate under `#`, and a rule
+ * that only fires for DMs would let that one through. Channels are otherwise
+ * untouched: a blurb that says something the slug does not — which is every
+ * desk that bothered to write one — comes back exactly as before.
+ */
+export function channelSubtitle(channel: Channel): string | null {
+  const purpose = channel.purpose.trim();
+  if (!purpose) return null;
+  if (purpose.toLowerCase() === channel.name.trim().toLowerCase()) return null;
+  return purpose;
 }
 
 /**

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -331,7 +331,13 @@ export function channelTitle(channel: Channel): string {
 export function channelSubtitle(channel: Channel): string | null {
   const purpose = channel.purpose.trim();
   if (!purpose) return null;
-  if (purpose.toLowerCase() === channel.name.trim().toLowerCase()) return null;
+  // Collapse runs of internal whitespace too, not just the outer trim — a
+  // manifest description copy-pasted from the role with a doubled space or a
+  // stray newline in the middle is still the same duplicate to a reader, and
+  // the doc comment above promises "whitespace-insensitive" without
+  // qualification.
+  const normalize = (s: string) => s.trim().replace(/\s+/g, " ").toLowerCase();
+  if (normalize(purpose) === normalize(channel.name)) return null;
   return purpose;
 }
 

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -336,6 +336,45 @@ export function channelSubtitle(channel: Channel): string | null {
 }
 
 /**
+ * The line under the identity block at the top of an empty transcript.
+ *
+ * Pure, exported and here rather than inline in `MessageTimeline` because it is
+ * four branches of prose over two nullable inputs, and prose defects are
+ * invisible to a type checker. The one this arrived with: the DM branch used to
+ * append a full stop by hand, which was right while the subtitle was a role
+ * (`Backend Engineer`) and produced "…and services.." the moment issue #1180
+ * made it a description that brings its own punctuation. `sentence` is the rule
+ * for that, so every branch goes through it.
+ *
+ * `loading` renders the subtitle alone: both finished sentences are positive
+ * claims that the channel has no history, and neither may be made before the
+ * host has answered (issue #934).
+ */
+export function channelIntroSentence(channel: Channel, loading: boolean): string {
+  const subtitle = channelSubtitle(channel);
+  if (loading) return subtitle ? sentence(subtitle) : "";
+  if (channel.kind === "dm") {
+    // No subtitle drops the clause, not the sentence: where you are is still
+    // worth saying, the tautology after it is not.
+    return subtitle
+      ? `This is the start of your direct message with ${channel.name} — ${sentence(lower(subtitle))}`
+      : `This is the start of your direct message with ${channel.name}.`;
+  }
+  return `This is the very beginning of ${channelTitle(channel)}.${subtitle ? ` ${sentence(subtitle)}` : ""}`;
+}
+
+/** Lowercases the first character only, for a clause continuing a sentence. */
+function lower(s: string): string {
+  return s.charAt(0).toLowerCase() + s.slice(1);
+}
+
+/** Terminates `s` with a full stop unless it already ends in punctuation. */
+function sentence(s: string): string {
+  const t = s.trim();
+  return /[.!?]$/.test(t) ? t : `${t}.`;
+}
+
+/**
  * The face a DM wears — the `Avatar` seed for the teammate on the other end —
  * or `null` for anything that has no face: a channel, and a DM with no roster
  * entry behind it (both of those wear a glyph instead).

--- a/frontend/test/unit/chat-channel-subtitle.test.ts
+++ b/frontend/test/unit/chat-channel-subtitle.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { TeamMember } from "@/lib/team";
-import { buildChannels, channelSubtitle, channelTitle, type Channel } from "@/views/chat/model";
+import {
+  buildChannels,
+  channelIntroSentence,
+  channelSubtitle,
+  channelTitle,
+  type Channel,
+} from "@/views/chat/model";
 
 /**
  * The second slot beside a chat title, and what it is allowed to say (issue
@@ -120,6 +126,60 @@ describe("channelSubtitle on a channel", () => {
     // Kind-agnostic on purpose: `#engineering │ Engineering` is the identical
     // non-fact, and a rule that only fired for DMs would ship it.
     expect(channelSubtitle(channelFor({ channel: "engineering", blurb: "Engineering" }))).toBeNull();
+  });
+});
+
+describe("channelIntroSentence", () => {
+  it("ends a DM's opening line with exactly one full stop", () => {
+    // The defect a browser caught and this suite did not. The clause used to
+    // take a hardcoded ".", which was invisible while the subtitle was a role
+    // and produced "…and services.." the moment it became a description that
+    // punctuates itself. Asserted as a suffix rule, not a fixed string, so it
+    // fails for any description whatever punctuation the manifest gave it.
+    const line = channelIntroSentence(dmFor(ROLE_ONLY), false);
+    expect(line).toBe(
+      "This is the start of your direct message with Backend Engineer — build and operate the backend and services.",
+    );
+    expect(line.endsWith("..")).toBe(false);
+  });
+
+  it("still supplies a full stop for a description that came without one", () => {
+    const dm = dmFor(
+      member({ id: "agent_ada", name: "Ada", role: "Engineer", description: "Keeps the schedulers honest" }),
+    );
+    expect(channelIntroSentence(dm, false)).toBe(
+      "This is the start of your direct message with Ada — keeps the schedulers honest.",
+    );
+  });
+
+  it("drops the clause, not the sentence, when there is nothing to add", () => {
+    // The #1180 read: no description and a name that IS the role. The line
+    // still says where you are; it just stops rather than repeating itself.
+    const dm = dmFor(member({ id: "agent_ops", name: "Ops Lead", role: "Ops Lead" }));
+    expect(channelIntroSentence(dm, false)).toBe(
+      "This is the start of your direct message with Ops Lead.",
+    );
+  });
+
+  it("keeps a channel's two-sentence opening", () => {
+    expect(
+      channelIntroSentence(channelFor({ channel: "engineering", blurb: "Build, test, and secure the product." }), false),
+    ).toBe("This is the very beginning of #engineering. Build, test, and secure the product.");
+  });
+
+  it("leaves no trailing space on a channel with no blurb", () => {
+    const line = channelIntroSentence(channelFor({ channel: "engineering", blurb: "" }), false);
+    expect(line).toBe("This is the very beginning of #engineering.");
+    expect(line).toBe(line.trimEnd());
+  });
+
+  it("makes no claim about emptiness while history is still loading (issue #934)", () => {
+    // Neither finished sentence may render before the host has answered — both
+    // assert the channel has no history. The subtitle alone is not a claim.
+    expect(channelIntroSentence(dmFor(ROLE_ONLY), true)).toBe(
+      "Build and operate the backend and services.",
+    );
+    expect(channelIntroSentence(dmFor(member({ id: "a", name: "Ops Lead", role: "Ops Lead" })), true)).toBe("");
   });
 });
 

--- a/frontend/test/unit/chat-channel-subtitle.test.ts
+++ b/frontend/test/unit/chat-channel-subtitle.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import type { TeamMember } from "@/lib/team";
+import { buildChannels, channelSubtitle, channelTitle, type Channel } from "@/views/chat/model";
+
+/**
+ * The second slot beside a chat title, and what it is allowed to say (issue
+ * #1180).
+ *
+ * The failure this guards renders perfectly. Nothing throws, no type objects,
+ * and the header is laid out exactly as designed — a title, a divider, a muted
+ * line — except that both sides of the divider hold the same words:
+ *
+ *     🫥  Backend Engineer  │  Backend Engineer
+ *
+ * It happens because the two slots read different fields that collapse to one
+ * string. The title is the teammate's name, and `fromDto` falls back
+ * `dto.name?.trim() || dto.role`; the slot used to read the role directly. A
+ * company that declares roles and never names people — which is every agent in
+ * `companies/agentic_software_company` — makes those the same string for every
+ * teammate it employs.
+ *
+ * So two things are pinned here. `buildChannels` must fill a DM's `purpose`
+ * from the field that is *parallel* to a desk's blurb (the description), and
+ * `channelSubtitle` must answer `null` rather than hand a caller a string that
+ * only repeats the title. The second is the load-bearing one: it is what keeps
+ * a future field swap from re-introducing the duplicate, and what the header
+ * keys on to drop the divider along with the text.
+ */
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
+  return {
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    avatar: "green",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  };
+}
+
+function dmFor(m: TeamMember): Channel {
+  const dms = buildChannels([m], []).find((s) => s.id === "dms");
+  expect(dms?.channels).toHaveLength(1);
+  return dms!.channels[0];
+}
+
+function channelFor(over: { channel: string; blurb: string }): Channel {
+  const sections = buildChannels([], [
+    { id: "d1", channel: over.channel, name: "Engineering", blurb: over.blurb },
+  ]);
+  const channels = sections.find((s) => s.id === "channels")!.channels;
+  expect(channels).toHaveLength(1);
+  return channels[0];
+}
+
+/** The roster shape the sample company actually produces: a role, no name. */
+const ROLE_ONLY = member({
+  id: "agent_backend",
+  name: "Backend Engineer",
+  role: "Backend Engineer",
+  description: "Build and operate the backend and services.",
+});
+
+describe("channelSubtitle on a DM", () => {
+  it("says what the teammate does, for a teammate the host never named", () => {
+    // The #1180 case end to end. The title says who; this says what for, out of
+    // the description the roster entry was carrying unused all along.
+    expect(channelSubtitle(dmFor(ROLE_ONLY))).toBe("Build and operate the backend and services.");
+  });
+
+  it("says nothing rather than the role when the role IS the title", () => {
+    // The regression guard. With no description the fallback is the role, and
+    // for this teammate the role is also the name — so the slot has no second
+    // fact to offer and must not pretend otherwise by restyling the first.
+    const dm = dmFor(member({ id: "agent_backend", name: "Backend Engineer", role: "Backend Engineer" }));
+    expect(channelSubtitle(dm)).toBeNull();
+    expect(channelSubtitle(dm)).not.toBe(channelTitle(dm));
+  });
+
+  it("keeps the role for a named teammate with no description", () => {
+    // Not a blanket "drop the role": for a teammate the host *did* name, the
+    // role is a genuinely different string from the title and worth the space.
+    const dm = dmFor(member({ id: "agent_ada", name: "Ada", role: "Backend Engineer" }));
+    expect(channelSubtitle(dm)).toBe("Backend Engineer");
+  });
+
+  it("catches a description that only restates the title in different case", () => {
+    // A duplicate is a duplicate to a reader whatever its casing or padding,
+    // and a manifest that answers "description" by retyping the role in
+    // sentence case is the most likely way to write one by hand.
+    const dm = dmFor(
+      member({
+        id: "agent_backend",
+        name: "Backend Engineer",
+        role: "Backend Engineer",
+        description: "  backend engineer ",
+      }),
+    );
+    expect(channelSubtitle(dm)).toBeNull();
+  });
+});
+
+describe("channelSubtitle on a channel", () => {
+  it("hands back the desk's blurb unchanged — a slug and a blurb are two facts", () => {
+    // The do-not-break-channels guard. `#engineering` and "Build, test, and
+    // secure the product." were never the duplicate this fixed, and the fix
+    // must not cost a channel the one line it has to explain itself.
+    expect(channelSubtitle(channelFor({ channel: "engineering", blurb: "Build, test, and secure the product." })))
+      .toBe("Build, test, and secure the product.");
+  });
+
+  it("says nothing for a desk that wrote no blurb", () => {
+    expect(channelSubtitle(channelFor({ channel: "engineering", blurb: "" }))).toBeNull();
+  });
+
+  it("applies the same rule to a blurb that just restates the slug", () => {
+    // Kind-agnostic on purpose: `#engineering │ Engineering` is the identical
+    // non-fact, and a rule that only fired for DMs would ship it.
+    expect(channelSubtitle(channelFor({ channel: "engineering", blurb: "Engineering" }))).toBeNull();
+  });
+});
+
+describe("buildChannels fills a DM's purpose from the description", () => {
+  it("prefers the description — the field parallel to a desk's blurb", () => {
+    expect(dmFor(ROLE_ONLY).purpose).toBe("Build and operate the backend and services.");
+  });
+
+  it("falls back to the role when the teammate has no description", () => {
+    // Still the fallback rather than an empty string: dropping the role here
+    // would take the subtitle away from every *named* teammate too, and
+    // `channelSubtitle` is the right place to decline a duplicate.
+    expect(dmFor(member({ id: "agent_ada", name: "Ada", role: "Backend Engineer" })).purpose)
+      .toBe("Backend Engineer");
+  });
+});

--- a/frontend/test/unit/chat-channel-subtitle.test.ts
+++ b/frontend/test/unit/chat-channel-subtitle.test.ts
@@ -107,6 +107,23 @@ describe("channelSubtitle on a DM", () => {
     );
     expect(channelSubtitle(dm)).toBeNull();
   });
+
+  it("catches a duplicate with doubled internal whitespace, not just outer padding", () => {
+    // The doc comment on `channelSubtitle` promises "whitespace-insensitive"
+    // without qualifying it to the ends of the string. A description
+    // copy-pasted from the role with an extra space or a stray newline typed
+    // in the middle is still the same non-fact to a reader, and a comparison
+    // that only trims the outer edges would miss it.
+    const dm = dmFor(
+      member({
+        id: "agent_backend",
+        name: "Backend Engineer",
+        role: "Backend Engineer",
+        description: "Backend   Engineer",
+      }),
+    );
+    expect(channelSubtitle(dm)).toBeNull();
+  });
 });
 
 describe("channelSubtitle on a channel", () => {


### PR DESCRIPTION
Closes #1180

## The bug

Open a DM with a teammate the host sends no display name for and the header says the same words twice:

```
🫥  Backend Engineer  │  Backend Engineer
    ↑ the title           ↑ the muted slot after the divider
```

Reproduced against `upstream/main` on `companies/agentic_software_company`, where every agent reads this way.

## The cause, restated as a modeling error

`buildChannels` filled the two kinds' `purpose` slot from **non-parallel** fields:

| kind | title | `purpose` |
|---|---|---|
| channel | `#${d.channel}` (slug) | `d.blurb` — the desk's **description** |
| dm | `m.name` | `m.role` — an **identity** field |

A desk's purpose is its description. A teammate's was set to their role — which `fromDto` also uses as the *name* fallback (`dto.name?.trim() || dto.role`). So a company that declares roles and names nobody has `name === role`, and an identity field sitting in a description slot renders the string the title just rendered.

## The judgement call

**When name and purpose are the same string, the second slot shows the teammate's `description`; when there is no description, it shows nothing.**

- A DM's `purpose` is now `m.description.trim() || m.role` — the field genuinely parallel to a desk's blurb. `TeamMember.description` was already carried through by `fromDto` and was going unused. For the sample company that turns a repeat into `Build and operate the backend and services.`
- The fallback can still echo the title, so `channelSubtitle()` returns `null` — not `""` — for a purpose that is empty or that only repeats the name, compared case- and whitespace-insensitively. The header then omits **the whole `<span>`, divider included**: the `border-l` lives on that element, so an empty one would leave a rule hanging beside the name.

I deliberately did **not** fill the slot with desk, status, or tier. Those already have homes on the members pane and the agent detail view, and inventing a new one here would be a design change smuggled into a bug fix. Dropping the slot is honest and costs nothing. Nothing in this PR prints the same string twice with two type styles and calls it a hierarchy.

The rule is kind-agnostic on purpose: a desk whose blurb just restates its slug is the identical non-fact under `#`, and a rule that only fired for DMs would ship it.

## Scope

`ChannelRail`'s row tooltip and `MessageTimeline`'s conversation-intro clause read `channel.purpose` too, and after the model change they would otherwise still render the duplicate a few pixels below the fixed header for the same company. Both go through the same helper — about six lines.

Fixed at the model layer rather than in `ChatHeader`, because the wrong field is chosen in `buildChannels`; the header was faithfully rendering what it was handed.

## A defect the browser caught

Verifying in a browser turned up something the tests did not: with `purpose` now a description, the intro clause's hardcoded full stop produced `…and services..`. Descriptions punctuate themselves; roles never did. `sentence()` was already the rule, so every branch now goes through it, and the four-branch expression moved out of `ChannelIntro` into a pure `channelIntroSentence()` so the suite can pin it. Confirmed the new test fails when the hardcoded stop is put back.

## Verified in a browser

Host on `:8371` with `--company companies/agentic_software_company`, console on `:5203`, signed in via magic link. All four cases in light and dark.

| case | title | muted slot |
|---|---|---|
| **No display name** (`Backend Engineer`, the common case) | Backend Engineer | Build and operate the backend and services. |
| **Distinct name + description** (`Ada Okonkwo`) | Ada Okonkwo | Owns the migration off the legacy scheduler. |
| **Distinct name, no description** (`Grace Bello`) | Grace Bello | Release Manager |
| **Name equals role, no description** (`Ops Lead`) | Ops Lead | *(nothing — span and divider both omitted)* |
| **Channel** (`#engineering`) | #engineering | Build, test, and secure the product. |

Before, on the same running build: title `Backend Engineer`, slot `Backend Engineer`, intro `…with Backend Engineer — backend Engineer.`

## Tests

New `frontend/test/unit/chat-channel-subtitle.test.ts`, 15 cases: description preferred, role kept for a named teammate, `null` for a duplicate (including case/whitespace variants), channels unchanged, and the intro sentence's punctuation, dropped clause, no-trailing-space, and issue-#934 loading branch.

```
npm run typecheck      ✓
npm run typecheck:unit ✓
npm test               ✓ 137 files, 1335 tests
```

## Note

`lower()` lowercases only the first character, so a title-cased role still reads `— release Manager.` in the intro. That predates this PR (it read `— backend Engineer.` before) and is left alone as a separate concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chat channel and direct-message subtitles using teammate descriptions, with role-based fallbacks.
  - Suppressed empty or duplicate subtitles and unnecessary separators across headers, channel lists, and conversation introductions.
  - Updated conversation intro messages for clearer, punctuation-safe wording in loading, channel, and direct-message states.

- **Documentation**
  - Added guidance describing teammate naming, subtitle fallback behavior, and when subtitles are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->