### PR TITLE
ci(staging): publish the tenant image via ConfigMap instead of restarting the manager

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -208,10 +208,24 @@ jobs:
           # alone (opencompany-microservice#38).
           #
           # Updating a ConfigMap does not touch the Deployment, so nothing rolls.
-          if kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
-               -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE_FILE")].value}' \
-             | grep -q .; then
+          # Resolved once and reused by the closing report, so the two can never
+          # disagree about which source is actually governing provisioning.
+          MOUNT_PATH=$(kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE_FILE")].value}')
+          if [ -n "${MOUNT_PATH}" ]; then
             echo "Publishing OCM_TENANT_IMAGE=${IMAGE} via ConfigMap (no manager restart)"
+
+            # Captured BEFORE the write so a failed verification can put the
+            # cluster back as it was. `HAD_CM` distinguishes "no ConfigMap yet"
+            # from "ConfigMap with an empty value", which need different undos.
+            HAD_CM=no
+            PRIOR_IMAGE=
+            if kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" >/dev/null 2>&1; then
+              HAD_CM=yes
+              PRIOR_IMAGE=$(kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" \
+                -o jsonpath='{.data.image}' 2>/dev/null || true)
+            fi
+
             kubectl -n "${K8S_NAMESPACE}" create configmap "${TENANT_IMAGE_CM}" \
               --from-literal=image="${IMAGE}" --dry-run=client -o yaml \
             | kubectl apply -f -
@@ -220,8 +234,6 @@ jobs:
             # minute. Confirm the manager actually SEES the new value rather than
             # assuming the write reached it — a silent miss here would provision
             # new tenants on the previous image with nothing to indicate it.
-            MOUNT_PATH=$(kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
-              -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE_FILE")].value}')
             seen=no
             for _ in $(seq 1 40); do
               current=$(kubectl -n "${K8S_NAMESPACE}" exec "deploy/${MANAGER_DEPLOY}" \
@@ -232,6 +244,21 @@ jobs:
             if [ "${seen}" != yes ]; then
               echo "ERROR: manager still does not see ${IMAGE} at ${MOUNT_PATH} after 200s" >&2
               echo "       it currently reads: ${current:-<empty>}" >&2
+              # Put the ConfigMap back. Leaving the new value in place would mean
+              # a FAILED deploy still eventually governs provisioning, once the
+              # kubelet gets round to refreshing the mount -- new tenants coming
+              # up on an image this deploy explicitly could not verify. That is
+              # the silent miss the verification exists to prevent, arriving late
+              # instead of never.
+              if [ "${HAD_CM}" = yes ]; then
+                echo "       restoring previous value: ${PRIOR_IMAGE:-<empty>}" >&2
+                kubectl -n "${K8S_NAMESPACE}" create configmap "${TENANT_IMAGE_CM}" \
+                  --from-literal=image="${PRIOR_IMAGE}" --dry-run=client -o yaml \
+                | kubectl apply -f - >&2
+              else
+                echo "       removing the ConfigMap this deploy created" >&2
+                kubectl -n "${K8S_NAMESPACE}" delete configmap "${TENANT_IMAGE_CM}" --ignore-not-found >&2
+              fi
               exit 1
             fi
             echo "Manager sees ${IMAGE}"
@@ -370,11 +397,15 @@ jobs:
             exit 1
           }
 
-          # Report the value that actually governs provisioning: the ConfigMap
-          # when the manager reads one, the env var otherwise.
-          if kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" >/dev/null 2>&1; then
-            echo "fleet tenant image (ConfigMap): $(kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" -o jsonpath='{.data.image}')"
+          # Exactly one source, chosen by the same capability check that decided
+          # where the value was written. Keying this on ConfigMap EXISTENCE
+          # instead would print a stale ConfigMap left by an earlier deploy
+          # alongside the env var, with nothing to say which one a tenant would
+          # actually get.
+          if [ -n "${MOUNT_PATH}" ]; then
+            echo "fleet tenant image (ConfigMap, authoritative): $(kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" -o jsonpath='{.data.image}' 2>/dev/null)"
+          else
+            kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
+              -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE")]}fleet tenant image (env, authoritative)={.value}{"\n"}{end}'
           fi
-          kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
-            -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE")]}OCM_TENANT_IMAGE (fallback)={.value}{"\n"}{end}'
           EOF

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -59,6 +59,9 @@ env:
   ECR_REPOSITORY: tinyhumansai/opencompany-tenant
   K8S_NAMESPACE: opencompany-system
   MANAGER_DEPLOY: opencompany-manager
+  # Holds the fleet-default tenant image outside the manager's pod template, so
+  # publishing it does not roll the manager (opencompany-microservice#38).
+  TENANT_IMAGE_CM: opencompany-tenant-image
   # The feature set the hosted tenant ships with. Changing it changes what
   # every tenant can do, so treat edits here as a product change, not a CI
   # tweak. Full belt: adds mcp/media/composio (the credential/real-money tool
@@ -131,7 +134,7 @@ jobs:
           REFRESH_ALL: ${{ inputs.refresh_all_tenants }}
         run: |
           ssh root@${SSH_HOST} \
-            "IMAGE='${IMAGE}' K8S_NAMESPACE='${{ env.K8S_NAMESPACE }}' MANAGER_DEPLOY='${{ env.MANAGER_DEPLOY }}' REFRESH_ALL='${REFRESH_ALL:-false}' bash -s" << 'EOF'
+            "IMAGE='${IMAGE}' K8S_NAMESPACE='${{ env.K8S_NAMESPACE }}' MANAGER_DEPLOY='${{ env.MANAGER_DEPLOY }}' TENANT_IMAGE_CM='${{ env.TENANT_IMAGE_CM }}' REFRESH_ALL='${REFRESH_ALL:-false}' bash -s" << 'EOF'
           set -euo pipefail
           export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
@@ -194,17 +197,61 @@ jobs:
           # re-pulled. The manager must be pointed at the immutable
           # staging-<sha> tag, which a tag not already present locally always
           # fetches. Never "deploy" by re-pushing :staging.
-          echo "Setting OCM_TENANT_IMAGE=${IMAGE}"
-          kubectl -n "${K8S_NAMESPACE}" set env "deploy/${MANAGER_DEPLOY}" "OCM_TENANT_IMAGE=${IMAGE}"
+          #
+          # Publish it through a ConfigMap rather than an env var on the manager
+          # Deployment. An env var is part of the pod template, so `set env`
+          # created a new ReplicaSet on EVERY tenant build — and the manager's
+          # strategy is Recreate (SQLite: never two writers), so the old pod
+          # stopped completely before the new one started. The manager proxies
+          # every hosted tenant, so each of those gaps took the whole fleet
+          # offline. On 2026-08-20 that happened nine times from this workflow
+          # alone (opencompany-microservice#38).
+          #
+          # Updating a ConfigMap does not touch the Deployment, so nothing rolls.
+          if kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
+               -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE_FILE")].value}' \
+             | grep -q .; then
+            echo "Publishing OCM_TENANT_IMAGE=${IMAGE} via ConfigMap (no manager restart)"
+            kubectl -n "${K8S_NAMESPACE}" create configmap "${TENANT_IMAGE_CM}" \
+              --from-literal=image="${IMAGE}" --dry-run=client -o yaml \
+            | kubectl apply -f -
 
-          if ! kubectl -n "${K8S_NAMESPACE}" rollout status "deploy/${MANAGER_DEPLOY}" --timeout=300s; then
-            echo "ERROR: manager did not roll out; events and logs follow" >&2
-            kubectl -n "${K8S_NAMESPACE}" describe "deploy/${MANAGER_DEPLOY}" | tail -30 >&2
-            kubectl -n "${K8S_NAMESPACE}" logs "deploy/${MANAGER_DEPLOY}" --tail=100 >&2 || true
-            echo "Rolling back..." >&2
-            kubectl -n "${K8S_NAMESPACE}" rollout undo "deploy/${MANAGER_DEPLOY}"
-            kubectl -n "${K8S_NAMESPACE}" rollout status "deploy/${MANAGER_DEPLOY}" --timeout=180s >&2 || true
-            exit 1
+            # The kubelet refreshes a ConfigMap mount lazily, typically within a
+            # minute. Confirm the manager actually SEES the new value rather than
+            # assuming the write reached it — a silent miss here would provision
+            # new tenants on the previous image with nothing to indicate it.
+            MOUNT_PATH=$(kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
+              -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE_FILE")].value}')
+            seen=no
+            for _ in $(seq 1 40); do
+              current=$(kubectl -n "${K8S_NAMESPACE}" exec "deploy/${MANAGER_DEPLOY}" \
+                -- cat "${MOUNT_PATH}" 2>/dev/null | tr -d '[:space:]' || true)
+              if [ "${current}" = "${IMAGE}" ]; then seen=yes; break; fi
+              sleep 5
+            done
+            if [ "${seen}" != yes ]; then
+              echo "ERROR: manager still does not see ${IMAGE} at ${MOUNT_PATH} after 200s" >&2
+              echo "       it currently reads: ${current:-<empty>}" >&2
+              exit 1
+            fi
+            echo "Manager sees ${IMAGE}"
+          else
+            # A manager predating OCM_TENANT_IMAGE_FILE ignores the ConfigMap
+            # entirely, so falling through to the ConfigMap alone would silently
+            # leave new tenants on the old image. Keep the old path for it,
+            # restart and all, rather than failing the deploy.
+            echo "Manager has no OCM_TENANT_IMAGE_FILE; falling back to set env (this restarts it)"
+            kubectl -n "${K8S_NAMESPACE}" set env "deploy/${MANAGER_DEPLOY}" "OCM_TENANT_IMAGE=${IMAGE}"
+
+            if ! kubectl -n "${K8S_NAMESPACE}" rollout status "deploy/${MANAGER_DEPLOY}" --timeout=300s; then
+              echo "ERROR: manager did not roll out; events and logs follow" >&2
+              kubectl -n "${K8S_NAMESPACE}" describe "deploy/${MANAGER_DEPLOY}" | tail -30 >&2
+              kubectl -n "${K8S_NAMESPACE}" logs "deploy/${MANAGER_DEPLOY}" --tail=100 >&2 || true
+              echo "Rolling back..." >&2
+              kubectl -n "${K8S_NAMESPACE}" rollout undo "deploy/${MANAGER_DEPLOY}"
+              kubectl -n "${K8S_NAMESPACE}" rollout status "deploy/${MANAGER_DEPLOY}" --timeout=180s >&2 || true
+              exit 1
+            fi
           fi
 
           # OCM_TENANT_IMAGE only reaches a tenant when the manager PROVISIONS
@@ -323,6 +370,11 @@ jobs:
             exit 1
           }
 
+          # Report the value that actually governs provisioning: the ConfigMap
+          # when the manager reads one, the env var otherwise.
+          if kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" >/dev/null 2>&1; then
+            echo "fleet tenant image (ConfigMap): $(kubectl -n "${K8S_NAMESPACE}" get configmap "${TENANT_IMAGE_CM}" -o jsonpath='{.data.image}')"
+          fi
           kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
-            -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE")]}OCM_TENANT_IMAGE={.value}{"\n"}{end}'
+            -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE")]}OCM_TENANT_IMAGE (fallback)={.value}{"\n"}{end}'
           EOF


### PR DESCRIPTION
Completes `opencompany-microservice#38`. **This is the step that actually stops the restarts** — the manager and cluster halves are already merged and deployed.

## The problem this workflow was causing

This workflow set `OCM_TENANT_IMAGE` with `kubectl set env` on the **manager's** Deployment. An env var is part of the pod template, so every tenant build created a new ReplicaSet — and the manager's strategy is `Recreate` (SQLite: never two writers), so the old pod stopped **completely** before the new one started.

The manager proxies every hosted tenant. Each of those gaps took the entire fleet offline — not degraded, failing.

**On 2026-08-20 there were eleven manager ReplicaSets. Three were manager deploys; the other nine came from this workflow.** Each gap is a handful of seconds, nothing alerts on it, and nobody had noticed. It surfaced only because a load test halted mid-run and the cause turned out to be unrelated to load.

## The change

Publish the image through a ConfigMap the manager reads via a mounted file. Updating a ConfigMap does not touch the Deployment, so nothing rolls.

```sh
kubectl -n "${K8S_NAMESPACE}" create configmap "${TENANT_IMAGE_CM}" \
  --from-literal=image="${IMAGE}" --dry-run=client -o yaml | kubectl apply -f -
```

## Two things that are deliberate, not incidental

**The old `set env` path is kept, behind a capability check.** A manager predating `OCM_TENANT_IMAGE_FILE` ignores the ConfigMap entirely, so writing only the ConfigMap would leave new tenants silently provisioning on the *previous* image — a worse failure than the restart, because nothing would report it. The check reads the env var straight off the live Deployment, so this picks the right path per-cluster with **no ordering requirement between repos** and no coordination needed.

**The write is verified, not assumed.** The kubelet refreshes a mount lazily, typically within a minute, so the workflow polls the manager until it reads back the exact image (up to 200s) and fails the deploy if it never does.

That second one matters: this change exists to remove a failure nothing was watching for. Replacing it with a *different* silent failure — a ConfigMap write that never reaches the manager — would be a poor trade.

## Verification

- workflow YAML parses
- the embedded remote script passes `bash -n`
- **the capability-detection jsonpath was run against live staging**, where it correctly selects the ConfigMap branch and reads back the currently-deployed image:

```
detection jsonpath -> /etc/opencompany/tenant-image/image
BRANCH: ConfigMap path (correct)
manager reads -> ...opencompany-tenant:staging-1e080ab4...
```

## Rollout state

```
✅ opencompany-microservice#39   manager reads the file        (merged, deployed)
✅ k8s#37                        ConfigMap + mount live         (merged, applied)
⬜ this PR                       workflow stops patching        ← stops the restarts
```

The ConfigMap on staging is already seeded with the current live image, so merging this changes *what* gets written, not what tenants run.

## Honest limits

- The fleet default only affects tenants provisioned **after** it changes — unchanged from before, and the `refresh_all_tenants` path still exists to move existing ones.
- The kubelet's ~60s refresh means the value is eventually-consistent rather than immediate. Fine for image rollouts, and the verify loop covers it, but worth stating rather than discovering.
- This does not stop the manager restarting on **its own** deploys, which is correct and unavoidable.

## Related

`opencompany-microservice#38` also notes that nothing watches for manager unavailability at all. Even after this, a `Recreate` manager has gaps on its own deploys, and today nothing distinguishes "brief expected gap" from "down for ten minutes".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved staging deployments by supporting tenant image updates through a shared configuration setting.
  * Added verification that supported managers use the updated image without requiring a restart.
  * Preserved fallback deployment behavior for older manager versions.
  * Enhanced deployment reporting to show the active tenant image and identify fallback configuration usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->