### PR TITLE
fix(workflows): say when a schedule is off, on the index and at create

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1356,6 +1356,71 @@ export function WorkflowsView({
     }
   }, [client, company, selectedId, graph]);
 
+  /**
+   * Say out loud that a write left this workflow's schedule off, and offer the
+   * one click that undoes it.
+   *
+   * Issue #1017 wrote this for the edit path; issue #1209 extracted it, because
+   * **create disarms too** and was raising a flat "Workflow created." over a
+   * workflow the host had just switched off. Two write paths that produce the
+   * same state owe the operator the same sentence, and a second copy of this
+   * closure is a second copy of the switched-company and switched-selection
+   * guards below — the two things this is careful about and the two things a
+   * copy would eventually stop being careful about.
+   *
+   * `lead` is the only part that differs ("Saved, and paused" / "Created, and
+   * paused"): what happened is not the same, what it means is.
+   */
+  const announceDisarm = useCallback(
+    (lead: string, workflow: WorkflowGraph) => {
+      toast.warning(
+        `${lead} “${workflow.name}”. Its schedule is off — it won't run on its own until you resume it.`,
+        {
+          action: {
+            label: "Resume",
+            onClick: () => {
+              void (async () => {
+                try {
+                  const resumeCompany = company;
+                  const updated = await setWorkflowEnabled(client, company, workflow.id, true);
+                  // The operator may have switched companies while this Resume
+                  // was in flight. Discard the response — the new company's list
+                  // is what matters, and mutating state keyed to the old one
+                  // would overwrite it.
+                  if (companyRef.current !== resumeCompany) return;
+                  // Newer than any list request already in flight.
+                  localWriteRef.current += 1;
+                  // The operator may have selected a different workflow while
+                  // this Resume was in flight. Only replace the displayed graph
+                  // when it still belongs to the selection — otherwise the
+                  // picker would identify the new workflow while the canvas
+                  // showed (and a later edit would mutate) the old one. The list
+                  // update below is safe unconditionally: it keys by id.
+                  if (selectedIdRef.current === updated.id) {
+                    setGraph(updated);
+                  }
+                  setWorkflows((prev) =>
+                    prev.map((w) =>
+                      w.id === updated.id ? { ...w, enabled: updated.enabled } : w,
+                    ),
+                  );
+                  toast.success(
+                    `Resumed “${updated.name}”. It will run on its schedule again.`,
+                  );
+                } catch (e) {
+                  toast.error(
+                    e instanceof Error ? e.message : "could not change the workflow",
+                  );
+                }
+              })();
+            },
+          },
+        },
+      );
+    },
+    [client, company],
+  );
+
   // Issue #259: the edit dialog saved. The host answers with the stored graph
   // AND a fresh version token, so holding onto it is what lets the operator
   // save again without a re-read — dropping it and re-fetching would be a round
@@ -1395,54 +1460,11 @@ export function WorkflowsView({
     // with a one-click Resume, instead of a "saved" that hid that its schedule
     // was switched off. Every other save keeps the plain acknowledgement.
     if (workflowSavedToast(wasEnabled, saved.enabled) === "disarmed") {
-      toast.warning(
-        `Saved, and paused “${saved.name}”. Its schedule is off — it won't run on its own until you resume it.`,
-        {
-          action: {
-            label: "Resume",
-            onClick: () => {
-              void (async () => {
-                try {
-                  const resumeCompany = company;
-                  const updated = await setWorkflowEnabled(client, company, saved.id, true);
-                  // The operator may have switched companies while this Resume
-                  // was in flight. Discard the response — the new company's list
-                  // is what matters, and mutating state keyed to the old one
-                  // would overwrite it.
-                  if (companyRef.current !== resumeCompany) return;
-                  // Newer than any list request already in flight.
-                  localWriteRef.current += 1;
-                  // The operator may have selected a different workflow while
-                  // this Resume was in flight. Only replace the displayed graph
-                  // when it still belongs to the selection — otherwise the
-                  // picker would identify the new workflow while the canvas
-                  // showed (and a later edit would mutate) the old one. The list
-                  // update below is safe unconditionally: it keys by id.
-                  if (selectedIdRef.current === updated.id) {
-                    setGraph(updated);
-                  }
-                  setWorkflows((prev) =>
-                    prev.map((w) =>
-                      w.id === updated.id ? { ...w, enabled: updated.enabled } : w,
-                    ),
-                  );
-                  toast.success(
-                    `Resumed “${updated.name}”. It will run on its schedule again.`,
-                  );
-                } catch (e) {
-                  toast.error(
-                    e instanceof Error ? e.message : "could not change the workflow",
-                  );
-                }
-              })();
-            },
-          },
-        },
-      );
+      announceDisarm("Saved, and paused", saved);
     } else {
       toast.success("Workflow saved.");
     }
-  }, [client, company, graph]);
+  }, [announceDisarm, graph]);
 
   // The creator posts the full graph back, so the new entry can be spliced
   // straight into the list and selected — no extra round trip to re-list.
@@ -1474,8 +1496,19 @@ export function WorkflowsView({
     // editing it. The hash mirror pushes that as a navigation, so Back returns
     // to the index they created it from.
     setSelectedId(created.id);
-    toast.success("Workflow created.");
-  }, []);
+    // Issue #1209: create disarms too. `#276`'s rule switches off any workflow
+    // authored WITH a schedule, and this used to acknowledge that with a flat
+    // "Workflow created." — leaving the operator to notice the paused chip on a
+    // detail screen nothing pointed them at. A create is armed-by-assumption
+    // before the host answers, so `true` is the honest "before" to classify
+    // against; the same reducer the edit path uses then names the one transition
+    // worth interrupting for.
+    if (workflowSavedToast(true, created.enabled) === "disarmed") {
+      announceDisarm("Created, and paused", created);
+    } else {
+      toast.success("Workflow created.");
+    }
+  }, [announceDisarm]);
 
   // Issue #1110: leave the workflow on screen and go back to the index.
   //

--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -12,12 +12,21 @@
 //
 // WHAT A CARD IS ALLOWED TO SAY is the whole design constraint here. Two
 // requests back this surface — `GET …/workflows` (id, name, description,
-// editable) and `GET …/workflows/runs` (the company-wide run journal) — and a
-// card renders strictly what those two carry. In particular it does NOT show a
-// schedule or a node count: both live only in the full graph, which is a
-// per-workflow `GET …/workflows/{wid}`, and fetching one per card would be an
-// N+1 on every render of this panel. Showing "no schedule" without having
-// looked would be a lie, so the card says nothing at all about schedules.
+// editable, enabled) and `GET …/workflows/runs` (the company-wide run journal)
+// — and a card renders strictly what those two carry. In particular it does NOT
+// show *when* a workflow is scheduled, or a node count: both live only in the
+// full graph, which is a per-workflow `GET …/workflows/{wid}`, and fetching one
+// per card would be an N+1 on every render of this panel. Showing "no schedule"
+// without having looked would be a lie, so the card never names a cron.
+//
+// It does say whether a schedule is OFF (issue #1209), because `enabled` is on
+// the list wire and needs no second request. The two are different claims: "it
+// runs at 02:15" needs the graph, "it will not start on its own" does not. The
+// host disarms every workflow created with a schedule (#276's rule), so a
+// company's scheduled workflows arrive paused — and without this badge an
+// operator who authored one is shown a row indistinguishable from the ones that
+// do fire. The detail header has said it since #276 (`workflow-paused-badge`);
+// this is the same reading, on the surface an operator meets first.
 
 import type { WorkflowRunOutcome, WorkflowSummary } from "@/api/workflows";
 import { Badge } from "@/components/ui/badge";
@@ -34,6 +43,34 @@ import {
 
 /** Which rendering the index is showing. Persisted by the caller. */
 export type IndexMode = "cards" | "list";
+
+/** The one sentence a paused row is allowed to say, and the way out of it.
+ * Named once because a card and a list row both carry it (the same reason
+ * {@link NO_RUNS_LABEL} is a constant) and two copies would drift. */
+const PAUSED_TITLE =
+  "This workflow's schedule is off, so it won't start on its own. " +
+  "Open it and press Resume to arm it.";
+
+/**
+ * The "this will not fire" badge, or `null` when the workflow is armed.
+ *
+ * Issue #276's rule, repeated exactly as the `editable` checks beside it
+ * repeat #259's: only an explicit `false` is off. A host predating #276 sends no
+ * field, and `undefined` must not render every workflow as paused.
+ */
+function PausedBadge({ enabled }: { enabled: boolean | undefined }) {
+  if (enabled !== false) return null;
+  return (
+    <Badge
+      variant="outline"
+      className="h-4 shrink-0 px-1.5 text-3xs font-normal border-status-blocked/40 bg-status-blocked-soft"
+      title={PAUSED_TITLE}
+      data-testid="workflow-index-paused"
+    >
+      Paused
+    </Badge>
+  );
+}
 
 /** How many recent runs the health strip shows per workflow. */
 const STRIP_RUNS = 5;
@@ -150,18 +187,23 @@ function WorkflowCard({
     >
       <div className="flex items-start justify-between gap-2">
         <span className="min-w-0 truncate text-sm font-semibold">{workflow.name}</span>
-        {/* Issue #259's rule, repeated exactly: only an explicit `false` is a
-            refusal — a host predating it sends no field, and `undefined` must
-            not render as "you can't edit this". */}
-        {workflow.editable === false && (
-          <Badge
-            variant="outline"
-            className="h-4 shrink-0 px-1.5 text-3xs font-normal"
-            title="Defined by a file in the company source tree, so it can't be changed or removed from the console."
-          >
-            in source
-          </Badge>
-        )}
+        <span className="flex shrink-0 items-center gap-1">
+          {/* Paused first: it is the one that changes whether this workflow
+              does anything, and "in source" only qualifies who may edit it. */}
+          <PausedBadge enabled={workflow.enabled} />
+          {/* Issue #259's rule, repeated exactly: only an explicit `false` is a
+              refusal — a host predating it sends no field, and `undefined` must
+              not render as "you can't edit this". */}
+          {workflow.editable === false && (
+            <Badge
+              variant="outline"
+              className="h-4 shrink-0 px-1.5 text-3xs font-normal"
+              title="Defined by a file in the company source tree, so it can't be changed or removed from the console."
+            >
+              in source
+            </Badge>
+          )}
+        </span>
       </div>
 
       {workflow.description ? (
@@ -226,7 +268,8 @@ function WorkflowRow({
           {workflow.name}
         </span>
         {/* Issue #1136: inside the name cell, not floating between columns —
-            the badge qualifies the name, so it travels with it. */}
+            the badges qualify the name, so they travel with it. */}
+        <PausedBadge enabled={workflow.enabled} />
         {workflow.editable === false && (
           <Badge
             variant="outline"

--- a/frontend/test/unit/workflow-index-paused.test.ts
+++ b/frontend/test/unit/workflow-index-paused.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph, WorkflowSummary } from "@/api/workflows";
+
+/**
+ * Issue #1209: the Workflows index says when a schedule is off.
+ *
+ * `#276`'s disarm rule switches off every workflow created with a schedule, so
+ * a company's scheduled workflows arrive paused. The index rendered them
+ * identically to the ones that do fire — 8 of 18 rows in the reproduction — and
+ * the create toast said only "Workflow created.". Both are facts about rendered
+ * output, so this renders the view the way `workflow-index-first.test.ts` does.
+ *
+ * The `undefined` case is the one worth pinning hardest: `enabled` is optional
+ * on the wire, and a host predating #276 sends no field. Badging that would put
+ * "Paused" on every workflow of every older host.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount; jsdom has no layout and no
+// `ResizeObserver`. None of these three is under test.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+/** One armed, one disarmed, one from a host that predates `enabled`. */
+const ROWS: WorkflowSummary[] = [
+  { id: "armed", name: "Armed digest", enabled: true },
+  { id: "paused", name: "Paused sweep", enabled: false },
+  { id: "unknown", name: "Older host" },
+];
+
+function graphFor(id: string): WorkflowGraph {
+  return {
+    id,
+    name: ROWS.find((r) => r.id === id)?.name ?? id,
+    version: "v1",
+    nodes: [{ id: "start", kind: "trigger", name: "Start" }],
+    edges: [],
+  };
+}
+
+function makeClient(rows: WorkflowSummary[] = ROWS, created?: WorkflowGraph) {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return rows;
+      if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
+      if (path.includes("/workflows/wired-channels")) return { channels: [] };
+      if (path.includes("/workflows/runs")) return [];
+      const m = path.match(/\/workflows\/([^/?]+)$/);
+      if (m) return graphFor(decodeURIComponent(m[1]));
+      return null;
+    },
+    post: async () => created ?? {},
+    del: async () => {},
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  window.location.hash = "";
+});
+
+async function mountIndex(client: OpenCompanyClient) {
+  window.location.hash = "#/workflows";
+  await act(async () => {
+    root.render(createElement(WorkflowsView, { client, company: "acme", sub: null }));
+  });
+}
+
+/** Whether the row for `name` carries the paused badge. Throws when no such
+ * row is on screen, so a selector that stops matching fails loudly rather than
+ * reporting every workflow as armed. */
+function pausedFor(selector: string, name: string): boolean {
+  const row = Array.from(container.querySelectorAll<HTMLElement>(selector)).find((el) =>
+    el.textContent?.includes(name),
+  );
+  if (!row) throw new Error(`no ${selector} for “${name}”`);
+  return row.querySelector('[data-testid="workflow-index-paused"]') !== null;
+}
+
+/** Sets a controlled input the way a keystroke would, so React's own value
+ * descriptor sees the change and `onChange` fires. */
+function type(selector: string, value: string) {
+  const input = document.querySelector<HTMLInputElement>(
+    `[data-slot="dialog-content"] ${selector}`,
+  );
+  if (!input) throw new Error(`no input matching ${selector}`);
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/** Opens the New-workflow dialog, fills the smallest draft `validate()` accepts
+ * (the starter trigger node already carries an id and a name), and submits. The
+ * stub client answers the POST with whatever `makeClient` was given. */
+async function createThroughDialog() {
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('[data-testid="workflow-create"]')?.click();
+  });
+  await act(async () => {
+    type('[placeholder="e.g. campaign_pipeline"]', "nightly");
+  });
+  await act(async () => {
+    type('[placeholder="e.g. Campaign pipeline"]', "Nightly sweep");
+  });
+  await act(async () => {
+    document
+      .querySelector<HTMLButtonElement>('[data-testid="workflow-dialog-submit"]')
+      ?.click();
+  });
+}
+
+describe("the workflows index shows a disarmed schedule", () => {
+  it("badges the paused card, and only the paused card", async () => {
+    await mountIndex(makeClient());
+
+    const card = (name: string) => pausedFor('[data-testid="workflow-card"]', name);
+    expect(card("Armed digest")).toBe(false);
+    expect(card("Paused sweep")).toBe(true);
+    // The whole point of matching `=== false` rather than falsy: an older host
+    // sends no field, and every one of its workflows would otherwise badge.
+    expect(card("Older host")).toBe(false);
+  });
+
+  it("badges the paused list row too, so the reading survives the toggle", async () => {
+    await mountIndex(makeClient());
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="workflow-index-list"]')?.click();
+    });
+
+    const row = (name: string) => pausedFor('[data-testid="workflow-list-row"]', name);
+    expect(row("Paused sweep")).toBe(true);
+    expect(row("Armed digest")).toBe(false);
+    expect(row("Older host")).toBe(false);
+  });
+
+  it("says so on create, rather than a flat acknowledgement", async () => {
+    await mountIndex(
+      makeClient(ROWS, {
+        id: "nightly",
+        name: "Nightly sweep",
+        version: "v1",
+        // What #276 does to any graph authored WITH a schedule.
+        enabled: false,
+        nodes: [{ id: "start", kind: "trigger", name: "Start", schedule: "15 2 * * *" }],
+        edges: [],
+      }),
+    );
+    await createThroughDialog();
+
+    expect(toasts.success).not.toHaveBeenCalledWith("Workflow created.");
+    expect(toasts.warning).toHaveBeenCalledTimes(1);
+    const [text, options] = toasts.warning.mock.calls[0] as [string, { action?: { label: string } }];
+    expect(text).toContain("Created, and paused");
+    expect(text).toContain("Nightly sweep");
+    // The recovery travels with the sentence, exactly as the edit path's does —
+    // being told a schedule is off is only half of what an operator needs.
+    expect(options?.action?.label).toBe("Resume");
+  });
+
+  it("keeps the plain acknowledgement when the create came back armed", async () => {
+    await mountIndex(
+      makeClient(ROWS, {
+        id: "manual",
+        name: "Manual only",
+        version: "v1",
+        enabled: true,
+        nodes: [{ id: "start", kind: "trigger", name: "Start" }],
+        edges: [],
+      }),
+    );
+    await createThroughDialog();
+
+    expect(toasts.success).toHaveBeenCalledWith("Workflow created.");
+    expect(toasts.warning).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1209.

## What was wrong

`#276`'s disarm rule switches off every workflow created with a schedule, and the Workflows index never said so. In a seeded company, **8 of 18 rows were paused and every one of them rendered exactly like the workflows that fire**:

> Nightly security sweep | Scans the dependency tree for new advisories … every night at 02:15 UTC. | ● Manual run not delivered (1) | 4m ago

Open that same workflow and the detail header has said "Schedule paused" since #276 — the console knew, the index just didn't render it. `grep -c enabled WorkflowIndex.tsx` was `0`.

The create path was silent the same way: pick "Daily — 09:00 UTC" in the New-workflow dialog, press Create, and the toast said **"Workflow created."** while the host returned `enabled: false`. The equivalent *edit* path already raises a warning toast with a one-click Resume (issue #1017) — so the same outcome got two different levels of honesty depending on which button produced it.

## What changed

**`frontend/src/views/workflows/WorkflowIndex.tsx`** — a `PausedBadge` rendered on both `WorkflowCard` and `WorkflowRow` when `enabled === false`, beside the existing "in source" badge and before it (paused changes whether the workflow does anything; "in source" only qualifies who may edit it). Only an explicit `false` badges, exactly as the `editable` checks beside it are written, so a host predating #276 does not mark every workflow paused. The header note is updated to draw the line the design constraint actually wants: the card still never names a cron (that needs the graph, and would be an N+1), but "it will not start on its own" is on the list wire already.

**`frontend/src/views/WorkflowsView.tsx`** — the disarm toast and its Resume action, previously inline in `handleSaved`, are extracted to an `announceDisarm(lead, workflow)` callback and reused from `handleCreated`. A create classifies through the same `workflowSavedToast` reducer against an armed "before", so a disarming create now says *"Created, and paused “X”. Its schedule is off — it won't run on its own until you resume it."* with the same Resume action. An armed create keeps the plain "Workflow created.". Extracting rather than copying keeps one copy of the switched-company and switched-selection guards the Resume handler carries.

**`frontend/test/unit/workflow-index-paused.test.ts`** — four cases: the badge appears on a paused card and row, does **not** appear for `enabled: undefined` (the older-host case, which a falsy check would have got wrong), a disarming create raises the warning with a Resume action, and an armed create keeps the plain toast.

## Verified

- `npm test` — 137 files, 1324 tests, all green
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `scripts/ci/assert-design-tokens.sh` — clean (the badge reuses `border-status-blocked/40 bg-status-blocked-soft`, already in this file)
- Driven in a real browser against a seeded 19-workflow company at 1440px and 1100px, light and dark: 9 of 19 rows badge, the 10 armed ones do not, and creating a workflow with a Daily schedule now raises the paused toast.
