### PR TITLE
fix(ledgers): stop a filtered ledger reporting itself empty, and name the status filter honestly

### DIFF
--- a/frontend/src/api/ledgers.ts
+++ b/frontend/src/api/ledgers.ts
@@ -281,6 +281,68 @@ export function composableFields(ledger: LedgerSummary): LedgerField[] {
   );
 }
 
+/**
+ * The sentinel the status filter stores for "do not filter".
+ *
+ * A `Select` item cannot carry an empty string, so the no-filter choice needs a
+ * value of its own — the same constraint the workflow destination picker met
+ * with `__none__` in issue #813.
+ */
+export const EVERY_STATUS = "all";
+
+/**
+ * What the status filter should *show* for a stored value (issue #1217).
+ *
+ * base-ui renders the raw stored value in a collapsed `Select` unless it is
+ * given explicit text, so without this the trigger read `all` while its own open
+ * list read "Every status", and a chosen board column read `in_progress` while
+ * the columns beside it read "In progress". Exactly the leak `destinationLabel`
+ * exists to stop on the workflows side.
+ *
+ * Prefers the declared `label` over the wire `name`, which is what that field is
+ * for: the board's statuses carry both, and the console deleted its own copy of
+ * that table when the host started sending it. An unrecognized value falls back
+ * to itself rather than to the sentinel — a filter we cannot name is still a
+ * filter, and rendering it as "Every status" would claim the opposite.
+ */
+export function statusFilterLabel(
+  ledger: LedgerSummary | null | undefined,
+  value: string,
+): string {
+  if (value === EVERY_STATUS || value === "") return "Every status";
+  const declared = ledger?.statuses.find((status) => status.name === value);
+  if (!declared) return value;
+  return `${declared.label ?? declared.name}${declared.closed ? " (closed)" : ""}`;
+}
+
+/**
+ * Why this ledger is showing nothing — the filtered reading, or `null` when no
+ * filter is on and "nothing recorded yet" is the honest answer (issue #1217).
+ *
+ * A ledger read is filtered **server-side**, so zero rows back means "no
+ * matches" and "no rows" indistinguishably. The view knows which it is, because
+ * the query and the status are its own state — this is that knowledge written
+ * down once, so the empty state stops telling an operator with 14 rows that
+ * their ledger is empty while the nav beside it counts them.
+ *
+ * Pure, and separate from the component, for the reason `workflowSavedToast` is:
+ * the branch is the whole bug and it should be assertable without a render.
+ */
+export function filteredEmptyNotice(
+  ledger: LedgerSummary | null | undefined,
+  query: string,
+  statusFilter: string,
+): string | null {
+  const searching = query.trim() !== "";
+  const narrowed = statusFilter !== EVERY_STATUS && statusFilter !== "";
+  if (!searching && !narrowed) return null;
+  if (searching && narrowed) {
+    return `No rows match “${query.trim()}” with status ${statusFilterLabel(ledger, statusFilter)}.`;
+  }
+  if (searching) return `No rows match “${query.trim()}”.`;
+  return `No rows with status ${statusFilterLabel(ledger, statusFilter)}.`;
+}
+
 /** Whether this status ends a row's life on this ledger. */
 export function isClosingStatus(ledger: LedgerSummary, status: string): boolean {
   return ledger.statuses.some(

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -73,6 +73,8 @@ import {
   composableFields,
   defineLedger,
   deleteEntry,
+  EVERY_STATUS,
+  filteredEmptyNotice,
   isClosingStatus,
   isWritable,
   listLedgers,
@@ -81,6 +83,7 @@ import {
   renderedLedger,
   retireLedger,
   statusField,
+  statusFilterLabel,
   statusNeedsReason,
   type LedgerEntry,
   type LedgerRead,
@@ -198,7 +201,7 @@ export function LedgersView({
   const [reading, setReading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState(EVERY_STATUS);
   const [composing, setComposing] = useState<Composing | null>(null);
   const [saving, setSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<LedgerEntry | null>(null);
@@ -252,6 +255,19 @@ export function LedgersView({
   /** The clock the "blocked since" labels measure against (issue #883). */
   const clock = now ?? Date.now();
 
+  /**
+   * Why this ledger is showing nothing, when a filter is the reason (#1217).
+   * `null` when nothing is filtering, which is the only case where "Nothing
+   * recorded here yet" is a true sentence.
+   */
+  const emptyNotice = filteredEmptyNotice(ledger, query, statusFilter);
+
+  /** Put the ledger back to showing everything it holds. */
+  const clearFilters = useCallback(() => {
+    setQuery("");
+    setStatusFilter(EVERY_STATUS);
+  }, []);
+
   const refreshList = useCallback(async () => {
     if (!company) return;
     try {
@@ -298,7 +314,7 @@ export function LedgersView({
       try {
         const next = await readLedger(client, company, selected, {
           q: query.trim() || undefined,
-          status: statusFilter === "all" ? undefined : statusFilter,
+          status: statusFilter === EVERY_STATUS ? undefined : statusFilter,
           limit: 100,
         });
         setRead(next);
@@ -686,17 +702,22 @@ export function LedgersView({
                 </div>
                 <Select
                   value={statusFilter}
-                  onValueChange={(value) => setStatusFilter(value ?? "all")}
+                  onValueChange={(value) => setStatusFilter(value ?? EVERY_STATUS)}
                 >
+                  {/* Explicit trigger text, for the reason issue #813 gave the
+                      destination picker its own: base-ui renders the stored
+                      value in the collapsed control unless told otherwise, so
+                      this read `all` while the list under it read "Every
+                      status", and a chosen board column read `in_progress`
+                      beside columns headed "In progress". */}
                   <SelectTrigger className="w-[12rem]">
-                    <SelectValue />
+                    <SelectValue>{statusFilterLabel(ledger, statusFilter)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Every status</SelectItem>
+                    <SelectItem value={EVERY_STATUS}>Every status</SelectItem>
                     {ledger.statuses.map((status) => (
                       <SelectItem key={status.name} value={status.name}>
-                        {status.name}
-                        {status.closed ? " (closed)" : ""}
+                        {statusFilterLabel(ledger, status.name)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -763,10 +784,26 @@ export function LedgersView({
                 </p>
               )}
 
+              {/* Issue #1217: zero rows back means "no matches" and "no rows"
+                  indistinguishably — the read is filtered server-side. The two
+                  are not the same claim, and saying the stronger one over a
+                  ledger the nav is counting 14 rows for is simply false. */}
               {read && read.entries.length === 0 && !reading && (
-                <p className="text-sm text-muted-foreground">
-                  Nothing recorded here yet.
-                </p>
+                emptyNotice ? (
+                  <div
+                    className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
+                    data-testid="ledger-filtered-empty"
+                  >
+                    <span>{emptyNotice}</span>
+                    <Button size="sm" variant="outline" onClick={clearFilters}>
+                      Clear filters
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground" data-testid="ledger-empty">
+                    Nothing recorded here yet.
+                  </p>
+                )
               )}
 
               {mode === "board" && read ? (

--- a/frontend/test/unit/ledger-filter-honesty.test.ts
+++ b/frontend/test/unit/ledger-filter-honesty.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EVERY_STATUS,
+  filteredEmptyNotice,
+  statusFilterLabel,
+  type LedgerSummary,
+} from "@/api/ledgers";
+
+/**
+ * Issue #1217: what a ledger says when it is showing nothing, and what its
+ * status filter calls itself.
+ *
+ * Both were the same class of mistake — a control reporting the wire's word
+ * instead of the operator's. Searching a 14-row ledger for a term that matched
+ * nothing produced "Nothing recorded here yet." beside a nav still counting
+ * "9 open · 5 closed"; the filter's collapsed trigger read `all` while its own
+ * open list read "Every status", and `in_progress` beside board columns headed
+ * "In progress".
+ *
+ * Both branches are pure, which is why they live in `api/ledgers.ts` rather
+ * than inside the view — the decision is the whole bug and it should be
+ * assertable without a render (the reasoning `workflow-saved-toast` uses).
+ */
+
+/** A declared ledger: plain status names, one of them closing. */
+const PROMISES = {
+  slug: "customer-promises",
+  title: "Customer promises",
+  purpose: "",
+  source: "events",
+  derived: "derived/CUSTOMER_PROMISES.md",
+  writtenBy: "",
+  builtin: false,
+  fields: [],
+  statuses: [
+    { name: "open" },
+    { name: "kept", closed: true },
+    { name: "broken", closed: true },
+  ],
+  sections: [],
+  open: 9,
+  closed: 5,
+} as unknown as LedgerSummary;
+
+/** The native board, whose statuses carry a `label` the wire word differs from. */
+const BOARD = {
+  ...PROMISES,
+  slug: "tasks",
+  source: "native",
+  statuses: [
+    { name: "in_progress", label: "In progress" },
+    { name: "done", label: "Done", closed: true },
+  ],
+} as unknown as LedgerSummary;
+
+describe("what the status filter calls itself", () => {
+  it("names the sentinel rather than printing it", () => {
+    expect(statusFilterLabel(PROMISES, EVERY_STATUS)).toBe("Every status");
+    // A `Select` cannot store an empty string, but a host or a future default
+    // that sends one must not render as a blank trigger either.
+    expect(statusFilterLabel(PROMISES, "")).toBe("Every status");
+  });
+
+  it("qualifies a closing status, so the trigger reads like the list", () => {
+    expect(statusFilterLabel(PROMISES, "open")).toBe("open");
+    expect(statusFilterLabel(PROMISES, "kept")).toBe("kept (closed)");
+  });
+
+  it("prefers the declared label, which is what the board sends it for", () => {
+    expect(statusFilterLabel(BOARD, "in_progress")).toBe("In progress");
+    expect(statusFilterLabel(BOARD, "done")).toBe("Done (closed)");
+  });
+
+  it("falls back to the value, never to “Every status”", () => {
+    // A filter we cannot name is still a filter. Rendering an unknown value as
+    // the no-filter label would claim the ledger is unfiltered when it is not.
+    expect(statusFilterLabel(PROMISES, "retired")).toBe("retired");
+    expect(statusFilterLabel(null, "open")).toBe("open");
+  });
+});
+
+describe("why a ledger is showing nothing", () => {
+  it("says nothing at all when nothing is filtering", () => {
+    // The one case where "Nothing recorded here yet." is a true sentence.
+    expect(filteredEmptyNotice(PROMISES, "", EVERY_STATUS)).toBeNull();
+    expect(filteredEmptyNotice(PROMISES, "   ", EVERY_STATUS)).toBeNull();
+  });
+
+  it("names the search that is hiding the rows", () => {
+    expect(filteredEmptyNotice(PROMISES, "zzzznotathing", EVERY_STATUS)).toBe(
+      "No rows match “zzzznotathing”.",
+    );
+    // Trimmed, so the quoted term is what the operator reads in the box.
+    expect(filteredEmptyNotice(PROMISES, "  sso  ", EVERY_STATUS)).toBe(
+      "No rows match “sso”.",
+    );
+  });
+
+  it("names the status that is hiding the rows, in the operator's words", () => {
+    expect(filteredEmptyNotice(PROMISES, "", "kept")).toBe(
+      "No rows with status kept (closed).",
+    );
+    expect(filteredEmptyNotice(BOARD, "", "in_progress")).toBe(
+      "No rows with status In progress.",
+    );
+  });
+
+  it("names both when both are on", () => {
+    expect(filteredEmptyNotice(PROMISES, "sso", "kept")).toBe(
+      "No rows match “sso” with status kept (closed).",
+    );
+  });
+});


### PR DESCRIPTION
Closes #1217.

## What was wrong

Three readings in one ledger toolbar, all of them the wire's word rather than the operator's.

1. **A filtered-to-nothing ledger reported itself empty.** Typing `zzzznotathing` into "Search every field" on `Customer promises` (14 rows) produced **"Nothing recorded here yet."** while the nav two inches away still read **"9 open · 5 closed"** — and nothing on screen said a filter was on.
2. **The status filter's collapsed trigger read `all`** while its own open list read "Every status" — issue #813's leak on a second `Select`.
3. **On the task board it read `in_progress`**, beside columns headed "In progress". `LedgerStatus.label` is documented as "what let the console delete its own copy of the board's label table"; this control never read it.

## What changed

**`frontend/src/api/ledgers.ts`** — two pure helpers beside `destinationLabel`'s equivalents:

- `statusFilterLabel(ledger, value)` — maps the `EVERY_STATUS` sentinel to "Every status", prefers a status's declared `label` over its wire `name`, appends `(closed)`, and falls back to the value itself for anything unrecognised. Deliberately *not* to "Every status": a filter we cannot name is still a filter, and labelling it as the no-filter case would claim the opposite.
- `filteredEmptyNotice(ledger, query, statusFilter)` — the branch that was the whole bug, returning `null` when nothing is filtering (the one case where "Nothing recorded here yet." is true) and otherwise naming what is hiding the rows.

Both are pure so the decision is assertable without a render — the reasoning `workflow-saved-toast.ts` uses.

**`frontend/src/views/LedgersView.tsx`** — the empty state branches on the notice and, when filtered, offers a **Clear filters** button that resets both the query and the status. The `Select` gets explicit `<SelectValue>` text and renders its items through the same labeller, so the trigger and the list can no longer disagree. The `"all"` literal is replaced by the exported `EVERY_STATUS` at all three sites that had a copy of it.

**`frontend/test/unit/ledger-filter-honesty.test.ts`** — 8 cases covering the sentinel, a closing status, the board's `label`, the unknown-value fallback, and each of the four notice shapes.

## Verified

- `npm test` — 137 files, 1328 tests, green
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `scripts/ci/assert-design-tokens.sh` — clean
- Driven in a browser against a seeded 14-row ledger:
  - default trigger now reads `Every status`
  - searching for a term that matches nothing renders `No rows match “zzzznotathing”.` with a Clear filters button, and the old plain empty state is absent (`0` matches)
  - Clear filters restores all 14 rows and empties the search box
  - choosing `kept` gives a trigger reading `kept (closed)`
  - the `tasks` ledger's filter now offers `To-do / Planning / In progress / Paused / In review / Done (closed)`
