### PR TITLE
fix(workflows): hold every authoring path to the channel-delivery rule (#1191)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.11"
+version = "0.63.9"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -155,8 +155,17 @@ are refused with a `400` when the workflow is written, not only when it runs:
 
 | Destination | Refused when | Checked in |
 | --- | --- | --- |
-| `channel` | the target is not one this **running company** can deliver to — `CompanyRuntime::deliverable_channel_ids()`, which is also what `GET …/workflows/wired-channels` serves the console's picker, and which never includes `operator` | `reject_undeliverable_channel_destinations`, on both write routes (the deliverable set is a runtime fact, not a record one) |
+| `channel` | the target is not one this **running company** can deliver to — `CompanyRuntime::deliverable_channel_ids()`, which is also what `GET …/workflows/wired-channels` serves the console's picker, and which never includes `operator` | `validate_draft_against_record` in `src/company/workflow_create.rs` (issue #1191), reading the deliverable set the caller passes in. Both write routes pass it; so does the proposal-apply path. The agent tool surfaces pass `None` (no runtime handle) and skip the rule |
 | `email` | this company's `[tools].allow` does not grant `email`, which delivery answers with `Denied` / `EmailNotGranted` before it even looks for a mailbox | `validate_draft_against_record` in `src/company/workflow_create.rs`, beside the `tool_call` grant gate — so the orchestrator's `create_workflow` tool is held to it too |
+
+The `channel` rule lived on the two write routes until issue #1191, which is
+why applying a copilot proposal persisted a graph the editor then refused to
+save back — the apply path is a save that never ran it. It now lives in the
+shared authoring core beside its `email` sibling, inside the `problems`
+accumulator, so the refusal is a `workflow_invalid` naming the node and the
+`destination.target` field rather than a bare `invalid_request` with no
+breakdown. The deliverable set is still a runtime fact: it is threaded in from
+the caller as `Option<&[String]>`, the same way #1046 threads `mail_configured`.
 
 Both are guards, not guarantees. Desks come and go and grants can be revoked, so
 a graph valid at save can be invalid at run, and delivery's own refusal stays the

--- a/docs/spec/runtime/workflow-build.md
+++ b/docs/spec/runtime/workflow-build.md
@@ -78,11 +78,21 @@ uses, on `updated_at_millis`).
 The direction is inverted exactly as in [Planning](planning.md): the **host**
 gathers the roster (which teammates an `agent` node may name), the node-kind
 vocabulary (the builder emits within `BUILDER_NODE_KINDS`, a subset of the
-authoring set — see [workflow-vocabulary.md](workflow-vocabulary.md)), and the
-names of the workflows that already exist, and hands the
-model a complete picture. The model runs with **no tools** and only synthesizes
+authoring set — see [workflow-vocabulary.md](workflow-vocabulary.md)), the
+channel ids an `output` node's `channel` destination may name
+(`deliverable_channel_ids()` — the same set the console's destination picker is
+served from, issue #1191), and the names of the workflows that already exist,
+and hands the model a complete picture. The model runs with **no tools** and only synthesizes
 — so collisions and unknown-agent references are rare by construction, and a
 builder pass can no more act on the world than a planning pass can.
+
+The channel section is the newest of these and was added for a reason worth
+recording: the pack had a roster section and a tools section and **no** channel
+section, and the graph contract named the concept without listing ids. Asked to
+"post a summary to the engineering desk", the model wrote `engineering-desk` —
+the desk's display name with `-desk` appended — for a runtime whose channels are
+`engineering`, `product_design`, `go_to_market`. Grounding is the fix; courtesy
+validation (below) is the guard behind it.
 
 The card's own plan (`TaskPlan`) is the strongest input when it has one: its
 steps become candidate nodes, its prerequisites are grounding a node cannot
@@ -110,8 +120,8 @@ machinery), the same legal move `abandon_run` uses.
 ## Review before creation — the graph does not exist yet
 
 The builder pass **never creates a workflow** (decision D2b). It generates a
-graph, courtesy-validates that it *could* be created — the same shape, render and
-roster checks `create_company_workflow` runs, minus persistence
+graph, courtesy-validates that it *could* be created — the same shape, render,
+roster and destination checks `create_company_workflow` runs, minus persistence
 (`courtesy_validate_draft`) — and stamps it on the card as a proposal. A proposal
 that could never apply never reaches In Review.
 
@@ -125,14 +135,20 @@ The one path a proposal becomes a real workflow, and the host is its authority:
 1. rebuild a `RawWorkflow` from the **stored** `ops` graph — never a
    client-supplied body — via `raw_workflow_from_spec`;
 2. run `create_company_workflow`, which takes the company write lock,
-   re-validates shape + roster + id/name uniqueness, and (issue #276) lands any
-   schedule-carrying graph **switched off** until a person arms it;
+   re-validates shape + roster + destinations + id/name uniqueness, and (issue
+   #276) lands any schedule-carrying graph **switched off** until a person arms
+   it. "The same validation an editor save runs" was not literally true until
+   issue #1191: the channel-destination rule lived on the two write routes, so
+   this path — the one path the operator did not author the graph — persisted a
+   graph `PUT …/workflows` then refused, and marked the card Done for it;
 3. stamp the card's `TaskOutput` linking the created workflow to the build
    attempt, and move the card to **Done**; clear the proposal.
 
 If the create is refused — the roster drifted since the proposal was generated, a
-name has since been taken — the reason is appended to the card's note, the card
-**stays In Review** with its proposal intact, and the refusal is a 400.
+name has since been taken, a destination names a channel nobody wired — the
+reason is appended to the card's note, the card **stays In Review** with its
+proposal intact, and the refusal is a 400 carrying the `workflow_invalid`
+envelope, so the console names the node rather than only the sentence.
 
 ### `POST …/tasks/{id}/workflow-proposal/reject`
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1318,6 +1318,30 @@ export function workflowProblemLocator(problem: WorkflowProblem): string | undef
   return parts.length ? parts.join(" · ") : undefined;
 }
 
+/**
+ * The per-node breakdown a refusal carries, or `null` when it carries none
+ * (issue #1191).
+ *
+ * A function rather than an inline ternary at each call site because the three
+ * branches are the whole of the decision and the console has no component-test
+ * harness that could catch getting them wrong in JSX:
+ *
+ * * not an {@link ApiError} at all (a network failure, an abort) — no breakdown;
+ * * an `ApiError` the host answered without a `problems` array (every refusal
+ *   that is not a workflow refusal) — no breakdown;
+ * * an `ApiError` carrying an EMPTY array — still no breakdown, because a list
+ *   with nothing in it renders as an empty bullet list under the sentence, which
+ *   reads as a rendering bug rather than as "there was nothing more to say".
+ *
+ * `null` rather than `undefined` so a caller holding it in state can distinguish
+ * "asked and there was none" from "never asked", and so the render guard is a
+ * single truthiness check.
+ */
+export function workflowRefusalProblems(error: unknown): WorkflowProblem[] | null {
+  if (!(error instanceof ApiError)) return null;
+  return error.problems?.length ? error.problems : null;
+}
+
 export class ApiError extends Error {
   /**
    * The raw response body, kept only when it was **not** the host's envelope

--- a/frontend/src/views/TaskWorkflowProposalPanel.tsx
+++ b/frontend/src/views/TaskWorkflowProposalPanel.tsx
@@ -12,7 +12,10 @@
 //   the created workflow, and returns it moved to Done — where #339's existing
 //   output link opens the new workflow. A refused create (a name taken since, a
 //   teammate off the roster) comes back rejected and the card stays In Review
-//   with its proposal intact; the host's own message is shown verbatim.
+//   with its proposal intact; the host's own message is shown verbatim, with the
+//   per-node breakdown beneath it when the refusal carries one (issue #1191 —
+//   the destination rules answer with `workflow_invalid` + `problems` now, so a
+//   refused Apply names the node instead of only the sentence).
 // * **Reject** clears the proposal and returns the card to To-do (decision D2c),
 //   keeping its `workflow` deliverable so dragging it back builds again.
 //
@@ -28,7 +31,12 @@ import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { applyWorkflowProposal, rejectWorkflowProposal, type Task } from "@/api/tasks";
-import { ApiError } from "@/api/types";
+import {
+  ApiError,
+  type WorkflowProblem,
+  workflowProblemLocator,
+  workflowRefusalProblems,
+} from "@/api/types";
 import type { GraphDiff } from "@/api/workflow-proposal";
 import { taskProposalDiff } from "@/lib/task-workflow-proposal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -66,12 +74,22 @@ export function TaskWorkflowProposalPanel({
   // reason must persist until the operator acts rather than blinking out on the
   // next re-render.
   const [error, setError] = useState<string | null>(null);
+  // The per-node breakdown behind {@link error}, when the host sent one (issue
+  // #1191). Rendered under the sentence rather than instead of it — the same
+  // treatment `ProposalCard` gives a refused copilot edit, so an operator meets
+  // one shape of refusal wherever the graph came from.
+  //
+  // A refused apply now carries this for the destination rules too: the check
+  // moved into the shared authoring core, so it answers with `workflow_invalid`
+  // + `problems` instead of a flat `invalid_request`.
+  const [problems, setProblems] = useState<WorkflowProblem[] | null>(null);
 
   const refused = "reason" in result;
 
   async function apply() {
     setBusy("apply");
     setError(null);
+    setProblems(null);
     try {
       const saved = await applyWorkflowProposal(client, company, task.id);
       onSaved(saved);
@@ -88,6 +106,7 @@ export function TaskWorkflowProposalPanel({
             ? e.message
             : "The workflow could not be created.",
       );
+      setProblems(workflowRefusalProblems(e));
     } finally {
       setBusy(null);
     }
@@ -96,6 +115,7 @@ export function TaskWorkflowProposalPanel({
   async function reject() {
     setBusy("reject");
     setError(null);
+    setProblems(null);
     try {
       const saved = await rejectWorkflowProposal(client, company, task.id);
       onSaved(saved);
@@ -144,7 +164,27 @@ export function TaskWorkflowProposalPanel({
       {error && (
         <Alert variant="destructive" className="mt-3 py-1.5" data-testid="task-workflow-proposal-error">
           <AlertTriangle className="size-3.5" />
-          <AlertDescription className="text-2xs leading-snug">{error}</AlertDescription>
+          <AlertDescription className="text-2xs leading-snug">
+            {error}
+            {/* Keyed by index because a problem carries no id of its own and one
+                node can legitimately raise two — the list is render-only and
+                never reordered, so index is stable here. Mirrors
+                `ProposalCard`'s block deliberately: same locator helper, same
+                markup, so the two refusal surfaces cannot drift. */}
+            {problems && problems.length > 0 && (
+              <ul className="mt-1 space-y-0.5" data-testid="task-workflow-proposal-problems">
+                {problems.map((problem, i) => {
+                  const locator = workflowProblemLocator(problem);
+                  return (
+                    <li key={i}>
+                      {locator && <span className="font-medium">{locator} — </span>}
+                      {problem.message}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </AlertDescription>
         </Alert>
       )}
 

--- a/frontend/test/unit/task-workflow-proposal.test.ts
+++ b/frontend/test/unit/task-workflow-proposal.test.ts
@@ -8,6 +8,7 @@ import type {
   TransportRequest,
   TransportResponse,
 } from "@/api/transport";
+import { ApiError, workflowRefusalProblems } from "@/api/types";
 import { computeTaskPatch } from "@/lib/task-edit";
 import { taskProposalDiff } from "@/lib/task-workflow-proposal";
 
@@ -21,6 +22,13 @@ import { taskProposalDiff } from "@/lib/task-workflow-proposal";
  *    to a pre-#580 one;
  * 3. the edit-dialog diff's deliverable arm — an untouched control emits no
  *    patch, a flip emits exactly `{ deliverable }`.
+ *
+ * Issue #1191 adds a fourth: the decision behind the panel's per-node breakdown
+ * of a refused Apply. The markup that renders it is NOT covered — this runner is
+ * for pure functions and the console has no component-test harness (no
+ * testing-library, and `include` collects only `*.test.ts`). What is covered is
+ * the branch that decides whether a breakdown exists at all, which is where the
+ * mistakes live; the JSX beneath it mirrors `ProposalCard`'s block line for line.
  */
 
 // ---------------------------------------------------------------------------
@@ -238,5 +246,42 @@ describe("computeTaskPatch deliverable", () => {
     const current = task({ deliverable: "workflow" });
     const draft = { ...seededDraft(current), deliverable: "once" as const };
     expect(computeTaskPatch(draft, current)).toEqual({ deliverable: "once" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. the refused-Apply breakdown — which refusals carry one (issue #1191)
+// ---------------------------------------------------------------------------
+
+describe("workflowRefusalProblems", () => {
+  const problem = {
+    node_id: "post_summary",
+    field: "destination.target",
+    message: "`engineering-desk` is not a workflow delivery channel",
+  };
+
+  it("returns the host's breakdown when the refusal carries one", () => {
+    const e = new ApiError(400, "workflow_invalid", "…", true);
+    e.problems = [problem];
+    expect(workflowRefusalProblems(e)).toEqual([problem]);
+  });
+
+  it("returns null for a refusal the host sent no breakdown for", () => {
+    // Every refusal that is not a workflow refusal: a 409 name clash, a 404.
+    const e = new ApiError(409, "conflict", "A workflow named `x` already exists.", true);
+    expect(workflowRefusalProblems(e)).toBeNull();
+  });
+
+  it("treats an empty array as no breakdown", () => {
+    // An empty list would render as an empty bullet list under the sentence,
+    // which reads as a rendering bug rather than as "nothing more to say".
+    const e = new ApiError(400, "workflow_invalid", "…", true);
+    e.problems = [];
+    expect(workflowRefusalProblems(e)).toBeNull();
+  });
+
+  it("returns null when the failure never reached the host", () => {
+    expect(workflowRefusalProblems(new Error("Failed to fetch"))).toBeNull();
+    expect(workflowRefusalProblems(null)).toBeNull();
   });
 });

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -149,8 +149,8 @@ pub use workflow_file::{
 // from its request body, renders it to TOML, and re-parses it through
 // `parse_workflow` above for validation before writing to disk.
 pub(crate) use workflow_file::{
-    RawEdge, RawNode, RawWorkflow, raw_workflow_from_toml, render_workflow,
-    required_config_problems,
+    RawEdge, RawNode, RawWorkflow, channel_destination_missing_target_message,
+    raw_workflow_from_toml, render_workflow, required_config_problems,
 };
 // Issue #661 (M7): the read half of the agent workflow-admin surface — a stored
 // graph projected onto the narrow agent authoring schema, plus the policy

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -204,6 +204,7 @@ pub(crate) async fn create_company_workflow(
     store: &Arc<dyn CompanyStore>,
     events: Option<&Arc<dyn EventLog>>,
     draft: RawWorkflow,
+    wired_channels: Option<&[String]>,
 ) -> Result<WorkflowFile> {
     // --- Input validation (no lock; pure function of the draft) -------------
     validate_draft_shape(&draft)?;
@@ -224,7 +225,7 @@ pub(crate) async fn create_company_workflow(
     // every `tool_call` node against the company's wired+granted tools.
     // `parse_workflow` checks the graph's own shape but has no record to validate
     // names against — the same helper gates create and update identically.
-    validate_draft_against_record(&draft, &record, source_dir)?;
+    validate_draft_against_record(&draft, &record, source_dir, wired_channels)?;
 
     // Id uniqueness against every id this company already answers for: the seed
     // files, the record's overlay bodies, and the manifest-enabled ids. The
@@ -556,7 +557,11 @@ pub(crate) fn workflow_spec_from_graph(file: WorkflowFile) -> WorkflowGraphSpec 
 /// `crate::harness::workflow_build`, so in the default build (no harness) this
 /// would be dead code.
 #[cfg(feature = "openhuman")]
-pub(crate) fn courtesy_validate_draft(draft: &RawWorkflow, record: &CompanyRecord) -> Result<()> {
+pub(crate) fn courtesy_validate_draft(
+    draft: &RawWorkflow,
+    record: &CompanyRecord,
+    wired_channels: Option<&[String]>,
+) -> Result<()> {
     validate_draft_shape(draft)?;
     let toml_src = render_workflow(draft)?;
     if toml_src.len() > MAX_WORKFLOW_TOML_BYTES {
@@ -581,7 +586,7 @@ pub(crate) fn courtesy_validate_draft(draft: &RawWorkflow, record: &CompanyRecor
     // existence is still checked against the record's overlays + enabled ids +
     // globals, only seed-file ids are out of reach here (the run-time cycle guard
     // stays the backstop).
-    validate_draft_against_record(draft, record, None)?;
+    validate_draft_against_record(draft, record, None, wired_channels)?;
     Ok(())
 }
 
@@ -720,10 +725,18 @@ fn validate_draft_shape(draft: &RawWorkflow) -> Result<()> {
 /// seed / legacy graphs never pass through this create path at all — so passing
 /// here means the draft was coherent when written, not that a run is forever
 /// permitted.
+///
+/// `wired_channels` is the one fact here that is NOT a property of the record:
+/// the deployment's deliverable channel set, supplied by the caller because
+/// only a caller holding a `CompanyRuntime` can read it (issue #1191, following
+/// the `mail_configured` / `wired_channels` precedent #1046 set in this file).
+/// `None` means the caller cannot see the deployment's wiring — the agent tool
+/// surfaces — and the `channel`-target rule is skipped rather than guessed at.
 fn validate_draft_against_record(
     draft: &RawWorkflow,
     record: &CompanyRecord,
     source_dir: Option<&Path>,
+    wired_channels: Option<&[String]>,
 ) -> Result<()> {
     let roster: HashSet<&str> = record
         .manifest
@@ -764,15 +777,22 @@ fn validate_draft_against_record(
             // the `tool_call` grant gate, because it is the same *kind* of fact
             // — a record grant, not a live runtime one — and because this
             // helper is the shared create/update gate, so the orchestrator's
-            // `create_workflow` tool is held to it too. Its sibling rule ("a
-            // `channel` target must be one this runtime can deliver to") cannot
-            // live here: the deliverable set is a property of the *running*
-            // company, not of its record, so that one stays on the write routes
-            // (`reject_undeliverable_channel_destinations`).
+            // `create_workflow` tool is held to it too.
+            //
+            // Its sibling rule ("a `channel` target must be one this runtime can
+            // deliver to") used to be excluded on the grounds that the
+            // deliverable set is a property of the *running* company rather than
+            // of its record — but that is an argument about data availability,
+            // not about where the rule belongs, and #1046 had already settled it
+            // the other way by threading `mail_configured` / `wired_channels` in
+            // from the caller. #1191 moves it here for the same reason: living
+            // on the write routes meant three of the five authoring paths
+            // skipped it, and applying a copilot proposal persisted a graph the
+            // editor then refused to save back.
             "output" => {
                 #[cfg(feature = "openhuman")]
                 validate_output_destination(node, record)?;
-                problems.extend(output_destination_problems(node));
+                problems.extend(output_destination_problems(node, wired_channels));
             }
             // Per-kind required config (issue #661, extended #1016): reject a
             // `condition` with no `field`, an `http_request` missing `method` or a
@@ -1067,9 +1087,21 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
 /// it came from. Reported here first, with the locator; the flat pass never runs
 /// because this returns before the render → parse round trip.
 ///
-/// Ungated on purpose: it reads nothing but the node, so the default-lane HTTP
-/// routes are held to it exactly as the harness lanes are.
-fn output_destination_problems(node: &RawNode) -> Vec<WorkflowProblem> {
+/// `wired_channels` is the deployment's deliverable set
+/// ([`deliverable_channel_ids`](crate::company::CompanyRuntime::deliverable_channel_ids)),
+/// or `None` when the caller has no runtime handle to read it from — the same
+/// idiom [`workflow_effective_tool_slugs`] uses for its `wired` argument, and
+/// the same meaning: `None` is "cannot see the wiring", never "nothing is
+/// wired". `Some(&[])` DOES refuse every target, because a company with no
+/// deliverable channel really can deliver nowhere.
+///
+/// Ungated on purpose: it reads nothing but the node and the `Vec<String>` the
+/// caller supplies, so the default-lane HTTP routes are held to it exactly as
+/// the harness lanes are.
+fn output_destination_problems(
+    node: &RawNode,
+    wired_channels: Option<&[String]>,
+) -> Vec<WorkflowProblem> {
     let mut problems = Vec::new();
     let Some(destination) = node.destination.as_ref() else {
         return problems;
@@ -1083,6 +1115,30 @@ fn output_destination_problems(node: &RawNode) -> Vec<WorkflowProblem> {
             &node.id,
             "destination.target",
             channel_destination_missing_target_message(&format!("node `{}`", node.id)),
+        ));
+        return problems;
+    }
+    // Issue #981, moved here by #1191: a `channel` target outside the set this
+    // runtime can deliver to is a report that lands nowhere on EVERY run. It
+    // used to live on the two write routes, which is why the three other callers
+    // of this core — proposal apply, the orchestrator's `create_workflow` tool,
+    // the agent `update_workflow` tool — skipped it entirely, and why its
+    // refusal was a bare `InvalidRequest` with no `problems` array while every
+    // sibling rule here answers with a located `WorkflowInvalid`.
+    if let Some(wired) = wired_channels
+        && !wired.iter().any(|id| id == target)
+    {
+        let live: Vec<&str> = wired.iter().map(String::as_str).collect();
+        problems.push(WorkflowProblem::node_field(
+            &node.id,
+            "destination.target",
+            // The sentence the write routes have always used, unchanged: the
+            // node prefix, then the shared message delivery itself would carry.
+            format!(
+                "node `{}`: {}",
+                node.id,
+                crate::runtime::undeliverable_channel_message(target, &live)
+            ),
         ));
     }
     problems
@@ -1382,6 +1438,7 @@ pub(crate) async fn update_company_workflow(
     events: Option<&Arc<dyn EventLog>>,
     draft: RawWorkflow,
     expected_version: Option<&str>,
+    wired_channels: Option<&[String]>,
 ) -> Result<WorkflowFile> {
     // --- Input validation (no lock; pure function of the draft) -------------
     validate_draft_shape(&draft)?;
@@ -1404,7 +1461,7 @@ pub(crate) async fn update_company_workflow(
     // Same record cross-check as create (roster + tool_call grants):
     // `parse_workflow` validates the graph's own shape but has no record to check
     // `agent`/`tool_call` node names against.
-    validate_draft_against_record(&draft, &record, source_dir)?;
+    validate_draft_against_record(&draft, &record, source_dir, wired_channels)?;
 
     // Display-name uniqueness, MINUS this workflow's own current name — a
     // re-save that doesn't rename must not collide with itself. Every other
@@ -1603,6 +1660,11 @@ pub(crate) async fn rollback_company_workflow(
     let mut draft = raw_workflow_from_toml(&revision.toml)?;
     draft.id = wid.to_string();
 
+    // `wired_channels: None` — a rollback restores a body this company already
+    // saved, and the channel rule was never run on this path. Refusing a
+    // rollback because a desk was renamed since would strand the operator on the
+    // broken revision with no way back; the arm-time gate (#1046) and delivery's
+    // own refusal still stand between a restored graph and a silent drop.
     update_company_workflow(
         company,
         source_dir,
@@ -1611,6 +1673,7 @@ pub(crate) async fn rollback_company_workflow(
         events,
         draft,
         expected_version,
+        None,
     )
     .await
 }
@@ -2468,6 +2531,7 @@ to = "done"
             &store,
             Some(&log_dyn),
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("creates");
@@ -2538,6 +2602,7 @@ to = "done"
             &store,
             None,
             valid_draft("dup", "First"),
+            None,
         )
         .await
         .expect("first create");
@@ -2547,6 +2612,7 @@ to = "done"
             &store,
             None,
             valid_draft("dup", "Second name"),
+            None,
         )
         .await
         .expect_err("second create with same id");
@@ -2568,6 +2634,7 @@ to = "done"
             &store,
             None,
             valid_draft("one", "Greeter"),
+            None,
         )
         .await
         .expect("first");
@@ -2577,6 +2644,7 @@ to = "done"
             &store,
             None,
             valid_draft("two", "  GREETER  "),
+            None,
         )
         .await
         .expect_err("name collides case-insensitively");
@@ -2594,7 +2662,7 @@ to = "done"
         let mut draft = valid_draft("wf", "WF");
         draft.nodes[1].agent = Some("ghost".to_string());
 
-        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft, None)
             .await
             .expect_err("unknown teammate");
         assert!(
@@ -2615,7 +2683,7 @@ to = "done"
         let mut draft = valid_draft("wf", "WF");
         draft.nodes[1].agent = None;
 
-        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft, None)
             .await
             .expect_err("agent node with no teammate");
         assert!(
@@ -2636,7 +2704,7 @@ to = "done"
         // Zero triggers.
         let mut zero = valid_draft("z", "Z");
         zero.nodes[0].kind = "output".to_string();
-        let err = create_company_workflow(&company, Some(dir.path()), &store, None, zero)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, zero, None)
             .await
             .expect_err("no trigger");
         assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
@@ -2644,7 +2712,7 @@ to = "done"
         // Two triggers.
         let mut two = valid_draft("t", "T");
         two.nodes[2].kind = "trigger".to_string();
-        let err = create_company_workflow(&company, Some(dir.path()), &store, None, two)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, two, None)
             .await
             .expect_err("two triggers");
         assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
@@ -2664,6 +2732,7 @@ to = "done"
             &store,
             None,
             valid_draft("../secrets", "Escape"),
+            None,
         )
         .await
         .expect_err("traversal id");
@@ -2698,7 +2767,7 @@ to = "done"
             });
         }
         assert!(draft.nodes.len() > MAX_WORKFLOW_NODES);
-        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft, None)
             .await
             .expect_err("too many nodes");
         assert!(err.to_string().contains("at most"), "{err}");
@@ -2715,7 +2784,7 @@ to = "done"
         // Stay within the node cap but blow the byte cap with a huge summary.
         let mut draft = valid_draft("fat", "Fat");
         draft.nodes[0].summary = Some("x".repeat(MAX_WORKFLOW_TOML_BYTES + 10));
-        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft, None)
             .await
             .expect_err("too many bytes");
         assert!(err.to_string().contains("byte"), "{err}");
@@ -2739,6 +2808,7 @@ to = "done"
             &store,
             None,
             valid_draft("rollback", "Rollback"),
+            None,
         )
         .await
         .expect_err("save fails");
@@ -2778,6 +2848,7 @@ to = "done"
             &store,
             None,
             valid_draft("hosted", "Hosted"),
+            None,
         )
         .await
         .expect("creates with no source dir");
@@ -2820,6 +2891,7 @@ to = "done"
             &store,
             None,
             valid_draft("seeded", "Different name"),
+            None,
         )
         .await
         .expect_err("id is taken by a seed file");
@@ -2847,6 +2919,7 @@ to = "done"
             &store,
             None,
             valid_draft("other", "  seeded FLOW  "),
+            None,
         )
         .await
         .expect_err("name collides with the seed file's name");
@@ -2863,13 +2936,26 @@ to = "done"
             manifest_with_assistant(),
         )));
 
-        create_company_workflow(&company, None, &store, None, valid_draft("one", "Greeter"))
-            .await
-            .expect("first");
-        let err =
-            create_company_workflow(&company, None, &store, None, valid_draft("two", "GREETER"))
-                .await
-                .expect_err("name collides with the overlay body");
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("one", "Greeter"),
+            None,
+        )
+        .await
+        .expect("first");
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("two", "GREETER"),
+            None,
+        )
+        .await
+        .expect_err("name collides with the overlay body");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
     }
 
@@ -2906,6 +2992,7 @@ to = "done"
             &store,
             None,
             stageless_scheduled_draft("campaign", "Campaign"),
+            None,
         )
         .await
         .expect("a stub mid-authoring is legitimate and must save");
@@ -2929,6 +3016,7 @@ to = "done"
             &store,
             None,
             stageless_scheduled_draft("campaign", "Campaign"),
+            None,
         )
         .await
         .expect("saves");
@@ -2976,6 +3064,7 @@ to = "done"
             &store,
             None,
             stageless_scheduled_draft("campaign", "Campaign"),
+            None,
         )
         .await
         .expect("saves");
@@ -3007,7 +3096,7 @@ to = "done"
 
         let mut draft = valid_draft("greeter", "Greeter");
         draft.nodes[0].schedule = Some("0 9 * * *".to_string());
-        create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+        create_company_workflow(&company, Some(dir.path()), &store, None, draft, None)
             .await
             .expect("saves");
 
@@ -3060,6 +3149,7 @@ to = "done"
             &store,
             None,
             scheduled_output_draft("digest", "Digest", "owner", None),
+            None,
         )
         .await
         .expect("saving a stub is legitimate and must succeed");
@@ -3105,7 +3195,7 @@ to = "done"
         // owner output, no mailbox — but drop the schedule so it is manual.
         let mut draft = scheduled_output_draft("digest", "Digest", "owner", None);
         draft.nodes[0].schedule = None;
-        create_company_workflow(&company, Some(dir.path()), &store, None, draft)
+        create_company_workflow(&company, Some(dir.path()), &store, None, draft, None)
             .await
             .expect("saves");
 
@@ -3141,6 +3231,7 @@ to = "done"
             &store,
             None,
             scheduled_output_draft("digest", "Digest", "owner", None),
+            None,
         )
         .await
         .expect("saves");
@@ -3177,6 +3268,7 @@ to = "done"
             &store,
             None,
             scheduled_output_draft("digest", "Digest", "channel", Some("engineering")),
+            None,
         )
         .await
         .expect("saves");
@@ -3214,6 +3306,7 @@ to = "done"
             &store,
             None,
             scheduled_output_draft("digest", "Digest", "channel", Some("operator")),
+            None,
         )
         .await
         .expect("saves");
@@ -3253,6 +3346,7 @@ to = "done"
             &store,
             None,
             scheduled_output_draft("digest", "Digest", "owner", None),
+            None,
         )
         .await
         .expect("saves");
@@ -3286,6 +3380,7 @@ to = "done"
             &store,
             None,
             valid_draft("new", "  LEGACY  "),
+            None,
         )
         .await
         .expect_err("name collides with the enabled-id fallback name");
@@ -3303,6 +3398,7 @@ to = "done"
             &store,
             None,
             valid_draft("wf", "WF"),
+            None,
         )
         .await
         .expect_err("no record");
@@ -3322,7 +3418,7 @@ to = "done"
         name: &str,
     ) -> (Arc<dyn CompanyStore>, String) {
         let store = store_of(MemStore::seeded(record(company, manifest_with_assistant())));
-        create_company_workflow(company, None, &store, None, valid_draft(id, name))
+        create_company_workflow(company, None, &store, None, valid_draft(id, name), None)
             .await
             .expect("seed create");
         let record = store.load(company).await.unwrap().unwrap();
@@ -3349,6 +3445,7 @@ to = "done"
             Some(&log_dyn),
             draft,
             Some(&version),
+            None,
         )
         .await
         .expect("updates");
@@ -3413,17 +3510,25 @@ to = "done"
         // Someone else edits first, unconditionally.
         let mut theirs = valid_draft("greeter", "Greeter");
         theirs.description = Some("Theirs landed first.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, theirs, None)
+        update_company_workflow(&company, None, &store, &revs(), None, theirs, None, None)
             .await
             .expect("first writer wins");
 
         // Our stale token is now wrong.
         let mut ours = valid_draft("greeter", "Greeter");
         ours.description = Some("Ours would clobber.".to_string());
-        let err =
-            update_company_workflow(&company, None, &store, &revs(), None, ours, Some(&stale))
-                .await
-                .expect_err("stale version must be refused");
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            ours,
+            Some(&stale),
+            None,
+        )
+        .await
+        .expect_err("stale version must be refused");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
 
         // And the other writer's edit is intact — the refusal is not partial.
@@ -3443,9 +3548,18 @@ to = "done"
 
         let mut once = valid_draft("greeter", "Greeter");
         once.description = Some("One.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, once, Some(&first))
-            .await
-            .expect("first conditional write");
+        update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            once,
+            Some(&first),
+            None,
+        )
+        .await
+        .expect("first conditional write");
 
         let record = store.load(&company).await.unwrap().unwrap();
         let second = workflow_version(&record.overlay_workflows[0].toml);
@@ -3453,9 +3567,18 @@ to = "done"
 
         let mut twice = valid_draft("greeter", "Greeter");
         twice.description = Some("Two.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, twice, Some(&second))
-            .await
-            .expect("refreshed token is accepted");
+        update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            twice,
+            Some(&second),
+            None,
+        )
+        .await
+        .expect("refreshed token is accepted");
     }
 
     /// No token at all is an unconditional write — the `curl` contract.
@@ -3465,7 +3588,7 @@ to = "done"
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
         let mut draft = valid_draft("greeter", "Greeter");
         draft.description = Some("No token needed.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, draft, None)
+        update_company_workflow(&company, None, &store, &revs(), None, draft, None, None)
             .await
             .expect("unconditional write");
     }
@@ -3477,9 +3600,18 @@ to = "done"
         let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
         let mut draft = valid_draft("greeter", "  greeter  ");
         draft.description = Some("Same name, different case and padding.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, draft, Some(&version))
-            .await
-            .expect("own name must not conflict with itself");
+        update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            draft,
+            Some(&version),
+            None,
+        )
+        .await
+        .expect("own name must not conflict with itself");
     }
 
     /// …but a *sibling's* name is still guarded.
@@ -3487,9 +3619,16 @@ to = "done"
     async fn taking_another_workflows_name_is_a_conflict() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        create_company_workflow(&company, None, &store, None, valid_draft("other", "Other"))
-            .await
-            .expect("second workflow");
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("other", "Other"),
+            None,
+        )
+        .await
+        .expect("second workflow");
 
         let err = update_company_workflow(
             &company,
@@ -3498,6 +3637,7 @@ to = "done"
             &revs(),
             None,
             valid_draft("greeter", "OTHER"),
+            None,
             None,
         )
         .await
@@ -3514,15 +3654,24 @@ to = "done"
         // Zero triggers.
         let mut no_trigger = valid_draft("greeter", "Greeter");
         no_trigger.nodes[0].kind = "output".to_string();
-        let err = update_company_workflow(&company, None, &store, &revs(), None, no_trigger, None)
-            .await
-            .expect_err("no trigger");
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            no_trigger,
+            None,
+            None,
+        )
+        .await
+        .expect_err("no trigger");
         assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
 
         // Off-roster teammate.
         let mut ghost = valid_draft("greeter", "Greeter");
         ghost.nodes[1].agent = Some("ghost".to_string());
-        let err = update_company_workflow(&company, None, &store, &revs(), None, ghost, None)
+        let err = update_company_workflow(&company, None, &store, &revs(), None, ghost, None, None)
             .await
             .expect_err("off-roster teammate");
         assert!(
@@ -3563,6 +3712,7 @@ to = "done"
             None,
             valid_draft("seeded", "Seeded flow"),
             None,
+            None,
         )
         .await
         .expect_err("a source-defined workflow is not editable");
@@ -3581,6 +3731,7 @@ to = "done"
             &revs(),
             None,
             valid_draft("ghost", "Ghost"),
+            None,
             None,
         )
         .await
@@ -3608,6 +3759,7 @@ to = "done"
             None,
             valid_draft("legacy", "Legacy"),
             None,
+            None,
         )
         .await
         .expect_err("no body to replace");
@@ -3623,14 +3775,14 @@ to = "done"
             manifest_with_assistant(),
         )));
         for (id, name) in [("a", "Alpha"), ("b", "Bravo"), ("c", "Charlie")] {
-            create_company_workflow(&company, None, &store, None, valid_draft(id, name))
+            create_company_workflow(&company, None, &store, None, valid_draft(id, name), None)
                 .await
                 .expect("seed");
         }
 
         let mut draft = valid_draft("a", "Alpha");
         draft.description = Some("Edited.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, draft, None)
+        update_company_workflow(&company, None, &store, &revs(), None, draft, None, None)
             .await
             .expect("edit the first");
 
@@ -3734,6 +3886,7 @@ to = "done"
             &store,
             None,
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("re-create");
@@ -3782,6 +3935,7 @@ to = "done"
             &store,
             Some(&log_dyn),
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("creates");
@@ -3953,7 +4107,7 @@ to = "done"
 
         let mut theirs = valid_draft("greeter", "Greeter");
         theirs.description = Some("Edited after you loaded it.".to_string());
-        update_company_workflow(&company, None, &store, &revs(), None, theirs, None)
+        update_company_workflow(&company, None, &store, &revs(), None, theirs, None, None)
             .await
             .expect("someone edits first");
 
@@ -4076,7 +4230,7 @@ to = "done"
             manifest_with_assistant(),
         )));
         for (id, name) in [("a", "Alpha"), ("b", "Bravo"), ("c", "Charlie")] {
-            create_company_workflow(&company, None, &store, None, valid_draft(id, name))
+            create_company_workflow(&company, None, &store, None, valid_draft(id, name), None)
                 .await
                 .expect("seed");
         }
@@ -4273,6 +4427,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf", "WF", None),
+            None,
         )
         .await
         .expect_err("tool_call with no slug");
@@ -4299,6 +4454,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf", "WF", Some("totally_bogus")),
+            None,
         )
         .await
         .expect_err("unwired slug");
@@ -4329,6 +4485,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf", "WF", Some("csv_export")),
+            None,
         )
         .await
         .expect_err("code slug not granted");
@@ -4349,6 +4506,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf2", "WF2", Some("csv_export")),
+            None,
         )
         .await
         .expect("code slug is granted");
@@ -4373,6 +4531,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf", "WF", Some("web_search")),
+            None,
         )
         .await
         .expect_err("wildcard never confers search");
@@ -4393,6 +4552,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf2", "WF2", Some("web_search")),
+            None,
         )
         .await
         .expect("explicit search grant is honored");
@@ -4408,7 +4568,7 @@ to = "done"
             &company,
             manifest_with_assistant(),
         )));
-        create_company_workflow(&company, None, &store, None, valid_draft("wf", "WF"))
+        create_company_workflow(&company, None, &store, None, valid_draft("wf", "WF"), None)
             .await
             .expect("seed create");
 
@@ -4419,6 +4579,7 @@ to = "done"
             &revs(),
             None,
             tool_call_draft("wf", "WF", Some("totally_bogus")),
+            None,
             None,
         )
         .await
@@ -4455,6 +4616,186 @@ to = "done"
         draft
     }
 
+    /// Issue #1191, the core of the fix: an unwired `channel` target is refused
+    /// by the shared authoring core — so EVERY caller of it is held to the rule,
+    /// not just the two write routes that used to run it themselves.
+    ///
+    /// The refusal is a located `WorkflowInvalid`, which is the second half of
+    /// the defect: it used to be a bare `InvalidRequest` with no `problems`
+    /// array, so the console got a flat banner for exactly the class of error
+    /// #836 asked for a highlight on.
+    #[tokio::test]
+    async fn an_unwired_channel_target_is_refused_by_the_authoring_core() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "channel", Some("engineering-desk")),
+            Some(&["engineering".to_string()]),
+        )
+        .await
+        .expect_err("a channel nobody wired must not persist");
+
+        let OpenCompanyError::WorkflowInvalid { problems } = &err else {
+            panic!("expected a located `WorkflowInvalid`, got: {err}");
+        };
+        assert_eq!(problems.len(), 1, "{problems:?}");
+        assert_eq!(problems[0].node_id.as_deref(), Some("done"));
+        assert_eq!(problems[0].field.as_deref(), Some("destination.target"));
+        assert!(
+            problems[0]
+                .message
+                .contains("is not a workflow delivery channel"),
+            "{:?}",
+            problems[0]
+        );
+        // The live set rides in the sentence, so the fix is legible from the
+        // refusal alone — the same message a failed delivery would have carried.
+        assert!(
+            problems[0].message.contains("engineering"),
+            "{:?}",
+            problems[0]
+        );
+    }
+
+    /// A wired target on the same company saves. The rule refuses what delivery
+    /// would refuse and nothing more.
+    #[tokio::test]
+    async fn a_wired_channel_target_saves() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "channel", Some("engineering")),
+            Some(&["engineering".to_string()]),
+        )
+        .await
+        .expect("a wired channel is a destination this runtime can deliver to");
+    }
+
+    /// `None` is "the caller cannot see this deployment's wiring", not "nothing
+    /// is wired" — the same meaning `workflow_effective_tool_slugs` gives its
+    /// `wired` argument. The agent tool surfaces pass it, and their behaviour is
+    /// deliberately unchanged by #1191.
+    #[tokio::test]
+    async fn an_unseen_wiring_skips_the_channel_rule() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "channel", Some("engineering-desk")),
+            None,
+        )
+        .await
+        .expect("with no deliverable set in hand the rule is skipped, not guessed");
+    }
+
+    /// `Some(&[])` is a real answer, not a missing one: a company with no desk
+    /// and no provider channel can deliver nowhere, so every channel target is
+    /// refused and the sentence says so.
+    #[tokio::test]
+    async fn an_empty_deliverable_set_refuses_every_channel_target() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "channel", Some("engineering")),
+            Some(&[]),
+        )
+        .await
+        .expect_err("nowhere to deliver means no channel target is honourable");
+        assert!(err.to_string().contains("no durable channels"), "{err}");
+    }
+
+    /// The update path runs the same rule through the same helper, so an edit
+    /// cannot introduce a destination a create would have refused.
+    #[tokio::test]
+    async fn update_refuses_an_unwired_channel_target_too() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(&company, None, &store, None, valid_draft("wf", "WF"), None)
+            .await
+            .expect("the base graph has no destination at all");
+
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            draft_with_destination("wf", "WF", "channel", Some("engineering-desk")),
+            None,
+            Some(&["engineering".to_string()]),
+        )
+        .await
+        .expect_err("an edit must be held to the create rule");
+        assert!(
+            matches!(err, OpenCompanyError::WorkflowInvalid { .. }),
+            "{err}"
+        );
+    }
+
+    /// The builder's courtesy pass runs the rule too (issue #1191), so a
+    /// proposal naming a channel nobody wired never reaches In Review — it
+    /// settles the card back to To-do with the reason instead.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn courtesy_validation_refuses_an_unwired_channel_target() {
+        let company = CompanyId::new("acme");
+        let record = record(&company, manifest_with_assistant());
+
+        let err = courtesy_validate_draft(
+            &draft_with_destination("wf", "WF", "channel", Some("engineering-desk")),
+            &record,
+            Some(&["engineering".to_string()]),
+        )
+        .expect_err("the courtesy pass must refuse what apply would refuse");
+        assert!(
+            err.to_string()
+                .contains("is not a workflow delivery channel"),
+            "{err}"
+        );
+
+        courtesy_validate_draft(
+            &draft_with_destination("wf", "WF", "channel", Some("engineering")),
+            &record,
+            Some(&["engineering".to_string()]),
+        )
+        .expect("a wired target passes the same pass");
+    }
+
     /// Issue #1191: a `channel` destination with no `target` is refused with a
     /// LOCATED problem — the node id and the config field — not a bare sentence.
     ///
@@ -4476,6 +4817,7 @@ to = "done"
             &store,
             None,
             draft_with_destination("wf", "WF", "channel", None),
+            None,
         )
         .await
         .expect_err("a channel destination with no target must not persist");
@@ -4511,6 +4853,7 @@ to = "done"
             &store,
             None,
             draft_with_destination("wf", "WF", "email", Some("ops@example.com")),
+            None,
         )
         .await
         .expect_err("email destination without the grant");
@@ -4532,6 +4875,7 @@ to = "done"
             &store,
             None,
             draft_with_destination("wf2", "WF2", "email", Some("ops@example.com")),
+            None,
         )
         .await
         .expect("email is granted");
@@ -4555,6 +4899,7 @@ to = "done"
             &store,
             None,
             draft_with_destination("wf", "WF", "owner", None),
+            None,
         )
         .await
         .expect("owner delivery needs no `email` grant");
@@ -4570,7 +4915,7 @@ to = "done"
             &company,
             manifest_with_allow(&["web.*"]),
         )));
-        create_company_workflow(&company, None, &store, None, valid_draft("wf", "WF"))
+        create_company_workflow(&company, None, &store, None, valid_draft("wf", "WF"), None)
             .await
             .expect("seed create");
 
@@ -4581,6 +4926,7 @@ to = "done"
             &revs(),
             None,
             draft_with_destination("wf", "WF", "email", Some("ops@example.com")),
+            None,
             None,
         )
         .await
@@ -4610,6 +4956,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf", "WF", Some(" csv_export ")),
+            None,
         )
         .await
         .expect_err("padded slug");
@@ -4641,6 +4988,7 @@ to = "done"
             &store,
             None,
             tool_call_draft("wf", "WF", Some("media_generate_image")),
+            None,
         )
         .await
         .expect_err("media is not a workflow tool family");
@@ -4671,6 +5019,7 @@ to = "done"
             &store,
             None,
             tool_call_draft_args("wf", "WF", Some("csv_export"), None),
+            None,
         )
         .await
         .expect_err("missing required args");
@@ -4715,6 +5064,7 @@ to = "done"
                 Some("csv_export"),
                 Some(toml::Value::Table(args)),
             ),
+            None,
         )
         .await
         .expect("required args present");
@@ -4737,6 +5087,7 @@ to = "done"
             &store,
             None,
             tool_call_draft_args("wf", "WF", Some("read_workspace_state"), None),
+            None,
         )
         .await
         .expect("read_workspace_state needs no args");
@@ -4772,6 +5123,7 @@ to = "done"
                 Some("csv_export"),
                 Some(toml::Value::Table(args)),
             ),
+            None,
         )
         .await
         .expect_err("blank required args count as missing");
@@ -4856,6 +5208,7 @@ to = "done"
             &store,
             None,
             condition_draft(None, Some("yes"), Some("no")),
+            None,
         )
         .await
         .expect_err("condition with no field");
@@ -4884,6 +5237,7 @@ to = "done"
             &store,
             None,
             condition_draft(Some("=item.ok"), Some("pass"), Some("no")),
+            None,
         )
         .await
         .expect_err("off-vocabulary condition label");
@@ -4909,6 +5263,7 @@ to = "done"
             &store,
             None,
             condition_draft(Some("=item.approved"), Some("yes"), Some("no")),
+            None,
         )
         .await
         .expect("a well-formed condition draft is accepted");
@@ -4962,7 +5317,7 @@ to = "done"
                 label: None,
             }],
         };
-        let err = create_company_workflow(&company, None, &store, None, draft)
+        let err = create_company_workflow(&company, None, &store, None, draft, None)
             .await
             .expect_err("http_request with no method or url");
         // Issue #1016: structured `WorkflowInvalid`, one problem per field, both
@@ -5015,6 +5370,7 @@ to = "done"
             store,
             Some(log),
             scheduled_draft(id, name, cron),
+            None,
         )
         .await
         .expect("creates")
@@ -5102,6 +5458,7 @@ to = "done"
             &store,
             Some(&log_dyn),
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("creates");
@@ -5142,6 +5499,7 @@ to = "done"
             &store,
             Some(&log_dyn),
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("creates");
@@ -5162,6 +5520,7 @@ to = "done"
             &revs(),
             Some(&log_dyn),
             scheduled_draft("greeter", "Greeter", "0 8 * * *"),
+            None,
             None,
         )
         .await
@@ -5222,6 +5581,7 @@ to = "done"
             Some(&log_dyn),
             scheduled_draft("digest", "Digest", "0 3 * * *"),
             None,
+            None,
         )
         .await
         .expect("updates");
@@ -5271,6 +5631,7 @@ to = "done"
             Some(&log_dyn),
             valid_draft("digest", "Digest"),
             None,
+            None,
         )
         .await
         .expect("updates");
@@ -5304,6 +5665,7 @@ to = "done"
             &store,
             Some(&log_dyn),
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("creates");
@@ -5503,6 +5865,7 @@ to = "done"
             None,
             valid_draft("seeded", "Seeded flow"),
             None,
+            None,
         )
         .await
         .expect_err("a seed-defined graph cannot be replaced");
@@ -5560,6 +5923,7 @@ to = "done"
             &store,
             None,
             valid_draft("greeter", "Greeter"),
+            None,
         )
         .await
         .expect("create");
@@ -5576,7 +5940,7 @@ to = "done"
         // Edit the description so the rendered body differs from A.
         let mut edit = valid_draft("greeter", "Greeter");
         edit.description = Some("edited once".to_string());
-        update_company_workflow(&company, None, &store, &revs_dyn, None, edit, None)
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit, None, None)
             .await
             .expect("update");
 
@@ -5606,6 +5970,7 @@ to = "done"
             None,
             valid_draft("greeter", "Greeter"),
             None,
+            None,
         )
         .await
         .expect("no-op resave");
@@ -5629,7 +5994,7 @@ to = "done"
         for i in 0..=MAX_WORKFLOW_REVISIONS {
             let mut edit = valid_draft("greeter", "Greeter");
             edit.description = Some(format!("edit {i}"));
-            update_company_workflow(&company, None, &store, &revs_dyn, None, edit, None)
+            update_company_workflow(&company, None, &store, &revs_dyn, None, edit, None, None)
                 .await
                 .expect("update");
         }
@@ -5650,7 +6015,7 @@ to = "done"
         // A → edit → B. One revision now holds A.
         let mut edit_b = valid_draft("greeter", "Greeter");
         edit_b.description = Some("this is B".to_string());
-        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None)
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None, None)
             .await
             .expect("edit to B");
         let body_b = current_toml(&store, &company, "greeter").await;
@@ -5695,7 +6060,7 @@ to = "done"
         // Edit to capture a revision (which still names `assistant`), then set B.
         let mut edit_b = valid_draft("greeter", "Greeter");
         edit_b.description = Some("B, assistant still valid here".to_string());
-        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None)
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None, None)
             .await
             .expect("edit to B");
         let body_b = current_toml(&store, &company, "greeter").await;
@@ -5730,7 +6095,7 @@ to = "done"
 
         let mut edit_b = valid_draft("greeter", "Greeter");
         edit_b.description = Some("B".to_string());
-        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None)
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None, None)
             .await
             .expect("edit to B");
         let body_b = current_toml(&store, &company, "greeter").await;
@@ -5798,7 +6163,7 @@ to = "done"
         // the "restored cron re-arms" hazard is real to test.
         let mut scheduled = valid_draft("greeter", "Greeter");
         scheduled.nodes[0].schedule = Some("0 9 * * *".to_string());
-        create_company_workflow(&company, None, &store, None, scheduled)
+        create_company_workflow(&company, None, &store, None, scheduled, None)
             .await
             .expect("create scheduled");
         set_company_workflow_enabled(&company, None, &store, None, "greeter", true, true, &[])
@@ -5809,9 +6174,18 @@ to = "done"
         // disarms), and the scheduled body is captured as a revision.
         let mut unscheduled = valid_draft("greeter", "Greeter");
         unscheduled.description = Some("no schedule now".to_string());
-        update_company_workflow(&company, None, &store, &revs_dyn, None, unscheduled, None)
-            .await
-            .expect("remove schedule");
+        update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs_dyn,
+            None,
+            unscheduled,
+            None,
+            None,
+        )
+        .await
+        .expect("remove schedule");
         assert!(
             store
                 .load(&company)
@@ -5931,6 +6305,7 @@ to = "done"
             &store,
             None,
             one_node_draft(oc_node("tf", "transform", None)),
+            None,
         )
         .await
         .expect_err("transform with no config.set");
@@ -5954,6 +6329,7 @@ to = "done"
             &store,
             None,
             one_node_draft(oc_node("so", "split_out", None)),
+            None,
         )
         .await
         .expect_err("split_out with no config.path");
@@ -5986,7 +6362,7 @@ to = "done"
             &company,
             manifest_with_assistant(),
         )));
-        let err = create_company_workflow(&company, None, &store, None, http_bad_url_draft())
+        let err = create_company_workflow(&company, None, &store, None, http_bad_url_draft(), None)
             .await
             .expect_err("http_request url = not-a-url");
         let problems = problems_of(&err);
@@ -6007,6 +6383,7 @@ to = "done"
             None,
             http_bad_url_draft(),
             Some(&version),
+            None,
         )
         .await
         .expect_err("update to a bad url");
@@ -6036,7 +6413,7 @@ to = "done"
                 label: None,
             }],
         };
-        let err = create_company_workflow(&company, None, &store, None, draft)
+        let err = create_company_workflow(&company, None, &store, None, draft, None)
             .await
             .expect_err("dangling from");
         let problems = problems_of(&err);
@@ -6069,7 +6446,7 @@ to = "done"
         )));
         let mut draft = sub_workflow_draft("nope");
         draft.id = "parent".to_string();
-        let err = create_company_workflow(&company, None, &store, None, draft)
+        let err = create_company_workflow(&company, None, &store, None, draft, None)
             .await
             .expect_err("unknown sub-workflow id");
         let problems = problems_of(&err);
@@ -6086,7 +6463,7 @@ to = "done"
         let mut draft = sub_workflow_draft("greeter");
         draft.id = "parent".to_string();
         draft.name = "Parent".to_string();
-        create_company_workflow(&company, None, &store, None, draft)
+        create_company_workflow(&company, None, &store, None, draft, None)
             .await
             .expect("sub_workflow referencing a saved workflow is accepted");
     }
@@ -6102,7 +6479,7 @@ to = "done"
         )));
         // draft.id defaults to "wf" — a self reference to the same id.
         let draft = sub_workflow_draft("wf");
-        let err = create_company_workflow(&company, None, &store, None, draft)
+        let err = create_company_workflow(&company, None, &store, None, draft, None)
             .await
             .expect_err("self-referencing sub_workflow");
         assert!(err.to_string().contains("run itself"), "{err}");
@@ -6124,6 +6501,7 @@ to = "done"
             &store,
             None,
             one_node_draft(oc_node("op", "output_parser", None)),
+            None,
         )
         .await
         .expect("schema-less output_parser is accepted");
@@ -6138,6 +6516,7 @@ to = "done"
             &store,
             None,
             one_node_draft(oc_node("mg", "merge", None)),
+            None,
         )
         .await
         .expect("config-less merge is accepted");

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -154,8 +154,8 @@ use sha2::{Digest, Sha256};
 
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowDestinationDef, WorkflowFile, WorkflowNodeKind,
-    list_workflows_union, parse_workflow, raw_workflow_from_toml, render_workflow,
-    required_config_problems,
+    channel_destination_missing_target_message, list_workflows_union, parse_workflow,
+    raw_workflow_from_toml, render_workflow, required_config_problems,
 };
 use crate::error::{OpenCompanyError, Result, WorkflowProblem};
 use crate::ports::events::EventLog;
@@ -772,6 +772,7 @@ fn validate_draft_against_record(
             "output" => {
                 #[cfg(feature = "openhuman")]
                 validate_output_destination(node, record)?;
+                problems.extend(output_destination_problems(node));
             }
             // Per-kind required config (issue #661, extended #1016): reject a
             // `condition` with no `field`, an `http_request` missing `method` or a
@@ -1054,6 +1055,39 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
     Ok(())
 }
 
+/// The author-time destination problems for an `output` node, each carrying the
+/// node id and the config field at fault so the console can anchor it on the
+/// node the author actually wrote (issue #1191).
+///
+/// [`parse_workflow`] states the same rules and keeps them — it is the load
+/// path, and a seed or legacy graph never passes through here. What it cannot
+/// do is locate them: it builds flat `String`s, which
+/// [`From<String>`](WorkflowProblem) turns into problems with no `node_id` and
+/// no `field`, so the console rendered the sentence with no indication of where
+/// it came from. Reported here first, with the locator; the flat pass never runs
+/// because this returns before the render → parse round trip.
+///
+/// Ungated on purpose: it reads nothing but the node, so the default-lane HTTP
+/// routes are held to it exactly as the harness lanes are.
+fn output_destination_problems(node: &RawNode) -> Vec<WorkflowProblem> {
+    let mut problems = Vec::new();
+    let Some(destination) = node.destination.as_ref() else {
+        return problems;
+    };
+    if destination.kind.trim() != "channel" {
+        return problems;
+    }
+    let target = destination.target.as_deref().map(str::trim).unwrap_or("");
+    if target.is_empty() {
+        problems.push(WorkflowProblem::node_field(
+            &node.id,
+            "destination.target",
+            channel_destination_missing_target_message(&format!("node `{}`", node.id)),
+        ));
+    }
+    problems
+}
+
 /// Author-time `output` destination check: an `email` destination needs the
 /// company to grant the `email` namespace in `[tools].allow` (issue #981).
 ///
@@ -1091,9 +1125,10 @@ fn validate_output_destination(node: &RawNode, record: &CompanyRecord) -> Result
     let Some(destination) = node.destination.as_ref() else {
         return Ok(());
     };
-    // Only `email`. A missing/unknown `kind`, and a `channel` with no target,
-    // are `parse_workflow`'s to report — it says something more specific about
-    // each, and reporting the wrong problem first is worse than second.
+    // Only `email`. A missing/unknown `kind` is `parse_workflow`'s to report —
+    // it says something more specific, and reporting the wrong problem first is
+    // worse than second. The `channel` arms are
+    // `output_destination_problems`' (issue #1191).
     if destination.kind.trim() != "email" {
         return Ok(());
     }
@@ -4418,6 +4453,42 @@ to = "done"
             target: target.map(str::to_string),
         });
         draft
+    }
+
+    /// Issue #1191: a `channel` destination with no `target` is refused with a
+    /// LOCATED problem — the node id and the config field — not a bare sentence.
+    ///
+    /// The rule itself is old and lived only on the load path, where it is built
+    /// as a flat `String` and converted with `node_id: None, field: None`. The
+    /// console reads `problems` to highlight the offending node, so the one class
+    /// of error #836 was filed about rendered as prose it could not anchor.
+    #[tokio::test]
+    async fn a_channel_destination_with_no_target_names_the_node_and_the_field() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            draft_with_destination("wf", "WF", "channel", None),
+        )
+        .await
+        .expect_err("a channel destination with no target must not persist");
+
+        let OpenCompanyError::WorkflowInvalid { problems } = &err else {
+            panic!("expected a located `WorkflowInvalid`, got: {err}");
+        };
+        let problem = problems
+            .iter()
+            .find(|p| p.message.contains("name the channel to post the report to"))
+            .unwrap_or_else(|| panic!("no channel-target problem in {problems:?}"));
+        assert_eq!(problem.node_id.as_deref(), Some("done"));
+        assert_eq!(problem.field.as_deref(), Some("destination.target"));
     }
 
     /// Issue #981: an `email` destination on a company whose `[tools].allow`

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1430,6 +1430,12 @@ fn check_expected_version(expected: Option<&str>, current_toml: &str) -> Result<
 /// cron introduced by an edit cannot fire before anyone has looked at it. See
 /// the module docs for why an edit never arms in the other direction and why a
 /// changed-but-already-present cron is left alone.
+// Eight: the four store/log handles this write needs, the draft, the
+// concurrency token, and (issue #1191) the deployment's deliverable channel set.
+// Bundling them into a context struct would only move the same list one hop and
+// break every caller for no legibility gain — `create_company_workflow` beside
+// it takes the same shape minus the revision store and the token.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_company_workflow(
     company: &CompanyId,
     source_dir: Option<&Path>,

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -51,6 +51,28 @@ pub const WORKFLOW_NODE_KINDS: &[&str] = &[
 /// deliberate addition, never a free-form string an author can invent.
 pub const WORKFLOW_DESTINATION_KINDS: &[&str] = &["owner", "email", "channel"];
 
+/// The one sentence for an `output` node whose `channel` destination names no
+/// `target` (issue #1191).
+///
+/// `label` is the caller's way of naming the node — `node `post_summary`` from
+/// [`validate`], which has only an index when a node has no id, or the same
+/// shape minted by the author-time gate in
+/// [`validate_draft_against_record`](crate::company::workflow_create) — so both
+/// callers say the identical thing and only differ in whether they can also
+/// carry the id as a structured locator.
+///
+/// A constructor rather than two literals because the sentence is pinned on
+/// three sides: the load path, the author-time path, and the console's
+/// pre-flight in `WorkflowCreateDialog.tsx` (the contract
+/// `destination_messages_match_the_console` asserts). One source means a
+/// rewording cannot silently drift the load path away from the author path.
+pub(crate) fn channel_destination_missing_target_message(label: &str) -> String {
+    format!(
+        "{label} has a `channel` destination with no `target` — name the channel to post the \
+         report to."
+    )
+}
+
 /// A node kind in a workflow graph.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WorkflowNodeKind {
@@ -1267,9 +1289,10 @@ pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
                 }
                 "channel" => {
                     if target.is_empty() {
-                        problems.push(format!(
-                            "{label} has a `channel` destination with no `target` — name the channel to post the report to."
-                        ));
+                        // The flat backstop. Seed and legacy graphs reach the
+                        // load path without ever passing the author-time gate,
+                        // so this stays — it just no longer owns the sentence.
+                        problems.push(channel_destination_missing_target_message(&label));
                     }
                 }
                 "" => problems.push(format!(

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -4601,6 +4601,15 @@ impl Tool for CreateWorkflowTool {
         // company record, which is the only writable surface a hosted tenant has
         // (issue #168).
         tracing::debug!(company = %self.company, workflow = %draft.id, "create_workflow: authoring");
+        // `wired_channels: None` (issue #1191) — this tool holds a store and an
+        // event log, not a `CompanyRuntime`, and the deliverable channel set can
+        // only be read off a running runtime. `None` means "cannot see the
+        // wiring", so the channel-destination rule is skipped rather than
+        // guessed at; delivery's own `ChannelNotWired` refusal stays the
+        // backstop for a graph authored this way. Deliberately unchanged by
+        // #1191, which moved the rule into this core so the paths that CAN see
+        // the wiring all run it; giving the agent tools a runtime handle is a
+        // separate change.
         match create_company_workflow(
             &self.company,
             self.source_dir.as_deref(),

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -4607,6 +4607,7 @@ impl Tool for CreateWorkflowTool {
             &self.store,
             self.events.as_ref(),
             draft,
+            None,
         )
         .await
         {

--- a/src/harness/built_in/workflow_admin.rs
+++ b/src/harness/built_in/workflow_admin.rs
@@ -704,6 +704,7 @@ impl Tool for UpdateWorkflowTool {
             self.admin.events.as_ref(),
             draft,
             Some(&expected_version),
+            None,
         )
         .await
         {

--- a/src/harness/built_in/workflow_admin.rs
+++ b/src/harness/built_in/workflow_admin.rs
@@ -696,6 +696,13 @@ impl Tool for UpdateWorkflowTool {
         }
 
         tracing::debug!(company = %self.admin.company, workflow = %wid, "update_workflow: replacing");
+        // `wired_channels: None` (issue #1191) — same reason as the
+        // orchestrator's `create_workflow` tool: the admin surface holds a store
+        // and a revision store, not a `CompanyRuntime`, so it cannot read the
+        // deliverable channel set. `None` skips the channel-destination rule
+        // rather than guessing at it, leaving delivery's own refusal as the
+        // backstop. Status quo, and greppable: the two agent tool surfaces are
+        // the only `None` callers that are not tests or a rollback.
         match update_company_workflow(
             &self.admin.company,
             self.admin.source_dir.as_deref(),

--- a/src/harness/built_in/workflow_admin/tests.rs
+++ b/src/harness/built_in/workflow_admin/tests.rs
@@ -437,6 +437,7 @@ async fn read_round_trips_into_an_update_that_keeps_the_workflow_enabled() {
             .unwrap(),
         )
         .unwrap(),
+        None,
     )
     .await
     .expect("creates");
@@ -530,6 +531,7 @@ async fn a_stale_version_token_is_the_company_layers_conflict() {
         &store,
         None,
         draft,
+        None,
     )
     .await
     .expect("creates");
@@ -557,6 +559,7 @@ async fn a_stale_version_token_is_the_company_layers_conflict() {
         &revisions,
         None,
         other,
+        None,
         None,
     )
     .await
@@ -679,6 +682,7 @@ async fn a_scheduled_workflow_is_refused_by_the_tools_and_still_writable_by_the_
         None,
         draft,
         None,
+        None,
     )
     .await
     .expect("the console path is not gated by the agent tools' refusal");
@@ -738,6 +742,7 @@ async fn delete_removes_the_body_the_enabled_id_and_the_history() {
         &store,
         None,
         draft,
+        None,
     )
     .await
     .expect("creates");
@@ -754,6 +759,7 @@ async fn delete_removes_the_body_the_enabled_id_and_the_history() {
         &revisions,
         None,
         edited,
+        None,
         None,
     )
     .await
@@ -882,6 +888,7 @@ async fn an_agent_edit_cannot_bypass_the_per_kind_config_rules() {
         &store,
         None,
         draft,
+        None,
     )
     .await
     .expect("creates");

--- a/src/harness/built_in/workflow_build.rs
+++ b/src/harness/built_in/workflow_build.rs
@@ -528,7 +528,7 @@ pub async fn run_workflow_build_pass(
             return;
         }
     };
-    if let Err(err) = courtesy_validate_draft(&draft, &evidence.record) {
+    if let Err(err) = courtesy_validate_draft(&draft, &evidence.record, None) {
         settle_to_todo(
             &runtime,
             &task_id,

--- a/src/harness/built_in/workflow_build.rs
+++ b/src/harness/built_in/workflow_build.rs
@@ -129,6 +129,15 @@ const MAX_PLAN_STEPS: usize = 30;
 const MAX_PLAN_PREREQS: usize = 30;
 const MAX_STEP_DETAIL_CHARS: usize = 400;
 
+/// How many wired channel ids the grounding section lists (issue #1191).
+///
+/// The deliverable set is one id per desk plus provider channels, so 30 is well
+/// past any real company — but it is a company-controlled list on a metered
+/// path, and every other list here is bounded. Overflow is stated rather than
+/// silently dropped: a model told "…and N more" knows the section is partial and
+/// can say so, instead of confidently inventing from a truncated set.
+const MAX_WIRED_CHANNELS: usize = 30;
+
 /// The node kinds the builder prompt actually specifies. Deliberately narrower
 /// than [`WORKFLOW_NODE_KINDS`](crate::company::WORKFLOW_NODE_KINDS): the model
 /// is only told how to shape these, so offering it the rest of the engine
@@ -528,7 +537,9 @@ pub async fn run_workflow_build_pass(
             return;
         }
     };
-    if let Err(err) = courtesy_validate_draft(&draft, &evidence.record, None) {
+    if let Err(err) =
+        courtesy_validate_draft(&draft, &evidence.record, Some(&evidence.wired_channels))
+    {
         settle_to_todo(
             &runtime,
             &task_id,
@@ -834,6 +845,9 @@ struct Evidence {
     existing_names: Vec<String>,
     /// Existing workflow ids, so the host mints a non-clashing id.
     existing_ids: HashSet<String>,
+    /// Channel ids an `output` node's `channel` destination may name (issue
+    /// #1191) — see [`CompanyEvidence::wired_channels`].
+    wired_channels: Vec<String>,
 }
 
 /// One roster teammate as the copilot grounds — and the deterministic resolver
@@ -872,6 +886,17 @@ struct CompanyEvidence {
     existing_names: Vec<String>,
     /// Existing workflow ids, so the host mints a non-clashing id.
     existing_ids: HashSet<String>,
+    /// Channel ids an `output` node's `channel` destination may name — this
+    /// deployment's deliverable set (issue #1191).
+    ///
+    /// The `destination` sibling of [`roster`](Self::roster) and the tool slugs:
+    /// gathered once, rendered into the prompt so the model copies a real id,
+    /// and read back by courtesy validation so a proposal that names something
+    /// else never reaches In Review. Before #1191 the pack had no channel
+    /// section at all, which is how the builder came to write `engineering-desk`
+    /// — the desk's display name with `-desk` appended — for a runtime whose
+    /// channels are `engineering`, `product_design`, `go_to_market`.
+    wired_channels: Vec<String>,
 }
 
 /// Reads the company's own state deterministically — the roster, the existing
@@ -920,6 +945,10 @@ async fn gather_company_evidence(runtime: &Arc<CompanyRuntime>) -> crate::Result
         roster,
         existing_names,
         existing_ids,
+        // The same accessor the console's destination picker and the write
+        // routes read, so what the model is offered and what validation accepts
+        // cannot drift.
+        wired_channels: runtime.deliverable_channel_ids(),
         record,
     })
 }
@@ -941,6 +970,7 @@ async fn gather_evidence(
         roster: company.roster,
         existing_names: company.existing_names,
         existing_ids: company.existing_ids,
+        wired_channels: company.wired_channels,
         record: company.record,
     })
 }
@@ -1317,6 +1347,8 @@ fn evidence_prompt(e: &Evidence) -> String {
         out.push_str(&roster_line(entry));
     }
 
+    render_channel_section(&mut out, &e.wired_channels);
+
     out.push_str("\n## Workflows that already exist (do not clash with these names)\n");
     if e.existing_names.is_empty() {
         out.push_str("- (none yet)\n");
@@ -1326,6 +1358,43 @@ fn evidence_prompt(e: &Evidence) -> String {
     }
 
     out
+}
+
+/// Renders the channel ids an `output` node's `channel` destination may name
+/// (issue #1191), in the voice of the roster and tool sections beside it.
+///
+/// The pack had no channel section at all until #1191, and `graph_contract`
+/// names the concept without listing ids — so a model asked to "post to the
+/// engineering desk" had nothing to copy and wrote the desk's display name with
+/// `-desk` appended. Courtesy validation is the guard — it turns that graph into
+/// a card settled back to To-do rather than a broken workflow; this section is
+/// what stops the model reaching for a name it had to invent in the first
+/// place.
+///
+/// The empty case is stated honestly rather than omitted — a company with no
+/// desk and no provider channel can deliver nowhere, and a silent section reads
+/// as "anything goes".
+fn render_channel_section(out: &mut String, wired_channels: &[String]) {
+    out.push_str(
+        "\n## Channels (an `output` node's `channel` `destination.target` must be one of these \
+         ids, copied exactly)\n",
+    );
+    if wired_channels.is_empty() {
+        out.push_str(
+            "- (no channels are wired — this company can deliver nowhere; use an `owner` \
+             destination, or no destination at all)\n",
+        );
+        return;
+    }
+    for id in wired_channels.iter().take(MAX_WIRED_CHANNELS) {
+        out.push_str(&format!("- `{id}`\n"));
+    }
+    if wired_channels.len() > MAX_WIRED_CHANNELS {
+        out.push_str(&format!(
+            "- (…and {} more not listed here)\n",
+            wired_channels.len() - MAX_WIRED_CHANNELS
+        ));
+    }
 }
 
 /// Renders one roster teammate as a prompt line (issue #813). Leads with the
@@ -1382,11 +1451,12 @@ fn description_evidence_prompt(
     out
 }
 
-/// The roster + wired-tool + existing-name grounding shared by the create-time
-/// draft ([`description_evidence_prompt`]) and the fix-from-run correction
-/// ([`fix_evidence_prompt`], issue #840 PR-3), so the two prompts cannot drift in
-/// how they name the teammates an `agent` node may hand work to, the slugs a
-/// `tool_call` may run, and the existing workflow names a new one must not clash
+/// The roster + wired-tool + wired-channel + existing-name grounding shared by
+/// the create-time draft ([`description_evidence_prompt`]) and the fix-from-run
+/// correction ([`fix_evidence_prompt`], issue #840 PR-3), so the two prompts
+/// cannot drift in how they name the teammates an `agent` node may hand work to,
+/// the slugs a `tool_call` may run, the channels an `output` may deliver to
+/// (issue #1191), and the existing workflow names a new one must not clash
 /// with.
 fn render_grounding_sections(
     out: &mut String,
@@ -1439,6 +1509,8 @@ fn render_grounding_sections(
         out.push_str(&granted_but_unwired_slugs.join(", "));
         out.push('\n');
     }
+
+    render_channel_section(out, &e.wired_channels);
 
     out.push_str("\n## Workflows that already exist (do not clash with these names)\n");
     if e.existing_names.is_empty() {

--- a/src/harness/built_in/workflow_build/test.rs
+++ b/src/harness/built_in/workflow_build/test.rs
@@ -1346,6 +1346,7 @@ async fn seed_workflow(runtime: &Arc<CompanyRuntime>, id: &str, name: &str) {
         runtime.store(),
         Some(runtime.events()),
         raw,
+        None,
     )
     .await
     .expect("seed workflow");

--- a/src/harness/built_in/workflow_build/test.rs
+++ b/src/harness/built_in/workflow_build/test.rs
@@ -740,6 +740,53 @@ fn a_spec_rebuilds_the_expected_raw_workflow() {
 // Pass tier
 // ---------------------------------------------------------------------------
 
+/// [`MANIFEST`] plus one desk, so the runtime's deliverable channel set is
+/// exactly `["engineering"]` (issue #1191). The default fixture declares no
+/// desk, which makes the set empty — enough to prove the "nowhere to deliver"
+/// fallback, useless for telling an accepted channel target from a refused one.
+const DESK_MANIFEST: &str = r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "maya"
+role = "Writer"
+tools = ["docs", "web"]
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering"
+members = ["maya"]
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["docs", "web"]
+"#;
+
+/// [`runtime_with`], on a company that has a desk to deliver to.
+async fn runtime_with_desk(model: Arc<ScriptedModel>) -> (tempfile::TempDir, Arc<CompanyRuntime>) {
+    let home = tempfile::Builder::new()
+        .prefix("opencompany-builder-desk-")
+        .tempdir()
+        .expect("tempdir");
+    let desk_manifest: CompanyManifest =
+        toml::from_str(DESK_MANIFEST).expect("the desk fixture manifest parses");
+    let mut runtime = crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), desk_manifest)
+        .with_id(CompanyId::new("acme"))
+        .build()
+        .await
+        .expect("runtime");
+    assert_eq!(
+        runtime.deliverable_channel_ids(),
+        vec!["engineering".to_string()],
+        "the fixture must have exactly one delivery channel, or these tests prove nothing"
+    );
+    runtime.set_builder(Arc::new(WorkflowBuilder::new(model, "chat-v1")));
+    (home, Arc::new(runtime))
+}
+
 async fn runtime_with(model: Arc<ScriptedModel>) -> (tempfile::TempDir, Arc<CompanyRuntime>) {
     let home = tempfile::Builder::new()
         .prefix("opencompany-builder-")
@@ -1244,6 +1291,107 @@ async fn an_out_of_vocabulary_kind_settles_to_todo() {
         "the offending kind is named on the card"
     );
     assert_eq!(run_status(&runtime, &run_id).await, RunStatus::Failed);
+}
+
+/// **The #1191 regression, at the builder.** The model routes the report to a
+/// channel this runtime cannot deliver to — the shape the QA pass found, where
+/// the builder appended `-desk` to a desk's display name.
+///
+/// Courtesy validation now runs the channel rule (it could not before: the rule
+/// lived on the write routes and the builder does not go through them), so the
+/// card settles back to To-do with the reason instead of reaching In Review
+/// carrying a proposal that Apply would persist and the editor would then
+/// refuse. The reason names the channels that WOULD work, so the next pass — and
+/// the operator reading the card — can see the fix without a second lookup.
+#[tokio::test]
+async fn a_proposal_naming_an_unwired_channel_settles_to_todo() {
+    let reply = r#"{"automatable":true,"summary":"post the digest","workflow":{"name":"Weekly digest",
+        "nodes":[{"id":"start","kind":"trigger","name":"Start","schedule":"0 17 * * 5"},
+                 {"id":"draft","kind":"agent","name":"Draft","agent":"maya"},
+                 {"id":"post_summary","kind":"output","name":"Post to engineering desk",
+                  "destination":{"kind":"channel","target":"engineering-desk"}}],
+        "edges":[{"from":"start","to":"draft"},{"from":"draft","to":"post_summary"}]}}"#;
+    let (_home, runtime) = runtime_with_desk(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-1191", None))
+        .await
+        .unwrap();
+    let run_id = open_run(&runtime, "t-1191").await;
+
+    run_workflow_build_pass(
+        Arc::clone(&runtime),
+        "t-1191".to_string(),
+        Some(run_id.clone()),
+    )
+    .await;
+
+    let after = read(&runtime, "t-1191").await;
+    assert_eq!(after.column, COLUMN_TODO);
+    assert!(
+        after.workflow_proposal.is_none(),
+        "a graph the editor would refuse must not reach In Review"
+    );
+    let note = after.note.unwrap_or_default();
+    assert!(
+        note.contains("is not a workflow delivery channel"),
+        "the destination problem is named on the card: {note}"
+    );
+    assert!(
+        note.contains("engineering"),
+        "the wired ids ride along so the fix is legible: {note}"
+    );
+    assert_eq!(run_status(&runtime, &run_id).await, RunStatus::Failed);
+}
+
+/// The other half of #1191: the model is *told* the channel ids, so it has
+/// something to copy instead of inventing one from a desk's display name.
+///
+/// The evidence pack had a roster section and a tools section and no channel
+/// section at all; `graph_contract` names the concept without listing ids.
+#[tokio::test]
+async fn the_card_prompt_grounds_the_wired_channels() {
+    let (_home, runtime) = runtime_with_desk(ScriptedModel::replying(VALID_GRAPH)).await;
+    let evidence = gather_evidence(&runtime, &card("t-ground", None))
+        .await
+        .expect("evidence");
+    assert_eq!(evidence.wired_channels, vec!["engineering".to_string()]);
+
+    let prompt = evidence_prompt(&evidence);
+    assert!(prompt.contains("## Channels"), "{prompt}");
+    assert!(prompt.contains("`engineering`"), "{prompt}");
+    assert!(
+        prompt.contains("copied exactly"),
+        "the section must say the id is copied, not paraphrased: {prompt}"
+    );
+}
+
+/// The create-time copilot's prompt grounds the same set through the shared
+/// `render_grounding_sections`, so a graph drafted from an operator's sentence
+/// and one built from a card name channels from one list.
+#[tokio::test]
+async fn the_description_prompt_grounds_the_wired_channels() {
+    let (_home, runtime) = runtime_with_desk(ScriptedModel::replying(DESC_GRAPH)).await;
+    let evidence = gather_company_evidence(&runtime).await.expect("evidence");
+    let prompt = description_evidence_prompt(&evidence, &[], &[], "post the weekly digest");
+    assert!(prompt.contains("## Channels"), "{prompt}");
+    assert!(prompt.contains("`engineering`"), "{prompt}");
+}
+
+/// A company with no desk and no provider channel says so in its own words,
+/// matching how the roster and tool sections state an empty set — a silent
+/// section would read as "anything goes".
+#[tokio::test]
+async fn an_empty_channel_set_renders_the_honest_fallback() {
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(VALID_GRAPH)).await;
+    let evidence = gather_evidence(&runtime, &card("t-empty", None))
+        .await
+        .expect("evidence");
+    assert!(evidence.wired_channels.is_empty());
+
+    let prompt = evidence_prompt(&evidence);
+    assert!(prompt.contains("## Channels"), "{prompt}");
+    assert!(prompt.contains("no channels are wired"), "{prompt}");
 }
 
 /// The model does not get a vote on approval gating: whatever `requires_approval`

--- a/src/harness/built_in/workflow_build/tools.rs
+++ b/src/harness/built_in/workflow_build/tools.rs
@@ -309,7 +309,11 @@ impl Tool for CheckWorkflowTool {
         // the same gate the create route runs, WITHOUT persisting.
         match raw_workflow_from_spec(&spec) {
             Ok(raw) => {
-                if let Err(err) = courtesy_validate_draft(&raw, &self.ctx.company.record, None) {
+                if let Err(err) = courtesy_validate_draft(
+                    &raw,
+                    &self.ctx.company.record,
+                    Some(&self.ctx.company.wired_channels),
+                ) {
                     problems.push(err.to_string());
                 }
             }
@@ -477,9 +481,11 @@ impl Tool for ProposeWorkflowTool {
             if errors.is_empty() {
                 match raw_workflow_from_spec(&spec) {
                     Ok(raw) => {
-                        if let Err(err) =
-                            courtesy_validate_draft(&raw, &self.ctx.company.record, None)
-                        {
+                        if let Err(err) = courtesy_validate_draft(
+                            &raw,
+                            &self.ctx.company.record,
+                            Some(&self.ctx.company.wired_channels),
+                        ) {
                             errors.push(err.to_string());
                         }
                     }

--- a/src/harness/built_in/workflow_build/tools.rs
+++ b/src/harness/built_in/workflow_build/tools.rs
@@ -309,7 +309,7 @@ impl Tool for CheckWorkflowTool {
         // the same gate the create route runs, WITHOUT persisting.
         match raw_workflow_from_spec(&spec) {
             Ok(raw) => {
-                if let Err(err) = courtesy_validate_draft(&raw, &self.ctx.company.record) {
+                if let Err(err) = courtesy_validate_draft(&raw, &self.ctx.company.record, None) {
                     problems.push(err.to_string());
                 }
             }
@@ -477,7 +477,9 @@ impl Tool for ProposeWorkflowTool {
             if errors.is_empty() {
                 match raw_workflow_from_spec(&spec) {
                     Ok(raw) => {
-                        if let Err(err) = courtesy_validate_draft(&raw, &self.ctx.company.record) {
+                        if let Err(err) =
+                            courtesy_validate_draft(&raw, &self.ctx.company.record, None)
+                        {
                             errors.push(err.to_string());
                         }
                     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -5300,6 +5300,7 @@ mod test {
             runtime.store(),
             None,
             wf_draft("daily_digest", "Daily Digest"),
+            None,
         )
         .await
         .unwrap();

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -589,6 +589,7 @@ async fn apply_workflow_proposal(
         company.runtime.store(),
         Some(company.runtime.events()),
         draft,
+        None,
     )
     .await
     {

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -547,8 +547,15 @@ async fn delete_task(
 /// [`RawWorkflow`](crate::company::RawWorkflow) from the **stored** `ops` — the
 /// host is the authority, the browser's copy is never trusted — and runs it
 /// through [`create_company_workflow`], which takes the company write lock,
-/// re-validates shape + roster + id/name uniqueness, and (issue #276) lands any
-/// schedule-carrying graph switched off until a person arms it.
+/// re-validates shape + roster + destinations + id/name uniqueness, and (issue
+/// #276) lands any schedule-carrying graph switched off until a person arms it.
+///
+/// "The same validation an editor save runs" is the whole contract here, and
+/// until issue #1191 it was not true: the channel-destination rule lived on the
+/// two write routes rather than in the shared core, so this path — the ONE path
+/// where the operator did not author the graph, the path #836 exists because of
+/// — was the path with no check. A proposal naming a channel nobody wired was
+/// persisted and the card marked Done.
 ///
 /// On success the card is stamped with a [`TaskOutput`] linking the created
 /// workflow to the build attempt (issue #339) and moved to **Done**, and the
@@ -583,13 +590,19 @@ async fn apply_workflow_proposal(
     })?;
     let draft = raw_workflow_from_spec(&spec)?;
 
+    // Issue #1191: the deliverable channel set, read off the SAME runtime the
+    // console's destination picker is served from. Apply is a save, and it used
+    // to be the one save that skipped the channel rule — so a proposal naming a
+    // channel nobody wired was persisted, the card was marked Done, and the
+    // resulting workflow could not be saved again from the editor without first
+    // fixing a destination the operator never chose.
     let file = match create_company_workflow(
         company.id(),
         company.runtime.source_dir(),
         company.runtime.store(),
         Some(company.runtime.events()),
         draft,
-        None,
+        Some(&company.runtime.deliverable_channel_ids()),
     )
     .await
     {

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -757,6 +757,7 @@ async fn create_workflow(
         company.runtime.store(),
         Some(company.runtime.events()),
         draft,
+        None,
     )
     .await
     .map_err(ApiError)?;
@@ -875,6 +876,7 @@ async fn update_workflow(
         Some(company.runtime.events()),
         draft,
         Some(expected.as_str()),
+        None,
     )
     .await
     .map_err(ApiError)?;

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -683,54 +683,6 @@ impl TryFrom<CreateWorkflowBody> for RawWorkflow {
     }
 }
 
-/// Rejects a draft whose `output` node routes its report to a channel this
-/// runtime cannot deliver to (issue #981).
-///
-/// The delivery layer already refuses such a target at run time with a
-/// `ChannelNotWired` row, and that row stays — desks come and go, so a graph
-/// valid at save can be invalid at run, and this is a guard rather than a
-/// guarantee. What it removes is the case the QA pass found: a workflow saved
-/// against `operator`, which delivery refuses **by name** on every runtime and
-/// so can never succeed, discovered only after a scheduled run nobody watched
-/// silently dropped its report.
-///
-/// Both write routes run it, from the same set the destination picker is served
-/// from and with the same sentence the failed delivery would have carried, so
-/// an author who trips it is told what a run would have told them.
-///
-/// Deliberately narrow. A missing target, a `destination` on a non-`output`
-/// node and an unknown `kind` are [`parse_workflow`](crate::company::parse_workflow)'s
-/// to report — it says something more specific about each, and reporting the
-/// wrong problem first is worse than reporting it second. This is also NOT run
-/// at TOML parse time: seed templates are parsed with no runtime in hand, and
-/// checking there would refuse to boot a template on a company whose desks are
-/// not resolved yet.
-fn reject_undeliverable_channel_destinations(
-    company: &ScopedCompany,
-    draft: &RawWorkflow,
-) -> Result<(), ApiError> {
-    let deliverable = company.runtime.deliverable_channel_ids();
-    for node in &draft.nodes {
-        let Some(destination) = &node.destination else {
-            continue;
-        };
-        if destination.kind.trim() != "channel" || node.kind.trim() != "output" {
-            continue;
-        }
-        let target = destination.target.as_deref().map(str::trim).unwrap_or("");
-        if target.is_empty() || deliverable.iter().any(|id| id == target) {
-            continue;
-        }
-        let live: Vec<&str> = deliverable.iter().map(String::as_str).collect();
-        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-            "node `{}`: {}",
-            node.id,
-            crate::runtime::undeliverable_channel_message(target, &live)
-        ))));
-    }
-    Ok(())
-}
-
 /// `POST …/workflows` — authors a new workflow graph (issues #69, #112, #168):
 /// the console's form creator, or any direct API caller, posts the graph shape
 /// and it is persisted on the company record.
@@ -750,14 +702,13 @@ async fn create_workflow(
     Json(body): Json<CreateWorkflowBody>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
     let draft = RawWorkflow::try_from(body)?;
-    reject_undeliverable_channel_destinations(&company, &draft)?;
     let file = create_company_workflow(
         company.id(),
         company.runtime.source_dir(),
         company.runtime.store(),
         Some(company.runtime.events()),
         draft,
-        None,
+        Some(&company.runtime.deliverable_channel_ids()),
     )
     .await
     .map_err(ApiError)?;
@@ -867,7 +818,6 @@ async fn update_workflow(
         )));
     };
     let draft = RawWorkflow::try_from(body.graph)?;
-    reject_undeliverable_channel_destinations(&company, &draft)?;
     let file = update_company_workflow(
         company.id(),
         company.runtime.source_dir(),
@@ -876,7 +826,7 @@ async fn update_workflow(
         Some(company.runtime.events()),
         draft,
         Some(expected.as_str()),
-        None,
+        Some(&company.runtime.deliverable_channel_ids()),
     )
     .await
     .map_err(ApiError)?;
@@ -4334,6 +4284,64 @@ mod tests {
                 "{message}"
             );
             assert!(message.contains("engineering"), "{message}");
+        }
+
+        /// Issue #1191: the refusal is the SAME envelope every sibling node-config
+        /// rule answers with — `workflow_invalid` plus a `problems` array whose
+        /// entry names the node and the field.
+        ///
+        /// It used to be `invalid_request` with no array at all, because the rule
+        /// sat outside the `problems` accumulator on the write route. So the
+        /// console, which reads `problems` to highlight the offending node
+        /// (#1123), got a flat banner for exactly the class of error #836 was
+        /// filed about. Asserting the envelope rather than the sentence is the
+        /// point: the sentence never changed.
+        #[tokio::test]
+        async fn an_undeliverable_channel_answers_with_a_located_problem() {
+            let home_dir = home();
+            let state = desk_state(home_dir.path()).await;
+
+            let response = post_create(
+                state,
+                body_with_destination("channel", Some("engineering-desk")),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = json_body(response).await;
+            assert_eq!(body["code"], "workflow_invalid", "{body}");
+            assert_eq!(body["problems"][0]["node_id"], "done", "{body}");
+            assert_eq!(body["problems"][0]["field"], "destination.target", "{body}");
+            assert!(
+                body["problems"][0]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("is not a workflow delivery channel"),
+                "{body}"
+            );
+        }
+
+        /// The sibling rule on the same field: a `channel` destination with no
+        /// `target` is located too (issue #1191). It was always a
+        /// `workflow_invalid`, but the entry carried `node_id: null` and
+        /// `field: null` because the load path mints it as a flat string.
+        #[tokio::test]
+        async fn a_channel_destination_with_no_target_is_located_too() {
+            let home_dir = home();
+            let state = desk_state(home_dir.path()).await;
+
+            let response = post_create(state, body_with_destination("channel", None)).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = json_body(response).await;
+            assert_eq!(body["code"], "workflow_invalid", "{body}");
+            assert_eq!(body["problems"][0]["node_id"], "done", "{body}");
+            assert_eq!(body["problems"][0]["field"], "destination.target", "{body}");
+            assert!(
+                body["problems"][0]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("name the channel to post the report to"),
+                "{body}"
+            );
         }
 
         /// The guard refuses what delivery would refuse and nothing more: a real

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -7635,6 +7635,157 @@ async fn a_proposal_that_fails_validation_keeps_the_card_in_review() {
     );
 }
 
+/// A company with one desk, so its runtime deliverable set is exactly
+/// `["engineering"]` — enough to tell a channel target that works from one that
+/// does not (issue #1191).
+fn desk_manifest() -> CompanyManifest {
+    toml::from_str(
+        "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+         [[group_chat]]\nid = \"engineering\"\nname = \"Engineering\"\nmembers = [\"ceo\"]\n\
+         [policy]\nmode = \"full\"\n",
+    )
+    .unwrap()
+}
+
+/// [`digest_ops`], with the output node posting its report to `target`.
+fn digest_ops_posting_to(target: &str) -> Value {
+    json!({
+        "id": "weekly-digest",
+        "name": "Weekly digest",
+        "description": "Post the weekly digest",
+        "nodes": [
+            { "id": "start", "kind": "trigger", "name": "Start" },
+            { "id": "write", "kind": "agent", "name": "Draft it", "agent": "ceo" },
+            {
+                "id": "post_summary",
+                "kind": "output",
+                "name": "Post to engineering desk",
+                "destination": { "kind": "channel", "target": target }
+            }
+        ],
+        "edges": [
+            { "from": "start", "to": "write" },
+            { "from": "write", "to": "post_summary" }
+        ]
+    })
+}
+
+/// **The #1191 regression.** The builder appended `-desk` to a desk's display
+/// name, so the proposal routed its report to `engineering-desk` — not a channel
+/// this runtime can deliver to.
+///
+/// Apply used to persist it: the operator was told "Workflow created — the card
+/// is done", the card flipped to Done, and the workflow that now existed could
+/// never deliver and could not be saved again from the editor without first
+/// fixing a destination the operator never chose. Apply is a save, and it is now
+/// held to the save rule — with the located `workflow_invalid` envelope, so the
+/// console can say WHICH node.
+#[tokio::test]
+async fn applying_a_proposal_with_an_unwired_channel_is_refused_and_keeps_the_card_in_review() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_manifest(&home, desk_manifest()).await;
+    let id = seed_proposal_card(&state, digest_ops_posting_to("engineering-desk")).await;
+
+    let (status, body) = send(
+        &state,
+        "POST",
+        &format!("/api/v1/company/tasks/{id}/workflow-proposal/apply"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["code"], "workflow_invalid", "{body}");
+    let problem = body["problems"]
+        .as_array()
+        .unwrap_or_else(|| panic!("the refusal must carry a breakdown: {body}"))
+        .iter()
+        .find(|p| p["node_id"] == "post_summary")
+        .unwrap_or_else(|| panic!("no problem names the output node: {body}"));
+    assert_eq!(problem["field"], "destination.target", "{body}");
+    assert!(
+        problem["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("is not a workflow delivery channel"),
+        "{body}"
+    );
+
+    // The card is recoverable, exactly as it is for roster drift: still In
+    // Review, still carrying its proposal, with the reason on its note.
+    let (_status, card) = send(&state, "GET", &format!("/api/v1/company/tasks/{id}"), None).await;
+    assert_eq!(card["task"]["column"], "in_review", "{card}");
+    assert!(card["task"].get("workflowProposal").is_some(), "{card}");
+    assert!(
+        card["task"]["note"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("still waiting for review"),
+        "{card}"
+    );
+
+    // …and nothing was persisted.
+    let (_status, workflows) = send(&state, "GET", "/api/v1/company/workflows", None).await;
+    assert!(
+        workflows
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|w| w["id"] != "weekly-digest"),
+        "a refused apply must not leave a workflow behind: {workflows}"
+    );
+}
+
+/// The invariant the defect broke, stated directly: whatever apply persists,
+/// the ordinary editor save route accepts back unchanged.
+///
+/// Before #1191 these two routes gave opposite answers to the same bytes —
+/// apply created the graph and `PUT` refused it — so the operator's first edit
+/// of a copilot-built workflow was blocked on a destination they never chose.
+#[tokio::test]
+async fn an_applied_proposal_can_be_saved_again_unchanged() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_manifest(&home, desk_manifest()).await;
+    let id = seed_proposal_card(&state, digest_ops_posting_to("engineering")).await;
+
+    let (status, card) = send(
+        &state,
+        "POST",
+        &format!("/api/v1/company/tasks/{id}/workflow-proposal/apply"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{card}");
+    assert_eq!(card["column"], "done");
+
+    // Read the created graph back and save it straight to the editor's route,
+    // byte-for-byte, with its own version token.
+    let (status, graph) = send(
+        &state,
+        "GET",
+        "/api/v1/company/workflows/weekly-digest",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{graph}");
+
+    let mut body = graph.clone();
+    body["expectedVersion"] = graph["version"].clone();
+    let (status, saved) = send(
+        &state,
+        "PUT",
+        "/api/v1/company/workflows/weekly-digest",
+        Some(body),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "what apply persists, the editor must accept back unchanged: {saved}"
+    );
+}
+
 /// Rejecting a proposal returns the card to To-do and clears the proposal
 /// (decision D2c). The card keeps its `workflow` deliverable, so it can be built
 /// again.


### PR DESCRIPTION
## Summary

Closes #1191.

Applying a workflow proposal from a task card persisted a graph that `PUT …/workflows`
refuses. The operator was told **"Workflow created — the card is done"**, the card
flipped to **Done**, and the resulting workflow could never deliver its report.

Found in the 2026-08-20 QA pass and reproduced end to end: the builder proposed an
output node targeting `engineering-desk` (it appended `-desk` to the desk's display
name; the wired id is `engineering`), Apply succeeded, and reading that graph back and
`PUT`ting it unchanged answered:

```
node `post_summary`: `engineering-desk` is not a workflow delivery channel
  — this runtime has: engineering, product_design, go_to_market
```

Same bytes, two routes, opposite answers.

**The reported repro was one symptom of a misplaced rule.**
`reject_undeliverable_channel_destinations` lived in the server-ops layer and was
called from only `create_workflow` and `update_workflow`, so **three of five authoring
paths skipped it** — proposal-apply, the orchestrator's `create_workflow` tool, and the
agent `update_workflow` tool.

The exclusion was deliberate and written down: the deliverable set is a property of the
*running* company, not of its record. But that is an argument about **data
availability, not correctness of placement** — and #1046 already overruled it in the
same file by threading `mail_configured` / `wired_channels` in, with the caller reading
them off the runtime. This does the same for channels.

## API Or Behavior Changes

- The channel-delivery rule now lives in `validate_draft_against_record`, the shared
  authoring core. The route-layer copy is **deleted** — one rule, one place, so a
  fourth caller cannot silently skip it.
- **Proposal-apply now refuses an unreachable destination.** The existing `Err` arm
  already appended the reason to the card note and kept the card In Review, so the
  Done-for-broken-work state dies with no change to that arm.
- **The refusal envelope changed for this rule**, from `invalid_request` with no detail
  to `workflow_invalid` with a located `problems[]` entry (`node_id`,
  `field: "destination.target"`). That flip is the fix, not an incidental: it is what
  lets the editor anchor the failure to a node. Existing assertions were updated
  deliberately, one at a time.
- **The `channel`-with-no-target message is now located too.** It was minted as a flat
  `String` inside `parse_workflow`, which converts with `node_id: None, field: None` —
  a locator was structurally impossible from that source. The sentence is lifted into a
  shared constructor called by both `parse_workflow` (still the flat backstop for
  seed/legacy on-disk graphs) and a new author-time arm. Only the two `channel` arms
  moved; `owner`/`email`/unknown-kind stay put, because lifting those changes error
  ordering for multi-rule drafts.
- **The builder is now grounded.** `evidence_prompt` and `render_grounding_sections`
  gained a channel section listing the real ids "copied exactly" — the builder wrote
  `engineering-desk` because no list was ever handed to it. The empty set renders the
  honest fallback. `graph_contract` is untouched: it is the invariant contract, and
  per-company facts belong in the grounding sections.
- Because `courtesy_validate_draft` calls the same validator, **a doomed proposal now
  never reaches In Review at all** — the card settles to To-do naming the wired ids,
  and the copilot's `propose_workflow` tool returns the problem to the model, which can
  fix it inside the same turn.
- The console panel renders `ApiError.problems` beneath the sentence, exactly as
  `ProposalCard` already does. **No rule was added to the console** — it stops throwing
  host output away.

**No repair heuristic.** `engineering-desk` normalises to `engineering desk`, not
`engineering`, so a rewrite would need suffix-stripping or display labels. Silently
repointing an author's delivery target is worse than refusing — `resolve_agent_ids`
refused exactly this fuzziness on purpose.

**Known gap, left as status quo and made greppable:** the orchestrator and agent
`update_workflow` tools pass `wired_channels: None` — they hold no runtime handle. That
is today's behaviour, backstopped by the delivery-time `ChannelNotWired` refusal, and
each site carries a comment naming why. Follow-up issue rather than a TODO; pulling it
in means threading new constructor params through every test that builds those tools.

## Tests

- `applying_a_proposal_with_an_unwired_channel_is_refused_and_keeps_the_card_in_review`
  — the reported defect. Asserts 400, `workflow_invalid`, a problem located at
  `post_summary` / `destination.target`, card still `in_review`, proposal intact,
  workflow absent. **On main: apply returns 200 and the card is `done`.**
- `an_applied_proposal_can_be_saved_again_unchanged` — apply, GET the graph, PUT it
  back untouched with its own `expectedVersion`. **On main: 200 then 400.** This tests
  the *invariant*, so it catches the next rule bolted onto a route instead of the core.
- Route tests extended to assert the envelope (`workflow_invalid` + located
  `problems[0]`), not just the sentence; the no-target case now carries `node_id` and
  `field`.
- Validator units: `None` accepts an unwired target (proving the agent-tool paths are
  unchanged), `Some(&["engineering"])` refuses `engineering-desk`, `Some(&[])` refuses
  any target.
- Builder tests: a model answer naming an unwired channel settles the card to To-do
  with the wired ids named; prompt-grounding tests pin the ids and "copied exactly",
  plus the empty-set fallback.

Gates, exit codes read unpiped, after rebase onto current `main`: `cargo check`,
`cargo fmt --all -- --check`, `cargo clippy --all-targets --no-deps -D warnings`, and
the same clippy on `--features openhuman,tinycortex` — all 0. Scoped `--lib`:
`company::workflow_create` 88, `server::ops::workflows` 111, `server::ops::write_test`
131, and on the gated lane `harness::workflow_build` 58, `harness::workflow_admin` 14.
Console: `typecheck`, `typecheck:unit`, `typecheck:e2e`, `build` all 0, `vitest run`
**143 files / 1377 tests**.

The console panel's own render is guarded by the compiler and by reading, not by a
component test — this console has no component-test harness
(`task-workflow-proposal.test.ts` covers the diff adapter, not the panel). Saying that
plainly rather than implying coverage that does not exist.

## Documentation

`docs/modules/server/workflow-routes.md` and `docs/spec/runtime/workflow-build.md`.

**Interaction with PR #1155**, already raised on that PR: its new
`POST …/workflows/validate` route runs `courtesy_validate_draft` and promises
"byte-for-byte the 400 Create would answer with". After this change that holds only
when its handler passes the wired-channel set; with `None` it would answer
`200 {"valid": true}` for a draft Create refuses — the same-bytes-two-routes shape,
recreated on a new route. Its handler already holds a `ScopedCompany`, so it is one
argument. No dependency either way; whichever lands second rebases and re-runs the
gates.

The broken `weekly-merged-pr-summary` workflow this fix was found through is still on
the smoke1 tenant. This change is preventive — a still-failing `PUT` on that graph is
the rule working, not the fix failing.
