### PR TITLE
fix(settings): stop the always-ask field recommending kinds that gate nothing

### DIFF
--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -9,6 +9,7 @@ import {
   resetPolicy,
   setPolicy,
 } from "@/api/policy";
+import { listWorkflowToolSlugs } from "@/api/workflows";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +22,50 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+
+/**
+ * Tools worth naming as an *example* of something to always ask about, most
+ * consequential first (issue #1226).
+ *
+ * A placeholder is a suggestion, so it should suggest a gate an operator might
+ * actually want. Taking the host's list in its own order put
+ * `read_workspace_state` — a read — in the worked example, which is a valid
+ * entry and a pointless one. This orders the candidates; the datalist under the
+ * field still carries the deployment's full set in the host's order, because
+ * that is a lookup rather than a recommendation.
+ *
+ * Not a validator and not a filter: anything wired here is offered, and a tool
+ * absent from this list simply sorts after the ones on it.
+ */
+const WORTH_GATING = [
+  "publish_artifact",
+  "shell",
+  "http_request",
+  "curl",
+  "git_operations",
+  "apply_patch",
+  "web_fetch",
+];
+
+/**
+ * Up to three worked examples, drawn from what this deployment wired.
+ *
+ * Falls back to real tool names when the host served nothing — a host predating
+ * `…/workflows/tool-slugs` still deserves an example that would work, and the
+ * one this field used to give (`payment.send, filing.submit, external.publish`)
+ * is the one issue #684 deleted for gating nothing.
+ */
+export function alwaysAskPlaceholder(wired: string[]): string {
+  if (wired.length === 0) return "shell, http_request, publish_artifact";
+  const rank = (slug: string) => {
+    const at = WORTH_GATING.indexOf(slug);
+    return at === -1 ? WORTH_GATING.length : at;
+  };
+  return [...wired]
+    .sort((a, b) => rank(a) - rank(b) || wired.indexOf(a) - wired.indexOf(b))
+    .slice(0, 3)
+    .join(", ");
+}
 
 interface Props {
   client: OpenCompanyClient;
@@ -62,6 +107,22 @@ export function PolicySettings({ client, company }: Props) {
   // half-typed effect kind never reaches the gate.
   const [draftAlways, setDraftAlways] = useState("");
   const [dirty, setDirty] = useState(false);
+  /**
+   * The tool names this deployment can actually gate (issue #1226).
+   *
+   * An `always_approve` entry IS a tool name on the harness path — see
+   * `src/policy/always_approve.rs`, which explains that the two were never
+   * separate namespaces. So the honest set of worked examples is the set of
+   * tools wired here, and this is the same read the workflow copilot grounds on
+   * (issues #783 / #874) for the same reason: so nothing suggests a tool this
+   * deployment does not have.
+   *
+   * Empty on a host predating the route, which degrades to the plain field the
+   * operator had before — the suggestions are help, never a constraint. The
+   * namespace stays open on purpose (a hosted brain may emit a kind this
+   * repository has never seen), so nothing here validates what is typed.
+   */
+  const [wiredTools, setWiredTools] = useState<string[]>([]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -84,6 +145,25 @@ export function PolicySettings({ client, company }: Props) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Deliberately silent about its own failure, and deliberately not part of
+  // `load`: these are suggestions under a free-text box. A host that cannot
+  // serve them costs the operator a datalist, not the setting, and a second
+  // error banner would report the policy card as broken when it is merely
+  // plainer — the same reasoning `LedgersView.refreshTasks` gives.
+  useEffect(() => {
+    let live = true;
+    void listWorkflowToolSlugs(client, company)
+      .then((r) => {
+        if (live) setWiredTools(r.slugs);
+      })
+      .catch(() => {
+        if (live) setWiredTools([]);
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   /**
    * Applies a server response.
@@ -233,20 +313,52 @@ export function PolicySettings({ client, company }: Props) {
 
             <div className="space-y-2">
               <Label htmlFor="always-approve">Always ask first</Label>
+              {/* Issue #1226: what an entry IS, said here rather than left to
+                  the placeholder. `payment.send, filing.submit,
+                  external.publish` used to be the only worked example this
+                  field offered — the exact three strings issue #684 deleted
+                  from the shipped default because, on the harness path, none of
+                  them names a tool and so none of them gated anything. An
+                  operator following the suggestion got a fence that was not
+                  there, confirmed by a "list updated" toast.
+
+                  A tool name and an effect kind were never two namespaces (see
+                  `src/policy/always_approve.rs`), so naming the tool case first
+                  is naming the case that applies to every company running the
+                  openhuman toolbelt. The prefix rule is stated because it is
+                  what `always_approve::matches` implements and nothing in the
+                  console said it. */}
               <p className="text-xs text-muted-foreground">
-                Effect kinds that park for approval whatever the tier — these win
-                even on Full. Comma-separated.
+                What the teammates always park for approval, whatever the tier —
+                these win even on Full. Comma-separated. An entry is a tool name
+                (<code>shell</code>, <code>http_request</code>), or a dotted
+                effect kind a hosted brain emits; a leading segment matches the
+                rest, so <code>invoice</code> covers{" "}
+                <code>invoice.send</code>.
               </p>
               <Input
                 id="always-approve"
                 value={draftAlways}
                 disabled={saving}
-                placeholder="payment.send, filing.submit, external.publish"
+                list={wiredTools.length > 0 ? "always-approve-tools" : undefined}
+                placeholder={alwaysAskPlaceholder(wiredTools)}
                 onChange={(event) => {
                   setDraftAlways(event.target.value);
                   setDirty(true);
                 }}
               />
+              {/* Suggestions, never a constraint: the effect namespace is open
+                  on purpose, because a hosted brain may emit a kind this
+                  repository has never seen, and a `datalist` leaves free text
+                  free. Rendered only when the host served the set, so a host
+                  predating the route degrades to the plain box. */}
+              {wiredTools.length > 0 && (
+                <datalist id="always-approve-tools">
+                  {wiredTools.map((slug) => (
+                    <option key={slug} value={slug} />
+                  ))}
+                </datalist>
+              )}
               {dirty && (
                 <Button
                   size="sm"

--- a/frontend/test/unit/policy-always-ask-vocabulary.test.ts
+++ b/frontend/test/unit/policy-always-ask-vocabulary.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { PolicyStatus } from "@/api/policy";
+import { alwaysAskPlaceholder } from "@/components/policy-settings";
+
+/**
+ * Issue #1226: the always-ask field's worked example.
+ *
+ * It used to be `payment.send, filing.submit, external.publish` — the three
+ * strings issue #684 deleted from the shipped default *because they gate
+ * nothing*: on the harness path an `always_approve` entry is matched against
+ * the tool name, and none of those three names a tool. An operator following
+ * the field's own suggestion got a fence that was not there, and a
+ * "list updated" toast confirming it.
+ *
+ * So the assertions here are about which vocabulary the control puts in front
+ * of an operator: the tools this deployment actually wired, and never the
+ * retired trio. The suggestions must stay *suggestions* — the effect namespace
+ * is deliberately open (`src/policy/always_approve.rs`), so a `datalist` and
+ * not a `select`, and nothing may reject typed text.
+ */
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { PolicySettings } = await import("@/components/policy-settings");
+
+const STATUS: PolicyStatus = {
+  mode: "auto",
+  alwaysApprove: [],
+  manifestMode: "auto",
+  manifestAlwaysApprove: [],
+  overridden: false,
+  takesEffect: "on the next turn",
+  tiers: [
+    { value: "auto", label: "Auto", description: "Works alone, stops before money." },
+    { value: "full", label: "Full", description: "Acts without asking." },
+  ],
+} as unknown as PolicyStatus;
+
+const WIRED = ["shell", "apply_patch", "git_operations", "web_fetch", "http_request"];
+
+/** A client serving the policy and, optionally, the wired tool slugs. */
+function makeClient({ slugs }: { slugs?: string[] | "unavailable" } = {}) {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.includes("/workflows/tool-slugs")) {
+        if (slugs === "unavailable") throw new Error("this host predates the route");
+        return { slugs: slugs ?? WIRED, unwired: [] };
+      }
+      if (path.endsWith("/policy")) return STATUS;
+      return null;
+    },
+    put: async () => STATUS,
+    del: async () => STATUS,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(PolicySettings, { client, company: "acme" }));
+  });
+}
+
+const field = () => container.querySelector<HTMLInputElement>("#always-approve");
+const options = () =>
+  Array.from(container.querySelectorAll<HTMLOptionElement>("datalist option")).map(
+    (o) => o.value,
+  );
+
+describe("what the always-ask field suggests", () => {
+  it("never offers the three kinds #684 removed for gating nothing", async () => {
+    await mount(makeClient());
+    const text = container.textContent ?? "";
+    const shown = `${field()?.placeholder ?? ""} ${options().join(" ")} ${text}`;
+    for (const retired of ["payment.send", "filing.submit", "external.publish"]) {
+      expect(shown, `still recommends ${retired}`).not.toContain(retired);
+    }
+  });
+
+  it("grounds its example on the tools this deployment wired", async () => {
+    await mount(makeClient());
+    expect(options()).toEqual(WIRED);
+    // The placeholder is drawn from the same set, so the one example an
+    // operator reads without opening anything is also a working entry.
+    const placeholder = field()?.placeholder ?? "";
+    for (const suggested of placeholder.split(", ")) {
+      expect(WIRED).toContain(suggested);
+    }
+  });
+
+  it("picks examples worth gating, not merely the first three wired", () => {
+    // The host's own order put `read_workspace_state` — a read — into the
+    // worked example. A valid entry and a pointless suggestion.
+    expect(alwaysAskPlaceholder(["read_workspace_state", "shell", "http_request"])).toBe(
+      "shell, http_request, read_workspace_state",
+    );
+    // A deployment wiring nothing consequential still gets its own tools back,
+    // in the host's order, rather than a name it does not have.
+    expect(alwaysAskPlaceholder(["image_info", "csv_export"])).toBe(
+      "image_info, csv_export",
+    );
+    expect(alwaysAskPlaceholder([])).toBe("shell, http_request, publish_artifact");
+  });
+
+  it("leaves the box free text — the effect namespace is open on purpose", async () => {
+    await mount(makeClient());
+    const input = field()!;
+    // A `datalist`, never a `select`: a hosted brain may emit a kind this
+    // repository has never seen, and the host deliberately does not validate.
+    expect(input.tagName).toBe("INPUT");
+    expect(input.getAttribute("list")).toBe("always-approve-tools");
+    await act(async () => {
+      input.value = "some.custom.kind";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(field()?.value).toBe("some.custom.kind");
+  });
+
+  it("degrades to a plain box when the host cannot serve the tool set", async () => {
+    await mount(makeClient({ slugs: "unavailable" }));
+    expect(options()).toEqual([]);
+    expect(field()?.getAttribute("list")).toBeNull();
+    // Still a working example rather than a retired one.
+    expect(field()?.placeholder).toBe("shell, http_request, publish_artifact");
+    // And a failed suggestions read must not report the policy card as broken.
+    expect(toasts.error).not.toHaveBeenCalled();
+  });
+
+  it("says what an entry is, including the prefix rule the matcher implements", async () => {
+    await mount(makeClient());
+    const text = container.textContent ?? "";
+    expect(text).toContain("tool name");
+    // The prefix rule, illustrated with a kind that is not one of the retired
+    // three — explaining the rule must not double as recommending them.
+    expect(text).toContain("invoice.send");
+  });
+});


### PR DESCRIPTION
Closes #1226.

## What was wrong

Settings → General → **Approvals → "Always ask first"** is where an operator goes to say *"never do X without asking me"*. Its placeholder — the only worked example the field offered — was:

```
payment.send, filing.submit, external.publish
```

Those are the exact three strings issue #684 **deleted from the shipped default because they gate nothing**. From `src/company/types.rs:78`:

> This shipped as `["payment.send", "filing.submit", "external.publish"]`, and the promise it read as was not one the runtime kept… On the **harness** path — the one every company using the openhuman toolbelt runs — the list is matched against the tool name, and none of those three names a tool, so nothing was gated at all.
> * **Two of the three name capabilities this product does not have.**
> * **The third must not be defaulted.** The real name behind `external.publish` is `publish_artifact`…

The console says the same thing about the third itself (`frontend/src/lib/language.ts:229`): *"`publish_artifact` does NOT park as `external.publish` (a native workflow-gate class the tool never builds)"*.

So #684 removed the inert list from the default and left the console inviting an operator to type it back in — with a `200` and an "Always-ask list updated" toast confirming a fence that is not there.

The host is right to accept whatever is typed: `src/policy/always_approve.rs` argues that entries are deliberately **not** validated, because a hosted brain may emit a kind this repository has never seen and "a registry-based validator would reject working custom fences". The openness is correct. Spending the one worked example on the vocabulary that does not apply is not.

## What changed

`frontend/src/components/policy-settings.tsx`:

- **The field is grounded on the tools this deployment wired.** It reads `…/workflows/tool-slugs` — the same read the workflow copilot uses (issues #783 / #874) for the same reason, so nothing suggests a tool this deployment does not have — and offers the slugs through a `datalist`. A `datalist`, not a `select`: the namespace stays open and typed text stays free.
- **The placeholder is drawn from that set**, ordered by `alwaysAskPlaceholder` so the example is a gate someone might actually want. Taking the host's order verbatim put `read_workspace_state` — a read — into the worked example; on this company it now reads `shell, http_request, curl`.
- **The helper text says what an entry is**: a tool name, or a dotted effect kind a hosted brain emits — and that a leading segment matches the rest (`invoice` covers `invoice.send`), which is what `always_approve::matches` implements and which nothing in the console previously stated. The prefix rule is illustrated with a kind that is *not* one of the retired three, since explaining the rule must not double as recommending them.
- **Degrades cleanly.** A host predating the route leaves a plain box with the static fallback `shell, http_request, publish_artifact` — real tool names — and the failed read is deliberately silent, because these are suggestions under a free-text field and a second error banner would report the policy card as broken when it is merely plainer.

`frontend/test/unit/policy-always-ask-vocabulary.test.ts` — 6 cases: none of the retired three appears anywhere in the rendered card; the suggestions equal the wired set; the box stays free text and accepts `some.custom.kind`; the no-host degrade keeps a working example and raises no error toast; the ordering prefers consequential tools; and the helper states the prefix rule.

## Verified

- `npm test` — 144 files, 1379 tests, green
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `scripts/ci/assert-design-tokens.sh` — clean
- Driven in a browser against the seeded company: placeholder `shell, http_request, curl`, `list="always-approve-tools"`, datalist carrying all 9 wired slugs, helper text as above.
