### PR TITLE
fix(mcp): stop offering a Sign in button where OAuth cannot complete (#1260)

### DIFF
--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   Info,
+  KeyRound,
   Loader2,
   LogIn,
   Plug,
@@ -36,6 +37,32 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { ProviderDetail } from "@/views/connections/ProviderDetail";
+
+/**
+ * What a server's health entitles its row to offer (issue #1260).
+ *
+ * A rule rather than two inline conditions, because the two OAuth states differ
+ * by exactly one thing an operator cannot see: whether the server advertises
+ * dynamic client registration. `oauth_required` means the server asked for
+ * OAuth; only the host knows whether this console can complete one, and it says
+ * so by sending `static_token_required` instead. Reading them as the same state
+ * is what put a Sign in button on a Slack row that could never sign in.
+ */
+export function credentialAffordance(
+  authHint: string | undefined,
+): "sign_in" | "add_token" | "none" {
+  switch (authHint) {
+    case "oauth_required":
+      return "sign_in";
+    case "static_token_required":
+    // A plain credential prompt wants the same field; it simply never had a
+    // sign-in button to withdraw.
+    case "credential_required":
+      return "add_token";
+    default:
+      return "none";
+  }
+}
 
 type McpLoad = "loading" | "ready" | "unavailable" | "error";
 type ToolsState =
@@ -96,6 +123,17 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
   // A name rather than the row itself, so an open panel re-derives from
   // `servers` after a refresh instead of showing the row as it was when clicked.
   const [opened, setOpened] = useState<string | null>(null);
+  /**
+   * The server whose inline credential field is open, and its draft value
+   * (issue #1260).
+   *
+   * Per-row rather than a shared field: the add form's Token creates a *new*
+   * server, so pointing an operator at it to fix an existing one would have
+   * them add a second copy. The host has accepted a credential rotation on
+   * `PUT …/mcp/servers/{name}` all along — this is the control that was missing.
+   */
+  const [credentialFor, setCredentialFor] = useState<string | null>(null);
+  const [credentialDraft, setCredentialDraft] = useState("");
   // Set by the unmount cleanup below. A sign-in poll that is mid-`await` when
   // this component goes away has already removed its own timer entry, so the
   // cleanup has nothing left to cancel — it checks this instead of re-arming.
@@ -210,7 +248,12 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       // Exception: an OAuth-required result is not an error to shout about — the
       // amber "needs config" badge carries a Sign in button, so a red alert here
       // would be redundant and misleading.
-      if (res.test && res.test.status !== "ok" && res.test.authHint !== "oauth_required") {
+      if (
+        res.test &&
+        res.test.status !== "ok" &&
+        res.test.authHint !== "oauth_required" &&
+        res.test.authHint !== "static_token_required"
+      ) {
         setAddError(res.test.message);
       } else if (res.warning) {
         setAddError(res.warning);
@@ -253,6 +296,32 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
   // Browser OAuth sign-in (issue #90): open the authorization URL in a new tab,
   // then poll the server's health until it flips to `ok` (the host stores the
   // token on its callback route) so the amber badge turns green on its own.
+  /**
+   * Rotate one server's credential from its own row (issue #1260).
+   *
+   * Re-tests on success rather than trusting the write: the whole point of the
+   * flow is that the operator does not know whether the token is the right one
+   * until the server answers, and a silent save would leave the amber badge
+   * sitting there with no way to tell "wrong token" from "not saved".
+   */
+  async function saveCredential(server: McpServer) {
+    if (busy) return;
+    const token = credentialDraft.trim();
+    if (!token) return;
+    setBusy(server.name);
+    try {
+      await updateMcpServer(client, company, server.name, { token, authKind: "bearer" });
+      setCredentialFor(null);
+      setCredentialDraft("");
+      await refresh();
+      await test(server);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't save the token.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function signIn(server: McpServer) {
     // Guard both the shared `busy` flag and a per-server poll already in flight:
     // the poll outlives `busy`, so without the second check a repeat click would
@@ -474,7 +543,32 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                             onCheckedChange={(v) => void toggle(server, v)}
                             aria-label={`Enable ${server.name}`}
                           />
-                          {health?.authHint === "oauth_required" && canManage && (
+                          {/* Issue #1260: `oauth_required` means the server asked for
+                              OAuth; it does NOT mean this console can complete one. A
+                              server advertising no dynamic client registration — Slack's
+                              MCP endpoint, for one — has no client for us to mint, so
+                              Sign in cannot succeed and the host says so with a distinct
+                              hint. Offering the button anyway spends a click to reach an
+                              error naming something the operator cannot act on, which is
+                              the same trade `hub_providers` already refuses to make for
+                              the Google and GitHub buttons. */}
+                          {credentialAffordance(health?.authHint) === "add_token" &&
+                            canManage &&
+                            credentialFor !== server.name && (
+                              <Button
+                                variant="default"
+                                size="sm"
+                                data-testid="mcp-add-token"
+                                disabled={busy === server.name}
+                                onClick={() => {
+                                  setCredentialDraft("");
+                                  setCredentialFor(server.name);
+                                }}
+                              >
+                                <KeyRound className="size-4" /> Add token
+                              </Button>
+                            )}
+                          {credentialAffordance(health?.authHint) === "sign_in" && canManage && (
                             <Button
                               variant="default"
                               size="sm"
@@ -557,6 +651,47 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                         ))}
                       {health && health.status !== "ok" && health.message && (
                         <p className="text-xs text-muted-foreground">{health.message}</p>
+                      )}
+                      {credentialFor === server.name && canManage && (
+                        <div className="flex items-end gap-2" data-testid="mcp-token-inline">
+                          <div className="flex-1 space-y-1">
+                            <Label htmlFor={`mcp-token-${server.name}`} className="text-xs">
+                              API token for {server.name}
+                            </Label>
+                            <Input
+                              id={`mcp-token-${server.name}`}
+                              type="password"
+                              autoComplete="new-password"
+                              placeholder="write-only"
+                              value={credentialDraft}
+                              onChange={(e) => setCredentialDraft(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") void saveCredential(server);
+                                if (e.key === "Escape") setCredentialFor(null);
+                              }}
+                            />
+                          </div>
+                          <Button
+                            size="sm"
+                            data-testid="mcp-token-save"
+                            disabled={busy === server.name || !credentialDraft.trim()}
+                            onClick={() => void saveCredential(server)}
+                          >
+                            {busy === server.name ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              "Save"
+                            )}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={busy === server.name}
+                            onClick={() => setCredentialFor(null)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
                       )}
                       <McpToolsList state={tools[server.name] ?? { kind: "idle" }} />
                     </li>

--- a/frontend/test/unit/mcp-credential-affordance.test.ts
+++ b/frontend/test/unit/mcp-credential-affordance.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { credentialAffordance } from "@/views/connections/McpServersSection";
+
+/**
+ * Issue #1260. The MCP row offered a **Sign in** button on a server whose OAuth
+ * could never complete: Slack's MCP endpoint answers `401` with a proper
+ * resource-metadata challenge but advertises no RFC 7591 dynamic client
+ * registration, so there is no client to mint. `POST …/oauth/start` refused
+ * with a `400` naming the real remedy — paste a static token — which the
+ * operator could only read by pressing a button that could not work.
+ *
+ * The host now distinguishes the two states. These pin the console half: which
+ * control a row offers is a function of that hint and nothing else.
+ */
+describe("credentialAffordance", () => {
+  it("offers sign-in only when the host says sign-in can complete", () => {
+    expect(credentialAffordance("oauth_required")).toBe("sign_in");
+  });
+
+  it("offers a token field when OAuth is required but undrivable", () => {
+    expect(credentialAffordance("static_token_required")).toBe("add_token");
+  });
+
+  it("never offers sign-in for a server that cannot complete one", () => {
+    // The regression itself. Both codes carry `status: needs_config` and both
+    // read as "an auth problem"; only this distinction stops the unusable
+    // button coming back.
+    expect(credentialAffordance("static_token_required")).not.toBe("sign_in");
+  });
+
+  it("routes a plain credential prompt to the same field", () => {
+    expect(credentialAffordance("credential_required")).toBe("add_token");
+  });
+
+  it("offers nothing for a healthy server or an unknown code", () => {
+    // A server that probed `ok` carries no hint at all, and must not sprout a
+    // credential control; an unrecognised future code must not either, because
+    // guessing which control it wants is how the wrong one gets offered.
+    expect(credentialAffordance(undefined)).toBe("none");
+    expect(credentialAffordance("token_rejected")).toBe("none");
+    expect(credentialAffordance("some_code_added_later")).toBe("none");
+  });
+});

--- a/src/company/mcp_oauth.rs
+++ b/src/company/mcp_oauth.rs
@@ -325,6 +325,51 @@ fn build_authorize_url(
 }
 
 /// Begin the browser-OAuth flow for `server_name` at `endpoint`: discover →
+/// How long [`supports_console_oauth`] will wait on OAuth discovery.
+///
+/// Short on purpose: this is a refinement of an answer the probe already has,
+/// not the answer itself, so it must not dominate the probe's own budget.
+const CONSOLE_OAUTH_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Whether console OAuth can actually drive this server (issue #1260).
+///
+/// [`begin`] answers this already, but only by attempting the flow and failing —
+/// which is too late for the health probe, whose answer decides whether the
+/// console offers a **Sign in** button or a credential field. A server can
+/// require OAuth and still be undrivable from here: Slack's MCP endpoint
+/// answers `401` with a proper resource-metadata challenge and advertises no
+/// `registration_endpoint`, so there is no client for us to mint and no sign-in
+/// we can complete.
+///
+/// Reuses [`select_auth_server`] rather than re-deriving the rule, so the
+/// question the probe asks and the one `begin` enforces cannot drift apart.
+///
+/// **Every failure answers `true`.** Discovery is a live outbound call and can
+/// fail for reasons that say nothing about the server's capabilities — a
+/// timeout, a transient 5xx, a network blip. Answering `false` on one of those
+/// would replace a working Sign in button with "paste a token" on a server that
+/// supports sign-in perfectly well, which is a worse outcome than today's
+/// behaviour. Unsure therefore means "leave it as it was".
+pub(crate) async fn supports_console_oauth(endpoint: &str) -> bool {
+    // Bounded explicitly: this sits on the health-probe path, and a metadata
+    // endpoint that accepts a connection and then hangs would otherwise stall
+    // the probe for whatever the HTTP client's own default happens to be.
+    // Timing out answers `true` for the same reason every other failure does.
+    let Ok(discovered) =
+        tokio::time::timeout(CONSOLE_OAUTH_DISCOVERY_TIMEOUT, discover(endpoint)).await
+    else {
+        return true;
+    };
+    match discovered {
+        // No authorization context at all: the server did not ask for OAuth on
+        // this probe. Nothing to downgrade — the caller's classification stands.
+        Ok(None) => true,
+        Ok(Some(ctx)) => select_auth_server(ctx).is_some(),
+        Err(_) => true,
+    }
+}
+
+/// Discover the server's OAuth metadata, register a client via RFC 7591
 /// dynamic client registration → PKCE, and return the live `/authorize` URL plus
 /// the [`PendingOAuth`] the caller parks (keyed by the returned `state`).
 ///

--- a/src/harness/built_in/mcp_probe.rs
+++ b/src/harness/built_in/mcp_probe.rs
@@ -69,6 +69,12 @@ enum FailureKind {
     /// Distinct from [`FailureKind::OauthRequired`] because the operator's next
     /// action is the opposite one — paste a static token, rather than press a
     /// Sign in button that cannot succeed.
+    ///
+    /// Only ever constructed by `refine_oauth_capability`, which is itself
+    /// gated on `feature = "mcp"` (no `mcp` feature means no `oauth/start`
+    /// route, so there is nothing to downgrade) — so this variant is
+    /// legitimately unconstructed in builds without that feature.
+    #[cfg_attr(not(feature = "mcp"), allow(dead_code))]
     StaticTokenRequired,
     /// Anything not otherwise recognised.
     Unknown,

--- a/src/harness/built_in/mcp_probe.rs
+++ b/src/harness/built_in/mcp_probe.rs
@@ -62,6 +62,14 @@ enum FailureKind {
     ServerError,
     /// A tool call was rejected by the server (JSON-RPC error in call context).
     ToolCallRejected,
+    /// The server requires OAuth, but console OAuth cannot drive it: it
+    /// advertises no RFC 7591 dynamic client registration, so there is no
+    /// client to mint and no sign-in to complete (issue #1260).
+    ///
+    /// Distinct from [`FailureKind::OauthRequired`] because the operator's next
+    /// action is the opposite one — paste a static token, rather than press a
+    /// Sign in button that cannot succeed.
+    StaticTokenRequired,
     /// Anything not otherwise recognised.
     Unknown,
 }
@@ -86,6 +94,7 @@ impl FailureKind {
         match self {
             FailureKind::CredentialRequired => "credential_required",
             FailureKind::OauthRequired => "oauth_required",
+            FailureKind::StaticTokenRequired => "static_token_required",
             FailureKind::TokenRejected => "token_rejected",
             FailureKind::Timeout => "timeout",
             FailureKind::Unreachable => "unreachable",
@@ -103,6 +112,7 @@ impl FailureKind {
         match self {
             FailureKind::CredentialRequired
             | FailureKind::OauthRequired
+            | FailureKind::StaticTokenRequired
             | FailureKind::TokenRejected => McpStatus::NeedsConfig,
             _ => McpStatus::Error,
         }
@@ -113,6 +123,7 @@ impl FailureKind {
         match self {
             FailureKind::CredentialRequired => Some("credential_required".to_string()),
             FailureKind::OauthRequired => Some("oauth_required".to_string()),
+            FailureKind::StaticTokenRequired => Some("static_token_required".to_string()),
             FailureKind::TokenRejected => Some("token_rejected".to_string()),
             _ => None,
         }
@@ -299,10 +310,13 @@ fn looks_like_tls(err: &anyhow::Error) -> bool {
 pub fn operator_message(server: &str, class: &ProbeClass, err: &anyhow::Error) -> String {
     match class.kind {
         FailureKind::CredentialRequired => format!(
-            "MCP server '{server}' needs a credential. Add its API token (or query-parameter key) in Connections, then Test again."
+            "MCP server '{server}' needs a credential. Add its API token (or query-parameter key) in its Token field, then Test again."
         ),
         FailureKind::OauthRequired => format!(
-            "MCP server '{server}' needs OAuth sign-in — click Sign in on the server in Connections to authorize it."
+            "MCP server '{server}' needs OAuth sign-in — click Sign in on this server to authorize it."
+        ),
+        FailureKind::StaticTokenRequired => format!(
+            "MCP server '{server}' requires OAuth, but it doesn't offer the automatic client registration this console signs in with. Paste a static API token in its Token field, then Test again."
         ),
         FailureKind::TokenRejected => format!(
             "MCP server '{server}' rejected the credential — it's wrong or expired. Update it and Test again."
@@ -360,6 +374,12 @@ pub async fn probe_server(decl: &McpServerDecl) -> McpHealth {
         }
         Err(err) => {
             let class = classify_mcp_error(&err, auth_configured, false);
+            // Issue #1260: "wants OAuth" and "we can sign in" are two different
+            // questions, and only the second decides whether the console should
+            // offer a Sign in button. Asked here rather than in
+            // `classify_mcp_error`, which is pure and synchronous by design —
+            // this needs a live discovery call.
+            let class = refine_oauth_capability(&decl.endpoint, class).await;
             let message = scrub(&operator_message(&decl.name, &class, &err), &secrets);
             McpHealth {
                 status: class.status,
@@ -370,6 +390,32 @@ pub async fn probe_server(decl: &McpServerDecl) -> McpHealth {
             }
         }
     }
+}
+
+/// Downgrade an `oauth_required` verdict to `static_token_required` when console
+/// OAuth provably cannot drive this server (issue #1260).
+///
+/// Only ever consulted for [`FailureKind::OauthRequired`], so a healthy server
+/// pays nothing: this runs on a server that already answered `401`.
+#[cfg(feature = "mcp")]
+async fn refine_oauth_capability(endpoint: &str, class: ProbeClass) -> ProbeClass {
+    if class.kind != FailureKind::OauthRequired
+        || crate::company::mcp_oauth::supports_console_oauth(endpoint).await
+    {
+        return class;
+    }
+    ProbeClass {
+        status: FailureKind::StaticTokenRequired.status(),
+        auth_hint: FailureKind::StaticTokenRequired.auth_hint(),
+        kind: FailureKind::StaticTokenRequired,
+    }
+}
+
+/// Without the `mcp` feature there is no `oauth/start` route for the console to
+/// call, so there is no Sign in button to withdraw and nothing to refine.
+#[cfg(not(feature = "mcp"))]
+async fn refine_oauth_capability(_endpoint: &str, class: ProbeClass) -> ProbeClass {
+    class
 }
 
 /// Scrub a message so it can be safely persisted, returned, or shown to an agent.
@@ -689,6 +735,104 @@ mod tests {
         let class = classify_mcp_error(&err, false, false);
         assert_eq!(class.auth_hint.as_deref(), Some("oauth_required"));
         assert_eq!(class.status, McpStatus::NeedsConfig);
+    }
+
+    /// Issue #1260: the two OAuth states are distinguishable on the wire, and
+    /// they carry the two different actions an operator has to take.
+    #[test]
+    fn the_two_oauth_states_do_not_share_a_hint() {
+        assert_eq!(
+            FailureKind::OauthRequired.auth_hint().as_deref(),
+            Some("oauth_required")
+        );
+        assert_eq!(
+            FailureKind::StaticTokenRequired.auth_hint().as_deref(),
+            Some("static_token_required")
+        );
+        assert_ne!(
+            FailureKind::OauthRequired.auth_hint(),
+            FailureKind::StaticTokenRequired.auth_hint(),
+            "the console renders a Sign in button off this code; collapsing the two \
+             is what put an unusable button on a Slack row"
+        );
+        // Both are a resting state the operator can fix, not a failure.
+        assert_eq!(
+            FailureKind::StaticTokenRequired.status(),
+            McpStatus::NeedsConfig
+        );
+        assert_eq!(
+            FailureKind::StaticTokenRequired.code(),
+            "static_token_required"
+        );
+    }
+
+    /// The message names the field the operator can actually use.
+    ///
+    /// The previous text sent them to Connections, which carries no MCP server
+    /// row at all — a instruction that cannot be followed reads as a broken
+    /// feature rather than a missing token.
+    #[test]
+    fn the_credential_messages_name_a_field_that_exists() {
+        for kind in [
+            FailureKind::StaticTokenRequired,
+            FailureKind::CredentialRequired,
+        ] {
+            let class = ProbeClass {
+                status: kind.status(),
+                auth_hint: kind.auth_hint(),
+                kind,
+            };
+            let msg = operator_message("slack", &class, &anyhow_str("x"));
+            assert!(
+                msg.contains("Token field"),
+                "{kind:?} must name the Token field: {msg}"
+            );
+            assert!(
+                !msg.contains("in Connections"),
+                "{kind:?} still points at Connections, which has no MCP row: {msg}"
+            );
+        }
+    }
+
+    /// A refinement only ever fires on the one kind it is about, and every
+    /// uncertain answer leaves the classification alone.
+    #[tokio::test]
+    async fn refinement_leaves_every_other_kind_untouched() {
+        for kind in [
+            FailureKind::CredentialRequired,
+            FailureKind::TokenRejected,
+            FailureKind::Timeout,
+            FailureKind::Unreachable,
+        ] {
+            let class = ProbeClass {
+                status: kind.status(),
+                auth_hint: kind.auth_hint(),
+                kind,
+            };
+            // An endpoint that cannot resolve: discovery fails, and a failed
+            // discovery must never rewrite a verdict.
+            let refined = refine_oauth_capability("https://127.0.0.1:1/mcp", class.clone()).await;
+            assert_eq!(refined, class, "{kind:?} was rewritten by the refinement");
+        }
+    }
+
+    /// Discovery that fails keeps `oauth_required` rather than downgrading.
+    ///
+    /// The safe direction is the one that does not regress a server whose sign-in
+    /// works: a timeout or a transient must not replace a working Sign in button
+    /// with "paste a token".
+    #[tokio::test]
+    async fn an_unreachable_discovery_keeps_sign_in() {
+        let class = ProbeClass {
+            status: FailureKind::OauthRequired.status(),
+            auth_hint: FailureKind::OauthRequired.auth_hint(),
+            kind: FailureKind::OauthRequired,
+        };
+        let refined = refine_oauth_capability("https://127.0.0.1:1/mcp", class.clone()).await;
+        assert_eq!(
+            refined, class,
+            "an unreachable discovery must leave the verdict as it was"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The MCP Servers tab offered a **Sign in** button on a server whose OAuth could never complete, and hid the only workable remedy inside the error you got for pressing it.

Slack's MCP endpoint answers `401` with a proper resource-metadata challenge but advertises no `registration_endpoint`, so there is no client to mint and `mcp_oauth::begin` refuses — correctly. Verified against Slack directly, no tenant involved:

```
POST https://mcp.slack.com/mcp
→ 401  www-authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"

GET  https://mcp.slack.com/.well-known/oauth-authorization-server
→ 200, carrying NO registration_endpoint
```

The probe could not say so, because `oauth_required` covered two states that need opposite actions. It answers *"did this server ask for OAuth"*; the console read it as *"can we complete a sign-in"*. Those come apart exactly when dynamic client registration is missing.

Nothing was ever at risk — `window.open` is only reached after the host returns an `authorizeUrl`, so no handshake started and no credential moved. It was a wasted click and a confusing error, not a broken flow.

## API Or Behavior Changes

**New probe state.** `authHint` gains `static_token_required` alongside `oauth_required`. Both are `needs_config`; existing codes are unchanged. A client that does not know the new code simply renders no credential control, as it does today for any unrecognised hint.

**A new control that had no equivalent.** Following the old error was impossible: the only Token input on the page belongs to the **add** form, so an operator told to paste a token for an existing server would have created a second copy of it. The host has accepted credential rotation on `PUT …/mcp/servers/{name}` all along (`token`, `authKind`, `headerName`, `paramName`) — the control was never built. The row now carries a per-server, write-only field that saves and re-tests.

**Both credential messages stop naming Connections**, which carries no MCP server row at all — `GET …/connections` returns nothing matching. They name the Token field instead.

**Gated on `mcp`** with a no-op fallback. A build without it has no `oauth/start` route, so there is no button to withdraw.

**Not in scope:** operator-supplied OAuth client credentials for servers that require a pre-registered client. That is a real feature and a separate issue — it needs client id/secret custody, a `scope` parameter the authorize URL does not currently send, and the callback URI surfaced for registration.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex,mcp --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex,mcp --tests` — **4764 passed, 0 failed**
- [x] `npm run typecheck` and `npx vitest run`

Rust (`mcp_probe`): the two hints cannot collapse into one; both credential messages name a field that exists and no longer say "in Connections"; the refinement leaves every other failure kind untouched; an unreachable discovery keeps Sign in rather than downgrading.

Console (`credentialAffordance`): sign-in only where the host says sign-in can complete, a token field where it cannot, plus the regression itself — **never** sign-in for a server that cannot complete one — and nothing at all for a healthy server or an unrecognised future code.

**Verified end-to-end on a local host** (`companies/e2e_harness`, real magic-link sign-in, rebuilt console):

| | |
|---|---|
| `slack` | `static_token_required`, **Add token**, no Sign in button |
| `deepwiki` (no auth) | `ok · 3 tools`, **no credential control** |
| junk token saved | `authConfigured: true`, auto re-tested, stayed `needs_config` rather than turning green |
| token in the list response | **0 occurrences** |

**Known nuance, deliberately not widened:** after saving a *wrong* token, Slack still reports `static_token_required` rather than `token_rejected`. That is pre-existing classifier behaviour — a typed 401 carrying OAuth metadata dominates the credential state, with its own test. The message stays accurate and actionable; it just does not acknowledge that a token was already tried.

## Documentation

Documented where it is read: the `supports_console_oauth` doc states why every uncertain answer is `true`, `refine_oauth_capability` states why it cannot live in `classify_mcp_error`, and `credentialAffordance` states what the two OAuth states differ by. No module README claims changed.

Closes #1260
