### PR TITLE
fix(workspace): confirm before deleting a note or folder

### DIFF
--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -111,6 +111,25 @@ export function subtreeIds(nodes: FsNode[], id: string): Set<string> {
 }
 
 /**
+ * Descendant counts for `id`, split by kind and excluding the node itself —
+ * for a delete confirmation to say "3 notes and 1 folder" rather than a bare
+ * "everything inside it" (issue #1255). Built on {@link subtreeIds}, which
+ * includes `id` itself; this one deliberately does not.
+ */
+export function subtreeCounts(nodes: FsNode[], id: string): { files: number; folders: number } {
+  const ids = subtreeIds(nodes, id);
+  ids.delete(id);
+  let files = 0;
+  let folders = 0;
+  for (const node of nodes) {
+    if (!ids.has(node.id)) continue;
+    if (node.kind === "file") files++;
+    else folders++;
+  }
+  return { files, folders };
+}
+
+/**
  * The tree as it stands after a duplicate-folder repair (issue #759).
  *
  * The host's answer is a list of *changes*, not a new tree, so this replays them

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -52,6 +52,16 @@ import {
   type WorkspaceOrigin,
 } from "@/api/workspace";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -89,6 +99,7 @@ import {
   nodeById,
   pathOf,
   readLegacyLocalNodes,
+  subtreeCounts,
   subtreeIds,
   titleOf,
 } from "@/lib/workspace";
@@ -401,6 +412,10 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   // ride along on both.
   const [repair, setRepair] = useState<RepairState | null>(null);
   const [repairing, setRepairing] = useState(false);
+  // The node awaiting a second click before its delete API call goes out — a
+  // folder recursively takes every note nested inside it, so the dialog must
+  // name what is about to go before it goes (issue #1255).
+  const [confirmDelete, setConfirmDelete] = useState<FsNode | null>(null);
   // The pending scratchpad partitioned by kind, once, for every surface that
   // describes or imports it: the banner's sentence, the import loops, and the
   // receipt. #500 partitioned inside `importLegacy` so the loops and the
@@ -1336,7 +1351,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               onOpen={(id) => void open(id)}
               onRename={(node) => setPrompt({ mode: "rename", node })}
               onMove={(node) => setMoving(node)}
-              onDelete={(node) => void remove(node)}
+              onDelete={(node) => setConfirmDelete(node)}
             />
           )}
         </div>
@@ -1544,6 +1559,18 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         busy={repairing}
         onClose={() => setRepair(null)}
         onConfirm={() => void confirmRepair()}
+      />
+      <DeleteDialog
+        nodes={nodes}
+        node={confirmDelete}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={(node) => {
+          // Close FIRST: remove() can clear openId/openFile out from under a
+          // still-mounted dialog (same reasoning as WorkflowsView's delete
+          // confirm).
+          setConfirmDelete(null);
+          void remove(node);
+        }}
       />
     </div>
   );
@@ -2065,6 +2092,64 @@ function MoveDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+/**
+ * Delete confirmation for a note or folder (issue #1255).
+ *
+ * A folder's delete recursively takes every note nested inside it in the same
+ * API call, so the dialog names exactly what that means — the file/folder
+ * counts under it, from {@link subtreeCounts} — rather than a bare "are you
+ * sure?" that reads the same for an empty folder and one holding a hundred
+ * notes.
+ */
+function DeleteDialog({
+  nodes,
+  node,
+  onClose,
+  onConfirm,
+}: {
+  nodes: FsNode[];
+  node: FsNode | null;
+  onClose: () => void;
+  onConfirm: (node: FsNode) => void;
+}) {
+  const counts = node ? subtreeCounts(nodes, node.id) : { files: 0, folders: 0 };
+  const description =
+    node?.kind === "file"
+      ? "This permanently deletes this note. There is no undo."
+      : counts.files === 0 && counts.folders === 0
+        ? "This folder is empty. Deleting it can’t be undone."
+        : `This folder and everything inside it — ${describeCounts(counts)} — will be permanently deleted. There is no undo.`;
+
+  return (
+    <AlertDialog open={Boolean(node)} onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete “{node ? titleOf(node) : ""}”?</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep it</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => node && onConfirm(node)}
+            className="bg-destructive text-white hover:bg-destructive/90"
+            data-testid="workspace-delete-confirm"
+          >
+            Delete {node?.kind === "folder" ? "folder" : "note"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+/** "3 notes and 1 folder" / "2 notes" / "1 folder" — for {@link DeleteDialog}. */
+function describeCounts(counts: { files: number; folders: number }): string {
+  const parts: string[] = [];
+  if (counts.files > 0) parts.push(`${counts.files} note${counts.files === 1 ? "" : "s"}`);
+  if (counts.folders > 0) parts.push(`${counts.folders} folder${counts.folders === 1 ? "" : "s"}`);
+  return parts.join(" and ");
 }
 
 /**

--- a/frontend/test/unit/workspace-delete-confirm.test.ts
+++ b/frontend/test/unit/workspace-delete-confirm.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1255: deleting a note or folder via the Workspace explorer's Actions
+ * menu used to call the delete API on the first click, no confirmation, no
+ * undo — and for a folder that one click took its entire nested subtree with
+ * it. This pins the fix the same way `ledger-retire-confirm.test.ts` pins
+ * #1216 on the Ledgers screen: render the real view against a fake host and
+ * assert the delete API is not called until a confirm button is pressed.
+ */
+
+/** A minimal `FsNode` off the wire — only the fields the tree reads. */
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}) {
+  return { ...over, updatedAt: 1 };
+}
+
+/** A fake host: `get` answers the workspace tree read, `del` the delete call. */
+function client(
+  tree: ReturnType<typeof node>[],
+  del: (path: string) => Promise<unknown>,
+): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(tree),
+    del: vi.fn(del),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+// Both the dropdown's Actions menu and the AlertDialog render through a
+// portal onto `document.body`, not inside `container` — so lookups search the
+// whole document, the same way `ledger-retire-confirm.test.ts` reaches
+// `ledger-retire-confirm` and `workflow-index-first.test.ts` reaches
+// `workflow-delete-confirm`.
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” button in:\n${document.body.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+function maybeButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+// `DropdownMenuItem` (base-ui `Menu.Item`) renders as `role="menuitem"`, not a
+// `<button>` — a separate lookup from the plain `<button>`s the AlertDialog
+// (and everything else in the tree) uses.
+function menuItem(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+    (el) => el.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” menu item in:\n${document.body.innerHTML}`);
+  return found as HTMLElement;
+}
+
+// Each tree row is exactly one `div.group` (see `TreeRow` in WorkspaceView.tsx),
+// holding the row's own name button and its own Actions dropdown trigger — so
+// matching on that class picks the one row rather than an ancestor container
+// that happens to also contain the name text and *some* Actions button.
+function actionsButtonFor(name: string): HTMLButtonElement {
+  const row = Array.from(container.querySelectorAll("div.group")).find((d) =>
+    d.textContent?.includes(name),
+  );
+  const found = row?.querySelector('[aria-label="Actions"]');
+  if (!found) throw new Error(`no Actions button for “${name}” in:\n${container.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(host: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, { client: host, company: "acme" }),
+      }),
+    );
+  });
+}
+
+/** Open the row's `…` Actions menu, then click its "Delete" item. */
+async function clickDelete(name: string) {
+  await act(async () => {
+    actionsButtonFor(name).click();
+  });
+  await act(async () => {
+    menuItem("Delete").click();
+  });
+}
+
+describe("deleting a note or folder asks before it deletes (issue #1255)", () => {
+  it("opens a confirm dialog on a file's Delete and does not call the delete API", async () => {
+    const tree = [node({ id: "note-1", name: "Plan.md", kind: "file" })];
+    const del = vi.fn(async (_path: string) => undefined);
+    await render(client(tree, del));
+
+    await clickDelete("Plan");
+
+    expect(del).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Delete “Plan”?");
+    expect(document.querySelector('[data-testid="workspace-delete-confirm"]')).not.toBeNull();
+  });
+
+  it("Keep it dismisses the dialog without ever calling the delete API", async () => {
+    const tree = [node({ id: "note-1", name: "Plan.md", kind: "file" })];
+    const del = vi.fn(async (_path: string) => undefined);
+    await render(client(tree, del));
+
+    await clickDelete("Plan");
+    expect(maybeButton("Keep it")).toBeDefined();
+
+    await act(async () => {
+      button("Keep it").click();
+    });
+
+    expect(del).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="workspace-delete-confirm"]')).toBeNull();
+  });
+
+  it("names the nested note and deletes only the folder id once confirmed", async () => {
+    const tree = [
+      node({ id: "folder-1", name: "Campaigns", kind: "folder" }),
+      node({ id: "note-1", name: "Q3.md", kind: "file", parentId: "folder-1" }),
+    ];
+    const del = vi.fn(async (_path: string) => undefined);
+    await render(client(tree, del));
+
+    // The folder's own row (and its Actions button) is present whether or not
+    // it is expanded — subtreeCounts reads the flat node list, not the UI's
+    // expanded set — so deleting a collapsed folder still names its contents.
+    await clickDelete("Campaigns");
+
+    expect(document.body.textContent).toContain("1 note");
+    expect(del).not.toHaveBeenCalled();
+
+    await act(async () => {
+      button("Delete folder").click();
+    });
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect((del.mock.calls[0] as [string])[0]).toContain("folder-1");
+    expect((del.mock.calls[0] as [string])[0]).not.toContain("note-1");
+  });
+});


### PR DESCRIPTION
## Summary
- Deleting a note or folder via the Workspace explorer's Actions menu was one unconfirmed click with no undo, and a folder's delete recursively took its entire nested subtree with it in that click.
- `remove()` in `frontend/src/views/WorkspaceView.tsx` is now gated behind a controlled `AlertDialog`, reusing the confirm pattern issue #1216 (PR #1232) established on the Ledgers screen: a divider + destructive styling on the trigger, an `AlertDialog` naming exactly what will happen, and the API call only fires from the confirm button.
- The dialog names the descendant note/folder counts for a folder (via a new `subtreeCounts` helper in `frontend/src/lib/workspace.ts`), so "delete this folder" reads as "this folder and everything inside it — 1 note — will be permanently deleted" rather than a generic warning.
- Added `frontend/test/unit/workspace-delete-confirm.test.ts`, asserting the delete API is not called until the confirm button is pressed (and never called on Cancel), mirroring the standard `ledger-retire-confirm.test.ts` set for #1216.

## Test plan
- [x] `npm run typecheck` (frontend) — clean
- [x] `npx vitest run` (frontend) — 149 files / 1420 tests passed, including the new `workspace-delete-confirm.test.ts`
- [x] Manual browser verification against a local host + console build (own port, own `OPENCOMPANY_DATA_DIR`): created a folder with a nested note and a standalone note, then for both:
  - Delete opens the confirmation dialog and fires zero `DELETE /workspace/...` calls
  - "Keep it" dismisses the dialog with zero API calls made, item still present
  - Confirming fires exactly one `DELETE` call (the target node's id only) and the item (and, for the folder, its nested note) is gone afterward

Closes #1255