### PR TITLE
fix(harness): baseline teammate steps aside for a company-authored tie

### DIFF
--- a/src/harness/built_in/planning.rs
+++ b/src/harness/built_in/planning.rs
@@ -1884,29 +1884,48 @@ fn resolve_assignee_candidates(
 /// baseline teammates, or between two company teammates, carries no such
 /// signal and is left untouched — issue #1106's park-and-ask stands for both.
 ///
-/// A candidate id that does not resolve to a manifest agent (a desk, or an
-/// overlay teammate — [`OverlayAgent`](crate::ports::types::OverlayAgent) has
-/// no `global` field, so it can never be one) counts as company-side: only a
-/// manifest agent explicitly marked `global` is baseline.
+/// A candidate id resolves to exactly one of three provenances: a manifest
+/// agent marked `global` is [`Baseline`](Provenance::Baseline); a manifest
+/// agent that is not, or an overlay teammate — which
+/// [`OverlayAgent`](crate::ports::types::OverlayAgent) can never be, having no
+/// `global` field at all — is [`Company`](Provenance::Company); anything else
+/// `resolve_assignee_candidates` could still have handed back (a desk) is
+/// neither. A desk is not the company's own choice of *teammate*, so its mere
+/// presence must not stand in for a real one: it neither triggers the drop nor
+/// is dropped by it, on either side of the tie.
+enum Provenance {
+    Baseline,
+    Company,
+}
+
+fn provenance_of(evidence: &Evidence, id: &str) -> Option<Provenance> {
+    if let Some(agent) = evidence.record.manifest.agents.iter().find(|a| a.id == id) {
+        return Some(if agent.global {
+            Provenance::Baseline
+        } else {
+            Provenance::Company
+        });
+    }
+    if evidence.record.overlay_agents.iter().any(|a| a.id == id) {
+        return Some(Provenance::Company);
+    }
+    None
+}
+
 fn prefer_company_over_baseline(
     evidence: &Evidence,
     candidates: Vec<AssigneeCandidate>,
 ) -> Vec<AssigneeCandidate> {
-    let is_baseline = |id: &str| {
-        evidence
-            .record
-            .manifest
-            .agents
-            .iter()
-            .find(|a| a.id == id)
-            .is_some_and(|a| a.global)
-    };
-    let has_company_side = candidates.iter().any(|c| !is_baseline(&c.id));
-    let has_baseline = candidates.iter().any(|c| is_baseline(&c.id));
-    if has_company_side && has_baseline {
+    let has_company = candidates
+        .iter()
+        .any(|c| matches!(provenance_of(evidence, &c.id), Some(Provenance::Company)));
+    let has_baseline = candidates
+        .iter()
+        .any(|c| matches!(provenance_of(evidence, &c.id), Some(Provenance::Baseline)));
+    if has_company && has_baseline {
         candidates
             .into_iter()
-            .filter(|c| !is_baseline(&c.id))
+            .filter(|c| !matches!(provenance_of(evidence, &c.id), Some(Provenance::Baseline)))
             .collect()
     } else {
         candidates

--- a/src/harness/built_in/planning.rs
+++ b/src/harness/built_in/planning.rs
@@ -352,6 +352,7 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
 
     let prerequisites = verify_prerequisites(&runtime, &evidence, &draft.prerequisites).await;
     let candidates = resolve_assignee_candidates(&evidence, &draft.assignee_candidates);
+    let candidates = prefer_company_over_baseline(&evidence, candidates);
     // Issue #1106. One surviving candidate is a proposal and behaves exactly as
     // it did before this change. Two or more is an open question, and a question
     // is not something to answer by taking the first element — so nothing is
@@ -692,6 +693,10 @@ struct TeammateBrief {
     description: Option<String>,
     /// Effective tool grants — namespace names only, never a credential.
     grants: Vec<String>,
+    /// Whether this teammate came from the global baseline rather than the
+    /// company's own roster (mirrors [`crate::company::types::Agent::global`]).
+    /// An overlay teammate is never global — it always has an author.
+    global: bool,
 }
 
 /// Everything the host gathered before the model was asked anything.
@@ -839,6 +844,7 @@ async fn gather_evidence(
             role: a.role.clone(),
             description: a.description.clone(),
             grants: crate::runtime::builder::agent_effective_grants(&allow, &a.tools),
+            global: a.global,
         })
         .collect();
     teammates.extend(
@@ -851,6 +857,7 @@ async fn gather_evidence(
                 role: overlay.role.clone(),
                 description: overlay.description.clone(),
                 grants: crate::runtime::builder::agent_effective_grants(&allow, &overlay.tools),
+                global: false,
             }),
     );
 
@@ -1345,6 +1352,9 @@ fn evidence_prompt(e: &Evidence) -> String {
         out.push_str(&format!("- `{}` — {} — may use: {grants}", t.id, t.role));
         if let Some(description) = &t.description {
             out.push_str(&format!(" — {description}"));
+        }
+        if t.global {
+            out.push_str(" — from the shared baseline");
         }
         out.push('\n');
     }
@@ -1860,6 +1870,47 @@ fn resolve_assignee_candidates(
         }
     }
     out
+}
+
+/// Issue #1196. Drops baseline candidates from a tie that also names a
+/// company-authored teammate.
+///
+/// `resolve_assignee_candidates` only validates names — it stays that way.
+/// This runs as a separate pass over its output because the tie it resolves
+/// is not about which name is real, it is about provenance: every company
+/// carries the same four baseline teammates ([`crate::globals`]), and when one
+/// of them ties against a role the company chose to staff itself, the company
+/// has already expressed the answer by staffing that role. A tie between two
+/// baseline teammates, or between two company teammates, carries no such
+/// signal and is left untouched — issue #1106's park-and-ask stands for both.
+///
+/// A candidate id that does not resolve to a manifest agent (a desk, or an
+/// overlay teammate — [`OverlayAgent`](crate::ports::types::OverlayAgent) has
+/// no `global` field, so it can never be one) counts as company-side: only a
+/// manifest agent explicitly marked `global` is baseline.
+fn prefer_company_over_baseline(
+    evidence: &Evidence,
+    candidates: Vec<AssigneeCandidate>,
+) -> Vec<AssigneeCandidate> {
+    let is_baseline = |id: &str| {
+        evidence
+            .record
+            .manifest
+            .agents
+            .iter()
+            .find(|a| a.id == id)
+            .is_some_and(|a| a.global)
+    };
+    let has_company_side = candidates.iter().any(|c| !is_baseline(&c.id));
+    let has_baseline = candidates.iter().any(|c| is_baseline(&c.id));
+    if has_company_side && has_baseline {
+        candidates
+            .into_iter()
+            .filter(|c| !is_baseline(&c.id))
+            .collect()
+    } else {
+        candidates
+    }
 }
 
 /// The note line a card parks with when the pass declined to choose.

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -1800,6 +1800,41 @@ async fn two_baseline_teammates_still_park_with_both() {
     );
 }
 
+/// Issue #1196. The prompt marks a baseline teammate as such, so the model
+/// has the provenance evidence directly — even on a pass where the host-side
+/// precedence never has to act on it, as here: one company teammate proposed,
+/// no tie in play.
+#[tokio::test]
+async fn the_prompt_marks_a_baseline_teammate_from_the_shared_baseline() {
+    let model = ScriptedModel::replying(CLEAN_PLAN);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-31", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-31".to_string()).await;
+
+    let prompt = model.last_prompt();
+    let writer_line = prompt
+        .lines()
+        .find(|l| l.contains("`writer`"))
+        .unwrap_or_else(|| panic!("the merged baseline puts `writer` on the roster:\n{prompt}"));
+    assert!(
+        writer_line.contains("— from the shared baseline"),
+        "{writer_line}"
+    );
+    let maya_line = prompt
+        .lines()
+        .find(|l| l.contains("`maya`"))
+        .unwrap_or_else(|| panic!("the company's own roster is still shown:\n{prompt}"));
+    assert!(
+        !maya_line.contains("— from the shared baseline"),
+        "a company-authored teammate is never mis-marked:\n{maya_line}"
+    );
+}
+
 /// Direct unit coverage of the precedence filter, independent of the planning
 /// pass and any one scripted model.
 #[test]

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -191,6 +191,7 @@ fn evidence() -> Evidence {
             role: a.role.clone(),
             description: a.description.clone(),
             grants: crate::runtime::builder::agent_effective_grants(&allow, &a.tools),
+            global: a.global,
         })
         .collect();
     Evidence {
@@ -1720,6 +1721,125 @@ async fn a_manifest_teammate_and_a_runtime_one_can_be_the_ambiguous_pair() {
         ids,
         vec!["maya".to_string(), "social_manager".to_string()],
         "the runtime teammate survives resolution exactly like the manifest one"
+    );
+}
+
+/// Issue #1196. A tie between a company-authored teammate and a baseline one
+/// is not the tie #1106 exists for: the company already expressed a
+/// preference by staffing its own `Writer` (`maya`), so the baseline `writer`
+/// (`globals/agents/writer.toml`, merged into every company's roster) steps
+/// aside and the card dispatches instead of parking. Mirrors issue #1196's own
+/// worked example — a company `Writer` tying against the global `writer`.
+#[tokio::test]
+async fn a_company_teammate_beats_a_baseline_tie_and_dispatches_without_parking() {
+    let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+        "verification":"v","scope":"s","assigneeCandidates":[
+          {"id":"maya","reason":"the company's own writer"},
+          {"id":"writer","reason":"the shared baseline writer"}]}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-29", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-29".to_string()).await;
+
+    let after = read(&runtime, "t-29").await;
+    assert_eq!(
+        after.column, COLUMN_IN_PROGRESS,
+        "the company's own pick dispatches rather than parking"
+    );
+    assert_eq!(after.assignee, "maya");
+    let plan = after.plan.expect("the brief is still written");
+    assert_eq!(
+        plan.proposed_assignee.as_deref(),
+        Some("maya"),
+        "the baseline candidate is dropped, leaving one proposal"
+    );
+    assert!(
+        plan.assignee_candidates.is_empty(),
+        "with one candidate left there is no ownership question to persist"
+    );
+}
+
+/// The baseline exists for a company that never staffed a role itself — so a
+/// tie between two baseline teammates carries no company preference and must
+/// keep parking exactly like #1106's original case.
+#[tokio::test]
+async fn two_baseline_teammates_still_park_with_both() {
+    let reply = r#"{"description":"do it","steps":[],"prerequisites":[],"risks":[],
+        "verification":"v","scope":"s","assigneeCandidates":[
+          {"id":"writer","reason":"could turn this into copy"},
+          {"id":"researcher","reason":"could dig up the source material first"}]}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-30", ""))
+        .await
+        .unwrap();
+
+    run_planning_pass(Arc::clone(&runtime), "t-30".to_string()).await;
+
+    let after = read(&runtime, "t-30").await;
+    assert_eq!(
+        after.column, COLUMN_TODO,
+        "neither baseline teammate outranks the other"
+    );
+    assert_eq!(after.assignee, "");
+    assert_eq!(
+        after
+            .plan
+            .expect("plan")
+            .assignee_candidates
+            .iter()
+            .map(|c| c.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["writer", "researcher"],
+        "both survive, the same as any other unresolved tie"
+    );
+}
+
+/// Direct unit coverage of the precedence filter, independent of the planning
+/// pass and any one scripted model.
+#[test]
+fn prefer_company_over_baseline_drops_only_a_true_mixed_tie() {
+    let mut evidence = evidence();
+    for agent in evidence.record.manifest.agents.iter_mut() {
+        if agent.id == "sam" {
+            agent.global = true;
+        }
+    }
+    let candidate = |id: &str| AssigneeCandidate {
+        id: id.to_string(),
+        reason: String::new(),
+    };
+
+    // A company teammate and a baseline one: the baseline is dropped.
+    let mixed = prefer_company_over_baseline(&evidence, vec![candidate("maya"), candidate("sam")]);
+    assert_eq!(
+        mixed.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+        vec!["maya"]
+    );
+
+    // A teammate and a desk: neither resolves to a baseline agent, so both
+    // count as company-side and the tie is untouched — #1106's case, and the
+    // reason an unresolved id (a desk) must default to company-side rather
+    // than silently misfiring as baseline.
+    let teammate_and_desk =
+        prefer_company_over_baseline(&evidence, vec![candidate("maya"), candidate("studio")]);
+    assert_eq!(
+        teammate_and_desk.len(),
+        2,
+        "no baseline teammate in the tie"
+    );
+
+    // A single baseline candidate, alone: nothing to prefer it over.
+    let solo_baseline = prefer_company_over_baseline(&evidence, vec![candidate("sam")]);
+    assert_eq!(
+        solo_baseline.len(),
+        1,
+        "a lone baseline candidate is not a tie"
     );
 }
 

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -1857,16 +1857,29 @@ fn prefer_company_over_baseline_drops_only_a_true_mixed_tie() {
         vec!["maya"]
     );
 
-    // A teammate and a desk: neither resolves to a baseline agent, so both
-    // count as company-side and the tie is untouched — #1106's case, and the
-    // reason an unresolved id (a desk) must default to company-side rather
-    // than silently misfiring as baseline.
+    // A teammate and a desk: no baseline teammate in the tie (the desk isn't
+    // one), so nothing is dropped — #1106's case.
     let teammate_and_desk =
         prefer_company_over_baseline(&evidence, vec![candidate("maya"), candidate("studio")]);
     assert_eq!(
         teammate_and_desk.len(),
         2,
         "no baseline teammate in the tie"
+    );
+
+    // A baseline teammate and a desk: a desk is not the company's own choice
+    // of *teammate*, so its presence must not stand in for one and silently
+    // knock the real baseline candidate out of a tie nobody actually resolved
+    // in the company's favour.
+    let baseline_and_desk =
+        prefer_company_over_baseline(&evidence, vec![candidate("sam"), candidate("studio")]);
+    assert_eq!(
+        baseline_and_desk
+            .iter()
+            .map(|c| c.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["sam", "studio"],
+        "a desk is neutral: it neither triggers the drop nor gets dropped by it"
     );
 
     // A single baseline candidate, alone: nothing to prefer it over.


### PR DESCRIPTION
## Summary

Closes #1196.

`gather_evidence` rendered a global/baseline teammate (`globals/agents/` —
`operations`, `page_builder`, `researcher`, `writer`) identically to a
teammate the company authored itself, so the planner could tie a company role
against the baseline padding every company carries. Since #1106, a tie parks
the card and asks a person — but a company that has already staffed a role
itself has already answered that question.

Per the issue thread's resolved shape (host-side precedence, not a prompt-only
nudge — see the discussion on #1196), this adds a `prefer_company_over_baseline`
pass, run right after `resolve_assignee_candidates` in `run_planning_pass`
(`src/harness/built_in/planning.rs`). It only acts when the candidate set mixes
a company-authored teammate with a baseline one: the baseline candidate(s) are
dropped, so the pass either collapses to a single proposal (dispatches, no
park) or, in the two-company or two-baseline cases, is untouched (still
parks — #1106 unchanged). `resolve_assignee_candidates` itself is untouched —
it still only validates names.

Also carries `Agent::global` into `TeammateBrief` and renders it in the
planner's roster prompt (`— from the shared baseline`), so the model has that
provenance as evidence too, even though the tie itself is resolved
host-side.

## API Or Behavior Changes

- A card whose plan ties a company-authored teammate against a global
  baseline teammate now dispatches to the company's own teammate instead of
  parking with an ownership question.
- A tie between two company teammates, or between two baseline teammates,
  behaves exactly as before (#1106: parks, both candidates recorded).
- The planning prompt's roster now marks baseline teammates with
  `— from the shared baseline`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --features openhuman -- -D warnings`
- [x] `cargo test --lib --features openhuman` (4657 passed, 0 failed)
- [ ] `cargo build --all-targets` (not run — `--lib` build/test/clippy covers the changed module; happy to run the full target set if CI flags a gap)

New/updated tests in `src/harness/built_in/planning/test.rs`:
- `a_company_teammate_beats_a_baseline_tie_and_dispatches_without_parking`
- `two_baseline_teammates_still_park_with_both`
- `prefer_company_over_baseline_drops_only_a_true_mixed_tie` (unit-level)

## Documentation

No docs reference this prompt behavior directly; none updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assignee selection when company-authored and baseline candidates are both eligible.
  * Company-authored candidates now take precedence in mixed ties, while ties among baseline candidates remain unresolved.
  * Cards with unresolved teammate or desk ties continue to be parked for review.
  * Added baseline provenance to planning context to improve assignment decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->