### PR TITLE
fix(company): say the teammate's name once

### DIFF
--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -145,6 +145,33 @@ export function initials(name: string): string {
   );
 }
 
+/**
+ * The muted line that sits under a teammate's name, or `null` when there is
+ * nothing left to say (issue #1208).
+ *
+ * A roster row carries a `name` and a `role`, and the console's own fallback
+ * makes them the same string whenever the host sends no display name:
+ * `fromDto` below resolves `name` as `dto.name?.trim() || dto.role`, and a
+ * manifest-declared agent has no `name` at all — `GET {scope}/team` answers
+ * `{"id":"backend_engineer","role":"Backend Engineer",…}`. Every surface that
+ * drew the title and then the role drew the same words twice.
+ *
+ * Answering `null` rather than an empty string is deliberate: a caller has to
+ * skip the element, not render an empty one, or the layout keeps the gap the
+ * repeat used to fill.
+ *
+ * Compared case-insensitively and whitespace-trimmed, because the two strings
+ * come from different places — one may have been typed by an operator into the
+ * add-teammate dialog while the other came out of a manifest — and "Backend
+ * engineer" under "Backend Engineer" is the same repeat wearing a different
+ * capital.
+ */
+export function roleSubtitle(name: string, role: string): string | null {
+  const trimmed = role.trim();
+  if (!trimmed) return null;
+  return trimmed.toLowerCase() === name.trim().toLowerCase() ? null : trimmed;
+}
+
 /** Map a host roster entry into the console's team model. */
 export function fromDto(dto: TeamMemberDto): TeamMember {
   const name = dto.name?.trim() || dto.role;

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -36,7 +36,7 @@ import {
   reportAddMember,
   type MissedStep,
 } from "@/lib/member-feedback";
-import { fromDto, newMember, type TeamMember } from "@/lib/team";
+import { fromDto, newMember, roleSubtitle, type TeamMember } from "@/lib/team";
 import { workloadByAssignee, type Workload } from "@/lib/team-workload";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/views/chat/Avatar";
@@ -563,6 +563,11 @@ function MemberCard({
   // An override exists (someone set this deliberately), as opposed to the cap
   // simply coming from the company's own definition.
   const overridden = member.budgetSetBy !== undefined;
+  // Issue #1208: the role only earns its line when it is not the name again.
+  // Every manifest-declared agent in the shipped companies resolves both to one
+  // string, so this slot was the same words twice on every card — directly
+  // above the description that actually says what the teammate does.
+  const subtitle = roleSubtitle(member.name, member.role);
   return (
     <Card data-testid="team-card">
       <CardContent className="flex h-full flex-col gap-3 py-4">
@@ -588,12 +593,16 @@ function MemberCard({
               data-testid="team-card-open"
             >
               <p className="truncate font-medium">{member.name}</p>
-              <p className="truncate text-xs text-muted-foreground">{member.role}</p>
+              {subtitle && (
+                <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+              )}
             </button>
           ) : (
             <div className="min-w-0 flex-1">
               <p className="truncate font-medium">{member.name}</p>
-              <p className="truncate text-xs text-muted-foreground">{member.role}</p>
+              {subtitle && (
+                <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+              )}
             </div>
           )}
           <DropdownMenu>

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { TeamMember } from "@/lib/team";
+import { roleSubtitle, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 
@@ -280,6 +280,10 @@ function MemberRow({
 }) {
   const capped = member.budgetUsdDaily !== undefined;
   const overridden = member.budgetSetBy !== undefined;
+  // Issue #1208: only when the role is not the name over again. The roster's
+  // name falls back to the role (`fromDto`), so every manifest-declared
+  // teammate said it twice here too.
+  const roleLine = roleSubtitle(member.name, member.role);
 
   return (
     <div className="group/member flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-accent/60">
@@ -302,7 +306,9 @@ function MemberRow({
               <Mail className="size-3 shrink-0 text-muted-foreground" aria-label="Has an inbox" />
             )}
           </span>
-          <span className="block truncate text-xs text-muted-foreground">{member.role}</span>
+          {roleLine && (
+            <span className="block truncate text-xs text-muted-foreground">{roleLine}</span>
+          )}
           <DailyBudgetLine member={member} setByLabel={setByLabel} />
         </span>
       </button>

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -46,6 +46,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import { roleSubtitle } from "@/lib/team";
 import {
   addMemberFailure,
   addOutcome,
@@ -835,6 +836,11 @@ function Seat({
   // state, so offering the link would send the operator to a dead end to
   // discover what the badge beside the name already says.
   const href = seat.known ? teamHref(seat.id) : null;
+  // Issue #1208: only when the role is not the name over again. A seat's two
+  // strings come from one roster row, and the console's own name fallback
+  // (`fromDto`) makes them identical for every agent a manifest declares
+  // without a display name — which was every seat on this chart.
+  const subtitle = roleSubtitle(seat.name, seat.role);
 
   const label = (
     <>
@@ -848,9 +854,9 @@ function Seat({
       <span className={cn("truncate", !seat.known && "text-muted-foreground")}>
         {seat.name}
       </span>
-      {seat.role && (
+      {subtitle && (
         <span className="truncate text-xs text-muted-foreground">
-          {seat.role}
+          {subtitle}
         </span>
       )}
       {/* A seat naming somebody the roster no longer has. Shown, not hidden:

--- a/frontend/test/unit/role-subtitle.test.ts
+++ b/frontend/test/unit/role-subtitle.test.ts
@@ -1,0 +1,67 @@
+// `roleSubtitle` — the one rule behind the muted line under a teammate's name
+// (issue #1208).
+//
+// The Company cards and the org chart's seats both drew the name and then the
+// role. A roster row carries both, and `fromDto` resolves `name` as
+// `dto.name?.trim() || dto.role`, so a manifest-declared agent — which is every
+// agent in every shipped company, none of which sets a `name` — made the two
+// one string and every row said it twice. This is the guard that keeps the
+// second slot honest, tested as a function rather than only through rendering.
+
+import { describe, expect, it } from "vitest";
+
+import { fromDto, roleSubtitle } from "@/lib/team";
+import type { TeamMemberDto } from "@/api/types";
+
+describe("roleSubtitle", () => {
+  it("keeps a role that says something the name does not", () => {
+    expect(roleSubtitle("Maya", "Backend Engineer")).toBe("Backend Engineer");
+  });
+
+  it("draws nothing when the role is the name over again", () => {
+    expect(roleSubtitle("Backend Engineer", "Backend Engineer")).toBeNull();
+  });
+
+  it("is not fooled by case or padding — the same repeat in another costume", () => {
+    expect(roleSubtitle("Backend Engineer", "backend engineer")).toBeNull();
+    expect(roleSubtitle("  Backend Engineer  ", "Backend Engineer")).toBeNull();
+    expect(roleSubtitle("Backend Engineer", "  Backend Engineer ")).toBeNull();
+  });
+
+  it("draws nothing for an empty or blank role, rather than an empty line", () => {
+    expect(roleSubtitle("Maya", "")).toBeNull();
+    expect(roleSubtitle("Maya", "   ")).toBeNull();
+  });
+
+  it("returns the trimmed role, so the rendered line carries no stray padding", () => {
+    expect(roleSubtitle("Maya", "  Backend Engineer  ")).toBe("Backend Engineer");
+  });
+
+  /**
+   * The case the issue was reported from, end to end: what the host actually
+   * sends for a manifest agent, through the same mapper the views use.
+   */
+  it("silences the repeat for a host roster row that carries no display name", () => {
+    const dto = {
+      id: "backend_engineer",
+      role: "Backend Engineer",
+      description: "Build and operate the backend and services.",
+    } as TeamMemberDto;
+    const member = fromDto(dto);
+
+    expect(member.name).toBe("Backend Engineer");
+    expect(roleSubtitle(member.name, member.role)).toBeNull();
+  });
+
+  /** A teammate the operator named keeps both lines, which is the whole point. */
+  it("keeps both lines for a teammate the host does name", () => {
+    const dto = {
+      id: "growth_analyst",
+      name: "Ada",
+      role: "Growth Analyst",
+    } as TeamMemberDto;
+    const member = fromDto(dto);
+
+    expect(roleSubtitle(member.name, member.role)).toBe("Growth Analyst");
+  });
+});


### PR DESCRIPTION
## Summary

The Company page said every teammate's name twice.

A roster row carries a `name` and a `role`. `fromDto` resolves the name as
`dto.name?.trim() || dto.role`, and a manifest-declared agent sends no `name` at
all — `GET {scope}/team` answers `{"id":"backend_engineer","role":"Backend
Engineer",…}` — so for every agent in every shipped company the two fields are
one string. Both surfaces that drew the title and then the role underneath drew
the same words twice.

Measured on `companies/agentic_software_company` before this change: 14 of 14
cards and 12 of 12 org-chart seats. Not an edge case — the whole page.

```
before                          after
Backend Engineer                Backend Engineer
Backend Engineer                Build and operate the backend and services.
Build and operate the …         Idle · 2 open tasks
Idle · 2 open tasks
```

On the card the repeat cost the most: it sat directly above the description
that actually says what the teammate does.

## What changed

- `frontend/src/lib/team.ts` — `roleSubtitle(name, role)`, the single rule.
  Trimmed and case-insensitive, because the two strings come from different
  places (one may have been typed into the add-teammate dialog, the other came
  out of a manifest) and "Backend engineer" under "Backend Engineer" is the same
  repeat in another costume. Answers `null` rather than `""` so a caller skips
  the element instead of rendering an empty one and keeping the gap.
- `frontend/src/views/TeamView.tsx` — the Company card's second line.
- `frontend/src/views/company/OrgChartView.tsx` — the org-chart seat's role span.

Nothing else moves: a teammate the host *does* name keeps both lines, which is
the whole point of the slot.

## Verified in the browser

Against a real host (`--features openhuman,tinycortex,mcp`, sample company,
signed in), with a teammate added specifically to hold the positive case:

```
#/company        BE  Backend Engineer / Build and operate the backend and services.
                 AL  Ada Lovelace / Data Scientist / Model the funnel and forecast.
#/company/desks  backend_engineer -> Backend Engineer | Blueprint
                 ada_lovelace     -> Ada Lovelace | Data Scientist
```

## Commands run

```
npx vitest run test/unit/role-subtitle.test.ts   # 7 passed
npm run typecheck
npm run typecheck:unit
npm run build
scripts/ci/assert-design-tokens.sh
```

## Not in scope

#1180 — the DM header's version of the same repeat. It has a different remedy
(that slot wants the teammate's `description`, not nothing), and it is filed
separately.

Closes #1208
