### PR TITLE
fix: send ledger status needsReason as camelCase on the wire

### DIFF
--- a/src/ledger/spec.rs
+++ b/src/ledger/spec.rs
@@ -136,6 +136,15 @@ pub struct StatusSpec {
     #[serde(default)]
     pub closed: bool,
     /// Whether closing into this status demands a `reason`.
+    ///
+    /// Plain snake_case on purpose (issue #1266's near-miss): this type is
+    /// also what a declared ledger round-trips through in every store
+    /// backend (`store/fs_ops.rs`, `sqlite.rs`, `mongodb.rs` all persist
+    /// `LedgerSpec` via this same `Serialize`/`Deserialize`), so a rename
+    /// here would make Serialize write one key and Deserialize expect
+    /// another — silently dropping `needs_reason` back to `false` on the
+    /// very next reload. The console-facing camelCase key belongs on a
+    /// wire-only DTO instead — see `server::ops::ledgers::LedgerStatusDto`.
     #[serde(default)]
     pub needs_reason: bool,
 }

--- a/src/ledger/spec_test.rs
+++ b/src/ledger/spec_test.rs
@@ -34,6 +34,28 @@ fn a_minimal_declaration_parses() {
     assert!(spec.written_by.contains("record_entry"));
 }
 
+/// **`StatusSpec` itself stays snake_case both ways** (issue #1266's
+/// near-miss): it is also what a declared ledger round-trips through in
+/// every store backend, so `needs_reason` in must equal `needs_reason` out
+/// or a save-then-reload silently drops the flag back to `false`. The
+/// console-facing camelCase key lives on a wire-only DTO instead
+/// (`server::ops::ledgers::LedgerStatusDto`), covered by
+/// `ledgers_test.rs`'s `a_status_that_needs_a_reason_carries_camel_case_on_the_wire`.
+#[test]
+fn status_spec_round_trips_needs_reason_through_its_own_serde_unchanged() {
+    let spec = parse(&minimal(), false).expect("declaration still parses with needs_reason");
+    let status = spec.status("closed").expect("the closed status");
+    assert!(status.needs_reason);
+
+    let wire = serde_json::to_value(status).unwrap();
+    assert_eq!(wire["needs_reason"], true);
+    let restored: StatusSpec = serde_json::from_value(wire).unwrap();
+    assert!(
+        restored.needs_reason,
+        "a store round-trip through this type's own serde must not lose the flag"
+    );
+}
+
 #[test]
 fn a_ledger_needs_exactly_one_id_field() {
     let mut document = minimal();

--- a/src/server/ops/ledgers.rs
+++ b/src/server/ops/ledgers.rs
@@ -47,6 +47,35 @@ pub fn router() -> Router<AppState> {
         ))
 }
 
+/// One status, wire-shaped for the console (issue #1266).
+///
+/// `crate::ledger::StatusSpec` stays plain snake_case in both directions,
+/// because it is also what a declared ledger round-trips through in every
+/// store backend — a rename there would make a save write one key and a
+/// reload expect another, silently dropping `needs_reason` back to `false`.
+/// This DTO exists so the API-output shape can be camelCase (matching every
+/// other field `LedgerSummary` sends) without that type doing double duty.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LedgerStatusDto {
+    name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    label: String,
+    closed: bool,
+    needs_reason: bool,
+}
+
+impl From<&crate::ledger::StatusSpec> for LedgerStatusDto {
+    fn from(status: &crate::ledger::StatusSpec) -> Self {
+        Self {
+            name: status.name.clone(),
+            label: status.label.clone(),
+            closed: status.closed,
+            needs_reason: status.needs_reason,
+        }
+    }
+}
+
 /// One ledger as the console lists it.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -65,7 +94,7 @@ struct LedgerSummary {
     /// Whether the runtime ships it. A built-in cannot be retired.
     builtin: bool,
     fields: Vec<crate::ledger::Field>,
-    statuses: Vec<crate::ledger::StatusSpec>,
+    statuses: Vec<LedgerStatusDto>,
     sections: Vec<crate::ledger::Section>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     writers: Vec<String>,
@@ -211,7 +240,7 @@ async fn summary(ctx: &ledgers::Ledgers, spec: &LedgerSpec) -> Result<LedgerSumm
         written_by: spec.written_by.clone(),
         builtin: spec.builtin,
         fields: spec.fields.clone(),
-        statuses: spec.statuses.clone(),
+        statuses: spec.statuses.iter().map(LedgerStatusDto::from).collect(),
         sections: spec.sections.clone(),
         writers: spec.writers.clone(),
         open: entries.open_count(spec),

--- a/src/server/ops/ledgers_test.rs
+++ b/src/server/ops/ledgers_test.rs
@@ -169,6 +169,33 @@ async fn a_ledger_round_trips_under_both_scope_forms() {
     assert_eq!(read["entries"][0]["id"], "vendor-slip");
 }
 
+/// **The wire regression, pinned.** `StatusSpec::needs_reason` used to
+/// serialize snake_case like every other declaration field, but the console
+/// reads `LedgerStatus.needsReason` — camelCase, matching `LedgerSummary`'s
+/// own `#[serde(rename_all = "camelCase")]`. The mismatch meant
+/// `statusNeedsReason()` always read `undefined` and never fired the console's
+/// "ask for a reason before closing" guard on any declared ledger (issue
+/// #1266). This reads the same field off the same response shape the
+/// frontend receives.
+#[tokio::test]
+async fn a_status_that_needs_a_reason_carries_camel_case_on_the_wire() {
+    let (state, _home) = state().await;
+    let (status, created) = send(&state, "POST", "/api/v1/company/ledgers", Some(risks())).await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+
+    let closed_status = created["statuses"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["name"] == "closed")
+        .expect("the closed status");
+    assert_eq!(closed_status["needsReason"], true, "{closed_status}");
+    assert!(
+        closed_status.get("needs_reason").is_none(),
+        "wire response must not also carry the snake_case key: {closed_status}"
+    );
+}
+
 /// The console renders the same Markdown the workspace holds, served from the
 /// derivation rather than by reading the file back — so a workspace write that
 /// failed can never show a stale page.


### PR DESCRIPTION
## Summary

Closes #1266.

The console's "ask for a reason before closing a ledger entry" guard never
fired on any declared ledger. The server sent a status's flag as
`StatusSpec::needs_reason` — plain snake_case — while the frontend's
`LedgerStatus.needsReason` (and every consumer of `statusNeedsReason()`)
expected camelCase. `LedgerSummary` in `src/server/ops/ledgers.rs` is
`#[serde(rename_all = "camelCase")]`, but that attribute does not recurse
into a nested type's own serde impl — it embedded `StatusSpec` verbatim, so
`needs_reason` stayed snake_case on the wire regardless.

## Root cause and the approach that looked right but wasn't

The obvious fix is renaming `StatusSpec::needs_reason` to serialize as
`needsReason`. **That was tried first and reverted** — `StatusSpec` is not
just an API response type, it's also the shape a declared ledger round-trips
through in every store backend (`store/fs_ops.rs`, `sqlite.rs`,
`mongodb.rs`). An asymmetric `#[serde(rename = "needsReason")]` on
`Serialize` alone (or a mismatched `alias`) makes a save write one key and a
later `Deserialize` expect the other — silently dropping the flag back to
`false` on the very next reload. This broke the existing
`closing_without_a_reason_is_a_400_that_says_so` test, which is exactly the
regression it would have introduced in production.

The correct fix keeps `StatusSpec` plain snake_case in both directions (see
the doc comment on `needs_reason` in `src/ledger/spec.rs`) and adds a
wire-only `LedgerStatusDto` in `src/server/ops/ledgers.rs`
(`#[serde(rename_all = "camelCase")]`, with `From<&StatusSpec>`).
`LedgerSummary.statuses` now builds through that DTO instead of embedding
`StatusSpec` directly.

## Tests added

- `src/server/ops/ledgers_test.rs`:
  `a_status_that_needs_a_reason_carries_camel_case_on_the_wire` — HTTP-level,
  asserts the wire response carries `needsReason` and not `needs_reason`.
- `src/ledger/spec_test.rs`:
  `status_spec_round_trips_needs_reason_through_its_own_serde_unchanged` —
  proves `StatusSpec`'s own serde round-trips the flag correctly, guarding
  against the exact regression the rejected approach would have caused.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --features openhuman,tinycortex,mcp -- -D warnings` — clean
- `cargo test --lib ledger --features openhuman,tinycortex,mcp` — 159 passed
  (including `closing_without_a_reason_is_a_400_that_says_so`, previously
  broken under the rejected approach)
- `cargo test --lib --features openhuman,tinycortex,mcp` — 4746 passed, 0
  failed, 3 ignored (full suite, after merging in `upstream/main`)
- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` —
  all clean (no frontend source change needed; it was already reading
  `needsReason` correctly per the issue)
- **Browser verification**: built the binary and console, ran a local host
  with `agentic_software_company`, opened the built-in Goals ledger, and
  drove the "New row" dialog. Selecting a closing status (`met`) with no
  reason disables the Record button and shows "Closing into `met` needs a
  reason. A row that does not say why it closed is worth nothing to whoever
  reads it next." Filling in a reason enables Record and the row lands in
  the Met column — confirming the fix actually changes user-visible
  behavior, not just green tests.
- Merged `upstream/main` (39 commits, including changes to
  `frontend/src/views/LedgersView.tsx`) with no conflicts; re-ran all of the
  above after the merge.

## Commands run locally

```
cargo fmt --all -- --check
cargo clippy --all-targets --features openhuman,tinycortex,mcp -- -D warnings
cargo test --lib ledger --features openhuman,tinycortex,mcp
cargo test --lib --features openhuman,tinycortex,mcp
npm run typecheck
npm run typecheck:unit
npm run typecheck:e2e
```