### PR TITLE
Surface the TinyMemory engines end to end: union CI lane, staging feature, boot health probe, operator docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,25 @@ OPENAI_API_KEY=
 OPENCOMPANY_STORAGE=fs
 OPENCOMPANY_MONGODB_URI=
 OPENCOMPANY_MONGODB_DB=
+
+# Memory engine overlay: store (default — the base backend serves memory),
+# embedded (the in-pod engine; add OPENCOMPANY_MEMORY_DRIVER=namespace for the
+# contract's durable store), remote (a hosted engine), or null (discard —
+# testing only). Full guide incl. the switch runbook:
+# docs/spec/runtime/memory-engine.md. Instance-wide and read once at boot;
+# switching engines is an infra-operator action: set, restart, verify /spec.
+# `remote`/`null` need a build with the `tinymemory` cargo feature;
+# `namespace` needs `tinymemory-embedded`.
+OPENCOMPANY_MEMORY=store
+# Which engine: namespace (embedded) | supermemory | mem0 | cognee (remote).
+OPENCOMPANY_MEMORY_DRIVER=
+# Hosted engine endpoint. Cognee Cloud is per-tenant
+# (https://tenant-<uuid>.aws.cognee.ai); there is no default.
+OPENCOMPANY_MEMORY_URL=
+# Hosted engine credential. Env is its only channel, on purpose — see
+# docs/spec/runtime/memory-engine.md.
+OPENCOMPANY_MEMORY_API_KEY=
+# Set to 1 to let an embedded engine open on ephemeral /data (mongodb
+# tenants). Off by default: losing memory silently is the failure the
+# refusal exists to prevent.
+OPENCOMPANY_MEMORY_ALLOW_EPHEMERAL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1137,9 +1137,12 @@ jobs:
         run: scripts/ci/run-scoped-suite.sh "tinymemory selection" acp,runner,tinymemory store::select
 
       # Issue #1113 gave `tinymemory-embedded` its own lane; these two steps are
-      # that lane moved onto the UNION every shipped tenant will actually run —
-      # `openhuman` + `tinycortex` + the provider seam in one binary. Until now
-      # that union existed only as `Check (--all-features)`: never linked as a
+      # that lane moved onto the union of the openhuman+tinycortex core and the
+      # provider seam — the first lane that LINKS AND EXECUTES the two together
+      # (the shipped tenant set is neither a subset nor a superset of this lane;
+      # what matters is that the combination stops existing only as a
+      # typecheck). Until now that union existed only as
+      # `Check (--all-features)`: never linked as a
       # binary, never executed, which is precisely the crack a feature-gated
       # merge collision (the duplicated-struct-field kind that `fmt`, clippy and
       # two green suites all missed once already) slips through. The union also

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1136,21 +1136,29 @@ jobs:
       - name: Test the memory engine selection surface
         run: scripts/ci/run-scoped-suite.sh "tinymemory selection" acp,runner,tinymemory store::select
 
-      # Issue #1113. `tinymemory-embedded` is the in-pod contract driver:
-      # `OPENCOMPANY_MEMORY=embedded` + `OPENCOMPANY_MEMORY_DRIVER=namespace`
-      # binds `tinymemory-core`'s durable `UnifiedMemory` through the same
-      # provider seam as the hosted engines. A separate feature from
-      # `tinymemory` — it deliberately links the in-pod engine weight (bundled
-      # SQLite) that the two steps above exist to keep OUT of the contract-only
-      # build — so its gated tests (the durable bind-store-reopen round trip in
-      # `store::memory`, the routing and ephemeral-data-dir refusals in
-      # `store::select`) are compiled by `Check (--all-features)` and executed
-      # only here.
-      - name: Test the embedded contract driver
-        run: scripts/ci/run-scoped-suite.sh "tinymemory embedded contract" acp,runner,tinymemory-embedded store::memory
+      # Issue #1113 gave `tinymemory-embedded` its own lane; these two steps are
+      # that lane moved onto the UNION every shipped tenant will actually run —
+      # `openhuman` + `tinycortex` + the provider seam in one binary. Until now
+      # that union existed only as `Check (--all-features)`: never linked as a
+      # binary, never executed, which is precisely the crack a feature-gated
+      # merge collision (the duplicated-struct-field kind that `fmt`, clippy and
+      # two green suites all missed once already) slips through. The union also
+      # runs the upstream driver-conformance suite against the providers
+      # `open_driver` constructs — the regression net for the namespace-driver
+      # defects #1201/#1238, which shipped while the driver's own upstream suite
+      # was green, because nothing ran it through THIS host's construction path.
+      #
+      # The two `tinymemory`-ALONE steps above stay, deliberately: per the #914
+      # rationale, the contract-only build (no bundled SQLite) must keep
+      # compiling and running on its own, or a regression in exactly that
+      # separation hides. The old `acp,runner,tinymemory-embedded` steps this
+      # replaces are subsumed — same filters, wider build — and feature-lanes.txt
+      # permits one lane per feature, so the row moved here with them.
+      - name: Test the memory engine union the tenant ships
+        run: scripts/ci/run-scoped-suite.sh "memory union contract" openhuman,tinycortex,tinymemory-embedded store::memory
 
-      - name: Test the embedded contract driver selection
-        run: scripts/ci/run-scoped-suite.sh "tinymemory embedded selection" acp,runner,tinymemory-embedded store::select
+      - name: Test the memory engine union selection
+        run: scripts/ci/run-scoped-suite.sh "memory union selection" openhuman,tinycortex,tinymemory-embedded store::select
 
       # Issue #477. Before this step, `tinyplace` was COMPILED by CI and
       # EXECUTED by nothing. `Check (--all-features)` above builds every

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,16 @@ env:
   # medulla (hosted brain transport), tinycortex (local memory backend), and
   # sidecar. `sqlite` is intentionally omitted — its bundled rusqlite needs a C
   # compiler the slim build image lacks, and it is redundant on a mongodb tenant.
-  TENANT_FEATURES: mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export,mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar,chargebee,paypal
+  #
+  # `tinymemory` is the hosted-memory contract: `OPENCOMPANY_MEMORY=remote` +
+  # `OPENCOMPANY_MEMORY_DRIVER=supermemory|mem0|cognee` (plus `null`), inert
+  # until an operator sets those. `tinymemory-embedded` is deliberately NOT
+  # here for the same two reasons `sqlite` isn't: tinymemory-core links a
+  # bundled rusqlite (the C compiler the slim image lacks), and its `namespace`
+  # store on a mongodb tenant is refused by the ephemeral-/data guard anyway.
+  # Self-hosters wanting the embedded contract driver compile it via
+  # OPENCOMPANY_FEATURES (deploy/README.md).
+  TENANT_FEATURES: mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export,mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar,chargebee,paypal,tinymemory
 
 jobs:
   deploy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,6 +3186,7 @@ dependencies = [
  "tinyflows",
  "tinymemory",
  "tinymemory-api",
+ "tinymemory-conformance",
  "tinymemory-core",
  "tinymemory-remote",
  "tinymemory-tinycortex",
@@ -5316,6 +5317,16 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "uuid",
+]
+
+[[package]]
+name = "tinymemory-conformance"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde_json",
+ "tinymemory-api",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5367,6 +5367,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -479,17 +478,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3204,7 +3192,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "tower",
  "tower-http 0.7.0",
@@ -3217,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.11"
+version = "0.63.13"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3283,7 +3271,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5241,7 +5229,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "walkdir",
@@ -5251,14 +5239,7 @@ dependencies = [
 name = "tinycortex-api"
 version = "0.1.1"
 dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "uuid",
+ "tinymemory-api",
 ]
 
 [[package]]
@@ -5343,7 +5324,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "chrono",
  "dirs",
  "futures",
@@ -5360,8 +5340,9 @@ dependencies = [
  "tinyagents",
  "tinycortex",
  "tinycortex-api",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-sources",
+ "tinymemory-sync",
  "tokio",
  "tracing",
  "url",
@@ -5379,8 +5360,39 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tinymemory",
  "tinymemory-api",
+]
+
+[[package]]
+name = "tinymemory-sources"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "regex",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tinymemory-api",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymemory-sync"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -5389,9 +5401,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
  "tinycortex",
- "tinymemory",
  "tinymemory-api",
+ "tinymemory-core",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -5552,6 +5570,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -5559,10 +5592,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5581,10 +5623,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5593,7 +5635,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6477,6 +6519,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -578,6 +578,15 @@ whisper-rs-sys = { git = "https://github.com/tinyhumansai/whisper-rs-sys.git", b
 
 [dev-dependencies]
 tempfile = "3"
+
+# The upstream driver-conformance suite (`assert_provider`, `retains_writes`),
+# run in `src/store/memory/upstream_conformance_test.rs` against the providers
+# `open_driver` constructs. Unconditional on purpose — dev-dependencies cannot
+# be optional — and cheap on purpose: the crate is contract-only
+# (tinymemory-api + async-trait + serde_json + anyhow), deliberately barred
+# from reaching any engine, so it adds no engine weight to any lane's graph.
+# Same byte-identical-path rule as the `tinymemory*` entries above.
+tinymemory-conformance = { path = "vendor/openhuman/vendor/tinymemory/conformance" }
 # `test-util` only — for `#[tokio::test(start_paused = true)]`, which the git
 # deadline test needs to fire a timeout deterministically instead of racing a
 # real child process. Dev-only: under resolver v2 this feature is not unified

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -536,6 +536,19 @@ chargebee = ["dep:reqwest"]
 # above — backend service code, per-company credentials, only `reqwest` gated.
 paypal = ["dep:reqwest"]
 
+# WS4 one level further: `tinycortex-api` (since tinycortex@8401346,
+# tinymemory#18 §A1) re-exports the TinyMemory contract and therefore depends
+# on `tinymemory-api` by git URL. A git source is not redirected by
+# `[patch.crates-io]`, so without this section that git checkout joins the
+# graph BESIDE the vendored path copy declared above — and every shared
+# contract type (`MemoryTaint`, `MemoryEntry`, ...) becomes two distinct
+# types, which stops `tinymemory-core` compiling. openhuman carries exactly
+# this entry for itself (`[patch."https://github.com/tinyhumansai/tinymemory"]`
+# in its Cargo.toml); replicated here with the path rebased onto the vendored
+# checkout, same as the WS4 entries below.
+[patch."https://github.com/tinyhumansai/tinymemory"]
+tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/api" }
+
 [patch.crates-io]
 # Reuse OpenHuman's own TinyAgents pin (2.1.0). This satisfies OpenHuman's
 # `^2.1` requirement while keeping a single checkout and crate identity.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,13 @@ Switch companies by editing `OPENCOMPANY_COMPANY` in `.env` and re-running
 `docker compose up`. Compile optional features into the host with
 `OPENCOMPANY_FEATURES="medulla tinyplace sqlite"`.
 
+For a selectable memory engine, add `tinymemory` (hosted engines —
+Supermemory, Mem0, Cognee — plus the `null` driver) and `tinymemory-embedded`
+(the durable in-pod `namespace` store) to `OPENCOMPANY_FEATURES`, then select
+one with the `OPENCOMPANY_MEMORY*` variables (`.env.example` has the block;
+`docs/spec/runtime/memory-engine.md` has the full guide and the
+engine-switch runbook).
+
 The console upstream is configurable via `OC_UPSTREAM` (default
 `opencompany:8080`), so the console image is portable across every target here.
 

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -354,9 +354,12 @@ data step comes first.
 Misconfiguration never falls back: an unknown mode, a missing driver, URL or
 key, or a missing cargo feature is a boot refusal naming the knob to change.
 
-> **`namespace` caveat (2026-08-20):** the embedded contract driver has two
-> open correctness defects — #1201 (writes corrupted by the PII scrubber's
-> digit redaction inside the stored envelope) and #1238 (a dropped context
-> chunk and reordered traces under the port conformance suite). Fixes are in
-> flight; until both land and the union CI lane is green over them, prefer the
-> incumbent `embedded` engine overlay or a hosted engine for anything real.
+> **`namespace` caveat (2026-08-20):** #1201 (writes corrupted by the PII
+> scrubber redacting Luhn-valid digit runs — most often `at_millis` timestamps
+> — into broken JSON) is fixed in this change's own stack: the scrubber now
+> corroborates before redacting, and two regression nets pin it (the
+> Luhn-timestamp round-trip, and the survival contract in
+> `store::memory::upstream_conformance_test`). One defect remains open —
+> #1238 (a dropped context chunk and reordered traces under the port
+> conformance suite). Until it lands, prefer the incumbent `embedded` engine
+> overlay or a hosted engine for anything real.

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -325,3 +325,38 @@ OPENCOMPANY_MEMORY_ALLOW_EPHEMERAL=1  # operator asserts /data is durable
 OPENCOMPANY_MONGODB_URI=mongodb://…
 # → boots; engine memory persists under /data/memory/<workspace>/ as usual.
 ```
+
+## Switching engines — the operator runbook
+
+Engine selection is **infra-operator only**: instance-wide, env-driven, read
+once at boot. There is no per-company choice, no API setter, and no Console
+setter — a Console admin must never be able to repoint a deployment's storage.
+Switching is therefore an env flip plus a restart, and because **nothing
+migrates between engines** (a switched engine starts empty by design), the
+data step comes first.
+
+1. **Export what the live engine holds** (until `export` reads the live
+   overlay, capture what matters by hand — the gap is tracked in the P1
+   follow-ups). A future `opencompany memory migrate --from --to` built on the
+   contract's Portability family is the intended tool here.
+2. **Set the variables** for the target engine (the `.env.example` block names
+   all five). A hosted engine needs the build to carry the `tinymemory`
+   feature; `namespace` needs `tinymemory-embedded`. A feature-less build
+   refuses at boot naming the missing feature.
+3. **Restart.** Selection is read once at boot; a running process never
+   re-reads it.
+4. **Verify on `GET /spec`**: `memory.backend` and `memory.driver_id` name
+   what you selected, `memory.capabilities` lists what it negotiated, and
+   `memory.healthy` reports the boot-time reachability probe — `false` means
+   bound-but-unreachable (bad endpoint or credential); absent means "not
+   probed" (the `store` default or the direct engine overlay).
+
+Misconfiguration never falls back: an unknown mode, a missing driver, URL or
+key, or a missing cargo feature is a boot refusal naming the knob to change.
+
+> **`namespace` caveat (2026-08-20):** the embedded contract driver has two
+> open correctness defects — #1201 (writes corrupted by the PII scrubber's
+> digit redaction inside the stored envelope) and #1238 (a dropped context
+> chunk and reordered traces under the port conformance suite). Fixes are in
+> flight; until both land and the union CI lane is green over them, prefer the
+> incumbent `embedded` engine overlay or a hosted engine for anything real.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -591,6 +591,12 @@ export interface MemorySpec {
   driver_id?: string;
   /** Capability families negotiated at bind time; empty = not negotiated. */
   capabilities: string[];
+  /**
+   * Whether the boot-time reachability probe answered ready. Absent = not
+   * probed (base store, direct engine, or an older host) — treat as unknown,
+   * not unhealthy.
+   */
+  healthy?: boolean;
 }
 
 export interface AppSpec {

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -50,7 +50,7 @@ platform-jwt   | tested       | (default)                       | In the default
 openhuman      | tested       | openhuman,tinycortex            | `rust-gated` runs `--tests`, which selects lib+bin units and every tests/ target.
 tinycortex     | tested       | openhuman,tinycortex            | Same lane, same unfiltered `--tests`.
 tinymemory     | partial      | acp,runner,tinymemory | store::memory store::select
-tinymemory-embedded | partial | acp,runner,tinymemory-embedded | store::memory store::select
+tinymemory-embedded | partial | openhuman,tinycortex,tinymemory-embedded | store::memory store::select
 tinyplace      | tested       | tinyplace                       | Runs the whole `--lib` deliberately (issue #477) — it gates code across the tree.
 
 # --- Partial: a lane exists, but filtered ----------------------------------

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1030,11 +1030,13 @@ impl AppState {
                 backend: crate::store::MemoryBackend::Store.as_str(),
                 driver_id: None,
                 capabilities: Vec::new(),
+                healthy: None,
             },
             Some(overlay) => MemorySpec {
                 backend: overlay.descriptor.backend.as_str(),
                 driver_id: Some(overlay.descriptor.driver_id.clone()),
                 capabilities: overlay.descriptor.capabilities.clone(),
+                healthy: overlay.descriptor.healthy,
             },
         }
     }
@@ -1127,6 +1129,15 @@ pub struct MemorySpec {
     /// provider. An operator reads this to see what a hosted engine does *not*
     /// support before a cycle discovers it.
     pub capabilities: Vec<String>,
+    /// Whether the boot-time reachability probe answered `Ready`.
+    ///
+    /// Absent means "not probed": the base backend serves memory, the in-pod
+    /// engine is driven directly, or this host predates the probe — a client
+    /// must treat absence as unknown, not unhealthy. `false` is a bound
+    /// engine whose probe failed at boot: still bound, and the first cycle
+    /// that needs memory will fail until the endpoint or credential is fixed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub healthy: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1129,7 +1129,9 @@ pub struct MemorySpec {
     /// provider. An operator reads this to see what a hosted engine does *not*
     /// support before a cycle discovers it.
     pub capabilities: Vec<String>,
-    /// Whether the boot-time reachability probe answered `Ready`.
+    /// Whether the boot-time reachability probe found the engine usable —
+    /// `Ready` or `Degraded` (reachable, possibly reduced); only `Down`
+    /// serializes as `false`.
     ///
     /// Absent means "not probed": the base backend serves memory, the in-pod
     /// engine is driven directly, or this host predates the probe — a client

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1486,7 +1486,16 @@ async fn async_main() -> Result<()> {
             // memory + context ports onto a dedicated engine on top of the base
             // backend. A selected-but-unavailable engine aborts boot, same as
             // the storage backend.
-            if let Some(overlay) = opencompany::store::open_memory_overlay(&storage_settings)? {
+            if let Some(mut overlay) = opencompany::store::open_memory_overlay(&storage_settings)? {
+                // One bounded reachability probe, so a dead endpoint or a
+                // revoked key shows on `/spec` at boot instead of surfacing as
+                // a mid-cycle failure days later. Advisory: it warns and
+                // records, never refuses — config errors already refused
+                // above, and a transient vendor outage must not crash-loop
+                // the tenant.
+                overlay
+                    .refresh_health(std::time::Duration::from_secs(5))
+                    .await;
                 state = state.with_memory_overlay(overlay);
                 // `as_str`, not `{:?}`: the enum's Debug name is `Tinycortex`
                 // while `/spec` and the docs call that engine `embedded`. An

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -933,4 +933,34 @@ mod tests {
             "/spec leaked the memory endpoint: {rendered}"
         );
     }
+
+    /// The other half of the health contract on the wire: once the boot probe
+    /// has run, `/spec` serves its answer. The `null` driver's `health()` is
+    /// `Ready` by contract, so this covers the probed-`true` serialization
+    /// deterministically; the unprobed case is asserted `null` above, and the
+    /// mapping of degraded/down/timeout onto the bit is pinned in
+    /// `store::select`.
+    #[cfg(feature = "tinymemory")]
+    #[tokio::test]
+    async fn spec_serves_the_boot_probes_health_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut overlay = crate::store::open_memory_overlay(&crate::store::StorageSettings {
+            memory_backend: crate::store::MemoryBackend::Null,
+            ..Default::default()
+        })
+        .expect("null binds")
+        .expect("null yields an overlay");
+        overlay
+            .refresh_health(std::time::Duration::from_secs(5))
+            .await;
+
+        let state = AppState::new(AppConfig::default())
+            .with_home(dir.path().to_path_buf())
+            .with_memory_overlay(overlay);
+        let body = spec_body(state).await;
+        assert_eq!(
+            body["memory"]["healthy"], true,
+            "probed health must reach /spec"
+        );
+    }
 }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -913,6 +913,12 @@ mod tests {
         let body = spec_body(state).await;
         assert_eq!(body["memory"]["backend"], "remote");
         assert_eq!(body["memory"]["driver_id"], "supermemory");
+        // Unprobed here (the probe is `serve`'s boot step, not `bind`'s), and
+        // the field is skipped when absent so old clients see the old shape.
+        assert!(
+            body["memory"]["healthy"].is_null(),
+            "an unprobed engine must not report health"
+        );
         // The mandatory three a hosted adapter advertises, so an operator can
         // see the tree/graph families it does not have.
         let caps = body["memory"]["capabilities"].to_string();

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -72,6 +72,14 @@ fn encode<T: Serialize>(record: &T) -> Result<String> {
 /// written by a version we do not understand. A single unreadable row must not
 /// fail a whole `list`: on a shared hosted engine the store may legitimately
 /// hold rows this build did not write.
+///
+/// A row *inside* our namespace that fails to parse is different: nothing else
+/// writes there, so it is a record this host stored and can no longer read — a
+/// corrupted write, not foreign data. It is still skipped (one bad row must not
+/// fail the list), but loudly: #1201 was exactly this shape — the embedded
+/// driver's PII scrubber redacted digits out of the JSON envelope, and the
+/// silent `None` here made a corrupted record indistinguishable from one that
+/// was never written.
 fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Option<T> {
     let reported = entry.namespace.as_deref().unwrap_or_default();
     if !namespace.contains(reported) {
@@ -82,8 +90,29 @@ fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Op
         );
         return None;
     }
-    let envelope: Envelope<T> = serde_json::from_str(&entry.content).ok()?;
-    (envelope.v == ENVELOPE_VERSION).then_some(envelope.record)
+    let envelope: Envelope<T> = match serde_json::from_str(&entry.content) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            tracing::warn!(
+                namespace = namespace.as_str(),
+                key = %entry.key,
+                %error,
+                "memory entry in our namespace failed to decode; dropping it \
+                 (a record we wrote and can no longer read — see #1201)"
+            );
+            return None;
+        }
+    };
+    if envelope.v != ENVELOPE_VERSION {
+        tracing::debug!(
+            namespace = namespace.as_str(),
+            key = %entry.key,
+            version = envelope.v,
+            "memory entry has an envelope version this build does not understand; skipping it"
+        );
+        return None;
+    }
+    Some(envelope.record)
 }
 
 /// Maps a provider error onto the crate error type.

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -90,16 +90,25 @@ fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Op
         );
         return None;
     }
-    let envelope: Envelope<T> = match serde_json::from_str(&entry.content) {
+    // Two-stage parse, version before record: a row written by an envelope
+    // version this build does not know may carry a record shape `T` cannot
+    // deserialize, and collapsing both steps into one `Envelope<T>` parse
+    // would misreport that legitimate skip as corruption. Only a row whose
+    // envelope is unreadable, or whose version matches and record still does
+    // not parse, is a record we wrote and can no longer read.
+    let corrupt = |error: &dyn std::fmt::Display| {
+        tracing::warn!(
+            namespace = namespace.as_str(),
+            key = %entry.key,
+            %error,
+            "memory entry in our namespace failed to decode; dropping it \
+             (a record we wrote and can no longer read — see #1201)"
+        );
+    };
+    let envelope: Envelope<serde_json::Value> = match serde_json::from_str(&entry.content) {
         Ok(envelope) => envelope,
         Err(error) => {
-            tracing::warn!(
-                namespace = namespace.as_str(),
-                key = %entry.key,
-                %error,
-                "memory entry in our namespace failed to decode; dropping it \
-                 (a record we wrote and can no longer read — see #1201)"
-            );
+            corrupt(&error);
             return None;
         }
     };
@@ -112,7 +121,13 @@ fn decode<T: DeserializeOwned>(entry: &MemoryEntry, namespace: &Namespace) -> Op
         );
         return None;
     }
-    Some(envelope.record)
+    match serde_json::from_value(envelope.record) {
+        Ok(record) => Some(record),
+        Err(error) => {
+            corrupt(&error);
+            None
+        }
+    }
 }
 
 /// Maps a provider error onto the crate error type.
@@ -769,5 +784,44 @@ mod test {
         let cut = snippet(&body);
         assert!(body.starts_with(&cut));
         assert!(cut.len() >= 200);
+    }
+
+    /// The decode classification #1248 review asked to pin: an entry from an
+    /// envelope version this build does not know is a legitimate skip even
+    /// when its record shape does not fit today's `T` — it must not be read
+    /// as corruption — while a matching version with an unreadable record,
+    /// or no envelope at all, is the #1201 corruption path. All three return
+    /// `None` rather than failing the list.
+    #[test]
+    fn decode_classifies_unknown_versions_and_corruption_separately() {
+        let namespace = Namespace::company_root(&CompanyId::new("acme"));
+        let entry = |content: &str| MemoryEntry {
+            id: "id".into(),
+            key: "key".into(),
+            content: content.into(),
+            namespace: Some(namespace.as_str().to_string()),
+            category: tinymemory_api::types::MemoryCategory::Custom("oc:trace".into()),
+            timestamp: String::new(),
+            session_id: None,
+            score: None,
+            taint: MemoryTaint::Internal,
+        };
+
+        // Round-trip control: a current-version envelope decodes.
+        let good = encode(&42u32).unwrap();
+        assert_eq!(decode::<u32>(&entry(&good), &namespace), Some(42));
+
+        // Unknown version, record shape incompatible with `T`: skipped, and
+        // reachable only through the version gate — the record is never
+        // parsed as `T`, so this cannot trip the corruption path.
+        let future = r#"{"v":9,"record":{"shape":"unknown"}}"#;
+        assert_eq!(decode::<u32>(&entry(future), &namespace), None);
+
+        // Matching version, unreadable record: the corruption path.
+        let mangled = r#"{"v":1,"record":{"at_millis":[REDACTED_PII_CREDIT_CARD]}}"#;
+        assert_eq!(decode::<u32>(&entry(mangled), &namespace), None);
+
+        // No envelope at all: also the corruption path.
+        assert_eq!(decode::<u32>(&entry("not json"), &namespace), None);
     }
 }

--- a/src/store/memory/mod.rs
+++ b/src/store/memory/mod.rs
@@ -246,3 +246,5 @@ impl BoundMemory {
 
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod upstream_conformance_test;

--- a/src/store/memory/test.rs
+++ b/src/store/memory/test.rs
@@ -730,6 +730,45 @@ mod namespace_driver_conformance {
         conformance::assert_context_chunk_stamps(engine.context()).await;
         drop(store_dir);
     }
+
+    /// #1201: the conformance suite failed at random on this driver because
+    /// its write path runs a PII scrubber over the serialized envelope, and a
+    /// 13-digit `at_millis` that happens to pass Luhn (~10% of epoch-millis
+    /// stamps do) was redacted into unparseable JSON — the read side then
+    /// dropped the whole record. Deterministic pin: the middle stamp below is
+    /// the Luhn-valid one from the original failure, so this test fails 100%
+    /// of the time on a driver with that defect, not 10%.
+    #[tokio::test]
+    async fn luhn_valid_timestamps_round_trip_on_the_namespace_driver() {
+        let (store_dir, engine) = real_engine();
+        let memory = engine.memory();
+        let traces = vec![
+            CompressedTrace {
+                cycle_id: "c0".into(),
+                summary: "summary 0".into(),
+                at_millis: 1_787_178_633_770,
+            },
+            CompressedTrace {
+                cycle_id: "c1".into(),
+                summary: "summary 1".into(),
+                at_millis: 1_787_178_633_773,
+            },
+            CompressedTrace {
+                cycle_id: "c2".into(),
+                summary: "summary 2".into(),
+                at_millis: 1_787_178_633_774,
+            },
+        ];
+        for trace in &traces {
+            memory.save_trace(&acme_id(), trace.clone()).await.unwrap();
+        }
+        let read = memory.recent_traces(&acme_id(), usize::MAX).await.unwrap();
+        assert_eq!(
+            read, traces,
+            "every trace round-trips regardless of its timestamp's digits"
+        );
+        drop(store_dir);
+    }
 }
 
 /// #914's acceptance names "taint survives export and re-import" and #1113

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -63,8 +63,18 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
             &company,
             CompressedTrace {
                 cycle_id: "cycle-1".into(),
-                // Digit runs shaped like a card number, deliberately: #1201 was
-                // a scrubber redacting exactly this out of the stored envelope.
+                // A card-shaped digit run in purchase-y prose, deliberately:
+                // #1201 was the embedded scrubber redacting digits INTO BROKEN
+                // JSON, so the whole record silently vanished. The contract
+                // pinned here is survival, not verbatim digits — an engine
+                // with a PII scrubber (the embedded driver, post-#1248) is
+                // entitled to redact the card number out of the *content*; it
+                // is never entitled to corrupt the envelope around it. #1248's
+                // own pin covers the sharper half (Luhn-valid `at_millis`
+                // stamps round-trip untouched); this one proves the decode
+                // path over every engine this host binds. On the hosted
+                // engines, which scrub nothing, the digits also come back —
+                // but that is engine policy, so it is not asserted.
                 summary: "ordered part 4111 1111 1111 1111 for the lathe".into(),
                 at_millis: 1_700_000_000_000,
             },
@@ -73,9 +83,14 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
         .expect("save_trace");
     let traces = memory.recent_traces(&company, 10).await.expect("traces");
     assert_eq!(traces.len(), 1, "the trace must survive the envelope");
+    assert_eq!(
+        traces[0].cycle_id, "cycle-1",
+        "the record's identity must survive"
+    );
     assert!(
-        traces[0].summary.contains("4111 1111 1111 1111"),
-        "the stored summary must come back byte-identical, not redacted"
+        traces[0].summary.contains("ordered part") && traces[0].summary.contains("for the lathe"),
+        "the non-sensitive prose must survive whatever the engine's scrubbing policy is; got: {:?}",
+        traces[0].summary
     );
 
     let facts = bound.facts();
@@ -145,15 +160,13 @@ mod embedded {
         assert_retains_then_conforms(provider).await;
     }
 
-    /// RED TODAY, deliberately written and deliberately parked: the summary
-    /// comes back with its digit runs redacted — #1201's exact shape, the
-    /// embedded scrubber mutating a host-stored payload. Same contract as a
-    /// feature-lanes `owed` row: the un-ignore lands with the fix, and until
-    /// then the runbook in `docs/spec/runtime/memory-engine.md` gates the
-    /// `namespace` driver on it. Run it by hand with `--ignored` to check a
-    /// candidate fix.
+    /// The #1201 regression net, armed. On the pre-#1248 driver the
+    /// card-shaped digits in `facade_round_trip` tripped the scrubber into
+    /// corrupting the stored envelope, and the record was silently gone.
+    /// Post-#1248 the scrubber may still redact the digits — that is its job
+    /// — but the record, its identity and its prose must survive, which is
+    /// exactly what the round-trip asserts.
     #[tokio::test]
-    #[ignore = "#1201: the embedded scrubber redacts digit runs inside the stored envelope; un-ignore with the fix"]
     async fn the_namespace_driver_round_trips_the_facades() {
         let dir = tempfile::tempdir().expect("tempdir");
         let (provider, class) = open(&namespace_config(dir.path()));

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -1,0 +1,631 @@
+//! The upstream driver-conformance suite, run against the providers **this
+//! host constructs**.
+//!
+//! The vendored tinymemory workspace already proves its adapters uphold the
+//! contract (`adapters/remote/src/conformance_test.rs`,
+//! `core/src/store/factories_provider_test.rs`) — but no OpenCompany lane runs
+//! that workspace, and none of it goes through `open_driver`. Namespace-driver
+//! defects #1201 and #1238 shipped through exactly that gap: the driver's own
+//! suite was green upstream while the driver this host binds misbehaved.
+//!
+//! So these run `tinymemory_conformance::assert_provider` — the same eleven
+//! behavioural assertions — against providers built the way production builds
+//! them: a [`MemoryDriverConfig`] through [`open_driver`], nothing constructed
+//! by hand. The embedded test binds the real `namespace` store on a tempdir;
+//! the hosted tests bind each HTTP adapter against an in-process double
+//! speaking that vendor's own wire shapes, ported from the vendored
+//! `adapters/remote/src/conformance_test.rs` (keep them in step with it when
+//! the adapters' dialects change).
+//!
+//! Each hosted engine also gets a **facade round-trip**: traces, facts and
+//! context driven through [`BoundMemory`]'s ports over real HTTP. The facades
+//! encode records into a JSON envelope inside `content` and re-derive
+//! everything on decode — the surface #1201 corrupted — and nothing else
+//! exercises that path against the hosted dialects.
+
+use std::sync::Arc;
+
+use tinymemory::registry::DriverClass;
+use tinymemory_api::provider::MemoryProvider;
+
+use super::BoundMemory;
+use super::driver::{MemoryDriverConfig, MemoryMode, open_driver};
+use crate::ports::{CompanyId, CompressedTrace, ContextChunk, FactKind, FactRecord};
+
+/// Opens a driver through the production path and fails the test on refusal.
+fn open(config: &MemoryDriverConfig) -> (Arc<dyn MemoryProvider>, DriverClass) {
+    open_driver(config)
+        .expect("the driver must bind")
+        .expect("this config names a driver, so `None` is a routing bug")
+}
+
+/// The suite skips every write-path assertion for a non-retaining driver, so a
+/// provider (or a broken double behind it) that dropped writes would let
+/// `assert_provider` pass having proved almost nothing. Guard first.
+async fn assert_retains_then_conforms(provider: Arc<dyn MemoryProvider>) {
+    assert!(
+        tinymemory_conformance::retains_writes(provider.as_ref()).await,
+        "driver `{}` must retain writes, or the conformance run is vacuous",
+        provider.driver_id()
+    );
+    tinymemory_conformance::assert_provider(provider).await;
+}
+
+/// Traces, facts and context through the decorator's ports — the JSON-envelope
+/// encode/decode path (#1201's shape) — against whatever engine is bound.
+async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass) {
+    let bound = BoundMemory::bind(provider, class).expect("bind");
+    let company = CompanyId::new("acme");
+
+    let memory = bound.memory();
+    memory
+        .save_trace(
+            &company,
+            CompressedTrace {
+                cycle_id: "cycle-1".into(),
+                // Digit runs shaped like a card number, deliberately: #1201 was
+                // a scrubber redacting exactly this out of the stored envelope.
+                summary: "ordered part 4111 1111 1111 1111 for the lathe".into(),
+                at_millis: 1_700_000_000_000,
+            },
+        )
+        .await
+        .expect("save_trace");
+    let traces = memory.recent_traces(&company, 10).await.expect("traces");
+    assert_eq!(traces.len(), 1, "the trace must survive the envelope");
+    assert!(
+        traces[0].summary.contains("4111 1111 1111 1111"),
+        "the stored summary must come back byte-identical, not redacted"
+    );
+
+    let facts = bound.facts();
+    facts
+        .upsert(
+            &company,
+            &FactRecord {
+                id: "fact-1".into(),
+                kind: FactKind::Fact,
+                title: "supplier".into(),
+                body: "lathe parts come from Initech".into(),
+                source: "cto".into(),
+                updated_at_millis: 1_700_000_000_001,
+            },
+        )
+        .await
+        .expect("fact upsert");
+    let listed = facts.list(&company, None, None).await.expect("fact list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].body, "lathe parts come from Initech");
+
+    let context = bound.context();
+    context
+        .put(
+            &company,
+            ContextChunk {
+                label: "notes/supplier".into(),
+                body: "the quick brown fox".into(),
+            },
+        )
+        .await
+        .expect("context put");
+    let hits = context
+        .search(&company, "quick brown", 10)
+        .await
+        .expect("context search");
+    assert_eq!(
+        hits.len(),
+        1,
+        "context must be recallable through the engine"
+    );
+}
+
+// ── The embedded `namespace` driver, on a real store ─────────────────────────
+
+#[cfg(feature = "tinymemory-embedded")]
+mod embedded {
+    use super::*;
+
+    fn namespace_config(dir: &std::path::Path) -> MemoryDriverConfig {
+        MemoryDriverConfig {
+            mode: MemoryMode::Embedded,
+            driver_id: Some("namespace".into()),
+            url: None,
+            api_key: None,
+            data_dir: Some(dir.to_path_buf()),
+        }
+    }
+
+    /// #1201/#1238 regression net: the durable SQLite store this host binds
+    /// under `OPENCOMPANY_MEMORY=embedded` + `OPENCOMPANY_MEMORY_DRIVER=
+    /// namespace`, under the upstream suite, through `open_driver`.
+    #[tokio::test]
+    async fn the_namespace_driver_upholds_the_contract() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (provider, _) = open(&namespace_config(dir.path()));
+        assert_retains_then_conforms(provider).await;
+    }
+
+    /// RED TODAY, deliberately written and deliberately parked: the summary
+    /// comes back with its digit runs redacted — #1201's exact shape, the
+    /// embedded scrubber mutating a host-stored payload. Same contract as a
+    /// feature-lanes `owed` row: the un-ignore lands with the fix, and until
+    /// then the runbook in `docs/spec/runtime/memory-engine.md` gates the
+    /// `namespace` driver on it. Run it by hand with `--ignored` to check a
+    /// candidate fix.
+    #[tokio::test]
+    #[ignore = "#1201: the embedded scrubber redacts digit runs inside the stored envelope; un-ignore with the fix"]
+    async fn the_namespace_driver_round_trips_the_facades() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (provider, class) = open(&namespace_config(dir.path()));
+        facade_round_trip(provider, class).await;
+    }
+}
+
+// ── Vendor doubles ───────────────────────────────────────────────────────────
+//
+// Ported from the vendored `adapters/remote/src/conformance_test.rs` at
+// tinymemory 38a34d2 — the shapes are each vendor's own, and the doubles
+// retain what they are sent, which is what lets the suite's write-path
+// assertions actually run. Auth headers are ignored: what the adapter *sends*
+// is pinned upstream; these tests are about what this host binds.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use axum::extract::{Path, Query, State};
+use axum::routing::{delete, get, post, put};
+use axum::{Json, Router};
+use serde_json::{Value, json};
+
+/// A record as one of the vendor doubles holds it.
+#[derive(Clone, Debug)]
+struct Row {
+    id: String,
+    content: String,
+    metadata: Value,
+    /// The `containerTag` the adapter sent at create time (Supermemory only;
+    /// Mem0 rows carry an empty one).
+    tag: String,
+}
+
+/// The doubles' shared store: `id -> Row`, plus a counter for fresh ids.
+#[derive(Default, Debug)]
+struct Backend {
+    rows: BTreeMap<String, Row>,
+    next: usize,
+}
+
+impl Backend {
+    fn fresh_id(&mut self) -> String {
+        self.next += 1;
+        format!("rec-{}", self.next)
+    }
+}
+
+type Store = Arc<Mutex<Backend>>;
+
+/// Serves `app` on an ephemeral port and returns its base URL.
+async fn serve(app: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let endpoint = format!("http://{}", listener.local_addr().expect("address"));
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    endpoint
+}
+
+/// The production remote config for one hosted engine, pointed at a double.
+fn remote_config(driver: &str, endpoint: &str) -> MemoryDriverConfig {
+    MemoryDriverConfig {
+        mode: MemoryMode::Remote,
+        driver_id: Some(driver.into()),
+        url: Some(endpoint.into()),
+        api_key: Some("test-key".into()),
+        data_dir: None,
+    }
+}
+
+// ── Mem0's native shapes ─────────────────────────────────────────────────────
+
+async fn mem0_list(State(store): State<Store>) -> Json<Value> {
+    let store = store.lock().expect("store lock");
+    let results: Vec<Value> = store
+        .rows
+        .values()
+        .map(|r| {
+            json!({
+                "id": r.id,
+                "memory": r.content,
+                "metadata": r.metadata,
+                "created_at": "1970-01-01T00:00:00Z",
+            })
+        })
+        .collect();
+    Json(json!({ "results": results }))
+}
+
+async fn mem0_create(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+    let mut store = store.lock().expect("store lock");
+    let id = store.fresh_id();
+    let content = body["messages"][0]["content"]
+        .as_str()
+        .unwrap_or_default()
+        .to_owned();
+    let metadata = body["metadata"].clone();
+    store.rows.insert(
+        id.clone(),
+        Row {
+            id: id.clone(),
+            content,
+            metadata,
+            tag: String::new(),
+        },
+    );
+    Json(json!({ "results": [{ "id": id }] }))
+}
+
+async fn mem0_update(
+    State(store): State<Store>,
+    Path(id): Path<String>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    let mut store = store.lock().expect("store lock");
+    if let Some(row) = store.rows.get_mut(&id) {
+        if let Some(text) = body["text"].as_str() {
+            row.content = text.to_owned();
+        }
+        if !body["metadata"].is_null() {
+            row.metadata = body["metadata"].clone();
+        }
+    }
+    Json(json!({ "id": id }))
+}
+
+async fn mem0_delete(State(store): State<Store>, Path(id): Path<String>) -> Json<Value> {
+    store.lock().expect("store lock").rows.remove(&id);
+    Json(json!({ "deleted": true }))
+}
+
+async fn mem0_search(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+    // Substring matching is enough: the suite asserts that recall *narrows*,
+    // not that the backend ranks well.
+    let needle = body["query"].as_str().unwrap_or_default().to_lowercase();
+    let limit = body["top_k"].as_u64().unwrap_or(100) as usize;
+    let store = store.lock().expect("store lock");
+    let results: Vec<Value> = store
+        .rows
+        .values()
+        .filter(|r| r.content.to_lowercase().contains(&needle))
+        .take(limit)
+        .map(|r| {
+            json!({
+                "id": r.id,
+                "memory": r.content,
+                "metadata": r.metadata,
+                "score": 0.9,
+            })
+        })
+        .collect();
+    Json(json!({ "results": results }))
+}
+
+async fn mem0_backend() -> String {
+    let store: Store = Arc::new(Mutex::new(Backend::default()));
+    let app = Router::new()
+        .route("/memories", get(mem0_list).post(mem0_create))
+        .route("/memories/{id}", put(mem0_update).delete(mem0_delete))
+        .route("/search", post(mem0_search))
+        .with_state(store);
+    serve(app).await
+}
+
+#[tokio::test]
+async fn the_mem0_driver_this_host_binds_upholds_the_contract() {
+    let endpoint = mem0_backend().await;
+    let (provider, _) = open(&remote_config("mem0", &endpoint));
+    assert_retains_then_conforms(provider).await;
+}
+
+#[tokio::test]
+async fn the_mem0_driver_round_trips_the_facades() {
+    let endpoint = mem0_backend().await;
+    let (provider, class) = open(&remote_config("mem0", &endpoint));
+    facade_round_trip(provider, class).await;
+}
+
+// ── Supermemory's native shapes ──────────────────────────────────────────────
+
+fn tag_of(row: &Row) -> String {
+    row.tag.clone()
+}
+
+async fn sm_tags(State(store): State<Store>) -> Json<Value> {
+    let store = store.lock().expect("store lock");
+    let mut tags: Vec<String> = store
+        .rows
+        .values()
+        .map(tag_of)
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    tags.sort();
+    tags.dedup();
+    Json(Value::Array(
+        tags.into_iter()
+            .map(|t| json!({ "containerTag": t }))
+            .collect(),
+    ))
+}
+
+async fn sm_list(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+    // The adapter pages until a short page comes back. One page, then empty.
+    let page = body["page"].as_u64().unwrap_or(1);
+    let wanted = body["containerTags"][0].as_str().unwrap_or_default();
+    let store = store.lock().expect("store lock");
+    let entries: Vec<Value> = if page > 1 {
+        Vec::new()
+    } else {
+        store
+            .rows
+            .values()
+            .filter(|r| tag_of(r) == wanted)
+            .map(|r| {
+                json!({
+                    "id": r.id,
+                    "content": r.content,
+                    "metadata": r.metadata,
+                    "createdAt": "1970-01-01T00:00:00Z",
+                    "isLatest": true,
+                    "isForgotten": false,
+                })
+            })
+            .collect()
+    };
+    Json(json!({ "memoryEntries": entries }))
+}
+
+async fn sm_create(
+    State(store): State<Store>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, axum::http::StatusCode> {
+    // The real v4 API requires `containerTag`; filing a malformed create under
+    // "" would hide an adapter regression.
+    let Some(tag) = body["containerTag"].as_str().filter(|tag| !tag.is_empty()) else {
+        return Err(axum::http::StatusCode::BAD_REQUEST);
+    };
+    let mut store = store.lock().expect("store lock");
+    let id = store.fresh_id();
+    let first = &body["memories"][0];
+    store.rows.insert(
+        id.clone(),
+        Row {
+            id: id.clone(),
+            content: first["content"].as_str().unwrap_or_default().to_owned(),
+            metadata: first["metadata"].clone(),
+            tag: tag.to_owned(),
+        },
+    );
+    Ok(Json(json!({ "memories": [{ "id": id }] })))
+}
+
+async fn sm_update(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+    let mut store = store.lock().expect("store lock");
+    let id = body["id"].as_str().unwrap_or_default().to_owned();
+    if let Some(row) = store.rows.get_mut(&id) {
+        if let Some(text) = body["newContent"].as_str() {
+            row.content = text.to_owned();
+        }
+        if !body["metadata"].is_null() {
+            row.metadata = body["metadata"].clone();
+        }
+    }
+    Json(json!({ "id": id }))
+}
+
+async fn sm_delete(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+    let id = body["id"].as_str().unwrap_or_default();
+    store.lock().expect("store lock").rows.remove(id);
+    Json(json!({ "deleted": true }))
+}
+
+async fn sm_search(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+    let needle = body["q"]
+        .as_str()
+        .or_else(|| body["query"].as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    let limit = body["limit"].as_u64().unwrap_or(100) as usize;
+    let tag = body["containerTag"].as_str();
+    let store = store.lock().expect("store lock");
+    let results: Vec<Value> = store
+        .rows
+        .values()
+        .filter(|r| tag.is_none_or(|t| tag_of(r) == t))
+        .filter(|r| r.content.to_lowercase().contains(&needle))
+        .take(limit)
+        .map(|r| {
+            json!({
+                "id": r.id,
+                "content": r.content,
+                "metadata": r.metadata,
+                "score": 0.9,
+            })
+        })
+        .collect();
+    Json(json!({ "results": results }))
+}
+
+async fn supermemory_backend() -> String {
+    let store: Store = Arc::new(Mutex::new(Backend::default()));
+    let app = Router::new()
+        .route("/v3/container-tags/list", get(sm_tags))
+        .route("/v4/memories/list", post(sm_list))
+        .route(
+            "/v4/memories",
+            post(sm_create).patch(sm_update).delete(sm_delete),
+        )
+        .route("/v4/search", post(sm_search))
+        .with_state(store);
+    serve(app).await
+}
+
+#[tokio::test]
+async fn the_supermemory_driver_this_host_binds_upholds_the_contract() {
+    let endpoint = supermemory_backend().await;
+    let (provider, _) = open(&remote_config("supermemory", &endpoint));
+    assert_retains_then_conforms(provider).await;
+}
+
+#[tokio::test]
+async fn the_supermemory_driver_round_trips_the_facades() {
+    let endpoint = supermemory_backend().await;
+    let (provider, class) = open(&remote_config("supermemory", &endpoint));
+    facade_round_trip(provider, class).await;
+}
+
+// ── Cognee's native shapes ───────────────────────────────────────────────────
+//
+// The odd one out: no per-record API. The adapter uploads each record as a
+// JSON *file* into a per-namespace dataset and reads it back through `/raw`,
+// so the double stores the uploaded bytes verbatim and serves them unchanged.
+
+type Datasets = Arc<Mutex<BTreeMap<String, BTreeMap<String, String>>>>;
+
+async fn cg_datasets(State(sets): State<Datasets>) -> Json<Value> {
+    let sets = sets.lock().expect("store lock");
+    Json(Value::Array(
+        sets.keys()
+            .map(|name| json!({ "id": name, "name": name }))
+            .collect(),
+    ))
+}
+
+async fn cg_data(State(sets): State<Datasets>, Path(dataset): Path<String>) -> Json<Value> {
+    let sets = sets.lock().expect("store lock");
+    let ids: Vec<Value> = sets
+        .get(&dataset)
+        .map(|d| d.keys().map(|id| json!({ "id": id, "name": id })).collect())
+        .unwrap_or_default();
+    Json(Value::Array(ids))
+}
+
+async fn cg_raw(
+    State(sets): State<Datasets>,
+    Path((dataset, data_id)): Path<(String, String)>,
+) -> String {
+    sets.lock()
+        .expect("store lock")
+        .get(&dataset)
+        .and_then(|d| d.get(&data_id))
+        .cloned()
+        .unwrap_or_default()
+}
+
+async fn cg_delete(
+    State(sets): State<Datasets>,
+    Path((dataset, data_id)): Path<(String, String)>,
+) -> Json<Value> {
+    if let Some(d) = sets.lock().expect("store lock").get_mut(&dataset) {
+        d.remove(&data_id);
+    }
+    Json(json!({ "deleted": true }))
+}
+
+/// Pulls the uploaded envelope and the dataset name out of a multipart body.
+async fn multipart_parts(mut form: axum::extract::Multipart) -> (String, String, String) {
+    let (mut body, mut dataset, mut filename) = (String::new(), String::new(), String::new());
+    while let Ok(Some(field)) = form.next_field().await {
+        match field.name().unwrap_or_default().to_owned().as_str() {
+            "datasetName" => dataset = field.text().await.unwrap_or_default(),
+            "data" | "file" | "files" => {
+                filename = field.file_name().unwrap_or_default().to_owned();
+                body = field.text().await.unwrap_or_default();
+            }
+            _ => {
+                let _ = field.bytes().await;
+            }
+        }
+    }
+    (body, dataset, filename)
+}
+
+async fn cg_remember(State(sets): State<Datasets>, form: axum::extract::Multipart) -> Json<Value> {
+    let (body, dataset, filename) = multipart_parts(form).await;
+    let mut sets = sets.lock().expect("store lock");
+    sets.entry(dataset).or_default().insert(filename, body);
+    Json(json!({ "status": "ok" }))
+}
+
+async fn cg_update(
+    State(sets): State<Datasets>,
+    Query(q): Query<BTreeMap<String, String>>,
+    form: axum::extract::Multipart,
+) -> Json<Value> {
+    let (body, _, _) = multipart_parts(form).await;
+    let dataset = q.get("dataset_id").cloned().unwrap_or_default();
+    let data_id = q.get("data_id").cloned().unwrap_or_default();
+    if let Some(d) = sets.lock().expect("store lock").get_mut(&dataset) {
+        d.insert(data_id, body);
+    }
+    Json(json!({ "status": "ok" }))
+}
+
+async fn cg_recall(State(sets): State<Datasets>, Json(body): Json<Value>) -> Json<Value> {
+    let needle = body["query"].as_str().unwrap_or_default().to_lowercase();
+    let limit = body["top_k"].as_u64().unwrap_or(100) as usize;
+    let wanted: Option<Vec<String>> = body["datasets"].as_array().map(|a| {
+        a.iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect()
+    });
+    let sets = sets.lock().expect("store lock");
+    let hits: Vec<Value> = sets
+        .iter()
+        .filter(|(name, _)| wanted.as_ref().is_none_or(|w| w.contains(name)))
+        .flat_map(|(_, d)| d.values())
+        .filter(|raw| raw.to_lowercase().contains(&needle))
+        .take(limit)
+        .map(|raw| json!({ "text": raw, "score": 0.9 }))
+        .collect();
+    // A TOP-LEVEL array, which is what the adapter's `search` iterates
+    // (`response.as_array()`, cognee.rs). This deliberately DIVERGES from the
+    // vendored double, which wraps hits in `{"results": …}` — a shape the
+    // adapter cannot see, so the upstream suite's recall coverage for Cognee
+    // is vacuously green. Caught here because the facade round-trip requires
+    // an actual hit; reported upstream rather than mirrored.
+    Json(Value::Array(hits))
+}
+
+async fn cognee_backend() -> String {
+    let sets: Datasets = Arc::new(Mutex::new(BTreeMap::new()));
+    let app = Router::new()
+        // The real API serves the collection at the slashed form and 307s the
+        // bare one; the adapter asks for `/api/v1/datasets/` directly.
+        .route("/api/v1/datasets/", get(cg_datasets))
+        .route("/api/v1/datasets/{dataset}/data", get(cg_data))
+        .route("/api/v1/datasets/{dataset}/data/{data_id}/raw", get(cg_raw))
+        .route(
+            "/api/v1/datasets/{dataset}/data/{data_id}",
+            delete(cg_delete),
+        )
+        .route("/api/v1/remember", post(cg_remember))
+        .route("/api/v1/update", axum::routing::patch(cg_update))
+        .route("/api/v1/recall", post(cg_recall))
+        .with_state(sets);
+    serve(app).await
+}
+
+#[tokio::test]
+async fn the_cognee_driver_this_host_binds_upholds_the_contract() {
+    let endpoint = cognee_backend().await;
+    let (provider, _) = open(&remote_config("cognee", &endpoint));
+    assert_retains_then_conforms(provider).await;
+}
+
+#[tokio::test]
+async fn the_cognee_driver_round_trips_the_facades() {
+    let endpoint = cognee_backend().await;
+    let (provider, class) = open(&remote_config("cognee", &endpoint));
+    facade_round_trip(provider, class).await;
+}

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -23,8 +23,13 @@
 //! everything on decode — the surface #1201 corrupted — and nothing else
 //! exercises that path against the hosted dialects.
 
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 
+use axum::extract::{Path, Query, State};
+use axum::routing::{delete, get, post, put};
+use axum::{Json, Router};
+use serde_json::{Value, json};
 use tinymemory::registry::DriverClass;
 use tinymemory_api::provider::MemoryProvider;
 
@@ -75,6 +80,8 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
                 // path over every engine this host binds. On the hosted
                 // engines, which scrub nothing, the digits also come back —
                 // but that is engine policy, so it is not asserted.
+                // nosemgrep: coderabbit.pii.credit-card-number-dashed -- test
+                // vector, not a credential; see the note above.
                 summary: "ordered part 4111 1111 1111 1111 for the lathe".into(),
                 at_millis: 1_700_000_000_000,
             },
@@ -182,14 +189,6 @@ mod embedded {
 // assertions actually run. Auth headers are ignored: what the adapter *sends*
 // is pinned upstream; these tests are about what this host binds.
 
-use std::collections::BTreeMap;
-use std::sync::Mutex;
-
-use axum::extract::{Path, Query, State};
-use axum::routing::{delete, get, post, put};
-use axum::{Json, Router};
-use serde_json::{Value, json};
-
 /// A record as one of the vendor doubles holds it.
 #[derive(Clone, Debug)]
 struct Row {
@@ -240,405 +239,418 @@ fn remote_config(driver: &str, endpoint: &str) -> MemoryDriverConfig {
     }
 }
 
-// ── Mem0's native shapes ─────────────────────────────────────────────────────
+/// Mem0's native shapes: the five routes `Mem0Dialect` issues, and the two
+/// suites over the driver this host binds against them.
+mod mem0 {
+    use super::*;
 
-async fn mem0_list(State(store): State<Store>) -> Json<Value> {
-    let store = store.lock().expect("store lock");
-    let results: Vec<Value> = store
-        .rows
-        .values()
-        .map(|r| {
-            json!({
-                "id": r.id,
-                "memory": r.content,
-                "metadata": r.metadata,
-                "created_at": "1970-01-01T00:00:00Z",
-            })
-        })
-        .collect();
-    Json(json!({ "results": results }))
-}
-
-async fn mem0_create(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
-    let mut store = store.lock().expect("store lock");
-    let id = store.fresh_id();
-    let content = body["messages"][0]["content"]
-        .as_str()
-        .unwrap_or_default()
-        .to_owned();
-    let metadata = body["metadata"].clone();
-    store.rows.insert(
-        id.clone(),
-        Row {
-            id: id.clone(),
-            content,
-            metadata,
-            tag: String::new(),
-        },
-    );
-    Json(json!({ "results": [{ "id": id }] }))
-}
-
-async fn mem0_update(
-    State(store): State<Store>,
-    Path(id): Path<String>,
-    Json(body): Json<Value>,
-) -> Json<Value> {
-    let mut store = store.lock().expect("store lock");
-    if let Some(row) = store.rows.get_mut(&id) {
-        if let Some(text) = body["text"].as_str() {
-            row.content = text.to_owned();
-        }
-        if !body["metadata"].is_null() {
-            row.metadata = body["metadata"].clone();
-        }
-    }
-    Json(json!({ "id": id }))
-}
-
-async fn mem0_delete(State(store): State<Store>, Path(id): Path<String>) -> Json<Value> {
-    store.lock().expect("store lock").rows.remove(&id);
-    Json(json!({ "deleted": true }))
-}
-
-async fn mem0_search(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
-    // Substring matching is enough: the suite asserts that recall *narrows*,
-    // not that the backend ranks well.
-    let needle = body["query"].as_str().unwrap_or_default().to_lowercase();
-    let limit = body["top_k"].as_u64().unwrap_or(100) as usize;
-    let store = store.lock().expect("store lock");
-    let results: Vec<Value> = store
-        .rows
-        .values()
-        .filter(|r| r.content.to_lowercase().contains(&needle))
-        .take(limit)
-        .map(|r| {
-            json!({
-                "id": r.id,
-                "memory": r.content,
-                "metadata": r.metadata,
-                "score": 0.9,
-            })
-        })
-        .collect();
-    Json(json!({ "results": results }))
-}
-
-async fn mem0_backend() -> String {
-    let store: Store = Arc::new(Mutex::new(Backend::default()));
-    let app = Router::new()
-        .route("/memories", get(mem0_list).post(mem0_create))
-        .route("/memories/{id}", put(mem0_update).delete(mem0_delete))
-        .route("/search", post(mem0_search))
-        .with_state(store);
-    serve(app).await
-}
-
-#[tokio::test]
-async fn the_mem0_driver_this_host_binds_upholds_the_contract() {
-    let endpoint = mem0_backend().await;
-    let (provider, _) = open(&remote_config("mem0", &endpoint));
-    assert_retains_then_conforms(provider).await;
-}
-
-#[tokio::test]
-async fn the_mem0_driver_round_trips_the_facades() {
-    let endpoint = mem0_backend().await;
-    let (provider, class) = open(&remote_config("mem0", &endpoint));
-    facade_round_trip(provider, class).await;
-}
-
-// ── Supermemory's native shapes ──────────────────────────────────────────────
-
-fn tag_of(row: &Row) -> String {
-    row.tag.clone()
-}
-
-async fn sm_tags(State(store): State<Store>) -> Json<Value> {
-    let store = store.lock().expect("store lock");
-    let mut tags: Vec<String> = store
-        .rows
-        .values()
-        .map(tag_of)
-        .filter(|tag| !tag.is_empty())
-        .collect();
-    tags.sort();
-    tags.dedup();
-    Json(Value::Array(
-        tags.into_iter()
-            .map(|t| json!({ "containerTag": t }))
-            .collect(),
-    ))
-}
-
-async fn sm_list(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
-    // The adapter pages until a short page comes back. One page, then empty.
-    let page = body["page"].as_u64().unwrap_or(1);
-    let wanted = body["containerTags"][0].as_str().unwrap_or_default();
-    let store = store.lock().expect("store lock");
-    let entries: Vec<Value> = if page > 1 {
-        Vec::new()
-    } else {
-        store
+    async fn mem0_list(State(store): State<Store>) -> Json<Value> {
+        let store = store.lock().expect("store lock");
+        let results: Vec<Value> = store
             .rows
             .values()
-            .filter(|r| tag_of(r) == wanted)
+            .map(|r| {
+                json!({
+                    "id": r.id,
+                    "memory": r.content,
+                    "metadata": r.metadata,
+                    "created_at": "1970-01-01T00:00:00Z",
+                })
+            })
+            .collect();
+        Json(json!({ "results": results }))
+    }
+
+    async fn mem0_create(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+        let mut store = store.lock().expect("store lock");
+        let id = store.fresh_id();
+        let content = body["messages"][0]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned();
+        let metadata = body["metadata"].clone();
+        store.rows.insert(
+            id.clone(),
+            Row {
+                id: id.clone(),
+                content,
+                metadata,
+                tag: String::new(),
+            },
+        );
+        Json(json!({ "results": [{ "id": id }] }))
+    }
+
+    async fn mem0_update(
+        State(store): State<Store>,
+        Path(id): Path<String>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mut store = store.lock().expect("store lock");
+        if let Some(row) = store.rows.get_mut(&id) {
+            if let Some(text) = body["text"].as_str() {
+                row.content = text.to_owned();
+            }
+            if !body["metadata"].is_null() {
+                row.metadata = body["metadata"].clone();
+            }
+        }
+        Json(json!({ "id": id }))
+    }
+
+    async fn mem0_delete(State(store): State<Store>, Path(id): Path<String>) -> Json<Value> {
+        store.lock().expect("store lock").rows.remove(&id);
+        Json(json!({ "deleted": true }))
+    }
+
+    async fn mem0_search(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+        // Substring matching is enough: the suite asserts that recall *narrows*,
+        // not that the backend ranks well.
+        let needle = body["query"].as_str().unwrap_or_default().to_lowercase();
+        let limit = body["top_k"].as_u64().unwrap_or(100) as usize;
+        let store = store.lock().expect("store lock");
+        let results: Vec<Value> = store
+            .rows
+            .values()
+            .filter(|r| r.content.to_lowercase().contains(&needle))
+            .take(limit)
+            .map(|r| {
+                json!({
+                    "id": r.id,
+                    "memory": r.content,
+                    "metadata": r.metadata,
+                    "score": 0.9,
+                })
+            })
+            .collect();
+        Json(json!({ "results": results }))
+    }
+
+    async fn mem0_backend() -> String {
+        let store: Store = Arc::new(Mutex::new(Backend::default()));
+        let app = Router::new()
+            .route("/memories", get(mem0_list).post(mem0_create))
+            .route("/memories/{id}", put(mem0_update).delete(mem0_delete))
+            .route("/search", post(mem0_search))
+            .with_state(store);
+        serve(app).await
+    }
+
+    #[tokio::test]
+    async fn the_mem0_driver_this_host_binds_upholds_the_contract() {
+        let endpoint = mem0_backend().await;
+        let (provider, _) = open(&remote_config("mem0", &endpoint));
+        assert_retains_then_conforms(provider).await;
+    }
+
+    #[tokio::test]
+    async fn the_mem0_driver_round_trips_the_facades() {
+        let endpoint = mem0_backend().await;
+        let (provider, class) = open(&remote_config("mem0", &endpoint));
+        facade_round_trip(provider, class).await;
+    }
+}
+
+/// Supermemory's native shapes: container tags are its namespace equivalent,
+/// so the double keeps a tag per row and the tag listing reflects real writes.
+mod supermemory {
+    use super::*;
+
+    fn tag_of(row: &Row) -> String {
+        row.tag.clone()
+    }
+
+    async fn sm_tags(State(store): State<Store>) -> Json<Value> {
+        let store = store.lock().expect("store lock");
+        let mut tags: Vec<String> = store
+            .rows
+            .values()
+            .map(tag_of)
+            .filter(|tag| !tag.is_empty())
+            .collect();
+        tags.sort();
+        tags.dedup();
+        Json(Value::Array(
+            tags.into_iter()
+                .map(|t| json!({ "containerTag": t }))
+                .collect(),
+        ))
+    }
+
+    async fn sm_list(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+        // The adapter pages until a short page comes back. One page, then empty.
+        let page = body["page"].as_u64().unwrap_or(1);
+        let wanted = body["containerTags"][0].as_str().unwrap_or_default();
+        let store = store.lock().expect("store lock");
+        let entries: Vec<Value> = if page > 1 {
+            Vec::new()
+        } else {
+            store
+                .rows
+                .values()
+                .filter(|r| tag_of(r) == wanted)
+                .map(|r| {
+                    json!({
+                        "id": r.id,
+                        "content": r.content,
+                        "metadata": r.metadata,
+                        "createdAt": "1970-01-01T00:00:00Z",
+                        "isLatest": true,
+                        "isForgotten": false,
+                    })
+                })
+                .collect()
+        };
+        Json(json!({ "memoryEntries": entries }))
+    }
+
+    async fn sm_create(
+        State(store): State<Store>,
+        Json(body): Json<Value>,
+    ) -> Result<Json<Value>, axum::http::StatusCode> {
+        // The real v4 API requires `containerTag`; filing a malformed create under
+        // "" would hide an adapter regression.
+        let Some(tag) = body["containerTag"].as_str().filter(|tag| !tag.is_empty()) else {
+            return Err(axum::http::StatusCode::BAD_REQUEST);
+        };
+        let mut store = store.lock().expect("store lock");
+        let id = store.fresh_id();
+        let first = &body["memories"][0];
+        store.rows.insert(
+            id.clone(),
+            Row {
+                id: id.clone(),
+                content: first["content"].as_str().unwrap_or_default().to_owned(),
+                metadata: first["metadata"].clone(),
+                tag: tag.to_owned(),
+            },
+        );
+        Ok(Json(json!({ "memories": [{ "id": id }] })))
+    }
+
+    async fn sm_update(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+        let mut store = store.lock().expect("store lock");
+        let id = body["id"].as_str().unwrap_or_default().to_owned();
+        if let Some(row) = store.rows.get_mut(&id) {
+            if let Some(text) = body["newContent"].as_str() {
+                row.content = text.to_owned();
+            }
+            if !body["metadata"].is_null() {
+                row.metadata = body["metadata"].clone();
+            }
+        }
+        Json(json!({ "id": id }))
+    }
+
+    async fn sm_delete(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+        let id = body["id"].as_str().unwrap_or_default();
+        store.lock().expect("store lock").rows.remove(id);
+        Json(json!({ "deleted": true }))
+    }
+
+    async fn sm_search(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
+        let needle = body["q"]
+            .as_str()
+            .or_else(|| body["query"].as_str())
+            .unwrap_or_default()
+            .to_lowercase();
+        let limit = body["limit"].as_u64().unwrap_or(100) as usize;
+        let tag = body["containerTag"].as_str();
+        let store = store.lock().expect("store lock");
+        let results: Vec<Value> = store
+            .rows
+            .values()
+            .filter(|r| tag.is_none_or(|t| tag_of(r) == t))
+            .filter(|r| r.content.to_lowercase().contains(&needle))
+            .take(limit)
             .map(|r| {
                 json!({
                     "id": r.id,
                     "content": r.content,
                     "metadata": r.metadata,
-                    "createdAt": "1970-01-01T00:00:00Z",
-                    "isLatest": true,
-                    "isForgotten": false,
+                    "score": 0.9,
                 })
             })
-            .collect()
-    };
-    Json(json!({ "memoryEntries": entries }))
-}
-
-async fn sm_create(
-    State(store): State<Store>,
-    Json(body): Json<Value>,
-) -> Result<Json<Value>, axum::http::StatusCode> {
-    // The real v4 API requires `containerTag`; filing a malformed create under
-    // "" would hide an adapter regression.
-    let Some(tag) = body["containerTag"].as_str().filter(|tag| !tag.is_empty()) else {
-        return Err(axum::http::StatusCode::BAD_REQUEST);
-    };
-    let mut store = store.lock().expect("store lock");
-    let id = store.fresh_id();
-    let first = &body["memories"][0];
-    store.rows.insert(
-        id.clone(),
-        Row {
-            id: id.clone(),
-            content: first["content"].as_str().unwrap_or_default().to_owned(),
-            metadata: first["metadata"].clone(),
-            tag: tag.to_owned(),
-        },
-    );
-    Ok(Json(json!({ "memories": [{ "id": id }] })))
-}
-
-async fn sm_update(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
-    let mut store = store.lock().expect("store lock");
-    let id = body["id"].as_str().unwrap_or_default().to_owned();
-    if let Some(row) = store.rows.get_mut(&id) {
-        if let Some(text) = body["newContent"].as_str() {
-            row.content = text.to_owned();
-        }
-        if !body["metadata"].is_null() {
-            row.metadata = body["metadata"].clone();
-        }
+            .collect();
+        Json(json!({ "results": results }))
     }
-    Json(json!({ "id": id }))
-}
 
-async fn sm_delete(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
-    let id = body["id"].as_str().unwrap_or_default();
-    store.lock().expect("store lock").rows.remove(id);
-    Json(json!({ "deleted": true }))
-}
-
-async fn sm_search(State(store): State<Store>, Json(body): Json<Value>) -> Json<Value> {
-    let needle = body["q"]
-        .as_str()
-        .or_else(|| body["query"].as_str())
-        .unwrap_or_default()
-        .to_lowercase();
-    let limit = body["limit"].as_u64().unwrap_or(100) as usize;
-    let tag = body["containerTag"].as_str();
-    let store = store.lock().expect("store lock");
-    let results: Vec<Value> = store
-        .rows
-        .values()
-        .filter(|r| tag.is_none_or(|t| tag_of(r) == t))
-        .filter(|r| r.content.to_lowercase().contains(&needle))
-        .take(limit)
-        .map(|r| {
-            json!({
-                "id": r.id,
-                "content": r.content,
-                "metadata": r.metadata,
-                "score": 0.9,
-            })
-        })
-        .collect();
-    Json(json!({ "results": results }))
-}
-
-async fn supermemory_backend() -> String {
-    let store: Store = Arc::new(Mutex::new(Backend::default()));
-    let app = Router::new()
-        .route("/v3/container-tags/list", get(sm_tags))
-        .route("/v4/memories/list", post(sm_list))
-        .route(
-            "/v4/memories",
-            post(sm_create).patch(sm_update).delete(sm_delete),
-        )
-        .route("/v4/search", post(sm_search))
-        .with_state(store);
-    serve(app).await
-}
-
-#[tokio::test]
-async fn the_supermemory_driver_this_host_binds_upholds_the_contract() {
-    let endpoint = supermemory_backend().await;
-    let (provider, _) = open(&remote_config("supermemory", &endpoint));
-    assert_retains_then_conforms(provider).await;
-}
-
-#[tokio::test]
-async fn the_supermemory_driver_round_trips_the_facades() {
-    let endpoint = supermemory_backend().await;
-    let (provider, class) = open(&remote_config("supermemory", &endpoint));
-    facade_round_trip(provider, class).await;
-}
-
-// ── Cognee's native shapes ───────────────────────────────────────────────────
-//
-// The odd one out: no per-record API. The adapter uploads each record as a
-// JSON *file* into a per-namespace dataset and reads it back through `/raw`,
-// so the double stores the uploaded bytes verbatim and serves them unchanged.
-
-type Datasets = Arc<Mutex<BTreeMap<String, BTreeMap<String, String>>>>;
-
-async fn cg_datasets(State(sets): State<Datasets>) -> Json<Value> {
-    let sets = sets.lock().expect("store lock");
-    Json(Value::Array(
-        sets.keys()
-            .map(|name| json!({ "id": name, "name": name }))
-            .collect(),
-    ))
-}
-
-async fn cg_data(State(sets): State<Datasets>, Path(dataset): Path<String>) -> Json<Value> {
-    let sets = sets.lock().expect("store lock");
-    let ids: Vec<Value> = sets
-        .get(&dataset)
-        .map(|d| d.keys().map(|id| json!({ "id": id, "name": id })).collect())
-        .unwrap_or_default();
-    Json(Value::Array(ids))
-}
-
-async fn cg_raw(
-    State(sets): State<Datasets>,
-    Path((dataset, data_id)): Path<(String, String)>,
-) -> String {
-    sets.lock()
-        .expect("store lock")
-        .get(&dataset)
-        .and_then(|d| d.get(&data_id))
-        .cloned()
-        .unwrap_or_default()
-}
-
-async fn cg_delete(
-    State(sets): State<Datasets>,
-    Path((dataset, data_id)): Path<(String, String)>,
-) -> Json<Value> {
-    if let Some(d) = sets.lock().expect("store lock").get_mut(&dataset) {
-        d.remove(&data_id);
+    async fn supermemory_backend() -> String {
+        let store: Store = Arc::new(Mutex::new(Backend::default()));
+        let app = Router::new()
+            .route("/v3/container-tags/list", get(sm_tags))
+            .route("/v4/memories/list", post(sm_list))
+            .route(
+                "/v4/memories",
+                post(sm_create).patch(sm_update).delete(sm_delete),
+            )
+            .route("/v4/search", post(sm_search))
+            .with_state(store);
+        serve(app).await
     }
-    Json(json!({ "deleted": true }))
+
+    #[tokio::test]
+    async fn the_supermemory_driver_this_host_binds_upholds_the_contract() {
+        let endpoint = supermemory_backend().await;
+        let (provider, _) = open(&remote_config("supermemory", &endpoint));
+        assert_retains_then_conforms(provider).await;
+    }
+
+    #[tokio::test]
+    async fn the_supermemory_driver_round_trips_the_facades() {
+        let endpoint = supermemory_backend().await;
+        let (provider, class) = open(&remote_config("supermemory", &endpoint));
+        facade_round_trip(provider, class).await;
+    }
 }
 
-/// Pulls the uploaded envelope and the dataset name out of a multipart body.
-async fn multipart_parts(mut form: axum::extract::Multipart) -> (String, String, String) {
-    let (mut body, mut dataset, mut filename) = (String::new(), String::new(), String::new());
-    while let Ok(Some(field)) = form.next_field().await {
-        match field.name().unwrap_or_default().to_owned().as_str() {
-            "datasetName" => dataset = field.text().await.unwrap_or_default(),
-            "data" | "file" | "files" => {
-                filename = field.file_name().unwrap_or_default().to_owned();
-                body = field.text().await.unwrap_or_default();
-            }
-            _ => {
-                let _ = field.bytes().await;
+/// Cognee's native shapes — the odd one out: no per-record API. The adapter
+/// uploads each record as a JSON *file* into a per-namespace dataset and reads
+/// it back through `/raw`, so the double stores the uploaded bytes verbatim
+/// and serves them unchanged.
+mod cognee {
+    use super::*;
+
+    type Datasets = Arc<Mutex<BTreeMap<String, BTreeMap<String, String>>>>;
+
+    async fn cg_datasets(State(sets): State<Datasets>) -> Json<Value> {
+        let sets = sets.lock().expect("store lock");
+        Json(Value::Array(
+            sets.keys()
+                .map(|name| json!({ "id": name, "name": name }))
+                .collect(),
+        ))
+    }
+
+    async fn cg_data(State(sets): State<Datasets>, Path(dataset): Path<String>) -> Json<Value> {
+        let sets = sets.lock().expect("store lock");
+        let ids: Vec<Value> = sets
+            .get(&dataset)
+            .map(|d| d.keys().map(|id| json!({ "id": id, "name": id })).collect())
+            .unwrap_or_default();
+        Json(Value::Array(ids))
+    }
+
+    async fn cg_raw(
+        State(sets): State<Datasets>,
+        Path((dataset, data_id)): Path<(String, String)>,
+    ) -> String {
+        sets.lock()
+            .expect("store lock")
+            .get(&dataset)
+            .and_then(|d| d.get(&data_id))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    async fn cg_delete(
+        State(sets): State<Datasets>,
+        Path((dataset, data_id)): Path<(String, String)>,
+    ) -> Json<Value> {
+        if let Some(d) = sets.lock().expect("store lock").get_mut(&dataset) {
+            d.remove(&data_id);
+        }
+        Json(json!({ "deleted": true }))
+    }
+
+    /// Pulls the uploaded envelope and the dataset name out of a multipart body.
+    async fn multipart_parts(mut form: axum::extract::Multipart) -> (String, String, String) {
+        let (mut body, mut dataset, mut filename) = (String::new(), String::new(), String::new());
+        while let Ok(Some(field)) = form.next_field().await {
+            match field.name().unwrap_or_default().to_owned().as_str() {
+                "datasetName" => dataset = field.text().await.unwrap_or_default(),
+                "data" | "file" | "files" => {
+                    filename = field.file_name().unwrap_or_default().to_owned();
+                    body = field.text().await.unwrap_or_default();
+                }
+                _ => {
+                    let _ = field.bytes().await;
+                }
             }
         }
+        (body, dataset, filename)
     }
-    (body, dataset, filename)
-}
 
-async fn cg_remember(State(sets): State<Datasets>, form: axum::extract::Multipart) -> Json<Value> {
-    let (body, dataset, filename) = multipart_parts(form).await;
-    let mut sets = sets.lock().expect("store lock");
-    sets.entry(dataset).or_default().insert(filename, body);
-    Json(json!({ "status": "ok" }))
-}
-
-async fn cg_update(
-    State(sets): State<Datasets>,
-    Query(q): Query<BTreeMap<String, String>>,
-    form: axum::extract::Multipart,
-) -> Json<Value> {
-    let (body, _, _) = multipart_parts(form).await;
-    let dataset = q.get("dataset_id").cloned().unwrap_or_default();
-    let data_id = q.get("data_id").cloned().unwrap_or_default();
-    if let Some(d) = sets.lock().expect("store lock").get_mut(&dataset) {
-        d.insert(data_id, body);
+    async fn cg_remember(
+        State(sets): State<Datasets>,
+        form: axum::extract::Multipart,
+    ) -> Json<Value> {
+        let (body, dataset, filename) = multipart_parts(form).await;
+        let mut sets = sets.lock().expect("store lock");
+        sets.entry(dataset).or_default().insert(filename, body);
+        Json(json!({ "status": "ok" }))
     }
-    Json(json!({ "status": "ok" }))
-}
 
-async fn cg_recall(State(sets): State<Datasets>, Json(body): Json<Value>) -> Json<Value> {
-    let needle = body["query"].as_str().unwrap_or_default().to_lowercase();
-    let limit = body["top_k"].as_u64().unwrap_or(100) as usize;
-    let wanted: Option<Vec<String>> = body["datasets"].as_array().map(|a| {
-        a.iter()
-            .filter_map(|v| v.as_str().map(str::to_owned))
-            .collect()
-    });
-    let sets = sets.lock().expect("store lock");
-    let hits: Vec<Value> = sets
-        .iter()
-        .filter(|(name, _)| wanted.as_ref().is_none_or(|w| w.contains(name)))
-        .flat_map(|(_, d)| d.values())
-        .filter(|raw| raw.to_lowercase().contains(&needle))
-        .take(limit)
-        .map(|raw| json!({ "text": raw, "score": 0.9 }))
-        .collect();
-    // A TOP-LEVEL array, which is what the adapter's `search` iterates
-    // (`response.as_array()`, cognee.rs). This deliberately DIVERGES from the
-    // vendored double, which wraps hits in `{"results": …}` — a shape the
-    // adapter cannot see, so the upstream suite's recall coverage for Cognee
-    // is vacuously green. Caught here because the facade round-trip requires
-    // an actual hit; reported upstream rather than mirrored.
-    Json(Value::Array(hits))
-}
+    async fn cg_update(
+        State(sets): State<Datasets>,
+        Query(q): Query<BTreeMap<String, String>>,
+        form: axum::extract::Multipart,
+    ) -> Json<Value> {
+        let (body, _, _) = multipart_parts(form).await;
+        let dataset = q.get("dataset_id").cloned().unwrap_or_default();
+        let data_id = q.get("data_id").cloned().unwrap_or_default();
+        if let Some(d) = sets.lock().expect("store lock").get_mut(&dataset) {
+            d.insert(data_id, body);
+        }
+        Json(json!({ "status": "ok" }))
+    }
 
-async fn cognee_backend() -> String {
-    let sets: Datasets = Arc::new(Mutex::new(BTreeMap::new()));
-    let app = Router::new()
-        // The real API serves the collection at the slashed form and 307s the
-        // bare one; the adapter asks for `/api/v1/datasets/` directly.
-        .route("/api/v1/datasets/", get(cg_datasets))
-        .route("/api/v1/datasets/{dataset}/data", get(cg_data))
-        .route("/api/v1/datasets/{dataset}/data/{data_id}/raw", get(cg_raw))
-        .route(
-            "/api/v1/datasets/{dataset}/data/{data_id}",
-            delete(cg_delete),
-        )
-        .route("/api/v1/remember", post(cg_remember))
-        .route("/api/v1/update", axum::routing::patch(cg_update))
-        .route("/api/v1/recall", post(cg_recall))
-        .with_state(sets);
-    serve(app).await
-}
+    async fn cg_recall(State(sets): State<Datasets>, Json(body): Json<Value>) -> Json<Value> {
+        let needle = body["query"].as_str().unwrap_or_default().to_lowercase();
+        let limit = body["top_k"].as_u64().unwrap_or(100) as usize;
+        let wanted: Option<Vec<String>> = body["datasets"].as_array().map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        });
+        let sets = sets.lock().expect("store lock");
+        let hits: Vec<Value> = sets
+            .iter()
+            .filter(|(name, _)| wanted.as_ref().is_none_or(|w| w.contains(name)))
+            .flat_map(|(_, d)| d.values())
+            .filter(|raw| raw.to_lowercase().contains(&needle))
+            .take(limit)
+            .map(|raw| json!({ "text": raw, "score": 0.9 }))
+            .collect();
+        // A TOP-LEVEL array, which is what the adapter's `search` iterates
+        // (`response.as_array()`, cognee.rs). This deliberately DIVERGES from the
+        // vendored double, which wraps hits in `{"results": …}` — a shape the
+        // adapter cannot see, so the upstream suite's recall coverage for Cognee
+        // is vacuously green. Caught here because the facade round-trip requires
+        // an actual hit; reported upstream rather than mirrored.
+        Json(Value::Array(hits))
+    }
 
-#[tokio::test]
-async fn the_cognee_driver_this_host_binds_upholds_the_contract() {
-    let endpoint = cognee_backend().await;
-    let (provider, _) = open(&remote_config("cognee", &endpoint));
-    assert_retains_then_conforms(provider).await;
-}
+    async fn cognee_backend() -> String {
+        let sets: Datasets = Arc::new(Mutex::new(BTreeMap::new()));
+        let app = Router::new()
+            // The real API serves the collection at the slashed form and 307s the
+            // bare one; the adapter asks for `/api/v1/datasets/` directly.
+            .route("/api/v1/datasets/", get(cg_datasets))
+            .route("/api/v1/datasets/{dataset}/data", get(cg_data))
+            .route("/api/v1/datasets/{dataset}/data/{data_id}/raw", get(cg_raw))
+            .route(
+                "/api/v1/datasets/{dataset}/data/{data_id}",
+                delete(cg_delete),
+            )
+            .route("/api/v1/remember", post(cg_remember))
+            .route("/api/v1/update", axum::routing::patch(cg_update))
+            .route("/api/v1/recall", post(cg_recall))
+            .with_state(sets);
+        serve(app).await
+    }
 
-#[tokio::test]
-async fn the_cognee_driver_round_trips_the_facades() {
-    let endpoint = cognee_backend().await;
-    let (provider, class) = open(&remote_config("cognee", &endpoint));
-    facade_round_trip(provider, class).await;
+    #[tokio::test]
+    async fn the_cognee_driver_this_host_binds_upholds_the_contract() {
+        let endpoint = cognee_backend().await;
+        let (provider, _) = open(&remote_config("cognee", &endpoint));
+        assert_retains_then_conforms(provider).await;
+    }
+
+    #[tokio::test]
+    async fn the_cognee_driver_round_trips_the_facades() {
+        let endpoint = cognee_backend().await;
+        let (provider, class) = open(&remote_config("cognee", &endpoint));
+        facade_round_trip(provider, class).await;
+    }
 }

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -233,10 +233,15 @@ pub struct MemoryOverlay {
     pub descriptor: MemoryDescriptor,
     /// The bound provider, kept solely so [`Self::refresh_health`] can probe
     /// it once at boot. `None` on the engine-overlay path, which drives the
-    /// in-pod engine directly and has no provider to ask. Never used for
-    /// reads or writes — the ports above are the only data path.
+    /// in-pod engine directly and has no provider to ask.
+    ///
+    /// Private on purpose: `MemoryCore` is a supertrait of `MemoryProvider`,
+    /// so a public handle here would let anything holding an `AppState` call
+    /// `store("<any namespace>", …)` directly — re-opening exactly the
+    /// raw-namespace door `store::memory`'s module docs promise is closed by
+    /// construction. The ports above are the only data path.
     #[cfg(feature = "tinymemory")]
-    pub probe: Option<Arc<dyn tinymemory_api::provider::MemoryProvider>>,
+    probe: Option<Arc<dyn tinymemory_api::provider::MemoryProvider>>,
 }
 
 impl MemoryOverlay {

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -231,6 +231,59 @@ pub struct MemoryOverlay {
     pub scratch: Option<Arc<dyn ContextStore>>,
     /// What is bound, for status output.
     pub descriptor: MemoryDescriptor,
+    /// The bound provider, kept solely so [`Self::refresh_health`] can probe
+    /// it once at boot. `None` on the engine-overlay path, which drives the
+    /// in-pod engine directly and has no provider to ask. Never used for
+    /// reads or writes — the ports above are the only data path.
+    #[cfg(feature = "tinymemory")]
+    pub probe: Option<Arc<dyn tinymemory_api::provider::MemoryProvider>>,
+}
+
+impl MemoryOverlay {
+    /// Probes the bound engine once and records the answer on the descriptor,
+    /// so `/spec` can tell an operator "bound but unreachable" before the
+    /// first cycle finds out — until this ran, a hosted engine with a dead
+    /// endpoint or a revoked key bound cleanly and failed days later, on a
+    /// path nobody was watching.
+    ///
+    /// Boot-time only, bounded by `timeout`, and advisory by design: a probe
+    /// failure logs loudly and records `healthy: Some(false)`, it never
+    /// refuses the boot. Configuration errors already refuse at open; a
+    /// transient vendor outage must not crash-loop a tenant that could serve
+    /// everything else. `healthy: None` means "not probed" — the engine
+    /// overlay path, or a build without the provider seam.
+    #[cfg(feature = "tinymemory")]
+    pub async fn refresh_health(&mut self, timeout: std::time::Duration) {
+        use tinymemory_api::health::MemoryHealth;
+        let Some(probe) = &self.probe else {
+            return;
+        };
+        let healthy = match tokio::time::timeout(timeout, probe.health()).await {
+            Ok(MemoryHealth::Ready) => true,
+            Ok(status) => {
+                tracing::warn!(
+                    driver_id = %self.descriptor.driver_id,
+                    status = ?status,
+                    "memory engine bound but not healthy; cycles that need memory will fail"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::warn!(
+                    driver_id = %self.descriptor.driver_id,
+                    timeout_secs = timeout.as_secs(),
+                    "memory engine health probe timed out; the endpoint may be unreachable"
+                );
+                false
+            }
+        };
+        self.descriptor.healthy = Some(healthy);
+    }
+
+    /// Without the provider seam there is nothing to probe; `healthy` stays
+    /// `None` ("not probed"), which is the truth.
+    #[cfg(not(feature = "tinymemory"))]
+    pub async fn refresh_health(&mut self, _timeout: std::time::Duration) {}
 }
 
 impl std::fmt::Debug for MemoryOverlay {
@@ -256,6 +309,13 @@ pub struct MemoryDescriptor {
     /// The capability families the bound driver negotiated, so an operator can
     /// see what the engine does *not* support before a cycle finds out.
     pub capabilities: Vec<String>,
+    /// Whether the boot-time reachability probe answered `Ready`.
+    ///
+    /// `None` means the engine was never probed — the engine-overlay path,
+    /// which has no provider seam to ask, or a boot path that skipped
+    /// [`MemoryOverlay::refresh_health`]. `Some(false)` is a bound engine
+    /// whose probe failed: still bound, loudly warned, visible on `/spec`.
+    pub healthy: Option<bool>,
 }
 
 /// Durable company → tenant ownership, for shared-database platform mode.
@@ -577,6 +637,10 @@ fn open_provider(settings: &StorageSettings) -> Result<Option<MemoryOverlay>> {
         }
         return Ok(None);
     };
+    // Kept aside for the boot-time health probe; `bind` consumes its argument
+    // and deliberately exposes no provider accessor (the ports are the only
+    // data path). Clone is an `Arc` bump.
+    let probe = provider.clone();
     let bound = BoundMemory::bind(provider, class)?;
     // Announce the bind: which engine, and — the part an operator cannot infer —
     // the class the *host* assigned it, since that is what decides whether the
@@ -612,7 +676,11 @@ fn open_provider(settings: &StorageSettings) -> Result<Option<MemoryOverlay>> {
                 .into_iter()
                 .map(str::to_string)
                 .collect(),
+            // Not probed yet: binding is offline by design, and the probe is
+            // the caller's boot-time step (`refresh_health`).
+            healthy: None,
         },
+        probe: Some(probe),
     }))
 }
 
@@ -736,7 +804,11 @@ fn open_tinycortex(settings: &StorageSettings) -> Result<Option<MemoryOverlay>> 
             // empty list says "not negotiated", which is the truth; claiming the
             // mandatory three here would be reporting a bind that did not happen.
             capabilities: Vec::new(),
+            // And nothing to probe, for the same reason: `None` = not probed.
+            healthy: None,
         },
+        #[cfg(feature = "tinymemory")]
+        probe: None,
     }))
 }
 
@@ -1070,6 +1142,41 @@ mod test {
             .expect("remote yields an overlay");
         assert_eq!(overlay.descriptor.backend, MemoryBackend::Remote);
         assert_eq!(overlay.descriptor.driver_id, "supermemory");
+        // Binding is offline: nothing has probed yet, and claiming health
+        // before a probe would be the same lie in the other direction.
+        assert_eq!(
+            overlay.descriptor.healthy, None,
+            "bind must not pre-claim health"
+        );
+        assert!(
+            overlay.probe.is_some(),
+            "the provider-seam overlay must carry a probe handle for the boot health check"
+        );
+    }
+
+    #[cfg(feature = "tinymemory")]
+    #[tokio::test]
+    async fn refresh_health_records_the_probe_answer() {
+        // `null` is the one driver whose health is deterministic offline —
+        // its `health()` is `Ready` by contract — so it proves the probe
+        // path end-to-end with no network: probe handle → `refresh_health`
+        // → `descriptor.healthy`, the value `/spec` serves.
+        let settings = StorageSettings {
+            memory_backend: MemoryBackend::Null,
+            ..StorageSettings::default()
+        };
+        let mut overlay = open_memory_overlay(&settings)
+            .expect("null binds")
+            .expect("null yields an overlay");
+        assert_eq!(overlay.descriptor.healthy, None);
+        overlay
+            .refresh_health(std::time::Duration::from_secs(5))
+            .await;
+        assert_eq!(
+            overlay.descriptor.healthy,
+            Some(true),
+            "the probe's answer must land on the descriptor"
+        );
     }
 
     #[cfg(feature = "tinymemory")]

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -320,7 +320,9 @@ pub struct MemoryDescriptor {
     /// The capability families the bound driver negotiated, so an operator can
     /// see what the engine does *not* support before a cycle finds out.
     pub capabilities: Vec<String>,
-    /// Whether the boot-time reachability probe answered `Ready`.
+    /// Whether the boot-time reachability probe found the engine usable:
+    /// `Ready`, or `Degraded` — reachable and serving, possibly reduced.
+    /// Only `Down` maps to `Some(false)`.
     ///
     /// `None` means the engine was never probed — the engine-overlay path,
     /// which has no provider seam to ask, or a boot path that skipped

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -254,29 +254,20 @@ impl MemoryOverlay {
     /// overlay path, or a build without the provider seam.
     #[cfg(feature = "tinymemory")]
     pub async fn refresh_health(&mut self, timeout: std::time::Duration) {
-        use tinymemory_api::health::MemoryHealth;
         let Some(probe) = &self.probe else {
             return;
         };
-        let healthy = match tokio::time::timeout(timeout, probe.health()).await {
-            Ok(MemoryHealth::Ready) => true,
-            Ok(status) => {
-                tracing::warn!(
-                    driver_id = %self.descriptor.driver_id,
-                    status = ?status,
-                    "memory engine bound but not healthy; cycles that need memory will fail"
-                );
-                false
-            }
-            Err(_) => {
-                tracing::warn!(
-                    driver_id = %self.descriptor.driver_id,
-                    timeout_secs = timeout.as_secs(),
-                    "memory engine health probe timed out; the endpoint may be unreachable"
-                );
-                false
-            }
-        };
+        let answer = tokio::time::timeout(timeout, probe.health()).await.ok();
+        let healthy = probe_answer_is_healthy(&answer);
+        if !healthy {
+            tracing::warn!(
+                driver_id = %self.descriptor.driver_id,
+                status = ?answer,
+                timeout_secs = timeout.as_secs(),
+                "memory engine bound but its health probe did not answer Ready or Degraded; \
+                 cycles that need memory will fail until the endpoint or credential is fixed"
+            );
+        }
         self.descriptor.healthy = Some(healthy);
     }
 
@@ -284,6 +275,21 @@ impl MemoryOverlay {
     /// `None` ("not probed"), which is the truth.
     #[cfg(not(feature = "tinymemory"))]
     pub async fn refresh_health(&mut self, _timeout: std::time::Duration) {}
+}
+
+/// Maps a probe outcome (`None` = timed out) onto the `healthy` bit.
+///
+/// `Ready` AND `Degraded` are healthy: a degraded engine is still serving —
+/// reduced, not absent — and reporting it as down would tell an operator to
+/// fix an endpoint that is answering. Only `Down` and a timeout mean the
+/// first cycle that needs memory will fail.
+#[cfg(feature = "tinymemory")]
+fn probe_answer_is_healthy(answer: &Option<tinymemory_api::health::MemoryHealth>) -> bool {
+    use tinymemory_api::health::MemoryHealth;
+    matches!(
+        answer,
+        Some(MemoryHealth::Ready) | Some(MemoryHealth::Degraded { .. })
+    )
 }
 
 impl std::fmt::Debug for MemoryOverlay {
@@ -1176,6 +1182,28 @@ mod test {
             overlay.descriptor.healthy,
             Some(true),
             "the probe's answer must land on the descriptor"
+        );
+    }
+
+    /// The whole health vocabulary, pinned per outcome: `Degraded` is still
+    /// serving — reduced, not absent — so it must read healthy; only `Down`
+    /// and a timeout mean the next memory-needing cycle fails.
+    #[cfg(feature = "tinymemory")]
+    #[test]
+    fn probe_mapping_counts_degraded_as_healthy_and_down_or_timeout_as_not() {
+        use tinymemory_api::health::MemoryHealth;
+        assert!(super::probe_answer_is_healthy(&Some(MemoryHealth::Ready)));
+        assert!(super::probe_answer_is_healthy(&Some(
+            MemoryHealth::Degraded {
+                reason: "index rebuilding".into()
+            }
+        )));
+        assert!(!super::probe_answer_is_healthy(&Some(MemoryHealth::Down {
+            reason: "connection refused".into()
+        })));
+        assert!(
+            !super::probe_answer_is_healthy(&None),
+            "a timed-out probe must read unhealthy, not unknown"
         );
     }
 


### PR DESCRIPTION
## Summary

Surfaces the TinyMemory engines end to end for the infra operator, in four pieces that only make sense together — which is why this is one PR.

**Stacked on #1248** (which carries the vendor/openhuman bump to upstream main, the `[patch."…/tinymemory"]` trait-identity fix, and the #1201 fix itself — #1271 is closed as superseded by it). The openhuman pin sits at #5608's **merge commit** (`6c0df607`, on openhuman main), pulling the vendored tinymemory f8bd9af → 38a34d2 — #63–#66, the hosted-adapter production fixes the staging feature flip depends on. Merge order: openhuman#5608 → #1248 → this. Review from the commit after #1248's.

### 1. The memory union CI lane (closes the #770-shaped gap for `openhuman + tinymemory-embedded`)

- Two new steps on the gated job run `store::memory` + `store::select` under `openhuman,tinycortex,tinymemory-embedded` — the first lane that links and *executes* the provider seam beside the openhuman+tinycortex core (the shipped tenant set is neither a subset nor a superset of the lane; what matters is the combination stops existing only as a typecheck). The two `tinymemory`-alone steps stay (the #914 contract-only separation must keep compiling on its own); the two `acp,runner,tinymemory-embedded` steps are subsumed and removed; the `feature-lanes.txt` row moves with them.
- New `src/store/memory/upstream_conformance_test.rs`: the vendored driver-conformance suite (`assert_provider`, `retains_writes` — via a new dev-dependency on the contract-only `tinymemory-conformance` crate) run against the providers **`open_driver` constructs**, not hand-built ones: the real `namespace` store on a tempdir, and each hosted adapter (Supermemory, Mem0, Cognee) against an in-process axum double speaking that vendor's wire shapes, ported from the vendored `adapters/remote/src/conformance_test.rs`. Plus a facade round-trip per engine — traces/facts/context through `BoundMemory`'s ports over real HTTP, the JSON-envelope encode/decode surface #1201 corrupted.

**The new net caught two real things on its first run:**

- `the_namespace_driver_round_trips_the_facades` **reproduced #1201 deterministically on the pre-#1248 driver** and ships armed on top of its fix. The contract it pins is survival, not verbatim digits: the scrubber may redact a card-shaped run out of the content (its job, post-#1248 corroboration), but the record, its identity and its non-sensitive prose must come back — the half that broke. Complements #1248's own sharper pin (Luhn-valid `at_millis` stamps round-trip untouched), and runs over every engine this host binds, hosted included.
- The vendored Cognee recall double answers `{"results": […]}`, but the adapter's `search` iterates a **top-level array** — so the upstream suite's recall coverage for Cognee is vacuously green. Our double deliberately diverges to the adapter's real shape (comment marks it); filing upstream.

### 2. Staging ships the hosted-memory contract (`tinymemory`)

`TENANT_FEATURES` gains `tinymemory` — remote (`supermemory`/`mem0`/`cognee`) + `null` modes, inert until an operator sets `OPENCOMPANY_MEMORY*`. Deliberately **not** `tinymemory-embedded`: tinymemory-core links a bundled rusqlite (the same C-compiler constraint that keeps `sqlite` out of the slim tenant image), and the `namespace` store on a mongodb tenant is refused by the ephemeral-`/data` guard anyway. Self-hosters compile it via `OPENCOMPANY_FEATURES` (documented). The gated e2e binary is untouched — it exists for belt specs.

### 3. Boot-time health probe → `/spec`

`open_provider` keeps a **private** probe handle on the overlay (private on purpose: `MemoryCore` is a supertrait of `MemoryProvider`, and a public handle would reopen the raw-namespace door the #936 decorator closed); `serve` runs one bounded (5s) `MemoryProvider::health()` after `BoundMemory::bind` — before the TCP listener binds, so a blackholed endpoint costs up to the timeout on a cold wake, taken knowingly — and records it as `MemoryDescriptor.healthy` → `MemorySpec.healthy` (skipped when absent, so old clients see the old shape; frontend type updated). Until now a hosted engine with a dead endpoint or revoked key bound cleanly and failed mid-cycle, days later. **Advisory by design**: probe failure warns loudly and shows `healthy: false` on `/spec`; it never refuses boot — config errors already refuse at open, and a transient vendor outage must not crash-loop a tenant. `/healthz` is untouched (its docs record the wake-proxy cold-start constraint; `busy` is a sibling for exactly that reason). `None` = "not probed" (the `store` default, the direct engine overlay, or an older host). Deterministic test via the `null` driver, whose `health()` is `Ready` by contract.

### 4. Operator discoverability

`.env.example` gains the five-variable `OPENCOMPANY_MEMORY*` block; `deploy/README.md` names the features for self-hosters; `docs/spec/runtime/memory-engine.md` gains the engine-switch runbook (set → restart → verify `/spec`), including the dated `namespace` caveat gated on #1201/#1238.

### What no opencompany lane covers (named so "conformance-backed" reads honestly)

The vendored `failure_test.rs` (write-failure surfaces, read-failure ≠ absence, 401 ≠ empty store, malformed 200, unreachable host, non-clearing cursor, paginated-export termination) and the per-vendor auth-header pinning in `mem0_test.rs`/`supermemory_test.rs`/`cognee_test.rs` run upstream only. Our doubles ignore auth headers by design — what the adapter *sends* is pinned upstream — so a regression where an adapter stops sending its credential would pass this suite.

## Verification

- `cargo fmt --all -- --check`; `scripts/ci/assert-feature-lanes.sh` (30 features, 0 owed)
- `run-scoped-suite.sh` under `openhuman,tinycortex,tinymemory-embedded` for `store::memory` and `store::select`, and under `acp,runner,tinymemory` for both
- `cargo check --locked` (default features — the cfg'd probe field compiles without the seam)
- `cargo clippy --locked --features openhuman,tinycortex,tinymemory-embedded --all-targets -- -D warnings`
- `npm run typecheck` in `frontend/`
- First union run before the fixes: 73 passed / 2 failed — both failures are the two findings above, one now a divergent-double fix, one the armed #1201 net

🤖 Generated with [Claude Code](https://claude.com/claude-code)
