### PR TITLE
chore(vendor): bump openhuman to the tinymemory-38a34d2 pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -479,17 +478,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3204,7 +3192,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "tower",
  "tower-http 0.7.0",
@@ -3217,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.11"
+version = "0.63.13"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3283,7 +3271,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5241,7 +5229,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "walkdir",
@@ -5251,14 +5239,7 @@ dependencies = [
 name = "tinycortex-api"
 version = "0.1.1"
 dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "uuid",
+ "tinymemory-api",
 ]
 
 [[package]]
@@ -5343,7 +5324,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "chrono",
  "dirs",
  "futures",
@@ -5360,8 +5340,9 @@ dependencies = [
  "tinyagents",
  "tinycortex",
  "tinycortex-api",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-sources",
+ "tinymemory-sync",
  "tokio",
  "tracing",
  "url",
@@ -5375,12 +5356,44 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tinymemory",
  "tinymemory-api",
+]
+
+[[package]]
+name = "tinymemory-sources"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "regex",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tinymemory-api",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymemory-sync"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -5389,9 +5402,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
  "tinycortex",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-core",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -5552,6 +5571,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -5559,10 +5593,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5581,10 +5624,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5593,7 +5636,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6477,6 +6520,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -585,3 +585,15 @@ criterion = { version = "0.8", default-features = false, features = [
 [[bench]]
 name = "journal_append"
 harness = false
+
+# The tinycortex pin (bfd2ea21, via vendor/openhuman) takes `tinymemory-api` BY
+# GIT in `tinycortex-api` (tinycortex#149 re-exports the contract instead of
+# duplicating it). Same WS4 rule as the `[patch.crates-io]` block above:
+# openhuman's own `[patch]` table is ignored when openhuman is consumed as a
+# path dependency, so its unification of that git dep onto the vendored path
+# copy must be replicated here, rebased. Without this entry cargo resolves TWO
+# `tinymemory-api` crates — the path one and the git one — which is two
+# nominally distinct `MemoryProvider`/`Memory` traits in one process, and
+# `tinymemory-core` fails with E0308s where the engine trait meets the contract.
+[patch."https://github.com/tinyhumansai/tinymemory"]
+tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/api" }


### PR DESCRIPTION
## Summary

Bump `vendor/openhuman` ded703dd → 3911b7b8 (openhuman#5608's head: upstream main 92bab8df + the tinymemory pin bump).

What rides in, for the memory surfacing work this unblocks:

- **tinymemory dc3a725 → 38a34d2** — the vendored tinymemory jumps from a mid-arc Aug-17 commit (97 behind) to the completed tinymemory#18 arc. Concretely: the `tinymemory-conformance` crate exists on disk (the next PR wires it into a CI lane), and the hosted adapters gain the #63–#66 production fixes — dead Cognee default endpoint removed, Mem0 cloud search no longer 400s on a null threshold, API keys no longer echoed into error text, named transport-failure classes, incremental response-body cap. Today's vendored adapters have all of those bugs, which is what made this bump a prerequisite for enabling `tinymemory` in shipped builds.
- **tinycortex 8401346b → bfd2ea21** — openhuman#5605's pin ("cc-corroboration").
- Everything else openhuman merged between ded703dd and current main.

Two OpenCompany-side changes ride along, both mechanical:

- **New `[patch."https://github.com/tinyhumansai/tinymemory"]` table** in the root `Cargo.toml`. The new tinycortex pin's `tinycortex-api` takes `tinymemory-api` **by git** (tinycortex#149), and openhuman's own patch table unifying that onto its vendored path copy is ignored when openhuman is a path dependency — the WS4 replication rule already documented above `[patch.crates-io]`. Without the entry cargo resolves two `tinymemory-api` crates and `tinymemory-core` fails with E0308s where the engine trait meets the contract (hit exactly as the handoff's "two-copies hazard" predicts; found by the compiler, fixed with the one-line patch mirroring openhuman's own).
- **`Cargo.lock` regenerated** for the vendored crate-version moves (`openhuman` 0.63.11 → 0.63.13, new `tinymemory-sources`/`tinymemory-sync` path crates, toml/winnow transitive bumps).

No OpenCompany source changes.

## Stacking

Depends on [openhuman#5608](https://github.com/tinyhumansai/openhuman/pull/5608) (draft). This PR pins its head commit so the chain can be validated now; **re-pin to the merge commit once #5608 lands, before this merges.**

Follow-ups that stack on this: the memory CI lane (union build + vendored driver-conformance), then enabling `tinymemory` in the staging tenant feature set.

## Verification

- `scripts/ci/init-vendored-submodules.sh` clean at the new pin
- `cargo metadata --locked` resolves after the lock regen
- `cargo check --features openhuman,tinycortex` (the gated tenant shape)
- `cargo check --features acp,runner,tinymemory-embedded` (the memory-seam shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
