### PR TITLE
fix(console): show a boot state instead of a white flash before React mounts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,11 +21,16 @@
     <!--
       Boot placeholder, replaced by React on mount.
 
-      A hosted company scales to zero when idle, so the first request to a quiet
-      one is *held* by the platform while its pod boots — measured at 8-13s. For
-      that whole window the browser has an empty document: no bundle, no React,
-      not even the theme. The page rendered plain white and was indistinguishable
-      from a broken deployment (#1241).
+      Covers the window between the HTML arriving and React mounting, when the
+      browser has a document but no bundle, no React and not even the theme —
+      so it would otherwise paint plain white.
+
+      It does NOT cover a cold start, and that limit is worth stating here so
+      nobody assumes otherwise. A hosted company scales to zero when idle and the
+      platform *holds* the request while its pod boots: measured TTFB on a parked
+      tenant is 8.2s, and this markup lives inside the HTML that has not arrived
+      yet. Fixing that needs a holding response from something that is always up
+      — the edge, or the manager's proxy — not the console (#1241).
 
       This is deliberately inert: inline styles and markup only, no script and no
       stylesheet link, so it paints on the first byte of HTML rather than waiting
@@ -50,7 +55,7 @@
           animation:boot-spin .8s linear infinite; opacity:.55;
         "></div>
         <div>Waking this company&hellip;</div>
-        <div id="boot-hint" style="font-size:12px; opacity:.6;">Idle companies start on demand, which takes a few seconds.</div>
+        <div id="boot-hint" style="font-size:12px;">Idle companies start on demand, which takes a few seconds.</div>
         <div id="boot-slow" style="font-size:12px; opacity:0; max-width:34ch; text-align:center;">
           This is taking longer than a normal wake. If it does not finish, the
           company may have failed to start rather than be starting.
@@ -64,13 +69,18 @@
          message that says "waking" forever would be a worse lie than the blank
          page it replaces. 35s is comfortably past both the measured 8-13s wake
          and the manager's 30s startup timeout. */
-      @keyframes boot-reveal { to { opacity:.75 } }
+      @keyframes boot-reveal { to { opacity:1 } }
       @keyframes boot-fade   { to { opacity:0 } }
       #boot-slow { animation: boot-reveal .4s ease 35s forwards }
       #boot-hint { animation: boot-fade .4s ease 35s forwards }
       /* Reduced motion: keep the indicator, drop the spin. */
       @media (prefers-reduced-motion: reduce) {
+        /* The spinner is decorative, so it stops entirely. The status swap is
+           not — it carries the "may have failed" message — so it keeps its 35s
+           delay and loses only the fade. `animation: none` here would suppress
+           the reveal and leave the misleading copy up forever. */
         #boot [style*="boot-spin"] { animation: none !important }
+        #boot-slow, #boot-hint { animation-duration: 0s !important }
       }
       @media (prefers-color-scheme: dark) {
         #boot { background:#08090B !important; color:#8A8A9A !important }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,7 +18,64 @@
     -->
   </head>
   <body>
-    <div id="root"></div>
+    <!--
+      Boot placeholder, replaced by React on mount.
+
+      A hosted company scales to zero when idle, so the first request to a quiet
+      one is *held* by the platform while its pod boots — measured at 8-13s. For
+      that whole window the browser has an empty document: no bundle, no React,
+      not even the theme. The page rendered plain white and was indistinguishable
+      from a broken deployment (#1241).
+
+      This is deliberately inert: inline styles and markup only, no script and no
+      stylesheet link, so it paints on the first byte of HTML rather than waiting
+      for anything else to load. It matches the app's own `--surface-*-bg`
+      primitives and follows `prefers-color-scheme`, so the handover to the real
+      shell is not a flash of a different colour.
+
+      The copy says "waking" rather than "loading" because that is the true
+      claim: nothing is broken and nothing is slow, a machine is being started.
+    -->
+    <div id="root">
+      <div id="boot" style="
+        position:fixed; inset:0; display:flex; flex-direction:column;
+        align-items:center; justify-content:center; gap:14px;
+        background:#F7F7FC; color:#6B6B7B;
+        font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+        font-size:14px; letter-spacing:.01em;
+      ">
+        <div style="
+          width:22px; height:22px; border-radius:50%;
+          border:2px solid currentColor; border-top-color:transparent;
+          animation:boot-spin .8s linear infinite; opacity:.55;
+        "></div>
+        <div>Waking this company&hellip;</div>
+        <div id="boot-hint" style="font-size:12px; opacity:.6;">Idle companies start on demand, which takes a few seconds.</div>
+        <div id="boot-slow" style="font-size:12px; opacity:0; max-width:34ch; text-align:center;">
+          This is taking longer than a normal wake. If it does not finish, the
+          company may have failed to start rather than be starting.
+        </div>
+      </div>
+    </div>
+    <style>
+      @keyframes boot-spin { to { transform: rotate(360deg) } }
+      /* After a wake budget's worth of waiting, stop claiming this is normal.
+         Done in CSS rather than script so the placeholder stays inert: a
+         message that says "waking" forever would be a worse lie than the blank
+         page it replaces. 35s is comfortably past both the measured 8-13s wake
+         and the manager's 30s startup timeout. */
+      @keyframes boot-reveal { to { opacity:.75 } }
+      @keyframes boot-fade   { to { opacity:0 } }
+      #boot-slow { animation: boot-reveal .4s ease 35s forwards }
+      #boot-hint { animation: boot-fade .4s ease 35s forwards }
+      /* Reduced motion: keep the indicator, drop the spin. */
+      @media (prefers-reduced-motion: reduce) {
+        #boot [style*="boot-spin"] { animation: none !important }
+      }
+      @media (prefers-color-scheme: dark) {
+        #boot { background:#08090B !important; color:#8A8A9A !important }
+      }
+    </style>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,33 @@
         };
       </script>
     -->
+    <style>
+      /* Styles for the boot placeholder in <body>. In <head> so they are
+         guaranteed parsed before the markup they target. Only keyframes and
+         state live here — the first paint is carried by inline styles, so the
+         placeholder still renders if this block is ever dropped. */
+      @keyframes boot-spin { to { transform: rotate(360deg) } }
+      /* After a wake budget's worth of waiting, stop claiming this is normal.
+         Done in CSS rather than script so the placeholder stays inert: a
+         message that says "waking" forever would be a worse lie than the blank
+         page it replaces. 35s is comfortably past both the measured 8-13s wake
+         and the manager's 30s startup timeout. */
+      @keyframes boot-reveal { to { opacity:1 } }
+      @keyframes boot-fade   { to { opacity:0 } }
+      #boot-slow { animation: boot-reveal .4s ease 35s forwards }
+      #boot-hint { animation: boot-fade .4s ease 35s forwards }
+      @media (prefers-reduced-motion: reduce) {
+        /* The spinner is decorative, so it stops entirely. The status swap is
+           not — it carries the "may have failed" message — so it keeps its 35s
+           delay and loses only the fade. `animation: none` here would suppress
+           the reveal and leave the misleading copy up forever. */
+        #boot-spinner { animation: none !important }
+        #boot-slow, #boot-hint { animation-duration: 0s !important }
+      }
+      @media (prefers-color-scheme: dark) {
+        #boot { background:#08090B !important; color:#8A8A9A !important }
+      }
+    </style>
   </head>
   <body>
     <!--
@@ -35,8 +62,11 @@
       This is deliberately inert: inline styles and markup only, no script and no
       stylesheet link, so it paints on the first byte of HTML rather than waiting
       for anything else to load. It matches the app's own `--surface-*-bg`
-      primitives and follows `prefers-color-scheme`, so the handover to the real
-      shell is not a flash of a different colour.
+      primitives and follows `prefers-color-scheme`, which is what the app itself
+      defaults to (`main.tsx`: `defaultTheme="system" enableSystem`). A reader who
+      has explicitly overridden the theme has that choice persisted in
+      `localStorage`, which only a script could read — so for them the handover
+      can still flash. Matching the majority case without a script is the trade.
 
       The copy says "waking" rather than "loading" because that is the true
       claim: nothing is broken and nothing is slow, a machine is being started.
@@ -49,7 +79,7 @@
         font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
         font-size:14px; letter-spacing:.01em;
       ">
-        <div style="
+        <div id="boot-spinner" style="
           width:22px; height:22px; border-radius:50%;
           border:2px solid currentColor; border-top-color:transparent;
           animation:boot-spin .8s linear infinite; opacity:.55;
@@ -62,30 +92,6 @@
         </div>
       </div>
     </div>
-    <style>
-      @keyframes boot-spin { to { transform: rotate(360deg) } }
-      /* After a wake budget's worth of waiting, stop claiming this is normal.
-         Done in CSS rather than script so the placeholder stays inert: a
-         message that says "waking" forever would be a worse lie than the blank
-         page it replaces. 35s is comfortably past both the measured 8-13s wake
-         and the manager's 30s startup timeout. */
-      @keyframes boot-reveal { to { opacity:1 } }
-      @keyframes boot-fade   { to { opacity:0 } }
-      #boot-slow { animation: boot-reveal .4s ease 35s forwards }
-      #boot-hint { animation: boot-fade .4s ease 35s forwards }
-      /* Reduced motion: keep the indicator, drop the spin. */
-      @media (prefers-reduced-motion: reduce) {
-        /* The spinner is decorative, so it stops entirely. The status swap is
-           not — it carries the "may have failed" message — so it keeps its 35s
-           delay and loses only the fade. `animation: none` here would suppress
-           the reveal and leave the misleading copy up forever. */
-        #boot [style*="boot-spin"] { animation: none !important }
-        #boot-slow, #boot-hint { animation-duration: 0s !important }
-      }
-      @media (prefers-color-scheme: dark) {
-        #boot { background:#08090B !important; color:#8A8A9A !important }
-      }
-    </style>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Closes #1241.

## The problem

Open a hosted company that has been idle and the browser sits on a **blank white
page** for several seconds — no spinner, no message, nothing. It then renders
fine.

Reported as `marketing.staging.opencompany.work` looking broken next to
`smoke1.staging.opencompany.work`. Nothing was broken: `smoke1` is polled
continuously so it is always awake; `marketing` had to cold-start.

Hosted companies scale to zero when idle
(opencompany-microservice#19), so the first request to a quiet one is *held*
while the pod boots. Measured on staging: **8–13s**. For that entire window the
browser has an empty document — no bundle, no React, not even the theme, which
is why it is white rather than dark.

Caught mid-load, the sequence is visible:

```
t+0     blank white     index.html still in flight
t+~8s   shell renders   "0 PILLARS", "Loading…"
t+~10s  full graph      "3 PILLARS"
```

## Why it is worth fixing rather than accepting

Every other layer already knows cold starts happen — the edge nginx carries

```
# Must exceed the manager's OCM_STARTUP_TIMEOUT_SECONDS (30s) so a cold
# tenant wake (0 -> 1) does not 504 at the edge before the manager
# finishes booting the pod.
proxy_read_timeout 120s;
```

The console was the only layer with no notion of it, so it presented "waking" and
"down" identically. That is the same distinction #19 phase 5 spent real effort
making legible at the API layer (typed 503 + `Retry-After` instead of a masked
500) — missing in the one place a person actually looks.

## The change

One file. A boot placeholder inside `#root`, which `createRoot` replaces on first
render.

**Deliberately inert** — inline styles and markup, no script, no stylesheet link.
It paints on the first byte of HTML, which matters because the white window is
precisely the period when nothing else has loaded. It uses the app's own
`--surface-*-bg` values (`#F7F7FC` / `#08090B`) and follows
`prefers-color-scheme`, so handover to the real shell is not a flash of a
different colour.

**Copy says "waking", not "loading"** — that is the true claim. Nothing is broken
and nothing is slow; a machine is being started.

## The bit worth reviewing

**After 35s it stops claiming this is normal.** A placeholder saying "waking"
forever would be a *worse* lie than the blank page it replaces — someone whose
company genuinely failed to start would sit reading a reassuring message
indefinitely.

Done with a delayed CSS animation rather than script, so the placeholder stays
inert. 35s is past both the measured wake and the manager's 30s startup timeout.
`prefers-reduced-motion` keeps the indicator and drops the spin.

## Verification

- `npm run build` passes (`tsc -b && vite build`)
- the placeholder is present in `dist/index.html`, ahead of the deferred
  `type="module"` bundle
- serving the built output confirms React clears it on mount with nothing left
  behind

## Not a regression

Scale-to-zero has been in place since phase 1 and the console has never had a
first-paint state. It became noticeable because tenants now sit parked far more
of the time — **75.7%** across the staging fleet over three days of sampling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading screen with a spinner and “Waking this company…” message during startup.
  * Displays a slow-start warning if loading takes longer than 35 seconds.
  * Added support for dark mode and reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->