### PR TITLE
fix(approvals): an unread queue is not an empty one

### DIFF
--- a/frontend/src/hooks/use-company.ts
+++ b/frontend/src/hooks/use-company.ts
@@ -6,9 +6,28 @@ import { startVisiblePolling } from "@/lib/visible-poll";
 
 const POLL_MS = 5000;
 
+/**
+ * How far the console has got with this company's approval queue (issue #1229).
+ *
+ * The distinction `approvals: []` cannot make on its own: an empty array is
+ * both "the host answered, with nothing parked" and "the host has never
+ * answered". The Approvals page renders the first as **"All clear — nothing is
+ * waiting on you"**, which is a confident instruction to stop looking, and it
+ * was rendering it for the second as well — beside a sidebar badge, carried
+ * over from the bootstrap status read, that said fourteen were waiting.
+ *
+ * `"error"` is only ever reached from `"loading"`. Once a queue has been read,
+ * a later failure keeps the last good view and stays `"ready"`: the rows on
+ * screen are real, only possibly stale, and blanking them for a dropped poll
+ * would be a second lie in the other direction.
+ */
+export type QueueLoad = "loading" | "ready" | "error";
+
 export interface CompanyFeed {
   status: CompanyStatus;
   approvals: ApprovalSummary[];
+  /** Whether {@link CompanyFeed.approvals} has ever been read. See {@link QueueLoad}. */
+  queue: QueueLoad;
   /** Wall-clock at the last successful refresh, for relative timestamps. */
   now: number;
   refresh: () => Promise<void>;
@@ -64,6 +83,7 @@ export function useCompany(
 ): CompanyFeed {
   const [status, setStatus] = useState<CompanyStatus>(initialStatus);
   const [approvals, setApprovals] = useState<ApprovalSummary[]>([]);
+  const [queue, setQueue] = useState<QueueLoad>("loading");
   const [now, setNow] = useState(() => Date.now());
   const mounted = useRef(true);
 
@@ -79,18 +99,41 @@ export function useCompany(
   useEffect(() => {
     setStatus(initialStatus);
     setApprovals([]);
+    // Back to "not read yet", for the same reason the queue is emptied: this
+    // console has not seen the new company's parked set, and the *previous*
+    // company's verdict must not vouch for it (issue #1229).
+    setQueue("loading");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [company]);
 
   const refresh = useCallback(async () => {
-    try {
-      const [s, a] = await Promise.all([client.status(company), client.approvals(company)]);
-      if (!mounted.current) return;
-      setStatus(withApprovalCount(s, a));
-      setApprovals(a);
+    // Settled rather than all-or-nothing (issue #1229). `Promise.all` rejects
+    // on the first failure and threw away the other response with it, so one
+    // bad status discarded a queue that had arrived intact — and the badge and
+    // the page were then reading two different moments with nothing saying so.
+    const [s, a] = await Promise.allSettled([
+      client.status(company),
+      client.approvals(company),
+    ]);
+    if (!mounted.current) return;
+
+    if (a.status === "fulfilled") {
+      setApprovals(a.value);
+      setQueue("ready");
+      // Reconciled only against a queue that actually arrived. A status paired
+      // with a failed read is a count with nothing to check it against.
+      if (s.status === "fulfilled") setStatus(withApprovalCount(s.value, a.value));
       setNow(Date.now());
-    } catch {
-      /* transient; keep the last good view */
+      return;
+    }
+
+    // The queue did not answer. A view that already has one keeps it — stale
+    // rows are still real rows — but a console that has never read one must
+    // say so rather than let an untouched `[]` render as "all clear".
+    setQueue((current) => (current === "ready" ? "ready" : "error"));
+    if (s.status === "fulfilled") {
+      setStatus(s.value);
+      setNow(Date.now());
     }
   }, [client, company]);
 
@@ -111,5 +154,5 @@ export function useCompany(
     };
   }, [refresh]);
 
-  return { status, approvals, now, refresh };
+  return { status, approvals, queue, now, refresh };
 }

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Check, Loader2, ShieldCheck, X } from "lucide-react";
+import { Check, Loader2, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -114,7 +114,7 @@ export function ApprovalsView({
   // an approve and a decline are different promises to the operator ("the agent
   // is doing it" vs "recorded"), and the card says which one it is waiting on.
   const [inFlight, setInFlight] = useState<ReadonlyMap<string, Verdict>>(() => new Map());
-  const { approvals, now } = feed;
+  const { approvals, now, queue } = feed;
   /**
    * The card the queue is narrowed to, or `null` for the whole queue (#883).
    *
@@ -278,7 +278,19 @@ export function ApprovalsView({
             </a>
           </div>
         )}
-        {visible.length === 0 ? (
+        {/* Issue #1229: "nothing parked" and "we could not read what is parked"
+            are different facts, and only one of them is an instruction to stop
+            looking. The queue's own load state decides which is on screen —
+            `approvals` being empty cannot, because it is empty in both cases.
+            A queue that has been read once keeps its rows through a later
+            failure, so this branch is only ever the cold path. */}
+        {queue !== "ready" && approvals.length === 0 ? (
+          queue === "loading" ? (
+            <LoadingApprovals />
+          ) : (
+            <UnreadableApprovals onRetry={() => void feed.refresh()} />
+          )
+        ) : visible.length === 0 ? (
           focusTaskId !== null ? (
             <ClearedForTask />
           ) : (
@@ -742,6 +754,61 @@ function ClearedForTask() {
           approvals of their own — use <span className="font-medium">Show all</span> to see them.
         </p>
       </div>
+    </div>
+  );
+}
+
+/**
+ * The queue is on the wire (issue #1229).
+ *
+ * A skeleton rather than the word "Loading": this page is a list, and the shape
+ * of the list is the honest placeholder for it. Deliberately *not* the "All
+ * clear" panel — that panel makes a claim, and nothing is known yet.
+ */
+function LoadingApprovals() {
+  return (
+    <div className="space-y-3" aria-busy="true" aria-label="Loading approvals">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="h-28 animate-pulse rounded-xl border bg-muted/40" />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The queue could not be read, and never has been (issue #1229).
+ *
+ * The page this replaces said "All clear — nothing is waiting on you" over a
+ * read that failed, beside a sidebar badge that said fourteen things were.
+ * On the one surface whose job is to catch what needs a person, a confident
+ * false negative is the most expensive thing it can say: every parked request
+ * has a deadline after which it is declined on its own.
+ *
+ * So this says what is actually known — nothing — and offers the only useful
+ * next move. `role="alert"` because it is a correction to what the operator
+ * came here to find out.
+ */
+function UnreadableApprovals({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="mt-16 flex flex-col items-center gap-3 text-center"
+      data-testid="approvals-unreadable"
+    >
+      <div className="flex size-12 items-center justify-center rounded-2xl bg-destructive/10 text-destructive">
+        <ShieldAlert className="size-6" />
+      </div>
+      <div className="space-y-1">
+        <p className="font-medium">Couldn&apos;t read what&apos;s waiting</p>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          The company host didn&apos;t answer. This is not the same as nothing
+          being parked — anything waiting is still waiting, and still on its
+          deadline.
+        </p>
+      </div>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        Try again
+      </Button>
     </div>
   );
 }

--- a/frontend/test/unit/approvals-queue-load.test.ts
+++ b/frontend/test/unit/approvals-queue-load.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ApprovalSummary, CompanyStatus } from "@/api/types";
+import { useCompany, type CompanyFeed } from "@/hooks/use-company";
+
+/**
+ * "Nothing is parked" and "we could not read what is parked" (issue #1229).
+ *
+ * `approvals: []` is both of those, and the Approvals page rendered the first
+ * for both: **"All clear — nothing is waiting on you"** over a read that never
+ * answered, beside a sidebar badge — carried over from the bootstrap status
+ * read — saying fourteen things were waiting. On the one surface whose job is
+ * to catch what needs a person, that is a confident instruction to stop
+ * looking, and every parked request has a deadline after which it is declined
+ * on its own.
+ *
+ * `queue` is the distinction the array cannot make. These tests are about when
+ * it says each of its three words.
+ */
+
+const STATUS: CompanyStatus = {
+  id: "acme",
+  name: "Acme",
+  lifecycle: "running",
+  pending_approvals: 0,
+};
+
+function approvals(n: number): ApprovalSummary[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `a${i}`,
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: 1_700_000_000_000 + i,
+    agent: "seo",
+    thread: "desk-marketing",
+  }));
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** Renders `hook` and hands back the latest value it returned. */
+function probe<T>(hook: () => T): () => T {
+  let latest: T | undefined;
+  const Probe = (): ReactElement | null => {
+    latest = hook();
+    return null;
+  };
+  act(() => root.render(createElement(Probe)));
+  return () => {
+    if (latest === undefined) throw new Error("the hook never rendered");
+    return latest;
+  };
+}
+
+/**
+ * Let the mount fetch settle before asserting.
+ *
+ * `Promise.allSettled` resolves a few microtasks later than the `Promise.all`
+ * it replaced, and `useCompany` also arms a visibility-gated poll, so a single
+ * flush is not enough and an unbounded wait would hang on a hook that never
+ * settles. Flush until the hook says it has left `loading`, with a ceiling.
+ */
+async function settle(feed: () => CompanyFeed) {
+  for (let i = 0; i < 20 && feed().queue === "loading"; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+/**
+ * A client whose two reads can each be made to fail independently — which is
+ * the point: they are two requests, and the bug was one of them taking the
+ * other down with it.
+ */
+function client(opts: {
+  status?: () => Promise<CompanyStatus>;
+  approvals?: () => Promise<ApprovalSummary[]>;
+}): OpenCompanyClient {
+  return {
+    status: opts.status ?? (async () => STATUS),
+    approvals: opts.approvals ?? (async () => []),
+  } as unknown as OpenCompanyClient;
+}
+
+const refuse = () => Promise.reject(new Error("connection refused"));
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useCompany — an unread queue is not an empty one (#1229)", () => {
+  it("starts as loading, before either read has answered", () => {
+    // Hoisted, not built inside the render: `useCompany` keys its poll on the
+    // client's identity, so a fresh object per render re-arms the effect
+    // forever. Same for the status object it is seeded with.
+    const c = client({});
+    const seed = { ...STATUS, pending_approvals: 14 };
+    const feed = probe<CompanyFeed>(() => useCompany(c, "acme", seed));
+
+    expect(feed().queue).toBe("loading");
+    // And the array it would have rendered "All clear" from.
+    expect(feed().approvals).toEqual([]);
+  });
+
+  it("says the queue could not be read when the first read fails", async () => {
+    const c = client({
+      approvals: refuse,
+      status: async () => ({ ...STATUS, pending_approvals: 14 }),
+    });
+    const seed = { ...STATUS, pending_approvals: 14 };
+    const feed = probe<CompanyFeed>(() => useCompany(c, "acme", seed));
+    await settle(feed);
+
+    expect(feed().queue).toBe("error");
+    // The reported symptom: this empty array was rendering as "All clear"
+    // while the badge beside it read 14.
+    expect(feed().approvals).toEqual([]);
+    expect(feed().status.pending_approvals).toBe(14);
+  });
+
+  it("says ready when the host answers with nothing parked", async () => {
+    const c = client({});
+    const feed = probe<CompanyFeed>(() => useCompany(c, "acme", STATUS));
+    await settle(feed);
+
+    // The genuinely-clear case, which must keep reading as clear.
+    expect(feed().queue).toBe("ready");
+    expect(feed().approvals).toEqual([]);
+  });
+
+  it("keeps the rows and stays ready when a later poll fails", async () => {
+    let fail = false;
+    const c = client({ approvals: () => (fail ? refuse() : Promise.resolve(approvals(3))) });
+    const feed = probe<CompanyFeed>(() => useCompany(c, "acme", STATUS));
+    await settle(feed);
+    expect(feed().queue).toBe("ready");
+    expect(feed().approvals).toHaveLength(3);
+
+    // A dropped poll must not blank rows that are real, only possibly stale.
+    fail = true;
+    await act(async () => {
+      await feed().refresh();
+    });
+
+    expect(feed().queue).toBe("ready");
+    expect(feed().approvals).toHaveLength(3);
+  });
+
+  it("keeps a queue that arrived even though the status beside it failed", async () => {
+    const c = client({ status: refuse, approvals: async () => approvals(2) });
+    const feed = probe<CompanyFeed>(() => useCompany(c, "acme", STATUS));
+    await settle(feed);
+
+    // `Promise.all` rejected on the status and discarded this queue with it,
+    // which is how the badge and the page came to be reading two moments.
+    expect(feed().queue).toBe("ready");
+    expect(feed().approvals).toHaveLength(2);
+  });
+
+  it("reconciles the badge to the queue only when both arrived", async () => {
+    const c = client({
+      status: async () => ({ ...STATUS, pending_approvals: 18 }),
+      approvals: async () => approvals(14),
+    });
+    const feed = probe<CompanyFeed>(() => useCompany(c, "acme", STATUS));
+    await settle(feed);
+
+    expect(feed().status.pending_approvals).toBe(14);
+  });
+});


### PR DESCRIPTION
## Summary

With the approvals read failing before it had ever succeeded, the Approvals
page said:

> **All clear** — Nothing is waiting on you.

…while the sidebar two inches to the left read **Approvals 14**.

`approvals: []` is both "the host answered, with nothing parked" and "the host
has never answered", and only the first is an instruction to stop looking.
Every parked request carries a 24-hour deadline after which it is declined on
its own — the page's own subtitle says so — so a false "all clear" on this
surface costs the whole queue.

## Measured

`#/approvals` with `GET {scope}/approvals` failing at the transport and every
other route healthy:

```
                before                                   after
page body       "All clear | Nothing is waiting on you"  "Couldn't read what's waiting | …
                                                          anything waiting is still waiting,
                                                          and still on its deadline | Try again"
sidebar         "Approvals14"                            "Approvals14"
[role=alert]    []                                       [the band above]
```

And the two cases it must not disturb, both re-checked in the browser:

```
host answers with []       → "All clear …"          (unchanged)
host answers with 14 rows  → "14 things need your approval", 14 cards
Try again, host recovered  → "14 things need your approval", 14 cards
```

## What changed

**`frontend/src/hooks/use-company.ts`**

- `CompanyFeed` gains `queue: "loading" | "ready" | "error"` — the distinction
  the array cannot make. `"error"` is only reachable from `"loading"`: once a
  queue has been read, a later failure keeps the last good view and stays
  `"ready"`, because those rows are real and only possibly stale. Blanking them
  for a dropped poll would be a second lie in the other direction.
- A company switch resets it to `"loading"`, for the same reason the switch
  already empties the queue: the previous company's verdict must not vouch for
  the new one.
- The refresh is `Promise.allSettled` rather than `Promise.all`. All-or-nothing
  rejected on the first failure and discarded the other response with it, so a
  bad status threw away a queue that had arrived intact — which is *how* the
  badge and the page came to be reading two different moments. Now each stands
  on its own, and `withApprovalCount` reconciles only when both arrived (a
  status paired with a failed read is a count with nothing to check it
  against).

**`frontend/src/views/ApprovalsView.tsx`**

- `LoadingApprovals` — a skeleton while the queue is on the wire. Deliberately
  not the "All clear" panel: that panel makes a claim and nothing is known yet.
- `UnreadableApprovals` — a `role="alert"` band saying what is actually known,
  with a Try again wired to `feed.refresh()`.
- The empty branch is now `queue !== "ready" && approvals.length === 0`, so it
  is only ever the cold path; a read queue keeps rendering exactly as before.

The file already knew the distinction mattered — the company-switch comment
spells it out ("the queue is empty because this console has not read the new
company's yet, which is an absence, not a count of zero"). That reasoning was
applied to the badge and not to the page.

## Tests

`frontend/test/unit/approvals-queue-load.test.ts`, six cases: the initial
`loading`; a failed first read reaching `error` with the badge still at 14 (the
reported symptom); a host answering with nothing staying `ready`; a later poll
failing without blanking rows; a queue surviving a failed status beside it; and
the #932 reconciliation still holding. All six fail on `main`.

## Commands run

```
npx vitest run test/unit/approvals-queue-load.test.ts        # 6 passed
npx vitest run test/unit/approvals-count-agreement.test.ts \
              test/unit/billing-company-switch.test.ts       # 8 passed
npm run typecheck
npm run typecheck:unit
npm run build
scripts/ci/assert-design-tokens.sh
```

Re-verified in a real browser against a live host with 14 approvals parked.

## Related

#1219 — the Overview does the same thing with six best-effort reads. Same
class, different surface, filed separately.

Closes #1229
