### PR TITLE
workflows: run history ordered by finish time, cursor pagination, bounded read

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -792,23 +792,41 @@ export function cancelWorkflowRun(
 }
 
 /**
- * The company's finished workflow runs, **newest first** (issue #228).
+ * One page of {@link listWorkflowRuns} (issue #1012).
+ *
+ * `hasMore` says whether an older page exists behind `beforeSeq` — the run
+ * history drawer's "Load older" affordance is gated on it, so a truncated
+ * history never silently reads as the whole thing.
+ */
+export interface WorkflowRunsPage {
+  runs: WorkflowRunOutcome[];
+  hasMore: boolean;
+}
+
+/**
+ * The company's finished workflow runs, **newest first** (issue #228) — now
+ * genuinely true of the *displayed* `seq`/`atMillis`, not just the order two
+ * runs started in (issue #1012).
  *
  * `workflow` narrows to one graph's runs; `limit` caps the page (the host
- * defaults to a short recent list and clamps a large ask). A host predating this
- * route answers 404 — callers should treat that as "no history yet" rather than
- * an error, since the console still works without it.
+ * defaults to a short recent list and clamps a large ask). `beforeSeq` pages
+ * further back: pass the `seq` of the oldest run already held to fetch the
+ * page before it (issue #1012) — `hasMore` on the returned page says whether
+ * one exists. A host predating this route answers 404 — callers should treat
+ * that as "no history yet" rather than an error, since the console still works
+ * without it.
  */
 export function listWorkflowRuns(
   client: OpenCompanyClient,
   company: string | null,
-  options?: { workflow?: string; limit?: number },
-): Promise<WorkflowRunOutcome[]> {
+  options?: { workflow?: string; limit?: number; beforeSeq?: number },
+): Promise<WorkflowRunsPage> {
   const params = new URLSearchParams();
   if (options?.workflow) params.set("workflow", options.workflow);
   if (options?.limit) params.set("limit", String(options.limit));
+  if (options?.beforeSeq) params.set("before_seq", String(options.beforeSeq));
   const query = params.toString();
-  return client.get<WorkflowRunOutcome[]>(
+  return client.get<WorkflowRunsPage>(
     `${client.scopeFor(company)}/workflows/runs${query ? `?${query}` : ""}`,
   );
 }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -408,6 +408,15 @@ export function WorkflowsView({
   // vanished when the drawer was dismissed and a scheduled run's never reached
   // the operator at all.
   const [runs, setRuns] = useState<WorkflowRunOutcome[]>([]);
+  // Issue #1012: whether an older page of `runs` exists behind the oldest
+  // `seq` currently held — gates the drawer's "Load older" affordance. Reset
+  // to `false` whenever the effect below replaces `runs` wholesale (a fresh
+  // newest-page fetch has not yet learned this), and updated by both that
+  // effect and `loadOlderRuns` from each fetch's own `hasMore`.
+  const [runsHasMore, setRunsHasMore] = useState(false);
+  // A "Load older" fetch in flight, so the drawer can disable the control and
+  // avoid a second click racing the first for the same older page.
+  const [loadingOlderRuns, setLoadingOlderRuns] = useState(false);
   // Which workflow the rows in `runs` were fetched for.
   //
   // `graph` and `runs` are two independent requests off the same selection, so
@@ -988,18 +997,25 @@ export function WorkflowsView({
     // whether the host serves this route.
     if (!selectedId) {
       setRuns([]);
+      setRunsHasMore(false);
       setRunsFor(null);
       return;
     }
     let live = true;
     (async () => {
       try {
-        const rows = await listWorkflowRuns(client, company, {
+        const { runs: rows, hasMore } = await listWorkflowRuns(client, company, {
           workflow: selectedId,
           limit: 50,
         });
         if (!live) return;
         setRuns(rows);
+        // Issue #1012: this effect always replaces the page wholesale (a
+        // company switch, a run event, an explicit refresh) — any older runs
+        // a "Load older" click had appended are gone with it, so `hasMore`
+        // starts back over from this fresh newest page's own answer rather
+        // than carrying forward whatever the appended state last said.
+        setRunsHasMore(hasMore);
         setRunsFor(selectedId);
         setHistorySupported(true);
         // Issue #371, the no-live-stream fallback. If the run we just POSTed is
@@ -1022,6 +1038,7 @@ export function WorkflowsView({
         // Degrade quietly: an older host simply has no history to show.
         console.debug("[WorkflowsView] run history unavailable", e);
         setRuns([]);
+        setRunsHasMore(false);
         // Still THIS workflow's answer — "the host has no history for it" — so
         // the pair agrees and the copilot may proceed, told via `runsKnown`
         // that nothing is known about runs rather than that there were none.
@@ -1038,6 +1055,36 @@ export function WorkflowsView({
     // inside, and listing it would re-run this fetch on that clear.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, company, selectedId, runsTick, runEventTick]);
+
+  // Issue #1012: "Load older", the run-history drawer's pagination affordance.
+  // APPENDS to `runs` rather than replacing it — unlike the effect above,
+  // which always starts over from the newest page. Paged off the `seq` of the
+  // oldest run currently held, matching the host's `?before_seq=` cursor
+  // semantics (issue #1012's ordering fix made `seq` the field every row's
+  // own display agrees with, which is what makes it a stable paging key).
+  const loadOlderRuns = useCallback(() => {
+    if (!selectedId || loadingOlderRuns) return;
+    const oldest = runs.at(-1)?.seq;
+    if (oldest === undefined) return;
+    setLoadingOlderRuns(true);
+    (async () => {
+      try {
+        const { runs: older, hasMore } = await listWorkflowRuns(client, company, {
+          workflow: selectedId,
+          limit: 50,
+          beforeSeq: oldest,
+        });
+        setRuns((prev) => [...prev, ...older]);
+        setRunsHasMore(hasMore);
+      } catch (e) {
+        // Same quiet degradation as the newest-page fetch — leave what is
+        // already shown in place rather than losing it to a failed page.
+        console.debug("[WorkflowsView] loading older run history failed", e);
+      } finally {
+        setLoadingOlderRuns(false);
+      }
+    })();
+  }, [client, company, selectedId, runs, loadingOlderRuns]);
 
   // Issue #303: the run page the index's health readings are folded from.
   //
@@ -1060,7 +1107,9 @@ export function WorkflowsView({
     let live = true;
     (async () => {
       try {
-        const rows = await listWorkflowRuns(client, company, { limit: 200 });
+        // `hasMore` is ignored here: the index only needs enough of the
+        // company-wide page to fold per-card health, not a pagination UI.
+        const { runs: rows } = await listWorkflowRuns(client, company, { limit: 200 });
         if (!live) return;
         setIndexRuns(rows);
         setIndexRunsLoaded(true);
@@ -2697,6 +2746,9 @@ export function WorkflowsView({
                 onFixWithCopilot={handleFixWithCopilot}
                 fixingRunSeq={fixingRunSeq}
                 fixReason={fixReason}
+                hasMore={runsHasMore}
+                onLoadOlder={loadOlderRuns}
+                loadingOlder={loadingOlderRuns}
               />
             ) : null
           }

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -168,6 +168,9 @@ export function RunHistoryPanel({
   onFixWithCopilot,
   fixingRunSeq,
   fixReason,
+  hasMore,
+  onLoadOlder,
+  loadingOlder,
 }: {
   runs: WorkflowRunOutcome[];
   /**
@@ -192,6 +195,19 @@ export function RunHistoryPanel({
   fixingRunSeq?: number | null;
   /** A run the copilot judged un-fixable, shown inline under that run's row. */
   fixReason?: { seq: number; reason: string } | null;
+  /**
+   * Whether an older page of `runs` exists behind the oldest `seq` currently
+   * held (issue #1012) — the silent-truncation half of that issue. Omitted
+   * (or `false`) hides "Load older" entirely, which is also how a host
+   * predating the pagination fields degrades: no crash, just no affordance.
+   */
+  hasMore?: boolean;
+  /** Fetch and append the next-older page. Absent hides "Load older" even if
+   * `hasMore` is true — a caller with nowhere to route the click should not
+   * offer it. */
+  onLoadOlder?: () => void;
+  /** An older-page fetch is in flight, so "Load older" shows as busy. */
+  loadingOlder?: boolean;
 }) {
   // Only one fix may be in flight at a time: `handleFixWithCopilot` sets a
   // single `prefilledDraft`/`editOpen` slot, so a second Fix started on a
@@ -266,6 +282,20 @@ export function RunHistoryPanel({
                 fixReason={fixReason?.seq === run.seq ? fixReason.reason : null}
               />
             ))}
+            {/* Issue #1012: the honest half of the page cap — a truncated
+                history says so, with a way to see more, rather than silently
+                ending at `limit` and reading as the whole story. */}
+            {hasMore && onLoadOlder && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full"
+                disabled={loadingOlder}
+                onClick={onLoadOlder}
+              >
+                {loadingOlder ? "Loading…" : "Load older"}
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/frontend/test/e2e/workflow-list-columns.spec.ts
+++ b/frontend/test/e2e/workflow-list-columns.spec.ts
@@ -101,7 +101,11 @@ async function openList(page: Page) {
     (url) => isRunPage(url),
     async (route: Route) => {
       if (route.request().method() !== "GET") return route.fallback();
-      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(RUNS) });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ runs: RUNS, hasMore: false }),
+      });
     },
   );
   await page.addInitScript(() => {

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -111,7 +111,7 @@ async function mockCompanySwitchApi(page: Page) {
     if (path === `/api/v1/companies/${company}/workflows`) return json(workflows[company]);
     if (path.endsWith("/workflows/tool-slugs")) return json({ slugs: [] });
     if (path.endsWith("/workflows/wired-channels")) return json({ channels: [] });
-    if (path.endsWith("/workflows/runs")) return json([]);
+    if (path.endsWith("/workflows/runs")) return json({ runs: [], hasMore: false });
 
     const workflowId = path.match(/\/workflows\/([^/]+)$/)?.[1];
     if (workflowId) {

--- a/frontend/test/unit/workflow-deeplink-reread.test.ts
+++ b/frontend/test/unit/workflow-deeplink-reread.test.ts
@@ -107,7 +107,7 @@ function makeClient(
       if (path.endsWith("/workflows")) return listFor();
       if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
       if (path.includes("/workflows/wired-channels")) return { channels: [] };
-      if (path.includes("/workflows/runs")) return [];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
       const m = path.match(/\/workflows\/([^/?]+)$/);
       if (m) {
         const id = decodeURIComponent(m[1]);

--- a/frontend/test/unit/workflow-index-first.test.ts
+++ b/frontend/test/unit/workflow-index-first.test.ts
@@ -95,7 +95,7 @@ function makeClient(rows: WorkflowSummary[] = ROWS) {
       if (path.endsWith("/workflows")) return rows;
       if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
       if (path.includes("/workflows/wired-channels")) return { channels: [] };
-      if (path.includes("/workflows/runs")) return [];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
       const m = path.match(/\/workflows\/([^/?]+)$/);
       if (m) {
         const id = decodeURIComponent(m[1]);

--- a/frontend/test/unit/workflow-index-paused.test.ts
+++ b/frontend/test/unit/workflow-index-paused.test.ts
@@ -85,7 +85,7 @@ function makeClient(rows: WorkflowSummary[] = ROWS, created?: WorkflowGraph) {
       if (path.endsWith("/workflows")) return rows;
       if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
       if (path.includes("/workflows/wired-channels")) return { channels: [] };
-      if (path.includes("/workflows/runs")) return [];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
       const m = path.match(/\/workflows\/([^/?]+)$/);
       if (m) return graphFor(decodeURIComponent(m[1]));
       return null;

--- a/frontend/test/unit/workflow-live-node-state.test.ts
+++ b/frontend/test/unit/workflow-live-node-state.test.ts
@@ -200,7 +200,7 @@ function fakeClient(): OpenCompanyClient {
     scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
     get: async (path: string) => {
       if (path.endsWith("/workflows")) return [{ id: GRAPH.id, name: GRAPH.name }];
-      if (path.includes("/workflows/runs")) return [RUNNING_ROW];
+      if (path.includes("/workflows/runs")) return { runs: [RUNNING_ROW], hasMore: false };
       return GRAPH;
     },
     post: async () => ({}),

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -92,7 +92,7 @@ function fakeClient(post: () => Promise<unknown>): OpenCompanyClient {
     scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
     get: async (path: string) => {
       if (path.endsWith("/workflows")) return [{ id: GRAPH.id, name: GRAPH.name }];
-      if (path.includes("/workflows/runs")) return [];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
       return GRAPH;
     },
     post,

--- a/frontend/test/unit/workflow-run-input.test.ts
+++ b/frontend/test/unit/workflow-run-input.test.ts
@@ -94,7 +94,7 @@ function fakeClient(posts: Posted[]): OpenCompanyClient {
     scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
     get: async (path: string) => {
       if (path.endsWith("/workflows")) return [{ id: GRAPH.id, name: GRAPH.name }];
-      if (path.includes("/workflows/runs")) return [];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
       return GRAPH;
     },
     post: async (path: string, body: unknown) => {

--- a/frontend/test/unit/workflow-toolbar-layout.test.ts
+++ b/frontend/test/unit/workflow-toolbar-layout.test.ts
@@ -101,7 +101,7 @@ function makeClient(rows: WorkflowSummary[] = ROWS) {
       if (path.endsWith("/workflows")) return rows;
       if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
       if (path.includes("/workflows/wired-channels")) return { channels: [] };
-      if (path.includes("/workflows/runs")) return [];
+      if (path.includes("/workflows/runs")) return { runs: [], hasMore: false };
       const m = path.match(/\/workflows\/([^/?]+)$/);
       if (m) return graphFor(decodeURIComponent(m[1]));
       return null;

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -1763,7 +1763,7 @@ base_url = "https://byo.example/v1"
         // The dead end left nothing behind — run history is still empty.
         let (status, runs, raw) = send(&state, "GET", "/api/v1/company/workflows/runs", None).await;
         assert_eq!(status, StatusCode::OK, "{raw}");
-        assert_eq!(runs.as_array().map(Vec::len), Some(0), "{runs}");
+        assert_eq!(runs["runs"].as_array().map(Vec::len), Some(0), "{runs}");
     }
 
     /// Issue #514 (review): a config that cannot be *read* is not evidence to

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -6252,7 +6252,7 @@ mod tests {
             // blocked-node list said "cannot be continued" and the run's own
             // one-word reading said "go and decide it", on the same row.
             assert_eq!(
-                body[0]["verdict"], "stranded",
+                body["runs"][0]["verdict"], "stranded",
                 "the verdict must be derived after the reconciliation, not before it: {body}"
             );
         }
@@ -6341,7 +6341,7 @@ mod tests {
                  stranded: {body}"
             );
             assert_eq!(
-                body[0]["verdict"], "blocked",
+                body["runs"][0]["verdict"], "blocked",
                 "a run with a live card is still blocked, not stranded: {body}"
             );
         }
@@ -6391,11 +6391,11 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert_eq!(
-                body[0]["strandedApprovals"], 2,
+                body["runs"][0]["strandedApprovals"], 2,
                 "both gates lost their card, and nothing else on this row says so: {body}"
             );
             assert_eq!(
-                body[0]["verdict"], "stranded",
+                body["runs"][0]["verdict"], "stranded",
                 "nothing in the queue is waiting on this run: {body}"
             );
         }
@@ -6475,11 +6475,11 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert!(
-                body[0].get("strandedApprovals").is_none(),
+                body["runs"][0].get("strandedApprovals").is_none(),
                 "the gate's card is on the queue, so nothing may be marked stranded: {body}"
             );
             assert_eq!(
-                body[0]["verdict"], "awaiting-approval",
+                body["runs"][0]["verdict"], "awaiting-approval",
                 "a decidable gate is still awaiting a person: {body}"
             );
         }
@@ -6527,11 +6527,11 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert!(
-                body[0].get("strandedApprovals").is_none(),
+                body["runs"][0].get("strandedApprovals").is_none(),
                 "a row with no run id cannot be joined, so it must report nothing: {body}"
             );
             assert_eq!(
-                body[0]["verdict"], "awaiting-approval",
+                body["runs"][0]["verdict"], "awaiting-approval",
                 "an unjoinable row keeps the reading it had before #1189: {body}"
             );
         }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -90,7 +90,7 @@ use crate::company::{
 };
 use crate::error::OpenCompanyError;
 use crate::ports::types::{
-    CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow, WorkflowNodeStatus,
+    CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow, StoredEvent, WorkflowNodeStatus,
 };
 use crate::ports::workflow_verdict::{RunVerdictFacts, WorkflowRunVerdict};
 use crate::runtime::cron::{CivilTime, CronExpr};
@@ -2369,7 +2369,15 @@ async fn workflow_wired_channels(company: ScopedCompany) -> Json<WiredChannelsRe
 const DEFAULT_RUN_LIMIT: usize = 20;
 const MAX_RUN_LIMIT: usize = 200;
 
-/// The `?workflow=` / `?limit=` selectors on the run-history read.
+/// The journal page size [`list_runs`] walks backward in (issue #1012). Same
+/// magnitude and rationale as `EVENT_PAGE` in
+/// [`history_for_desk`](crate::server::chat_history::history_for_desk):
+/// walking backward in fixed-size pages keeps the newest `limit` runs without
+/// ever materialising the unrelated journal beyond them.
+const RUN_EVENT_PAGE: usize = 512;
+
+/// The `?workflow=` / `?limit=` / `?before_seq=` selectors on the run-history
+/// read.
 #[derive(Debug, Deserialize)]
 struct RunsQuery {
     /// Return only runs of this workflow id. Absent = every workflow.
@@ -2378,6 +2386,14 @@ struct RunsQuery {
     /// default rather than returning an empty page, which is never what a
     /// caller means.
     limit: Option<usize>,
+    /// Opaque pagination cursor (issue #1012): only runs whose displayed
+    /// `seq` is strictly less than this are considered. Absent reads the
+    /// newest page. The console walks backward through history by passing the
+    /// `seq` of the oldest run it already holds — the same `before_seq` shape
+    /// [`chat_history`](crate::server::chat_history)'s `?before=` and
+    /// `TaskDetailQuery`'s `?discussionBefore=` already use for the same
+    /// problem.
+    before_seq: Option<u64>,
 }
 
 /// One finished run as the console's history panel renders it (camelCase).
@@ -2567,64 +2583,50 @@ impl From<crate::ports::WorkflowRunNodeRow> for WorkflowRunNode {
     }
 }
 
-/// `GET …/workflows/runs?workflow=&limit=` — the company's finished workflow
-/// runs, **newest first** (issue #228).
+/// Folds a chronologically-ordered slice of journal rows into per-run outcomes
+/// (issue #371's group-by-run fold). Extracted out of [`list_runs`] by issue
+/// #1012 so the caller can run it repeatedly over a growing, backward-paged
+/// buffer instead of once over an unbounded forward read — see the read loop
+/// there.
 ///
-/// This is the durable half of the issue: a manual run's delivery rows used to
-/// live only in the console drawer until it was dismissed, and a scheduled run's
-/// only on host stdout. Folding
-/// [`CompanyEvent::WorkflowRunFinished`](crate::ports::types::CompanyEvent) out
-/// of the journal makes both survive a console reload, which is the whole point.
+/// Issue #371 turned this from a filter into a **group-by-run fold**: a run
+/// now contributes up to N+2 rows (a start, one per node, a finish) instead of
+/// one, and they have to come back as a single history entry.
 ///
-/// The fold reads the company's whole event log
-/// (`read_from(0, MAX)`) — the same thing
-/// [`chat_history`](crate::server::chat_history) already does on every history
-/// GET. Following that precedent keeps this route from inventing an index the
-/// rest of the read plane doesn't have; if the journal scan ever becomes the
-/// bottleneck it should be fixed for both surfaces at once, not just here.
-async fn list_runs(
-    company: ScopedCompany,
-    Query(query): Query<RunsQuery>,
-) -> Result<Json<Vec<WorkflowRunOutcome>>, ApiError> {
-    let limit = match query.limit {
-        Some(0) | None => DEFAULT_RUN_LIMIT,
-        Some(n) => n.min(MAX_RUN_LIMIT),
-    };
-
-    let stored = company
-        .runtime
-        .events()
-        .read_from(company.id(), EventSeq::new(0), usize::MAX)
-        .await
-        .map_err(ApiError)?;
-
-    // Issue #371 turned this from a filter into a **group-by-run fold**: a run
-    // now contributes up to N+2 rows (a start, one per node, a finish) instead
-    // of one, and they have to come back as a single history entry.
-    //
-    // The invariant that keeps it simple: the journal is append-only and
-    // single-writer, so a run's rows are ordered `Started < Node… < Finished` —
-    // the runner drains and joins its progress collector before returning, which
-    // is what makes the last part true rather than a race. Rows of *different*
-    // runs may interleave (two workflows can run at once), so the grouping is
-    // keyed on run id rather than on adjacency.
-    //
-    // A pre-#371 finished row has no run id and no start, so it simply folds to
-    // itself — one row in, one entry out, exactly as before.
+/// The invariant that keeps it simple: the journal is append-only and
+/// single-writer, so a run's rows are ordered `Started < Node… < Finished` —
+/// the runner drains and joins its progress collector before returning, which
+/// is what makes the last part true rather than a race. Rows of *different*
+/// runs may interleave (two workflows can run at once), so the grouping is
+/// keyed on run id rather than on adjacency. **`rows` must be chronologically
+/// ordered (ascending `seq`)** for this invariant to hold — a caller reading
+/// backward via [`EventLog::read_before`](crate::ports::EventLog::read_before)
+/// (which comes back newest-first) must reverse each page before it is folded
+/// in.
+///
+/// A pre-#371 finished row has no run id and no start, so it simply folds to
+/// itself — one row in, one entry out, exactly as before. The same shape
+/// results for a post-#371 row whose start fell outside `rows` — whether
+/// because the caller's window does not reach that far back yet, or because a
+/// retention pass pruned the `WorkflowRunStarted` row while keeping its
+/// `WorkflowRunFinished` (the two are independently prunable; see
+/// `CompanyEvent::retention_class`). Both are "legitimate" in the sense the
+/// original comment on this fold already drew: nothing here tells them apart,
+/// and nothing needs to — a caller paging backward for more history is exactly
+/// how the first case resolves itself into the second, or into a real match.
+///
+/// Returns the folded runs, in fold/push order (not sorted or truncated — the
+/// caller does that), and the highest `seq` seen among EVERY row, matched or
+/// not — the `read_through` high-water mark [`list_runs`]'s #1009 cross-check
+/// resumes reading from.
+fn fold_run_events(rows: Vec<StoredEvent>, wanted: Option<&str>) -> (Vec<WorkflowRunOutcome>, u64) {
     let mut runs: Vec<WorkflowRunOutcome> = Vec::new();
     let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    // The `?workflow=` filter is applied per event rather than after the `limit`
-    // cut, so asking for one workflow returns that workflow's most recent N —
-    // not "whichever of the last N happen to match".
-    let wanted = query.workflow.as_deref();
     let matches = |workflow_id: &str| wanted.is_none_or(|w| w == workflow_id);
-    // The high-water mark of the snapshot above, kept over EVERY row rather than
-    // only the matched ones. It is where the settle below resumes reading, which
-    // is what tells a run that died apart from one that merely finished while
-    // this request was folding.
+    // The high-water mark over EVERY row rather than only the matched ones.
     let mut read_through = 0u64;
 
-    for stored in stored {
+    for stored in rows {
         let seq = stored.seq.value();
         let at_millis = stored.at_millis;
         read_through = read_through.max(seq);
@@ -2815,216 +2817,338 @@ async fn list_runs(
         }
     }
 
-    // Issue #1009: cross-check the still-`running` rows against the live run set
-    // and settle the ones nobody is running.
-    //
-    // The fold above marks a start with no finish `running: true`, which is only
-    // ever settled by the boot sweep ([`sweep_interrupted_runs`]). Three ways a
-    // finish never lands — a task that panicked, an append that failed, a host
-    // that died — therefore all read as an eternal spinner *until the next host
-    // restart*, with a Stop button that cannot help and a 2s console poll that
-    // never stops. This closes the gap between restarts: any run the fold thinks
-    // is in flight whose id is **absent** from the supervisor's live set has no
-    // task behind it here and now, so it is journaled a synthetic finish (the
-    // same `INTERRUPTED_BY_RESTART` the boot sweep uses) and flipped in the
-    // in-memory row, so this very response is already self-consistent.
-    //
-    // Keyed strictly on `live()` membership. A run the current process is
-    // genuinely running is registered there and is left untouched — the watchdog
-    // (issue #1009, path A) is what guarantees a *panicking* run never reaches
-    // this predicate, because it journals its own finish before its guard drops.
-    //
-    // The one accepted false positive: a run that survived a live
-    // `rebuild_company` swap is registered on the *old* supervisor and so is
-    // absent from the successor's `live()`, so this could settle a run that is
-    // still walking its graph. Accepted because (i) the watchdog keeps panics out
-    // of this path entirely, (ii) that run's real finish lands later in journal
-    // order and wins the read's last-writer-wins display, and (iii) it is the
-    // same class the boot sweep already accepts — which is why that sweep gates
-    // on the handover being absent (see the runtime builder call site). It never
-    // corrupts the journal: that run's second, truthful finish lands *after* the
-    // synthetic one and so supersedes it.
-    //
-    // That last argument turns on ORDER, and it does not carry to a run which
-    // settles inside this request — there the truthful finish lands first and
-    // loses. See the window handled below; it is closed rather than accepted.
-    let live_ids: HashSet<String> = company
-        .runtime
-        .run_supervisor()
-        .live()
-        .into_iter()
-        .map(|(run_id, _workflow_id)| run_id)
-        .collect();
-    let mut dead: Vec<usize> = Vec::new();
-    for (index, entry) in runs.iter().enumerate() {
-        if !entry.running {
-            continue;
-        }
-        let Some(run_id) = entry.run_id.as_ref() else {
-            continue;
-        };
-        if live_ids.contains(run_id) {
-            continue;
-        }
-        dead.push(index);
-    }
+    (runs, read_through)
+}
 
-    // ── The window between the snapshot and `live()` ────────────────────────
-    //
-    // `live()` is consulted AFTER the journal snapshot was taken, and a run can
-    // settle in between: it appends its finish (too late for the snapshot) and
-    // then drops its guard (in time to be missing from `live()`). Such a run is
-    // indistinguishable, on the two facts above, from one that died — but it is
-    // the opposite, and settling it is worse than the hang this repairs.
-    //
-    // The ordering is what makes it worse rather than merely wrong. The rebuild
-    // false positive this block already accepts is self-correcting because the
-    // run's real finish lands *after* the synthetic one, and the fold settles an
-    // entry from the last finish it sees. Here the real finish lands *first*, so
-    // the synthetic one wins for good: a successful run reads
-    // `INTERRUPTED_BY_RESTART` permanently, and because the fold overwrites
-    // `deliveries` from whichever finish settles last, the record of what it
-    // sent is replaced by an empty list.
-    //
-    // So before writing anything, read the journal on from where the snapshot
-    // stopped and drop any candidate whose finish turns up there. That is
-    // exact rather than a heuristic: a run whose start was in the snapshot was
-    // registered before it (`begin` precedes both the spawn and the runner's
-    // `WorkflowRunStarted`), so a candidate missing from `live()` has already
-    // been deregistered — and a deregistered run journaled its finish first, if
-    // it was ever going to. Anything appended before that point is at a higher
-    // sequence than the whole snapshot, so this second read cannot miss it.
-    //
-    // Cheap where it matters: it runs only when there are candidates at all,
-    // which after the first settle is nothing, and it reads only the tail.
-    if !dead.is_empty() {
-        match company
+/// `GET …/workflows/runs?workflow=&limit=&before_seq=` — the company's
+/// finished workflow runs, **newest first** (issue #228), a page at a time
+/// (issue #1012).
+///
+/// This is the durable half of the issue: a manual run's delivery rows used to
+/// live only in the console drawer until it was dismissed, and a scheduled run's
+/// only on host stdout. Folding
+/// [`CompanyEvent::WorkflowRunFinished`](crate::ports::types::CompanyEvent) out
+/// of the journal makes both survive a console reload, which is the whole point.
+///
+/// The fold walks the journal **backward**, in bounded
+/// [`RUN_EVENT_PAGE`]-sized pages via
+/// [`EventLog::read_before`](crate::ports::EventLog::read_before) — the same
+/// pattern [`history_for_desk`](crate::server::chat_history::history_for_desk)
+/// already uses for a desk transcript, which has the same
+/// unbounded-forever-growing-journal problem and answers it the same way.
+/// Before #1012 this read all of `read_from(0, MAX)` on every call (a company's
+/// *entire* event history, not just its workflow runs — the same call
+/// `chat_history` used to make too), which got slower as the journal grew and
+/// never stopped growing; the backward-paged walk instead reads only as much
+/// of the journal as it takes to answer this page's `limit`, plus one extra run
+/// to know whether there is more (`hasMore`).
+///
+/// A run is a *group* of events (`Started`, N × node events, `Finished`), not
+/// one — so a page of raw events is not a page of runs. See the loop below and
+/// [`fold_run_events`]'s doc for how a bracket split across a page boundary is
+/// handled.
+async fn list_runs(
+    company: ScopedCompany,
+    Query(query): Query<RunsQuery>,
+) -> Result<Json<WorkflowRunsResponse>, ApiError> {
+    let limit = match query.limit {
+        Some(0) | None => DEFAULT_RUN_LIMIT,
+        Some(n) => n.min(MAX_RUN_LIMIT),
+    };
+    // The `?workflow=` filter is applied per event rather than after the `limit`
+    // cut, so asking for one workflow returns that workflow's most recent N —
+    // not "whichever of the last N happen to match".
+    let wanted = query.workflow.as_deref();
+
+    // A run counts as ready to answer with once its `Started` row has been
+    // found (full data — `startedNodes`, `nodes`, `startedAtMillis` — is then
+    // known), or it has no run id at all (a pre-#371/gapped orphan finish,
+    // complete by definition — nothing more to wait for). A run whose
+    // `Finished`/node row has been seen but whose `Started` has not (yet) is
+    // still open: walking backward means its `Started` row, if it exists, is
+    // further back than what has been read so far.
+    let is_settled =
+        |run: &WorkflowRunOutcome| run.run_id.is_none() || run.started_at_millis.is_some();
+
+    let mut cursor = query.before_seq.map(EventSeq::new);
+    let mut buffer: Vec<StoredEvent> = Vec::new();
+    let mut runs: Vec<WorkflowRunOutcome> = Vec::new();
+    let mut read_through = 0u64;
+    // Whether the walk reached the true beginning of the journal — the only
+    // condition under which an open (not-yet-settled) run can be trusted as
+    // permanently orphaned rather than merely not-yet-resolved. See the
+    // `retain` below. No placeholder initial value: every path out of the loop
+    // assigns it before breaking, so the compiler can already prove it is set
+    // by the time it is read after the loop. `mut` because the loop can
+    // reassign it once per page before the page that finally breaks out.
+    let mut exhausted;
+    loop {
+        let page = company
             .runtime
             .events()
-            .read_from(
-                company.id(),
-                EventSeq::new(read_through.saturating_add(1)),
-                usize::MAX,
-            )
+            .read_before(company.id(), cursor, RUN_EVENT_PAGE)
             .await
-        {
-            Ok(tail) => {
-                let settled_since: HashSet<String> = tail
-                    .into_iter()
-                    .filter_map(|stored| match stored.event {
-                        CompanyEvent::WorkflowRunFinished {
-                            run_id: Some(run_id),
-                            ..
-                        } => Some(run_id),
-                        _ => None,
-                    })
-                    .collect();
-                dead.retain(|index| {
-                    runs[*index]
-                        .run_id
-                        .as_ref()
-                        .is_none_or(|run_id| !settled_since.contains(run_id))
-                });
-            }
-            Err(err) => {
-                // Unprovable, so nothing is settled. The row keeps reporting
-                // `running` and a later poll retries — strictly better than
-                // stamping "interrupted" on a run that may well be finishing.
-                tracing::warn!(
-                    company = %company.id(),
-                    %err,
-                    "could not re-read the journal to confirm a workflow run is dead; \
-                     leaving it as running"
-                );
-                dead.clear();
-            }
+            .map_err(ApiError)?;
+        if page.is_empty() {
+            exhausted = true;
+            break;
+        }
+        // A page shorter than asked-for proves there is nothing older left to
+        // read, without waiting for one more round trip that would only
+        // confirm it empty.
+        exhausted = page.len() < RUN_EVENT_PAGE;
+        // `read_before` returns newest-first; its own last element is this
+        // page's oldest row, and the correct cursor to resume strictly before.
+        cursor = page.last().map(|event| event.seq);
+        let mut chrono_page = page;
+        chrono_page.reverse();
+        buffer.splice(0..0, chrono_page);
+
+        let (folded, through) = fold_run_events(buffer.clone(), wanted);
+        // `read_through`'s meaning — the high-water mark of a "now" snapshot,
+        // which the #1009 cross-check below resumes reading from — is fixed
+        // by the FIRST page: `fold_run_events` computes it as the buffer's max
+        // `seq`, and the buffer only grows *older* on every later page, so
+        // this value cannot change after the first assignment. Reassigning it
+        // unconditionally is simplest and gives the identical answer.
+        read_through = through;
+        let settled = folded.iter().filter(|run| is_settled(run)).count();
+        runs = folded;
+        if exhausted || settled > limit {
+            break;
         }
     }
-
-    for index in &dead {
-        let entry = &mut runs[*index];
-        let Some(run_id) = entry.run_id.clone() else {
-            continue;
-        };
-        // Durable half: append the finish so it survives this response, folds
-        // settled on the next `GET …/workflows/runs`, and stops the boot sweep
-        // from having to. Best-effort by construction — a failed append leaves
-        // the row as the in-memory flip below still makes it, and the next read
-        // simply retries.
-        crate::runtime::record_run_finished(
-            company.runtime.events(),
-            company.id(),
-            &entry.workflow_id,
-            entry.scheduled,
-            &run_id,
-            Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.into()),
-        )
-        .await;
-        // In-memory half: flip the row this response returns, so the console does
-        // not have to wait for the next poll to stop the spinner.
-        entry.running = false;
-        entry.error = Some(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.to_string());
+    if !exhausted {
+        // Drop any run still open: walking further back might yet resolve it
+        // (find its `Started` row) or might not, and returning it now, in the
+        // fold's orphan placeholder shape, would risk showing a real run's
+        // history as gapped when the only reason it looks that way is that
+        // this page chose not to read far enough. Once the journal actually IS
+        // exhausted, every remaining open row is a genuine orphan — see
+        // `fold_run_events`'s doc — and is kept exactly as the fold shaped it.
+        runs.retain(is_settled);
     }
 
-    // ── Serve the row the NEXT read will fold, identically ──────────────────
-    //
-    // The fold keys a settled entry on its **finish**, taking `seq` and
-    // `at_millis` from that row. So flipping `running` while leaving the
-    // start's values in place means this response and the one 2s later carry
-    // *different* `seq` for the same run — and the console keys its history
-    // rows on exactly that field (`RunHistoryPanel`: `key={run.seq}`, with
-    // `selectedRunSeq` / `fixingRunSeq` / `fixReason.seq` compared against it).
-    // The row remounts and any selection on it is dropped, in the one window
-    // where an operator is most likely to be looking: the 2s recovery poll runs
-    // precisely because someone is watching this run.
-    //
-    // So the appended rows are read back and their real `seq` / `at_millis`
-    // stamped on. Read back rather than returned from `record_run_finished`,
-    // which reports only whether the append happened — the values served are
-    // then the durable ones rather than a second construction of them.
-    if !dead.is_empty() {
-        match company
+    // Issue #1012: this cross-check only makes sense against "now" — an
+    // older page (a `before_seq` cursor was given) is not the newest state,
+    // so a `running: true` row on it is out of scope here: either it was
+    // already resolved by an earlier newest-page read (whose synthetic
+    // finish will surface naturally once an older page's window reaches
+    // that seq), or it is a genuinely long-lived run outside what
+    // pagination is meant to answer.
+    if query.before_seq.is_none() {
+        // Issue #1009: cross-check the still-`running` rows against the live run set
+        // and settle the ones nobody is running.
+        //
+        // The fold above marks a start with no finish `running: true`, which is only
+        // ever settled by the boot sweep ([`sweep_interrupted_runs`]). Three ways a
+        // finish never lands — a task that panicked, an append that failed, a host
+        // that died — therefore all read as an eternal spinner *until the next host
+        // restart*, with a Stop button that cannot help and a 2s console poll that
+        // never stops. This closes the gap between restarts: any run the fold thinks
+        // is in flight whose id is **absent** from the supervisor's live set has no
+        // task behind it here and now, so it is journaled a synthetic finish (the
+        // same `INTERRUPTED_BY_RESTART` the boot sweep uses) and flipped in the
+        // in-memory row, so this very response is already self-consistent.
+        //
+        // Keyed strictly on `live()` membership. A run the current process is
+        // genuinely running is registered there and is left untouched — the watchdog
+        // (issue #1009, path A) is what guarantees a *panicking* run never reaches
+        // this predicate, because it journals its own finish before its guard drops.
+        //
+        // The one accepted false positive: a run that survived a live
+        // `rebuild_company` swap is registered on the *old* supervisor and so is
+        // absent from the successor's `live()`, so this could settle a run that is
+        // still walking its graph. Accepted because (i) the watchdog keeps panics out
+        // of this path entirely, (ii) that run's real finish lands later in journal
+        // order and wins the read's last-writer-wins display, and (iii) it is the
+        // same class the boot sweep already accepts — which is why that sweep gates
+        // on the handover being absent (see the runtime builder call site). It never
+        // corrupts the journal: that run's second, truthful finish lands *after* the
+        // synthetic one and so supersedes it.
+        //
+        // That last argument turns on ORDER, and it does not carry to a run which
+        // settles inside this request — there the truthful finish lands first and
+        // loses. See the window handled below; it is closed rather than accepted.
+        let live_ids: HashSet<String> = company
             .runtime
-            .events()
-            .read_from(
-                company.id(),
-                EventSeq::new(read_through.saturating_add(1)),
-                usize::MAX,
-            )
-            .await
-        {
-            Ok(appended) => {
-                let stamped: std::collections::HashMap<String, (u64, u64)> = appended
-                    .into_iter()
-                    .filter_map(|stored| match stored.event {
-                        CompanyEvent::WorkflowRunFinished {
-                            run_id: Some(run_id),
-                            ..
-                        } => Some((run_id, (stored.seq.value(), stored.at_millis))),
-                        _ => None,
-                    })
-                    .collect();
-                for index in &dead {
-                    let entry = &mut runs[*index];
-                    let Some((seq, at_millis)) =
-                        entry.run_id.as_ref().and_then(|id| stamped.get(id))
-                    else {
-                        continue;
-                    };
-                    entry.seq = *seq;
-                    entry.at_millis = *at_millis;
+            .run_supervisor()
+            .live()
+            .into_iter()
+            .map(|(run_id, _workflow_id)| run_id)
+            .collect();
+        let mut dead: Vec<usize> = Vec::new();
+        for (index, entry) in runs.iter().enumerate() {
+            if !entry.running {
+                continue;
+            }
+            let Some(run_id) = entry.run_id.as_ref() else {
+                continue;
+            };
+            if live_ids.contains(run_id) {
+                continue;
+            }
+            dead.push(index);
+        }
+
+        // ── The window between the snapshot and `live()` ────────────────────────
+        //
+        // `live()` is consulted AFTER the journal snapshot was taken, and a run can
+        // settle in between: it appends its finish (too late for the snapshot) and
+        // then drops its guard (in time to be missing from `live()`). Such a run is
+        // indistinguishable, on the two facts above, from one that died — but it is
+        // the opposite, and settling it is worse than the hang this repairs.
+        //
+        // The ordering is what makes it worse rather than merely wrong. The rebuild
+        // false positive this block already accepts is self-correcting because the
+        // run's real finish lands *after* the synthetic one, and the fold settles an
+        // entry from the last finish it sees. Here the real finish lands *first*, so
+        // the synthetic one wins for good: a successful run reads
+        // `INTERRUPTED_BY_RESTART` permanently, and because the fold overwrites
+        // `deliveries` from whichever finish settles last, the record of what it
+        // sent is replaced by an empty list.
+        //
+        // So before writing anything, read the journal on from where the snapshot
+        // stopped and drop any candidate whose finish turns up there. That is
+        // exact rather than a heuristic: a run whose start was in the snapshot was
+        // registered before it (`begin` precedes both the spawn and the runner's
+        // `WorkflowRunStarted`), so a candidate missing from `live()` has already
+        // been deregistered — and a deregistered run journaled its finish first, if
+        // it was ever going to. Anything appended before that point is at a higher
+        // sequence than the whole snapshot, so this second read cannot miss it.
+        //
+        // Cheap where it matters: it runs only when there are candidates at all,
+        // which after the first settle is nothing, and it reads only the tail.
+        if !dead.is_empty() {
+            match company
+                .runtime
+                .events()
+                .read_from(
+                    company.id(),
+                    EventSeq::new(read_through.saturating_add(1)),
+                    usize::MAX,
+                )
+                .await
+            {
+                Ok(tail) => {
+                    let settled_since: HashSet<String> = tail
+                        .into_iter()
+                        .filter_map(|stored| match stored.event {
+                            CompanyEvent::WorkflowRunFinished {
+                                run_id: Some(run_id),
+                                ..
+                            } => Some(run_id),
+                            _ => None,
+                        })
+                        .collect();
+                    dead.retain(|index| {
+                        runs[*index]
+                            .run_id
+                            .as_ref()
+                            .is_none_or(|run_id| !settled_since.contains(run_id))
+                    });
+                }
+                Err(err) => {
+                    // Unprovable, so nothing is settled. The row keeps reporting
+                    // `running` and a later poll retries — strictly better than
+                    // stamping "interrupted" on a run that may well be finishing.
+                    tracing::warn!(
+                        company = %company.id(),
+                        %err,
+                        "could not re-read the journal to confirm a workflow run is dead; \
+                         leaving it as running"
+                    );
+                    dead.clear();
                 }
             }
-            Err(err) => {
-                // The settle itself stands — it is already durable. Only the
-                // row's identity is left at the start's, which the next read
-                // corrects.
-                tracing::warn!(
-                    company = %company.id(),
-                    %err,
-                    "settled a dead workflow run but could not read back its finish row; \
-                     this response carries the start's seq and time"
-                );
+        }
+
+        for index in &dead {
+            let entry = &mut runs[*index];
+            let Some(run_id) = entry.run_id.clone() else {
+                continue;
+            };
+            // Durable half: append the finish so it survives this response, folds
+            // settled on the next `GET …/workflows/runs`, and stops the boot sweep
+            // from having to. Best-effort by construction — a failed append leaves
+            // the row as the in-memory flip below still makes it, and the next read
+            // simply retries.
+            crate::runtime::record_run_finished(
+                company.runtime.events(),
+                company.id(),
+                &entry.workflow_id,
+                entry.scheduled,
+                &run_id,
+                Err(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.into()),
+            )
+            .await;
+            // In-memory half: flip the row this response returns, so the console does
+            // not have to wait for the next poll to stop the spinner.
+            entry.running = false;
+            entry.error =
+                Some(crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART.to_string());
+        }
+
+        // ── Serve the row the NEXT read will fold, identically ──────────────────
+        //
+        // The fold keys a settled entry on its **finish**, taking `seq` and
+        // `at_millis` from that row. So flipping `running` while leaving the
+        // start's values in place means this response and the one 2s later carry
+        // *different* `seq` for the same run — and the console keys its history
+        // rows on exactly that field (`RunHistoryPanel`: `key={run.seq}`, with
+        // `selectedRunSeq` / `fixingRunSeq` / `fixReason.seq` compared against it).
+        // The row remounts and any selection on it is dropped, in the one window
+        // where an operator is most likely to be looking: the 2s recovery poll runs
+        // precisely because someone is watching this run.
+        //
+        // So the appended rows are read back and their real `seq` / `at_millis`
+        // stamped on. Read back rather than returned from `record_run_finished`,
+        // which reports only whether the append happened — the values served are
+        // then the durable ones rather than a second construction of them.
+        if !dead.is_empty() {
+            match company
+                .runtime
+                .events()
+                .read_from(
+                    company.id(),
+                    EventSeq::new(read_through.saturating_add(1)),
+                    usize::MAX,
+                )
+                .await
+            {
+                Ok(appended) => {
+                    let stamped: std::collections::HashMap<String, (u64, u64)> = appended
+                        .into_iter()
+                        .filter_map(|stored| match stored.event {
+                            CompanyEvent::WorkflowRunFinished {
+                                run_id: Some(run_id),
+                                ..
+                            } => Some((run_id, (stored.seq.value(), stored.at_millis))),
+                            _ => None,
+                        })
+                        .collect();
+                    for index in &dead {
+                        let entry = &mut runs[*index];
+                        let Some((seq, at_millis)) =
+                            entry.run_id.as_ref().and_then(|id| stamped.get(id))
+                        else {
+                            continue;
+                        };
+                        entry.seq = *seq;
+                        entry.at_millis = *at_millis;
+                    }
+                }
+                Err(err) => {
+                    // The settle itself stands — it is already durable. Only the
+                    // row's identity is left at the start's, which the next read
+                    // corrects.
+                    tracing::warn!(
+                        company = %company.id(),
+                        %err,
+                        "settled a dead workflow run but could not read back its finish row; \
+                         this response carries the start's seq and time"
+                    );
+                }
             }
         }
     }
@@ -3043,10 +3167,29 @@ async fn list_runs(
         run.verdict = run.derive_verdict();
     }
 
-    // Newest first: a history panel leads with the run that just happened. The
-    // `limit` now cuts *runs* rather than journal rows, which is the number the
-    // caller was asking about all along.
-    runs.reverse();
+    // Newest first: a history panel leads with the run that just happened.
+    //
+    // Issue #1012: sorted explicitly by `(at_millis, seq)` descending — the
+    // very pair every row *displays* — rather than `reverse()`d. `reverse()`
+    // only flips the fold's push order, which is the order runs *started* (an
+    // entry is pushed once, at its `WorkflowRunStarted` row, and only mutated
+    // in place — never re-pushed — when its `WorkflowRunFinished` row later
+    // overwrites `seq`/`at_millis` to the finish's own). Two runs that
+    // interleave (B starts after A, but finishes first) therefore used to come
+    // back in *start* order while every row read as if it were ordered by
+    // *finish* — the row for A would lead even though B's `seq`/`atMillis` say
+    // B is newer. Sorting on the same field the row displays makes the two
+    // agree by construction, for a run still in flight (which sorts on its own
+    // start) exactly as for one already settled.
+    //
+    // The `limit` now cuts *runs* rather than journal rows, which is the
+    // number the caller was asking about all along.
+    runs.sort_by_key(|r| std::cmp::Reverse((r.at_millis, r.seq)));
+    // Issue #1012: the backward-paged read above stopped once it had settled
+    // at least `limit + 1` runs (or ran out of journal), precisely so this
+    // count is known here — one more than fit on the page means there is a
+    // page after this one.
+    let has_more = runs.len() > limit;
     runs.truncate(limit);
 
     // Issue #1143. A blocked node's `approval_ids` is a receipt of what the run
@@ -3087,7 +3230,22 @@ async fn list_runs(
         }
     }
 
-    Ok(Json(runs))
+    Ok(Json(WorkflowRunsResponse { runs, has_more }))
+}
+
+/// The `GET …/workflows/runs` response body (issue #1012).
+///
+/// Wrapped rather than a bare array — as this route answered before — because
+/// `hasMore` has nowhere else to ride: the console's history drawer cannot
+/// otherwise tell "this is the whole history" from "this page was truncated at
+/// `limit`", which is exactly the silent-truncation half of the issue.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunsResponse {
+    runs: Vec<WorkflowRunOutcome>,
+    /// Whether a further, older page exists behind `?before_seq=<oldest
+    /// returned run's seq>`.
+    has_more: bool,
 }
 
 /// Relabels a run's node rows for the nodes it blocked on a human (issue #881).
@@ -5322,7 +5480,7 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 2, "body: {body}");
 
             // Newest first: the history panel leads with the run that just ran.
@@ -5390,7 +5548,7 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 3, "body: {body}");
 
             // The more serious fact first: a run that broke mid-graph AND did
@@ -5449,7 +5607,7 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "body: {body}");
             assert_eq!(rows[0]["running"], true, "{body}");
             assert_eq!(rows[0]["verdict"], "running", "{body}");
@@ -5538,10 +5696,10 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert_eq!(
-                body[0]["error"],
+                body["runs"][0]["error"],
                 "no inference source for agent node `worker`"
             );
-            assert_eq!(body[0]["deliveries"].as_array().unwrap().len(), 0);
+            assert_eq!(body["runs"][0]["deliveries"].as_array().unwrap().len(), 0);
         }
 
         // ── Issue #371: the per-node progress fold ─────────────────────────
@@ -5690,7 +5848,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "four journal rows fold to one run: {body}");
 
             assert_eq!(rows[0]["runId"], "run-1");
@@ -5746,7 +5904,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "one run: {body}");
             assert_eq!(rows[0]["running"], true, "still in flight: {body}");
             assert_eq!(rows[0]["runId"], run, "{body}");
@@ -5794,7 +5952,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "only the asked-for workflow: {body}");
             assert_eq!(rows[0]["runId"], "run-mine");
             let started = rows[0]["startedNodes"].as_array().expect("startedNodes");
@@ -5828,7 +5986,7 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert!(
-                body[0].get("startedNodes").is_none(),
+                body["runs"][0].get("startedNodes").is_none(),
                 "an empty trail is absent, not `[]`: {body}"
             );
         }
@@ -5868,11 +6026,13 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            assert!(body[0].get("running").is_none(), "settled: {body}");
-            let started = body[0]["startedNodes"].as_array().expect("startedNodes");
+            assert!(body["runs"][0].get("running").is_none(), "settled: {body}");
+            let started = body["runs"][0]["startedNodes"]
+                .as_array()
+                .expect("startedNodes");
             assert_eq!(started.len(), 2, "{body}");
             assert_eq!(started[1], "draft");
-            let nodes = body[0]["nodes"].as_array().expect("nodes");
+            let nodes = body["runs"][0]["nodes"].as_array().expect("nodes");
             assert_eq!(nodes.len(), 1, "`draft` never finished: {body}");
         }
 
@@ -5943,7 +6103,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "{body}");
             assert!(
                 rows[0].get("error").is_none(),
@@ -6007,7 +6167,7 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert_eq!(
-                body[0]["blockedNodes"][0]["stranded"], 1,
+                body["runs"][0]["blockedNodes"][0]["stranded"], 1,
                 "an approval id the journal no longer holds must read as stranded, \
                  or the drawer goes on linking to an empty queue: {body}"
             );
@@ -6092,7 +6252,7 @@ mod tests {
                 .unwrap();
             let body = json_body(response).await;
             assert!(
-                body[0]["blockedNodes"][0].get("stranded").is_none(),
+                body["runs"][0]["blockedNodes"][0].get("stranded").is_none(),
                 "a parked approval is still decidable, so nothing may be marked \
                  stranded: {body}"
             );
@@ -6131,9 +6291,9 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            assert_eq!(body[0]["running"], true, "{body}");
-            assert_eq!(body[0]["nodes"].as_array().unwrap().len(), 1);
-            assert!(body[0].get("error").is_none(), "{body}");
+            assert_eq!(body["runs"][0]["running"], true, "{body}");
+            assert_eq!(body["runs"][0]["nodes"].as_array().unwrap().len(), 1);
+            assert!(body["runs"][0].get("error").is_none(), "{body}");
         }
 
         /// An event log that lets exactly one run settle **inside** `list_runs`'
@@ -6318,7 +6478,7 @@ mod tests {
             // still the snapshot's, `running: true`. That is honest: the run WAS
             // in flight when the journal was sampled. What matters is that it is
             // not stamped dead.
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "{body}");
             assert!(
                 rows[0].get("error").is_none(),
@@ -6335,9 +6495,12 @@ mod tests {
                     .unwrap(),
             )
             .await;
-            assert!(next[0].get("running").is_none(), "settled: {next}");
-            assert!(next[0].get("error").is_none(), "a successful run: {next}");
-            assert_eq!(next[0]["deliveries"][0]["status"], "sent", "{next}");
+            assert!(next["runs"][0].get("running").is_none(), "settled: {next}");
+            assert!(
+                next["runs"][0].get("error").is_none(),
+                "a successful run: {next}"
+            );
+            assert_eq!(next["runs"][0]["deliveries"][0]["status"], "sent", "{next}");
         }
 
         /// **A settled row keeps one identity across reads.** The response that
@@ -6374,21 +6537,24 @@ mod tests {
             )
             .await;
 
-            assert!(first[0].get("running").is_none(), "settled: {first}");
+            assert!(
+                first["runs"][0].get("running").is_none(),
+                "settled: {first}"
+            );
             assert_eq!(
-                first[0]["seq"], second[0]["seq"],
+                first["runs"][0]["seq"], second["runs"][0]["seq"],
                 "the settling read and the one after it must agree on the row's \
                  identity: {first} then {second}"
             );
             assert_eq!(
-                first[0]["atMillis"], second[0]["atMillis"],
+                first["runs"][0]["atMillis"], second["runs"][0]["atMillis"],
                 "…and on when it settled: {first} then {second}"
             );
             // Specifically the FINISH's row, which is what the next fold uses —
             // not the start's, which is the only other candidate.
             assert!(
-                first[0]["atMillis"].as_u64().unwrap()
-                    >= first[0]["startedAtMillis"].as_u64().unwrap(),
+                first["runs"][0]["atMillis"].as_u64().unwrap()
+                    >= first["runs"][0]["startedAtMillis"].as_u64().unwrap(),
                 "the settle cannot predate the start: {first}"
             );
         }
@@ -6410,7 +6576,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0]["workflowId"], "digest");
             assert!(rows[0].get("nodes").is_none(), "{body}");
@@ -6440,7 +6606,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 2, "{body}");
             let by_id = |run: &str| {
                 rows.iter()
@@ -6452,6 +6618,44 @@ mod tests {
             assert_eq!(by_id("run-a")["nodes"].as_array().unwrap().len(), 1);
             assert_eq!(by_id("run-b")["nodes"][0]["nodeId"], "b1");
             assert_eq!(by_id("run-b")["nodes"].as_array().unwrap().len(), 1);
+        }
+
+        /// Issue #1012. Two interleaved runs — `run-a` starts first but
+        /// `run-b` finishes last — must come back ordered by **finish**, the
+        /// field every row displays, not by the order they started. The old
+        /// `runs.reverse()` only flipped the fold's push order (start order),
+        /// so this exact fixture used to list `run-a` first despite `run-b`
+        /// carrying the newer `seq`/`atMillis`.
+        #[tokio::test]
+        async fn run_history_orders_by_finish_not_start() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            // Start order: a, then b. Finish order: a, then b — so b is both
+            // the last to start AND the last to finish, which alone would not
+            // distinguish "ordered by start" from "ordered by finish". Insert
+            // a THIRD run, `c`, that starts before `b` but finishes before `a`
+            // too, so the two orderings genuinely disagree on where it lands.
+            journal_start(&state, &id, "wf", "run-a", false).await;
+            journal_start(&state, &id, "wf", "run-c", false).await;
+            journal_finish(&state, &id, "wf", "run-c", false, None).await;
+            journal_start(&state, &id, "wf", "run-b", false).await;
+            journal_finish(&state, &id, "wf", "run-a", false, None).await;
+            journal_finish(&state, &id, "wf", "run-b", false, None).await;
+
+            // Start order: a, c, b. Finish order: c, a, b.
+            // By-start reversal would read: b, c, a (wrong).
+            // By-finish descending must read: b, a, c.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body["runs"].as_array().expect("array");
+            assert_eq!(rows.len(), 3, "{body}");
+            let ids: Vec<&str> = rows.iter().map(|r| r["runId"].as_str().unwrap()).collect();
+            assert_eq!(ids, vec!["run-b", "run-a", "run-c"], "{body}");
         }
 
         /// `?limit=` now cuts **runs**, not journal rows — the number the caller
@@ -6480,7 +6684,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 2, "{body}");
             // Newest first, and each one whole.
             assert_eq!(rows[0]["runId"], "run-2");
@@ -6513,7 +6717,7 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            let rows = body.as_array().expect("array");
+            let rows = body["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 1, "body: {body}");
             assert_eq!(rows[0]["workflowId"], "digest");
         }
@@ -6545,14 +6749,14 @@ mod tests {
 
             // Explicit cap, taken from the newest end.
             let capped = page("/api/v1/company/workflows/runs?limit=3").await;
-            let rows = capped.as_array().expect("array");
+            let rows = capped["runs"].as_array().expect("array");
             assert_eq!(rows.len(), 3);
             assert_eq!(rows[0]["workflowId"], "wf-24", "newest first: {capped}");
 
             // No `limit` → the default page, not the whole 25.
             let defaulted = page("/api/v1/company/workflows/runs").await;
             assert_eq!(
-                defaulted.as_array().unwrap().len(),
+                defaulted["runs"].as_array().unwrap().len(),
                 DEFAULT_RUN_LIMIT,
                 "{defaulted}"
             );
@@ -6560,11 +6764,15 @@ mod tests {
             // `limit=0` means "I didn't really mean zero" — an empty page is
             // never what a caller wants, so it falls back to the default.
             let zero = page("/api/v1/company/workflows/runs?limit=0").await;
-            assert_eq!(zero.as_array().unwrap().len(), DEFAULT_RUN_LIMIT, "{zero}");
+            assert_eq!(
+                zero["runs"].as_array().unwrap().len(),
+                DEFAULT_RUN_LIMIT,
+                "{zero}"
+            );
 
             // Above the ceiling clamps; with only 25 rows that is all of them.
             let huge = page("/api/v1/company/workflows/runs?limit=100000").await;
-            assert_eq!(huge.as_array().unwrap().len(), 25, "{huge}");
+            assert_eq!(huge["runs"].as_array().unwrap().len(), 25, "{huge}");
         }
 
         /// A company that has never run a workflow gets an empty list, not a
@@ -6580,7 +6788,10 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            assert_eq!(json_body(response).await.as_array().unwrap().len(), 0);
+            assert_eq!(
+                json_body(response).await["runs"].as_array().unwrap().len(),
+                0
+            );
         }
 
         /// **Route-ordering pin.** `runs` is a syntactically valid `wid`, so
@@ -6604,9 +6815,12 @@ mod tests {
                 StatusCode::OK,
                 "the static /workflows/runs must win over /workflows/{{wid}}"
             );
-            // An array of outcomes, not a single graph object.
+            // A runs page — `{ runs: [...], hasMore }` — not a single graph object.
             let body = json_body(response).await;
-            assert!(body.is_array(), "graph read shadowed the history: {body}");
+            assert!(
+                body["runs"].is_array(),
+                "graph read shadowed the history: {body}"
+            );
         }
 
         // -------------------------------------------------------------------
@@ -6737,7 +6951,7 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             let body = json_body(response).await;
-            assert_eq!(body[0]["workflowId"], "digest");
+            assert_eq!(body["runs"][0]["workflowId"], "digest");
         }
 
         // ── Issue #259: edit + delete at the HTTP boundary ──────────────────
@@ -7298,12 +7512,9 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            let rows = json_body(response).await;
-            assert_eq!(
-                rows.as_array().unwrap().len(),
-                1,
-                "past runs must outlive the workflow: {rows}"
-            );
+            let body = json_body(response).await;
+            let rows = body["runs"].as_array().unwrap();
+            assert_eq!(rows.len(), 1, "past runs must outlive the workflow: {body}");
             assert_eq!(rows[0]["workflowId"], "greeter");
         }
 
@@ -7552,15 +7763,15 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            assert_eq!(body.as_array().unwrap().len(), 1);
+            assert_eq!(body["runs"].as_array().unwrap().len(), 1);
             // `running` is skip-serialized when false, so a settled row simply
             // omits it — assert it is not `true` rather than equal to `false`.
             assert_ne!(
-                body[0]["running"], true,
+                body["runs"][0]["running"], true,
                 "an absent run is settled on the read, not left spinning: {body}"
             );
             assert_eq!(
-                body[0]["error"],
+                body["runs"][0]["error"],
                 crate::runtime::workflow_outcome::INTERRUPTED_BY_RESTART
             );
 
@@ -7602,9 +7813,9 @@ mod tests {
                 .await
                 .unwrap();
             let body = json_body(response).await;
-            assert_eq!(body.as_array().unwrap().len(), 1);
+            assert_eq!(body["runs"].as_array().unwrap().len(), 1);
             assert_eq!(
-                body[0]["running"], true,
+                body["runs"][0]["running"], true,
                 "a run the process is running must not be settled from under it"
             );
 
@@ -8182,7 +8393,7 @@ label = "ok"
                 .await
                 .unwrap();
             let rows = json_body(response).await;
-            let row = &rows.as_array().expect("array")[0];
+            let row = &rows["runs"].as_array().expect("array")[0];
             assert_eq!(row["runId"], run_id.as_str(), "{rows}");
             assert_eq!(row["cancelled"], true, "{rows}");
             assert!(

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -9114,7 +9114,7 @@ async fn the_run_history_carries_a_runs_board_rows() {
 
     let (status, runs) = send(&state, "GET", "/api/v1/company/workflows/runs", None).await;
     assert_eq!(status, StatusCode::OK);
-    let runs = runs.as_array().expect("an array of runs");
+    let runs = runs["runs"].as_array().expect("an array of runs");
 
     let settled = runs
         .iter()


### PR DESCRIPTION
## Summary
`GET .../workflows/runs` now returns a `WorkflowRunsPage` envelope (`{ runs, hasMore }`) instead of a bare array:

- Runs are ordered newest-first by actual settle time (`seq`/`atMillis`), not just start order.
- `beforeSeq`-based cursor pagination — pass the `seq` of the oldest run already held to fetch the page before it — so a page can be fetched further back without an unbounded read.
- `hasMore` on the returned page says whether an older page exists; `RunHistoryPanel` gains a "Load older" affordance gated on it.

Closes #1012

## Test plan
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features openhuman,tinycortex,mcp -- -D warnings` — clean
- `cargo test --lib server::ops::` — 519/519 pass
- `npm run typecheck` — clean
- `npx vitest run` — 149 files / 1420 tests pass

## Note on provenance
Implemented by a background agent that stopped without committing (~600 lines across Rust and frontend, uncommitted in the worktree). I found and verified the work, fixed 2 clippy findings (explicit-auto-deref, unnecessary-sort-by) and 8 test call sites across 7 frontend files + 3 Rust files that still expected the old bare-array response shape after the envelope change, then committed, merged current `main`, re-verified, and pushed. I did not author the original implementation.