### PR TITLE
fix: a lone default acp harness no longer silently runs on the embedded engine

### DIFF
--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -118,6 +118,23 @@ impl CompanyManifest {
             .and_then(|h| h.inference)
     }
 
+    /// The full default `Harness`, resolved by [`default_harness_id`](Self::default_harness_id).
+    ///
+    /// Total, like `default_harness_id` — falls back to the implicit `built_in`
+    /// harness so this never panics on a manifest reached before validation.
+    /// Exists so callers that need more than the id (chiefly `kind`, to decide
+    /// whether the default lane is even runnable — see
+    /// [`lanes::build`](crate::harness::lanes::build)) do not each re-derive
+    /// the same "find by default id" lookup [`default_harness_inference`](Self::default_harness_inference)
+    /// already does.
+    pub fn default_harness(&self) -> Harness {
+        let default_id = self.default_harness_id();
+        self.effective_harnesses()
+            .into_iter()
+            .find(|h| h.id == default_id)
+            .unwrap_or_else(Harness::implicit)
+    }
+
     /// The harness `agent_id` runs on, resolving an unset binding to the
     /// default. `None` only when the named harness does not exist — which
     /// [`validate`](Self::validate) rejects, so a validated manifest always
@@ -1998,6 +2015,26 @@ mod harness_tests {
             "an agent naming no harness lands on the implicit one"
         );
         assert!(harness_problems(&manifest).is_empty());
+    }
+
+    /// `default_harness` resolves the same entry `default_harness_id` names,
+    /// full struct and all — for both the implicit `built_in` case and a
+    /// declared `acp` default. Pinned separately from `default_harness_id`
+    /// because `lanes::build` (issue #1244) reads `.kind` off this to decide
+    /// whether the default lane is even runnable; a lookup that silently
+    /// resolved to the wrong harness would reintroduce the bug that fixed.
+    #[test]
+    fn default_harness_resolves_the_full_declared_entry() {
+        let implicit = parse(BASE);
+        assert_eq!(implicit.default_harness().id, IMPLICIT_HARNESS_ID);
+        assert_eq!(implicit.default_harness().kind, "built_in");
+
+        let acp_default = parse(&format!(
+            "{BASE}\n[[harness]]\nid = \"laptop\"\nkind = \"acp\"\ndefault = true\n\n\
+             [harness.acp]\ntransport = \"local\"\nagent = \"claude\"\n"
+        ));
+        assert_eq!(acp_default.default_harness().id, "laptop");
+        assert_eq!(acp_default.default_harness().kind, "acp");
     }
 
     /// Naming a harness when none is declared is an error rather than a silent

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -194,6 +194,23 @@ pub struct HarnessBrain {
     unavailable: Vec<(String, String)>,
     /// The harness id agents naming none run on.
     default_harness: String,
+    /// Override for the default harness's engine, from
+    /// [`lanes::build`](crate::harness::lanes::build)'s resolution
+    /// (issue #1244).
+    ///
+    /// `None` — before [`Self::with_default_engine`] is ever called — means
+    /// "no override yet": [`Self::run_turn`] falls back to building the
+    /// embedded `built_in` engine from `pool`/`deps`, lazily, exactly as it
+    /// always did before named harnesses existed. That laziness matters: doing
+    /// it eagerly here in [`Self::new`] would hold a second `Arc` on `deps` for
+    /// the brain's whole lifetime, breaking every test (and any real caller)
+    /// that assumes the brain is `deps`'s sole holder before the first turn.
+    ///
+    /// Once set, `Some(engine)` is authoritative even when `engine` is itself
+    /// `None` — "this host cannot run the default harness", with the reason in
+    /// `unavailable` — which must win over the lazy built-in fallback, or the
+    /// exact silent-fallback bug #1244 fixed comes back.
+    default_engine: Option<Option<Arc<dyn RunTurn>>>,
     /// The LLM triage escalation, built on first use (issue #678).
     ///
     /// Lazy because it needs the company id, and a brain outlives any one
@@ -316,6 +333,7 @@ impl HarnessBrain {
             bindings,
             unavailable: Vec::new(),
             default_harness,
+            default_engine: None,
             record: std::sync::RwLock::new(Arc::new(record)),
             responder,
             runs: None,
@@ -342,21 +360,48 @@ impl HarnessBrain {
         self
     }
 
+    /// Overrides the default harness's engine with
+    /// [`lanes::build`](crate::harness::lanes::build)'s actual resolution —
+    /// `None` when this host cannot run it, which must win over the lazy
+    /// built-in fallback [`Self::run_turn`] otherwise takes (issue #1244).
+    /// Pass `lanes.default_engine` straight through; its accompanying
+    /// `unavailable` entry, if any, goes through
+    /// [`Self::with_unavailable_lanes`].
+    pub fn with_default_engine(mut self, default_engine: Option<Arc<dyn RunTurn>>) -> Self {
+        self.default_engine = Some(default_engine);
+        self
+    }
+
     /// The [`RunTurn`] this brain's turns go through.
     ///
-    /// With no extra lanes this is the default harness alone — byte-identical
-    /// behaviour to before named harnesses existed, and no routing table is
-    /// consulted. With lanes, it is a [`HarnessRouter`] that sends each agent's
-    /// turn to the harness it is bound to.
+    /// With no extra lanes and a runnable default this is the default engine
+    /// alone — byte-identical behaviour to before named harnesses existed, and
+    /// no routing table is consulted. Otherwise it is a [`HarnessRouter`] that
+    /// sends each agent's turn to the harness it is bound to; a `None` default
+    /// engine (from [`Self::with_default_engine`]) routes through it exactly
+    /// like any other unavailable harness, rather than falling back to the
+    /// lazily-built embedded engine (issue #1244).
     fn run_turn(&self) -> Arc<dyn RunTurn> {
-        let default_lane: Arc<dyn RunTurn> =
-            Arc::new(HarnessRunTurn::new(self.pool.clone(), self.deps.clone()));
-        if self.lanes.is_empty() && self.unavailable.is_empty() {
-            return default_lane;
+        // No override set — every test, and any pre-#1244 caller — falls back
+        // to building the embedded engine fresh, exactly as this always did.
+        // Lazy on purpose: building it eagerly in `new` would hold a second
+        // `Arc` on `deps` for the brain's whole lifetime.
+        let default_engine = self.default_engine.clone().unwrap_or_else(|| {
+            Some(
+                Arc::new(HarnessRunTurn::new(self.pool.clone(), self.deps.clone()))
+                    as Arc<dyn RunTurn>,
+            )
+        });
+
+        if self.lanes.is_empty()
+            && self.unavailable.is_empty()
+            && let Some(engine) = &default_engine
+        {
+            return engine.clone();
         }
         Arc::new(crate::harness::router::HarnessRouter::from_lanes(
             &self.default_harness,
-            default_lane,
+            default_engine,
             &self.lanes,
             &self.unavailable,
             &self.bindings,
@@ -9140,6 +9185,97 @@ kind = "built_in"
         assert!(brain.bindings.is_empty());
         assert_eq!(brain.default_harness, "default");
     }
+
+    /// Issue #1244: a company whose *only* declared harness is `kind = "acp"`
+    /// must not silently run turns on the embedded engine.
+    ///
+    /// Before the fix, `lanes::build`'s early return for a single declared
+    /// harness meant nobody ever asked what *kind* that lone harness was — the
+    /// caller (here, and identically in `RuntimeBuilder`) unconditionally built
+    /// a `HarnessRunTurn` from the shared pool regardless. This exercises the
+    /// real `lanes::build` output rather than a hand-simulated one, so a
+    /// regression in either `lanes::build` or `HarnessBrain::run_turn` fails it.
+    #[tokio::test]
+    async fn a_lone_acp_default_harness_does_not_silently_run_embedded() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest: CompanyManifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+
+[[harness]]
+id = "laptop"
+kind = "acp"
+default = true
+
+[harness.acp]
+transport = "local"
+agent = "claude"
+"#,
+        )
+        .expect("valid manifest");
+        let record = CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+        };
+
+        let brain = brain_over_mock_with(dir.path(), record);
+        let secrets: Arc<dyn crate::ports::SecretStore> =
+            Arc::new(crate::store::FsSecretStore::new(dir.path()));
+        let lanes = crate::harness::lanes::build(
+            &brain.record(),
+            Arc::new(HarnessPool::new()),
+            &brain.deps,
+            secrets,
+            None,
+        );
+
+        assert!(
+            lanes.default_engine.is_none(),
+            "an acp default harness has no built-in engine to fall back to"
+        );
+        assert!(
+            lanes.unavailable.iter().any(|(id, _)| id == "laptop"),
+            "the default harness's own id must carry the unavailable reason: {:?}",
+            lanes.unavailable
+        );
+
+        // Wire the brain exactly as `RuntimeBuilder` would, and confirm the
+        // turn actually fails instead of quietly answering from the embedded
+        // `MockProvider`.
+        let brain = brain
+            .with_lanes(lanes.lanes)
+            .with_unavailable_lanes(lanes.unavailable)
+            .with_default_engine(lanes.default_engine);
+
+        let err = brain
+            .run_turn()
+            .run(&CompanyId::new("acme"), "ceo", "hi", None)
+            .await
+            .expect_err("must not fall back to the embedded engine");
+        let msg = err.to_string();
+        assert!(msg.contains("ceo"), "{msg}");
+        assert!(msg.contains("laptop"), "{msg}");
+        assert!(msg.contains("ACP transport"), "names the fix: {msg}");
+    }
+
     /// Issue #966: a workflow-copilot reply is authored by the copilot.
     ///
     /// This is the assertion the #885 fix was missing on this branch. The bubble

--- a/src/harness/lanes.rs
+++ b/src/harness/lanes.rs
@@ -25,6 +25,16 @@
 //! unavailable with the reason, and a turn bound to it fails saying so. Falling
 //! back would be the worst outcome available — the turn would succeed, on a
 //! model and a credential nobody chose.
+//!
+//! This applies to the **default** harness exactly as much as a named one
+//! (issue #1244). It used to not: every caller built the default lane straight
+//! from `HarnessDeps`/`HarnessPool` on its own, without ever asking what kind
+//! the default harness actually was, so a company whose *only* declared
+//! harness was `kind = "acp"` still ran on the embedded engine — a silent
+//! fallback of exactly the kind this module's own doctrine forbids. Resolving
+//! the default the same way as every other harness, in this one place, is what
+//! closes that gap for good instead of leaving a second opinion for a future
+//! caller to reintroduce.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -38,14 +48,33 @@ use crate::ports::SecretStore;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::delegation::RunTurn;
 
+/// Why a declared harness of `kind` has no engine on this host — the one
+/// message both the default-harness path and the named-harness loop use, so
+/// they cannot drift into saying different things about the same gap.
+fn unavailable_reason(kind: &str) -> String {
+    match kind {
+        "acp" => "it is an ACP harness and this build has no ACP transport wired — \
+                  run it from the desktop app, or bind these agents to a `built_in` harness"
+            .to_string(),
+        other => format!("`{other}` is not a harness kind this build knows how to run"),
+    }
+}
+
 /// The engines a company's declared harnesses resolve to on this host.
 pub struct Lanes {
     /// Agents the **default** harness serves, when the company declares more
     /// than one. `None` means the whole roster — the single-harness case.
     pub default_serves: Option<HashSet<String>>,
+    /// The engine for the default harness itself, when this host can run it.
+    ///
+    /// `None` if and only if the default harness's id has a matching entry in
+    /// `unavailable` — callers must not substitute another engine in that
+    /// case; see the module docs.
+    pub default_engine: Option<Arc<dyn RunTurn>>,
     /// Every lane beyond the default: its harness id and the engine serving it.
     pub lanes: Vec<(String, Arc<dyn RunTurn>)>,
-    /// Declared harnesses this host cannot run, and why.
+    /// Declared harnesses this host cannot run, and why. Includes the default
+    /// harness's own id when `default_engine` is `None`.
     pub unavailable: Vec<(String, String)>,
 }
 
@@ -71,33 +100,44 @@ fn agents_on(record: &CompanyRecord, harness_id: &str, default_harness: &str) ->
     ids
 }
 
-/// Builds the lanes for `record`, given the deps the **default** harness runs
-/// on.
+/// Builds the lanes for `record`, given the shared pool and deps the
+/// **default** harness runs on when it is runnable at all.
 ///
-/// Returns no lanes at all for a company that declares no `[[harness]]` (or
-/// declares exactly one): there is nothing to route, and the caller keeps its
-/// single pool untouched. That is the path every existing company takes.
+/// `default_serves` is `None` — "the whole roster, no narrowing" — for a
+/// company that declares no `[[harness]]` (or declares exactly one): the
+/// byte-identical single-pool path every existing company takes. That stays
+/// true regardless of whether the default harness turns out to be runnable;
+/// what changed (issue #1244) is that `default_engine`/`unavailable` are now
+/// always resolved too, instead of every caller resolving the default
+/// separately (and inconsistently) on its own.
 pub fn build(
     record: &CompanyRecord,
+    pool: Arc<HarnessPool>,
     base: &HarnessDeps,
     secrets: Arc<dyn SecretStore>,
     env_default: Option<EnvDefault>,
 ) -> Lanes {
     let declared = record.manifest.effective_harnesses();
-    let default_harness = record.manifest.default_harness_id();
-
-    if declared.len() <= 1 {
-        return Lanes {
-            default_serves: None,
-            lanes: Vec::new(),
-            unavailable: Vec::new(),
-        };
-    }
+    let default_harness = record.manifest.default_harness();
+    let default_harness_id = default_harness.id.clone();
 
     let mut lanes = Vec::new();
     let mut unavailable = Vec::new();
 
-    for harness in declared.iter().filter(|h| h.id != default_harness) {
+    let default_engine = match default_harness.kind.as_str() {
+        // The base deps already resolved the default's own `[harness.inference]`
+        // precedence (`default_harness_inference`) before this was called —
+        // wrap them in the caller's shared pool exactly as it always did.
+        "built_in" => {
+            Some(Arc::new(HarnessRunTurn::new(pool, Arc::new(base.clone()))) as Arc<dyn RunTurn>)
+        }
+        kind => {
+            unavailable.push((default_harness_id.clone(), unavailable_reason(kind)));
+            None
+        }
+    };
+
+    for harness in declared.iter().filter(|h| h.id != default_harness_id) {
         match harness.kind.as_str() {
             "built_in" => lanes.push((
                 harness.id.clone(),
@@ -107,27 +147,22 @@ pub fn build(
                     &secrets,
                     env_default.clone(),
                     harness,
-                    &default_harness,
+                    &default_harness_id,
                 ),
             )),
-            // The ACP transports are supplied by the desktop shell (a stdio
-            // subprocess) and the runner lane (a socket); a server build has
-            // neither, so there is nothing to hand a turn to.
-            "acp" => unavailable.push((
-                harness.id.clone(),
-                "it is an ACP harness and this build has no ACP transport wired — \
-                 run it from the desktop app, or bind these agents to a `built_in` harness"
-                    .to_string(),
-            )),
-            other => unavailable.push((
-                harness.id.clone(),
-                format!("`{other}` is not a harness kind this build knows how to run"),
-            )),
+            kind => unavailable.push((harness.id.clone(), unavailable_reason(kind))),
         }
     }
 
+    let default_serves = if declared.len() <= 1 {
+        None
+    } else {
+        Some(agents_on(record, &default_harness_id, &default_harness_id))
+    };
+
     Lanes {
-        default_serves: Some(agents_on(record, &default_harness, &default_harness)),
+        default_serves,
+        default_engine,
         lanes,
         unavailable,
     }

--- a/src/harness/router.rs
+++ b/src/harness/router.rs
@@ -107,14 +107,25 @@ impl HarnessRouter {
     /// The single place both the brain and the workflow runner assemble a
     /// router from the same four pieces, so the two dispatch points cannot
     /// drift about which agent lands on which engine.
+    ///
+    /// `default_lane` is `None` when the default harness itself has no engine
+    /// on this host (e.g. an `acp` default with no ACP transport wired) — the
+    /// caller must have already recorded its reason in `unavailable`, keyed by
+    /// `default_harness` ([`lanes::build`](crate::harness::lanes::build)
+    /// guarantees this). `engine_for` then falls through to that entry the same
+    /// way it does for any other harness with no engine, instead of this
+    /// constructor silently substituting something.
     pub fn from_lanes(
         default_harness: &str,
-        default_lane: Arc<dyn RunTurn>,
+        default_lane: Option<Arc<dyn RunTurn>>,
         lanes: &[(String, Arc<dyn RunTurn>)],
         unavailable: &[(String, String)],
         bindings: &HashMap<String, String>,
     ) -> Self {
-        let mut router = Self::new(default_harness).with_engine(default_harness, default_lane);
+        let mut router = Self::new(default_harness);
+        if let Some(default_lane) = default_lane {
+            router = router.with_engine(default_harness, default_lane);
+        }
         for (id, engine) in lanes {
             router = router.with_engine(id, engine.clone());
         }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -31,8 +31,6 @@ use crate::feedback::tinyhumans::TinyHumansClient;
 use crate::feedback::tool::BuiltinToolProvider;
 use crate::feedback::types::ConsentMode;
 #[cfg(feature = "openhuman")]
-use crate::harness::built_in::run_turn::HarnessRunTurn;
-#[cfg(feature = "openhuman")]
 use crate::harness::provider::{HostedProviderConfig, TenantProvider};
 #[cfg(feature = "openhuman")]
 use crate::harness::router::HarnessRouter;
@@ -2655,6 +2653,7 @@ impl RuntimeBuilder {
                             // actually serves.
                             let lanes = crate::harness::lanes::build(
                                 &record,
+                                pool.clone(),
                                 &deps,
                                 secrets.clone(),
                                 env_default,
@@ -2676,27 +2675,40 @@ impl RuntimeBuilder {
                             // lane plus each named lane, indexed by agent. Shared
                             // by the brain and the workflow runner so they cannot
                             // disagree about which agent lands on which engine.
-                            let default_lane: Arc<dyn RunTurn> =
-                                Arc::new(HarnessRunTurn::new(pool.clone(), Arc::new(deps.clone())));
-                            let turn: Arc<dyn RunTurn> = if lanes.lanes.is_empty()
-                                && lanes.unavailable.is_empty()
-                            {
-                                default_lane
-                            } else {
-                                let default_harness = record.manifest.default_harness_id();
-                                let bindings: HashMap<String, String> = record
-                                    .manifest
-                                    .agents
-                                    .iter()
-                                    .filter_map(|a| a.harness.clone().map(|h| (a.id.clone(), h)))
-                                    .collect();
-                                Arc::new(HarnessRouter::from_lanes(
-                                    &default_harness,
-                                    default_lane,
-                                    &lanes.lanes,
-                                    &lanes.unavailable,
-                                    &bindings,
-                                ))
+                            //
+                            // `default_engine` is `lanes::build`'s call, not ours
+                            // (issue #1244): a non-`built_in` default harness
+                            // resolves to `None` there, with its own reason
+                            // already folded into `lanes.unavailable` — this must
+                            // not paper over that with a `HarnessRunTurn` built
+                            // straight from `pool`/`deps` the way it used to.
+                            let default_engine = lanes.default_engine.clone();
+                            let turn: Arc<dyn RunTurn> = match (
+                                &default_engine,
+                                lanes.lanes.is_empty(),
+                                lanes.unavailable.is_empty(),
+                            ) {
+                                // The byte-identical single-pool path: a lone
+                                // `built_in` default, nothing else declared.
+                                (Some(engine), true, true) => engine.clone(),
+                                _ => {
+                                    let default_harness = record.manifest.default_harness_id();
+                                    let bindings: HashMap<String, String> = record
+                                        .manifest
+                                        .agents
+                                        .iter()
+                                        .filter_map(|a| {
+                                            a.harness.clone().map(|h| (a.id.clone(), h))
+                                        })
+                                        .collect();
+                                    Arc::new(HarnessRouter::from_lanes(
+                                        &default_harness,
+                                        default_engine.clone(),
+                                        &lanes.lanes,
+                                        &lanes.unavailable,
+                                        &bindings,
+                                    ))
+                                }
                             };
 
                             // Workflow agent nodes route through the shared
@@ -2742,6 +2754,7 @@ impl RuntimeBuilder {
                                 HarnessBrain::new(pool, deps, record)
                                     .with_lanes(lanes.lanes)
                                     .with_unavailable_lanes(lanes.unavailable)
+                                    .with_default_engine(default_engine)
                                     .with_runs(ops.runs.clone()),
                             ) as Arc<dyn Brain>)
                         } else {


### PR DESCRIPTION
## Summary

Closes #1244.

`lanes::build` early-returned for a company with a single declared harness, so nobody ever checked what *kind* that harness was. Both `RuntimeBuilder::build` and `HarnessBrain::run_turn` independently, unconditionally built the default lane as `HarnessRunTurn` regardless of `kind` — so a company whose only harness was `kind = "acp"` (fully valid per `CompanyManifest::validate`) silently ran every turn on the embedded engine instead of failing loudly, contradicting the doctrine both `harnesses.md` and `providers.md` already state: a declared harness with no engine must fail the turn, never fall back to another engine's model/credential.

`lanes::build` now always resolves `Lanes::default_engine` for every company (not just multi-harness ones), reusing the exact same `unavailable`-reason path a named harness already gets — one place decides for every harness, default included, instead of two callers independently (and inconsistently) building a fallback.

## Changes

- `CompanyManifest::default_harness()` (`src/company/manifest.rs`) — the full default `Harness` struct, not just its id, so callers can read `.kind`.
- `lanes::build` (`src/harness/lanes.rs`) — no more early return for `declared.len() <= 1`; always resolves `default_engine: Option<Arc<dyn RunTurn>>`, pushing the same `unavailable_reason` a named non-`built_in` harness gets when the default itself isn't `built_in`.
- `HarnessRouter::from_lanes` (`src/harness/router.rs`) — `default_lane` is now `Option<Arc<dyn RunTurn>>`; `None` relies on the caller having already recorded the default's own `unavailable` entry, exactly like any other harness.
- `RuntimeBuilder::build` (`src/runtime/builder.rs`) — consumes `lanes.default_engine` instead of unconditionally constructing its own `HarnessRunTurn`.
- `HarnessBrain` (`src/harness/built_in/brain.rs`) — new `with_default_engine` override, `default_engine: Option<Option<Arc<dyn RunTurn>>>`. Deliberately **lazy**: `None` (no override set) falls back to building the embedded engine fresh at `run_turn()` time, exactly as it always did — building it eagerly in `new()` would hold a second `Arc` on `deps` for the brain's whole lifetime, which broke `a_store_error_on_a_published_file_propagates` (an `Arc::get_mut` test relies on the brain being `deps`'s sole holder before the first turn) during development of this fix. Every existing caller that never wires lanes (every test, every pre-#1244 call site) is therefore unaffected.

## API Or Behavior Changes

Behavior fix only: a company whose sole/default harness is `kind = "acp"` now correctly fails bound turns with "this build has no ACP transport wired..." instead of silently running the embedded engine. No change for any `built_in`-default company (single- or multi-harness), which is every existing company — pinned by the existing `a_company_with_no_harness_block_is_unrouted` / `the_default_lane_serves_every_overlay_agent` tests, both still green.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features openhuman --all-targets` (clean — one unrelated, pre-existing `whisper-rs-sys` patch warning)
- [x] `cargo test --features openhuman --lib` (4656 passed, 0 failed)
- [x] `cargo test --lib` (default feature lane, 3095 passed, 0 failed)
- [x] `scripts/ci/assert-feature-lanes.sh`

New tests:
- `company::manifest::harness_tests::default_harness_resolves_the_full_declared_entry`
- `harness::built_in::brain::tests::a_lone_acp_default_harness_does_not_silently_run_embedded` — exercises the real `lanes::build` output end-to-end (not a hand-simulated one), proving a regression in either `lanes::build` or `HarnessBrain::run_turn` would fail it.

## Documentation

No spec doc changes — this fixes a gap against `harnesses.md`'s/`providers.md`'s *existing* stated doctrine ("must not fall back to another harness's engine") rather than changing it.