### PR TITLE
workflows: take the run input off the detail toolbar, behind Run

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -12,6 +12,7 @@ import { useTheme } from "next-themes";
 import {
   ArrowLeft,
   Bot,
+  ChevronDown,
   FlaskConical,
   History,
   LayoutGrid,
@@ -66,6 +67,14 @@ import {
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
@@ -342,8 +351,21 @@ export function WorkflowsView({
   // Issue #154: what the operator is asking this run to work on. `ranWith` is
   // pinned when the run is dispatched so the result panel echoes the request the
   // shown output came from, not whatever has been typed since.
+  //
+  // Issue #1204: `request` is the DRAFT held by the "Run with input" dialog, not
+  // an implicit argument to running. It used to be a text box wired straight
+  // into `run()`'s closure, sitting open on the toolbar; taking the box off the
+  // bar without also cutting that wire would have been worse than leaving it
+  // there, because a draft typed once and then forgotten would keep riding
+  // along on every later press of Run with nothing on screen to say so. So the
+  // payload is a PARAMETER of `run()` now (see below) and this state is only
+  // ever read at the moment a dialog button is pressed. It survives the dialog
+  // closing on purpose — reopening restores what was typed, which is what makes
+  // "run it again with a tweak" one edit rather than a retype.
   const [request, setRequest] = useState("");
   const [ranWith, setRanWith] = useState("");
+  // Issue #1204: whether that dialog is up.
+  const [runInputOpen, setRunInputOpen] = useState(false);
   // Issue #1002: the roster read behind the cards' "Asked by" line, keyed to the
   // approvals of the run on screen rather than to the whole queue — so a console
   // with a run drawer closed does not fetch the roster for cards it is not
@@ -1079,7 +1101,13 @@ export function WorkflowsView({
     return byId;
   }, [indexRuns]);
 
-  const run = useCallback(async (dryRun = false) => {
+  // `input` is the trigger payload for THIS dispatch (issue #1204), handed in by
+  // whichever control fired rather than read out of `request` state. The toolbar's
+  // Run and Test run pass nothing and therefore genuinely run with no input; only
+  // the "Run with input" dialog passes its draft. That is the whole guarantee the
+  // dialog rests on: there is no way to run with a payload the operator cannot
+  // see at the moment they press the button.
+  const run = useCallback(async (dryRun = false, input = "") => {
     if (!selectedId) return;
     setStarting(true);
     // Clear the last refusal and the own-run-start watch before this attempt, so
@@ -1111,7 +1139,7 @@ export function WorkflowsView({
     setOptimistic(dryRun ? null : graph ? initialRunState(graph) : null);
     // Trimmed once here so the echoed request and the payload the host receives
     // can never disagree.
-    const asked = request.trim();
+    const asked = input.trim();
     // Issue #1007: the browser's own clock, not the host's. It is what the
     // failure panel measures against and what the optimistic history row counts
     // from, and both are on screen before the host has said anything at all.
@@ -1238,7 +1266,10 @@ export function WorkflowsView({
     } finally {
       setStarting(false);
     }
-  }, [client, company, selectedId, request, graph]);
+    // `request` is deliberately NOT a dependency (issue #1204): the payload
+    // arrives as an argument, so this callback no longer changes identity on
+    // every keystroke in the dialog.
+  }, [client, company, selectedId, graph]);
 
   /**
    * Issue #383: stop the run this view started.
@@ -1735,6 +1766,12 @@ export function WorkflowsView({
     // the newly-selected one's.
     setRunFailure(null);
     setPendingRun(null);
+    // Issue #1204: and the run-input draft, which names work for the workflow
+    // being LEFT — "the Q3 board deck" carried onto another workflow's dialog is
+    // the same category of wrong as the drawers above, and the dialog itself
+    // must not survive a switch it was opened on the other side of.
+    setRequest("");
+    setRunInputOpen(false);
     // Issue #863: the adopted run belonged to the workflow being left. Holding
     // it across the switch would keep painting one graph's trail onto another's
     // canvas the moment the two share a node id.
@@ -1801,6 +1838,30 @@ export function WorkflowsView({
   // The Run guard, derived rather than held: the request is in flight, or a run
   // we started has not settled yet.
   const running = starting || activeRunId !== null;
+
+  /**
+   * Issue #1204: dispatch from the run-input dialog.
+   *
+   * Closes first, then runs. A synchronous run holds the request open for the
+   * whole run (#528), so a dialog left up would sit over the canvas and the
+   * history rail — the two surfaces that report what is happening — for as long
+   * as the run takes.
+   *
+   * The draft is deliberately NOT cleared: the operator who ran on "Q3 board
+   * deck" and wants to run again on "Q4 board deck" should be editing two
+   * characters, not retyping the line. It is cleared when the workflow changes,
+   * where it stops being about the work in front of them.
+   */
+  const runWithInput = useCallback(
+    (dryRun: boolean) => {
+      // The buttons are disabled in these states and Enter bypasses them, so the
+      // guard is here rather than only on the controls.
+      if (!selectedId || running || loadingGraph) return;
+      setRunInputOpen(false);
+      void run(dryRun, request);
+    },
+    [selectedId, running, loadingGraph, run, request],
+  );
 
   // What the canvas actually paints, in priority order: a past run the operator
   // explicitly asked to see, else the live fold, else the optimistic frontier.
@@ -2074,34 +2135,59 @@ export function WorkflowsView({
               data-testid="workflow-detail-actions"
             >
               {/* run intent — the point of the screen, and the only filled
-                  button on it. */}
+                  control on it.
+
+                  Issue #1204: it is ONE control in two halves now, not a text
+                  box and a button. The box — "What should this run work on?" —
+                  was the widest thing on a row of nine and empty on almost every
+                  visit, so the common case (press Run) was reached past an input
+                  that the uncommon case needed. The halves invert that: Run is a
+                  click, and the payload is a click plus a dialog.
+
+                  What the second half must NOT become is a hiding place. The
+                  capability behind it is real (issue #154 — the host seeds the
+                  payload as the trigger node's item, and a first step bound to
+                  `=items` reads it), which is exactly why the draft is passed to
+                  `run()` explicitly rather than left in a closure: pressing the
+                  left half always means "no input", visibly and always. */}
               <div className="flex min-w-0 items-center gap-2">
-                <Input
-                  value={request}
-                  onChange={(e) => setRequest(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && selectedId && !running && !loadingGraph) {
-                      void run();
-                    }
-                  }}
-                  disabled={!selectedId || running}
-                  placeholder="What should this run work on?"
-                  aria-label="Request for this run"
-                  className="h-8 w-64 max-w-full"
-                />
-                <Button
-                  size="sm"
-                  onClick={() => void run()}
-                  disabled={!selectedId || running || loadingGraph}
-                  data-testid="workflow-run"
-                >
-                  {running ? (
-                    <Loader2 className="mr-1.5 size-4 animate-spin" />
-                  ) : (
-                    <Play className="mr-1.5 size-4" />
-                  )}
-                  Run
-                </Button>
+                <div className="flex items-center" data-testid="workflow-run-split">
+                  <Button
+                    size="sm"
+                    onClick={() => void run()}
+                    disabled={!selectedId || running || loadingGraph}
+                    data-testid="workflow-run"
+                    className="rounded-r-none"
+                  >
+                    {running ? (
+                      <Loader2 className="mr-1.5 size-4 animate-spin" />
+                    ) : (
+                      <Play className="mr-1.5 size-4" />
+                    )}
+                    Run
+                  </Button>
+                  {/* The other half. Same fill and no gap, because a detached
+                      outline button beside Run reads as a ninth control rather
+                      than as more of this one; the hairline is what says the two
+                      belong together. Icon-only, with the name carried by
+                      `sr-only` text so it is announced and so it does not widen
+                      the row back out.
+
+                      Its `disabled` predicate is Run's, copied whole and not
+                      narrowed: opening the dialog against a graph that has not
+                      loaded would offer a run that cannot be dispatched. */}
+                  <Button
+                    size="sm"
+                    onClick={() => setRunInputOpen(true)}
+                    disabled={!selectedId || running || loadingGraph}
+                    data-testid="workflow-run-with-input"
+                    className="rounded-l-none border-l border-primary-foreground/25 px-2"
+                    title="Run this workflow on something specific — a topic, a link, a question. The first step receives it."
+                  >
+                    <ChevronDown className="size-4" />
+                    <span className="sr-only">Run with input…</span>
+                  </Button>
+                </div>
                 {/* Issue #383. Present only while a run this view started is actually
                     in flight — which is knowable at all because the host now hands
                     back the run id before the run ends. Hidden once the host has told
@@ -2682,6 +2768,69 @@ export function WorkflowsView({
           onClose={() => setRunFailure(null)}
         />
       )}
+
+      {/* Issue #1204: where the toolbar's run-input box went.
+          
+          Both dispatches live here, not just Run. The box fed the toolbar's Run
+          AND its Test run, so a dialog offering only Run would have quietly
+          taken "prove this graph against a real input, without sending
+          anything" away — the rehearsal that matters most for a workflow whose
+          first step reads `=items`. */}
+      <Dialog open={runInputOpen} onOpenChange={setRunInputOpen}>
+        <DialogContent className="sm:max-w-lg" data-testid="workflow-run-input-dialog">
+          <DialogHeader>
+            <DialogTitle>Run with input</DialogTitle>
+            {/* Says what the payload DOES, which the bare placeholder never
+                did. An operator who has to guess whether their graph reads this
+                will guess wrong in both directions. */}
+            <DialogDescription>
+              What this run should work on. It is handed to the workflow&rsquo;s first
+              step, and any step bound to <code className="font-mono">=items</code>{" "}
+              reads it. Leave it empty to run the workflow as its schedule does.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            autoFocus
+            value={request}
+            onChange={(e) => setRequest(e.target.value)}
+            onKeyDown={(e) => {
+              // Enter runs, exactly as it did from the toolbar box (#154).
+              if (e.key === "Enter") runWithInput(false);
+            }}
+            placeholder="What should this run work on?"
+            aria-label="Request for this run"
+          />
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setRunInputOpen(false)}
+              data-testid="workflow-run-input-cancel"
+            >
+              Cancel
+            </Button>
+            {/* Issue #542&apos;s test run, carrying the same payload. Outline
+                beside the filled Run for the same reason it is outline on the
+                toolbar: it is the rehearsal, not the act. */}
+            <Button
+              variant="outline"
+              onClick={() => runWithInput(true)}
+              disabled={!selectedId || running || loadingGraph}
+              data-testid="workflow-run-input-test-run"
+            >
+              <FlaskConical className="mr-1.5 size-4" />
+              Test run
+            </Button>
+            <Button
+              onClick={() => runWithInput(false)}
+              disabled={!selectedId || running || loadingGraph}
+              data-testid="workflow-run-input-submit"
+            >
+              <Play className="mr-1.5 size-4" />
+              Run
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <WorkflowCreateDialog
         client={client}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2770,7 +2770,7 @@ export function WorkflowsView({
       )}
 
       {/* Issue #1204: where the toolbar's run-input box went.
-          
+
           Both dispatches live here, not just Run. The box fed the toolbar's Run
           AND its Test run, so a dialog offering only Run would have quietly
           taken "prove this graph against a real input, without sending

--- a/frontend/test/e2e/workflow-run-with-input.spec.ts
+++ b/frontend/test/e2e/workflow-run-with-input.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+import { openWorkflow } from "./workflows";
+
+/**
+ * The run input, after issue #1204 took it off the toolbar.
+ *
+ * The bar is tidier — `workflow-toolbar-reachable.spec.ts` measures that — and
+ * this spec is the other half: that the capability it carried is still there
+ * and still delivers. That capability is real. The host seeds the payload as
+ * the trigger node's item, a first step bound to `=items` reads it, and the run
+ * echoes it back (issue #154); a version of this change that tidied the row and
+ * quietly stopped sending the payload would look like a success and would run
+ * those workflows on nothing.
+ *
+ * Delivery is asserted on the **outgoing request body**, not on the rendering.
+ * A screenshot of a dialog proves the box exists; only the POST proves what
+ * reached the host. That also makes the spec independent of whether this host
+ * has a brain: it does not care what the run produced, only what it was asked.
+ *
+ * The echo is then asserted against **either** run drawer. A run on a host with
+ * no inference source may well fail, and that is not this spec's business — the
+ * echo has to be right either way, and both drawers carry it (`RunResultPanel`
+ * from `ranWith`, `RunFailurePanel` from the failure's own captured request).
+ */
+
+const COMPANY_SCOPE = "/api/v1/company";
+const WORKFLOW_ID = "e2e-1204-run-input";
+const WORKFLOW_NAME = "Run input plumbing";
+
+/** The tour's overlay swallows pointer events; tolerate its absence. */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+async function createWorkflow(request: APIRequestContext) {
+  const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
+    data: {
+      id: WORKFLOW_ID,
+      name: WORKFLOW_NAME,
+      description: "Created by the #1204 e2e spec.",
+      nodes: [
+        { id: "start", kind: "trigger", name: "Start" },
+        { id: "done", kind: "output", name: "Report" },
+      ],
+      edges: [{ from: "start", to: "done" }],
+    },
+  });
+  expect(res.ok(), `create: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+/** Best-effort teardown. `expectedVersion` is required (issue #1013). */
+async function removeWorkflow(request: APIRequestContext) {
+  const version = await request
+    .get(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}`)
+    .then(async (res) => (res.ok() ? ((await res.json()).version as string | null) : null))
+    .catch(() => null);
+  const query = version ? `?expectedVersion=${encodeURIComponent(version)}` : "";
+  await request
+    .delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}${query}`)
+    .catch(() => undefined);
+}
+
+/** The trigger input, wherever on the page it currently is. */
+function requestField(page: Page) {
+  return page.getByLabel("Request for this run");
+}
+
+test.describe("running a workflow on a specific input (#1204)", () => {
+  test.beforeEach(async ({ request }) => {
+    await removeWorkflow(request);
+    await createWorkflow(request);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await removeWorkflow(request);
+  });
+
+  test("the field is off the toolbar and behind the second half of Run", async ({
+    page,
+  }) => {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await openWorkflow(page, WORKFLOW_NAME);
+
+    // The complaint, stated as an assertion: no free-text box on the bar.
+    await expect(requestField(page)).toHaveCount(0);
+
+    const trigger = page.getByTestId("workflow-run-with-input");
+    await expect(trigger).toBeVisible();
+    // Icon-only, so its name comes from `sr-only` text — which is the thing an
+    // operator on a screen reader has instead of the placeholder that went away.
+    await expect(trigger).toHaveAccessibleName(/run with input/i);
+
+    await trigger.click();
+    await expect(page.getByTestId("workflow-run-input-dialog")).toBeVisible();
+    await expect(requestField(page)).toBeVisible();
+  });
+
+  test("what is typed reaches the host as the run's trigger input", async ({ page }) => {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await openWorkflow(page, WORKFLOW_NAME);
+
+    await page.getByTestId("workflow-run-with-input").click();
+    await requestField(page).fill("the Q3 board deck");
+
+    const posted = page.waitForRequest(
+      (req) => req.url().includes(`/workflows/${WORKFLOW_ID}/run`) && req.method() === "POST",
+    );
+    await page.getByTestId("workflow-run-input-submit").click();
+    const body = (await posted).postDataJSON();
+
+    // The whole capability, in one line: the operator's words, on the wire, in
+    // the field the host seeds the trigger node's item from.
+    expect(body).toMatchObject({ input: { request: "the Q3 board deck" } });
+
+    // And it comes back — from whichever drawer this run earned.
+    const echo = page
+      .getByTestId("workflow-run-result")
+      .or(page.getByTestId("workflow-run-failure"));
+    await expect(echo).toBeVisible({ timeout: 60_000 });
+    await expect(echo).toContainText("Requested:");
+    await expect(echo).toContainText("the Q3 board deck");
+  });
+
+  test("the toolbar's Run still runs with no input, draft or not", async ({ page }) => {
+    // The defect this change could have introduced: a field that used to be in
+    // plain sight becoming one nobody can see. Typing a draft and dismissing
+    // the dialog must leave Run exactly as it was.
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await openWorkflow(page, WORKFLOW_NAME);
+
+    await page.getByTestId("workflow-run-with-input").click();
+    await requestField(page).fill("a draft nobody meant to send");
+    await page.getByTestId("workflow-run-input-cancel").click();
+    await expect(page.getByTestId("workflow-run-input-dialog")).toHaveCount(0);
+
+    const posted = page.waitForRequest(
+      (req) => req.url().includes(`/workflows/${WORKFLOW_ID}/run`) && req.method() === "POST",
+    );
+    await page.getByTestId("workflow-run").click();
+    const body = (await posted).postDataJSON();
+
+    // `{}` is the host's "run with a null input" — what a scheduled run gets.
+    expect(body.input).toEqual({});
+  });
+});

--- a/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
+++ b/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
@@ -131,8 +131,21 @@ const DETAIL_CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> =
     find: (p) => p.getByTestId("workflow-back-to-index"),
   },
   {
+    // Issue #1204 made Run a split control, so it is addressed by test id now.
+    // The name match it used to use — `{ name: "Run", exact: false }.first()` —
+    // would silently resolve to whichever half rendered first, and "whichever
+    // half" is not what a reachability spec should be measuring.
     label: "Run",
-    find: (p) => p.getByRole("button", { name: "Run", exact: false }).first(),
+    find: (p) => p.getByTestId("workflow-run"),
+  },
+  {
+    // The other half: the affordance the run-input field moved behind. It is
+    // the newest control on the row, which by this spec's own reasoning — "the
+    // row grows every time a control is added" — is exactly the one most worth
+    // measuring. Icon-only, with its name in `sr-only` text, so it is addressed
+    // by test id like Pause and the back link.
+    label: "Run with input",
+    find: (p) => p.getByTestId("workflow-run-with-input"),
   },
   {
     label: "Test run",

--- a/frontend/test/unit/workflow-run-input.test.ts
+++ b/frontend/test/unit/workflow-run-input.test.ts
@@ -1,0 +1,301 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph } from "@/api/workflows";
+
+/**
+ * The run input, after it came off the toolbar (issue #1204).
+ *
+ * The field being gone is the easy half and `workflow-toolbar-layout.test.ts`
+ * pins it. This file pins the hard half: that the *capability* survived the
+ * move intact. It is a real capability — the host seeds the payload as the
+ * trigger node's item and any step bound to `=items` reads it (issue #154) — so
+ * a version of this change that tidied the bar and quietly stopped delivering
+ * the input would look like a success and would run those workflows on nothing.
+ *
+ * Four claims, and the third is the one that is easy to get wrong:
+ *
+ *  1. the dialog behind the split control's second half delivers the draft;
+ *  2. the dialog's Test run delivers it too — the toolbar box fed BOTH
+ *     dispatches, so a dialog that only ran for real would have dropped the
+ *     rehearsal;
+ *  3. the toolbar's own Run runs with NO input even when a draft is sitting in
+ *     the dialog. The draft is a parameter of `run()`, not state it closes
+ *     over; if it were state, moving the box out of sight would have turned a
+ *     visible field into an invisible one, which is worse than the bar it was
+ *     removed from; and
+ *  4. what was asked is echoed back on the run's detail.
+ *
+ * These are claims about wiring between a control and a POST body, so they can
+ * only be made against a rendered view — the same exception
+ * `workflow-run-failure.test.ts` takes.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount and jsdom has no layout; these
+// three stubs are what let the view render at all. None is under test.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+const GRAPH: WorkflowGraph = {
+  id: "digest",
+  name: "Weekly digest",
+  version: null,
+  nodes: [
+    { id: "start", kind: "trigger", name: "Monday morning" },
+    { id: "n_3", kind: "agent", name: "Draft the digest", agent: "writer" },
+  ],
+  edges: [{ from: "start", to: "n_3" }],
+};
+
+/** Every run POST this view made, in order. */
+type Posted = { path: string; body: unknown };
+
+function fakeClient(posts: Posted[]): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return [{ id: GRAPH.id, name: GRAPH.name }];
+      if (path.includes("/workflows/runs")) return [];
+      return GRAPH;
+    },
+    post: async (path: string, body: unknown) => {
+      posts.push({ path, body });
+      return { runId: "r1", output: { text: "done" }, pendingApprovals: [] };
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let posts: Posted[];
+
+/**
+ * The dialog is portaled out of the view's own subtree, so everything inside it
+ * is addressed from the document rather than from `container`.
+ */
+const inDocument = <T extends HTMLElement>(selector: string) =>
+  document.querySelector<T>(selector);
+const inView = <T extends HTMLElement>(selector: string) =>
+  container.querySelector<T>(selector);
+const byTestId = (id: string) => inDocument<HTMLElement>(`[data-testid="${id}"]`);
+
+/** The trigger input, wherever it currently lives. */
+const requestField = () =>
+  inDocument<HTMLInputElement>('input[aria-label="Request for this run"]');
+
+async function click(id: string) {
+  const el = byTestId(id);
+  if (!el) throw new Error(`no “${id}” on screen`);
+  await act(async () => {
+    el.click();
+  });
+}
+
+/** Opens the dialog behind the split control and types `text` into it. */
+async function typeIntoDialog(text: string) {
+  await click("workflow-run-with-input");
+  const field = requestField();
+  if (!field) throw new Error("the dialog mounted no request field");
+  await act(async () => {
+    // React tracks the DOM value node-side, so the setter has to be the
+    // prototype's for `onChange` to see a change at all.
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(field, text);
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  return field;
+}
+
+async function mount() {
+  await act(async () => {
+    root.render(
+      createElement(WorkflowsView, {
+        client: fakeClient(posts),
+        company: "acme",
+        sub: GRAPH.id,
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  posts = [];
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("the run input is off the toolbar but still reachable (#1204)", () => {
+  it("mounts no field on the bar, and a second half of Run that opens one", async () => {
+    await mount();
+
+    expect(inView('input[aria-label="Request for this run"]')).toBeNull();
+    // The affordance that replaces it, named for a screen reader even though it
+    // draws as an icon.
+    const trigger = byTestId("workflow-run-with-input");
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toContain("Run with input");
+
+    expect(byTestId("workflow-run-input-dialog")).toBeNull();
+    await click("workflow-run-with-input");
+    expect(byTestId("workflow-run-input-dialog")).not.toBeNull();
+    expect(requestField()).not.toBeNull();
+  });
+
+  it("delivers what was typed as the run's trigger input", async () => {
+    await mount();
+    await typeIntoDialog("the Q3 board deck");
+    await click("workflow-run-input-submit");
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].path).toBe("/api/v1/acme/workflows/digest/run");
+    expect(posts[0].body).toEqual({ input: { request: "the Q3 board deck" } });
+    // And it closes behind the dispatch — a synchronous run holds the request
+    // open for the whole run, and the canvas is what reports on it.
+    expect(byTestId("workflow-run-input-dialog")).toBeNull();
+  });
+
+  it("trims the draft, so the echo and the payload cannot disagree", async () => {
+    await mount();
+    await typeIntoDialog("   spaced out   ");
+    await click("workflow-run-input-submit");
+
+    expect(posts[0].body).toEqual({ input: { request: "spaced out" } });
+  });
+
+  it("runs with no input at all when the field was left empty", async () => {
+    await mount();
+    await click("workflow-run-with-input");
+    await click("workflow-run-input-submit");
+
+    // `{}` is the host's "run with a null input" (src/server/ops/workflows.rs),
+    // which is what a schedule-driven run gets. Not `{ request: "" }`.
+    expect(posts[0].body).toEqual({ input: {} });
+  });
+
+  it("carries the same draft into a test run", async () => {
+    // The toolbar box fed Run AND Test run. Proving a graph that reads `=items`
+    // against a real input without sending anything is the rehearsal that
+    // matters most for exactly the workflows this input exists for.
+    await mount();
+    await typeIntoDialog("dry subject");
+    await click("workflow-run-input-test-run");
+
+    expect(posts[0].body).toEqual({
+      input: { request: "dry subject" },
+      dry_run: true,
+    });
+  });
+
+  it("runs on Enter, as the toolbar field did", async () => {
+    await mount();
+    const field = await typeIntoDialog("typed then entered");
+    await act(async () => {
+      field.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body).toEqual({ input: { request: "typed then entered" } });
+  });
+
+  it("keeps the draft for the next visit, so a re-run is an edit not a retype", async () => {
+    await mount();
+    await typeIntoDialog("the Q3 board deck");
+    await click("workflow-run-input-submit");
+    await click("workflow-run-with-input");
+
+    expect(requestField()?.value).toBe("the Q3 board deck");
+  });
+});
+
+describe("the toolbar's Run never carries a payload nobody can see (#1204)", () => {
+  it("posts an empty input even with a draft sitting in the dialog", async () => {
+    // The defect this change could have introduced. The field used to be on the
+    // bar, in plain sight, wired into `run()`'s closure. Moving it behind a
+    // dialog WITHOUT cutting that wire would leave a draft typed once riding
+    // along on every later press of Run, with nothing on screen to say so.
+    await mount();
+    await typeIntoDialog("the Q3 board deck");
+    await click("workflow-run-input-cancel");
+
+    await click("workflow-run");
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body).toEqual({ input: {} });
+  });
+
+  it("and neither does the toolbar's Test run", async () => {
+    await mount();
+    await typeIntoDialog("the Q3 board deck");
+    await click("workflow-run-input-cancel");
+
+    await click("workflow-test-run");
+    expect(posts[0].body).toEqual({ input: {}, dry_run: true });
+  });
+});
+
+describe("what was asked is echoed on the run's detail (#154)", () => {
+  it("shows the request the shown output came from", async () => {
+    await mount();
+    await typeIntoDialog("the Q3 board deck");
+    await click("workflow-run-input-submit");
+
+    const drawer = byTestId("workflow-run-result");
+    expect(drawer).not.toBeNull();
+    expect(drawer?.textContent).toContain("Requested:");
+    expect(drawer?.textContent).toContain("the Q3 board deck");
+  });
+});

--- a/frontend/test/unit/workflow-toolbar-layout.test.ts
+++ b/frontend/test/unit/workflow-toolbar-layout.test.ts
@@ -183,7 +183,20 @@ describe("the detail toolbar carries only this workflow's controls (#1135)", () 
 describe("one filled button per screen (#1135)", () => {
   it("makes Run the detail screen's primary, and nothing else", async () => {
     await mountAt("#/workflows/alpha", makeClient());
-    expect(filled()).toEqual(["Run"]);
+    // Issue #1204 made Run a split control, so the fill is worn by two
+    // elements. That is not a second primary: they are the two halves of one
+    // button, which the next assertion is what actually proves — the pair is
+    // accepted only because both sit inside `workflow-run-split`. A filled
+    // button anywhere ELSE on the detail screen still fails here, which is the
+    // property #1135 asked for.
+    expect(filled()).toEqual(["Run", "Run with input…"]);
+    const split = testId("workflow-run-split");
+    expect(split).not.toBeNull();
+    for (const button of buttons().filter((b) =>
+      b.className.split(/\s+/).includes("bg-primary"),
+    )) {
+      expect(split?.contains(button)).toBe(true);
+    }
   });
 
   it("makes New workflow the index's primary, and nothing else", async () => {
@@ -220,7 +233,9 @@ describe("the detail toolbar is two rows (#1135)", () => {
 
     const order = idsWithin("workflow-detail-actions");
     expect(order).toEqual([
+      "workflow-run-split",
       "workflow-run",
+      "workflow-run-with-input",
       "workflow-test-run",
       "workflow-copilot-toggle",
       "workflow-history-toggle",
@@ -229,13 +244,25 @@ describe("the detail toolbar is two rows (#1135)", () => {
       "workflow-delete",
     ]);
 
+    // Issue #1204: the free-text field is OFF the bar. This used to assert that
+    // the field and Run shared a parent, which is the arrangement the issue was
+    // filed against — the widest control on a row of nine, in the way of the
+    // one thing an operator comes here to press. The stronger statement is that
+    // the toolbar mounts no such field at all, which is false for the old
+    // layout and for any half-measure that merely narrowed the box.
+    expect(
+      container.querySelector('input[aria-label="Request for this run"]'),
+    ).toBeNull();
+
     // Grouped, not one undifferentiated strip. Asserted as what each group
-    // EXCLUDES as well as what it holds: "Run and the field share a parent" is
+    // EXCLUDES as well as what it holds: "the two halves share a parent" is
     // also true of the flat row this issue replaced, since everything shared
     // one parent there.
-    const requestField = container.querySelector('input[aria-label="Request for this run"]');
-    const runGroup = testId("workflow-run")?.parentElement;
-    expect(runGroup).toBe(requestField?.parentElement);
+    const split = testId("workflow-run-split");
+    expect(split?.contains(testId("workflow-run"))).toBe(true);
+    expect(split?.contains(testId("workflow-run-with-input"))).toBe(true);
+    expect(split?.contains(testId("workflow-test-run"))).toBe(false);
+    const runGroup = split?.parentElement;
     expect(runGroup?.contains(testId("workflow-test-run"))).toBe(false);
 
     const utility = testId("workflow-delete")?.closest("div");


### PR DESCRIPTION
Closes #1204

## What changed

The workflow detail toolbar's free-text field — **"What should this run work on?"** — is off the bar. `Run` is now a split control: the left half runs, the attached right half opens a **Run with input** dialog carrying the field.

| before | after |
| --- | --- |
| `[ What should this run work on?…… ] [Run] │ [Test run] [Copilot] [History] [Edit] [Delete]` | `[Run│⌄] │ [Test run] [Copilot] [History] [Edit] [Delete]` |

## Why option 1 (behind Run), and not 2 or 3

**Option 2 (in a run dialog)** presupposes a run dialog this console does not have. Introducing one would put a modal in front of the *common* case — pressing Run — which is the same complaint the issue is making, moved one step later.

**Option 3 (show it only when the graph references `=items`)** is the one the issue itself flags as conditional on the graph read being "cheap and reliable", and it is neither. A node can reach the trigger's item through a chain of upstream bindings, through a `sub_workflow` whose own graph is a separate document, or through an expression that merely contains `items` as a substring. Every one of those has to be resolved correctly or the field disappears from a workflow that needs it — and the failure mode is the exact one the issue names as the worst outcome, arriving quietly and only for the graphs that depend on the payload most. Option 1 costs the rare case one extra click and cannot be wrong about which graphs those are.

## The capability is intact, and is now harder to break

`ranWith`, the `{ request: asked }` payload, the trim, the `runFailureFrom` capture, and the "Requested:" echo are all unchanged. Three things were added around them:

1. **The payload is a parameter of `run()`, not state it closes over.** This is the load-bearing change. `run()` used to read `request` out of its closure, so simply relocating the box behind a dialog would have left a draft typed once riding along on every later press of Run, with nothing on screen to say so — a visible field turned into an invisible one, which is worse than the bar it was removed from. Now the toolbar's Run and Test run pass nothing and therefore genuinely run with no input.
2. **The dialog carries both dispatches.** The old box fed Run *and* Test run, so a dialog offering only Run would have quietly removed "prove this graph against a real input without sending anything" — the rehearsal that matters most for exactly the workflows this input exists for.
3. **The draft is cleared on workflow switch**, alongside the run drawers that are already cleared there for the same reason.

Enter-to-run, the disabled predicates, and the `sr-only` accessible name are all preserved.

## `ranWith` on a failed run — checked, and it is fine

The issue asks whether the "Requested:" echo is missing or stale on a failed run, since `ranWith` is pinned only on the success arm. It is correct today, and #1007 is why:

- `setResult` has six call sites and only one sets a value — the success arm, one line after `setRanWith(asked)`. `RunResultPanel` cannot mount against any other run, so its `request={ranWith}` is always that run's.
- The failed path renders `RunFailurePanel`, which reads `failure.request` — captured in the same `catch` from the same `asked` local, independently of `ranWith`.

Verified in the browser: a run that failed showed **`Requested: the Q3 board deck`** in the failure drawer. No separate issue filed.

## Verification

Browser, against a local host with the console on Vite, light and dark:

- toolbar before/after — the field is gone, the row is eight controls instead of nine plus a 256px input;
- the dialog's Run put **`{"input":{"request":"the Q3 board deck"}}`** on the wire (captured off the outgoing POST, not inferred from the UI);
- the run detail echoed `Requested: the Q3 board deck` — on a host **with** execution wired (`--features openhuman` + the suite's `mock-brain.mjs`), so this is the success drawer and a real run, not the failure path;
- that run's engine output confirms the payload went where issue #154 says it does — `run.trigger = {"request":"the Q3 board deck"}`, seeded as the trigger node's `items`, and carried downstream to the next node's `items`. The `=items` path is intact;
- reopening the dialog restored the draft.

Commands: `npm run typecheck`, `typecheck:unit`, `typecheck:e2e`, `npm test` (137 files, 1330 tests), and `npx playwright test workflow-` — 49 passed, 4 skipped (the `LIVE_BRAIN`-gated ones).

## Tests

Updated, not weakened:

- **`test/unit/workflow-toolbar-layout.test.ts`** — `"puts the actions on row 2…"` gains `workflow-run-split` / `workflow-run-with-input` in the expected order, and its old "the field and Run share a parent" assertion is replaced by the **stronger** "the toolbar mounts no request field at all", which is false for the old layout and for any half-measure that merely narrowed the box. `"makes Run the detail screen's primary, and nothing else"` now expects the two halves of the one split control, *and* asserts every filled button is inside `workflow-run-split` — so a genuinely second primary elsewhere still fails.
- **`test/e2e/workflow-toolbar-reachable.spec.ts`** — the `Run` entry moves from `getByRole("button", { name: "Run", exact: false }).first()` (ambiguous the moment a second Run-ish control exists) to `getByTestId("workflow-run")`, and `Run with input` is added so the newest control on the row is held to the same in-viewport/clickable property.

Added:

- **`test/unit/workflow-run-input.test.ts`** (10 tests) — delivery, trimming, empty-field `{}`, test-run parity, Enter-to-run, draft retention, the "Requested:" echo, and the invariant that the toolbar's Run and Test run post `input: {}` even with a draft sitting in the dialog.
- **`test/e2e/workflow-run-with-input.spec.ts`** — the same end to end, asserting on the **outgoing POST body** rather than on the rendering, so it does not depend on whether the host under test has a brain.
