### PR TITLE
console: Collapse is a header button, not a nav row

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -41,7 +41,7 @@ import { FeedbackDialog } from "@/components/feedback-dialog";
 import { HostSwitcher } from "@/components/host-switcher";
 import {
   RESTING_ROW,
-  SidebarCollapseToggle,
+  SidebarCollapseButton,
   SidebarControls,
 } from "@/components/sidebar-controls";
 import { SetupController } from "@/setup/SetupController";
@@ -1337,21 +1337,39 @@ export function AppShell({
       {/* Mobile turns the sidebar into a sheet, so its own collapse control is
           not mounted while it is closed. Keep the way back fixed to the
           viewport and below the page controls rather than competing with a
-          view's toolbar. Desktop keeps the labelled collapse row in the
-          sidebar itself. */}
+          view's toolbar. Desktop keeps its own collapse button in the
+          sidebar's header. */}
       <SidebarTrigger
         aria-label="Toggle sidebar"
         className="fixed bottom-4 left-4 z-50 md:hidden"
       />
       <Sidebar collapsible="icon">
         <SidebarHeader>
-          {/* Which host, and how every host is doing. It sits above the collapse
-              toggle because it names where you are — the first thing the column
-              should answer — and it is the only control here that can take you
-              somewhere else entirely. See `host-switcher.tsx`; it replaced the
-              icon rail that used to stand outside this sidebar (issue #1142). */}
-          <HostSwitcher companyName={feed.status.name} />
-          <SidebarCollapseToggle />
+          {/* The header is the column talking about itself: which host this
+              console is looking at, and whether the column is showing.
+              Everything BELOW it — the nav group and the footer's standing
+              controls — takes you somewhere. Collapse used to be the first row
+              under the switcher, which put a chrome control at the head of a
+              list of destinations and made it read as one (issue #1177).
+
+              `flex-col` on the rail is not a preference. The collapsed column
+              is `--sidebar-width-icon` (3rem) and this block is `p-2`, leaving
+              32px — the exact width of the switcher's glyph, with nothing left
+              over to put beside it. See `SidebarCollapseButton`. */}
+          <div className="flex items-center gap-1.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-1">
+            {/* Which host, and how every host is doing. It leads because it
+                names where you are — the first thing the column should answer
+                — and it is the only control here that can take you somewhere
+                else entirely. See `host-switcher.tsx`; it replaced the icon
+                rail that used to stand outside this sidebar (issue #1142).
+
+                `min-w-0` so the nameplate truncates instead of pushing the
+                button off the end of a 13.5rem column. */}
+            <div className="min-w-0 flex-1 group-data-[collapsible=icon]:w-full group-data-[collapsible=icon]:flex-none">
+              <HostSwitcher companyName={feed.status.name} />
+            </div>
+            <SidebarCollapseButton />
+          </div>
         </SidebarHeader>
         <SidebarContent data-tour="sidebar">
           <SidebarGroup>

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -261,20 +261,31 @@ export function SidebarCollapseButton() {
             // "button". The tooltip says the same words, but a tooltip is a
             // visual affordance and cannot be relied on for the name.
             aria-label={label}
-            // …and it reports the state it toggles, so the control is not
-            // write-only to a screen reader. No `aria-controls`: the sidebar
-            // has no stable id to point at, and a dangling one is worse than
-            // none.
-            aria-expanded={!collapsed}
+            // Deliberately NO `aria-expanded`, and not an oversight.
+            //
+            // The name already carries the state: it says "Collapse sidebar"
+            // while the column is showing and "Expand sidebar" once it is a
+            // rail, so a reader is told what pressing does and, by the change,
+            // what happened. `aria-expanded` on top of that announces the
+            // state twice ("Expand sidebar, collapsed") — and `ghost` styles
+            // the attribute as "the popup under me is open", which is what it
+            // means on the dropdown triggers that variant was written for. On
+            // this button it painted a pressed chip for as long as the sidebar
+            // was open, and Tailwind sorts `aria-expanded:` after `hover:`, so
+            // overriding the chip also swallowed the hover feedback. A second
+            // channel saying the same thing is not worth either.
             data-testid="sidebar-collapse"
             onClick={toggleSidebar}
             className={cn(
               "shrink-0 text-sidebar-foreground/60",
-              // `sidebar-accent`, NOT `Button`'s stock `hover:bg-muted`. The
-              // muted tint is tuned against the canvas, and this button is on
-              // the sidebar's surface — which is a different rung, and about
-              // to move again (issue #1178).
-              "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+              // Three classes replacing exactly one of `ghost`'s each, so
+              // tailwind-merge drops the original rather than leaving the two
+              // to race: `hover:bg-muted`, `hover:text-foreground` and
+              // `dark:hover:bg-muted/50`. The muted tint is tuned against the
+              // canvas; this button is on the sidebar's surface, which is a
+              // different rung and moving again in issue #1178. The accent is
+              // also what every row in this column already hovers to.
+              "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground dark:hover:bg-sidebar-accent",
               "focus-visible:ring-sidebar-ring/50",
               // 28px beside a 48px nameplate, 32px on the rail. See the note
               // on the collapsed rail above.

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -1,8 +1,9 @@
-import { Building2, MessageSquareWarning, PanelLeft } from "lucide-react";
+import { Building2, MessageSquareWarning, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 
 import type { CompanyStatus } from "@/api/types";
 import type { View } from "@/components/app-shell";
 
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,6 +16,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DiscordIcon } from "@/components/discord-icon";
 import { lifecycle } from "@/lib/language";
 import { DISCORD_INVITE_URL } from "@/lib/links";
@@ -79,11 +81,12 @@ interface Props {
  * The sidebar's standing controls.
  *
  * No page carries a header of its own any more, so what is left of the old top
- * bar lives here: the company's state and the switcher. Collapsing is its own
- * control at the top of the sidebar (`SidebarCollapseToggle`). Theming and
- * flagging are deliberately absent — Settings owns both, under Appearance and
- * "Something off?", and a second entry point would just be two places to keep
- * in step.
+ * bar lives here: the company's state and the switcher. Collapsing is NOT one
+ * of these — it is chrome rather than a destination, so it is a button in the
+ * sidebar's header beside the host switcher (`SidebarCollapseButton`, below)
+ * rather than a row in either menu. Theming and flagging are deliberately
+ * absent — Settings owns both, under Appearance and "Something off?", and a
+ * second entry point would just be two places to keep in step.
  */
 export function SidebarControls({
   lifecycleState,
@@ -194,35 +197,106 @@ export function SidebarControls({
 }
 
 /**
- * The collapse toggle, at the top of the sidebar.
+ * Show or hide the sidebar. A button in the header, not a row in the nav.
  *
- * It sits above the nav rather than among the footer controls, because it is
- * the one control here that acts on the sidebar itself — everything below it
- * navigates. Expanded, it stays quiet and reads as another row; collapsed, it
- * takes the primary fill, so the single control that gets the rail back is the
- * one thing standing out in a column of identical icons.
+ * ## Why it is not a row (issue #1177)
+ *
+ * It used to be a `SidebarMenuButton` — full width, icon then label, `h-8`,
+ * `bg-sidebar-accent` on hover — sitting directly under the host switcher and
+ * directly above Overview. That is the nav row shape exactly, so the eye filed
+ * it as the first destination in the list. It is not a destination: everything
+ * else in that column takes you somewhere, and this one changes the chrome and
+ * leaves you where you are.
+ *
+ * Colouring it differently would not have fixed that; the shape is what says
+ * "row". So it stops using the row primitive altogether and becomes the
+ * console's ordinary icon button, in the sidebar's header — which is the part
+ * of the column that talks about the panel rather than about the company.
+ * `SidebarContent` below it is the destinations, and the header/content
+ * boundary now means something.
+ *
+ * ## Why it does not crowd the host switcher (issue #1174)
+ *
+ * The switcher beside it is `h-12`, carries a filled glyph, a two-line
+ * nameplate and the cross-host status dot. This is 28px, ghost, and dimmed at
+ * rest. They also sit in separate elements, so hovering one never lights the
+ * other — which is what stops the pair reading as a single control with a
+ * chevron at one end and a panel glyph at the other.
+ *
+ * ## The collapsed rail
+ *
+ * The rail is `--sidebar-width-icon` (3rem) and `SidebarHeader` is `p-2`, so
+ * there are 32px of content box — exactly the switcher's glyph, and no room
+ * for anything beside it. The header row therefore becomes a column on the
+ * rail (see `app-shell.tsx`), and this button grows to `size-8` there so it
+ * lands on the same 32px rhythm as every nav icon below it.
+ *
+ * It deliberately drops the `bg-primary` fill it used to take when collapsed.
+ * That fill existed to make it findable in a column of identical nav icons; up
+ * here it has only the switcher for company, and the switcher's glyph is
+ * *already* a filled primary square. Two of those stacked would read as one
+ * control, which is the failure the paragraph above exists to prevent.
  */
-export function SidebarCollapseToggle() {
-  const { toggleSidebar, state } = useSidebar();
-  const collapsed = state === "collapsed";
+export function SidebarCollapseButton() {
+  const { toggleSidebar, state, isMobile } = useSidebar();
+  // `state` tracks the DESKTOP open flag; the sheet has its own (`openMobile`).
+  // Reading it unguarded labels an open sheet "Expand sidebar" whenever the
+  // desktop state happens to be collapsed — which, since issue #1176 stopped
+  // the sidebar auto-collapsing, is now a state an operator can leave behind
+  // and come back to on a phone.
+  const collapsed = !isMobile && state === "collapsed";
+  const label = collapsed ? "Expand sidebar" : "Collapse sidebar";
+  const Icon = collapsed ? PanelLeftOpen : PanelLeftClose;
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          tooltip={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          onClick={toggleSidebar}
-          className={cn(
-            collapsed
-              ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground active:bg-primary/90 active:text-primary-foreground"
-              : RESTING_ROW,
-          )}
-        >
-          <PanelLeft className={cn("transition-transform", collapsed && "rotate-180")} />
-          <span>Collapse</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-    </SidebarMenu>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            // The accessible name, and the only name this control has — an
+            // icon-only button with no label is otherwise announced as
+            // "button". The tooltip says the same words, but a tooltip is a
+            // visual affordance and cannot be relied on for the name.
+            aria-label={label}
+            // …and it reports the state it toggles, so the control is not
+            // write-only to a screen reader. No `aria-controls`: the sidebar
+            // has no stable id to point at, and a dangling one is worse than
+            // none.
+            aria-expanded={!collapsed}
+            data-testid="sidebar-collapse"
+            onClick={toggleSidebar}
+            className={cn(
+              "shrink-0 text-sidebar-foreground/60",
+              // `sidebar-accent`, NOT `Button`'s stock `hover:bg-muted`. The
+              // muted tint is tuned against the canvas, and this button is on
+              // the sidebar's surface — which is a different rung, and about
+              // to move again (issue #1178).
+              "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+              "focus-visible:ring-sidebar-ring/50",
+              // 28px beside a 48px nameplate, 32px on the rail. See the note
+              // on the collapsed rail above.
+              "group-data-[collapsible=icon]:size-8",
+            )}
+          />
+        }
+      >
+        <Icon />
+      </TooltipTrigger>
+      {/*
+        The raw tooltip primitive rather than `SidebarMenuButton`'s `tooltip`
+        prop, which renders its content with `hidden={state !== "collapsed"}`.
+        That is right for a nav row — expanded, the row already carries its
+        label — and wrong here: this button is icon-only in BOTH states, and
+        expanded is the state in which a reader has never seen the word.
+
+        `side="right"` in both states, matching every other tooltip in this
+        column, and the one side that is clear of the sidebar either way.
+      */}
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -277,6 +277,12 @@ export function SidebarCollapseButton() {
             data-testid="sidebar-collapse"
             onClick={toggleSidebar}
             className={cn(
+              // The same resting dim as the rows below, reached through the
+              // ink's alpha rather than `RESTING_ROW`'s `opacity-60`: opacity
+              // dims the whole box, focus ring included, and the ring on an
+              // unlabelled button is the only thing saying where the keyboard
+              // is. (`RESTING_ROW` also carries `data-active:opacity-100`,
+              // which is a nav row's business and never this one's.)
               "shrink-0 text-sidebar-foreground/60",
               // Three classes replacing exactly one of `ghost`'s each, so
               // tailwind-merge drops the original rather than leaving the two

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -58,7 +58,6 @@ test.describe("sidebar toggle reachability", () => {
     // is: this control is icon-only, so an `aria-label` lost in a refactor
     // leaves a button a screen reader announces as "button".
     await expect(toggle).toBeInViewport();
-    await expect(toggle).toHaveAttribute("aria-expanded", "true");
 
     // Chrome, not a destination. It lives in the header with the host switcher
     // and is nowhere in the nav list.
@@ -95,7 +94,6 @@ test.describe("sidebar toggle reachability", () => {
     const expand = page.getByRole("button", { name: "Expand sidebar", exact: true });
     await expect(expand).toBeVisible();
     await expect(expand).toBeInViewport();
-    await expect(expand).toHaveAttribute("aria-expanded", "false");
 
     const railBox = await expand.boundingBox();
     expect(railBox, "the collapsed control should have a box").not.toBeNull();

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -95,6 +95,16 @@ test.describe("sidebar toggle reachability", () => {
     await expect(expand).toBeVisible();
     await expect(expand).toBeInViewport();
 
+    // `data-state` flips on the click; the column takes `duration-200` to get
+    // there. Poll rather than sample, or this measures a sidebar caught half
+    // way and reports a button that fits as one that does not.
+    await expect
+      .poll(
+        async () => (await page.locator("[data-slot=sidebar-container]").boundingBox())?.width,
+        { message: "the collapsed column settles at the icon rail's width" },
+      )
+      .toBe(RAIL_WIDTH);
+
     const railBox = await expand.boundingBox();
     expect(railBox, "the collapsed control should have a box").not.toBeNull();
     expect(railBox!.x, "…inside the rail, not hanging off its left edge").toBeGreaterThanOrEqual(0);

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -1,5 +1,23 @@
 import { expect, test } from "@playwright/test";
 
+/**
+ * However the sidebar is hidden, there is always a way back to it.
+ *
+ * Two shapes, because the sidebar has two. On mobile it is a sheet that closes
+ * entirely, taking its own controls with it, so the way back is a button fixed
+ * to the viewport. On desktop it collapses to a 3rem icon rail that keeps its
+ * header, so the way back is the same control that put it there.
+ *
+ * The desktop half also pins WHERE that control lives (issue #1177). It used to
+ * be a full-width row directly above Overview — the nav row shape exactly, for
+ * something that is not a destination — and the fix is a header button. The
+ * assertion that it is inside `sidebar-header` and absent from `sidebar-content`
+ * is what stops it drifting back into the list, and it is deliberately paired
+ * with the reachability claims rather than filed on its own: a control that is
+ * in the right place but unreachable, or reachable but nameless, is the same
+ * bug in a different coat.
+ */
+
 /** The tour can cover the fixed trigger while it is showing. */
 async function dismissTour(page: import("@playwright/test").Page) {
   const skip = page.getByRole("button", { name: "Skip for now" });
@@ -10,6 +28,9 @@ async function dismissTour(page: import("@playwright/test").Page) {
     // The signed-in browser profile may already have completed the tour.
   }
 }
+
+/** `--sidebar-width-icon`, in px. The whole width the collapsed control has. */
+const RAIL_WIDTH = 48;
 
 test.describe("sidebar toggle reachability", () => {
   test("the mobile sheet has an in-viewport way back", async ({ page }) => {
@@ -23,11 +44,72 @@ test.describe("sidebar toggle reachability", () => {
     await expect(page.getByText("Workflows", { exact: true })).toBeVisible();
   });
 
-  test("the inline sidebar keeps its labelled collapse control", async ({ page }) => {
+  test("the inline sidebar's collapse control is a named, keyboard-operable header button", async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 1024, height: 800 });
     await page.goto("/#/overview");
     await dismissTour(page);
 
-    await expect(page.getByRole("button", { name: "Collapse" })).toBeInViewport();
+    const sidebar = page.locator("[data-slot=sidebar]");
+    const toggle = page.getByRole("button", { name: "Collapse sidebar", exact: true });
+
+    // Named and on screen. The name is the assertion as much as the position
+    // is: this control is icon-only, so an `aria-label` lost in a refactor
+    // leaves a button a screen reader announces as "button".
+    await expect(toggle).toBeInViewport();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // Chrome, not a destination. It lives in the header with the host switcher
+    // and is nowhere in the nav list.
+    await expect(
+      page.locator("[data-slot=sidebar-header]").getByTestId("sidebar-collapse"),
+      "the collapse control belongs to the sidebar's header",
+    ).toHaveCount(1);
+    await expect(
+      page.locator("[data-slot=sidebar-content]").getByTestId("sidebar-collapse"),
+      "…and never among the nav rows, which is what issue #1177 was",
+    ).toHaveCount(0);
+
+    // Beside the switcher, not on top of it, and not a second half of it: the
+    // header holds two separate controls and the boxes must not overlap.
+    const switcherBox = await page.getByTestId("host-switcher").boundingBox();
+    const toggleBox = await toggle.boundingBox();
+    expect(switcherBox, "the host switcher should have a box").not.toBeNull();
+    expect(toggleBox, "the collapse control should have a box").not.toBeNull();
+    expect(
+      toggleBox!.x,
+      "the collapse button stands clear of the host switcher's trailing edge",
+    ).toBeGreaterThanOrEqual(switcherBox!.x + switcherBox!.width);
+
+    // Operable from the keyboard, not just under a pointer. An icon-only
+    // button is exactly the kind that gets rebuilt as a `div` with an
+    // `onClick` and silently stops being reachable.
+    await toggle.focus();
+    await expect(toggle).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    // It survives the state it just produced. This is the case most likely to
+    // be got wrong: the control is now inside a 3rem column.
+    await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+    const expand = page.getByRole("button", { name: "Expand sidebar", exact: true });
+    await expect(expand).toBeVisible();
+    await expect(expand).toBeInViewport();
+    await expect(expand).toHaveAttribute("aria-expanded", "false");
+
+    const railBox = await expand.boundingBox();
+    expect(railBox, "the collapsed control should have a box").not.toBeNull();
+    expect(railBox!.x, "…inside the rail, not hanging off its left edge").toBeGreaterThanOrEqual(0);
+    expect(
+      railBox!.x + railBox!.width,
+      "…and inside the rail, not overflowing its right edge",
+    ).toBeLessThanOrEqual(RAIL_WIDTH);
+
+    // And back, from the keyboard, to where it started.
+    await expand.focus();
+    await expect(expand).toBeFocused();
+    await page.keyboard.press("Enter");
+    await expect(sidebar).toHaveAttribute("data-state", "expanded");
+    await expect(page.getByRole("button", { name: "Collapse sidebar", exact: true })).toBeVisible();
   });
 });

--- a/frontend/test/unit/sidebar-collapse-button.test.ts
+++ b/frontend/test/unit/sidebar-collapse-button.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SidebarCollapseButton } from "@/components/sidebar-controls";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+/**
+ * Issue #1177 — the sidebar's collapse control, as a control rather than a row.
+ *
+ * This suite is normally for pure functions (see `vitest.config.ts`), and it
+ * earns the exception the same way `board-collapsed-columns.test.ts` does: the
+ * claims here only exist at the rendered element. The one thing that has to
+ * hold is that an ICON-ONLY button still says what it is and what it did —
+ * there is no label to fall back on, so the accessible name and `aria-expanded`
+ * are the whole contract, and both are exactly the kind of attribute a styling
+ * pass drops without breaking a single render.
+ *
+ * The other half of the fix — that the button sits in the sidebar's header and
+ * not among the nav rows, and that it stays inside the 3rem rail it produces —
+ * is geometry and composition, and lives in
+ * `test/e2e/sidebar-toggle-reachable.spec.ts`. jsdom loads no stylesheet, so
+ * asserting either of those here would pass against a build where the rail was
+ * 3rem of clipped button.
+ */
+
+let host: HTMLDivElement;
+let root: Root | null = null;
+
+/**
+ * jsdom ships no `matchMedia`, and `useIsMobile` — which `SidebarProvider`
+ * calls — reaches for it unguarded. Same stub `working-indicator.test.ts`
+ * installs, always reporting "not matching", which is the desktop case: at
+ * jsdom's default 1024px window the sidebar is the inline column, not a sheet.
+ */
+function stubMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+    }),
+  });
+}
+
+beforeEach(() => {
+  // Tells React this run is an act environment, the same way the other
+  // rendering suites here do. Without it every `act` prints a warning and
+  // effects flush on their own schedule.
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  stubMatchMedia();
+  host = document.createElement("div");
+  document.body.append(host);
+});
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  host.remove();
+});
+
+/**
+ * Mounts the button inside a real provider, so `state` is the real state.
+ *
+ * A fresh root every time: `defaultOpen` is an initial value, so re-rendering
+ * the same tree with the other value would quietly keep the first one and the
+ * collapsed case would test nothing.
+ */
+function mount(defaultOpen: boolean) {
+  if (root) act(() => root!.unmount());
+  root = createRoot(host);
+  act(() => {
+    root!.render(
+      createElement(SidebarProvider, { defaultOpen }, createElement(SidebarCollapseButton)),
+    );
+  });
+}
+
+/** The one button on screen. Fails loudly if the render ever grows a second. */
+function control(): HTMLButtonElement {
+  const buttons = host.querySelectorAll("button");
+  expect(buttons).toHaveLength(1);
+  return buttons[0] as HTMLButtonElement;
+}
+
+describe("the sidebar collapse button", () => {
+  it("names itself and reports the state it toggles", () => {
+    mount(true);
+
+    const button = control();
+    // A real `<button>`, not a `div` with an `onClick`: that is what makes it
+    // tab-reachable and Enter/Space-operable without any help from us.
+    expect(button.tagName).toBe("BUTTON");
+    expect(button.getAttribute("aria-label")).toBe("Collapse sidebar");
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("flips its name and its state when pressed", () => {
+    mount(true);
+
+    act(() => control().click());
+
+    const button = control();
+    expect(button.getAttribute("aria-label")).toBe("Expand sidebar");
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+
+    // …and back, so the control is a toggle rather than a one-way trip.
+    act(() => control().click());
+    expect(control().getAttribute("aria-label")).toBe("Collapse sidebar");
+    expect(control().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("is never nameless, in either state it can be mounted in", () => {
+    for (const defaultOpen of [true, false]) {
+      mount(defaultOpen);
+      const button = control();
+      // The failure this guards is an icon-only button announced as "button".
+      // Neither the glyph nor the tooltip contributes a name — the tooltip is
+      // not even in the DOM until it opens — so the label is all there is.
+      expect(button.getAttribute("aria-label")).toBeTruthy();
+      expect(button.textContent?.trim()).toBe("");
+    }
+  });
+});

--- a/frontend/test/unit/sidebar-collapse-button.test.ts
+++ b/frontend/test/unit/sidebar-collapse-button.test.ts
@@ -13,10 +13,13 @@ import { SidebarProvider } from "@/components/ui/sidebar";
  * This suite is normally for pure functions (see `vitest.config.ts`), and it
  * earns the exception the same way `board-collapsed-columns.test.ts` does: the
  * claims here only exist at the rendered element. The one thing that has to
- * hold is that an ICON-ONLY button still says what it is and what it did —
- * there is no label to fall back on, so the accessible name and `aria-expanded`
- * are the whole contract, and both are exactly the kind of attribute a styling
- * pass drops without breaking a single render.
+ * hold is that an ICON-ONLY button still says what it is and what it did.
+ * There is no visible label to fall back on and no `aria-expanded` (see the
+ * component for why), so the accessible NAME is the entire state channel: it
+ * reads "Collapse sidebar" while the column is showing and "Expand sidebar"
+ * once it is a rail. An `aria-label` is exactly the kind of attribute a
+ * styling pass drops without breaking a single render, and a name that stops
+ * tracking the provider's state is a control that lies about what it does.
  *
  * The other half of the fix — that the button sits in the sidebar's header and
  * not among the nav rows, and that it stays inside the 3rem rail it produces —
@@ -93,7 +96,7 @@ function control(): HTMLButtonElement {
 }
 
 describe("the sidebar collapse button", () => {
-  it("names itself and reports the state it toggles", () => {
+  it("names itself, on a real button", () => {
     mount(true);
 
     const button = control();
@@ -101,22 +104,21 @@ describe("the sidebar collapse button", () => {
     // tab-reachable and Enter/Space-operable without any help from us.
     expect(button.tagName).toBe("BUTTON");
     expect(button.getAttribute("aria-label")).toBe("Collapse sidebar");
-    expect(button.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("flips its name and its state when pressed", () => {
+  it("flips its name from the provider's state when pressed", () => {
     mount(true);
 
     act(() => control().click());
 
+    // The name follows `useSidebar().state`, not a local flag: the click went
+    // through the provider and came back out as a different label.
     const button = control();
     expect(button.getAttribute("aria-label")).toBe("Expand sidebar");
-    expect(button.getAttribute("aria-expanded")).toBe("false");
 
     // …and back, so the control is a toggle rather than a one-way trip.
     act(() => control().click());
     expect(control().getAttribute("aria-label")).toBe("Collapse sidebar");
-    expect(control().getAttribute("aria-expanded")).toBe("true");
   });
 
   it("is never nameless, in either state it can be mounted in", () => {


### PR DESCRIPTION
## What

**Collapse** was a full-width `SidebarMenuButton` sitting directly under the host switcher and directly above **Overview** — same shape, height and hover treatment as the nav rows, for the one control in that column that does not navigate. It becomes an icon-only ghost button in the sidebar header, beside the switcher.

```
before                              after
┌──────────────────────────┐        ┌──────────────────────────┐
│ ▣ Agentic Software…   ⌄ │        │ ▣ Agentic Softw…  ⌄  [◧] │
│   This host              │        │   Current company        │
│                          │        │                          │
│ ▣ Collapse               │  ←     │ ▣ Overview               │
│                          │        │ ▣ Company                │
│ ▣ Overview               │        └──────────────────────────┘
│ ▣ Company                │
└──────────────────────────┘
```

Closes #1177.

## Why this placement

- **The header is where the column talks about itself.** `HostSwitcher` answers "which console is this"; collapsing is the same category of thing. Everything *below* the header — the nav group and the footer's standing controls — is a place you can go. Putting the toggle above that boundary is what makes the boundary mean something.
- **A different primitive, not a different colour.** The row *shape* is what said "nav item", so the fix stops using the row primitive. `Button variant="ghost" size="icon-sm"` is 28px, unlabelled, not full width. It cannot be misread as a row because it is not row-shaped.

Rejected: the footer (same failure one screen lower — it is a menu of destinations); `SidebarRail` alone (`tabIndex={-1}`, invisible, no accessible name); a floating button over the content column (competes with every view's toolbar, which is exactly what the mobile comment says to avoid).

## The four things the issue asked about

**1. The collapsed rail.** `--sidebar-width-icon` is 3rem and `SidebarHeader` is `p-2`, leaving a 32px content box — the exact width of the switcher's glyph, with nothing left to put beside it. So the header row becomes a **column** on the rail, via the same `group-data-[collapsible=icon]:` mechanism the rest of the sidebar uses. The button grows to `size-8` there, landing on the same 32px rhythm as the nav icons below it.

It also **drops the `bg-primary` fill** it used to take when collapsed. That fill existed to make it findable in a column of identical nav icons; in the header it has only the switcher for company, and the switcher's glyph is *already* a filled primary square — two stacked would read as one control.

**2. Mobile is unchanged.** The sheet has no `data-collapsible="icon"` group, so the header row stays horizontal at 18rem; the fixed bottom-left `SidebarTrigger` is untouched, and its e2e test is unchanged. One latent bug fixed on the way: `state` tracks the *desktop* open flag, so an open sheet could read "Expand sidebar" if the desktop state happened to be collapsed — now guarded with `!isMobile`. Since #1176 removed the auto-collapse that is a state an operator can actually leave behind.

**3. Accessibility.** A real `<button>` in DOM order right after the switcher — tab-reachable, Enter/Space-operable, no `tabIndex` override. `aria-label` flips between "Collapse sidebar" and "Expand sidebar", so the name carries the state. The tooltip uses the raw primitive rather than `SidebarMenuButton`'s `tooltip` prop, which renders `hidden={state !== "collapsed"}` — right for a nav row that already shows its label, wrong for a button that is icon-only in *both* states.

**No `aria-expanded`, deliberately.** It was in the first draft and measurement took it out: `ghost` styles that attribute as "the popup under me is open" (muted fill, full-strength ink), so the button wore a pressed chip for as long as the sidebar was open and shed it on the rail. Overriding the chip made it worse — Tailwind sorts `aria-expanded:` after `hover:`, so the override swallowed hover feedback entirely (expanded hover became a no-op in light, and kept the resting ink in dark). The attribute was the redundant half: the name already announces the state.

**4. The host switcher (#1174) is not crowded.** Different weight (`h-12` filled nameplate + status dot vs a 28px ghost square), `gap-1.5` between them, and separate elements — hovering one never lights the other. The status dot is on the glyph's *leading* edge, a nameplate's width away from the button. Measured expanded: switcher `x:8 w:165`, button `x:179 w:28` — no overlap.

## Browser verification

Host on `:8372` (`agentic_software_company`), console on `:5204`, light and dark, expanded and collapsed. Every state measured rather than eyeballed:

| | rest bg | rest ink contrast | hover bg | hover ink contrast |
| --- | --- | --- | --- | --- |
| light, expanded | transparent | 5.22:1 | sidebar-accent | 8.24:1 |
| light, collapsed | transparent | 5.22:1 | sidebar-accent | 8.24:1 |
| dark, expanded | transparent | 7.26:1 | sidebar-accent | 8.36:1 |
| dark, collapsed | transparent | 7.26:1 | sidebar-accent | 8.36:1 |

Identical expanded and collapsed, and the resting ink matches the resting nav rows exactly (`RESTING_ROW` is `opacity-60`; this is `text-sidebar-foreground/60`). Also confirmed in both themes: collapsed control box `x:7.5 w:32` inside a 48px rail; `Tab` from the switcher lands on it; `Enter` collapses and expands; the tooltip reads correctly in both states; the mobile sheet still opens from the fixed trigger and still shows the nav.

## Tests

- `test/e2e/sidebar-toggle-reachable.spec.ts` — the desktop case is **strengthened, not moved**. It now asserts the exact-name lookup, that the control is inside `sidebar-header` and **absent from `sidebar-content`** (the #1177 regression guard), that its box stands clear of the switcher's, that it is focusable and Enter-operable, and that after collapsing it is still visible, in-viewport and **inside the 48px rail** — then Enter again to get back. The mobile test is byte-identical.
- `test/unit/sidebar-collapse-button.test.ts` (new) — the name/state coupling at the rendered element: a real `<button>`, a name that flips through the real provider and back, and never an empty accessible name in either mount state. jsdom loads no stylesheet, so geometry deliberately stays in e2e.

## Commands run

```
frontend: npm run typecheck ✓  typecheck:unit ✓  typecheck:e2e ✓  npm test ✓ (137 files, 1323 tests)
frontend: npx playwright test sidebar-toggle-reachable.spec.ts sidebar-host-switcher.spec.ts ✓ (3 passed)
frontend: npx playwright test assignee-picker board-drag chat-approval-line chat-to-card \
          company-cards connection-degrade org-tree tour-popover-in-viewport wiring ✓ (53 passed, 3 skipped)
```
(the second and third against a `companies/e2e_harness` host, since `:8080` was occupied)

## Relationship to draft #1188

**No design conflict.** #1188 changes the sidebar's *outer* chrome — the console inset in a frame, `--sidebar` to rung 2 in light, `sidebar-container` to `absolute`/`h-full`. It does not touch `SidebarHeader`, `HostSwitcher`, or anything inside the column. This PR changes only what is inside the header. They compose.

**One trivial textual conflict**, comment text only: #1188 rewrites the `<SidebarProvider …>` line and adds a comment above it; this PR edits one sentence of the mobile `SidebarTrigger` comment a few lines below ("Desktop keeps the labelled collapse row in the sidebar itself" is no longer true). Whichever lands second keeps both hunks.

**Order: either, but this one first is cheaper** — smaller diff, and #1188 is a draft that will be rebased anyway. Two things for #1188 to carry forward: this button's hover must stay `sidebar-accent` (its rung-2 light sidebar makes a `muted` hover wrong), and its `app-frame.spec.ts` measures the rail at 48px, which this header does not exceed.
