### PR TITLE
console: collapse nested main landmark, add page h1s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -479,17 +478,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3204,7 +3192,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "tower",
  "tower-http 0.7.0",
@@ -3283,7 +3271,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5241,7 +5229,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "walkdir",
@@ -5251,14 +5239,7 @@ dependencies = [
 name = "tinycortex-api"
 version = "0.1.1"
 dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "uuid",
+ "tinymemory-api",
 ]
 
 [[package]]
@@ -5343,7 +5324,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "chrono",
  "dirs",
  "futures",
@@ -5360,8 +5340,9 @@ dependencies = [
  "tinyagents",
  "tinycortex",
  "tinycortex-api",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-sources",
+ "tinymemory-sync",
  "tokio",
  "tracing",
  "url",
@@ -5379,8 +5360,39 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tinymemory",
  "tinymemory-api",
+]
+
+[[package]]
+name = "tinymemory-sources"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "regex",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tinymemory-api",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymemory-sync"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -5389,9 +5401,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
  "tinycortex",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-core",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -5552,6 +5570,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -5559,10 +5592,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5581,10 +5623,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5593,7 +5635,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6477,6 +6519,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1430,7 +1430,11 @@ export function AppShell({
           strip held the "Done" column, which is why a card could not be dragged
           into it (issue #334); every view was losing the same strip. */}
       <SidebarInset className="min-h-0 min-w-0">
-        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* A `div`, not `main`: `SidebarInset` above is already the console's
+            one `<main>` landmark. This is only a flex/scroll container — a
+            second nested `<main>` here gave every page two identical
+            "skip to content" destinations (issue #1221). */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {view === "overview" && (
             <Overview client={client} company={company} />
           )}
@@ -1709,7 +1713,7 @@ export function AppShell({
             />
           )}
           {view === "feedback" && <FeedbackView client={client} company={company} />}
-        </main>
+        </div>
       </SidebarInset>
 
       <FeedbackDialog

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -262,6 +262,10 @@ export function ApprovalsView({
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-4 py-6">
+        {/* The queue's own count heading below only renders once loaded, so
+            it can't be the page's one `h1` — this stays present through
+            loading, error and empty states alike (issue #1221). */}
+        <h1 className="sr-only">Approvals</h1>
         {/* Issue #883: the filter says so, and offers the way out of itself.
             A narrowed queue that looked identical to the whole one would make a
             decided-elsewhere approval look like it had vanished. */}

--- a/frontend/src/views/BillingView.tsx
+++ b/frontend/src/views/BillingView.tsx
@@ -254,9 +254,9 @@ export function BillingView({ client, company }: Props) {
     <div className="flex-1 overflow-y-auto" data-testid="billing-view">
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div>
-          <h2 className="flex items-center gap-2 text-lg font-medium">
+          <h1 className="flex items-center gap-2 text-lg font-medium">
             <CreditCard className="size-5" /> Billing
-          </h2>
+          </h1>
           <p className="text-sm text-muted-foreground">
             Connect Chargebee so your teammates can raise invoices and answer
             questions about who has paid, and PayPal so they can report the

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -484,7 +484,7 @@ export function ConnectionsView({ client, company }: Props) {
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
-            <h2 className="text-2xl font-semibold tracking-tight">Connections</h2>
+            <h1 className="text-2xl font-semibold tracking-tight">Connections</h1>
             <p className="text-sm text-muted-foreground">
               Wire in the accounts your company acts through. It only uses what you connect.
             </p>

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -154,9 +154,9 @@ export function HostingView({ client, company }: Props) {
     <div className="flex-1 overflow-y-auto" data-testid="hosting-view">
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div>
-          <h2 className="flex items-center gap-2 text-lg font-medium">
+          <h1 className="flex items-center gap-2 text-lg font-medium">
             <Globe className="size-5" /> Hosting
-          </h2>
+          </h1>
           <p className="text-sm text-muted-foreground">
             Connect a hosting provider so your teammates can put a site from this
             company&rsquo;s workspace on the internet — with a managed database

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -50,7 +50,7 @@ export function McpServersView({ client, company }: Props) {
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div className="space-y-1">
-          <h2 className="text-2xl font-semibold tracking-tight">MCP Servers</h2>
+          <h1 className="text-2xl font-semibold tracking-tight">MCP Servers</h1>
           <p className="text-sm text-muted-foreground">
             The tool servers this company&apos;s teammates can call, from its manifest and the
             ones you add here.

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -194,6 +194,10 @@ export function Overview({ client, company }: Props) {
       // the page now, so the graph is what gets spotlighted.
       data-tour="overview-graph"
     >
+      {/* The graph is the page and draws no visible title of its own (issue
+          #1221) — this names it for a screen reader the same way every other
+          view's title does. */}
+      <h1 className="sr-only">Company overview</h1>
       {/* The snapshot line: what the page is, when it was taken, and the way to
           take another. The graph is not live, and says so rather than leaving an
           operator to assume a stale wheel is the current company. */}

--- a/frontend/src/views/PagesView.tsx
+++ b/frontend/src/views/PagesView.tsx
@@ -170,6 +170,7 @@ export function PagesView({ client, company }: Props) {
   if (load === "loading") {
     return (
       <div className="flex flex-1 gap-2 p-4">
+        <h1 className="sr-only">Pages</h1>
         <div className="w-64 shrink-0 space-y-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="h-9 rounded-lg" />
@@ -183,6 +184,7 @@ export function PagesView({ client, company }: Props) {
   if (load === "error") {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+        <h1 className="sr-only">Pages</h1>
         <AppWindow className="size-8" />
         <div className="space-y-1">
           <p className="font-medium text-foreground">Pages unavailable</p>
@@ -198,6 +200,7 @@ export function PagesView({ client, company }: Props) {
   if (visible.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+        <h1 className="sr-only">Pages</h1>
         <AppWindow className="size-8" />
         <div className="space-y-1">
           <p className="font-medium text-foreground">No pages yet</p>
@@ -212,6 +215,10 @@ export function PagesView({ client, company }: Props) {
 
   return (
     <div className="flex flex-1 overflow-hidden">
+      {/* Each page's own title lives inside its sandboxed iframe, a separate
+          document this console doesn't control — this names the console-side
+          page for a screen reader (issue #1221). */}
+      <h1 className="sr-only">Pages</h1>
       <section className="hidden w-64 shrink-0 flex-col overflow-y-auto border-r py-2 md:flex" data-testid="pages-list">
         {visible.map((page) => (
           <button

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -51,6 +51,9 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
+        {/* This sub-page draws no visible title of its own — the sub-nav rail
+            beside it already says "Settings" (issue #1221). */}
+        <h1 className="sr-only">General settings</h1>
         {/* Pairing this machine. Renders nothing in a browser, where the
             session cookie already works. */}
         <DevicePairing />

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -179,7 +179,7 @@ export function SkillsView({ client, company }: Props) {
       <div className="mx-auto w-full max-w-5xl space-y-5 px-4 py-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
-            <h2 className="text-2xl font-semibold tracking-tight">Skills</h2>
+            <h1 className="text-2xl font-semibold tracking-tight">Skills</h1>
             <p className="text-sm text-muted-foreground">
               Playbooks your teammates read. Enable, install from the registry, or add your own.
             </p>

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -726,7 +726,7 @@ function DetailHeader({
   return (
     <div className="rounded-xl border bg-card p-4">
       <div className="flex items-start justify-between gap-3">
-        <h2 className="text-lg font-semibold leading-snug">{task.title}</h2>
+        <h1 className="text-lg font-semibold leading-snug">{task.title}</h1>
         <Badge
           variant="outline"
           className={cn("shrink-0 capitalize", priorityStyle(task.priority))}

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -389,7 +389,7 @@ export function TeamView({
         */}
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
-            <h2 className="text-2xl font-semibold tracking-tight">Company</h2>
+            <h1 className="text-2xl font-semibold tracking-tight">Company</h1>
             <p className="text-sm text-muted-foreground">
               The teammates that make up your company — what each does, and what
               they're on. {fromHost ? "Defined by this company." : "Start from these and shape your own."}

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -140,7 +140,7 @@ export function UsageView({ client, company }: Props) {
       <div className="mx-auto w-full max-w-6xl space-y-6 px-4 py-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
-            <h2 className="text-2xl font-semibold tracking-tight">Usage</h2>
+            <h1 className="text-2xl font-semibold tracking-tight">Usage</h1>
             <p className="text-sm text-muted-foreground">
               What your company is burning — tokens and OAuth calls.
             </p>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2126,9 +2126,9 @@ export function WorkflowsView({
                 {/* Navigation is not identity. The hairline says so, so the
                     name reads as a heading rather than as the next link. */}
                 <span aria-hidden className="h-4 w-px shrink-0 bg-border" />
-                <h2 className="min-w-0 truncate text-sm font-semibold" data-testid="workflow-detail-name">
+                <h1 className="min-w-0 truncate text-sm font-semibold" data-testid="workflow-detail-name">
                   {selected?.name ?? graph?.name ?? selectedId}
-                </h2>
+                </h1>
                 {/* Issue #228: the last run's outcome at a glance — including for
                     a scheduled run nobody watched, which is the case the issue is
                     about. Absent until this workflow has run at least once. */}
@@ -2427,7 +2427,7 @@ export function WorkflowsView({
              act on the list rather than on any workflow in it. */
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2">
-              <h2 className="text-sm font-semibold">Workflows</h2>
+              <h1 className="text-sm font-semibold">Workflows</h1>
               <Badge variant="secondary">{workflows.length}</Badge>
             </div>
             <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1187,6 +1187,10 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
 
   return (
     <div className="flex flex-1 overflow-hidden">
+      {/* The file tree and editor are the page, with no title of their own
+          (issue #1221) — this names the page for a screen reader the same
+          way every other view's title does. */}
+      <h1 className="sr-only">Workspace</h1>
       {/* Explorer */}
       <aside
         className={cn(

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -421,7 +421,7 @@ export function OrgChartView({ client, company, focusDeskId, onBack }: Props) {
         )}
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
-            <h2 className="text-2xl font-semibold tracking-tight">Desks</h2>
+            <h1 className="text-2xl font-semibold tracking-tight">Desks</h1>
             <p className="text-sm text-muted-foreground">
               How your company is organised: the desks it works from and who
               staffs each one. Add a desk, move someone between desks, or change

--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -413,9 +413,9 @@ function Identity({ agent }: { agent: AgentDetailDto }) {
       />
       <div className="min-w-0 flex-1 space-y-2">
         <div>
-          <h2 className="truncate text-2xl font-semibold tracking-tight" data-testid="agent-name">
+          <h1 className="truncate text-2xl font-semibold tracking-tight" data-testid="agent-name">
             {display}
-          </h2>
+          </h1>
           {subtitle && (
             <p className="truncate text-sm text-muted-foreground" data-testid="agent-role">
               {subtitle}

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -57,7 +57,7 @@ test("a legacy cancelled-handshake query lands in the console, not on a dead pag
 
   // The console renders — the operator is not stranded on raw JSON.
   await dismissWelcome(page);
-  await expect(page.getByRole("heading", { name: "Connections", level: 2 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
 
   // The param is stripped, so a refresh doesn't re-fire the toast.
   await expect
@@ -88,7 +88,7 @@ test("an unknown failure code still produces a usable message", async ({ page })
   await page.goto("/connections?connect_error=something_new_2099");
   await expect(page.getByText(/couldn't connect/i)).toBeVisible();
   await dismissWelcome(page);
-  await expect(page.getByRole("heading", { name: "Connections", level: 2 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
 });
 
 test("the tour resumes on the Connections stop after a redirect", async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #1221.

Every console page rendered two nested `<main>` landmarks: `SidebarInset`
(`frontend/src/components/ui/sidebar.tsx:316-329`) already renders one, and
`app-shell.tsx` rendered a second one directly inside it as a flex/scroll
wrapper. The inner one is now a plain `<div>` — same className, same
position in the tree, no visual change. `SidebarInset` is the console's one
`<main>` landmark for every view.

Most pages also had no `<h1>`, so a screen reader landed mid-outline with no
top-level heading. Each reachable view now has exactly one:

- **Existing page-title `<h2>` promoted to `<h1>`** (className/`data-testid`
  unchanged): Company roster (`TeamView`), Desks (`OrgChartView`), teammate
  detail (`AgentDetailView`), Workflows index and workflow detail
  (`WorkflowsView`, both branches — only one ever renders), task detail
  (`TaskDetailView`), and the Settings sub-pages Connections, MCP Servers,
  Billing, Hosting, Skills, Usage.
- **New visually-hidden `<h1>`** (Tailwind's `sr-only`, already used
  elsewhere in this codebase) on views that draw no visible title at all:
  Overview ("Company overview"), Approvals ("Approvals" — the queue's own
  count heading is conditional and doesn't cover the loading/error/empty
  states), general Settings ("General settings"), Workspace ("Workspace"),
  and Pages ("Pages", added to all four of its mutually-exclusive
  loading/error/empty/populated return blocks).
- **Left untouched**: Chat (`h1` = channel name) and Ledgers (`h1` =
  "Ledgers") were already correct. People already had an `h1`. `Styleguide`
  is a standalone route outside the shell and already has its own `h1`.
  `FeedbackView`, `InboxView`, `MemoryView`, `FinancesView`, `Conversation`,
  and `TeamView`'s bare (no-`sub`) branch reached via the literal `team`
  view id are `HIDDEN_VIEWS` — per their own header comments, "unmounted
  from the console — hidden, not retired" — and not reachable through any
  live UI control, so they're out of scope here.

## Test plan

- [x] `cd frontend && npm run typecheck` / `typecheck:unit` / `typecheck:e2e` — clean
- [x] `npx vitest run` — 147 files / 1404 tests pass
- [x] Built the frontend and ran the host locally (`opencompany serve` with an
      isolated `OPENCOMPANY_DATA_DIR`), signed in via a magic link, and used
      Playwright to walk the DOM/accessibility tree of every NAV page plus
      several sub-pages: `#/overview`, `#/company`, `#/company/desks`,
      `#/chat`, `#/ledgers`, `#/workspace`, `#/approvals`, `#/workflows`,
      `#/settings`, `#/settings/people`, `#/settings/connections`,
      `#/settings/billing`, `#/team/<agentId>` (via a roster card click).
      Every one resolved to `document.querySelectorAll("main").length === 1`,
      zero nested `<main>`s, and exactly one `<h1>`.