### PR TITLE
workflows: run result and run failure become a right rail

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2676,11 +2676,12 @@ export function WorkflowsView({
           )}
         </div>
       ) : (
-        /* Issue #1107: canvas and left rail side by side. `CanvasShell` owns
-           the detail view's column layout and documents which slot a new panel
-           belongs in — left rail, right overlay, or bottom strip. */
+        /* Issue #1107 (extended by #1205): canvas with a rail on each side.
+           `CanvasShell` owns the detail view's column layout and documents
+           which slot a new panel belongs in — left rail, right rail, or right
+           overlay. */
         <CanvasShell
-          rail={
+          leftRail={
             historyOpen && historySupported ? (
               <RunHistoryPanel
                 runs={historyRows}
@@ -2696,6 +2697,37 @@ export function WorkflowsView({
                 onFixWithCopilot={handleFixWithCopilot}
                 fixingRunSeq={fixingRunSeq}
                 fixReason={fixReason}
+              />
+            ) : null
+          }
+          // Issue #1205: `result` and `runFailure` are mutually exclusive by
+          // construction — `run()` clears both on dispatch, and only one arm
+          // of its try/catch sets one — so this is a ternary, not two
+          // independent siblings. Both are per-workflow chrome, so this is
+          // still gated by being inside the `detailOpen` branch, same as the
+          // left rail above.
+          rightRail={
+            result ? (
+              <RunResultPanel
+                result={result}
+                graph={graph}
+                request={ranWith}
+                onClose={() => setResult(null)}
+                // Issue #1002: the whole queue, narrowed by the panel to this
+                // run. Handed in unfiltered on purpose — the Approvals page
+                // reads the same array and must keep showing every row.
+                approvals={approvals}
+                now={approvalsNow}
+                askerNames={askerNames}
+                deciding={decidingApprovals}
+                decided={decidedApprovals}
+                failed={failedApprovals}
+                onDecide={onDecideApproval}
+              />
+            ) : runFailure ? (
+              <RunFailurePanel
+                failure={runFailure}
+                onClose={() => setRunFailure(null)}
               />
             ) : null
           }
@@ -2765,42 +2797,14 @@ export function WorkflowsView({
         </CanvasShell>
       )}
 
-      {/* Issue #1110: the two strips below belong to ONE workflow, so neither
-          may outlive leaving it. Their state is cleared on every selection
-          change, but a drawer is the wrong thing to be wrong about —
-          `detailOpen` makes it structural rather than a promise about ordering.
-          The third drawer this used to cover, run history, is now the detail
-          view's left rail (#1107) and is gated by the same branch structurally:
-          it renders inside `CanvasShell`, which only the detail side has. */}
-      {detailOpen && result && (
-        <RunResultPanel
-          result={result}
-          graph={graph}
-          request={ranWith}
-          onClose={() => setResult(null)}
-          // Issue #1002: the whole queue, narrowed by the panel to this run.
-          // Handed in unfiltered on purpose — the Approvals page reads the same
-          // array and must keep showing every row.
-          approvals={approvals}
-          now={approvalsNow}
-          askerNames={askerNames}
-          deciding={decidingApprovals}
-          decided={decidedApprovals}
-          failed={failedApprovals}
-          onDecide={onDecideApproval}
-        />
-      )}
-
-      {/* Issue #1007: the same slot, for the outcome that had no surface at all.
-          The two are mutually exclusive by construction — `run()` clears both on
-          dispatch and only one of its arms sets one — so they are rendered as
-          siblings rather than as a branch. */}
-      {detailOpen && runFailure && (
-        <RunFailurePanel
-          failure={runFailure}
-          onClose={() => setRunFailure(null)}
-        />
-      )}
+      {/* Issue #1110's reasoning, extended by #1205: `result` and `runFailure`
+          are per-workflow chrome that must not outlive leaving the workflow.
+          Both used to render as full-width strips here, below `CanvasShell`.
+          They are now `CanvasShell`'s `rightRail` (see the call above), gated
+          by the very same `detailOpen` branch structurally — a list of
+          workflows has no single run's outcome to show, so there is nothing
+          for a rail to be beside, the same reason run history (#1107) lives
+          inside `CanvasShell` rather than out here. */}
 
       {/* Issue #1204: where the toolbar's run-input box went.
 

--- a/frontend/src/views/workflows/CanvasShell.tsx
+++ b/frontend/src/views/workflows/CanvasShell.tsx
@@ -1,5 +1,5 @@
 // The workflow DETAIL view's column layout — and the convention for where a
-// panel mounts (issue #1107).
+// panel mounts (issue #1107, extended by #1205).
 //
 // Scope first, because it is load-bearing since issue #1110: this is the shell
 // for `#/workflows/<id>`, never for `#/workflows`. The index is a list of
@@ -9,49 +9,67 @@
 // index side, which is what makes "no run chrome on the index" structural
 // rather than a rule each panel has to remember.
 //
-// Before this, every panel the view grew was appended to one vertical stack
+// Before #1107, every panel the view grew was appended to one vertical stack
 // under the canvas, and each one ate the dimension a workflow graph needs most.
 // Run history was the worst case: tall rows in a `max-h-72` horizontal strip,
-// showing two runs at a time while spending the full width of the screen.
+// showing two runs at a time while spending the full width of the screen. #1205
+// found the run-result drawer in the same state and gave it the same fix.
 //
-// The detail view has three slots, and each one is a decision about the panel's
-// LIFETIME, not about where there happens to be room:
+// The detail view now has three slots — two rails and one overlay — and each
+// is a decision about the panel's LIFETIME, not about where there happens to be
+// room:
 //
-//   left   — an in-flow rail. A browsing context the operator opened on
-//            purpose and keeps open while they work: it shrinks the canvas,
-//            because it is meant to be read alongside it. Run history is the
-//            only occupant today. Single occupancy — a second rail must
-//            replace this one rather than stack under it, the same way the
-//            right slot already arbitrates between its two panels.
+//   leftRail  — in-flow, shrinks the canvas. A browsing context the operator
+//               opened on purpose and keeps open while they work: it is meant
+//               to be read alongside the graph, not over it. Run history is the
+//               only occupant today. Single occupancy — a second panel wanting
+//               this rail must replace it rather than stack under it.
 //
-//   right  — a floating overlay, mounted `absolute right-3 top-3 bottom-3
-//            z-10` INSIDE the canvas (see `CopilotPanel` and
-//            `NodeDetailPanel`). A transient focus that covers the graph and
-//            is dismissed: the canvas keeps its full width underneath, so
-//            closing the panel restores it instantly. Also single occupancy,
-//            and `WorkflowsView` arbitrates it with a ternary — opening the
-//            copilot clears the selected node.
+//   rightRail — in-flow, shrinks the canvas from the other side. Issue #1205's
+//               answer for `RunResultPanel` and `RunFailurePanel`: a receipt
+//               for something that just happened, dismissed when read, but
+//               tall and vertically stacking (a delivery block, a Steps list,
+//               one card per node) — exactly the shape `leftRail` already
+//               proved a horizontal strip cannot show well. It is built the
+//               same way as `leftRail`, mirrored: in-flow only at `xl`
+//               (≥1280px viewport), collapsing to a full-width strip below the
+//               canvas beneath that — see `RunResultPanel`/`RunFailurePanel`
+//               for the class pattern, copied from `RunHistoryPanel`. Single
+//               occupancy; the two panels are mutually exclusive by
+//               construction in `WorkflowsView` (a run either produces a
+//               result or a failure, never both), so no arbitration beyond
+//               that is needed.
 //
-//   bottom — a full-width strip below BOTH canvas and rail, mounted as a
-//            sibling of this component (and, like this component, only on the
-//            detail side of the branch). The receipt for something that just
-//            happened and is dismissed when read: `RunResultPanel` and
-//            `RunFailurePanel`. Full width because it spans the whole view,
-//            and below the rail because the rail answers "what has run
-//            before" while the strip answers "what did the run I just started
-//            do" — two questions, two places.
+//   right overlay — a floating overlay, mounted `absolute right-3 top-3
+//               bottom-3 z-10` INSIDE the canvas (see `CopilotPanel` and
+//               `NodeDetailPanel`, unchanged by #1205). A transient focus that
+//               covers the graph and is dismissed: the canvas keeps its full
+//               width underneath, so closing the panel restores it instantly.
+//               Single occupancy, arbitrated by `WorkflowsView` with a
+//               ternary — opening the copilot clears the selected node.
 //
-// The arithmetic that fixes the breakpoint: the rail is in-flow, so it costs
-// the canvas real width, while the right overlays only cover it. A 320px rail
-// plus a 384px overlay is 704px of chrome, which is most of a laptop window
-// once the app's own nav sidebar is subtracted. So the rail is in-flow only at
-// `xl` (≥1280px viewport, ≥~1024px of view) — below that it falls back to the
-// bottom strip it has always been, which never competes with the right slot.
+// **Why the overlay and `rightRail` can never collide.** They are not siblings
+// in the same box: the overlay is `absolute` against the canvas's own
+// `relative` container (`children` below), not against this shell. When
+// `rightRail` is present it takes real flex width, so the canvas container
+// itself gets narrower — and the overlay's containing block shrinks with it.
+// The overlay's right edge is always the (now-narrower) canvas's right edge,
+// which is `rightRail`'s left edge, never underneath or past it. No z-index
+// race, no arbitration code: the overlay simply has less canvas to sit over.
+//
+// The arithmetic that fixes the breakpoint: a rail is in-flow, so it costs the
+// canvas real width, while the overlay only covers it. Two 320px rails (640px)
+// plus the app's own 216px nav sidebar is 856px before the canvas or the
+// overlay even enter into it — most of a laptop window. So both rails are
+// in-flow only at `xl` (≥1280px viewport) — below that each falls back to the
+// bottom strip it has always been, stacking canvas → leftRail's strip →
+// rightRail's strip, which never competes with the overlay slot.
 
 import type { ReactNode } from "react";
 
 export function CanvasShell({
-  rail,
+  leftRail,
+  rightRail,
   children,
 }: {
   /**
@@ -60,14 +78,25 @@ export function CanvasShell({
    * layout's reading order is unchanged, and the rail names itself as a
    * landmark so assistive tech can reach it directly either way.
    */
-  rail?: ReactNode;
-  /** The canvas. Positioned, because the right slot mounts inside it. */
+  leftRail?: ReactNode;
+  /**
+   * The right rail, or nothing (issue #1205). Rendered AFTER the canvas and
+   * the left rail in the DOM, with NO `order` override: at `xl` (flex-row)
+   * that natural position already reads as "on the right" (canvas, then the
+   * reordered-first left rail, then this); below `xl` (flex-col) it naturally
+   * stacks last, under both the canvas and the left rail's own strip.
+   */
+  rightRail?: ReactNode;
+  /** The canvas. Positioned, because the right overlay slot mounts inside it. */
   children: ReactNode;
 }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
       <div className="relative min-h-0 flex-1">{children}</div>
-      {rail && <div className="shrink-0 xl:order-first xl:w-80">{rail}</div>}
+      {leftRail && (
+        <div className="shrink-0 xl:order-first xl:w-80">{leftRail}</div>
+      )}
+      {rightRail && <div className="shrink-0 xl:w-80">{rightRail}</div>}
     </div>
   );
 }

--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -30,7 +30,14 @@ export function RunFailurePanel({
   // died after four minutes got somewhere first.
   const ranFor = Math.max(0, failure.atMillis - failure.startedAtMillis);
   return (
-    <div className="border-t bg-card/60" data-testid="workflow-run-failure">
+    // Issue #1205: a right rail at `xl`, the bottom strip it used to always be
+    // below that — same pattern as `RunResultPanel` next door, which is the
+    // mutually exclusive sibling this panel replaces in the same slot.
+    <aside
+      aria-label="Run failure"
+      className="flex h-full flex-col border-t bg-card/60 xl:border-t-0 xl:border-l"
+      data-testid="workflow-run-failure"
+    >
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm font-medium">Run failed</span>
@@ -57,7 +64,8 @@ export function RunFailurePanel({
           Dismiss
         </Button>
       </div>
-      <div className="max-h-72 overflow-auto px-4 pb-3">
+      {/* Capped as a strip, growing as a rail — see `RunResultPanel`'s body. */}
+      <div className="max-h-72 overflow-auto px-4 pb-3 xl:min-h-0 xl:max-h-none xl:flex-1">
         <Alert variant="destructive" className="py-2">
           <AlertDescription
             className="text-xs"
@@ -87,16 +95,20 @@ export function RunFailurePanel({
         )}
         {/* Two genuinely different next steps, and collapsing them sends the
             operator to the wrong place. A host that answered has journaled the
-            run (#228), so its per-node trail is one drawer down. Something that
+            run (#228), so its per-node trail is in Run history. Something that
             gave up in between may have left no run at all — and telling someone
             to look in History for a row that does not exist is how a transport
-            failure comes to read as a missing feature. */}
+            failure comes to read as a missing feature.
+
+            No positional wording ("below") on purpose: History has been a left
+            rail since #1107, and this panel is itself a right rail since #1205,
+            so neither is spatially "below" the other. */}
         <p className="mt-2 text-2xs text-muted-foreground">
           {failure.fromHost
-            ? "The host records failed runs, so this one is in Run history below with the step it stopped at."
-            : "The request didn't complete, so the host may or may not have started this run. Run history below is the answer either way."}
+            ? "The host records failed runs, so this one is in Run history, with the step it stopped at."
+            : "The request didn't complete, so the host may or may not have started this run. Run history is the answer either way."}
         </p>
       </div>
-    </div>
+    </aside>
   );
 }

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -161,7 +161,16 @@ export function RunResultPanel({
   const canDecideHere = runRows.length > 0 && !!onDecide;
 
   return (
-    <div className="border-t bg-card/60" data-testid="workflow-run-result">
+    // Issue #1205: a right rail at `xl`, the bottom strip it used to always be
+    // below that — the same pattern `RunHistoryPanel` proved on the left for
+    // issue #1107, mirrored. `border-l` (not `border-r`) because this rail
+    // sits on the canvas's right, so it borders the canvas on its OWN left
+    // edge; `CanvasShell` owns the placement and the width.
+    <aside
+      aria-label="Run result"
+      className="flex h-full flex-col border-t bg-card/60 xl:border-t-0 xl:border-l"
+      data-testid="workflow-run-result"
+    >
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Run result</span>
@@ -224,7 +233,11 @@ export function RunResultPanel({
           Dismiss
         </Button>
       </div>
-      <div className="max-h-72 overflow-auto px-4 pb-3">
+      {/* Capped as a strip, growing as a rail — same as `RunHistoryPanel`'s
+          body. `min-h-0` is what actually lets it scroll inside the column;
+          without it the flex item floors at its content height and the rail
+          overflows the view instead. */}
+      <div className="max-h-72 overflow-auto px-4 pb-3 xl:min-h-0 xl:max-h-none xl:flex-1">
         {request && (
           <p className="mb-2 text-xs text-muted-foreground">
             <span className="font-medium text-foreground">Requested:</span>{" "}
@@ -339,7 +352,7 @@ export function RunResultPanel({
           </pre>
         </details>
       </div>
-    </div>
+    </aside>
   );
 }
 

--- a/frontend/test/e2e/workflow-run-result-rail.spec.ts
+++ b/frontend/test/e2e/workflow-run-result-rail.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { openWorkflow } from "./workflows";
+
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
+/**
+ * Issue #1205: the run-result drawer is a RIGHT RAIL beside the canvas on a
+ * wide viewport, and the bottom strip it has always been below `xl` (1280px) —
+ * the same fix issue #1107 made for run history on the left, mirrored.
+ *
+ * Pinned as geometry rather than as class names, for the same reason
+ * `workflow-run-history-rail.spec.ts` is: `RunResultPanel`'s content stacks
+ * vertically (a delivery block, a Steps list, one card per node), so a
+ * horizontal strip shows very little of it while spending the canvas's
+ * scarcest dimension.
+ *
+ * The third test is the one that keeps the two-rail arithmetic honest: with
+ * BOTH the history rail (left) and the run result rail (right) open at once,
+ * the canvas is squeezed from both sides — see `CanvasShell.tsx`'s header
+ * comment for the arithmetic this pins.
+ *
+ * These specs need a real run (a run needs a brain to produce per-node text),
+ * so they gate on `LIVE_BRAIN` like `workflow-run-result.spec.ts` does.
+ */
+
+/** Dismisses the first-run tour if it is up; tolerates its absence. */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** The canvas ReactFlow paints into — the surface the rail is competing with. */
+function canvas(page: Page) {
+  return page.locator(".react-flow").first();
+}
+
+/** Runs the committed fixture workflow and waits for the result drawer. */
+async function runAndAwaitResult(page: Page) {
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+  const panel = page.getByTestId("workflow-run-result");
+  await expect(panel).toBeVisible({ timeout: 60_000 });
+  return panel;
+}
+
+test("at xl the run result is a right rail, and the canvas keeps a usable width", async ({
+  page,
+}) => {
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await openWorkflow(page, "Committed flow");
+
+  const flow = canvas(page);
+  await expect(flow).toBeVisible();
+
+  const panel = await runAndAwaitResult(page);
+  const rail = (await panel.boundingBox())!;
+  const graph = (await flow.boundingBox())!;
+
+  // Right of the canvas, not under it.
+  expect(rail.x, "the rail must sit right of the canvas").toBeGreaterThanOrEqual(
+    graph.x + graph.width - 1,
+  );
+  // Full height of the canvas region, mirroring the left rail's own check.
+  expect(
+    Math.abs(rail.height - graph.height),
+    "the rail runs the full height of the canvas region",
+  ).toBeLessThan(4);
+  // Only one rail open here, so the floor matches the left rail's own case.
+  expect(graph.width, "the canvas keeps a usable width beside the rail").toBeGreaterThan(
+    640,
+  );
+});
+
+test("below xl the run result falls back to a strip under the canvas", async ({
+  page,
+}) => {
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
+  await page.setViewportSize({ width: 1024, height: 800 });
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await openWorkflow(page, "Committed flow");
+
+  const flow = canvas(page);
+  await expect(flow).toBeVisible();
+
+  const panel = await runAndAwaitResult(page);
+  const strip = (await panel.boundingBox())!;
+  const graph = (await flow.boundingBox())!;
+
+  // Under the canvas, full width — same shape as the left rail's fallback.
+  expect(strip.y, "the strip must sit below the canvas").toBeGreaterThanOrEqual(
+    graph.y + graph.height - 1,
+  );
+  expect(
+    Math.abs(strip.width - graph.width),
+    "the strip spans the same width as the canvas",
+  ).toBeLessThan(4);
+});
+
+test("both rails open at once: history left, run result right, canvas squeezed but usable", async ({
+  page,
+}) => {
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await openWorkflow(page, "Committed flow");
+
+  const flow = canvas(page);
+  await expect(flow).toBeVisible();
+
+  const historyToggle = page.getByTestId("workflow-history-toggle");
+  await historyToggle.waitFor({ state: "visible", timeout: 30_000 });
+  await historyToggle.click();
+  const history = page.getByTestId("workflow-run-history");
+  await expect(history).toBeVisible();
+
+  const result = await runAndAwaitResult(page);
+
+  const left = (await history.boundingBox())!;
+  const graph = (await flow.boundingBox())!;
+  const right = (await result.boundingBox())!;
+
+  // History stays left of the canvas, result stays right of it — neither rail
+  // overlaps the canvas or the other rail.
+  expect(left.x + left.width, "history sits left of the canvas").toBeLessThanOrEqual(
+    graph.x + 1,
+  );
+  expect(right.x, "run result sits right of the canvas").toBeGreaterThanOrEqual(
+    graph.x + graph.width - 1,
+  );
+
+  // The arithmetic `CanvasShell.tsx` documents: 1440 viewport, 216px app
+  // sidebar, two 320px rails ⇒ ~584px of canvas left. A band, not an exact
+  // pixel, to tolerate scrollbar/border rounding — but it pins the number so a
+  // future change to either rail's width has to look at this test.
+  expect(
+    graph.width,
+    "the canvas keeps a real, if tight, width with both rails open",
+  ).toBeGreaterThan(500);
+  expect(
+    graph.width,
+    "the canvas is not wider than the two-rail arithmetic predicts",
+  ).toBeLessThan(650);
+});


### PR DESCRIPTION
Closes #1205.

## The decision

`RunResultPanel` and `RunFailurePanel` become a **right rail** — in-flow, shrinking the canvas — mirroring the left rail `RunHistoryPanel` already proved for run history in #1107. Not a third absolute overlay in the slot `CopilotPanel`/`NodeDetailPanel` already share.

This answers the issue's four questions:

1. **No new arbitration needed between the rail and the overlay.** `CopilotPanel`/`NodeDetailPanel` stay exactly as they are — `absolute right-3 top-3 bottom-3` *inside the canvas's own `relative` container*. When the new right rail is open, that container itself gets narrower (it's a flex sibling now taking real width), so the overlay's containing block shrinks with it. The overlay's right edge is always the canvas's (now-narrower) right edge — never underneath or past the rail. Copilot vs. node-inspector keeps its existing ternary (copilot wins); nothing there changes.
2. **Canvas width, both rails open** (216px app sidebar + two 320px rails): **584px** at 1440, **424px** at 1280 (the `xl` threshold itself). Both stay a real, pannable graph — not a sliver — though 1280 is tight; that combination (history open *and* a fresh run result) is a transient, operator-chosen edge case, and the result panel is dismissed once read.
3. **Yes, in-flow, not an overlay** — a receipt read alongside the graph, not a transient inspector, same reasoning the issue gives.
4. **Same `xl` (1280px) breakpoint**, same fallback to a full-width bottom strip below it — the exact class pattern `RunHistoryPanel` already uses, mirrored (`border-l` instead of `border-r`, since this rail borders the canvas on its own left edge).

`RunFailurePanel` moves too: it's the mutually-exclusive sibling of `RunResultPanel` in the exact same slot (a run either produces a result or a failure, never both), so leaving one as a bottom strip while the other floats right would be inconsistent on the two possible outcomes of the same click. Its "Run history below" wording was also already stale (history has been a left rail since #1107) — fixed alongside.

Draft PR #1188 (inset app frame) is still open/unmerged; this is designed against current `main`'s geometry and doesn't touch the outer app shell.

## Changes

- `CanvasShell.tsx` — renamed `rail` → `leftRail`, added a `rightRail` slot (same `xl:w-80` wrapper, no `order` override needed — natural DOM position already reads right at `xl` and stacks last below it). Rewrote the header doc to describe the new three-slot model (`leftRail`, `rightRail`, right overlay) and explain why the overlay and `rightRail` structurally cannot collide.
- `RunResultPanel.tsx` / `RunFailurePanel.tsx` — root `<div>` → `<aside>` with `RunHistoryPanel`'s rail/strip class pattern; body wrapper gets the matching `xl:min-h-0 xl:max-h-none xl:flex-1`. No prop or content changes.
- `WorkflowsView.tsx` — both panels now pass through `CanvasShell`'s `rightRail` prop (mutually exclusive ternary), gated by the same `detailOpen` branch as the left rail. Removed the old post-`CanvasShell` sibling blocks.
- New `frontend/test/e2e/workflow-run-result-rail.spec.ts`, modeled on `workflow-run-history-rail.spec.ts`: right-rail geometry at `xl`, bottom-strip fallback below it, and a third case with both rails open that pins the ~584px canvas-width arithmetic.

## Commands run locally

```
frontend: npm run typecheck · typecheck:unit · typecheck:e2e
          npm test (143 files, 1373 tests, all passing)
          npm run build
```

## Verified in a real browser

Built the frontend, ran the compiled `opencompany` binary against a scratch data dir on its own port, minted a magic link, and drove it with the repo's pinned Playwright at 1440×900 and 1024×800, light and dark. Confirmed:

- The right rail renders correctly in both themes, `border-l` visible, content scrolling inside `xl:flex-1` rather than clipping.
- The hardest case — run history (left rail) **+** the node inspector overlay **+** the run-failure right rail, all open at once — renders with zero overlap: history left, canvas (with the overlay bounded to its own narrower box) in the middle, failure panel right.
- Opening Copilot in the same state shows it correctly bounded within the shrunk canvas, its right edge stopping before the right rail begins.
- Below `xl` (1024px), the panel falls back to a full-width strip under the canvas, matching the left rail's existing behavior.
- The corrected "Run history, with the step it stopped at" wording (no more stale "below") is visible in the screenshots.

(The test company's engine wasn't wired for real workflow execution in this local deployment, so the run I drove came back as a failure rather than a success — which is exactly what let me verify `RunFailurePanel`'s relocation directly; `RunResultPanel` shares the identical CSS/DOM mechanism via the same `rightRail` slot, verified through the code and the new geometry spec.)