### PR TITLE
Fix #1201: PII scrubber was corrupting memory envelopes — bump the chain, log the drops, pin the regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -479,17 +478,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3204,7 +3192,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "tower",
  "tower-http 0.7.0",
@@ -3217,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.11"
+version = "0.63.13"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3283,7 +3271,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5241,7 +5229,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "walkdir",
@@ -5251,14 +5239,7 @@ dependencies = [
 name = "tinycortex-api"
 version = "0.1.1"
 dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "uuid",
+ "tinymemory-api",
 ]
 
 [[package]]
@@ -5343,7 +5324,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "chrono",
  "dirs",
  "futures",
@@ -5360,8 +5340,9 @@ dependencies = [
  "tinyagents",
  "tinycortex",
  "tinycortex-api",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-sources",
+ "tinymemory-sync",
  "tokio",
  "tracing",
  "url",
@@ -5379,8 +5360,39 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tinymemory",
  "tinymemory-api",
+]
+
+[[package]]
+name = "tinymemory-sources"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "regex",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tinymemory-api",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymemory-sync"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -5389,9 +5401,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
  "tinycortex",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-core",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -5552,6 +5570,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -5559,10 +5592,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5581,10 +5623,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5593,7 +5635,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6477,6 +6519,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -536,6 +536,19 @@ chargebee = ["dep:reqwest"]
 # above — backend service code, per-company credentials, only `reqwest` gated.
 paypal = ["dep:reqwest"]
 
+# WS4 one level further: `tinycortex-api` (since tinycortex@8401346,
+# tinymemory#18 §A1) re-exports the TinyMemory contract and therefore depends
+# on `tinymemory-api` by git URL. A git source is not redirected by
+# `[patch.crates-io]`, so without this section that git checkout joins the
+# graph BESIDE the vendored path copy declared above — and every shared
+# contract type (`MemoryTaint`, `MemoryEntry`, ...) becomes two distinct
+# types, which stops `tinymemory-core` compiling. openhuman carries exactly
+# this entry for itself (`[patch."https://github.com/tinyhumansai/tinymemory"]`
+# in its Cargo.toml); replicated here with the path rebased onto the vendored
+# checkout, same as the WS4 entries below.
+[patch."https://github.com/tinyhumansai/tinymemory"]
+tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/api" }
+
 [patch.crates-io]
 # Reuse OpenHuman's own TinyAgents pin (2.1.0). This satisfies OpenHuman's
 # `^2.1` requirement while keeping a single checkout and crate identity.

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -72,6 +72,14 @@ fn encode<T: Serialize>(record: &T) -> Result<String> {
 /// written by a version we do not understand. A single unreadable row must not
 /// fail a whole `list`: on a shared hosted engine the store may legitimately
 /// hold rows this build did not write.
+///
+/// A row *inside* our namespace that fails to parse is different: nothing else
+/// writes there, so it is a record this host stored and can no longer read — a
+/// corrupted write, not foreign data. It is still skipped (one bad row must not
+/// fail the list), but loudly: #1201 was exactly this shape — the embedded
+/// driver's PII scrubber redacted digits out of the JSON envelope, and the
+/// silent `None` here made a corrupted record indistinguishable from one that
+/// was never written.
 fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Option<T> {
     let reported = entry.namespace.as_deref().unwrap_or_default();
     if !namespace.contains(reported) {
@@ -82,8 +90,29 @@ fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Op
         );
         return None;
     }
-    let envelope: Envelope<T> = serde_json::from_str(&entry.content).ok()?;
-    (envelope.v == ENVELOPE_VERSION).then_some(envelope.record)
+    let envelope: Envelope<T> = match serde_json::from_str(&entry.content) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            tracing::warn!(
+                namespace = namespace.as_str(),
+                key = %entry.key,
+                %error,
+                "memory entry in our namespace failed to decode; dropping it \
+                 (a record we wrote and can no longer read — see #1201)"
+            );
+            return None;
+        }
+    };
+    if envelope.v != ENVELOPE_VERSION {
+        tracing::debug!(
+            namespace = namespace.as_str(),
+            key = %entry.key,
+            version = envelope.v,
+            "memory entry has an envelope version this build does not understand; skipping it"
+        );
+        return None;
+    }
+    Some(envelope.record)
 }
 
 /// Maps a provider error onto the crate error type.

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -90,16 +90,25 @@ fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Op
         );
         return None;
     }
-    let envelope: Envelope<T> = match serde_json::from_str(&entry.content) {
+    // Two-stage parse, version before record: a row written by an envelope
+    // version this build does not know may carry a record shape `T` cannot
+    // deserialize, and collapsing both steps into one `Envelope<T>` parse
+    // would misreport that legitimate skip as corruption. Only a row whose
+    // envelope is unreadable, or whose version matches and record still does
+    // not parse, is a record we wrote and can no longer read.
+    let corrupt = |error: &dyn std::fmt::Display| {
+        tracing::warn!(
+            namespace = namespace.as_str(),
+            key = %entry.key,
+            %error,
+            "memory entry in our namespace failed to decode; dropping it \
+             (a record we wrote and can no longer read — see #1201)"
+        );
+    };
+    let envelope: Envelope<serde_json::Value> = match serde_json::from_str(&entry.content) {
         Ok(envelope) => envelope,
         Err(error) => {
-            tracing::warn!(
-                namespace = namespace.as_str(),
-                key = %entry.key,
-                %error,
-                "memory entry in our namespace failed to decode; dropping it \
-                 (a record we wrote and can no longer read — see #1201)"
-            );
+            corrupt(&error);
             return None;
         }
     };
@@ -112,7 +121,13 @@ fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Op
         );
         return None;
     }
-    Some(envelope.record)
+    match serde_json::from_value(envelope.record) {
+        Ok(record) => Some(record),
+        Err(error) => {
+            corrupt(&error);
+            None
+        }
+    }
 }
 
 /// Maps a provider error onto the crate error type.
@@ -769,5 +784,44 @@ mod test {
         let cut = snippet(&body);
         assert!(body.starts_with(&cut));
         assert!(cut.len() >= 200);
+    }
+
+    /// The decode classification #1248 review asked to pin: an entry from an
+    /// envelope version this build does not know is a legitimate skip even
+    /// when its record shape does not fit today's `T` — it must not be read
+    /// as corruption — while a matching version with an unreadable record,
+    /// or no envelope at all, is the #1201 corruption path. All three return
+    /// `None` rather than failing the list.
+    #[test]
+    fn decode_classifies_unknown_versions_and_corruption_separately() {
+        let namespace = Namespace::company_root(&CompanyId::new("acme"));
+        let entry = |content: &str| MemoryEntry {
+            id: "id".into(),
+            key: "key".into(),
+            content: content.into(),
+            namespace: Some(namespace.as_str().to_string()),
+            category: tinymemory_api::types::MemoryCategory::Custom("oc:trace".into()),
+            timestamp: String::new(),
+            session_id: None,
+            score: None,
+            taint: MemoryTaint::Internal,
+        };
+
+        // Round-trip control: a current-version envelope decodes.
+        let good = encode(&42u32).unwrap();
+        assert_eq!(decode::<u32>(&entry(&good), &namespace), Some(42));
+
+        // Unknown version, record shape incompatible with `T`: skipped, and
+        // reachable only through the version gate — the record is never
+        // parsed as `T`, so this cannot trip the corruption path.
+        let future = r#"{"v":9,"record":{"shape":"unknown"}}"#;
+        assert_eq!(decode::<u32>(&entry(future), &namespace), None);
+
+        // Matching version, unreadable record: the corruption path.
+        let mangled = r#"{"v":1,"record":{"at_millis":[REDACTED_PII_CREDIT_CARD]}}"#;
+        assert_eq!(decode::<u32>(&entry(mangled), &namespace), None);
+
+        // No envelope at all: also the corruption path.
+        assert_eq!(decode::<u32>(&entry("not json"), &namespace), None);
     }
 }

--- a/src/store/memory/test.rs
+++ b/src/store/memory/test.rs
@@ -730,6 +730,45 @@ mod namespace_driver_conformance {
         conformance::assert_context_chunk_stamps(engine.context()).await;
         drop(store_dir);
     }
+
+    /// #1201: the conformance suite failed at random on this driver because
+    /// its write path runs a PII scrubber over the serialized envelope, and a
+    /// 13-digit `at_millis` that happens to pass Luhn (~10% of epoch-millis
+    /// stamps do) was redacted into unparseable JSON — the read side then
+    /// dropped the whole record. Deterministic pin: the middle stamp below is
+    /// the Luhn-valid one from the original failure, so this test fails 100%
+    /// of the time on a driver with that defect, not 10%.
+    #[tokio::test]
+    async fn luhn_valid_timestamps_round_trip_on_the_namespace_driver() {
+        let (store_dir, engine) = real_engine();
+        let memory = engine.memory();
+        let traces = vec![
+            CompressedTrace {
+                cycle_id: "c0".into(),
+                summary: "summary 0".into(),
+                at_millis: 1_787_178_633_770,
+            },
+            CompressedTrace {
+                cycle_id: "c1".into(),
+                summary: "summary 1".into(),
+                at_millis: 1_787_178_633_773,
+            },
+            CompressedTrace {
+                cycle_id: "c2".into(),
+                summary: "summary 2".into(),
+                at_millis: 1_787_178_633_774,
+            },
+        ];
+        for trace in &traces {
+            memory.save_trace(&acme_id(), trace.clone()).await.unwrap();
+        }
+        let read = memory.recent_traces(&acme_id(), usize::MAX).await.unwrap();
+        assert_eq!(
+            read, traces,
+            "every trace round-trips regardless of its timestamp's digits"
+        );
+        drop(store_dir);
+    }
 }
 
 /// #914's acceptance names "taint survives export and re-import" and #1113


### PR DESCRIPTION
## Summary

#1201's "embedded namespace driver loses writes" is real data loss, but not a dropped write and not a timestamp-key collision: **the driver's write path runs tinycortex's PII scrubber over the serialized JSON envelope, and any bare 13-19 digit run that passes Luhn was redacted as a credit card.** Luhn passes ~10% of arbitrary digit runs, and `at_millis` is a 13-digit run — so ~10% of stored traces/chunks had their timestamp rewritten to `[REDACTED_PII_CREDIT_CARD]`, corrupting the JSON. `decode()` then silently dropped the whole record on read.

Proof from the issue's own paste: of the three stamps, only the missing record's `1787178633773` is Luhn-valid (`…770`/`…774` are not). `assert_export_totality` writes 6 such stamps → 1 − 0.9⁶ ≈ 47% expected failure; ~36% observed over 11 runs. Reproduced deterministically here: pinning that stamp fails **100%** of runs on the old pin, and the failing shape is byte-identical to the issue (`left: [c0, c2]`).

## The chain

| # | PR | What |
|---|---|---|
| 1 | tinyhumansai/tinycortex#154 | Root fix: bare runs need Luhn **and** (real network IIN at an issued length, or a card keyword nearby); separated runs keep Luhn-only. Timestamps have no IIN — out of scope entirely. |
| 2 | tinyhumansai/openhuman#5605 | `vendor/tinycortex` bump |
| 3 | this PR | `vendor/openhuman` bump + two local pieces below |

**Merge order is 1 → 2 → 3** (tinycortex squash-merges, so each downstream pin gets re-pointed to the real merged SHA before its own merge; current pins ride `refs/pull/N/head` so CI is green pre-merge).

## Local changes

- **`decode()` stops being silent about corruption** (`src/store/memory/facades.rs`): an unparseable row *inside our namespace* is a record we wrote and can no longer read — still skipped, now `warn!`ed with key + parse error (version mismatch → `debug!`). The silent `.ok()?` is what made this loss look like records never written.
- **Deterministic regression test** (`src/store/memory/test.rs`): three traces round-trip over the real driver with the Luhn-valid stamp pinned. Red 100% on the old pin, green on the new — the issue's suggested probe (spacing timestamps out) is deliberately not used, since changing the digits would have falsely confirmed the collision hypothesis.
- **New `[patch."…/tinymemory"]` entry** (`Cargo.toml`): required by any bump onto current openhuman main — since tinycortex@8401346 (tinymemory#18 §A1), tinycortex-api pulls tinymemory-api by git URL, which `[patch.crates-io]` does not redirect; without it two copies of every contract type enter the graph and tinymemory-core does not compile. Same entry openhuman carries for itself.

## Verification

- `cargo test --features acp,runner,tinymemory-embedded --lib store::memory`: 68 passed on the exact pinned SHAs
- **20 consecutive full-suite runs: 0 failures** (baseline ~36%/run — odds of that under the old behavior ≈ 0.01%)
- tinycortex at the pin: 1260 + 132 tests, fmt, clippy all clean
- Follow-up filed for the same defect class in the NANP phone rule (no checksum at all): tinyhumansai/tinycortex#155

Closes #1201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when stored memory records are malformed or use unsupported versions. Invalid entries are skipped with appropriate diagnostics, allowing valid records to remain available.
  * Fixed namespace-backed trace storage and retrieval to preserve valid traces reliably.

* **Chores**
  * Updated the bundled OpenHuman component reference.
  * Aligned TinyMemory integration to ensure consistent shared types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->