### PR TITLE
fix(company): the teammate detail header says the name once too

### DIFF
--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -22,7 +22,7 @@ import {
   type AgentFieldKey,
 } from "@/lib/agent";
 import { fetchBoardColumns } from "@/lib/board-columns";
-import { toneFor } from "@/lib/team";
+import { roleSubtitle, toneFor } from "@/lib/team";
 import { workloadByAssignee, type Workload } from "@/lib/team-workload";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/views/chat/Avatar";
@@ -396,6 +396,10 @@ export function AgentDetailView({
 /** Name, role, id, and the two facts that classify an agent. */
 function Identity({ agent }: { agent: AgentDetailDto }) {
   const display = agent.name?.trim() || agent.role;
+  // #1208, on the page a teammate *is*. `display` already falls back to the
+  // role, and a manifest-declared agent has no `name` at all, so the line under
+  // the title was the title again on every teammate in every shipped company.
+  const subtitle = roleSubtitle(display, agent.role);
   const tone = toneFor(agent.id || display);
   return (
     <div className="flex items-start gap-4">
@@ -412,9 +416,11 @@ function Identity({ agent }: { agent: AgentDetailDto }) {
           <h2 className="truncate text-2xl font-semibold tracking-tight" data-testid="agent-name">
             {display}
           </h2>
-          <p className="truncate text-sm text-muted-foreground" data-testid="agent-role">
-            {agent.role}
-          </p>
+          {subtitle && (
+            <p className="truncate text-sm text-muted-foreground" data-testid="agent-role">
+              {subtitle}
+            </p>
+          )}
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="secondary" className="gap-1" data-testid="agent-tier">

--- a/frontend/test/unit/role-subtitle.test.ts
+++ b/frontend/test/unit/role-subtitle.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from "vitest";
 
 import { fromDto, roleSubtitle } from "@/lib/team";
-import type { TeamMemberDto } from "@/api/types";
+import type { AgentDetailDto, TeamMemberDto } from "@/api/types";
 
 describe("roleSubtitle", () => {
   it("keeps a role that says something the name does not", () => {
@@ -51,6 +51,18 @@ describe("roleSubtitle", () => {
 
     expect(member.name).toBe("Backend Engineer");
     expect(roleSubtitle(member.name, member.role)).toBeNull();
+  });
+
+  /**
+   * The agent detail page derives its title the same way, from a different DTO
+   * (`AgentDetailDto`, not the roster row), so the repeat reached that page too.
+   */
+  it("silences the repeat on the agent detail header, which derives its title separately", () => {
+    const agent = { id: "backend_engineer", role: "Backend Engineer" } as AgentDetailDto;
+    const display = agent.name?.trim() || agent.role;
+
+    expect(display).toBe("Backend Engineer");
+    expect(roleSubtitle(display, agent.role)).toBeNull();
   });
 
   /** A teammate the operator named keeps both lines, which is the whole point. */


### PR DESCRIPTION
## Summary

#1215 fixed the name-said-twice repeat on three surfaces — the Company cards,
the org-chart seats, and the chat members pane. Re-driving the console found a
fourth, and it is the one it looks worst on: the page a teammate *is*.

```
before                       after
BE  Backend Engineer         BE  Backend Engineer
    Backend Engineer             Worker · Company blueprint · backend_engineer
    Worker · Company blueprint
```

`Identity` derives its title with the same fallback the roster uses and then
prints the role under it (`frontend/src/views/team/AgentDetailView.tsx:398`,
`:416`):

```ts
const display = agent.name?.trim() || agent.role;
…
<p data-testid="agent-role">{agent.role}</p>
```

A manifest-declared teammate carries no `name` — `GET {scope}/team/{id}` answers
`{"id":"backend_engineer","role":"Backend Engineer",…}` — so the two are one
string for every teammate in every shipped company.

## What changed

The role line now goes through `roleSubtitle`, the helper #1215 added, so this
page follows the same rule as the other three. Nothing else moves.

The derivation happens here off `AgentDetailDto` rather than the roster row, so
the test covers that shape explicitly rather than assuming the roster case
generalises.

## Verified in the browser

Against a live host, with a teammate added to hold the positive case:

```
#/team/backend_engineer   name="Backend Engineer"  role slots rendered: 0
#/team/ada_lovelace       name="Ada Lovelace"      role slots rendered: 1 → "Data Scientist"
```

`agent-detail.spec.ts` keeps its `agent-role` assertion: the teammate it creates
is named "Detail Spec" with role "Spec Runner II", which are different strings,
so the line still renders there.

## Commands run

```
npx vitest run test/unit/role-subtitle.test.ts   # 8 passed
npm run typecheck
npm run build
scripts/ci/assert-design-tokens.sh
```

Refs #1208
