### PR TITLE
fix: let the org chart move a teammate between desks

### DIFF
--- a/frontend/src/lib/org.ts
+++ b/frontend/src/lib/org.ts
@@ -193,6 +193,24 @@ export function addableTo(tree: OrgTree, desk: OrgDesk): TeamMember[] {
 }
 
 /**
+ * Whether a seat can be dragged onto a *different* desk (issue #1227).
+ *
+ * Only its provenance decides this. A same-desk reorder only ever calls
+ * `setDeskOrder`, which the host accepts for either provenance — but a
+ * cross-desk move also has to call `removeDeskMember` on the source, and the
+ * host refuses that for a blueprint seat: it is declared in the manifest, not
+ * the overlay, so runtime cannot let go of it. Accepting the drop anyway
+ * would only fail one step later, as a 409 the operator never asked to see;
+ * this is the one predicate every drag/drop-over gate in the chart consults
+ * before accepting a cross-desk drop, so the refusal is decided once and
+ * shown up front — a "not allowed" cursor, or a toast — rather than
+ * discovered from a failed write.
+ */
+export function canDragAcrossDesks(seat: Pick<OrgSeat, "provenance">): boolean {
+  return seat.provenance === "overlay";
+}
+
+/**
  * The desk's member order with `index` moved one place in `direction`, or
  * `null` when that would run off either end.
  *

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -58,6 +58,7 @@ import {
 import {
   addableTo,
   buildOrgTree,
+  canDragAcrossDesks,
   reorderedIds,
   reorderedIdsAfterDrop,
   summarize,
@@ -65,6 +66,7 @@ import {
   type OrgPerson,
   type OrgSeat,
   type OrgTree,
+  type Provenance,
 } from "@/lib/org";
 import { cn } from "@/lib/utils";
 import { DeskCreateDialog } from "@/views/company/DeskCreateDialog";
@@ -74,6 +76,31 @@ import {
 } from "@/views/chat/AddMemberDialog";
 
 const SEAT_MIME = "application/x-opencompany-seat";
+
+/**
+ * The seat currently being dragged, if any — lifted to `Chart` (issue #1227).
+ *
+ * `draggingIndex` used to live inside each `DeskNode`, which meant the desk
+ * you dropped *onto* had never heard of a seat coming from a *different*
+ * desk's `DeskNode` instance — that silence was the whole bug. Lifting this
+ * one level, to the common ancestor of every `DeskNode`, is what lets a
+ * target desk answer "what's being dragged, and can I take it" instead of
+ * "I don't recognise this drop."
+ *
+ * `provenance` travels with it because that answer differs by desk: a
+ * same-desk reorder only ever calls `setDeskOrder`, which is fine for a
+ * blueprint seat, but a cross-desk move calls `removeDeskMember` on the
+ * source — and the host refuses that for a blueprint seat. The gate needs to
+ * know which kind of seat this is before a drop is even accepted, not after
+ * the host says no.
+ */
+interface DragSeat {
+  deskId: string;
+  index: number;
+  seatId: string;
+  seatName: string;
+  provenance: Provenance;
+}
 
 /**
  * Where a teammate named on this chart opens: `#/team/<agentId>`, the sub-page
@@ -97,6 +124,20 @@ const SEAT_MIME = "application/x-opencompany-seat";
 function teamHref(agentId: string | null | undefined): string | null {
   const id = agentId?.trim();
   return id ? `#/team/${encodeURIComponent(id)}` : null;
+}
+
+/**
+ * Why a cross-desk drag was refused, for a blueprint seat (issue #1227).
+ *
+ * A blueprint seat is declared in the manifest, and the host refuses to
+ * remove a manifest-declared member from its desk — that is a real backend
+ * invariant, not a frontend bug to work around. The old behaviour was to say
+ * nothing at all when a cross-desk drop landed anywhere; saying *why* here is
+ * the whole fix for that seat's half of the issue, not a workaround for the
+ * refusal itself.
+ */
+function blueprintMoveRefusal(seatName: string): string {
+  return `${seatName} is a blueprint member of their current desk — the manifest still declares them there, so they can't be moved to another desk. Same-desk reordering still works.`;
 }
 
 interface Props {
@@ -504,13 +545,41 @@ export function OrgChartView({ client, company, focusDeskId, onBack }: Props) {
                     client.setDeskOrder(desk.id, next, company),
                   );
                 }}
-                onDrop={(desk, fromIndex, toIndex) => {
+                onReorder={(desk, fromIndex, toIndex) => {
                   const next = reorderedIdsAfterDrop(desk, fromIndex, toIndex);
                   if (!next) return;
                   void mutate(`drag:${desk.id}`, () =>
                     client.setDeskOrder(desk.id, next, company),
                   );
                 }}
+                onMoveAcrossDesks={(fromDesk, seatId, toDesk) =>
+                  void mutate(`move:${seatId}`, async () => {
+                    // The host has no "move" verb, only add and remove — so a
+                    // cross-desk move is those two calls plus one refetch
+                    // (`mutate` already does the refetch). The add is not
+                    // wrapped in its own try/catch: nothing has changed on the
+                    // host yet if it fails, so `mutate`'s own catch-and-toast
+                    // is the right place for that failure to land.
+                    await client.addDeskMember(toDesk.id, seatId, company);
+                    try {
+                      await client.removeDeskMember(
+                        fromDesk.id,
+                        seatId,
+                        company,
+                      );
+                    } catch (e) {
+                      // Half-landed: the teammate is now on both desks, which
+                      // is a real, visible inconsistency the operator has to
+                      // resolve by hand — silently swallowing this would be
+                      // exactly the kind of no-op #1227 is about.
+                      throw new Error(
+                        `Added to ${toDesk.name}, but couldn't remove them from ${fromDesk.name}: ${
+                          e instanceof Error ? e.message : "unknown error"
+                        }. They're on both desks now — remove them from ${fromDesk.name} by hand.`,
+                      );
+                    }
+                  })
+                }
                 onDelete={(desk) =>
                   void mutate(`delete:${desk.id}`, () =>
                     client.deleteDesk(desk.id, company),
@@ -555,7 +624,8 @@ function Chart({
   onAdd,
   onRemove,
   onMove,
-  onDrop,
+  onReorder,
+  onMoveAcrossDesks,
   onDelete,
 }: {
   tree: OrgTree;
@@ -567,9 +637,18 @@ function Chart({
   onAdd: (desk: OrgDesk, agentId: string) => void;
   onRemove: (desk: OrgDesk, agentId: string) => void;
   onMove: (desk: OrgDesk, index: number, direction: "up" | "down") => void;
-  onDrop: (desk: OrgDesk, fromIndex: number, toIndex: number) => void;
+  onReorder: (desk: OrgDesk, fromIndex: number, toIndex: number) => void;
+  onMoveAcrossDesks: (
+    fromDesk: OrgDesk,
+    seatId: string,
+    toDesk: OrgDesk,
+  ) => void;
   onDelete: (desk: OrgDesk) => void;
 }) {
+  // The drag source, lifted here rather than into `DeskNode` — see `DragSeat`.
+  // This is what lets a *different* desk's drop handlers know a seat is being
+  // dragged at all, which is the fix for #1227's cross-desk silent no-op.
+  const [dragSeat, setDragSeat] = useState<DragSeat | null>(null);
   return (
     <div role="tree" aria-label="Company org chart" className="space-y-3">
       <div
@@ -601,13 +680,32 @@ function Chart({
                 addable={addableTo(tree, desk)}
                 busy={busy}
                 focused={focusMark === desk.id}
+                dragSeat={dragSeat}
                 onAdd={(agentId) => onAdd(desk, agentId)}
                 onCreateMember={() => onCreateMember(desk)}
                 onRemove={(agentId) => onRemove(desk, agentId)}
                 onMove={(index, direction) => onMove(desk, index, direction)}
-                onDrop={(fromIndex, toIndex) =>
-                  onDrop(desk, fromIndex, toIndex)
+                onSeatDragStart={(seat, index) =>
+                  setDragSeat({
+                    deskId: desk.id,
+                    index,
+                    seatId: seat.id,
+                    seatName: seat.name,
+                    provenance: seat.provenance,
+                  })
                 }
+                onSeatDragEnd={() => setDragSeat(null)}
+                onReorder={(fromIndex, toIndex) =>
+                  onReorder(desk, fromIndex, toIndex)
+                }
+                onMoveIn={() => {
+                  if (!dragSeat || dragSeat.deskId === desk.id) return;
+                  const fromDesk = tree.desks.find(
+                    (d) => d.id === dragSeat.deskId,
+                  );
+                  if (!fromDesk) return;
+                  onMoveAcrossDesks(fromDesk, dragSeat.seatId, desk);
+                }}
                 onDelete={() => onDelete(desk)}
               />
             ))}
@@ -624,11 +722,15 @@ function DeskNode({
   addable,
   busy,
   focused,
+  dragSeat,
   onCreateMember,
   onAdd,
   onRemove,
   onMove,
-  onDrop,
+  onSeatDragStart,
+  onSeatDragEnd,
+  onReorder,
+  onMoveIn,
   onDelete,
 }: {
   desk: OrgDesk;
@@ -636,15 +738,70 @@ function DeskNode({
   busy: string | null;
   /** This desk is the one a `#/company/<deskId>` link asked for. */
   focused: boolean;
+  /** The seat currently being dragged anywhere on the chart, if any. */
+  dragSeat: DragSeat | null;
   onCreateMember: () => void;
   onAdd: (agentId: string) => void;
   onRemove: (agentId: string) => void;
   onMove: (index: number, direction: "up" | "down") => void;
-  onDrop: (fromIndex: number, toIndex: number) => void;
+  onSeatDragStart: (seat: OrgSeat, index: number) => void;
+  onSeatDragEnd: () => void;
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  /** A seat from another desk has been dropped onto this one. */
+  onMoveIn: () => void;
   onDelete: () => void;
 }) {
   const locked = busy !== null;
-  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  // Whether the seat currently being dragged (from anywhere on the chart)
+  // could land on *this* desk: it must come from a different desk, and it
+  // must be an overlay seat — the host refuses to remove a blueprint member
+  // from its desk, so accepting the drop here would only fail one step later
+  // with a 409 the operator never asked to see (issue #1227).
+  const crossDeskDropAllowed =
+    dragSeat !== null &&
+    dragSeat.deskId !== desk.id &&
+    canDragAcrossDesks({ provenance: dragSeat.provenance });
+  const crossDeskDropBlocked =
+    dragSeat !== null &&
+    dragSeat.deskId !== desk.id &&
+    !canDragAcrossDesks({ provenance: dragSeat.provenance });
+  /**
+   * Whether this desk has already told the operator, for the drag in
+   * progress, that it cannot take a blueprint seat.
+   *
+   * Fired on `dragenter` rather than `drop`: whether a browser lets `drop`
+   * fire at all depends on whether *any* element preventDefaulted `dragover`
+   * during the gesture, and this desk deliberately never does that for a
+   * blocked seat (that's what draws the native "not allowed" cursor). A toast
+   * that only fired from a `drop` handler could end up as silent as the bug
+   * this fixes, on a browser that honours the cursor and never sends `drop`
+   * at all. `dragenter` needs no such cooperation — it always fires.
+   */
+  const warnedRef = useRef(false);
+  useEffect(() => {
+    warnedRef.current = false;
+  }, [dragSeat]);
+  function dragEnterDesk() {
+    if (crossDeskDropBlocked && dragSeat && !warnedRef.current) {
+      warnedRef.current = true;
+      toast.error(blueprintMoveRefusal(dragSeat.seatName));
+    }
+  }
+  /**
+   * Accept a drop landing on the desk's open space rather than on a specific
+   * seat row — the only way an empty desk (or the space below its last seat)
+   * can ever be a drop target, since there is no `Seat` there to catch the
+   * event otherwise.
+   */
+  function dragOverGroup(event: DragEvent<HTMLDivElement>) {
+    if (!crossDeskDropAllowed) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+  }
+  function dropOnGroup(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    if (crossDeskDropAllowed) onMoveIn();
+  }
   return (
     <div
       role="treeitem"
@@ -661,6 +818,10 @@ function DeskNode({
       // how a screen reader is told where the link landed, but a desk wrapper
       // is not a control and does not belong in the tab order.
       tabIndex={-1}
+      // The desk-wide warning that a blueprint seat can't land here — see
+      // `dragEnterDesk`. Placed on the whole wrapper, not just the seat
+      // list, so entering over the header or the border counts too.
+      onDragEnter={dragEnterDesk}
       className={cn(
         "scroll-mt-4 rounded-xl outline-none",
         focused && "ring-2 ring-primary ring-offset-2 ring-offset-background",
@@ -705,7 +866,16 @@ function DeskNode({
           )}
         </div>
 
-        <div role="group" className="space-y-1 border-t px-3 py-2">
+        <div
+          role="group"
+          className="space-y-1 border-t px-3 py-2"
+          // The empty-space fallback drop target: an empty desk (or the space
+          // below its last seat) has no `Seat` row to catch the event, so it
+          // needs its own handlers to ever be a valid cross-desk drop target
+          // (issue #1227).
+          onDragOver={dragOverGroup}
+          onDrop={dropOnGroup}
+        >
           {desk.seats.length === 0 && (
             <p className="py-1 text-xs text-muted-foreground">
               Nobody staffs this desk yet.
@@ -722,14 +892,16 @@ function DeskNode({
               last={index === desk.seats.length - 1}
               busy={busy === `${desk.id}:${seat.id}`}
               locked={locked}
+              dragSeat={dragSeat}
               onUp={() => onMove(index, "up")}
               onDown={() => onMove(index, "down")}
               onRemove={() => onRemove(seat.id)}
-              onDragStart={() => setDraggingIndex(index)}
-              onDrop={(toIndex) => {
-                if (draggingIndex !== null) onDrop(draggingIndex, toIndex);
-                setDraggingIndex(null);
-              }}
+              onDragStart={() => onSeatDragStart(seat, index)}
+              onDragEnd={onSeatDragEnd}
+              onReorderDrop={(fromIndex, toIndex) =>
+                onReorder(fromIndex, toIndex)
+              }
+              onCrossDeskDrop={onMoveIn}
             />
           ))}
 
@@ -793,11 +965,14 @@ function Seat({
   last,
   busy,
   locked,
+  dragSeat,
   onUp,
   onDown,
   onRemove,
   onDragStart,
-  onDrop,
+  onDragEnd,
+  onReorderDrop,
+  onCrossDeskDrop,
 }: {
   seat: OrgSeat;
   index: number;
@@ -807,11 +982,17 @@ function Seat({
   last: boolean;
   busy: boolean;
   locked: boolean;
+  /** The seat currently being dragged anywhere on the chart, if any. */
+  dragSeat: DragSeat | null;
   onUp: () => void;
   onDown: () => void;
   onRemove: () => void;
   onDragStart: () => void;
-  onDrop: (toIndex: number) => void;
+  onDragEnd: () => void;
+  /** Same-desk reorder: the dragged seat's own index, and where it landed. */
+  onReorderDrop: (fromIndex: number, toIndex: number) => void;
+  /** A seat from another desk landed on this desk (issue #1227). */
+  onCrossDeskDrop: () => void;
 }) {
   function startDrag(event: DragEvent<HTMLDivElement>) {
     onDragStart();
@@ -820,14 +1001,44 @@ function Seat({
     event.dataTransfer.setData("text/plain", `${deskId}:${index}`);
   }
 
-  function drop(event: DragEvent<HTMLDivElement>) {
+  /**
+   * Whether dropping the seat currently in flight, here, is something this
+   * row would honour: a same-desk reorder always is, and a cross-desk
+   * landing only is when the source is an overlay seat — the host refuses to
+   * remove a blueprint member from its desk, so a blueprint source can never
+   * land anywhere but back where it started (issue #1227).
+   */
+  function dropAllowed(): boolean {
+    if (!dragSeat) return false;
+    return (
+      dragSeat.deskId === deskId ||
+      canDragAcrossDesks({ provenance: dragSeat.provenance })
+    );
+  }
+
+  function dragOver(event: DragEvent<HTMLDivElement>) {
+    if (!dropAllowed()) return; // no preventDefault: the browser draws its
+    // own "not allowed" cursor for the rest of the gesture — the visible
+    // refusal a blueprint-sourced cross-desk drag gets instead of silence.
     event.preventDefault();
-    const payload =
-      event.dataTransfer.getData(SEAT_MIME) ||
-      event.dataTransfer.getData("text/plain");
-    const [sourceDeskId, sourceIndex] = payload.split(":");
-    const fromIndex = Number(sourceIndex);
-    if (sourceDeskId === deskId && Number.isInteger(fromIndex)) onDrop(index);
+    event.dataTransfer.dropEffect = "move";
+  }
+
+  function drop(event: DragEvent<HTMLDivElement>) {
+    if (!dropAllowed() || !dragSeat) return;
+    event.preventDefault();
+    // Stop the desk's own fallback handler (on the seat-list container, for
+    // the empty-desk case) from also seeing this same drop and repeating the
+    // write it is about to trigger.
+    event.stopPropagation();
+    if (dragSeat.deskId === deskId) {
+      onReorderDrop(dragSeat.index, index);
+    } else {
+      // Cross-desk: which row it lands on doesn't matter. The host has an
+      // add verb, not an insert-at-position verb, so the whole desk is the
+      // drop target and every row on it lands the seat the same way.
+      onCrossDeskDrop();
+    }
   }
 
   // Where this seat opens, or `null` when it opens nowhere. A seat the roster
@@ -877,7 +1088,8 @@ function Seat({
       draggable={!locked}
       data-seat-id={seat.id}
       onDragStart={startDrag}
-      onDragOver={(event) => event.preventDefault()}
+      onDragEnd={onDragEnd}
+      onDragOver={dragOver}
       onDrop={drop}
       className={cn(
         "flex cursor-grab items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm active:cursor-grabbing",

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -169,8 +169,16 @@ async function mockApi(page: Page) {
     // DELETE .../desks/{id}/members/{agent}
     const member = path.match(/\/desks\/([^/]+)\/members\/([^/]+)$/);
     if (member && method === "DELETE") {
-      writes.push({ method, path });
       const target = desk(member[1]);
+      // A manifest-declared (blueprint) member cannot be let go at runtime —
+      // matches the real host, per `client.ts`'s own doc on `removeDeskMember`.
+      // Issue #1227's cross-desk move relies on this refusal never being
+      // silent, so the stub has to actually produce it.
+      if (target && !(target.overlayMembers ?? []).includes(member[2])) {
+        writes.push({ method, path });
+        return json({ error: "blueprint member cannot be removed" }, 409);
+      }
+      writes.push({ method, path });
       if (target) {
         target.members = target.members.filter((m) => m !== member[2]);
         target.overlayMembers = (target.overlayMembers ?? []).filter(
@@ -730,6 +738,97 @@ test("#839 dragging a seat reorders the desk and persists the new lead", async (
     reloadedSeats.first().getByRole("img", { name: "Desk lead" }),
   ).toBeVisible();
   await expect(reloadedSeats.nth(1)).toContainText("Grace");
+});
+
+test("#1227 dragging a seat across desks moves it, and persists", async ({
+  page,
+}) => {
+  // The org chart's own subtitle promises "move someone between desks" — this
+  // is the drag the subtitle was lying about before the fix: same gesture as
+  // same-desk reorder (`dragTo`, real `dragstart`/`dragover`/`drop`), just
+  // crossing a desk boundary. Hedy is Growth's *overlay* member, so the host
+  // will let her go.
+  await mockApi(page);
+  await openChart(page);
+
+  const growth = deskNode(page, "Growth");
+  const growthSeats = growth.locator('[role="treeitem"][aria-level="3"]');
+  const engineering = deskNode(page, "Engineering");
+  const engineeringSeats = engineering.locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
+  await expect(growthSeats).toHaveCount(2);
+  await expect(engineeringSeats).toHaveCount(2);
+
+  await growthSeats.filter({ hasText: "Hedy" }).dragTo(engineeringSeats.first());
+
+  // Landed: gone from Growth, present on Engineering.
+  await expect(growth.getByText("Hedy")).toHaveCount(0);
+  await expect(engineering.getByText("Hedy")).toBeVisible();
+  await expect(toasts(page).filter({ hasText: /error|fail|wrong/i })).toHaveCount(0);
+
+  // Add-then-remove, in that order — nothing invented beyond the host's own
+  // two verbs (issue #1227's "what a fix would be").
+  expect(
+    writes.find(
+      (w) => w.method === "POST" && w.path === "/api/v1/companies/acme/desks/engineering/members",
+    )?.body,
+  ).toEqual({ agent_id: "hedy" });
+  expect(
+    writes.some(
+      (w) =>
+        w.method === "DELETE" &&
+        w.path === "/api/v1/companies/acme/desks/growth/members/hedy",
+    ),
+  ).toBe(true);
+
+  await page.reload();
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  await expect(deskNode(page, "Growth").getByText("Hedy")).toHaveCount(0);
+  await expect(deskNode(page, "Engineering").getByText("Hedy")).toBeVisible();
+});
+
+test("#1227 dragging a blueprint seat across desks is refused, visibly", async ({
+  page,
+}) => {
+  // Linus is Growth's *blueprint* founder — the manifest still declares him
+  // there, and the host refuses to remove a blueprint member from its desk
+  // (simulated above as a 409). Before the fix this drag was a total silent
+  // no-op; the fix is refusing it visibly, not making it work — the host
+  // invariant is real, not a frontend bug.
+  await mockApi(page);
+  await openChart(page);
+
+  const growth = deskNode(page, "Growth");
+  const growthSeats = growth.locator('[role="treeitem"][aria-level="3"]');
+  const engineering = deskNode(page, "Engineering");
+  const engineeringSeats = engineering.locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
+
+  await growthSeats
+    .filter({ hasText: "Linus" })
+    .dragTo(engineeringSeats.first());
+
+  // Nothing moved.
+  await expect(growth.getByText("Linus")).toBeVisible();
+  await expect(engineering.getByText("Linus")).toHaveCount(0);
+  // And nothing was silent about it: a toast named the reason.
+  await expect(toasts(page).filter({ hasText: /blueprint/i })).toBeVisible();
+  // Never even asked the host to do what it would refuse.
+  expect(
+    writes.some(
+      (w) =>
+        w.path === "/api/v1/companies/acme/desks/growth/members/linus" ||
+        (w.method === "POST" &&
+          w.path === "/api/v1/companies/acme/desks/engineering/members"),
+    ),
+  ).toBe(false);
+
+  await page.reload();
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  await expect(deskNode(page, "Growth").getByText("Linus")).toBeVisible();
+  await expect(deskNode(page, "Engineering").getByText("Linus")).toHaveCount(0);
 });
 
 test("#311 blueprint structure offers no control the host would refuse", async ({

--- a/frontend/test/unit/org-tree.test.ts
+++ b/frontend/test/unit/org-tree.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   addableTo,
   buildOrgTree,
+  canDragAcrossDesks,
   depthOf,
   MAX_DEPTH,
   reorderedIds,
@@ -171,6 +172,25 @@ describe("addableTo", () => {
       ROSTER,
     );
     expect(addableTo(full, full.desks[0])).toEqual([]);
+  });
+});
+
+describe("canDragAcrossDesks", () => {
+  // issue #1227: a same-desk reorder only ever calls `setDeskOrder`, which the
+  // host accepts for either provenance, but a cross-desk move also has to
+  // call `removeDeskMember` on the source — and the host refuses that for a
+  // blueprint seat. This predicate is the one place that refusal is decided,
+  // before any write is attempted.
+  it("allows an overlay seat", () => {
+    const growth = tree().desks[1];
+    expect(canDragAcrossDesks(growth.seats[1])).toBe(true); // hedy, overlay
+  });
+
+  it("refuses a blueprint seat", () => {
+    const growth = tree().desks[1];
+    expect(canDragAcrossDesks(growth.seats[0])).toBe(false); // linus, blueprint
+    const engineering = tree().desks[0];
+    expect(engineering.seats.every((s) => !canDragAcrossDesks(s))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1227.

The org chart's own subtitle promises "move someone between desks", but dragging a seat across a desk boundary was a total silent no-op: `Seat.drop` only accepted a drop whose payload named its own desk, and `draggingIndex` lived inside each `DeskNode`, so the desk you dropped *onto* never learned what was being dragged from a *different* desk's `DeskNode` instance.

- Lift the drag source (`DragSeat`: desk id, index, seat id/name, provenance) to `Chart`, the common ancestor of every `DeskNode`, so a cross-desk drop can be recognised at all.
- A cross-desk move is add-to-target then remove-from-source — the host has no "move" verb, only `POST .../desks/{id}/members` and `DELETE .../desks/{id}/members/{agentId}` — refetching once through the existing `mutate()` helper. A partial failure (add lands, remove fails) surfaces a specific toast naming that the teammate is now on both desks, rather than a generic error.
- **Blueprint seats**: the host refuses to remove a manifest-declared member from its desk (409), so making them draggable-and-failing would just relocate the silence one step later. Instead this is refused *up front, visibly*: the browser draws its native "not allowed" cursor for the whole drag (no element ever calls `preventDefault()` on `dragover` for a blocked cross-desk target), and a toast fires on `dragenter` naming the reason — so the refusal is visible even on a drop that a browser never sends a `drop` event for at all. Same-desk reordering of a blueprint seat is untouched and still works (it only calls `setDeskOrder`, never remove).
- Also closes a latent leak in the same state being touched: `draggingIndex` previously only cleared inside a *successful* drop, so a cancelled or off-target drag left stale "something is being dragged" state. `onDragEnd` now clears it unconditionally.
- New `canDragAcrossDesks(seat)` predicate in `src/lib/org.ts` (`provenance === "overlay"`) is the single place every drag/dragover/drop gate in the chart consults, so the accept/refuse logic can't drift between the three call sites (per-seat, and the desk's seat-list container for the empty-desk drop-target case).

## Scope

Blueprint-seat dragging is fixed as "refuse visibly instead of silently" per the issue's own preferred framing — the host's refusal to let go of a manifest-declared member is a real backend invariant, not a frontend bug to work around. Making a blueprint seat *actually* movable would require a host-side change and is out of scope here.

## Commands run locally

- `npm run typecheck`, `npm run typecheck:e2e`, `npm run typecheck:unit` — all clean
- `npm test` — 1406/1406 passing (147 files), including new `canDragAcrossDesks` coverage in `test/unit/org-tree.test.ts`
- `npm run build` — succeeds
- `npx playwright test test/e2e/org-tree.spec.ts` (24/24 passing, including 2 new cross-desk-drag specs) against a real running host on its own port/data-dir
- Manual verification in a real browser against a freshly built host (`agentic_software_company`, own port + `OPENCOMPANY_DATA_DIR`, console via `npm run dev` with `OC_API_TARGET`): added an overlay teammate to Engineering, dragged them onto Product & Design — moved, persisted across reload; dragged a genuine blueprint seat (Backend Engineer) across desks — refused, unchanged, with a visible toast naming the reason. Screenshots confirm both.

## Test plan

- [x] Cross-desk drag of an overlay-provenance seat moves it and persists across reload
- [x] Cross-desk drag of a blueprint-provenance seat is refused, with a visible toast, no API calls made
- [x] Same-desk drag reorder is unchanged (regression covered by the existing `#839` spec)
- [x] Real-browser manual verification against a live host