### PR TITLE
fix(workflows): stop a stranded run advertising itself as approvable (#1189)

### DIFF
--- a/docs/modules/server/run-verdict.md
+++ b/docs/modules/server/run-verdict.md
@@ -6,7 +6,7 @@ the synchronous `POST …/workflows/{wid}/run` body and every row of
 `GET …/workflows/runs`:
 
 ```text
-running | failed | stopped | blocked | undelivered | awaiting-approval | ok
+running | failed | stopped | stranded | blocked | undelivered | awaiting-approval | ok
 ```
 
 **Always serialized**, unlike the optional fields around it. Its whole purpose
@@ -41,10 +41,75 @@ green on some surface:
 | `running` | `running` | an unsettled run has no error, no cancel and no deliveries yet, so without this it falls to `ok` |
 | `failed` | `error` | **the more serious fact first** — a run that broke mid-graph *and* dropped a report reads `failed`, with its delivery rows still on the body |
 | `stopped` | `cancelled` | issue #383: a stop somebody asked for is not a fault, and a cancelled run has no deliveries to weigh |
+| `stranded` | `pendingApprovals` **and** `strandedApprovals` | issue #1189: every gate has lost its card, so the two readings below — both of which say "go and decide it" — are the one thing that is no longer true |
 | `blocked` | `blockedNodes` | issue #881: carries no error, is not cancelled, is not running and routed no report — the shape that fell through every check |
 | `undelivered` | `deliveries` | issue #981: a report that will not go out without a change outranks one waiting on a human |
 | `awaiting-approval` | `pendingApprovals` **and** `pending` delivery rows | issue #846: a run that paused at a gate reached no `output` node, so a delivery-only read scored the gated case clean |
 | `ok` | — | finished, delivered what it routed, waiting on nobody |
+
+## A run nobody can act on any more (issue #1189)
+
+`stranded` fires when the run stopped for somebody, **every** one of those gates
+has no live card left in the queue, and no report is parked either. A run only
+*partly* stranded keeps its old verdict — something there really is still
+decidable, and the per-node `blockedNodes[].stranded` count carries the loss.
+
+### Why it needed a word of its own
+
+A run has two ways to stop for a person and only one of them was ever
+reconciled against the live queue:
+
+| shape | what it records | join key |
+| --- | --- | --- |
+| **blocked node** | `blockedNodes[].approvalIds` — the ids its gated calls parked. The cards are ordinary tool-call effects and carry no node id. | approval id (issue #1143) |
+| **gate** | nothing but a node id on `pendingApprovals`. `park_pending_gates` writes no approval-row receipt and no blocked-node row; the parked `workflow.approve` card is the only thing that knows the pair. | `(run_id, node_id)` (issue #1189) |
+
+#1143's join is keyed on ids the gate shape does not have, so it structurally
+could not reach it — and the gate shape is the larger half. On the marketing
+tenant, 34 of 60 runs are `{"verdict":"awaiting-approval","pendingApprovals":
+["fetch_bbc","fetch_espn","fetch_guardian"],"blockedNodes":[],"approvals":[]}`
+against an **empty** queue: a third of the tenant's history claiming to wait on
+a person who had nothing to answer.
+
+Without this arm there was no honest verdict for that state, so it kept the
+dishonest one. `blocked` and `awaiting-approval` both tell an operator to go and
+decide something; `stranded` is precisely the state in which there is nothing to
+decide, which is why it outranks them rather than sitting below.
+
+### It claims nothing about why
+
+Approving a gate does not continue the parent run: `resume_run` →
+`spawn_continuation` starts a **new** run with a new id and records no link back
+to the one that paused. So a run whose gates were all *approved* is
+indistinguishable, from this end, from one whose cards were *lost*. The join is
+still right — no decision left can move either run — but the copy must not claim
+data loss. Every surface says only what is observable ("nothing here is waiting
+on you any more; this run cannot be continued") and offers a re-run as an
+option, never as a remedy for a stated cause.
+
+The console paints it `idle`, not the amber `blocked`/`awaiting-approval` share:
+amber is the "needs your attention, go and decide this" state, and reprinting
+that in colour is the claim this reading exists to remove. Not red either — the
+graph did not break. See `docs/design-system/color.md`.
+
+### Derived after the reconciliation, not before it
+
+`strandedApprovals` is computed on each read of `GET …/workflows/runs`, and the
+verdict pass now runs **after** that join. Until #1189 the pass sat above
+`reverse()`/`truncate()` and above the join, so even the shape #1143 *did*
+reconcile got a verdict read from pre-join data — a blocked-node list saying
+"cannot be continued" beside a run verdict saying `blocked`.
+
+`reverse` and `truncate` moved above the pass to make room. Neither touches a
+single field of a row — they reorder and drop whole rows — so the invariant the
+pass is placed on ("derive after everything that can still change its inputs")
+is not weakened. It is extended: the reconciliation genuinely does change an
+input.
+
+The synchronous `POST …/workflows/{wid}/run` path deliberately passes a literal
+`0`. Its body is written microseconds after `park_pending_gates` minted the
+cards, so joining against the queue there would be a guaranteed-zero query on
+the hot path; the reconciliation is a fact about a run somebody comes back to.
 
 An empty `error` string is not a failure. No producer writes one, and the
 console's `if (run.error)` has always read it as falsy — the host agreeing costs

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -221,14 +221,21 @@ export interface DeliveryReport {
  * anything folding `nodes[].status` — the QA harness included — scored a
  * dropped report green.
  *
- * The seven words are unchanged from the ladder this console has always used,
- * in the same precedence order; only the place they are decided has moved. See
+ * The words are unchanged from the ladder this console has always used, in the
+ * same precedence order; only the place they are decided has moved. See
  * {@link runTone}.
+ *
+ * `stranded` is the one addition (issue #1189): every person the run stopped
+ * for has nothing left to answer, so no decision can move it. It outranks
+ * `blocked` and `awaiting-approval` because it contradicts them — both tell an
+ * operator to go and decide something, and this is the state in which there is
+ * nothing there.
  */
 export type WorkflowRunVerdict =
   | "running"
   | "failed"
   | "stopped"
+  | "stranded"
   | "blocked"
   | "undelivered"
   | "awaiting-approval"
@@ -510,6 +517,21 @@ export interface WorkflowRunOutcome {
   deliveries: DeliveryReport[];
   /** Node ids the run left waiting on a human approval. */
   pendingApprovals: string[];
+  /**
+   * How many of `pendingApprovals` have **no live card left in the queue**
+   * (issue #1189) — the gate-shaped sibling of `blockedNodes[].stranded`.
+   *
+   * A gate the engine paused at is parked as a `workflow.approve` card that
+   * records no receipt and no blocked-node row, so #1143's per-node count
+   * cannot describe it: the only join is `(runId, nodeId)`, and only the host
+   * can make it. Absent when zero, and absent entirely from a host predating
+   * this — which the console reads as "not reconciled", never as "nothing is
+   * stranded".
+   *
+   * Derived on each read, like `blockedNodes[].stranded`, so it reflects the
+   * queue as it is now rather than what the run recorded when it stopped.
+   */
+  strandedApprovals?: number;
   /** Set when the run failed outright instead of finishing with rows. */
   error?: string;
   /**

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -22,10 +22,11 @@ import { BlockedNodeApprovals } from "./BlockedNodeApprovals";
 import { failedNodeOf, nodeName } from "./graph";
 import {
   awaitingCount,
-  decidableApprovalCount,
   formatDuration,
   isBlocked,
   isRunning,
+  isStranded,
+  liveParkedApprovalCount,
   relativeTime,
   runDuration,
   runTone,
@@ -316,12 +317,20 @@ function RunHistoryRow({
   // Issue #881 / #880: read once, so the chip, the badge and the terminal line
   // below cannot disagree about whether this run stopped for a person.
   const blocked = run.blockedNodes ?? [];
-  // Issue #900: `decidableApprovalCount`, not `parkedApprovalCount` — this
-  // paragraph tells the operator a card is waiting, so it must count only
-  // the receipts that actually landed one. Counting a failed park here said
-  // "needs your approval" and "decide it in Approvals" about a call the very
-  // next sentence admitted nobody would ever be asked about.
-  const parked = decidableApprovalCount(run);
+  // Issue #900: only the receipts that actually landed a card, because this
+  // paragraph tells the operator one is waiting. Counting a failed park here
+  // said "needs your approval" and "decide it in Approvals" about a call the
+  // very next sentence admitted nobody would ever be asked about.
+  //
+  // Issue #1189 took the same argument one step further: a card that landed and
+  // has since fallen out of the queue is in exactly the position of one that
+  // never landed, and `decidableApprovalCount` cannot see the difference —
+  // a receipt records that a card was opened, never that it is still open. So
+  // the count is the live one, and the sentence below can stand behind it.
+  const parked = liveParkedApprovalCount(run);
+  // Issue #1189: the run's own reading, so the paragraph, the badge and the
+  // blocked-node list beneath them all branch off ONE fact.
+  const stranded = isStranded(run);
   // The loud half: calls nobody will ever be asked about, because the park
   // itself failed or the excess was dropped past the per-turn cap. Strictly
   // worse than a parked one — there is no card to click.
@@ -370,6 +379,12 @@ function RunHistoryRow({
             parked {parked} approval{parked === 1 ? "" : "s"}
           </Badge>
         ) : (
+          // Issue #1189: `!stranded`, because this badge is the run row's own
+          // copy of the claim the drawer makes below. A stranded run has an
+          // empty receipt (a paused gate files none), so `parked` is 0 and this
+          // fallback fired — painting "3 pending approvals", in amber, on the
+          // one run for which nothing is pending at all.
+          !stranded &&
           run.pendingApprovals.length > 0 && (
             <Badge
               variant="outline"
@@ -517,12 +532,23 @@ function RunHistoryRow({
               unparkable — a call nobody will ever be asked about. That read
               as a promise of a card that does not exist, and contradicted the
               closing sentence below whenever `parked` was 0. */}
+          {/* Issue #1189: THREE branches, on both clauses, because dropping
+              `parked` to 0 for a stranded run flipped each of them to something
+              wrong in its own way. The opening clause became "could not be
+              queued for approval" — but these calls WERE queued; the card was
+              opened and later lost, which is a different fact and the only one
+              of the two an operator can act on differently. The closing clause
+              became "change the policy and run the workflow again" — but no
+              policy refused anything here, so it sends them to edit a setting
+              that was never the problem. */}
           Not finished — {blocked.map((b) => `“${b.nodeId}”`).join(", ")}{" "}
           {parked > 0
             ? blocked.length === 1
               ? "needs your approval"
               : "need your approval"
-            : "could not be queued for approval"}, so{" "}
+            : stranded
+              ? "needed your approval"
+              : "could not be queued for approval"}, so{" "}
           {blocked.length === 1 ? "it" : "they"} produced nothing and the steps
           after {blocked.length === 1 ? "it" : "them"} did not run.{" "}
           {parked > 0 &&
@@ -531,7 +557,15 @@ function RunHistoryRow({
             `${unparkable} call${unparkable === 1 ? "" : "s"} could not be queued for approval at all, so you will not be asked about ${unparkable === 1 ? "it" : "them"}. `}
           {parked > 0
             ? `Approve ${parked === 1 ? "it" : "them"} in Approvals and this run continues on its own — approving re-runs the step, so a changed decision may ask again.`
-            : "Nothing here can be approved; change the policy and run the workflow again."}
+            : stranded
+              ? // Says only what is observable. Approving a gate starts a NEW
+                // run rather than continuing this one, and records no link back
+                // — so a run whose approvals were all decided and one whose
+                // cards were lost look identical from here, and claiming
+                // either would be a diagnosis the console cannot make. Re-run
+                // is offered as an option, not as a remedy for a stated cause.
+                "Nothing here is waiting on you any more, and this run cannot be continued. Run the workflow again if you still need it."
+              : "Nothing here can be approved; change the policy and run the workflow again."}
         </p>
         {/* Issue #1014 (PR-B): the gated tool names per blocked node and a link
             per parked card to the Approvals queue — the sentence above says
@@ -549,6 +583,44 @@ function RunHistoryRow({
         <p className="text-2xs text-muted-foreground">
           Still running — reports are routed when it finishes.
         </p>
+      ) : stranded ? (
+        // Issue #1189, and the arm the issue text does not enumerate — but the
+        // one the 34 runs actually render. The chain above it is
+        // `error → cancelled → isBlocked → running`, and `isBlocked` reads
+        // `blockedNodes.length`. A fully stranded GATE run has no blocked-node
+        // rows at all (a paused gate writes none), so it fell straight through
+        // to the `pendingApprovals` arm below — whose closing line is "Approve
+        // or decline it in Approvals to carry the run on." Fixing the summary,
+        // the badge and the verdict and leaving this would have shipped the
+        // same defect on the half the issue calls bigger.
+        //
+        // Placed above `pendingApprovals` to mirror the host ladder, where
+        // `stranded` outranks `awaiting-approval` for exactly this reason: both
+        // arms describe a run stopped for a person, and only one of them is
+        // still true.
+        //
+        // Muted rather than amber: amber is the console's "needs your
+        // attention" state, and nothing here needs anybody's. Same reasoning as
+        // the tone in `run-health.ts`.
+        <>
+          {/* The reports it DID route before the gate, on the same terms the
+              awaiting arm shows them: replacing them would trade one silent
+              omission for another. */}
+          {run.deliveries.length > 0 && (
+            <DeliveryRows deliveries={run.deliveries} />
+          )}
+          <p
+            className="text-2xs text-muted-foreground"
+            data-testid="workflow-run-stranded"
+          >
+            Not finished — this run stopped for your approval on{" "}
+            {run.pendingApprovals.map((node) => `“${node}”`).join(", ")}, and
+            nothing here is waiting on you any more. No decision left can move
+            it
+            {run.deliveries.length === 0 ? ", and no reports were routed" : ""}.
+            Run the workflow again if you still need it.
+          </p>
+        </>
       ) : run.pendingApprovals.length > 0 ? (
         <>
           {/* A paused run can still have routed reports — the output nodes it

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -113,7 +113,40 @@ export function pendingCount(deliveries: DeliveryReport[]): number {
  * whether somebody is being waited on.
  */
 export function awaitingCount(run: WorkflowRunOutcome): number {
-  return (run.pendingApprovals?.length ?? 0) + pendingCount(run.deliveries);
+  return liveApprovalCount(run) + pendingCount(run.deliveries);
+}
+
+/**
+ * The gate nodes this run stopped at that STILL have a card in the queue
+ * (issue #1189).
+ *
+ * `pendingApprovals` is a receipt of where the run stopped and cannot go stale
+ * — but the question each entry points at can, and on one staging tenant 34 of
+ * 60 runs were pointing at nothing. The host reconciles the two and reports the
+ * difference as `strandedApprovals`; this is the subtraction, done once, so the
+ * header chip, the drawer and the summary line cannot disagree about whether
+ * anybody is being waited on.
+ *
+ * Clamped at 0. The two numbers come from the same host read, so the count can
+ * never legitimately exceed the list — but a negative here would render as
+ * "-1 awaiting approval", which is a worse failure than the one being fixed.
+ */
+export function liveApprovalCount(run: WorkflowRunOutcome): number {
+  const pending = run.pendingApprovals?.length ?? 0;
+  return Math.max(0, pending - strandedApprovalCount(run));
+}
+
+/**
+ * The gate nodes this run stopped at with **no live card left** (issue #1189).
+ *
+ * Host-derived, never guessed: only the host can join a gate to the queue, and
+ * a host predating #1189 sends no key at all — which reads as 0, i.e. "not
+ * reconciled". That is the safe direction. Inventing a dead end would retire a
+ * run an operator can still act on, which is strictly worse than the defect
+ * this closes: an operator cannot argue with a run the console says is over.
+ */
+export function strandedApprovalCount(run: WorkflowRunOutcome): number {
+  return run.strandedApprovals ?? 0;
 }
 
 /**
@@ -149,6 +182,35 @@ export function decidableApprovalCount(run: WorkflowRunOutcome): number {
 }
 
 /**
+ * The approvals this run parked that are STILL on the Approvals page (issue
+ * #1189).
+ *
+ * {@link decidableApprovalCount} is live-blind: it reads the run's receipt, and
+ * a receipt records that a card was opened, never that it is still open. That
+ * was right for #900's question ("did the park land?") and is wrong for any
+ * copy that tells the operator to go and decide something — which is how the
+ * drawer came to say "Approve them in Approvals and this run continues on its
+ * own" one line above "none of its approvals are in the queue any more".
+ *
+ * Subtracts the per-node `stranded` counts the host already computes (#1143).
+ * Both numbers are in the same units — approval **ids** — because `stranded` is
+ * a filter over `blockedNodes[].approvalIds` and the receipt rows are keyed by
+ * the same ids.
+ *
+ * Clamped at 0 for the same reason {@link liveApprovalCount} is, plus one of
+ * its own: the receipt deliberately excludes parks that never landed while
+ * `stranded` counts only ids that did, so the two lists are not identical and
+ * arithmetic across them must not be trusted to stay ordered.
+ */
+export function liveParkedApprovalCount(run: WorkflowRunOutcome): number {
+  const stranded = (run.blockedNodes ?? []).reduce(
+    (n, b) => n + (b.stranded ?? 0),
+    0,
+  );
+  return Math.max(0, decidableApprovalCount(run) - stranded);
+}
+
+/**
  * Whether this run stopped short because a step is waiting on a person (issue
  * #881).
  *
@@ -160,6 +222,30 @@ export function decidableApprovalCount(run: WorkflowRunOutcome): number {
  */
 export function isBlocked(run: WorkflowRunOutcome): boolean {
   return (run.blockedNodes?.length ?? 0) > 0;
+}
+
+/**
+ * Whether nothing in the queue is waiting on this run any more, so no decision
+ * can move it (issue #1189).
+ *
+ * The host's word first, exactly as {@link verdictOf} takes it: the host is the
+ * only reader that can join a gate against the live queue. The local fold is
+ * the fallback for a host predating #1189 that nevertheless sent the per-node
+ * `stranded` counts #1143 added — the `feature_pipeline` case — and it mirrors
+ * the host's rule rather than inventing a second one: it stopped for somebody,
+ * EVERY gate lost its card, and no report is parked either.
+ *
+ * A partly stranded run is deliberately NOT stranded. Something there really is
+ * still decidable, and the per-node count is what carries the loss.
+ */
+export function isStranded(run: WorkflowRunOutcome): boolean {
+  if (run.verdict) return run.verdict === "stranded";
+  const pending = run.pendingApprovals?.length ?? 0;
+  return (
+    pending > 0 &&
+    strandedApprovalCount(run) >= pending &&
+    pendingCount(run.deliveries) === 0
+  );
 }
 
 /** A compact "N minutes ago" for a run timestamp — enough to tell last night's
@@ -203,6 +289,23 @@ const VERDICT_TONE: Record<WorkflowRunVerdict, { dot: string; label: string }> =
     // Issue #383: a stop somebody asked for is not a fault. Idle is the state
     // for "nothing is happening and nothing went wrong".
     stopped: { dot: "bg-status-idle", label: "stopped" },
+    // Issue #1189: idle, NOT the amber it shares a shape with.
+    //
+    // The status vocabulary is a closed set of five (docs/design-system/color.md),
+    // so this picks from them rather than adding a sixth. Amber is the console's
+    // "needs your attention, nothing is broken" state — it is what `blocked` and
+    // `awaiting approval` wear, and both of them mean "go and decide this". A
+    // stranded run is the one state in which that is false: there is nothing to
+    // decide and nothing is owed. Painting it amber would reprint, in colour,
+    // the exact claim this issue was filed to remove.
+    //
+    // Idle is `stopped`'s token for "nothing is happening and nothing went
+    // wrong", and this run is inert in the same way. It is deliberately not
+    // `failed` either: the graph did not break, and — since approving a gate
+    // spawns a NEW run with no link back — a run whose gates were all approved
+    // is indistinguishable from one whose cards were lost. Red would be a claim
+    // about which, and the console cannot tell.
+    stranded: { dot: "bg-status-idle", label: "stranded" },
     // Issue #881: deliberately not red. A blocked run stopped short of its work
     // but nothing about it failed. The label says what happened to the run, not
     // what is owed; the count of what it parked belongs on the row beneath.
@@ -221,7 +324,8 @@ const VERDICT_TONE: Record<WorkflowRunVerdict, { dot: string; label: string }> =
 /**
  * A run's verdict — **the host's when it sends one** (issue #981).
  *
- * The seven words and their precedence order are unchanged; what changed is who
+ * The words and their precedence order are unchanged (bar #1189's
+ * `stranded`); what changed is who
  * owns them. They lived only here, in this console's TypeScript, so every other
  * reader of the same run had to re-derive them — and the obvious derivation,
  * folding `nodes[].status`, is wrong for the one case that matters: delivery
@@ -247,6 +351,8 @@ export function verdictOf(run: WorkflowRunOutcome): WorkflowRunVerdict {
   if (isRunning(run)) return "running";
   if (run.error) return "failed";
   if (run.cancelled) return "stopped";
+  // Issue #1189, above both readings that say "go and decide it".
+  if (isStranded(run)) return "stranded";
   if (isBlocked(run)) return "blocked";
   if (undeliveredCount(run.deliveries) > 0) return "undelivered";
   if (awaitingCount(run) > 0) return "awaiting-approval";

--- a/frontend/test/unit/qa-harness.test.ts
+++ b/frontend/test/unit/qa-harness.test.ts
@@ -129,6 +129,7 @@ const TONE_TO_VERDICT: Record<string, string> = {
   running: "running",
   failed: "failed",
   stopped: "stopped",
+  stranded: "stranded",
   blocked: "blocked",
   "not delivered": "undelivered",
   "awaiting approval": "awaiting-approval",
@@ -335,6 +336,37 @@ describe("runVerdict agrees with the console's runTone", () => {
       name: "blocked is judged before the delivery rows",
       run: run({ blockedNodes: [blocked("approve")], deliveries: [delivery("failed")] }),
       label: "blocked",
+    },
+    {
+      // #1189: the shape that scored `awaiting-approval` forever. Every gate
+      // has lost its card, so both readings below it — "blocked" and "awaiting
+      // approval" — tell the operator to go and decide something that is not
+      // there.
+      name: "every gate has lost its card",
+      run: run({
+        pendingApprovals: ["fetch_bbc", "fetch_espn"],
+        strandedApprovals: 2,
+      } as Partial<WorkflowRunOutcome>),
+      label: "stranded",
+    },
+    {
+      name: "stranded outranks blocked",
+      run: run({
+        blockedNodes: [blocked("approve")],
+        pendingApprovals: ["approve"],
+        strandedApprovals: 1,
+      } as Partial<WorkflowRunOutcome>),
+      label: "stranded",
+    },
+    {
+      // The negative: one gate is still decidable, so the run is still awaiting
+      // and the per-node count carries the loss.
+      name: "a partly stranded run is still awaiting",
+      run: run({
+        pendingApprovals: ["fetch_bbc", "fetch_espn"],
+        strandedApprovals: 1,
+      } as Partial<WorkflowRunOutcome>),
+      label: "awaiting approval",
     },
     {
       name: "every node ok but the report was dropped (#981)",

--- a/frontend/test/unit/workflow-run-approval-links.test.ts
+++ b/frontend/test/unit/workflow-run-approval-links.test.ts
@@ -242,6 +242,38 @@ describe("a blocked run whose approvals the queue no longer holds", () => {
     expect(container.textContent).not.toContain("decide in Approvals");
   });
 
+  /**
+   * Issue #1189: the paragraph above the list and the list itself must say the
+   * SAME thing, not merely avoid saying opposite things.
+   *
+   * This is the contradiction the issue opens on, verbatim from the product
+   * tenant: the list said "none of its approvals are in the queue any more, so
+   * this run cannot be continued" while the paragraph directly above it said
+   * "Approve them in Approvals and this run continues on its own". Both were
+   * rendered, in that order, on one row. Pinning them in one test is what stops
+   * a future change fixing one and leaving the other.
+   */
+  it("agrees with the paragraph above it when every card is gone", async () => {
+    await renderHistory(
+      blockedOutcome({
+        strandedApprovals: 1,
+        verdict: "stranded",
+        blockedNodes: [
+          {
+            nodeId: "spec",
+            tools: ["publish_artifact", "web_search"],
+            approvalIds: ["appr-1", "appr-2"],
+            stranded: 2,
+          },
+        ],
+      }),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("cannot be continued");
+    expect(text).not.toContain("continues on its own");
+    expect(text).not.toContain("Approve them in Approvals");
+  });
+
   it("keeps linking the cards that survive, and counts the ones that did not", async () => {
     await renderHistory(
       blockedOutcome({

--- a/frontend/test/unit/workflow-run-stranded.test.ts
+++ b/frontend/test/unit/workflow-run-stranded.test.ts
@@ -1,0 +1,321 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { WorkflowGraph, WorkflowRunOutcome } from "@/api/workflows";
+import { RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
+import {
+  awaitingCount,
+  isStranded,
+  liveApprovalCount,
+  liveParkedApprovalCount,
+  runTone,
+} from "@/views/workflows/run-health";
+
+/**
+ * Issue #1189: a run nobody can act on any more must stop being advertised as
+ * approvable.
+ *
+ * #1150 stopped the blocked-node LIST offering a stranded approval as a
+ * decision. The same run went on saying the opposite thing three more times —
+ * in the summary sentence, in the header chip, and in the host's own verdict —
+ * and a fourth time in the outcome chain, which is the one the marketing
+ * tenant's 34 runs actually render: they carry `pendingApprovals` and NO
+ * `blockedNodes`, so `isBlocked` is false and they land in the
+ * `pendingApprovals` arm, whose copy is "Approve or decline it in Approvals to
+ * carry the run on."
+ *
+ * A jsdom render rather than a pure test wherever the claim is about what the
+ * drawer paints. Every test below fails on the code before this change.
+ */
+
+const GRAPH: WorkflowGraph = {
+  id: "daily_sports_news",
+  name: "Daily sports news",
+  version: null,
+  nodes: [
+    { id: "fetch_bbc", kind: "agent", name: "Fetch BBC", agent: "writer" },
+    { id: "fetch_espn", kind: "agent", name: "Fetch ESPN", agent: "writer" },
+  ],
+  edges: [],
+};
+
+/** The marketing tenant's shape: gates on `pendingApprovals`, no blocked nodes,
+ * no receipts, and the host reporting every gate stranded. */
+function strandedGateRun(
+  over: Partial<WorkflowRunOutcome> = {},
+): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    workflowId: "daily_sports_news",
+    scheduled: true,
+    runId: "run-g",
+    deliveries: [],
+    pendingApprovals: ["fetch_bbc", "fetch_espn", "fetch_guardian"],
+    strandedApprovals: 3,
+    verdict: "stranded",
+    nodes: [],
+    ...over,
+  };
+}
+
+/** The `feature_pipeline` shape: a blocked node whose every card the queue lost. */
+function strandedBlockedRun(
+  over: Partial<WorkflowRunOutcome> = {},
+): WorkflowRunOutcome {
+  return {
+    seq: 2,
+    atMillis: 1_700_000_000_000,
+    workflowId: "feature_pipeline",
+    scheduled: false,
+    runId: "run-b",
+    deliveries: [],
+    pendingApprovals: ["backend"],
+    strandedApprovals: 1,
+    verdict: "stranded",
+    nodes: [{ nodeId: "backend", status: "blocked", elapsedMs: 42_000 }],
+    blockedNodes: [
+      {
+        nodeId: "backend",
+        tools: ["shell", "curl"],
+        approvalIds: ["appr-1", "appr-2", "appr-3"],
+        stranded: 3,
+      },
+    ],
+    approvals: [
+      { nodeId: "backend", tool: "shell", outcome: "parked", approvalId: "appr-1" },
+      { nodeId: "backend", tool: "curl", outcome: "parked", approvalId: "appr-2" },
+      { nodeId: "backend", tool: "shell", outcome: "parked", approvalId: "appr-3" },
+    ],
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderHistory(run: WorkflowRunOutcome) {
+  await act(async () => {
+    root.render(
+      createElement(RunHistoryPanel, {
+        runs: [run],
+        graph: GRAPH,
+        workflowName: "Daily sports news",
+        onClose: () => {},
+        selectedRunSeq: null,
+        onSelectRun: () => {},
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("a gate run whose cards the queue no longer holds", () => {
+  it("renders the stranded line instead of pointing at Approvals", async () => {
+    await renderHistory(strandedGateRun());
+    const line = container.querySelector(
+      '[data-testid="workflow-run-stranded"]',
+    );
+    expect(line).not.toBeNull();
+    expect(line?.textContent).toContain("nothing here is waiting on you");
+    // The sentence #1143 exists to kill, on the arm nothing had fixed.
+    expect(container.textContent).not.toContain(
+      "Approve or decline it in Approvals",
+    );
+    // And it must not have fallen into the old awaiting arm at all.
+    expect(
+      container.querySelector('[data-testid="workflow-run-awaiting"]'),
+    ).toBeNull();
+  });
+
+  it("says nothing about WHY the cards are gone", async () => {
+    await renderHistory(strandedGateRun());
+    const text = container.textContent ?? "";
+    // Approving a gate spawns a NEW run and records no link back, so an
+    // all-approved run and a card-loss run are indistinguishable from here.
+    // The copy may not claim either.
+    expect(text).not.toMatch(/lost|expired|deleted|discarded/i);
+    // Re-run is offered as an option, not as a remedy for a stated cause.
+    expect(text).toContain("Run the workflow again if you still need it");
+  });
+
+  it("keeps the reports it routed before the gate", async () => {
+    await renderHistory(
+      strandedGateRun({
+        deliveries: [
+          {
+            node: "digest",
+            kind: "channel",
+            target: "engineering",
+            status: "sent",
+            detail: "posted",
+            reason: "channel-posted",
+          },
+        ],
+      }),
+    );
+    expect(container.textContent).toContain("engineering");
+    expect(container.textContent).not.toContain("no reports were routed");
+  });
+
+  it("does not badge the run with a pending-approval count", async () => {
+    await renderHistory(strandedGateRun());
+    // The row badge is the run row's own copy of the drawer's claim. A paused
+    // gate files no receipt, so `parked` is 0 and the fallback used to paint
+    // "3 pending approvals" in amber on the one run with nothing pending.
+    expect(container.textContent).not.toContain("pending approval");
+  });
+});
+
+describe("the header chip for a stranded run", () => {
+  it("does not say anything is awaiting approval", () => {
+    const run = strandedGateRun();
+    // The count behind the chip's ` · N awaiting approval` segment.
+    expect(awaitingCount(run)).toBe(0);
+    expect(liveApprovalCount(run)).toBe(0);
+    expect(runTone(run).label).not.toContain("awaiting approval");
+    expect(runTone(run).label).toBe("stranded");
+  });
+
+  it("wears the idle dot, not the amber one", () => {
+    // Amber is the console's "needs your attention, go and decide this" state,
+    // which is the one claim a stranded run must not make.
+    expect(runTone(strandedGateRun()).dot).toBe("bg-status-idle");
+  });
+});
+
+describe("a blocked run whose every card the queue lost", () => {
+  it("stops promising the run continues on its own", async () => {
+    await renderHistory(strandedBlockedRun());
+    const text = container.textContent ?? "";
+    expect(text).not.toContain(
+      "Approve them in Approvals and this run continues on its own",
+    );
+    expect(text).toContain("Nothing here is waiting on you any more");
+    // …and it must NOT have fallen into the "the policy refused this" copy,
+    // which is where a naive `parked === 0` lands. No policy refused anything.
+    expect(text).not.toContain("change the policy");
+    expect(text).not.toContain("could not be queued for approval");
+  });
+
+  it("still renders the blocked-node list #1143 added", async () => {
+    await renderHistory(strandedBlockedRun());
+    // The paragraph and the list must say the same thing, not merely avoid
+    // saying opposite things — this is the pairing that broke in the issue.
+    expect(
+      container.querySelector(
+        '[data-testid="workflow-blocked-approval-stranded"]',
+      )?.textContent,
+    ).toContain("cannot be continued");
+    expect(
+      container.querySelectorAll(
+        '[data-testid="workflow-blocked-approval-link"]',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("keeps the Approve copy and the decide links when only SOME are gone", async () => {
+    // The negative that makes the two above mean anything. A rule that fired on
+    // any stranded card would satisfy them and be worse than no rule: it would
+    // retire a run with a decision still sitting in the queue.
+    await renderHistory(
+      strandedBlockedRun({
+        strandedApprovals: 0,
+        verdict: "blocked",
+        blockedNodes: [
+          {
+            nodeId: "backend",
+            tools: ["shell", "curl"],
+            approvalIds: ["appr-1", "appr-2", "appr-3"],
+            stranded: 1,
+          },
+        ],
+      }),
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain(
+      "Approve them in Approvals and this run continues on its own",
+    );
+    expect(
+      container.querySelectorAll(
+        '[data-testid="workflow-blocked-approval-link"]',
+      ).length,
+    ).toBeGreaterThan(0);
+    // Two of three receipts survive, so the sentence counts two.
+    expect(text).toContain("This run parked 2 approvals");
+  });
+});
+
+describe("the counts the drawer branches on", () => {
+  it("subtracts stranded gates from the awaiting count", () => {
+    const run = strandedGateRun({ strandedApprovals: 1, verdict: "blocked" });
+    // Three gates, one with no card left → two people are still being waited on.
+    expect(liveApprovalCount(run)).toBe(2);
+    expect(awaitingCount(run)).toBe(2);
+  });
+
+  it("counts a parked report on top of the live gates", () => {
+    const run = strandedGateRun({
+      strandedApprovals: 3,
+      deliveries: [
+        {
+          node: "digest",
+          kind: "channel",
+          target: "engineering",
+          status: "pending",
+          detail: "parked",
+          reason: "parked-for-approval",
+        },
+      ],
+    });
+    // Every gate is stranded, but the report is genuinely parked — somebody is
+    // still being waited on, and the run is NOT stranded.
+    expect(liveApprovalCount(run)).toBe(0);
+    expect(awaitingCount(run)).toBe(1);
+    expect(isStranded({ ...run, verdict: undefined })).toBe(false);
+  });
+
+  it("clamps the live parked count at zero", () => {
+    // The receipt excludes parks that never landed while `stranded` counts only
+    // ids that did, so the two lists are not identical and the subtraction must
+    // not be trusted to stay ordered.
+    const run = strandedBlockedRun({
+      approvals: [
+        { nodeId: "backend", tool: "shell", outcome: "parked", approvalId: "appr-1" },
+      ],
+      blockedNodes: [
+        {
+          nodeId: "backend",
+          tools: ["shell"],
+          approvalIds: ["appr-1", "appr-2", "appr-3"],
+          stranded: 3,
+        },
+      ],
+    });
+    expect(liveParkedApprovalCount(run)).toBe(0);
+  });
+
+  it("reads a host that sent no stranded key as 'not reconciled'", () => {
+    // Never as "nothing is stranded" — but also never as stranded. Inventing a
+    // dead end would retire a run an operator can still act on.
+    const old = strandedGateRun({ strandedApprovals: undefined, verdict: undefined });
+    expect(isStranded(old)).toBe(false);
+    expect(awaitingCount(old)).toBe(3);
+  });
+});

--- a/qa/oc-qa.js
+++ b/qa/oc-qa.js
@@ -178,6 +178,13 @@
    *   both colours are claims the host has not made.
    * - `cancelled` before the delivery reads: a stop somebody asked for is not a
    *   fault, and a cancelled run has no deliveries to weigh.
+   * - `stranded` (issue #1189) above BOTH of them: a run whose every gate has
+   *   lost its card is the one state in which "go and decide it" is false, and
+   *   `blocked` and `awaiting-approval` both say exactly that. Only the host can
+   *   make the join — it needs the live approvals queue — so the fallback
+   *   reads the host's own `strandedApprovals`, and treats its absence as "not
+   *   reconciled" rather than as "nothing is stranded". A run only PARTLY
+   *   stranded keeps its old verdict.
    * - `blocked` (issue #881) before the delivery reads: a run that stopped short
    *   at a gate carries no `error`, is not `cancelled`, is not `running` and
    *   routed no report — so before its own arm it fell through every check to
@@ -190,7 +197,7 @@
    *   reached an `output` node, so its `deliveries` are empty and a
    *   delivery-only read scored the gated case — the common one — as clean.
    *
-   * These are exactly the seven words the host's `WorkflowRunVerdict` uses, in
+   * These are exactly the eight words the host's `WorkflowRunVerdict` uses, in
    * the same order — which is what makes the fallback and the answer
    * interchangeable rather than merely similar.
    */
@@ -200,6 +207,7 @@
     if (run.running === true) return "running";
     if (run.error) return "failed";
     if (run.cancelled) return "stopped";
+    if (isStranded(run)) return "stranded";
     if (isBlocked(run)) return "blocked";
     if (undeliveredCount(run.deliveries) > 0) return "undelivered";
     if (awaitingCount(run) > 0) return "awaiting-approval";
@@ -215,14 +223,46 @@
   }
 
   /**
-   * Everything about this run that is waiting on a person: the gates it paused
-   * at **and** the reports it parked (issue #846).
+   * Whether nothing in the queue is waiting on this run any more, so no
+   * decision can move it (issue #1189).
+   *
+   * `pendingApprovals` is a receipt of where the run stopped and cannot go
+   * stale — but the question each entry points at can, and on one staging
+   * tenant 34 of 60 runs were pointing at nothing. Only the host can reconcile
+   * the two, because the join needs the live approvals queue; a host predating
+   * #1189 sends no `strandedApprovals` at all, which reads here as "not
+   * reconciled" and never as "nothing is stranded".
+   *
+   * Mirrors the host's rule rather than inventing a second one: it stopped for
+   * somebody, EVERY gate lost its card, and no report is parked either. A
+   * partly stranded run keeps its old verdict — something there really is still
+   * decidable.
+   */
+  function isStranded(run) {
+    const pending = (run.pendingApprovals || []).length;
+    return (
+      pending > 0 &&
+      (run.strandedApprovals || 0) >= pending &&
+      pendingCount(run.deliveries) === 0
+    );
+  }
+
+  /**
+   * Everything about this run that is **still** waiting on a person: the gates
+   * it paused at that still have a card, plus the reports it parked (issues
+   * #846, #1189).
    *
    * The two were never read together, and that is what let a run report success
-   * while a human had not answered it.
+   * while a human had not answered it. Issue #1189 added the other half: the
+   * gates were counted raw, so a run whose cards the queue had lost went on
+   * claiming somebody was being waited on. `strandedApprovals` is the host's
+   * reconciliation; clamped at 0 because a negative would render as
+   * "-1 awaiting approval", which is a worse failure than the one being fixed.
    */
   function awaitingCount(run) {
-    return (run.pendingApprovals || []).length + pendingCount(run.deliveries);
+    const pending = (run.pendingApprovals || []).length;
+    const live = Math.max(0, pending - (run.strandedApprovals || 0));
+    return live + pendingCount(run.deliveries);
   }
 
   /**

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2415,6 +2415,41 @@ impl CompanyRuntime {
         self.journal.has_undescribed_history()
     }
 
+    /// The approvals queue as it is right now, in the two shapes a workflow run
+    /// is joined against it by (issue #1189).
+    ///
+    /// One pass over the same parked effects [`pending_approvals`](Self::pending_approvals)
+    /// projects, collecting both keys at once: every live approval id, and every
+    /// live `(run, gate node)` pair. See
+    /// [`LiveApprovals`](crate::ports::workflow_verdict::LiveApprovals) for why
+    /// one key cannot answer for both shapes.
+    ///
+    /// It reads the **raw** effects rather than the projected summaries on
+    /// purpose. `ApprovalSummary::payload` is `display_payload` — redacted and
+    /// node-budget-bounded — so recovering a gate's node id from it would be
+    /// reading a rendering of the fact instead of the fact, and would break
+    /// silently the day the redaction rules change. Building the answer here
+    /// also keeps raw parked effects out of the HTTP layer, which is the whole
+    /// reason the projection exists.
+    ///
+    /// No task-link discrimination is needed for the gate half, unlike
+    /// [`workflow_run_of`]: `gate_node_id` kind-checks `workflow.approve`, a
+    /// kind only `park_pending_gates` ever mints, and on that effect `run_id` is
+    /// always the workflow run that paused.
+    pub fn live_approvals(&self) -> crate::ports::workflow_verdict::LiveApprovals {
+        let mut live = crate::ports::workflow_verdict::LiveApprovals::default();
+        for parked in self.journal.pending() {
+            live.insert_id(parked.id.as_ref());
+            if let (Some(run_id), Some(node_id)) = (
+                parked.effect.run_id.as_deref(),
+                crate::runtime::workflow_resume::gate_node_id(&parked.effect),
+            ) {
+                live.insert_gate(run_id, node_id);
+            }
+        }
+        live
+    }
+
     /// The approvals currently awaiting the operator.
     ///
     /// The single projection point for [`ApprovalSummary`], and therefore the

--- a/src/ports/workflow_verdict.rs
+++ b/src/ports/workflow_verdict.rs
@@ -50,7 +50,9 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ports::workflow_runner::{DeliveryReason, DeliveryReport, DeliveryStatus};
+use crate::ports::workflow_runner::{
+    DeliveryReason, DeliveryReport, DeliveryStatus, WorkflowBlockedNode,
+};
 
 /// The approvals queue as it is **right now**, in the two shapes a workflow run
 /// can be joined against it by (issue #1189).
@@ -340,6 +342,66 @@ pub fn awaiting_count(deliveries: &[DeliveryReport], pending_approvals: usize) -
             .iter()
             .filter(|d| matches!(d.status, DeliveryStatus::Pending))
             .count()
+}
+
+/// How many of a run's pending gate nodes have **no live card left** — the
+/// question "is anything here still decidable?", answered against the queue as
+/// it is now (issue #1189).
+///
+/// `awaiting_count` reads `pendingApprovals` raw, which is a receipt of where
+/// the run stopped and cannot go stale — but the *question* each entry points at
+/// can, and does. `ApprovalParked` is journaled at `Durability::Process` on the
+/// reasoning that losing it is harmless because "the agent parks it again on its
+/// next attempt"; that holds for a chat turn, which retries, and is false for a
+/// workflow run, which halted at the gate and never re-enters it.
+///
+/// # A node is live if EITHER join finds it
+///
+/// * `(run_id, node)` is a parked `workflow.approve` card — the gate shape.
+/// * any of the node's [`WorkflowBlockedNode::approval_ids`] is still parked —
+///   the blocked-node shape, whose cards are tool-call effects carrying no node
+///   id of their own.
+///
+/// **Any** live id on a blocked node makes the node live: while one of its
+/// gated calls can still be decided, the node is still a question, and the
+/// per-node `stranded` count that #1143 renders is what carries the nuance of a
+/// partial loss.
+///
+/// # A run with no id answers 0
+///
+/// A row journaled before issue #371 carries no `run_id`, so the gate join has
+/// no key — and calling every node of it stranded on the strength of a missing
+/// field would retire live work an operator can still act on. Zero is the
+/// pre-#1189 reading, which is the safe direction here for exactly the reason
+/// `denied_in_input` is tolerant: inventing a dead end is worse than missing
+/// one.
+pub fn stranded_approvals(
+    run_id: Option<&str>,
+    pending_approvals: &[String],
+    blocked: &[WorkflowBlockedNode],
+    live: &LiveApprovals,
+) -> usize {
+    let Some(run_id) = run_id else {
+        return 0;
+    };
+    pending_approvals
+        .iter()
+        .filter(|node| !node_still_decidable(run_id, node, blocked, live))
+        .count()
+}
+
+/// Whether either join still finds a card for this run's gate node.
+fn node_still_decidable(
+    run_id: &str,
+    node: &str,
+    blocked: &[WorkflowBlockedNode],
+    live: &LiveApprovals,
+) -> bool {
+    live.holds_gate(run_id, node)
+        || blocked
+            .iter()
+            .filter(|b| b.node_id == node)
+            .any(|b| b.approval_ids.iter().any(|id| live.holds_id(id)))
 }
 
 #[cfg(test)]
@@ -654,6 +716,103 @@ mod test {
                 );
             }
         }
+    }
+
+    // ── Issue #1189: the fold that reconciles a gate against the live queue ──
+
+    /// A blocked node carrying `approval_ids`, for the id-keyed half of the
+    /// join.
+    fn blocked_node(node: &str, ids: &[&str]) -> WorkflowBlockedNode {
+        WorkflowBlockedNode {
+            node_id: node.to_string(),
+            tools: vec!["shell".to_string()],
+            approval_ids: ids.iter().map(|id| id.to_string()).collect(),
+            unparkable: 0,
+            stranded: 0,
+        }
+    }
+
+    fn nodes(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    /// The marketing tenant's shape: gate nodes on `pendingApprovals`, no
+    /// blocked-node rows at all, and an empty queue.
+    #[test]
+    fn a_gate_with_no_card_left_is_stranded() {
+        let live = LiveApprovals::default();
+        assert_eq!(
+            stranded_approvals(
+                Some("run-1"),
+                &nodes(&["fetch_bbc", "fetch_espn", "fetch_guardian"]),
+                &[],
+                &live
+            ),
+            3
+        );
+    }
+
+    /// The negative that makes the one above mean anything: a fold that marked
+    /// everything stranded would satisfy it and be worse than no fold at all.
+    #[test]
+    fn a_gate_whose_card_is_still_parked_is_not_stranded() {
+        let mut live = LiveApprovals::default();
+        live.insert_gate("run-1", "fetch_bbc");
+        assert_eq!(
+            stranded_approvals(Some("run-1"), &nodes(&["fetch_bbc"]), &[], &live),
+            0
+        );
+    }
+
+    /// Keyed on the **pair**. Two runs of one workflow park the same node id, so
+    /// a node-only key would keep every historical run of `daily-sports-news`
+    /// advertised as approvable for as long as any one of them has a live card.
+    #[test]
+    fn the_same_node_parked_under_a_different_run_does_not_count() {
+        let mut live = LiveApprovals::default();
+        live.insert_gate("run-2", "fetch_bbc");
+        assert_eq!(
+            stranded_approvals(Some("run-1"), &nodes(&["fetch_bbc"]), &[], &live),
+            1
+        );
+    }
+
+    /// The id-keyed half: a blocked node's cards carry no node id, so the node
+    /// is reached through `approval_ids`.
+    #[test]
+    fn a_blocked_node_is_live_if_any_of_its_approvals_is() {
+        let mut live = LiveApprovals::default();
+        live.insert_id("appr-2");
+        let blocked = [blocked_node("backend", &["appr-1", "appr-2", "appr-3"])];
+        assert_eq!(
+            stranded_approvals(Some("run-1"), &nodes(&["backend"]), &blocked, &live),
+            0,
+            "one decidable call still makes the node a question"
+        );
+    }
+
+    /// …and the same node with every id gone is stranded, which is the
+    /// `feature_pipeline` shape issue #1189 opens on.
+    #[test]
+    fn a_blocked_node_whose_every_approval_is_gone_is_stranded() {
+        let live = LiveApprovals::default();
+        let blocked = [blocked_node("backend", &["appr-1", "appr-2", "appr-3"])];
+        assert_eq!(
+            stranded_approvals(Some("run-1"), &nodes(&["backend"]), &blocked, &live),
+            1
+        );
+    }
+
+    /// A pre-#371 row has no run id, so the gate join has no key. Marking its
+    /// nodes stranded on the strength of a missing field would retire work an
+    /// operator can still act on.
+    #[test]
+    fn a_run_with_no_id_is_never_stranded() {
+        let live = LiveApprovals::default();
+        assert_eq!(
+            stranded_approvals(None, &nodes(&["fetch_bbc"]), &[], &live),
+            0
+        );
     }
 
     /// `sent` and `pending` are excused by **status**, so no reason can pull

--- a/src/ports/workflow_verdict.rs
+++ b/src/ports/workflow_verdict.rs
@@ -142,6 +142,28 @@ pub enum WorkflowRunVerdict {
     /// An operator stopped it (issue #383). Not a fault, and deliberately not
     /// grouped with `failed`: nothing about the graph went wrong.
     Stopped,
+    /// Every person this run stopped for has **nothing left to answer**, and
+    /// the run cannot go on (issue #1189).
+    ///
+    /// The reading that did not exist, and whose absence is the whole defect:
+    /// a run whose gates have no card left in the queue went on scoring
+    /// [`AwaitingApproval`](Self::AwaitingApproval) forever, so a third of one
+    /// tenant's history claimed to be waiting on a person who had nothing to
+    /// decide. There was no honest word for it, so it kept the dishonest one.
+    ///
+    /// Above [`Blocked`](Self::Blocked) and [`AwaitingApproval`](Self::AwaitingApproval)
+    /// because it *contradicts* them rather than refining them: both tell an
+    /// operator to go and decide something, and this is the state in which
+    /// there is nothing to decide. The more specific fact wins, exactly as
+    /// `failed` wins over `undelivered`.
+    ///
+    /// **It claims nothing about why.** Approving a gate does not continue the
+    /// parent run — `resume_run` spawns a *new* run with a new id and records
+    /// no link back — so a run whose gates were all approved and a run whose
+    /// cards were lost are indistinguishable from here. What is observable, and
+    /// all this word means, is that nothing in the queue is waiting on this run
+    /// any more and no decision can move it.
+    Stranded,
     /// A node stopped short because a tool call inside its turn is waiting on a
     /// person (issue #881). Not a failure and not a pause — the run will not
     /// continue on its own.
@@ -173,6 +195,7 @@ impl WorkflowRunVerdict {
             Self::Running => "running",
             Self::Failed => "failed",
             Self::Stopped => "stopped",
+            Self::Stranded => "stranded",
             Self::Blocked => "blocked",
             Self::Undelivered => "undelivered",
             Self::AwaitingApproval => "awaiting-approval",
@@ -194,6 +217,11 @@ impl WorkflowRunVerdict {
     /// * `stopped` before the delivery reads (issue #383) — a stop somebody
     ///   asked for is not a fault, and a cancelled run has no deliveries to
     ///   weigh anyway.
+    /// * `stranded` above both of them (issue #1189) — a run every one of whose
+    ///   gates has lost its card is the one state in which "go and decide it"
+    ///   is false, and `blocked` and `awaiting-approval` both say exactly that.
+    ///   A run only **partly** stranded keeps its old verdict: something there
+    ///   really is still decidable, and the per-node count carries the rest.
     /// * `blocked` before the delivery reads (issue #881) — a blocked run
     ///   carries no error, is not cancelled, is not running and routed no
     ///   report, which is precisely the shape that fell through every check.
@@ -212,6 +240,9 @@ impl WorkflowRunVerdict {
         }
         if facts.cancelled {
             return Self::Stopped;
+        }
+        if facts.fully_stranded() {
+            return Self::Stranded;
         }
         if facts.blocked_nodes > 0 {
             return Self::Blocked;
@@ -252,6 +283,13 @@ pub struct RunVerdictFacts<'a> {
     pub deliveries: &'a [DeliveryReport],
     /// How many nodes the run is waiting on a human for.
     pub pending_approvals: usize,
+    /// How many of those nodes have **no live card left** (issue #1189) — the
+    /// output of [`stranded_approvals`], which is where the join lives.
+    ///
+    /// Never greater than [`pending_approvals`](Self::pending_approvals), since
+    /// it is a filter over the same list. Zero for every caller that cannot
+    /// reconcile against the queue, which is the pre-#1189 reading.
+    pub stranded_approvals: usize,
 }
 
 impl RunVerdictFacts<'_> {
@@ -263,6 +301,34 @@ impl RunVerdictFacts<'_> {
     /// run neither of them can explain.
     fn failed(&self) -> bool {
         self.error.is_some_and(|e| !e.is_empty())
+    }
+
+    /// Whether **every** person this run stopped for has nothing left to answer
+    /// (issue #1189).
+    ///
+    /// Three conditions, and each excludes a run that is still actionable:
+    ///
+    /// * it stopped for somebody at all — a run with no gates was never
+    ///   awaiting anything, and `stranded` is a correction to `awaiting`, not a
+    ///   new way to score a clean run;
+    /// * **all** of those gates lost their card. A partly stranded run keeps
+    ///   its old verdict, because a decision that can still be made must still
+    ///   be offered; the per-node count is what says the rest was lost;
+    /// * no report is parked either. A `pending` delivery row is a *second*
+    ///   thing waiting on a person, on its own queue, and it is untouched by
+    ///   the gate join — so a run holding one is still genuinely awaiting.
+    ///
+    /// `==` rather than `>=` on purpose: the count is a filter over the same
+    /// list and cannot exceed it, so a larger value means a caller built the
+    /// facts by hand and got them wrong — in which case falling through to the
+    /// old reading is the safe direction.
+    fn fully_stranded(&self) -> bool {
+        self.pending_approvals > 0
+            && self.stranded_approvals == self.pending_approvals
+            && !self
+                .deliveries
+                .iter()
+                .any(|d| matches!(d.status, DeliveryStatus::Pending))
     }
 }
 
@@ -430,6 +496,7 @@ mod test {
             blocked_nodes: 0,
             deliveries: &[],
             pending_approvals: 0,
+            stranded_approvals: 0,
         }
     }
 
@@ -510,6 +577,9 @@ mod test {
             blocked_nodes: 1,
             deliveries: &dropped,
             pending_approvals: 1,
+            // Issue #1189: the one gate this run stopped for has no card left,
+            // so the facts satisfy `stranded` too.
+            stranded_approvals: 1,
         };
         assert_eq!(
             WorkflowRunVerdict::of(everything),
@@ -530,11 +600,24 @@ mod test {
             }),
             WorkflowRunVerdict::Stopped
         );
+        // Issue #1189. It sits ABOVE `blocked` and above `awaiting-approval`,
+        // and these facts satisfy both — which is the whole claim: a run whose
+        // every gate lost its card must not be told to go and decide it.
         assert_eq!(
             WorkflowRunVerdict::of(RunVerdictFacts {
                 running: false,
                 error: None,
                 cancelled: false,
+                ..everything
+            }),
+            WorkflowRunVerdict::Stranded
+        );
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                running: false,
+                error: None,
+                cancelled: false,
+                stranded_approvals: 0,
                 ..everything
             }),
             WorkflowRunVerdict::Blocked
@@ -544,6 +627,7 @@ mod test {
                 running: false,
                 error: None,
                 cancelled: false,
+                stranded_approvals: 0,
                 blocked_nodes: 0,
                 ..everything
             }),
@@ -554,6 +638,7 @@ mod test {
                 running: false,
                 error: None,
                 cancelled: false,
+                stranded_approvals: 0,
                 blocked_nodes: 0,
                 deliveries: &[],
                 ..everything
@@ -608,7 +693,7 @@ mod test {
         );
     }
 
-    /// The wire tokens are the console's seven words, and `as_str` may not
+    /// The wire tokens are the console's eight words, and `as_str` may not
     /// drift from them.
     #[test]
     fn the_wire_tokens_are_the_consoles_words() {
@@ -616,6 +701,7 @@ mod test {
             (WorkflowRunVerdict::Running, "running"),
             (WorkflowRunVerdict::Failed, "failed"),
             (WorkflowRunVerdict::Stopped, "stopped"),
+            (WorkflowRunVerdict::Stranded, "stranded"),
             (WorkflowRunVerdict::Blocked, "blocked"),
             (WorkflowRunVerdict::Undelivered, "undelivered"),
             (WorkflowRunVerdict::AwaitingApproval, "awaiting-approval"),
@@ -716,6 +802,101 @@ mod test {
                 );
             }
         }
+    }
+
+    // ── Issue #1189: a run nobody can act on any more ────────────────────────
+
+    /// The marketing tenant's 34 runs: three gate nodes on `pendingApprovals`,
+    /// no blocked-node rows at all, and an empty approvals queue.
+    ///
+    /// Before this arm they scored `awaiting-approval` forever — a third of the
+    /// tenant's whole history claiming to wait on a person with nothing to
+    /// answer, and #1143's reconciliation could not reach them because it joins
+    /// on approval ids this shape never had.
+    #[test]
+    fn a_run_whose_every_gate_lost_its_card_is_stranded_not_awaiting() {
+        let verdict = WorkflowRunVerdict::of(RunVerdictFacts {
+            pending_approvals: 3,
+            stranded_approvals: 3,
+            ..clean()
+        });
+        assert_eq!(verdict, WorkflowRunVerdict::Stranded);
+        assert_ne!(
+            verdict,
+            WorkflowRunVerdict::AwaitingApproval,
+            "nothing in the queue is waiting on this run, so it must not say so"
+        );
+    }
+
+    /// The negative that makes the test above mean anything.
+    ///
+    /// A rule that fired on *any* stranded gate would satisfy it and be worse
+    /// than no rule: it would retire a run with a decision still sitting in the
+    /// queue. Two of the three are gone; the third can still be made, so the
+    /// verdict must go on saying so and the per-node count carries the loss.
+    #[test]
+    fn a_partly_stranded_run_is_still_awaiting() {
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                pending_approvals: 3,
+                stranded_approvals: 1,
+                ..clean()
+            }),
+            WorkflowRunVerdict::AwaitingApproval
+        );
+    }
+
+    /// A parked **report** is a second thing waiting on a person, on its own
+    /// queue, and the gate join does not look at it. So a run whose gates are
+    /// all stranded but whose report is still parked is genuinely awaiting —
+    /// there really is a card to decide.
+    #[test]
+    fn a_stranded_run_with_a_parked_report_is_still_awaiting() {
+        let parked = [row(
+            DeliveryStatus::Pending,
+            DeliveryReason::ParkedForApproval,
+        )];
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                deliveries: &parked,
+                pending_approvals: 2,
+                stranded_approvals: 2,
+                ..clean()
+            }),
+            WorkflowRunVerdict::AwaitingApproval
+        );
+    }
+
+    /// The `feature_pipeline` shape from the issue: a blocked node whose every
+    /// card the queue has lost. #1143 already says so in the blocked-node list;
+    /// this is the verdict finally agreeing with it instead of reading
+    /// `blocked` — which, like `awaiting-approval`, tells the operator to go
+    /// and decide something that is not there.
+    #[test]
+    fn a_fully_stranded_blocked_run_reads_stranded_not_blocked() {
+        let verdict = WorkflowRunVerdict::of(RunVerdictFacts {
+            blocked_nodes: 1,
+            pending_approvals: 1,
+            stranded_approvals: 1,
+            ..clean()
+        });
+        assert_eq!(verdict, WorkflowRunVerdict::Stranded);
+        assert_ne!(verdict, WorkflowRunVerdict::Blocked);
+    }
+
+    /// A run with no gates at all is not stranded, whatever else is true of it.
+    /// `stranded` is a correction to `awaiting`, never a new way to score a run
+    /// that was waiting on nobody.
+    #[test]
+    fn a_run_that_stopped_for_nobody_is_never_stranded() {
+        assert_eq!(
+            WorkflowRunVerdict::of(RunVerdictFacts {
+                pending_approvals: 0,
+                stranded_approvals: 0,
+                ..clean()
+            }),
+            WorkflowRunVerdict::Ok
+        );
     }
 
     // ── Issue #1189: the fold that reconciles a gate against the live queue ──

--- a/src/ports/workflow_verdict.rs
+++ b/src/ports/workflow_verdict.rs
@@ -46,9 +46,81 @@
 //! neither `failed` nor `ok` — and every existing consumer of `error`,
 //! `cancelled`, `running` and `nodes[].status` sees exactly what it saw before.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::ports::workflow_runner::{DeliveryReason, DeliveryReport, DeliveryStatus};
+
+/// The approvals queue as it is **right now**, in the two shapes a workflow run
+/// can be joined against it by (issue #1189).
+///
+/// # Why two shapes and not one
+///
+/// A run has two ways to stop for a person, and they leave different traces.
+///
+/// * A **blocked node** — an agent node whose gated tool calls were parked by
+///   `park_gated_calls` — records the ids those parks returned on
+///   [`WorkflowBlockedNode::approval_ids`](crate::ports::WorkflowBlockedNode).
+///   Those cards are ordinary tool-call effects (the policy stamps an `agent`
+///   on them), so they carry no node id and can only be joined **by id**. That
+///   is the join issue #1143 added.
+/// * A **gate** — a `requires_approval` node the engine paused at — is parked by
+///   `park_pending_gates` as a `workflow.approve` effect and records *nothing*:
+///   no approval-row receipt, no blocked-node row, only the node id on the run's
+///   `pendingApprovals`. Its card is the only thing that knows the pair, and it
+///   knows it exactly: `Effect::run_id` is the run that paused and
+///   `payload.node_id` is the gate. So that shape is joined **by
+///   `(run_id, node_id)`**.
+///
+/// #1143's join is keyed on ids the second shape does not have, which is why it
+/// could not reach it — and the gate shape is the larger half of the defect.
+///
+/// # Built where the raw effects are
+///
+/// Assembled by `CompanyRuntime::live_approvals`, off the journal's parked
+/// effects, so no raw `Effect` has to reach the HTTP layer. The projected
+/// [`ApprovalSummary`](crate::runtime::ApprovalSummary) is not a substitute: its
+/// `payload` is `display_payload` — redacted and node-budget-bounded — so a
+/// node id read back out of it would be reading a rendering, and would drift
+/// the day the redaction rules change.
+#[derive(Clone, Debug, Default)]
+pub struct LiveApprovals {
+    ids: HashSet<String>,
+    gates: HashSet<(String, String)>,
+}
+
+impl LiveApprovals {
+    /// Records a live approval id — every parked card, whatever shape it is.
+    pub fn insert_id(&mut self, id: impl Into<String>) {
+        self.ids.insert(id.into());
+    }
+
+    /// Records a live `(run, gate node)` pair — a parked `workflow.approve`
+    /// card, which is the only shape that knows both halves.
+    pub fn insert_gate(&mut self, run_id: impl Into<String>, node_id: impl Into<String>) {
+        self.gates.insert((run_id.into(), node_id.into()));
+    }
+
+    /// Whether the queue still holds this approval id.
+    pub fn holds_id(&self, id: &str) -> bool {
+        self.ids.contains(id)
+    }
+
+    /// Whether the queue still holds a gate card for this run's node.
+    ///
+    /// Keyed on the pair rather than the node alone: two runs of the same
+    /// workflow park the same node id, and answering "some run's `fetch_bbc` is
+    /// still parked" about *this* run would keep a stranded run advertised as
+    /// approvable for as long as any sibling run has a live card.
+    pub fn holds_gate(&self, run_id: &str, node_id: &str) -> bool {
+        // Borrowed lookup without allocating a `(String, String)`: the set is
+        // small, and this is called once per pending node per returned run.
+        self.gates
+            .iter()
+            .any(|(run, node)| run == run_id && node == node_id)
+    }
+}
 
 /// What a workflow run adds up to, as a closed set (issue #981).
 ///

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1475,6 +1475,13 @@ async fn run_workflow(
                 blocked_nodes: run.blocked_nodes.len(),
                 deliveries: &run.deliveries,
                 pending_approvals: run.pending_approvals.len(),
+                // Issue #1189: deliberately not reconciled here, and a literal
+                // rather than a lookup. This body is written microseconds after
+                // `park_pending_gates` minted the cards, so joining against the
+                // queue would be a guaranteed-zero query on the hot path — the
+                // reconciliation is a fact about a run somebody comes back to,
+                // which is what the history route is for.
+                stranded_approvals: 0,
             });
             Ok(RunWorkflowOk::Settled(Box::new(RunWorkflowResponse {
                 output: run.output,
@@ -2475,6 +2482,7 @@ impl WorkflowRunOutcome {
             blocked_nodes: self.blocked_nodes.len(),
             deliveries: &self.deliveries,
             pending_approvals: self.pending_approvals.len(),
+            stranded_approvals: 0,
         })
     }
 }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2339,6 +2339,14 @@ struct RunsQuery {
     limit: Option<usize>,
 }
 
+/// `skip_serializing_if` predicate for a count that is almost always zero —
+/// the same one `crate::ports::workflow_runner` uses for the per-node
+/// `unparkable` / `stranded` pair, so the two counts are omitted on identical
+/// terms.
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
+
 /// One finished run as the console's history panel renders it (camelCase).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -2452,6 +2460,24 @@ struct WorkflowRunOutcome {
     /// count becomes a fresh lie the moment somebody approves one.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
+    /// How many of [`pending_approvals`](Self::pending_approvals) have **no
+    /// live card left in the queue** (issue #1189).
+    ///
+    /// The gate-shaped sibling of `blockedNodes[].stranded`, and the number the
+    /// console needs to stop telling an operator to go and decide something
+    /// that is not there. #1143's per-node count is keyed on approval ids, and
+    /// a gate parked by `park_pending_gates` records none — no approval-row
+    /// receipt and no blocked-node row, only its node id here — so that count
+    /// structurally cannot describe this shape. On the marketing tenant it is
+    /// the shape of 34 of 60 runs.
+    ///
+    /// **Computed on the read, never journaled**, on exactly the terms
+    /// `WorkflowBlockedNode::stranded` is: the journal records what happened and
+    /// is not edited to reflect what is true now, and a stored "still waiting"
+    /// count is a fresh lie the moment the queue moves. Skipped when zero, which
+    /// is every healthy run, so an unaffected row's wire shape is unchanged.
+    #[serde(skip_serializing_if = "is_zero")]
+    stranded_approvals: usize,
     /// What this run adds up to, in one word (issue #981).
     ///
     /// **Always serialized**, and **derived in a single pass** once the fold
@@ -2482,7 +2508,9 @@ impl WorkflowRunOutcome {
             blocked_nodes: self.blocked_nodes.len(),
             deliveries: &self.deliveries,
             pending_approvals: self.pending_approvals.len(),
-            stranded_approvals: 0,
+            // Issue #1189: filled in by the join below, which is why the verdict
+            // pass now runs AFTER it. See `list_runs`.
+            stranded_approvals: self.stranded_approvals,
         })
     }
 }
@@ -2637,6 +2665,10 @@ async fn list_runs(
                     // True of a row that has only a start — and re-derived
                     // anyway by the single pass below, which is what makes it
                     // right for a row the finish or the settle changes.
+                    // Issue #1189: filled by the join in the tail, on the rows
+                    // actually being returned. Zero here is the honest default —
+                    // this row has not been reconciled against the queue yet.
+                    stranded_approvals: 0,
                     verdict: WorkflowRunVerdict::Running,
                 });
             }
@@ -2768,6 +2800,10 @@ async fn list_runs(
                     blocked_nodes,
                     approvals,
                     // Re-derived by the single pass below, like the start arm's.
+                    // Issue #1189: filled by the join in the tail, on the rows
+                    // actually being returned. Zero here is the honest default —
+                    // this row has not been reconciled against the queue yet.
+                    stranded_approvals: 0,
                     verdict: WorkflowRunVerdict::Running,
                 });
             }
@@ -2989,62 +3025,84 @@ async fn list_runs(
         }
     }
 
-    // Issue #981: the run verdicts, read in ONE pass, here — after the fold has
-    // settled every open row and after the #1009 cross-check has flipped the
-    // dead ones to `error: INTERRUPTED_BY_RESTART`.
-    //
-    // Position is the correctness argument. Every input the verdict reads is
-    // written by the settle arm *after* its row was pushed (`running`, `error`,
-    // `cancelled`, `deliveries`, `pendingApprovals`, `blockedNodes`), and two of
-    // them are written again by the cross-check above. Deriving at construction
-    // would score the row the fold had at the time and never revisit it — the
-    // exact staleness a *stored* verdict would have, reintroduced by placement.
-    for run in &mut runs {
-        run.verdict = run.derive_verdict();
-    }
-
     // Newest first: a history panel leads with the run that just happened. The
     // `limit` now cuts *runs* rather than journal rows, which is the number the
     // caller was asking about all along.
+    //
+    // Issue #1189 moved this ABOVE the verdict pass. Neither `reverse` nor
+    // `truncate` touches a single field of a row — they reorder and drop whole
+    // rows — so the invariant the verdict pass is placed on ("derive after
+    // everything that can still change its inputs") is not weakened by running
+    // them first. It is *extended*: the reconciliation below genuinely does
+    // change an input, and with the old ordering the verdict was read before it.
     runs.reverse();
     runs.truncate(limit);
 
-    // Issue #1143. A blocked node's `approval_ids` is a receipt of what the run
-    // parked, and a receipt cannot go stale — but the *question* it points at
-    // can. `ApprovalParked` is journaled at `Durability::Process` on the stated
-    // reasoning that losing it is harmless because "the agent parks it again on
-    // its next attempt". That holds for a chat turn, which retries; it is false
-    // for a workflow run, which halted at the blocked node and never re-enters
-    // the gate. So a run that outlived its own approvals goes on reporting that
-    // it waits on cards the queue does not have, and the drawer's "decide in
-    // Approvals" links land on an empty page. #1145 carries the durability
-    // decision; this reconciliation deliberately does not pre-empt it.
+    // Issues #1143 + #1189. A run's record of what it stopped for is a receipt
+    // and cannot go stale — but the *question* it points at can. `ApprovalParked`
+    // is journaled at `Durability::Process` on the stated reasoning that losing
+    // it is harmless because "the agent parks it again on its next attempt".
+    // That holds for a chat turn, which retries; it is false for a workflow run,
+    // which halted at the gate and never re-enters it. So a run that outlived
+    // its own approvals goes on reporting that it waits on cards the queue does
+    // not have. #1145 carries the durability decision; this reconciliation
+    // deliberately does not pre-empt it.
+    //
+    // TWO joins, because a run has two ways to stop for a person and they leave
+    // different traces:
+    //
+    // * `blockedNodes[].approvalIds` — the ids an agent node's gated calls
+    //   parked. Those cards are tool-call effects and carry no node id, so the
+    //   only key is the id (issue #1143).
+    // * `pendingApprovals` — the gate nodes the engine paused at. Their cards
+    //   are `workflow.approve` effects that record no receipt and no
+    //   blocked-node row at all, so #1143's id-keyed join structurally could not
+    //   reach them; they are joined on `(run_id, node_id)` instead (issue
+    //   #1189). This is the bigger half: 34 of the marketing tenant's 60 runs.
     //
     // Done HERE, on the read, for the same reason `relabel_blocked` above
     // relabels rather than rewriting the durable node rows: the journal records
     // what happened and is not edited to reflect what is true now. After the
     // truncate, so the join costs one journal snapshot and covers only the rows
     // actually being returned — and skipped entirely when no returned run
-    // parked anything, which is nearly every read.
-    if runs
-        .iter()
-        .any(|r| r.blocked_nodes.iter().any(|b| !b.approval_ids.is_empty()))
-    {
-        let live: std::collections::HashSet<String> = company
-            .runtime
-            .pending_approvals()
-            .into_iter()
-            .map(|a| a.id.as_ref().to_string())
-            .collect();
+    // stopped for anybody, which is nearly every read.
+    if runs.iter().any(|r| {
+        !r.pending_approvals.is_empty()
+            || r.blocked_nodes.iter().any(|b| !b.approval_ids.is_empty())
+    }) {
+        let live = company.runtime.live_approvals();
         for run in &mut runs {
             for blocked in &mut run.blocked_nodes {
                 blocked.stranded = blocked
                     .approval_ids
                     .iter()
-                    .filter(|id| !live.contains(id.as_str()))
+                    .filter(|id| !live.holds_id(id))
                     .count();
             }
+            run.stranded_approvals = crate::ports::workflow_verdict::stranded_approvals(
+                run.run_id.as_deref(),
+                &run.pending_approvals,
+                &run.blocked_nodes,
+                &live,
+            );
         }
+    }
+
+    // Issue #981: the run verdicts, read in ONE pass, here — after the fold has
+    // settled every open row, after the #1009 cross-check has flipped the dead
+    // ones to `error: INTERRUPTED_BY_RESTART`, and (issue #1189) after the
+    // reconciliation above.
+    //
+    // Position is the correctness argument. Every input the verdict reads is
+    // written by the settle arm *after* its row was pushed (`running`, `error`,
+    // `cancelled`, `deliveries`, `pendingApprovals`, `blockedNodes`), two of
+    // them are written again by the cross-check, and `strandedApprovals` is
+    // written by the join. Deriving at construction — or, as it was until
+    // #1189, before the join — scores the row against inputs that have since
+    // moved underneath it: the exact staleness a *stored* verdict would have,
+    // reintroduced by placement.
+    for run in &mut runs {
+        run.verdict = run.derive_verdict();
     }
 
     Ok(Json(runs))
@@ -6029,6 +6087,15 @@ mod tests {
                 "an approval id the journal no longer holds must read as stranded, \
                  or the drawer goes on linking to an empty queue: {body}"
             );
+            // Issue #1189, and the assertion that pins the reordering: the
+            // verdict pass now runs AFTER this join, so it can see what the join
+            // wrote. With the old ordering the row read `blocked` here — the
+            // blocked-node list said "cannot be continued" and the run's own
+            // one-word reading said "go and decide it", on the same row.
+            assert_eq!(
+                body[0]["verdict"], "stranded",
+                "the verdict must be derived after the reconciliation, not before it: {body}"
+            );
         }
 
         /// The other direction, and the reason the test above proves anything.
@@ -6113,6 +6180,200 @@ mod tests {
                 body[0]["blockedNodes"][0].get("stranded").is_none(),
                 "a parked approval is still decidable, so nothing may be marked \
                  stranded: {body}"
+            );
+            assert_eq!(
+                body[0]["verdict"], "blocked",
+                "a run with a live card is still blocked, not stranded: {body}"
+            );
+        }
+
+        /// Issue #1189, THE regression test for the bigger half of the defect.
+        ///
+        /// The marketing tenant's shape, verbatim: gate nodes on
+        /// `pendingApprovals`, `blockedNodes` empty, `approvals` empty, and an
+        /// empty queue. #1143's join is keyed on approval ids this shape never
+        /// records, so it could not touch these rows — 34 of the tenant's 60
+        /// runs went on scoring `awaiting-approval` about a person with nothing
+        /// to answer.
+        #[tokio::test]
+        async fn run_history_scores_a_gate_run_with_no_live_card_as_stranded() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "sports_blog", "run-g", true).await;
+            let runtime = state.registry().get(&id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: "sports_blog".to_string(),
+                        scheduled: true,
+                        run_id: Some("run-g".to_string()),
+                        deliveries: Vec::new(),
+                        pending_approvals: vec!["fetch_bbc".to_string(), "fetch_espn".to_string()],
+                        error: None,
+                        cancelled: false,
+                        notices: Vec::new(),
+                        board: Vec::new(),
+                        // The whole point of this shape: a paused gate writes
+                        // NEITHER of the two things #1143 reads.
+                        blocked_nodes: Vec::new(),
+                        approvals: Vec::new(),
+                    },
+                )
+                .await
+                .expect("append");
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(
+                body[0]["strandedApprovals"], 2,
+                "both gates lost their card, and nothing else on this row says so: {body}"
+            );
+            assert_eq!(
+                body[0]["verdict"], "stranded",
+                "nothing in the queue is waiting on this run: {body}"
+            );
+        }
+
+        /// The negative twin, and the reason the test above proves anything.
+        ///
+        /// A join that marked every gate run stranded would satisfy it and be
+        /// far worse than no join: it would retire runs an operator can still
+        /// act on. Here the gate's card is genuinely parked — a real
+        /// `workflow.approve` effect carrying this run's id and this node's id,
+        /// which is the pair the join keys on — so the run stays awaiting and
+        /// `strandedApprovals` is skipped off the wire entirely.
+        #[tokio::test]
+        async fn run_history_leaves_a_gate_run_with_a_live_card_awaiting() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            let runtime = state.registry().get(&id).expect("registered");
+
+            // Built by the same `gate_effect` the runner parks with, so the
+            // shape the join reads is the shape the park writes.
+            let effect = crate::runtime::workflow_resume::gate_effect(
+                "sports_blog",
+                "fetch_bbc",
+                &serde_json::json!({}),
+                "run-live-gate",
+                &[],
+                &[],
+                None,
+            );
+            let approval_id = runtime
+                .approvals
+                .park(runtime.id(), effect.clone())
+                .await
+                .expect("park");
+            runtime
+                .journal()
+                .record_parked(
+                    &approval_id,
+                    &effect,
+                    crate::ports::now_millis(),
+                    crate::runtime::journal::TaskLink::Unlinked,
+                    crate::runtime::journal::ApprovalConversation {
+                        thread: None,
+                        parent: None,
+                    },
+                    None,
+                )
+                .await
+                .expect("record");
+
+            journal_start(&state, &id, "sports_blog", "run-live-gate", true).await;
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: "sports_blog".to_string(),
+                        scheduled: true,
+                        run_id: Some("run-live-gate".to_string()),
+                        deliveries: Vec::new(),
+                        pending_approvals: vec!["fetch_bbc".to_string()],
+                        error: None,
+                        cancelled: false,
+                        notices: Vec::new(),
+                        board: Vec::new(),
+                        blocked_nodes: Vec::new(),
+                        approvals: Vec::new(),
+                    },
+                )
+                .await
+                .expect("append");
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert!(
+                body[0].get("strandedApprovals").is_none(),
+                "the gate's card is on the queue, so nothing may be marked stranded: {body}"
+            );
+            assert_eq!(
+                body[0]["verdict"], "awaiting-approval",
+                "a decidable gate is still awaiting a person: {body}"
+            );
+        }
+
+        /// A row journaled before issue #371 carries no `run_id`, so the
+        /// `(run, node)` join has no key at all.
+        ///
+        /// It must therefore be left exactly as it read before #1189. Calling
+        /// its gates stranded on the strength of a *missing field* would retire
+        /// live work — the failure mode that is strictly worse than the one this
+        /// issue closes, because an operator cannot argue with a run the console
+        /// says is over.
+        #[tokio::test]
+        async fn run_history_leaves_a_pre_371_row_unreconciled() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            let runtime = state.registry().get(&id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: "sports_blog".to_string(),
+                        scheduled: true,
+                        // The pre-#371 shape: no correlation id, and so no start
+                        // row to pair with either.
+                        run_id: None,
+                        deliveries: Vec::new(),
+                        pending_approvals: vec!["fetch_bbc".to_string()],
+                        error: None,
+                        cancelled: false,
+                        notices: Vec::new(),
+                        board: Vec::new(),
+                        blocked_nodes: Vec::new(),
+                        approvals: Vec::new(),
+                    },
+                )
+                .await
+                .expect("append");
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert!(
+                body[0].get("strandedApprovals").is_none(),
+                "a row with no run id cannot be joined, so it must report nothing: {body}"
+            );
+            assert_eq!(
+                body[0]["verdict"], "awaiting-approval",
+                "an unjoinable row keeps the reading it had before #1189: {body}"
             );
         }
 


### PR DESCRIPTION
## Summary

#1150 stopped the blocked-node list offering a stranded approval as a decision, but the same run still says the opposite on three surfaces #1150 never touched: the run-history **summary sentence**, the run **header badge**, and the server-side **verdict**. An operator reading a stranded run is told to go to Approvals by two paragraphs, told the queue is empty by the paragraph between them, and shown a header pill claiming something is waiting. This makes all four agree.

## Problem

A stranded run is one whose parked approvals are gone from the live queue (`blockedNodes: [{stranded: N}]`, queue holds none) — it cannot be continued, only re-run. Only the blocked-node paragraph learned that. The summary sentence and the third "decide them in Approvals and run again" line still shipped, bracketing #1150's own fix; the header badge still counted the stranded approvals as "awaiting"; and the server verdict still reported the run as actionable. The read side never reconciled a run's recorded gates against what the queue actually still holds.

## Solution

- Read the live approvals queue in **both join shapes** and fold each run's recorded gates against it, so "is this still approvable?" is answered from current truth, not the stale journal.
- Give a run **nobody can act on its own verdict** — a stranded run resolves to a terminal "cannot continue, re-run" state rather than an actionable one — and reconcile that verdict on the history read.
- Console: teach the run reading about the stranded case so the drawer stops telling the operator to decide what is gone; the summary sentence, the header badge, and the verdict now all say the same thing.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features openhuman,tinycortex --all-targets`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex --lib` — `server::ops::workflows` (117), `company::runtime` (23), `ports::workflow_verdict` (27)
- [x] `npm run typecheck` + `typecheck:unit` + `typecheck:e2e` + `build`
- [x] `npx vitest run` — 1434 tests (149 files), incl. new `workflow-run-stranded.test.ts` pinning what a stranded run may and may not say

## Impact

An operator can no longer be told a stranded run is waiting on them across three surfaces while a fourth admits the queue is empty. The header badge, summary sentence, drawer body and server verdict now agree: it cannot be continued, only re-run. The QA harness + module doc transcribe the stranded reading so it stays pinned.

## Related

Closes #1189. Completes the trio around #1150 / #1143 (the blocked-node list) by covering the summary, header badge, and verdict the earlier fixes left contradicting them. Found in the 2026-08-20 QA pass on both staging tenants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct **Stranded** workflow run status for runs whose approval cards are no longer actionable.
  * Run history now explains that no decision remains, preserves prior deliveries, and guides users to rerun the workflow.
  * Approval counts distinguish active approval requests from stranded ones.
* **Bug Fixes**
  * Prevented stranded runs from displaying misleading approval links or instructions.
  * Improved classification of partially stranded runs so remaining active approvals stay actionable.
* **Documentation**
  * Documented the new `stranded` workflow verdict and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->