### PR TITLE
fix(workflows): give the canvas minimap something to draw

### DIFF
--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -19,6 +19,29 @@ import {
 const COL_GAP = 300;
 const ROW_GAP = 150;
 
+/**
+ * A nominal node size, for consumers that read the node object we hand React
+ * Flow rather than the size React Flow measured (issue #1230).
+ *
+ * The minimap is the one that matters. `MiniMapNodes` reads
+ * `node.internals.userNode` — the object THIS function returns — and skips any
+ * node for which `measured ?? width ?? initialWidth` is undefined. This layout
+ * is a `useMemo` that rebuilds every node on every run-state repaint, so React
+ * Flow's measurement never survives onto that object and the minimap painted
+ * **nothing**: an empty 200x150 box in every workflow, in both themes, while
+ * `fitView` worked fine because it reads `node.internals` instead.
+ *
+ * `initialWidth`/`initialHeight` rather than `width`/`height` on purpose: they
+ * are a hint, and `measured` still wins for layout, hit-testing and the fit. So
+ * nothing on the canvas moves — only the minimap gains something to draw.
+ *
+ * Measured values on a real graph run 180-204 x 56-71 (the node grows with a
+ * summary line); these are the middle of that, which is all a 200px-wide
+ * overview needs.
+ */
+const NODE_W = 190;
+const NODE_H = 64;
+
 /** The result of folding the SSE frame window down to one run's canvas state. */
 export interface LiveRun {
   runId: string;
@@ -427,6 +450,11 @@ export function layout(
     return {
       id: n.id,
       type: "oc",
+      // See NODE_W/NODE_H: a size hint the minimap can read off the node we
+      // hand over, since this array is rebuilt on every repaint and React
+      // Flow's own measurement does not survive that.
+      initialWidth: NODE_W,
+      initialHeight: NODE_H,
       position: { x: layer * COL_GAP, y: row * ROW_GAP },
       data: {
         kind: n.kind,

--- a/frontend/test/unit/workflow-canvas-node-size.test.ts
+++ b/frontend/test/unit/workflow-canvas-node-size.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowGraph } from "@/api/workflows";
+import { layout } from "@/views/workflows/graph";
+
+/**
+ * Issue #1230: the laid-out nodes carry their own size.
+ *
+ * React Flow's minimap reads `node.internals.userNode` — the object `layout`
+ * returns — and skips any node whose `measured ?? width ?? initialWidth` is
+ * `undefined` (`nodeHasDimensions` in `@xyflow/system`). This layout is a
+ * `useMemo` that rebuilds every node on every run-state repaint, so React
+ * Flow's own measurement never survives onto that object: the minimap painted a
+ * blank box in every workflow while `fitView` worked fine, because the fit
+ * reads `node.internals` instead.
+ *
+ * A pure assertion on the layout, which is where the omission was — not a
+ * render test of the minimap. The thing that broke is a missing field on a
+ * plain object.
+ */
+
+function graph(nodes: { id: string; kind: string; name: string }[], edges: { from: string; to: string }[] = []): WorkflowGraph {
+  return { id: "w", name: "W", version: "v1", nodes, edges } as unknown as WorkflowGraph;
+}
+
+const CHAIN = graph(
+  [
+    { id: "start", kind: "trigger", name: "On escalation" },
+    { id: "triage", kind: "agent", name: "Triage the report" },
+    { id: "out", kind: "output", name: "Escalation summary" },
+  ],
+  [
+    { from: "start", to: "triage" },
+    { from: "triage", to: "out" },
+  ],
+);
+
+describe("the laid-out canvas nodes", () => {
+  it("carry a size hint, so a consumer reading the node object has dimensions", () => {
+    const { nodes } = layout(CHAIN);
+    expect(nodes).toHaveLength(3);
+    for (const node of nodes) {
+      expect(node.initialWidth, `${node.id} has no width hint`).toBeGreaterThan(0);
+      expect(node.initialHeight, `${node.id} has no height hint`).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the hint on every repaint, which is when the array is rebuilt", () => {
+    // The memo re-runs whenever a node's run state changes; that is exactly the
+    // moment React Flow's measurement was being discarded.
+    const painted = layout(CHAIN, { triage: "running" }, { triage: 42 }, new Set(["out"]));
+    for (const node of painted.nodes) {
+      expect(node.initialWidth).toBeGreaterThan(0);
+      expect(node.initialHeight).toBeGreaterThan(0);
+    }
+  });
+
+  it("leaves the real geometry to React Flow", () => {
+    // A hint, not an override: `measured` wins for layout and hit-testing, so
+    // setting `width`/`height` here instead would freeze every node at one size
+    // regardless of whether it carries a summary line.
+    const { nodes } = layout(CHAIN);
+    for (const node of nodes) {
+      expect(node.width).toBeUndefined();
+      expect(node.height).toBeUndefined();
+    }
+  });
+
+  it("still lays the chain out left to right", () => {
+    // The hint must not disturb positioning — the same columns as before.
+    const { nodes } = layout(CHAIN);
+    const x = Object.fromEntries(nodes.map((n) => [n.id, n.position.x]));
+    expect(x.start).toBeLessThan(x.triage);
+    expect(x.triage).toBeLessThan(x.out);
+  });
+});


### PR DESCRIPTION
Closes #1230.

## What was wrong

Every workflow canvas carries a `pannable zoomable` 200×150 minimap. It was **empty in every graph, in both themes** — no node shapes at all. The whole SVG was one path:

```html
<svg width="200" height="150" viewBox="-141.83 -488.18 1374.66 1047.36">
  <path class="react-flow__minimap-mask" .../>   <!-- and nothing else -->
</svg>
```

Note the `viewBox` **is** the node bounding box — the minimap knew where the four nodes were and painted none of them.

React Flow's `MiniMapNodes` reads the app's own node object, not the measured internals (`@xyflow/react@12.11.2`):

```js
const userNode = node.internals.userNode;
const { width, height } = getNodeDimensions(userNode);
if (!node || node.hidden || !nodeHasDimensions(node)) return null;
```

```js
// @xyflow/system
function nodeHasDimensions(node) {
  return ((node.measured?.width ?? node.width ?? node.initialWidth) !== undefined && ...);
}
```

`WorkflowsView.tsx:1925` rebuilds the node array from scratch through `layout()` on every run-state repaint, so React Flow's measurement never survives onto the object the minimap reads — all three fields were `undefined`, and every minimap node returned `null`. `fitView` kept working because it reads `node.internals`, which is exactly why the emptiness was invisible from outside.

## What changed

`frontend/src/views/workflows/graph.ts` — the laid-out nodes now carry `initialWidth` / `initialHeight` (190 × 64), named beside `COL_GAP` / `ROW_GAP`, which already encode the same assumption about node size. Measured values on a real graph run 180–204 × 56–71 (a node grows with its summary line); 190 × 64 is the middle of that, which is all a 200px-wide overview needs.

`initialWidth`/`initialHeight` rather than `width`/`height` deliberately: they are a *hint*, and `measured` still wins for layout, hit-testing and the fit — so nothing on the canvas moves, and a node with a summary line still renders taller than one without. Setting `width`/`height` would have frozen every node at one size.

`frontend/test/unit/workflow-canvas-node-size.test.ts` — 4 cases: every laid-out node has a positive size hint; the hint survives a repaint (the moment the measurement was being discarded); `width`/`height` stay `undefined` so the hint cannot override the real geometry; and the chain still lays out left to right.

## Verified

- `npm test` — 144 files, 1377 tests, green
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `scripts/ci/assert-design-tokens.sh` — clean
- Driven in a browser on `#/workflows/customer-escalation`, before/after:

```
before: querySelectorAll(".react-flow__minimap-node").length === 0
after:  4 rects — x=0/300/600/900, 190x64, fill rgb(228,228,228) light / rgb(43,43,43) dark
```

The canvas itself is byte-identical: node boxes still measure 180×56 / 180×71 / 204×71 / 191×56 as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow canvas minimap sizing by providing accurate initial dimensions for workflow nodes.
  * Preserved node sizing and left-to-right layout when workflow run-state updates trigger a repaint.

* **Tests**
  * Added coverage confirming node dimensions remain valid without overriding React Flow’s measured geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->