### PR TITLE
Memory data lifecycle: facts in the bundle, live-engine export/import, engine-to-engine migrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1135,6 +1135,13 @@ jobs:
 
       - name: Test the memory engine selection surface
         run: scripts/ci/run-scoped-suite.sh "tinymemory selection" acp,runner,tinymemory store::select
+      # The `memory migrate` / bundle-command guards live in the lib
+      # (store::memory::migrate, store::select) and run above; this executes
+      # the bin target's own tests under the same features so nothing
+      # bin-resident is ever compile-only again (#1279 review: no lane ran
+      # `cargo test --bin` at any feature set).
+      - name: Bin tests (tinymemory)
+        run: cargo test --locked --features acp,runner,tinymemory --bin opencompany
 
       # Issue #1113 gave `tinymemory-embedded` its own lane; these two steps are
       # that lane moved onto the union of the openhuman+tinycortex core and the

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ worktrees/*
 # which is the one thing that file exists not to do.
 instance-id
 .lock
+/target

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -343,8 +343,9 @@ hosted) is a possible future refinement of *routing*, not of selection.
 ## Switching engines — the operator runbook
 
 Selection is infra-operator only (previous section), so switching is an env
-flip plus a restart — and because **nothing migrates between engines** (a
-switched engine starts empty by design), the data step comes first.
+flip plus a restart — and because **the flip alone moves no data** (a
+switched engine starts empty until something puts records in it), the
+migration below is the step that moves it, and it comes first.
 
 0. **Stop the writes.** Pause the workload (or scale the tenant to zero)
    before migrating: the copy is page-by-page with no dual-write, so anything

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -358,8 +358,9 @@ switched engine starts empty by design), the data step comes first.
    environment yet, so it still names the old engine) into the target, over
    the contract's Portability family: namespaces, record kinds and provenance
    taint round-trip untouched. `--dry-run` counts first; a stopped run prints
-   the `--resume-cursor` to re-enter at (already-present records re-import as
-   `skipped`, so re-running a failed page is safe). Hosted targets warn about
+   the `--resume-cursor` to re-enter at (import is idempotent by
+   `(namespace, key)`, so re-running a failed page cannot duplicate — drivers
+   that detect presence report `skipped`, the rest overwrite in place). Hosted targets warn about
    their enumeration-based write cost. The `store` default and the
    EngineCortex overlay have no provider seam and are refused by name — for
    those, `opencompany export` now reads the live engine (base backend plus

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -370,9 +370,13 @@ switched engine starts empty by design), the data step comes first.
    namespace the source credential can see crosses, which is exactly right
    when each tenant has its own hosted account and credential — and exactly
    wrong if two tenants ever shared one, so keep hosted memory credentials
-   per-tenant. And the target credential arrives as a CLI flag: run the
-   command through `kubectl exec` (or equivalent) without a shell history,
-   the same care the env patch itself gets.
+   per-tenant. And pass the target credential through
+   `OPENCOMPANY_MEMORY_TARGET_API_KEY`, not `--to-api-key`: a flag sits in
+   `/proc/<pid>/cmdline`, world-readable for the whole (possibly long) run,
+   which no shell-history hygiene fixes. The flag remains only for
+   compatibility. On completion the command re-counts the **target's own**
+   export as a receipt, so the evidence is the target's answer rather than
+   the migration's own counters.
 2. **Set the variables** for the target engine (the `.env.example` block names
    all five). A hosted engine needs the build to carry the `tinymemory`
    feature; `namespace` needs `tinymemory-embedded`. A feature-less build

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -346,10 +346,32 @@ Selection is infra-operator only (previous section), so switching is an env
 flip plus a restart — and because **nothing migrates between engines** (a
 switched engine starts empty by design), the data step comes first.
 
-1. **Export what the live engine holds** (until `export` reads the live
-   overlay, capture what matters by hand — the gap is tracked in the P1
-   follow-ups). A future `opencompany memory migrate --from --to` built on the
-   contract's Portability family is the intended tool here.
+0. **Stop the writes.** Pause the workload (or scale the tenant to zero)
+   before migrating: the copy is page-by-page with no dual-write, so anything
+   a live cycle writes to the source *after* its page was exported is lost to
+   the target. The export cursor is also the source driver's own — against a
+   store that keeps changing underneath it, a hosted cursor can skip or repeat
+   rows. A paused company loses nothing: chat still parks, and the whole
+   procedure is one restart long anyway.
+1. **Move the data.** `opencompany memory migrate --to <driver>` copies every
+   record from the env-selected engine (the source — you have not flipped the
+   environment yet, so it still names the old engine) into the target, over
+   the contract's Portability family: namespaces, record kinds and provenance
+   taint round-trip untouched. `--dry-run` counts first; a stopped run prints
+   the `--resume-cursor` to re-enter at (already-present records re-import as
+   `skipped`, so re-running a failed page is safe). Hosted targets warn about
+   their enumeration-based write cost. The `store` default and the
+   EngineCortex overlay have no provider seam and are refused by name — for
+   those, `opencompany export` now reads the live engine (base backend plus
+   memory overlay, operator facts included) and is the capture tool.
+
+   Two hosted-deployment cautions. The copy is **engine-level**: every
+   namespace the source credential can see crosses, which is exactly right
+   when each tenant has its own hosted account and credential — and exactly
+   wrong if two tenants ever shared one, so keep hosted memory credentials
+   per-tenant. And the target credential arrives as a CLI flag: run the
+   command through `kubectl exec` (or equivalent) without a shell history,
+   the same care the env patch itself gets.
 2. **Set the variables** for the target engine (the `.env.example` block names
    all five). A hosted engine needs the build to carry the `tinymemory`
    feature; `namespace` needs `tinymemory-embedded`. A feature-less build

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -898,37 +898,13 @@ async fn live_ports(
     Option<Arc<dyn opencompany::ports::FactStore>>,
 )> {
     use opencompany::store::{
-        FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsOps, MemoryBackend,
-        StorageKind, StorageSettings, open_memory_overlay, open_storage,
+        FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsOps, StorageSettings,
+        open_memory_overlay, open_storage,
     };
     let settings = StorageSettings::from_env()?;
-    let live = settings.kind != StorageKind::Fs || settings.memory_backend != MemoryBackend::Store;
-    if settings.memory_backend == MemoryBackend::Null {
-        return Err(opencompany::error::OpenCompanyError::Config(
-            "OPENCOMPANY_MEMORY=null retains nothing: an export would capture no memory and an \
-             import would discard every record while reporting success. Unset OPENCOMPANY_MEMORY \
-             for bundle operations."
-                .into(),
-        ));
-    }
-    if live && home_was_flagged {
-        return Err(opencompany::error::OpenCompanyError::Config(format!(
-            "--home names an fs data set, but this environment selects storage `{}` and memory \
-             `{}` — the bundle would mix two deployments. Unset OPENCOMPANY_STORAGE and \
-             OPENCOMPANY_MEMORY* to operate on the fs home, or drop --home to operate on the \
-             live deployment.",
-            settings.kind.as_str(),
-            settings.memory_backend.as_str()
-        )));
-    }
-    if live && std::env::var("OPENCOMPANY_TENANT_ID").is_ok_and(|t| !t.trim().is_empty()) {
-        return Err(opencompany::error::OpenCompanyError::Config(
-            "shared-single-DB tenant mode (OPENCOMPANY_TENANT_ID) namespaces company ids and \
-             owner rows at the app layer; bundle operations write neither. Run them without \
-             tenant mode, from the manager path."
-                .into(),
-        ));
-    }
+    // Every refusal lives in the lib (`store::select::refuse_bundle_env`)
+    // where the feature lanes execute its tests; the bin only reports.
+    opencompany::store::refuse_bundle_env(&settings, home_was_flagged)?;
     let (store, events, mut memory, mut context, mut facts) = match open_storage(&settings, home)
         .await?
     {
@@ -1171,6 +1147,20 @@ async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result
     let ((store, events, memory, context), facts) = live_ports(&home, home_was_flagged).await?;
     let id = import_bundle(&root, store, events, memory, context, facts).await?;
     restore_fs_artifacts(&root, Bundle::new(home.clone(), &id).dir()).await?;
+    // On a non-fs base backend the records above went to the live backend
+    // while these artifacts (secrets/, keys/) are fs-only by design and land
+    // under the resolved home. Same split serve itself runs with there — but
+    // say it, so a restore onto a fresh pod knows to mount that home.
+    let settings = opencompany::store::StorageSettings::from_env()?;
+    if settings.kind != opencompany::store::StorageKind::Fs {
+        eprintln!(
+            "note: records imported into the live `{}` backend; fs-only artifacts (secrets/, \
+             keys/) restored under {} — on an ephemeral filesystem, re-provision them there \
+             after a pod replacement.",
+            settings.kind.as_str(),
+            home.display()
+        );
+    }
     println!("imported company `{id}` into {}", home.display());
     Ok(())
 }
@@ -1184,9 +1174,9 @@ async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result
 /// `store` default and the EngineCortex overlay are refused by name.
 #[cfg(feature = "tinymemory")]
 async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
-    use opencompany::store::memory::driver::{MemoryDriverConfig, MemoryMode, open_driver};
+    use opencompany::store::StorageSettings;
+    use opencompany::store::memory::driver::{MemoryMode, open_driver};
     use opencompany::store::memory::migrate::migrate;
-    use opencompany::store::{MemoryBackend, StorageSettings};
 
     let MemoryCmd::Migrate {
         to,
@@ -1199,125 +1189,40 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
     } = cmd;
 
     let settings = StorageSettings::from_env()?;
-    let from_mode = match settings.memory_backend {
-        MemoryBackend::Store => {
-            return Err(opencompany::error::OpenCompanyError::Config(
-                "OPENCOMPANY_MEMORY=store: the base backend serves memory directly and has no \
-                 provider seam to export through. Use `opencompany export` for a bundle instead."
-                    .into(),
-            ));
-        }
-        MemoryBackend::Null => {
-            return Err(opencompany::error::OpenCompanyError::Config(
-                "OPENCOMPANY_MEMORY=null retains nothing; there is nothing to migrate.".into(),
-            ));
-        }
-        MemoryBackend::Tinycortex
-            if settings
-                .memory_driver
-                .as_deref()
-                .map(str::trim)
-                .filter(|d| !d.is_empty())
-                .is_none() =>
-        {
-            return Err(opencompany::error::OpenCompanyError::Config(
-                "OPENCOMPANY_MEMORY=embedded without OPENCOMPANY_MEMORY_DRIVER is the \
-                 EngineCortex overlay, which is driven directly rather than through the \
-                 provider seam — its data cannot migrate through this command. Use \
-                 `opencompany export` for a bundle of what it holds."
-                    .into(),
-            ));
-        }
-        MemoryBackend::Tinycortex => MemoryMode::Embedded,
-        MemoryBackend::Remote => MemoryMode::Remote,
-    };
-    let from_config = MemoryDriverConfig {
-        mode: from_mode,
-        driver_id: settings.memory_driver.clone(),
-        url: settings.memory_url.clone(),
-        api_key: settings.memory_api_key.clone(),
-        data_dir: settings.data_dir.clone(),
-    };
+    // The credential prefers the environment: argv is world-readable in
+    // /proc/<pid>/cmdline for the whole (possibly long) run. --to-api-key
+    // stays for compatibility but the env var is the documented channel.
+    let to_api_key = to_api_key.or_else(|| {
+        std::env::var("OPENCOMPANY_MEMORY_TARGET_API_KEY")
+            .ok()
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty())
+    });
+    // Every refusal and both configurations come from the lib
+    // (`store::memory::migrate::resolve_migrate_configs`), where the feature
+    // lanes execute the guards' tests; the bin drives the loop and reports.
+    let (from_config, to_config) = opencompany::store::memory::migrate::resolve_migrate_configs(
+        &settings,
+        &to,
+        to_url,
+        to_api_key,
+        to_data_dir,
+    )?;
 
-    let to_config = match to.as_str() {
-        "namespace" => {
-            // The same durability refusal `open_provider` enforces at boot
-            // (src/store/select.rs): on a mongodb base, /data is ephemeral
-            // scratch, and a migration that "succeeds" into it is data loss
-            // with a success message — worse than the refusal.
-            if settings.kind == opencompany::store::StorageKind::Mongodb
-                && !settings.allow_ephemeral_memory
-            {
-                return Err(opencompany::error::OpenCompanyError::Config(
-                    "OPENCOMPANY_STORAGE=mongodb treats the data dir as ephemeral scratch, and \
-                     the boot path refuses the namespace driver there for exactly that reason. \
-                     Migrating into it would report success on data the next container \
-                     replacement deletes. If the data dir is genuinely a durable volume, assert \
-                     it with OPENCOMPANY_MEMORY_ALLOW_EPHEMERAL=1."
-                        .into(),
-                ));
-            }
-            MemoryDriverConfig {
-                mode: MemoryMode::Embedded,
-                driver_id: Some(to.clone()),
-                url: None,
-                api_key: None,
-                data_dir: to_data_dir.clone().or_else(|| settings.data_dir.clone()),
-            }
-        }
-        "supermemory" | "mem0" | "cognee" => MemoryDriverConfig {
-            mode: MemoryMode::Remote,
-            driver_id: Some(to.clone()),
-            url: to_url.clone(),
-            api_key: to_api_key.clone(),
-            data_dir: None,
-        },
-        "null" => {
-            return Err(opencompany::error::OpenCompanyError::Config(
-                "--to null would discard every record; that is `null`'s contract, not a \
-                 migration."
-                    .into(),
-            ));
-        }
-        other => {
-            return Err(opencompany::error::OpenCompanyError::Config(format!(
-                "--to {other} names no migratable driver: namespace, supermemory, mem0, cognee."
-            )));
-        }
+    // The same exclusive root lock serve holds, whenever an embedded store is
+    // on either side: a migration reading a SQLite store a live host is
+    // writing walks a shifting export cursor (skipped or repeated records).
+    // Hosted-to-hosted has no local store to lock; the pause-first
+    // precondition printed below still applies to the remote writer.
+    let _home_lock = if matches!(from_config.mode, MemoryMode::Embedded)
+        || matches!(to_config.mode, MemoryMode::Embedded)
+    {
+        Some(opencompany::store::lock::acquire(&resolve_home_migrated(
+            None,
+        )?)?)
+    } else {
+        None
     };
-
-    // Same engine, same target = a copy onto itself: on the embedded store it
-    // is one SQLite file open twice; on a hosted store the export cursor
-    // shifts under the concurrent writes and records skip or repeat. Compared
-    // mode-aware and normalized, because the naive field-equality version
-    // could never fire remote-to-remote (the source carries the env data_dir,
-    // the target None) and let trailing-slash or whitespace spellings of the
-    // same location through.
-    let norm_id = |id: &Option<String>| id.as_deref().map(str::trim).map(str::to_owned);
-    let norm_url = |url: &Option<String>| {
-        url.as_deref()
-            .map(str::trim)
-            .map(|u| u.trim_end_matches('/').to_owned())
-    };
-    let norm_dir = |dir: &Option<PathBuf>| {
-        dir.as_ref()
-            .map(|d| d.components().collect::<std::path::PathBuf>())
-    };
-    let same_engine = from_config.mode == to_config.mode
-        && norm_id(&from_config.driver_id) == norm_id(&to_config.driver_id)
-        && match to_config.mode {
-            MemoryMode::Remote => norm_url(&from_config.url) == norm_url(&to_config.url),
-            MemoryMode::Embedded => {
-                norm_dir(&from_config.data_dir) == norm_dir(&to_config.data_dir)
-            }
-            MemoryMode::Null => true,
-        };
-    if same_engine {
-        return Err(opencompany::error::OpenCompanyError::Config(
-            "the source and the target are the same engine at the same location; nothing to do."
-                .into(),
-        ));
-    }
 
     let (from, _) = open_driver(&from_config)?.ok_or_else(|| {
         opencompany::error::OpenCompanyError::Config(
@@ -1331,23 +1236,12 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
     // writing anything" must mean the filesystem too.
     if dry_run {
         let resumed = resume_cursor.is_some();
-        let mut total: u64 = 0;
-        let mut cursor = resume_cursor;
-        loop {
-            let page = from
-                .export_page(cursor.as_deref(), page_size)
-                .await
-                .map_err(|e| {
-                    opencompany::error::OpenCompanyError::Store(format!(
-                        "source export failed: {e}"
-                    ))
-                })?;
-            total += page.records.len() as u64;
-            match page.next_cursor {
-                Some(next) => cursor = Some(next),
-                None => break,
-            }
-        }
+        let total = opencompany::store::memory::migrate::count_records(
+            &from,
+            resume_cursor.clone(),
+            page_size,
+        )
+        .await?;
         if resumed {
             println!(
                 "dry run (from --resume-cursor): {} records remain to migrate {} -> {}",
@@ -1404,11 +1298,34 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
     .await?;
     match outcome {
         Ok(summary) => {
-            println!(
-                "done: {} exported, {} imported, {} already present, over {} pages. Now flip \
-                 OPENCOMPANY_MEMORY* to the target, restart, and verify /spec.",
-                summary.exported, summary.imported, summary.skipped, summary.pages
-            );
+            // The receipt: count the TARGET's own export, so the operator's
+            // evidence is the target's answer rather than the migration's own
+            // counters. Costs one enumeration of the target — the same order
+            // of work the migration itself just did. Best-effort: a target
+            // that cannot re-export right now degrades the receipt to a
+            // warning, not the completed migration to a failure.
+            match opencompany::store::memory::migrate::count_records(&target, None, page_size).await
+            {
+                Ok(target_total) => {
+                    println!(
+                        "done: {} exported, {} imported, {} already present, over {} pages. \
+                         Target now exports {target_total} records (its own count, not ours). \
+                         Now flip OPENCOMPANY_MEMORY* to the target, restart, and verify /spec.",
+                        summary.exported, summary.imported, summary.skipped, summary.pages
+                    );
+                }
+                Err(e) => {
+                    println!(
+                        "done: {} exported, {} imported, {} already present, over {} pages. Now \
+                         flip OPENCOMPANY_MEMORY* to the target, restart, and verify /spec.",
+                        summary.exported, summary.imported, summary.skipped, summary.pages
+                    );
+                    eprintln!(
+                        "note: could not verify by re-counting the target ({e}); the counters \
+                         above are the migration's own."
+                    );
+                }
+            }
             Ok(())
         }
         Err(stopped) => {

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -879,17 +879,56 @@ fn resolve_home_migrated(flag: Option<PathBuf>) -> Result<PathBuf> {
 /// that is the wrong data, silently. Routing through the same selection
 /// `serve` uses means a bundle now reads and writes the live engine, and a
 /// misconfigured engine refuses here exactly as it refuses a boot.
+///
+/// One deployment per bundle, enforced: with a non-default environment
+/// (`OPENCOMPANY_STORAGE` or `OPENCOMPANY_MEMORY` set), an explicit `--home`
+/// is refused rather than mixed in — the base ports would come from the flag
+/// while the engine roots at `OPENCOMPANY_DATA_DIR`, and a bundle spanning
+/// two deployments is a company that never existed. Under the fs+store
+/// default the environment is inert and `--home` means exactly what it
+/// always has. `null` is refused in both directions (an export of nothing,
+/// an import into a black hole, both exiting 0), and so is shared-single-DB
+/// tenant mode (bundle ops write no owner rows; raw slugs would miss the
+/// `<tenant>--` namespaced ids).
 async fn live_ports(
     home: &std::path::Path,
+    home_was_flagged: bool,
 ) -> Result<(
     opencompany::store::export::Ports,
     Option<Arc<dyn opencompany::ports::FactStore>>,
 )> {
     use opencompany::store::{
-        FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsOps, StorageSettings,
-        open_memory_overlay, open_storage,
+        FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsOps, MemoryBackend,
+        StorageKind, StorageSettings, open_memory_overlay, open_storage,
     };
     let settings = StorageSettings::from_env()?;
+    let live = settings.kind != StorageKind::Fs || settings.memory_backend != MemoryBackend::Store;
+    if settings.memory_backend == MemoryBackend::Null {
+        return Err(opencompany::error::OpenCompanyError::Config(
+            "OPENCOMPANY_MEMORY=null retains nothing: an export would capture no memory and an \
+             import would discard every record while reporting success. Unset OPENCOMPANY_MEMORY \
+             for bundle operations."
+                .into(),
+        ));
+    }
+    if live && home_was_flagged {
+        return Err(opencompany::error::OpenCompanyError::Config(format!(
+            "--home names an fs data set, but this environment selects storage `{}` and memory \
+             `{}` — the bundle would mix two deployments. Unset OPENCOMPANY_STORAGE and \
+             OPENCOMPANY_MEMORY* to operate on the fs home, or drop --home to operate on the \
+             live deployment.",
+            settings.kind.as_str(),
+            settings.memory_backend.as_str()
+        )));
+    }
+    if live && std::env::var("OPENCOMPANY_TENANT_ID").is_ok_and(|t| !t.trim().is_empty()) {
+        return Err(opencompany::error::OpenCompanyError::Config(
+            "shared-single-DB tenant mode (OPENCOMPANY_TENANT_ID) namespaces company ids and \
+             owner rows at the app layer; bundle operations write neither. Run them without \
+             tenant mode, from the manager path."
+                .into(),
+        ));
+    }
     let (store, events, mut memory, mut context, mut facts) = match open_storage(&settings, home)
         .await?
     {
@@ -925,9 +964,10 @@ fn unique_temp(tag: &str) -> PathBuf {
     std::env::temp_dir().join(format!("opencompany-{tag}-{}-{nanos}", std::process::id()))
 }
 
-/// Exports `id`'s bundle over the fs ports into the directory `dest`.
+/// Exports `id`'s bundle over the selected ports into the directory `dest`.
 async fn export_to_dir(
     home: &std::path::Path,
+    home_was_flagged: bool,
     id: &CompanyId,
     include_secrets: bool,
     dest: &std::path::Path,
@@ -935,7 +975,11 @@ async fn export_to_dir(
     use opencompany::store::export::{ExportOpts, export_bundle};
     use opencompany::store::paths::Bundle;
 
-    let ((store, events, memory, context), facts) = live_ports(home).await?;
+    // The same exclusive root lock `serve` holds: a bundle read while the host
+    // is writing is torn, and the refusal here names the running process
+    // instead of silently racing it.
+    let _home_lock = opencompany::store::lock::acquire(home)?;
+    let ((store, events, memory, context), facts) = live_ports(home, home_was_flagged).await?;
     let opts = ExportOpts {
         include_secrets,
         fs_bundle: Some(Bundle::new(home.to_path_buf(), id).dir().to_path_buf()),
@@ -952,10 +996,11 @@ async fn run_export(
     include_secrets: bool,
     home: Option<PathBuf>,
 ) -> Result<()> {
+    let home_was_flagged = home.is_some();
     let home = resolve_home_migrated(home)?;
     let id = CompanyId::new(company);
     let dest = out.unwrap_or_else(|| PathBuf::from(format!("{}-bundle", id.as_ref())));
-    export_to_dir(&home, &id, include_secrets, &dest).await?;
+    export_to_dir(&home, home_was_flagged, &id, include_secrets, &dest).await?;
     println!(
         "exported bundle for `{id}` to {} (build with --features export to produce a .tar)",
         dest.display()
@@ -1059,6 +1104,7 @@ async fn run_export(
 ) -> Result<()> {
     use opencompany::store::export::pack_tar;
 
+    let home_was_flagged = home.is_some();
     let home = resolve_home_migrated(home)?;
     let id = CompanyId::new(company);
     let out = out.unwrap_or_else(|| PathBuf::from(format!("{}.tar", id.as_ref())));
@@ -1067,7 +1113,7 @@ async fn run_export(
     let staging = unique_temp("export");
     let bundle_dir = staging.join(id.as_ref());
     let result = async {
-        export_to_dir(&home, &id, include_secrets, &bundle_dir).await?;
+        export_to_dir(&home, home_was_flagged, &id, include_secrets, &bundle_dir).await?;
         pack_tar(&bundle_dir, &out)
     }
     .await;
@@ -1113,12 +1159,16 @@ async fn run_import(path: PathBuf, home: Option<PathBuf>) -> Result<()> {
 /// Imports the bundle rooted under `dir` into `home` through the fs ports,
 /// restoring any fs-only secrets/keys the bundle carried.
 async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result<()> {
+    let home_was_flagged = home.is_some();
     use opencompany::store::export::{find_bundle_root, import_bundle, restore_fs_artifacts};
     use opencompany::store::paths::Bundle;
 
     let home = resolve_home_migrated(home)?;
     let root = find_bundle_root(dir)?;
-    let ((store, events, memory, context), facts) = live_ports(&home).await?;
+    // Exclusive, same as `serve`: an import into stores a running host has
+    // open is the single-writer violation the lock module exists to prevent.
+    let _home_lock = opencompany::store::lock::acquire(&home)?;
+    let ((store, events, memory, context), facts) = live_ports(&home, home_was_flagged).await?;
     let id = import_bundle(&root, store, events, memory, context, facts).await?;
     restore_fs_artifacts(&root, Bundle::new(home.clone(), &id).dir()).await?;
     println!("imported company `{id}` into {}", home.display());
@@ -1190,13 +1240,31 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
     };
 
     let to_config = match to.as_str() {
-        "namespace" => MemoryDriverConfig {
-            mode: MemoryMode::Embedded,
-            driver_id: Some(to.clone()),
-            url: None,
-            api_key: None,
-            data_dir: to_data_dir.clone().or_else(|| settings.data_dir.clone()),
-        },
+        "namespace" => {
+            // The same durability refusal `open_provider` enforces at boot
+            // (src/store/select.rs): on a mongodb base, /data is ephemeral
+            // scratch, and a migration that "succeeds" into it is data loss
+            // with a success message — worse than the refusal.
+            if settings.kind == opencompany::store::StorageKind::Mongodb
+                && !settings.allow_ephemeral_memory
+            {
+                return Err(opencompany::error::OpenCompanyError::Config(
+                    "OPENCOMPANY_STORAGE=mongodb treats the data dir as ephemeral scratch, and \
+                     the boot path refuses the namespace driver there for exactly that reason. \
+                     Migrating into it would report success on data the next container \
+                     replacement deletes. If the data dir is genuinely a durable volume, assert \
+                     it with OPENCOMPANY_MEMORY_ALLOW_EPHEMERAL=1."
+                        .into(),
+                ));
+            }
+            MemoryDriverConfig {
+                mode: MemoryMode::Embedded,
+                driver_id: Some(to.clone()),
+                url: None,
+                api_key: None,
+                data_dir: to_data_dir.clone().or_else(|| settings.data_dir.clone()),
+            }
+        }
         "supermemory" | "mem0" | "cognee" => MemoryDriverConfig {
             mode: MemoryMode::Remote,
             driver_id: Some(to.clone()),
@@ -1218,13 +1286,33 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
         }
     };
 
-    // Same engine, same target = a copy onto itself: every record would come
-    // back `skipped` at best, and on the embedded store it is the same SQLite
-    // file open twice.
-    if from_config.driver_id == to_config.driver_id
-        && from_config.url == to_config.url
-        && from_config.data_dir == to_config.data_dir
-    {
+    // Same engine, same target = a copy onto itself: on the embedded store it
+    // is one SQLite file open twice; on a hosted store the export cursor
+    // shifts under the concurrent writes and records skip or repeat. Compared
+    // mode-aware and normalized, because the naive field-equality version
+    // could never fire remote-to-remote (the source carries the env data_dir,
+    // the target None) and let trailing-slash or whitespace spellings of the
+    // same location through.
+    let norm_id = |id: &Option<String>| id.as_deref().map(str::trim).map(str::to_owned);
+    let norm_url = |url: &Option<String>| {
+        url.as_deref()
+            .map(str::trim)
+            .map(|u| u.trim_end_matches('/').to_owned())
+    };
+    let norm_dir = |dir: &Option<PathBuf>| {
+        dir.as_ref()
+            .map(|d| d.components().collect::<std::path::PathBuf>())
+    };
+    let same_engine = from_config.mode == to_config.mode
+        && norm_id(&from_config.driver_id) == norm_id(&to_config.driver_id)
+        && match to_config.mode {
+            MemoryMode::Remote => norm_url(&from_config.url) == norm_url(&to_config.url),
+            MemoryMode::Embedded => {
+                norm_dir(&from_config.data_dir) == norm_dir(&to_config.data_dir)
+            }
+            MemoryMode::Null => true,
+        };
+    if same_engine {
         return Err(opencompany::error::OpenCompanyError::Config(
             "the source and the target are the same engine at the same location; nothing to do."
                 .into(),
@@ -1238,13 +1326,11 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
                 .into(),
         )
     })?;
-    let (target, target_class) = open_driver(&to_config)?.ok_or_else(|| {
-        opencompany::error::OpenCompanyError::Config(
-            "the target configuration bound no provider (host bug).".into(),
-        )
-    })?;
-
+    // Dry run touches ONLY the source: opening the target would create its
+    // store (a namespace target mints the SQLite dir on open), and "without
+    // writing anything" must mean the filesystem too.
     if dry_run {
+        let resumed = resume_cursor.is_some();
         let mut total: u64 = 0;
         let mut cursor = resume_cursor;
         loop {
@@ -1262,14 +1348,29 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
                 None => break,
             }
         }
-        println!(
-            "dry run: {} records would migrate {} -> {}",
-            total,
-            from.driver_id(),
-            target.driver_id()
-        );
+        if resumed {
+            println!(
+                "dry run (from --resume-cursor): {} records remain to migrate {} -> {}",
+                total,
+                from.driver_id(),
+                to
+            );
+        } else {
+            println!(
+                "dry run: {} records would migrate {} -> {}",
+                total,
+                from.driver_id(),
+                to
+            );
+        }
         return Ok(());
     }
+
+    let (target, target_class) = open_driver(&to_config)?.ok_or_else(|| {
+        opencompany::error::OpenCompanyError::Config(
+            "the target configuration bound no provider (host bug).".into(),
+        )
+    })?;
 
     if matches!(target_class, tinymemory::registry::DriverClass::External) {
         eprintln!(
@@ -1321,8 +1422,8 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
                 .unwrap_or_else(|| "the beginning (the first page failed)".into());
             Err(opencompany::error::OpenCompanyError::Store(format!(
                 "migration stopped after {} imported / {} skipped of {} exported; fix the \
-                 target and re-run with {resume} — already-present records re-import as \
-                 `skipped`, so re-running the failed page is safe.",
+                 target and re-run with {resume} — import is idempotent by (namespace, key), \
+                 so re-running the failed page cannot duplicate.",
                 stopped.summary.imported, stopped.summary.skipped, stopped.summary.exported
             )))
         }
@@ -1814,9 +1915,15 @@ async fn async_main() -> Result<()> {
             // backend. A selected-but-unavailable engine aborts boot, same as
             // the storage backend.
             if let Some(mut overlay) = opencompany::store::open_memory_overlay(&storage_settings)? {
-                // One bounded reachability probe, so a dead endpoint or a
+                // One bounded reachability probe — after `BoundMemory::bind`,
+                // BEFORE the TCP listener binds — so a dead endpoint or a
                 // revoked key shows on `/spec` at boot instead of surfacing as
-                // a mid-cycle failure days later. Advisory: it warns and
+                // a mid-cycle failure days later. The placement means a
+                // blackholed hosted endpoint costs up to the timeout on a cold
+                // wake (the manager's wake proxy blocks on `/healthz`); taken
+                // knowingly — it only fires when OPENCOMPANY_MEMORY selects an
+                // engine, and moving it post-listen needs a mutable descriptor
+                // seam this deliberately avoids. Advisory: it warns and
                 // records, never refuses — config errors already refused
                 // above, and a transient vendor outage must not crash-loop
                 // the tenant.

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -91,10 +91,13 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// Export a company's bundle: read everything through the storage ports and
-    /// write the canonical filesystem layout. With `--features export` the output
-    /// is a single `.tar`; otherwise an unpacked bundle directory. Secrets and
-    /// keys are excluded unless `--include-secrets` is set.
+    /// Export a company's bundle: read everything through the storage ports —
+    /// the env-selected backend (`OPENCOMPANY_STORAGE`) with the env-selected
+    /// memory engine (`OPENCOMPANY_MEMORY*`) overlaid, so the bundle captures
+    /// what the deployment actually remembers, operator facts included — and
+    /// write the canonical filesystem layout. With `--features export` the
+    /// output is a single `.tar`; otherwise an unpacked bundle directory.
+    /// Secrets and keys are excluded unless `--include-secrets` is set.
     Export {
         /// Company id (slug) to export.
         company: String,
@@ -111,7 +114,9 @@ enum Command {
         home: Option<PathBuf>,
     },
     /// Import a company bundle (a `.tar` under `--features export`, else an
-    /// unpacked bundle directory) into a home through the storage ports.
+    /// unpacked bundle directory) through the storage ports — the same
+    /// env-selected backend + memory engine an export reads, so a bundle
+    /// lands on whatever this deployment actually runs.
     Import {
         /// Bundle `.tar` or unpacked bundle directory to import.
         path: PathBuf,
@@ -119,6 +124,13 @@ enum Command {
         /// `$HOME/.opencompany`, with bundles under `companies/<slug>`.
         #[arg(long)]
         home: Option<PathBuf>,
+    },
+    /// Memory-engine operations: today, migrating every record from the
+    /// env-selected engine into another one — the data half of the
+    /// engine-switch runbook (`docs/spec/runtime/memory-engine.md`).
+    Memory {
+        #[command(subcommand)]
+        cmd: MemoryCmd,
     },
     /// Launch a sibling OpenHuman checkout: the core binary (`--mode core`)
     /// or the Tauri desktop host (`--mode desktop`). Desktop calls `cargo tauri`
@@ -147,6 +159,70 @@ enum Command {
         #[arg(last = true)]
         args: Vec<String>,
     },
+}
+
+/// The `memory` subcommands.
+#[derive(clap::Subcommand)]
+enum MemoryCmd {
+    /// Copy every record from the env-selected memory engine (the FROM side —
+    /// `OPENCOMPANY_MEMORY*`, exactly what a boot would bind today) into
+    /// another engine, over the contract's Portability family. Namespaces,
+    /// record kinds and provenance taint round-trip untouched. Run it BEFORE
+    /// flipping the environment: migrate, then set the variables, restart,
+    /// and verify `/spec`.
+    Migrate {
+        /// Target driver: `namespace`, `supermemory`, `mem0`, or `cognee`.
+        #[arg(long)]
+        to: String,
+        /// Target endpoint (hosted engines only).
+        #[arg(long)]
+        to_url: Option<String>,
+        /// Target credential (hosted engines only).
+        #[arg(long)]
+        to_api_key: Option<String>,
+        /// Target data root (`namespace` only). Defaults to the env data dir —
+        /// refused when that resolves to the source's own store.
+        #[arg(long)]
+        to_data_dir: Option<PathBuf>,
+        /// Records per page.
+        #[arg(long, default_value_t = 500)]
+        page_size: usize,
+        /// Count what would move without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Re-enter a stopped migration at the cursor it printed.
+        #[arg(long)]
+        resume_cursor: Option<String>,
+    },
+}
+
+impl std::fmt::Debug for MemoryCmd {
+    /// Renders the target identity and never the credential — the same
+    /// `<set>` convention as `StorageSettings`' manual impl, because the
+    /// parent `Command` derives `Debug` and a derived impl here would carry
+    /// the key into any future `{:?}` of the parsed CLI.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Migrate {
+                to,
+                to_url,
+                to_api_key,
+                to_data_dir,
+                page_size,
+                dry_run,
+                resume_cursor,
+            } => f
+                .debug_struct("Migrate")
+                .field("to", to)
+                .field("to_url", &to_url.as_ref().map(|_| "<set>"))
+                .field("to_api_key", &to_api_key.as_ref().map(|_| "<set>"))
+                .field("to_data_dir", to_data_dir)
+                .field("page_size", page_size)
+                .field("dry_run", dry_run)
+                .field("resume_cursor", &resume_cursor.is_some())
+                .finish(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -793,15 +869,49 @@ fn resolve_home_migrated(flag: Option<PathBuf>) -> Result<PathBuf> {
     Ok(home)
 }
 
-/// Builds the four fs storage ports over `home` as trait objects.
-fn fs_ports(home: &std::path::Path) -> opencompany::store::export::Ports {
-    use opencompany::store::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore};
-    (
-        Arc::new(FsCompanyStore::new(home.to_path_buf())),
-        Arc::new(FsEventLog::new(home.to_path_buf())),
-        Arc::new(FsMemoryStore::new(home.to_path_buf())),
-        Arc::new(FsContextStore::new(home.to_path_buf())),
-    )
+/// The bundle ports plus the fact port, resolved the way `serve` resolves
+/// them: the env-selected storage backend (`OPENCOMPANY_STORAGE`), with the
+/// env-selected memory engine (`OPENCOMPANY_MEMORY*`) overlaid on top.
+///
+/// Export and import used to hardwire the fs ports over `home`, which made a
+/// bundle capture the *base* stores rather than what the deployment actually
+/// remembers — on a host running a memory engine (or a sqlite/mongodb base),
+/// that is the wrong data, silently. Routing through the same selection
+/// `serve` uses means a bundle now reads and writes the live engine, and a
+/// misconfigured engine refuses here exactly as it refuses a boot.
+async fn live_ports(
+    home: &std::path::Path,
+) -> Result<(
+    opencompany::store::export::Ports,
+    Option<Arc<dyn opencompany::ports::FactStore>>,
+)> {
+    use opencompany::store::{
+        FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsOps, StorageSettings,
+        open_memory_overlay, open_storage,
+    };
+    let settings = StorageSettings::from_env()?;
+    let (store, events, mut memory, mut context, mut facts) = match open_storage(&settings, home)
+        .await?
+    {
+        Some(h) => (h.company, h.events, h.memory, h.context, Some(h.facts)),
+        // The fs default: the same ports the old hardwired path built,
+        // plus the fs fact store the old path silently left behind.
+        None => (
+            Arc::new(FsCompanyStore::new(home.to_path_buf())) as _,
+            Arc::new(FsEventLog::new(home.to_path_buf())) as _,
+            Arc::new(FsMemoryStore::new(home.to_path_buf())) as _,
+            Arc::new(FsContextStore::new(home.to_path_buf())) as _,
+            Some(Arc::new(FsOps::new(home.to_path_buf())) as Arc<dyn opencompany::ports::FactStore>),
+        ),
+    };
+    if let Some(overlay) = open_memory_overlay(&settings)? {
+        memory = overlay.memory;
+        context = overlay.context;
+        if let Some(f) = overlay.facts {
+            facts = Some(f);
+        }
+    }
+    Ok(((store, events, memory, context), facts))
 }
 
 /// A process-unique temporary path under the system temp dir. Used only by the
@@ -825,12 +935,12 @@ async fn export_to_dir(
     use opencompany::store::export::{ExportOpts, export_bundle};
     use opencompany::store::paths::Bundle;
 
-    let (store, events, memory, context) = fs_ports(home);
+    let ((store, events, memory, context), facts) = live_ports(home).await?;
     let opts = ExportOpts {
         include_secrets,
         fs_bundle: Some(Bundle::new(home.to_path_buf(), id).dir().to_path_buf()),
     };
-    export_bundle(id, dest, store, events, memory, context, opts).await
+    export_bundle(id, dest, store, events, memory, context, facts, opts).await
 }
 
 /// Default build: export writes an unpacked bundle directory (no `.tar` support
@@ -1008,11 +1118,228 @@ async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result
 
     let home = resolve_home_migrated(home)?;
     let root = find_bundle_root(dir)?;
-    let (store, events, memory, context) = fs_ports(&home);
-    let id = import_bundle(&root, store, events, memory, context).await?;
+    let ((store, events, memory, context), facts) = live_ports(&home).await?;
+    let id = import_bundle(&root, store, events, memory, context, facts).await?;
     restore_fs_artifacts(&root, Bundle::new(home.clone(), &id).dir()).await?;
     println!("imported company `{id}` into {}", home.display());
     Ok(())
+}
+
+/// `memory migrate`: the data half of the engine-switch runbook.
+///
+/// FROM is deliberately not a flag: it is the env-selected engine, exactly
+/// what a boot would bind — you migrate *before* flipping the environment, so
+/// the environment still names the source. Only provider-backed engines can
+/// migrate (the seam is what `export_page`/`import_records` live on); the
+/// `store` default and the EngineCortex overlay are refused by name.
+#[cfg(feature = "tinymemory")]
+async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
+    use opencompany::store::memory::driver::{MemoryDriverConfig, MemoryMode, open_driver};
+    use opencompany::store::memory::migrate::migrate;
+    use opencompany::store::{MemoryBackend, StorageSettings};
+
+    let MemoryCmd::Migrate {
+        to,
+        to_url,
+        to_api_key,
+        to_data_dir,
+        page_size,
+        dry_run,
+        resume_cursor,
+    } = cmd;
+
+    let settings = StorageSettings::from_env()?;
+    let from_mode = match settings.memory_backend {
+        MemoryBackend::Store => {
+            return Err(opencompany::error::OpenCompanyError::Config(
+                "OPENCOMPANY_MEMORY=store: the base backend serves memory directly and has no \
+                 provider seam to export through. Use `opencompany export` for a bundle instead."
+                    .into(),
+            ));
+        }
+        MemoryBackend::Null => {
+            return Err(opencompany::error::OpenCompanyError::Config(
+                "OPENCOMPANY_MEMORY=null retains nothing; there is nothing to migrate.".into(),
+            ));
+        }
+        MemoryBackend::Tinycortex
+            if settings
+                .memory_driver
+                .as_deref()
+                .map(str::trim)
+                .filter(|d| !d.is_empty())
+                .is_none() =>
+        {
+            return Err(opencompany::error::OpenCompanyError::Config(
+                "OPENCOMPANY_MEMORY=embedded without OPENCOMPANY_MEMORY_DRIVER is the \
+                 EngineCortex overlay, which is driven directly rather than through the \
+                 provider seam — its data cannot migrate through this command. Use \
+                 `opencompany export` for a bundle of what it holds."
+                    .into(),
+            ));
+        }
+        MemoryBackend::Tinycortex => MemoryMode::Embedded,
+        MemoryBackend::Remote => MemoryMode::Remote,
+    };
+    let from_config = MemoryDriverConfig {
+        mode: from_mode,
+        driver_id: settings.memory_driver.clone(),
+        url: settings.memory_url.clone(),
+        api_key: settings.memory_api_key.clone(),
+        data_dir: settings.data_dir.clone(),
+    };
+
+    let to_config = match to.as_str() {
+        "namespace" => MemoryDriverConfig {
+            mode: MemoryMode::Embedded,
+            driver_id: Some(to.clone()),
+            url: None,
+            api_key: None,
+            data_dir: to_data_dir.clone().or_else(|| settings.data_dir.clone()),
+        },
+        "supermemory" | "mem0" | "cognee" => MemoryDriverConfig {
+            mode: MemoryMode::Remote,
+            driver_id: Some(to.clone()),
+            url: to_url.clone(),
+            api_key: to_api_key.clone(),
+            data_dir: None,
+        },
+        "null" => {
+            return Err(opencompany::error::OpenCompanyError::Config(
+                "--to null would discard every record; that is `null`'s contract, not a \
+                 migration."
+                    .into(),
+            ));
+        }
+        other => {
+            return Err(opencompany::error::OpenCompanyError::Config(format!(
+                "--to {other} names no migratable driver: namespace, supermemory, mem0, cognee."
+            )));
+        }
+    };
+
+    // Same engine, same target = a copy onto itself: every record would come
+    // back `skipped` at best, and on the embedded store it is the same SQLite
+    // file open twice.
+    if from_config.driver_id == to_config.driver_id
+        && from_config.url == to_config.url
+        && from_config.data_dir == to_config.data_dir
+    {
+        return Err(opencompany::error::OpenCompanyError::Config(
+            "the source and the target are the same engine at the same location; nothing to do."
+                .into(),
+        ));
+    }
+
+    let (from, _) = open_driver(&from_config)?.ok_or_else(|| {
+        opencompany::error::OpenCompanyError::Config(
+            "the source configuration bound no provider (host bug — the routing above should \
+             have refused)."
+                .into(),
+        )
+    })?;
+    let (target, target_class) = open_driver(&to_config)?.ok_or_else(|| {
+        opencompany::error::OpenCompanyError::Config(
+            "the target configuration bound no provider (host bug).".into(),
+        )
+    })?;
+
+    if dry_run {
+        let mut total: u64 = 0;
+        let mut cursor = resume_cursor;
+        loop {
+            let page = from
+                .export_page(cursor.as_deref(), page_size)
+                .await
+                .map_err(|e| {
+                    opencompany::error::OpenCompanyError::Store(format!(
+                        "source export failed: {e}"
+                    ))
+                })?;
+            total += page.records.len() as u64;
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        println!(
+            "dry run: {} records would migrate {} -> {}",
+            total,
+            from.driver_id(),
+            target.driver_id()
+        );
+        return Ok(());
+    }
+
+    if matches!(target_class, tinymemory::registry::DriverClass::External) {
+        eprintln!(
+            "note: `{}` is a hosted engine — its exact-CRUD writes are enumeration-based, so a \
+             large import is slow and chatty. Prefer off-peak, and expect wall-clock to grow \
+             with store size.",
+            target.driver_id()
+        );
+    }
+
+    // The one operational precondition this command cannot enforce itself:
+    // there is no dual-write, so live cycles writing the source mid-copy are
+    // lost to the target. Said here as well as in the runbook, because the
+    // runbook is optional reading and this line is not.
+    eprintln!(
+        "note: pause the workload first — writes landing on the source during the copy do not \
+         reach the target."
+    );
+    println!(
+        "migrating {} -> {} ({} records/page)…",
+        from.driver_id(),
+        target.driver_id(),
+        page_size
+    );
+    let outcome = migrate(&from, &target, page_size, resume_cursor, |progress| {
+        println!(
+            "  page {}: {} exported, {} imported, {} skipped",
+            progress.pages, progress.exported, progress.imported, progress.skipped
+        );
+    })
+    .await?;
+    match outcome {
+        Ok(summary) => {
+            println!(
+                "done: {} exported, {} imported, {} already present, over {} pages. Now flip \
+                 OPENCOMPANY_MEMORY* to the target, restart, and verify /spec.",
+                summary.exported, summary.imported, summary.skipped, summary.pages
+            );
+            Ok(())
+        }
+        Err(stopped) => {
+            for error in &stopped.errors {
+                eprintln!("target error: {error}");
+            }
+            let resume = stopped
+                .resume_cursor
+                .as_deref()
+                .map(|c| format!("--resume-cursor {c}"))
+                .unwrap_or_else(|| "the beginning (the first page failed)".into());
+            Err(opencompany::error::OpenCompanyError::Store(format!(
+                "migration stopped after {} imported / {} skipped of {} exported; fix the \
+                 target and re-run with {resume} — already-present records re-import as \
+                 `skipped`, so re-running the failed page is safe.",
+                stopped.summary.imported, stopped.summary.skipped, stopped.summary.exported
+            )))
+        }
+    }
+}
+
+/// Without the provider seam there is nothing to migrate through; refuse by
+/// naming the feature, the same shape as the selection refusals in
+/// `store::select`.
+#[cfg(not(feature = "tinymemory"))]
+async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
+    let MemoryCmd::Migrate { .. } = cmd;
+    Err(opencompany::error::OpenCompanyError::Config(
+        "`memory migrate` requires a build with the `tinymemory` feature (the provider seam \
+         its Portability family lives on)."
+            .into(),
+    ))
 }
 
 /// Handle the `openhuman` subcommand: build the launch request, reject
@@ -1694,6 +2021,7 @@ async fn async_main() -> Result<()> {
             home,
         }) => run_export(company, out, include_secrets, home).await,
         Some(Command::Import { path, home }) => run_import(path, home).await,
+        Some(Command::Memory { cmd }) => run_memory_cmd(cmd).await,
         Some(Command::OpenHuman {
             root,
             mode,

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -896,6 +896,7 @@ async fn live_ports(
 ) -> Result<(
     opencompany::store::export::Ports,
     Option<Arc<dyn opencompany::ports::FactStore>>,
+    opencompany::store::StorageKind,
 )> {
     use opencompany::store::{
         FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsOps, StorageSettings,
@@ -926,7 +927,7 @@ async fn live_ports(
             facts = Some(f);
         }
     }
-    Ok(((store, events, memory, context), facts))
+    Ok(((store, events, memory, context), facts, settings.kind))
 }
 
 /// A process-unique temporary path under the system temp dir. Used only by the
@@ -955,7 +956,7 @@ async fn export_to_dir(
     // is writing is torn, and the refusal here names the running process
     // instead of silently racing it.
     let _home_lock = opencompany::store::lock::acquire(home)?;
-    let ((store, events, memory, context), facts) = live_ports(home, home_was_flagged).await?;
+    let ((store, events, memory, context), facts, _) = live_ports(home, home_was_flagged).await?;
     let opts = ExportOpts {
         include_secrets,
         fs_bundle: Some(Bundle::new(home.to_path_buf(), id).dir().to_path_buf()),
@@ -1144,20 +1145,23 @@ async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result
     // Exclusive, same as `serve`: an import into stores a running host has
     // open is the single-writer violation the lock module exists to prevent.
     let _home_lock = opencompany::store::lock::acquire(&home)?;
-    let ((store, events, memory, context), facts) = live_ports(&home, home_was_flagged).await?;
+    let ((store, events, memory, context), facts, storage_kind) =
+        live_ports(&home, home_was_flagged).await?;
     let id = import_bundle(&root, store, events, memory, context, facts).await?;
     restore_fs_artifacts(&root, Bundle::new(home.clone(), &id).dir()).await?;
     // On a non-fs base backend the records above went to the live backend
     // while these artifacts (secrets/, keys/) are fs-only by design and land
     // under the resolved home. Same split serve itself runs with there — but
     // say it, so a restore onto a fresh pod knows to mount that home.
-    let settings = opencompany::store::StorageSettings::from_env()?;
-    if settings.kind != opencompany::store::StorageKind::Fs {
+    // The kind comes back from live_ports rather than a second from_env():
+    // an env re-read that failed HERE would report an error for an import
+    // that already committed.
+    if storage_kind != opencompany::store::StorageKind::Fs {
         eprintln!(
             "note: records imported into the live `{}` backend; fs-only artifacts (secrets/, \
              keys/) restored under {} — on an ephemeral filesystem, re-provision them there \
              after a pod replacement.",
-            settings.kind.as_str(),
+            storage_kind.as_str(),
             home.display()
         );
     }
@@ -1189,15 +1193,16 @@ async fn run_memory_cmd(cmd: MemoryCmd) -> Result<()> {
     } = cmd;
 
     let settings = StorageSettings::from_env()?;
-    // The credential prefers the environment: argv is world-readable in
-    // /proc/<pid>/cmdline for the whole (possibly long) run. --to-api-key
-    // stays for compatibility but the env var is the documented channel.
-    let to_api_key = to_api_key.or_else(|| {
-        std::env::var("OPENCOMPANY_MEMORY_TARGET_API_KEY")
-            .ok()
-            .map(|k| k.trim().to_string())
-            .filter(|k| !k.is_empty())
-    });
+    // The credential prefers the environment — and the environment WINS over
+    // the flag, not just fills its absence: argv is world-readable in
+    // /proc/<pid>/cmdline for the whole (possibly long) run, so when both are
+    // set the one that was passed safely is the one that counts. --to-api-key
+    // stays only for compatibility.
+    let to_api_key = std::env::var("OPENCOMPANY_MEMORY_TARGET_API_KEY")
+        .ok()
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+        .or(to_api_key);
     // Every refusal and both configurations come from the lib
     // (`store::memory::migrate::resolve_migrate_configs`), where the feature
     // lanes execute the guards' tests; the bin drives the loop and reports.

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1885,7 +1885,7 @@ mod test {
 
     /// The third knowledge port finally travels: facts written on the source
     /// come back from the imported bundle, and the bundle carries them in
-    /// `memory/facts.jsonl` beside the traces they conceptually sit with.
+    /// `facts.jsonl (bundle root)` beside the traces they conceptually sit with.
     #[tokio::test]
     async fn operator_facts_travel_with_the_bundle() {
         use crate::ports::facts::FactStore;
@@ -1996,9 +1996,16 @@ mod test {
         .await
         .unwrap();
         let (s4, e4, m4, c4) = fs_ports(&home4);
-        let err = import_bundle(&dest2, s4, e4, m4, c4, None)
+        let err = import_bundle(&dest2, s4.clone(), e4, m4, c4, None)
             .await
             .expect_err("facts with no target port must refuse");
         assert!(err.to_string().contains("fact"), "{err}");
+        // The property the refuse-before-write ordering exists for: NOTHING
+        // landed. A refusal after `store.save` would leave a half-import
+        // whose append-only retry duplicates history.
+        assert!(
+            s4.load(&id2).await.unwrap().is_none(),
+            "the refusal must precede every write"
+        );
     }
 }

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -28,6 +28,7 @@ use crate::company::CompanyManifest;
 use crate::error::OpenCompanyError;
 use crate::ports::context::ContextStore;
 use crate::ports::events::EventLog;
+use crate::ports::facts::{FactRecord, FactStore};
 use crate::ports::memory::MemoryStore;
 use crate::ports::store::CompanyStore;
 use crate::ports::types::{
@@ -44,6 +45,13 @@ const EVENTS_JSONL: &str = "events.jsonl";
 const LEDGER_JSONL: &str = "ledger.jsonl";
 const MEMORY_DIR: &str = "memory";
 const TRACES_JSONL: &str = "traces.jsonl";
+/// Operator facts, beside the traces they conceptually sit with. Absent from
+/// bundles written before facts joined the export (issue: the spec promised
+/// "all three knowledge ports travel with the bundle" while only two did);
+/// `read_jsonl` treats an absent file as empty, so both directions stay
+/// compatible — an old importer ignores the new file, a new importer accepts
+/// an old bundle.
+const FACTS_JSONL: &str = "facts.jsonl";
 const CONTEXT_DIR: &str = "context";
 const CONTEXT_INDEX_JSONL: &str = "index.jsonl";
 const CONTEXT_BLOBS_DIR: &str = "blobs";
@@ -183,6 +191,9 @@ struct BundleContents {
     ledger: Vec<LedgerEntry>,
     events: Vec<StoredEvent>,
     traces: Vec<CompressedTrace>,
+    /// Operator facts. Empty when the source served no fact port (an old
+    /// bundle, or an export run without one) — never a failure.
+    facts: Vec<FactRecord>,
     context: Vec<ExportedChunk>,
     /// The operator team overlay (operator-added teammates), carried through the
     /// bundle so export→import preserves the operator roster.
@@ -226,6 +237,7 @@ impl BundleContents {
         events: Arc<dyn EventLog>,
         memory: Arc<dyn MemoryStore>,
         context: Arc<dyn ContextStore>,
+        facts: Option<Arc<dyn FactStore>>,
     ) -> Result<Self> {
         let record = store
             .load(id)
@@ -240,6 +252,10 @@ impl BundleContents {
         let events =
             scrub_redacted_discussion(events.read_from(id, EventSeq::new(0), usize::MAX).await?);
         let traces = memory.recent_traces(id, usize::MAX).await?;
+        let facts = match facts {
+            Some(port) => port.list(id, None, None).await?,
+            None => Vec::new(),
+        };
 
         let metas = context.list(id, "").await?;
         let mut chunks = Vec::with_capacity(metas.len());
@@ -261,6 +277,7 @@ impl BundleContents {
             ledger: record.ledger,
             events,
             traces,
+            facts,
             context: chunks,
             overlay_agents: record.overlay_agents,
             overlay_desk_members: record.overlay_desk_members,
@@ -284,6 +301,7 @@ impl BundleContents {
         events: Arc<dyn EventLog>,
         memory: Arc<dyn MemoryStore>,
         context: Arc<dyn ContextStore>,
+        facts: Option<Arc<dyn FactStore>>,
     ) -> Result<()> {
         // The manifest + lifecycle; ledger is appended separately so the store's
         // append-only ledger stays authoritative.
@@ -314,6 +332,19 @@ impl BundleContents {
         }
         for trace in &self.traces {
             memory.save_trace(&self.id, trace.clone()).await?;
+        }
+        if let Some(port) = &facts {
+            for fact in &self.facts {
+                port.upsert(&self.id, fact).await?;
+            }
+        } else if !self.facts.is_empty() {
+            // A bundle carrying facts imported into a target with no fact port
+            // would drop them silently — the exact shape this field exists to
+            // end. Refuse, naming what would be lost.
+            return Err(OpenCompanyError::Store(format!(
+                "bundle carries {} operator facts but the import target serves no fact port",
+                self.facts.len()
+            )));
         }
         for chunk in &self.context {
             context
@@ -368,6 +399,15 @@ impl BundleContents {
             jsonl(&self.traces)?.as_bytes(),
         )
         .await?;
+        // Only when there are any: an empty file would make every new export
+        // differ from an old host's byte-for-byte for no information.
+        if !self.facts.is_empty() {
+            write_file(
+                &memory_dir.join(FACTS_JSONL),
+                jsonl(&self.facts)?.as_bytes(),
+            )
+            .await?;
+        }
 
         let context_dir = dest.join(CONTEXT_DIR);
         let blobs_dir = context_dir.join(CONTEXT_BLOBS_DIR);
@@ -429,6 +469,8 @@ impl BundleContents {
             scrub_redacted_discussion(read_jsonl::<StoredEvent>(&src.join(EVENTS_JSONL)).await?);
         let traces =
             read_jsonl::<CompressedTrace>(&src.join(MEMORY_DIR).join(TRACES_JSONL)).await?;
+        // Absent on bundles that predate facts-in-the-bundle: empty, not an error.
+        let facts = read_jsonl::<FactRecord>(&src.join(MEMORY_DIR).join(FACTS_JSONL)).await?;
 
         let context_dir = src.join(CONTEXT_DIR);
         let index = read_jsonl::<IndexEntry>(&context_dir.join(CONTEXT_INDEX_JSONL)).await?;
@@ -452,6 +494,7 @@ impl BundleContents {
             ledger,
             events,
             traces,
+            facts,
             context,
             overlay_agents: meta.overlay_agents,
             overlay_desk_members: meta.overlay_desk_members,
@@ -539,9 +582,11 @@ pub async fn export_bundle(
     events: Arc<dyn EventLog>,
     memory: Arc<dyn MemoryStore>,
     context: Arc<dyn ContextStore>,
+    facts: Option<Arc<dyn FactStore>>,
     opts: ExportOpts,
 ) -> Result<()> {
-    let contents = BundleContents::read_via_ports(id, store, events, memory, context).await?;
+    let contents =
+        BundleContents::read_via_ports(id, store, events, memory, context, facts).await?;
     contents.write_to_dir(dest).await?;
 
     if opts.include_secrets
@@ -567,11 +612,12 @@ pub async fn import_bundle(
     events: Arc<dyn EventLog>,
     memory: Arc<dyn MemoryStore>,
     context: Arc<dyn ContextStore>,
+    facts: Option<Arc<dyn FactStore>>,
 ) -> Result<CompanyId> {
     let contents = BundleContents::read_from_dir(src).await?;
     let id = contents.id.clone();
     contents
-        .write_via_ports(store, events, memory, context)
+        .write_via_ports(store, events, memory, context, facts)
         .await?;
     Ok(id)
 }
@@ -767,6 +813,27 @@ mod test {
         toml::from_str(toml_src).expect("parse manifest")
     }
 
+    /// A minimal running company record for tests that only need one to exist.
+    fn company_record(id: &CompanyId) -> CompanyRecord {
+        CompanyRecord {
+            id: id.clone(),
+            manifest: manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".into(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+        }
+    }
+
     fn fs_ports(root: &Path) -> Ports {
         (
             Arc::new(FsCompanyStore::new(root.to_path_buf())),
@@ -840,15 +907,17 @@ mod test {
             e1.clone(),
             m1.clone(),
             c1.clone(),
+            None,
             ExportOpts::default(),
         )
         .await
         .expect("export");
 
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        let imported_id = import_bundle(&dest, s2.clone(), e2.clone(), m2.clone(), c2.clone())
-            .await
-            .expect("import");
+        let imported_id =
+            import_bundle(&dest, s2.clone(), e2.clone(), m2.clone(), c2.clone(), None)
+                .await
+                .expect("import");
         assert_eq!(imported_id, id, "id preserved through the bundle");
 
         // Charter + lifecycle identical.
@@ -928,6 +997,7 @@ mod test {
             e.clone(),
             m.clone(),
             c.clone(),
+            None,
             ExportOpts::default(),
         )
         .await
@@ -947,6 +1017,7 @@ mod test {
             e,
             m,
             c,
+            None,
             ExportOpts {
                 include_secrets: true,
                 fs_bundle: Some(bundle.dir().to_path_buf()),
@@ -1008,11 +1079,11 @@ mod test {
         .await
         .unwrap();
 
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        import_bundle(&dest, s2.clone(), e2.clone(), m2, c2)
+        import_bundle(&dest, s2.clone(), e2.clone(), m2, c2, None)
             .await
             .unwrap();
 
@@ -1112,7 +1183,7 @@ mod test {
         .await
         .unwrap();
 
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
 
@@ -1135,7 +1206,9 @@ mod test {
 
         // 2 and 3. What the importing instance ends up holding.
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        import_bundle(&dest, s2, e2.clone(), m2, c2).await.unwrap();
+        import_bundle(&dest, s2, e2.clone(), m2, c2, None)
+            .await
+            .unwrap();
         let events = e2
             .read_from(&id, EventSeq::new(0), usize::MAX)
             .await
@@ -1227,7 +1300,7 @@ mod test {
         .await
         .unwrap();
 
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
 
@@ -1239,7 +1312,9 @@ mod test {
         tokio::fs::write(&path, old_shape).await.unwrap();
 
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        import_bundle(&dest, s2, e2.clone(), m2, c2).await.unwrap();
+        import_bundle(&dest, s2, e2.clone(), m2, c2, None)
+            .await
+            .unwrap();
         let events = e2
             .read_from(&id, EventSeq::new(0), usize::MAX)
             .await
@@ -1297,11 +1372,13 @@ mod test {
         .unwrap();
 
         // Export → import into a fresh home.
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        let imported = import_bundle(&dest, s2.clone(), e2, m2, c2).await.unwrap();
+        let imported = import_bundle(&dest, s2.clone(), e2, m2, c2, None)
+            .await
+            .unwrap();
         assert_eq!(imported, id, "id preserved through the bundle");
 
         // The imported record carries the identical provenance — all three fields.
@@ -1415,11 +1492,13 @@ mod test {
         let src_record = s1.load(&id).await.unwrap().unwrap();
         assert_eq!(src_record.effective_desk_members("eng")[0], "cto");
 
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        import_bundle(&dest, s2.clone(), e2, m2, c2).await.unwrap();
+        import_bundle(&dest, s2.clone(), e2, m2, c2, None)
+            .await
+            .unwrap();
 
         // Every overlay came across intact — not reset to an empty list.
         let dst_record = s2.load(&id).await.unwrap().unwrap();
@@ -1592,11 +1671,13 @@ mod test {
         assert_eq!(src_record.effective_budget("ceo"), Some(0.0));
         assert_eq!(src_record.effective_budget("cto"), None);
 
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        import_bundle(&dest, s2.clone(), e2, m2, c2).await.unwrap();
+        import_bundle(&dest, s2.clone(), e2, m2, c2, None)
+            .await
+            .unwrap();
 
         let dst_record = s2.load(&id).await.unwrap().unwrap();
         assert_eq!(
@@ -1690,7 +1771,7 @@ mod test {
         })
         .await
         .unwrap();
-        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
 
@@ -1721,7 +1802,7 @@ mod test {
             .unwrap();
 
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        let err = import_bundle(&dest, s2.clone(), e2, m2, c2)
+        let err = import_bundle(&dest, s2.clone(), e2, m2, c2, None)
             .await
             .expect_err("import must refuse a bundle with two overrides for one teammate");
         let message = err.to_string();
@@ -1762,7 +1843,7 @@ mod test {
 
         let (s, e, m, c) = fs_ports(&home);
         let bundle_dir = tmp_root("tar-bundle").join(id.as_ref());
-        export_bundle(&id, &bundle_dir, s, e, m, c, ExportOpts::default())
+        export_bundle(&id, &bundle_dir, s, e, m, c, None, ExportOpts::default())
             .await
             .unwrap();
 
@@ -1780,7 +1861,9 @@ mod test {
         // Import the unpacked bundle into a fresh home.
         let home2 = tmp_root("tar-dst");
         let (s2, e2, m2, c2) = fs_ports(&home2);
-        let imported = import_bundle(&root, s2.clone(), e2, m2, c2).await.unwrap();
+        let imported = import_bundle(&root, s2.clone(), e2, m2, c2, None)
+            .await
+            .unwrap();
         assert_eq!(imported, id);
         let rec = s2.load(&id).await.unwrap().unwrap();
         assert_eq!(rec.manifest.company.name, "Export Co");
@@ -1794,5 +1877,123 @@ mod test {
         ] {
             tokio::fs::remove_dir_all(&dir).await.ok();
         }
+    }
+
+    /// The third knowledge port finally travels: facts written on the source
+    /// come back from the imported bundle, and the bundle carries them in
+    /// `memory/facts.jsonl` beside the traces they conceptually sit with.
+    #[tokio::test]
+    async fn operator_facts_travel_with_the_bundle() {
+        use crate::ports::facts::FactStore;
+        use crate::ports::{FactKind, FactRecord};
+        use crate::store::FsOps;
+
+        let home1 = tmp_root("facts-src");
+        let home2 = tmp_root("facts-dst");
+        let dest = tmp_root("facts-bundle");
+        let id = CompanyId::new("facts-co");
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&company_record(&id)).await.unwrap();
+        let f1: Arc<dyn FactStore> = Arc::new(FsOps::new(home1.clone()));
+        f1.upsert(
+            &id,
+            &FactRecord {
+                id: "supplier".into(),
+                kind: FactKind::Fact,
+                title: "supplier".into(),
+                body: "lathe parts come from Initech".into(),
+                source: "cto".into(),
+                updated_at_millis: 1,
+            },
+        )
+        .await
+        .unwrap();
+
+        export_bundle(&id, &dest, s1, e1, m1, c1, Some(f1), ExportOpts::default())
+            .await
+            .unwrap();
+        assert!(
+            dest.join(MEMORY_DIR).join(FACTS_JSONL).is_file(),
+            "the bundle must carry the facts file"
+        );
+
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        let f2: Arc<dyn FactStore> = Arc::new(FsOps::new(home2.clone()));
+        let imported = import_bundle(&dest, s2, e2, m2, c2, Some(f2.clone()))
+            .await
+            .unwrap();
+        let listed = f2.list(&imported, None, None).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].body, "lathe parts come from Initech");
+    }
+
+    /// Both compatibility directions: a bundle written without facts (an old
+    /// host, or an export run without the port) imports clean into a target
+    /// that has one — empty, never an error — and a bundle WITH facts refuses
+    /// a target with no fact port rather than dropping them silently.
+    #[tokio::test]
+    async fn facts_compatibility_is_explicit_in_both_directions() {
+        use crate::ports::facts::FactStore;
+        use crate::ports::{FactKind, FactRecord};
+        use crate::store::FsOps;
+
+        // Old bundle (no facts file) into a facts-capable target: clean.
+        let home1 = tmp_root("factless-src");
+        let home2 = tmp_root("factless-dst");
+        let dest = tmp_root("factless-bundle");
+        let id = CompanyId::new("factless-co");
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&company_record(&id)).await.unwrap();
+        export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
+            .await
+            .unwrap();
+        assert!(!dest.join(MEMORY_DIR).join(FACTS_JSONL).exists());
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        let f2: Arc<dyn FactStore> = Arc::new(FsOps::new(home2.clone()));
+        let imported = import_bundle(&dest, s2, e2, m2, c2, Some(f2.clone()))
+            .await
+            .unwrap();
+        assert!(f2.list(&imported, None, None).await.unwrap().is_empty());
+
+        // Facts-bearing bundle into a target with no fact port: a refusal
+        // naming the loss, not a silent drop.
+        let home3 = tmp_root("factful-src");
+        let home4 = tmp_root("factful-dst");
+        let dest2 = tmp_root("factful-bundle");
+        let id2 = CompanyId::new("factful-co");
+        let (s3, e3, m3, c3) = fs_ports(&home3);
+        s3.save(&company_record(&id2)).await.unwrap();
+        let f3: Arc<dyn FactStore> = Arc::new(FsOps::new(home3.clone()));
+        f3.upsert(
+            &id2,
+            &FactRecord {
+                id: "f".into(),
+                kind: FactKind::Fact,
+                title: "t".into(),
+                body: "b".into(),
+                source: "s".into(),
+                updated_at_millis: 1,
+            },
+        )
+        .await
+        .unwrap();
+        export_bundle(
+            &id2,
+            &dest2,
+            s3,
+            e3,
+            m3,
+            c3,
+            Some(f3),
+            ExportOpts::default(),
+        )
+        .await
+        .unwrap();
+        let (s4, e4, m4, c4) = fs_ports(&home4);
+        let err = import_bundle(&dest2, s4, e4, m4, c4, None)
+            .await
+            .expect_err("facts with no target port must refuse");
+        assert!(err.to_string().contains("fact"), "{err}");
     }
 }

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -313,6 +313,16 @@ impl BundleContents {
                 self.facts.len()
             )));
         }
+        // Facts land FIRST, for the same append-only reason the refusal above
+        // fires first: `upsert` is idempotent, so a failure here leaves a
+        // retry-safe state — whereas a fact failure AFTER `store.save` and the
+        // ledger/event appends would leave a half-import whose retry
+        // duplicates history.
+        if let Some(port) = &facts {
+            for fact in &self.facts {
+                port.upsert(&self.id, fact).await?;
+            }
+        }
         // The manifest + lifecycle; ledger is appended separately so the store's
         // append-only ledger stays authoritative.
         store
@@ -342,11 +352,6 @@ impl BundleContents {
         }
         for trace in &self.traces {
             memory.save_trace(&self.id, trace.clone()).await?;
-        }
-        if let Some(port) = &facts {
-            for fact in &self.facts {
-                port.upsert(&self.id, fact).await?;
-            }
         }
         for chunk in &self.context {
             context
@@ -403,9 +408,22 @@ impl BundleContents {
         .await?;
         // Only when there are any: an empty file would make every new export
         // differ from an old host's byte-for-byte for no information. At the
-        // bundle root, matching `paths::Bundle::facts_jsonl`.
+        // bundle root, matching `paths::Bundle::facts_jsonl`. A factless
+        // export must also REMOVE a stale file a previous export left in the
+        // same directory — otherwise a later import resurrects facts that are
+        // absent from the selected source.
         if !self.facts.is_empty() {
             write_file(&dest.join(FACTS_JSONL), jsonl(&self.facts)?.as_bytes()).await?;
+        } else {
+            match tokio::fs::remove_file(dest.join(FACTS_JSONL)).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(OpenCompanyError::Store(format!(
+                        "cannot remove a stale facts file from the bundle: {e}"
+                    )));
+                }
+            }
         }
 
         let context_dir = dest.join(CONTEXT_DIR);
@@ -2006,6 +2024,133 @@ mod test {
         assert!(
             s4.load(&id2).await.unwrap().is_none(),
             "the refusal must precede every write"
+        );
+    }
+    /// The fact-port failure case of the ordering guarantee: facts are the
+    /// FIRST write, so a failing fact port leaves zero company state behind —
+    /// the retry-safety claim, asserted rather than narrated.
+    #[tokio::test]
+    async fn a_failing_fact_port_leaves_nothing_written() {
+        use crate::ports::facts::FactStore;
+        use crate::ports::{FactKind, FactRecord};
+        use crate::store::FsOps;
+
+        struct FailingFacts;
+        #[async_trait::async_trait]
+        impl FactStore for FailingFacts {
+            async fn list(
+                &self,
+                _: &CompanyId,
+                _: Option<&str>,
+                _: Option<FactKind>,
+            ) -> crate::Result<Vec<FactRecord>> {
+                Ok(Vec::new())
+            }
+            async fn upsert(&self, _: &CompanyId, _: &FactRecord) -> crate::Result<()> {
+                Err(crate::error::OpenCompanyError::Store(
+                    "injected fact-port failure".into(),
+                ))
+            }
+            async fn delete(&self, _: &CompanyId, _: &str) -> crate::Result<bool> {
+                Ok(false)
+            }
+        }
+
+        let home_src = tmp_root("factfail-src");
+        let home_dst = tmp_root("factfail-dst");
+        let dest = tmp_root("factfail-bundle");
+        let id = CompanyId::new("factfail-co");
+        let (s1, e1, m1, c1) = fs_ports(&home_src);
+        s1.save(&company_record(&id)).await.unwrap();
+        let f1: Arc<dyn FactStore> = Arc::new(FsOps::new(home_src.clone()));
+        f1.upsert(
+            &id,
+            &FactRecord {
+                id: "f".into(),
+                kind: FactKind::Fact,
+                title: "t".into(),
+                body: "b".into(),
+                source: "s".into(),
+                updated_at_millis: 1,
+            },
+        )
+        .await
+        .unwrap();
+        export_bundle(&id, &dest, s1, e1, m1, c1, Some(f1), ExportOpts::default())
+            .await
+            .unwrap();
+
+        let (s2, e2, m2, c2) = fs_ports(&home_dst);
+        let err = import_bundle(&dest, s2.clone(), e2, m2, c2, Some(Arc::new(FailingFacts)))
+            .await
+            .expect_err("the injected fact failure must surface");
+        assert!(err.to_string().contains("injected"), "{err}");
+        assert!(
+            s2.load(&id).await.unwrap().is_none(),
+            "a fact-port failure must precede every append-only write"
+        );
+    }
+
+    /// Re-exporting a now-factless company into the SAME directory must not
+    /// leave the previous export's facts behind for a later import to
+    /// resurrect.
+    #[tokio::test]
+    async fn a_factless_reexport_removes_the_stale_facts_file() {
+        use crate::ports::facts::FactStore;
+        use crate::ports::{FactKind, FactRecord};
+        use crate::store::FsOps;
+
+        let home = tmp_root("stale-src");
+        let dest = tmp_root("stale-bundle");
+        let id = CompanyId::new("stale-co");
+        let (s1, e1, m1, c1) = fs_ports(&home);
+        s1.save(&company_record(&id)).await.unwrap();
+        let facts: Arc<dyn FactStore> = Arc::new(FsOps::new(home.clone()));
+        facts
+            .upsert(
+                &id,
+                &FactRecord {
+                    id: "f".into(),
+                    kind: FactKind::Fact,
+                    title: "t".into(),
+                    body: "b".into(),
+                    source: "s".into(),
+                    updated_at_millis: 1,
+                },
+            )
+            .await
+            .unwrap();
+        export_bundle(
+            &id,
+            &dest,
+            s1.clone(),
+            e1.clone(),
+            m1.clone(),
+            c1.clone(),
+            Some(facts.clone()),
+            ExportOpts::default(),
+        )
+        .await
+        .unwrap();
+        assert!(dest.join(FACTS_JSONL).is_file());
+
+        // The operator deletes the fact, then re-exports into the same dir.
+        assert!(facts.delete(&id, "f").await.unwrap());
+        export_bundle(
+            &id,
+            &dest,
+            s1,
+            e1,
+            m1,
+            c1,
+            Some(facts),
+            ExportOpts::default(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !dest.join(FACTS_JSONL).exists(),
+            "a factless re-export must remove the stale facts file"
         );
     }
 }

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -45,9 +45,10 @@ const EVENTS_JSONL: &str = "events.jsonl";
 const LEDGER_JSONL: &str = "ledger.jsonl";
 const MEMORY_DIR: &str = "memory";
 const TRACES_JSONL: &str = "traces.jsonl";
-/// Operator facts, beside the traces they conceptually sit with. Absent from
-/// bundles written before facts joined the export (issue: the spec promised
-/// "all three knowledge ports travel with the bundle" while only two did);
+/// Operator facts, at the bundle ROOT — the same place the live fs bundle
+/// keeps them (`paths::Bundle::facts_jsonl`), so an export stays diffable
+/// against a live home and a direct reader finds them where the canonical
+/// layout says. Absent from bundles written before facts joined the export;
 /// `read_jsonl` treats an absent file as empty, so both directions stay
 /// compatible — an old importer ignores the new file, a new importer accepts
 /// an old bundle.
@@ -303,6 +304,15 @@ impl BundleContents {
         context: Arc<dyn ContextStore>,
         facts: Option<Arc<dyn FactStore>>,
     ) -> Result<()> {
+        // Refused BEFORE anything is written: the event log and ledger are
+        // append-only, so a refusal after `store.save`/`append` would leave a
+        // half-imported company whose retry duplicates history.
+        if facts.is_none() && !self.facts.is_empty() {
+            return Err(OpenCompanyError::Store(format!(
+                "bundle carries {} operator facts but the import target serves no fact port",
+                self.facts.len()
+            )));
+        }
         // The manifest + lifecycle; ledger is appended separately so the store's
         // append-only ledger stays authoritative.
         store
@@ -337,14 +347,6 @@ impl BundleContents {
             for fact in &self.facts {
                 port.upsert(&self.id, fact).await?;
             }
-        } else if !self.facts.is_empty() {
-            // A bundle carrying facts imported into a target with no fact port
-            // would drop them silently — the exact shape this field exists to
-            // end. Refuse, naming what would be lost.
-            return Err(OpenCompanyError::Store(format!(
-                "bundle carries {} operator facts but the import target serves no fact port",
-                self.facts.len()
-            )));
         }
         for chunk in &self.context {
             context
@@ -400,13 +402,10 @@ impl BundleContents {
         )
         .await?;
         // Only when there are any: an empty file would make every new export
-        // differ from an old host's byte-for-byte for no information.
+        // differ from an old host's byte-for-byte for no information. At the
+        // bundle root, matching `paths::Bundle::facts_jsonl`.
         if !self.facts.is_empty() {
-            write_file(
-                &memory_dir.join(FACTS_JSONL),
-                jsonl(&self.facts)?.as_bytes(),
-            )
-            .await?;
+            write_file(&dest.join(FACTS_JSONL), jsonl(&self.facts)?.as_bytes()).await?;
         }
 
         let context_dir = dest.join(CONTEXT_DIR);
@@ -470,7 +469,7 @@ impl BundleContents {
         let traces =
             read_jsonl::<CompressedTrace>(&src.join(MEMORY_DIR).join(TRACES_JSONL)).await?;
         // Absent on bundles that predate facts-in-the-bundle: empty, not an error.
-        let facts = read_jsonl::<FactRecord>(&src.join(MEMORY_DIR).join(FACTS_JSONL)).await?;
+        let facts = read_jsonl::<FactRecord>(&src.join(FACTS_JSONL)).await?;
 
         let context_dir = src.join(CONTEXT_DIR);
         let index = read_jsonl::<IndexEntry>(&context_dir.join(CONTEXT_INDEX_JSONL)).await?;
@@ -575,6 +574,11 @@ fn scrub_redacted_discussion(events: Vec<StoredEvent>) -> Vec<StoredEvent> {
 /// backend's private on-disk shape. When [`ExportOpts::include_secrets`] is set
 /// and [`ExportOpts::fs_bundle`] points at the source fs bundle, the fs-only
 /// `secrets/` and `keys/` directories are copied verbatim.
+// Eight arguments is over clippy's default ceiling, taken knowingly: five of
+// them are the durable ports, and folding them into a struct is a wider
+// refactor than this addition warrants (the repo carries the same allow at
+// its other port-heavy seams).
+#[allow(clippy::too_many_arguments)]
 pub async fn export_bundle(
     id: &CompanyId,
     dest: &Path,
@@ -1914,8 +1918,9 @@ mod test {
             .await
             .unwrap();
         assert!(
-            dest.join(MEMORY_DIR).join(FACTS_JSONL).is_file(),
-            "the bundle must carry the facts file"
+            dest.join(FACTS_JSONL).is_file(),
+            "the bundle must carry the facts file at the bundle root, where \
+             the live fs layout keeps it"
         );
 
         let (s2, e2, m2, c2) = fs_ports(&home2);
@@ -1948,7 +1953,7 @@ mod test {
         export_bundle(&id, &dest, s1, e1, m1, c1, None, ExportOpts::default())
             .await
             .unwrap();
-        assert!(!dest.join(MEMORY_DIR).join(FACTS_JSONL).exists());
+        assert!(!dest.join(FACTS_JSONL).exists());
         let (s2, e2, m2, c2) = fs_ports(&home2);
         let f2: Arc<dyn FactStore> = Arc::new(FsOps::new(home2.clone()));
         let imported = import_bundle(&dest, s2, e2, m2, c2, Some(f2.clone()))

--- a/src/store/memory/migrate.rs
+++ b/src/store/memory/migrate.rs
@@ -1,0 +1,221 @@
+//! Engine-to-engine migration over the contract's Portability family.
+//!
+//! `export_page` → `import_records`, page by page, between two providers this
+//! host constructed through [`open_driver`](super::driver::open_driver). The
+//! records cross in the exporting driver's own vocabulary — kind, namespace
+//! and taint round-trip untouched (`ExportRecord`'s own contract), so every
+//! company's namespaces move together and provenance is never re-stamped.
+//!
+//! This is the data half of the engine-switch runbook in
+//! `docs/spec/runtime/memory-engine.md`: migrate, then flip the
+//! `OPENCOMPANY_MEMORY*` variables and restart.
+//!
+//! # Failure is a stop, never a guess
+//!
+//! The contract's error type is still one coarse variant (`MemoryError::Other`
+//! — tinymemory#18 §A4), so mid-migration this code cannot tell a transient
+//! 500 from a real rejection. It therefore never retries (an import retried
+//! into a driver that half-applied the page could double-write) and instead
+//! stops at the first failed page, reporting the cursor that *started* that
+//! page. `--resume-cursor` re-enters there: `import_records` reports
+//! already-present records as `skipped`, which is what makes re-running the
+//! failed page safe.
+
+use std::sync::Arc;
+
+use tinymemory_api::provider::MemoryProvider;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+
+/// What a finished (or stopped) migration did.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MigrateSummary {
+    /// Pages pulled from the source.
+    pub pages: u32,
+    /// Records the source exported.
+    pub exported: u64,
+    /// Records the target wrote.
+    pub imported: u64,
+    /// Records the target recognised as already present (a resumed run).
+    pub skipped: u64,
+}
+
+/// A migration that stopped partway: what happened, and where to resume.
+#[derive(Debug)]
+pub struct MigrateStopped {
+    /// What had already moved before the stop.
+    pub summary: MigrateSummary,
+    /// The cursor that started the failed page — pass to `--resume-cursor`.
+    /// `None` means the very first page failed.
+    pub resume_cursor: Option<String>,
+    /// The target driver's own reasons, bounded by it.
+    pub errors: Vec<String>,
+}
+
+/// The outcome: complete, or stopped with a resume point.
+pub type MigrateOutcome = std::result::Result<MigrateSummary, Box<MigrateStopped>>;
+
+/// Copies every record `from` exports into `to`, `page_size` records at a time,
+/// starting at `resume` (a cursor a previous stopped run printed, or `None`
+/// for the beginning). `on_page` observes progress after each imported page.
+///
+/// # Errors
+///
+/// A source `export_page` failure surfaces as a crate error (nothing was
+/// half-applied). A target `import_records` failure — or a page the target
+/// reports `failed > 0` for — returns [`MigrateStopped`] with the resume
+/// cursor, because the *next* attempt must re-enter at the failed page, not at
+/// the beginning.
+pub async fn migrate(
+    from: &Arc<dyn MemoryProvider>,
+    to: &Arc<dyn MemoryProvider>,
+    page_size: usize,
+    resume: Option<String>,
+    mut on_page: impl FnMut(&MigrateSummary),
+) -> Result<MigrateOutcome> {
+    let mut summary = MigrateSummary::default();
+    let mut cursor = resume;
+    loop {
+        // The cursor that names THIS page, kept for the stop report.
+        let page_start = cursor.clone();
+        let page = from
+            .export_page(page_start.as_deref(), page_size)
+            .await
+            .map_err(|e| {
+                OpenCompanyError::Store(format!(
+                    "source engine `{}` failed to export a page: {e}",
+                    from.driver_id()
+                ))
+            })?;
+        summary.pages += 1;
+        summary.exported += page.records.len() as u64;
+
+        if !page.records.is_empty() {
+            let outcome = match to.import_records(page.records).await {
+                Ok(outcome) => outcome,
+                Err(e) => {
+                    return Ok(Err(Box::new(MigrateStopped {
+                        summary,
+                        resume_cursor: page_start,
+                        errors: vec![format!(
+                            "target engine `{}` failed to import: {e}",
+                            to.driver_id()
+                        )],
+                    })));
+                }
+            };
+            summary.imported += u64::from(outcome.imported);
+            summary.skipped += u64::from(outcome.skipped);
+            if outcome.failed > 0 {
+                return Ok(Err(Box::new(MigrateStopped {
+                    summary,
+                    resume_cursor: page_start,
+                    errors: outcome.errors,
+                })));
+            }
+        }
+        on_page(&summary);
+
+        // `next_cursor: None` is the terminator — NOT an empty page, which is
+        // legal mid-export (the contract says so explicitly).
+        match page.next_cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    Ok(Ok(summary))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tinymemory_api::types::{MemoryCategory, MemoryTaint};
+    use tinymemory_conformance::InMemoryProvider;
+
+    fn provider() -> Arc<dyn MemoryProvider> {
+        Arc::new(InMemoryProvider::default())
+    }
+
+    async fn seed(p: &Arc<dyn MemoryProvider>, n: usize) {
+        for i in 0..n {
+            p.store(
+                &format!("oc/team-{}", i % 3),
+                &format!("key-{i}"),
+                &format!("record {i}"),
+                MemoryCategory::Core,
+                None,
+                MemoryTaint::Internal,
+            )
+            .await
+            .expect("seed");
+        }
+    }
+
+    async fn count(p: &Arc<dyn MemoryProvider>) -> u64 {
+        let mut total = 0;
+        let mut cursor: Option<String> = None;
+        loop {
+            let page = p.export_page(cursor.as_deref(), 10).await.expect("page");
+            total += page.records.len() as u64;
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => return total,
+            }
+        }
+    }
+
+    /// The whole point: every record crosses, across page boundaries, and the
+    /// target's own export agrees with the source's count.
+    #[tokio::test]
+    async fn every_record_crosses_between_engines() {
+        let (from, to) = (provider(), provider());
+        seed(&from, 23).await;
+        let outcome = migrate(&from, &to, 7, None, |_| {})
+            .await
+            .expect("no source failure")
+            .expect("no stop");
+        assert_eq!(outcome.exported, 23);
+        assert_eq!(outcome.imported, 23);
+        assert_eq!(outcome.skipped, 0);
+        assert!(outcome.pages >= 4, "23 records at page size 7 is 4 pages");
+        assert_eq!(
+            count(&to).await,
+            23,
+            "the target must hold what the source held"
+        );
+    }
+
+    /// A resumed run re-imports the failed page; the target reports the
+    /// already-present half as skipped rather than double-writing it.
+    #[tokio::test]
+    async fn a_rerun_skips_what_already_crossed() {
+        let (from, to) = (provider(), provider());
+        seed(&from, 5).await;
+        let first = migrate(&from, &to, 2, None, |_| {})
+            .await
+            .expect("ok")
+            .expect("complete");
+        assert_eq!(first.imported, 5);
+        let second = migrate(&from, &to, 2, None, |_| {})
+            .await
+            .expect("ok")
+            .expect("complete");
+        assert_eq!(second.imported, 0, "nothing new to write");
+        assert_eq!(second.skipped, 5, "everything recognised as present");
+        assert_eq!(count(&to).await, 5, "no duplicates");
+    }
+
+    /// An empty source completes with zero of everything rather than erroring —
+    /// migrating before first use is legal, if pointless.
+    #[tokio::test]
+    async fn an_empty_source_completes_empty() {
+        let (from, to) = (provider(), provider());
+        let outcome = migrate(&from, &to, 10, None, |_| {})
+            .await
+            .expect("ok")
+            .expect("complete");
+        assert_eq!(outcome.exported, 0);
+        assert_eq!(count(&to).await, 0);
+    }
+}

--- a/src/store/memory/migrate.rs
+++ b/src/store/memory/migrate.rs
@@ -835,12 +835,11 @@ mod test {
 
     #[test]
     fn source_backends_without_a_seam_refuse() {
+        // Each needle is the refusal's distinctive phrase, asserted whole — a
+        // first-word shortcut here reduced the Store case to "no", which any
+        // refusal contains.
         for (backend, driver, needle) in [
-            (
-                MemoryBackend::Store,
-                None,
-                "no \\\n                 provider seam",
-            ),
+            (MemoryBackend::Store, None, "provider seam"),
             (MemoryBackend::Null, None, "nothing to migrate"),
             (MemoryBackend::Tinycortex, None, "EngineCortex overlay"),
         ] {
@@ -852,11 +851,7 @@ mod test {
             let err = resolve(&settings, "mem0", Some("https://t.example"), None)
                 .expect_err("must refuse")
                 .to_string();
-            let plain = needle.replace("\\\n                 ", " ");
-            assert!(
-                err.contains(plain.split_whitespace().next().unwrap()),
-                "backend {backend:?}: {err}"
-            );
+            assert!(err.contains(needle), "backend {backend:?}: {err}");
         }
     }
 

--- a/src/store/memory/migrate.rs
+++ b/src/store/memory/migrate.rs
@@ -17,9 +17,10 @@
 //! 500 from a real rejection. It therefore never retries (an import retried
 //! into a driver that half-applied the page could double-write) and instead
 //! stops at the first failed page, reporting the cursor that *started* that
-//! page. `--resume-cursor` re-enters there: `import_records` reports
-//! already-present records as `skipped`, which is what makes re-running the
-//! failed page safe.
+//! page. `--resume-cursor` re-enters there safely because import is
+//! idempotent by `(namespace, key)`: a driver that recognises a present
+//! record reports it `skipped`, and one that does not simply overwrites in
+//! place — either way, re-running the failed page cannot duplicate.
 
 use std::sync::Arc;
 
@@ -32,12 +33,14 @@ use crate::error::OpenCompanyError;
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct MigrateSummary {
     /// Pages pulled from the source.
-    pub pages: u32,
+    pub pages: u64,
     /// Records the source exported.
     pub exported: u64,
     /// Records the target wrote.
     pub imported: u64,
-    /// Records the target recognised as already present (a resumed run).
+    /// Records the target recognised as already present (a resumed run, on a
+    /// driver that detects presence — upsert-style drivers report a re-import
+    /// under `imported` instead, having overwritten in place).
     pub skipped: u64,
 }
 
@@ -90,6 +93,21 @@ pub async fn migrate(
             })?;
         summary.pages += 1;
         summary.exported += page.records.len() as u64;
+
+        // A cursor that comes back unchanged would loop this function forever,
+        // re-importing the same page (a driver bug, or a paginated API that
+        // clamps an unknown cursor to the first page). Checked before the
+        // import so the echoed page is not even re-written once.
+        if page.next_cursor.is_some() && page.next_cursor == page_start {
+            return Ok(Err(Box::new(MigrateStopped {
+                summary,
+                resume_cursor: page_start,
+                errors: vec![format!(
+                    "source engine `{}` returned a cursor that did not advance; refusing to loop",
+                    from.driver_id()
+                )],
+            })));
+        }
 
         if !page.records.is_empty() {
             let outcome = match to.import_records(page.records).await {
@@ -186,10 +204,14 @@ mod test {
         );
     }
 
-    /// A resumed run re-imports the failed page; the target reports the
-    /// already-present half as skipped rather than double-writing it.
+    /// A full re-run cannot duplicate: import is idempotent by
+    /// `(namespace, key)`. The reference driver overwrites in place (so the
+    /// re-run reports `imported` again, `skipped` stays 0 — presence
+    /// detection is optional in the contract); what must hold on every
+    /// driver is the count: the target ends with exactly the source's
+    /// records, however the outcome buckets them.
     #[tokio::test]
-    async fn a_rerun_skips_what_already_crossed() {
+    async fn a_rerun_cannot_duplicate() {
         let (from, to) = (provider(), provider());
         seed(&from, 5).await;
         let first = migrate(&from, &to, 2, None, |_| {})
@@ -201,9 +223,16 @@ mod test {
             .await
             .expect("ok")
             .expect("complete");
-        assert_eq!(second.imported, 0, "nothing new to write");
-        assert_eq!(second.skipped, 5, "everything recognised as present");
-        assert_eq!(count(&to).await, 5, "no duplicates");
+        assert_eq!(
+            second.imported + second.skipped,
+            5,
+            "every record accounted for, in whichever bucket the driver uses"
+        );
+        assert_eq!(
+            count(&to).await,
+            5,
+            "no duplicates, however it was bucketed"
+        );
     }
 
     /// An empty source completes with zero of everything rather than erroring —

--- a/src/store/memory/migrate.rs
+++ b/src/store/memory/migrate.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 
 use tinymemory_api::provider::MemoryProvider;
 
+use super::driver::{MemoryDriverConfig, MemoryMode};
 use crate::Result;
 use crate::error::OpenCompanyError;
 
@@ -110,6 +111,7 @@ pub async fn migrate(
         }
 
         if !page.records.is_empty() {
+            let page_len = page.records.len() as u64;
             let outcome = match to.import_records(page.records).await {
                 Ok(outcome) => outcome,
                 Err(e) => {
@@ -125,6 +127,28 @@ pub async fn migrate(
             };
             summary.imported += u64::from(outcome.imported);
             summary.skipped += u64::from(outcome.skipped);
+            // A target that under-reports — imported+skipped+failed short of
+            // the page it was handed — has dropped records while saying
+            // nothing, the exact worst outcome this command exists to
+            // prevent. Stop and say so; the operator resumes at this page.
+            let accounted = u64::from(outcome.imported)
+                + u64::from(outcome.skipped)
+                + u64::from(outcome.failed);
+            if accounted < page_len {
+                return Ok(Err(Box::new(MigrateStopped {
+                    summary,
+                    resume_cursor: page_start,
+                    errors: vec![format!(
+                        "target engine `{}` accounted for {accounted} of {page_len} records in \
+                         the page (imported {} + skipped {} + failed {}); refusing to continue \
+                         past silently dropped records",
+                        to.driver_id(),
+                        outcome.imported,
+                        outcome.skipped,
+                        outcome.failed
+                    )],
+                })));
+            }
             if outcome.failed > 0 {
                 return Ok(Err(Box::new(MigrateStopped {
                     summary,
@@ -143,6 +167,234 @@ pub async fn migrate(
         }
     }
     Ok(Ok(summary))
+}
+
+/// Counts every record `provider` exports, paging with the same
+/// non-advancing-cursor guard [`migrate`] uses — the dry-run counter and the
+/// post-migration receipt both call this, so there is exactly one pager to
+/// get the echo case right in (a hand-rolled twin without the guard is how a
+/// stale `--resume-cursor` turns `--dry-run` into an infinite loop).
+///
+/// `start` counts from a resume cursor; `None` counts the whole store.
+pub async fn count_records(
+    provider: &Arc<dyn MemoryProvider>,
+    start: Option<String>,
+    page_size: usize,
+) -> Result<u64> {
+    let mut total: u64 = 0;
+    let mut cursor = start;
+    loop {
+        let page_start = cursor.clone();
+        let page = provider
+            .export_page(page_start.as_deref(), page_size)
+            .await
+            .map_err(|e| {
+                OpenCompanyError::Store(format!(
+                    "engine `{}` failed to export a page while counting: {e}",
+                    provider.driver_id()
+                ))
+            })?;
+        total += page.records.len() as u64;
+        if page.next_cursor.is_some() && page.next_cursor == page_start {
+            return Err(OpenCompanyError::Store(format!(
+                "engine `{}` returned a cursor that did not advance while counting; refusing to \
+                 loop (driver bug, or a stale --resume-cursor this engine clamps)",
+                provider.driver_id()
+            )));
+        }
+        match page.next_cursor {
+            Some(next) => cursor = Some(next),
+            None => return Ok(total),
+        }
+    }
+}
+
+/// Resolves the `memory migrate` source and target configurations, with every
+/// refusal the command makes — moved out of the bin so the guards execute
+/// under the same feature lanes that run this module's tests, instead of
+/// living in a binary no CI lane ever `cargo test`s (the review finding on
+/// the first cut: all eight refusals were mutation-proof-untested).
+///
+/// `to_api_key` should already carry the `OPENCOMPANY_MEMORY_TARGET_API_KEY`
+/// fallback (resolved by the caller, where the environment belongs).
+pub fn resolve_migrate_configs(
+    settings: &crate::store::StorageSettings,
+    to: &str,
+    to_url: Option<String>,
+    to_api_key: Option<String>,
+    to_data_dir: Option<std::path::PathBuf>,
+) -> Result<(MemoryDriverConfig, MemoryDriverConfig)> {
+    use crate::store::{MemoryBackend, StorageKind};
+
+    // Shared-single-DB tenant mode namespaces company ids at the app layer;
+    // the Portability records cross with their namespaces verbatim, so a
+    // migration would move every tenant the source credential can see, into a
+    // target that knows nothing of the `<tenant>--` scheme. The sibling
+    // bundle commands refuse this; so does this one.
+    if settings
+        .tenant_id
+        .as_deref()
+        .is_some_and(|t| !t.trim().is_empty())
+    {
+        return Err(OpenCompanyError::Config(
+            "shared-single-DB tenant mode (OPENCOMPANY_TENANT_ID) is active: a migration would \
+             move every namespace the source credential can see, across tenants. Run migrations \
+             from the manager path, per tenant, without tenant mode."
+                .into(),
+        ));
+    }
+
+    let from_mode = match settings.memory_backend {
+        MemoryBackend::Store => {
+            return Err(OpenCompanyError::Config(
+                "OPENCOMPANY_MEMORY=store: the base backend serves memory directly and has no \
+                 provider seam to export through. Use `opencompany export` for a bundle instead."
+                    .into(),
+            ));
+        }
+        MemoryBackend::Null => {
+            return Err(OpenCompanyError::Config(
+                "OPENCOMPANY_MEMORY=null retains nothing; there is nothing to migrate.".into(),
+            ));
+        }
+        MemoryBackend::Tinycortex
+            if settings
+                .memory_driver
+                .as_deref()
+                .map(str::trim)
+                .filter(|d| !d.is_empty())
+                .is_none() =>
+        {
+            return Err(OpenCompanyError::Config(
+                "OPENCOMPANY_MEMORY=embedded without OPENCOMPANY_MEMORY_DRIVER is the \
+                 EngineCortex overlay, which is driven directly rather than through the \
+                 provider seam — its data cannot migrate through this command. Use \
+                 `opencompany export` for a bundle of what it holds."
+                    .into(),
+            ));
+        }
+        MemoryBackend::Tinycortex => MemoryMode::Embedded,
+        MemoryBackend::Remote => MemoryMode::Remote,
+    };
+    let from_config = MemoryDriverConfig {
+        mode: from_mode,
+        driver_id: settings.memory_driver.clone(),
+        url: settings.memory_url.clone(),
+        api_key: settings.memory_api_key.clone(),
+        data_dir: settings.data_dir.clone(),
+    };
+
+    let to_config = match to {
+        "namespace" => {
+            // The same durability refusal `open_provider` enforces at boot:
+            // on a mongodb base, /data is ephemeral scratch, and a migration
+            // that "succeeds" into it is data loss with a success message.
+            if settings.kind == StorageKind::Mongodb && !settings.allow_ephemeral_memory {
+                return Err(OpenCompanyError::Config(
+                    "OPENCOMPANY_STORAGE=mongodb treats the data dir as ephemeral scratch, and \
+                     the boot path refuses the namespace driver there for exactly that reason. \
+                     Migrating into it would report success on data the next container \
+                     replacement deletes. If the data dir is genuinely a durable volume, assert \
+                     it with OPENCOMPANY_MEMORY_ALLOW_EPHEMERAL=1."
+                        .into(),
+                ));
+            }
+            let data_dir = to_data_dir.clone().or_else(|| settings.data_dir.clone());
+            // Validated HERE, in the target's own vocabulary. Letting
+            // `open_driver` refuse later produces "OPENCOMPANY_MEMORY_URL is
+            // required"-style messages that name the SOURCE env — advice
+            // which, followed, silently repoints the source at a different
+            // (likely empty) engine and reports `0 exported` as success.
+            if data_dir.is_none() {
+                return Err(OpenCompanyError::Config(
+                    "--to namespace needs a directory for the target store: pass --to-data-dir \
+                     (OPENCOMPANY_DATA_DIR also serves as its default when set)."
+                        .into(),
+                ));
+            }
+            MemoryDriverConfig {
+                mode: MemoryMode::Embedded,
+                driver_id: Some(to.to_string()),
+                url: None,
+                api_key: None,
+                data_dir,
+            }
+        }
+        "supermemory" | "mem0" | "cognee" => {
+            if to_url
+                .as_deref()
+                .map(str::trim)
+                .filter(|u| !u.is_empty())
+                .is_none()
+            {
+                return Err(OpenCompanyError::Config(format!(
+                    "--to {to} is a hosted engine and needs --to-url (the target's endpoint). \
+                     Do NOT set OPENCOMPANY_MEMORY_URL for this — that variable configures the \
+                     SOURCE, and changing it repoints what you are migrating from."
+                )));
+            }
+            MemoryDriverConfig {
+                mode: MemoryMode::Remote,
+                driver_id: Some(to.to_string()),
+                url: to_url,
+                api_key: to_api_key,
+                data_dir: None,
+            }
+        }
+        "null" => {
+            return Err(OpenCompanyError::Config(
+                "--to null would discard every record; that is `null`'s contract, not a \
+                 migration."
+                    .into(),
+            ));
+        }
+        other => {
+            return Err(OpenCompanyError::Config(format!(
+                "--to {other} names no migratable driver: namespace, supermemory, mem0, cognee."
+            )));
+        }
+    };
+
+    // Same engine, same target = a copy onto itself: on the embedded store it
+    // is one SQLite file open twice; on a hosted store the export cursor
+    // shifts under the concurrent writes and records skip or repeat. Compared
+    // mode-aware and normalized — the naive field-equality version could
+    // never fire remote-to-remote (the source carries the env data_dir, the
+    // target None) — and dirs are canonicalised when they resolve, so
+    // `--to-data-dir ../data` from `/var` cannot evade a source at
+    // `/var/data` by spelling.
+    let norm_id = |id: &Option<String>| id.as_deref().map(str::trim).map(str::to_owned);
+    let norm_url = |url: &Option<String>| {
+        url.as_deref()
+            .map(str::trim)
+            .map(|u| u.trim_end_matches('/').to_owned())
+    };
+    let norm_dir = |dir: &Option<std::path::PathBuf>| {
+        dir.as_ref().map(|d| {
+            // Canonical when the path exists (resolves `..`, symlinks and the
+            // CWD); the component-normalized spelling when it does not (a
+            // not-yet-created target dir cannot canonicalise, and refusing a
+            // fresh dir over that would block every first migration).
+            std::fs::canonicalize(d)
+                .unwrap_or_else(|_| d.components().collect::<std::path::PathBuf>())
+        })
+    };
+    let same_engine = from_config.mode == to_config.mode
+        && norm_id(&from_config.driver_id) == norm_id(&to_config.driver_id)
+        && match to_config.mode {
+            MemoryMode::Remote => norm_url(&from_config.url) == norm_url(&to_config.url),
+            MemoryMode::Embedded => {
+                norm_dir(&from_config.data_dir) == norm_dir(&to_config.data_dir)
+            }
+            MemoryMode::Null => true,
+        };
+    if same_engine {
+        return Err(OpenCompanyError::Config(
+            "the source and the target are the same engine at the same location; nothing to do."
+                .into(),
+        ));
+    }
+    Ok((from_config, to_config))
 }
 
 #[cfg(test)]
@@ -246,5 +498,485 @@ mod test {
             .expect("complete");
         assert_eq!(outcome.exported, 0);
         assert_eq!(count(&to).await, 0);
+    }
+    // ── The failure doubles: one wrapper, behaviour injected per test ──────
+
+    /// Wraps [`InMemoryProvider`] and misbehaves on demand: fail or
+    /// under-report an import, echo an export cursor. Everything else
+    /// delegates, so the data is real and only the defect under test is fake.
+    struct FlakyProvider {
+        inner: InMemoryProvider,
+        /// Fail `import_records` outright on its Nth call (1-based).
+        fail_import_on_call: Option<u32>,
+        /// Report `failed: 1` (with a reason) on the Nth import call.
+        reject_on_call: Option<u32>,
+        /// Report an all-zero outcome for every import (the under-reporter).
+        under_report: bool,
+        /// Echo the request cursor back as `next_cursor` (the clamping pager).
+        echo_cursor: bool,
+        import_calls: std::sync::atomic::AtomicU32,
+    }
+
+    impl FlakyProvider {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryProvider::default(),
+                fail_import_on_call: None,
+                reject_on_call: None,
+                under_report: false,
+                echo_cursor: false,
+                import_calls: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+    }
+
+    use tinymemory_api::error::MemoryError;
+    use tinymemory_api::provider::types::SourceScope;
+    use tinymemory_api::provider::types::{ExportPage, ImportOutcome};
+    use tinymemory_api::provider::{ExportRecord, MemoryCore, MemoryPortability, MemoryRecall};
+    use tinymemory_api::recall::OwnedRecallOpts;
+    use tinymemory_api::types::{MemoryEntry, NamespaceSummary};
+
+    #[async_trait::async_trait]
+    impl MemoryCore for FlakyProvider {
+        async fn store(
+            &self,
+            namespace: &str,
+            key: &str,
+            content: &str,
+            category: MemoryCategory,
+            session_id: Option<&str>,
+            taint: MemoryTaint,
+        ) -> std::result::Result<(), MemoryError> {
+            self.inner
+                .store(namespace, key, content, category, session_id, taint)
+                .await
+        }
+        async fn get(
+            &self,
+            namespace: &str,
+            key: &str,
+        ) -> std::result::Result<Option<MemoryEntry>, MemoryError> {
+            self.inner.get(namespace, key).await
+        }
+        async fn forget(
+            &self,
+            namespace: &str,
+            key: &str,
+        ) -> std::result::Result<bool, MemoryError> {
+            self.inner.forget(namespace, key).await
+        }
+        async fn list(
+            &self,
+            namespace: Option<&str>,
+            category: Option<&MemoryCategory>,
+            session_id: Option<&str>,
+        ) -> std::result::Result<Vec<MemoryEntry>, MemoryError> {
+            self.inner.list(namespace, category, session_id).await
+        }
+        async fn namespaces(&self) -> std::result::Result<Vec<NamespaceSummary>, MemoryError> {
+            self.inner.namespaces().await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MemoryRecall for FlakyProvider {
+        async fn recall(
+            &self,
+            query: &str,
+            limit: usize,
+            opts: &OwnedRecallOpts,
+            scope: Option<&SourceScope>,
+        ) -> std::result::Result<Vec<MemoryEntry>, MemoryError> {
+            self.inner.recall(query, limit, opts, scope).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MemoryPortability for FlakyProvider {
+        async fn export_page(
+            &self,
+            cursor: Option<&str>,
+            limit: usize,
+        ) -> std::result::Result<ExportPage, MemoryError> {
+            let mut page = self.inner.export_page(cursor, limit).await?;
+            if self.echo_cursor {
+                page.next_cursor = cursor.map(str::to_owned).or(page.next_cursor);
+                if cursor.is_some() {
+                    page.next_cursor = cursor.map(str::to_owned);
+                }
+            }
+            Ok(page)
+        }
+        async fn import_records(
+            &self,
+            records: Vec<ExportRecord>,
+        ) -> std::result::Result<ImportOutcome, MemoryError> {
+            let call = self
+                .import_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
+            if self.fail_import_on_call == Some(call) {
+                return Err(MemoryError::Other(anyhow::anyhow!(
+                    "injected import failure"
+                )));
+            }
+            if self.reject_on_call == Some(call) {
+                let mut outcome = ImportOutcome {
+                    failed: 1,
+                    errors: vec!["injected rejection".into()],
+                    ..ImportOutcome::default()
+                };
+                outcome.imported = (records.len() as u32).saturating_sub(1);
+                return Ok(outcome);
+            }
+            if self.under_report {
+                // Swallows the page while claiming nothing happened.
+                return Ok(ImportOutcome::default());
+            }
+            self.inner.import_records(records).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl tinymemory_api::provider::MemoryProvider for FlakyProvider {
+        fn driver_id(&self) -> &str {
+            "flaky"
+        }
+        fn capabilities(&self) -> tinymemory_api::capabilities::Capabilities {
+            tinymemory_api::capabilities::Capabilities::mandatory()
+        }
+        async fn health(&self) -> tinymemory_api::health::MemoryHealth {
+            tinymemory_api::health::MemoryHealth::Ready
+        }
+    }
+
+    /// A target `import_records` **error** stops with the failed page's start
+    /// cursor, and resuming there with a healthy target completes without
+    /// duplicating what page one already moved.
+    #[tokio::test]
+    async fn target_error_stops_with_resume_cursor_and_resume_completes() {
+        let from = provider();
+        seed(&from, 23).await;
+        let flaky = FlakyProvider {
+            fail_import_on_call: Some(2),
+            ..FlakyProvider::new()
+        };
+        let to: Arc<dyn MemoryProvider> = Arc::new(flaky);
+        let stopped = migrate(&from, &to, 7, None, |_| {})
+            .await
+            .expect("source is healthy")
+            .expect_err("page two must stop the run");
+        assert_eq!(
+            stopped.summary.imported, 7,
+            "page one landed before the stop"
+        );
+        let resume = stopped.resume_cursor.clone();
+        assert!(resume.is_some(), "a mid-run stop must name its page");
+
+        // Resume against the SAME target (now healthy): nothing duplicates.
+        let healthy = FlakyProvider::new();
+        // Rebuild target state as page one left it, then resume.
+        let to2: Arc<dyn MemoryProvider> = Arc::new(healthy);
+        let first_page = from.export_page(None, 7).await.unwrap();
+        to2.import_records(first_page.records).await.unwrap();
+        let outcome = migrate(&from, &to2, 7, resume, |_| {})
+            .await
+            .expect("healthy")
+            .expect("completes");
+        assert_eq!(
+            count(&to2).await,
+            23,
+            "resume must deliver exactly the full set, no duplicates"
+        );
+        assert!(
+            outcome.exported < 23,
+            "a resumed run must not have re-exported the whole store"
+        );
+    }
+
+    /// A page the target *rejects* (`failed > 0`) stops with the page's own
+    /// errors surfaced.
+    #[tokio::test]
+    async fn rejected_records_stop_with_the_drivers_reasons() {
+        let from = provider();
+        seed(&from, 10).await;
+        let to: Arc<dyn MemoryProvider> = Arc::new(FlakyProvider {
+            reject_on_call: Some(1),
+            ..FlakyProvider::new()
+        });
+        let stopped = migrate(&from, &to, 10, None, |_| {})
+            .await
+            .expect("source healthy")
+            .expect_err("a rejected record must stop");
+        assert_eq!(stopped.errors, vec!["injected rejection".to_string()]);
+        assert!(stopped.resume_cursor.is_none(), "the FIRST page failed");
+    }
+
+    /// The under-reporter: a full page met with an all-zero outcome must stop
+    /// as silently-dropped records, never complete as success.
+    #[tokio::test]
+    async fn an_under_reporting_target_stops_the_run() {
+        let from = provider();
+        seed(&from, 5).await;
+        let to: Arc<dyn MemoryProvider> = Arc::new(FlakyProvider {
+            under_report: true,
+            ..FlakyProvider::new()
+        });
+        let stopped = migrate(&from, &to, 10, None, |_| {})
+            .await
+            .expect("source healthy")
+            .expect_err("swallowed records must stop the run");
+        assert!(
+            stopped.errors[0].contains("accounted for 0 of 5"),
+            "{:?}",
+            stopped.errors
+        );
+    }
+
+    /// The clamping pager: a source that echoes the cursor stops instead of
+    /// looping, and does not import the echoed page a second time.
+    #[tokio::test]
+    async fn an_echoed_cursor_stops_instead_of_looping() {
+        let flaky = FlakyProvider {
+            echo_cursor: true,
+            ..FlakyProvider::new()
+        };
+        // Seed through the wrapper's core delegation.
+        for i in 0..9 {
+            flaky
+                .store(
+                    "oc/team",
+                    &format!("k{i}"),
+                    "v",
+                    MemoryCategory::Core,
+                    None,
+                    MemoryTaint::Internal,
+                )
+                .await
+                .unwrap();
+        }
+        let from: Arc<dyn MemoryProvider> = Arc::new(flaky);
+        let to = provider();
+        let stopped = migrate(&from, &to, 4, None, |_| {})
+            .await
+            .expect("no crate error")
+            .expect_err("echo must stop");
+        assert!(
+            stopped.errors[0].contains("did not advance"),
+            "{:?}",
+            stopped.errors
+        );
+        assert!(count(&to).await <= 8, "the echoed page must not re-import");
+    }
+
+    /// `count_records` — the dry-run/receipt pager — counts, resumes, and
+    /// carries the same echo guard.
+    #[tokio::test]
+    async fn count_records_counts_resumes_and_refuses_echo() {
+        let from = provider();
+        seed(&from, 23).await;
+        assert_eq!(count_records(&from, None, 7).await.unwrap(), 23);
+        let first = from.export_page(None, 7).await.unwrap();
+        let rest = count_records(&from, first.next_cursor.clone(), 7)
+            .await
+            .unwrap();
+        assert_eq!(rest, 23 - first.records.len() as u64);
+
+        let echo = FlakyProvider {
+            echo_cursor: true,
+            ..FlakyProvider::new()
+        };
+        echo.store(
+            "oc/a",
+            "k",
+            "v",
+            MemoryCategory::Core,
+            None,
+            MemoryTaint::Internal,
+        )
+        .await
+        .unwrap();
+        let echo: Arc<dyn MemoryProvider> = Arc::new(echo);
+        let cursor = Some("stale".to_string());
+        let err = count_records(&echo, cursor, 1).await;
+        assert!(err.is_err(), "echoed cursor must refuse, not loop");
+    }
+
+    // ── resolve_migrate_configs: every refusal, executed ──────────────────
+
+    use crate::store::{MemoryBackend, StorageKind, StorageSettings};
+
+    fn base_settings() -> StorageSettings {
+        StorageSettings {
+            memory_backend: MemoryBackend::Remote,
+            memory_driver: Some("supermemory".into()),
+            memory_url: Some("https://source.example".into()),
+            memory_api_key: Some("sk-src".into()),
+            data_dir: Some(std::path::PathBuf::from("/data")),
+            ..StorageSettings::default()
+        }
+    }
+
+    fn resolve(
+        settings: &StorageSettings,
+        to: &str,
+        to_url: Option<&str>,
+        to_data_dir: Option<&str>,
+    ) -> crate::Result<(MemoryDriverConfig, MemoryDriverConfig)> {
+        resolve_migrate_configs(
+            settings,
+            to,
+            to_url.map(str::to_owned),
+            None,
+            to_data_dir.map(std::path::PathBuf::from),
+        )
+    }
+
+    #[test]
+    fn source_backends_without_a_seam_refuse() {
+        for (backend, driver, needle) in [
+            (
+                MemoryBackend::Store,
+                None,
+                "no \\\n                 provider seam",
+            ),
+            (MemoryBackend::Null, None, "nothing to migrate"),
+            (MemoryBackend::Tinycortex, None, "EngineCortex overlay"),
+        ] {
+            let settings = StorageSettings {
+                memory_backend: backend,
+                memory_driver: driver,
+                ..base_settings()
+            };
+            let err = resolve(&settings, "mem0", Some("https://t.example"), None)
+                .expect_err("must refuse")
+                .to_string();
+            let plain = needle.replace("\\\n                 ", " ");
+            assert!(
+                err.contains(plain.split_whitespace().next().unwrap()),
+                "backend {backend:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn to_null_and_unknown_targets_refuse() {
+        let s = base_settings();
+        assert!(
+            resolve(&s, "null", None, None)
+                .expect_err("null")
+                .to_string()
+                .contains("discard every record")
+        );
+        assert!(
+            resolve(&s, "banana", None, None)
+                .expect_err("unknown")
+                .to_string()
+                .contains("names no migratable driver")
+        );
+    }
+
+    #[test]
+    fn tenant_mode_refuses_before_anything_else() {
+        let settings = StorageSettings {
+            tenant_id: Some("acme-tenant".into()),
+            ..base_settings()
+        };
+        let err = resolve(&settings, "mem0", Some("https://t.example"), None)
+            .expect_err("tenant mode must refuse")
+            .to_string();
+        assert!(err.contains("OPENCOMPANY_TENANT_ID"), "{err}");
+    }
+
+    /// The review's blocker two: a missing TARGET endpoint must be named in
+    /// the target's own vocabulary (`--to-url`), and must explicitly warn off
+    /// the source env var whose advice would silently repoint the source.
+    #[test]
+    fn a_missing_target_url_names_the_flag_not_the_source_env() {
+        let err = resolve(&base_settings(), "mem0", None, None)
+            .expect_err("hosted target without --to-url must refuse")
+            .to_string();
+        assert!(err.contains("--to-url"), "{err}");
+        assert!(
+            err.contains("SOURCE"),
+            "must warn that OPENCOMPANY_MEMORY_URL is the source's: {err}"
+        );
+    }
+
+    #[test]
+    fn a_namespace_target_with_no_dir_anywhere_names_the_flag() {
+        let settings = StorageSettings {
+            data_dir: None,
+            ..base_settings()
+        };
+        let err = resolve(&settings, "namespace", None, None)
+            .expect_err("no dir at all must refuse")
+            .to_string();
+        assert!(err.contains("--to-data-dir"), "{err}");
+    }
+
+    #[test]
+    fn a_mongodb_base_refuses_an_ephemeral_namespace_target() {
+        let settings = StorageSettings {
+            kind: StorageKind::Mongodb,
+            ..base_settings()
+        };
+        let err = resolve(&settings, "namespace", None, Some("/data/mem"))
+            .expect_err("ephemeral target must refuse")
+            .to_string();
+        assert!(err.contains("OPENCOMPANY_MEMORY_ALLOW_EPHEMERAL"), "{err}");
+        let allowed = StorageSettings {
+            allow_ephemeral_memory: true,
+            ..settings
+        };
+        resolve(&allowed, "namespace", None, Some("/data/mem"))
+            .expect("the operator override must open the path");
+    }
+
+    #[test]
+    fn the_same_engine_guard_fires_remote_to_remote_and_normalizes() {
+        // Identical endpoint, spelled with a trailing slash and whitespace:
+        // the naive field-equality version could never fire here because the
+        // source carries the env data_dir and the target None.
+        let err = resolve(
+            &base_settings(),
+            "supermemory",
+            Some(" https://source.example/ "),
+            None,
+        )
+        .expect_err("same hosted engine at the same endpoint must refuse")
+        .to_string();
+        assert!(err.contains("same engine"), "{err}");
+
+        // A different endpoint proceeds.
+        resolve(
+            &base_settings(),
+            "supermemory",
+            Some("https://new.example"),
+            None,
+        )
+        .expect("a genuinely different endpoint is a migration");
+    }
+
+    #[test]
+    fn the_same_engine_guard_canonicalizes_dirs() {
+        // A real directory reached by two spellings: direct, and via `..`.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("data");
+        std::fs::create_dir_all(&real).unwrap();
+        let dotted = dir.path().join("sub").join("..").join("data");
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+
+        let settings = StorageSettings {
+            memory_backend: MemoryBackend::Tinycortex,
+            memory_driver: Some("namespace".into()),
+            data_dir: Some(real),
+            ..StorageSettings::default()
+        };
+        let err = resolve(&settings, "namespace", None, Some(dotted.to_str().unwrap()))
+            .expect_err("a dotted spelling of the same dir must refuse")
+            .to_string();
+        assert!(err.contains("same engine"), "{err}");
     }
 }

--- a/src/store/memory/mod.rs
+++ b/src/store/memory/mod.rs
@@ -53,6 +53,7 @@
 
 pub mod driver;
 pub mod facades;
+pub mod migrate;
 mod namespace;
 
 use std::sync::Arc;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -100,7 +100,7 @@ pub use migrate::migrate_legacy_nest_announced;
 pub use paths::{Bundle, DATA_DIR_ENV, home_divergence_warning, resolve_home};
 pub use select::{
     MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,
-    open_memory_overlay, open_storage, plaintext_secret_refusal,
+    open_memory_overlay, open_storage, plaintext_secret_refusal, refuse_bundle_env,
 };
 
 #[cfg(feature = "sqlite")]

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -548,6 +548,52 @@ pub async fn open_storage(
     }
 }
 
+/// The bundle-command environment refusals (`export` / `import`), extracted
+/// from the bin's `live_ports` so they execute under this module's tests —
+/// the first cut left them in the binary, where no CI lane runs tests and a
+/// mutation (`if false &&`) went green (the #1279 review's finding).
+///
+/// One deployment per bundle: with a non-default environment an explicit
+/// `--home` is refused rather than mixed in; `null` is refused in both
+/// directions; shared-single-DB tenant mode is refused (bundle ops write no
+/// owner rows). Under the fs+store default every check passes and `--home`
+/// means exactly what it always has.
+pub fn refuse_bundle_env(settings: &StorageSettings, home_was_flagged: bool) -> crate::Result<()> {
+    let live = settings.kind != StorageKind::Fs || settings.memory_backend != MemoryBackend::Store;
+    if settings.memory_backend == MemoryBackend::Null {
+        return Err(crate::error::OpenCompanyError::Config(
+            "OPENCOMPANY_MEMORY=null retains nothing: an export would capture no memory and an \
+             import would discard every record while reporting success. Unset OPENCOMPANY_MEMORY \
+             for bundle operations."
+                .into(),
+        ));
+    }
+    if live && home_was_flagged {
+        return Err(crate::error::OpenCompanyError::Config(format!(
+            "--home names an fs data set, but this environment selects storage `{}` and memory \
+             `{}` — the bundle would mix two deployments. Unset OPENCOMPANY_STORAGE and \
+             OPENCOMPANY_MEMORY* to operate on the fs home, or drop --home to operate on the \
+             live deployment.",
+            settings.kind.as_str(),
+            settings.memory_backend.as_str()
+        )));
+    }
+    if live
+        && settings
+            .tenant_id
+            .as_deref()
+            .is_some_and(|t| !t.trim().is_empty())
+    {
+        return Err(crate::error::OpenCompanyError::Config(
+            "shared-single-DB tenant mode (OPENCOMPANY_TENANT_ID) namespaces company ids and \
+             owner rows at the app layer; bundle operations write neither. Run them without \
+             tenant mode, from the manager path."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Opens the memory + context overlay selected by `OPENCOMPANY_MEMORY`.
 ///
 /// `Ok(None)` means [`MemoryBackend::Store`] — the base backend keeps its own
@@ -1644,5 +1690,56 @@ mod test {
             ..Default::default()
         };
         assert!(open_storage(&settings, Path::new("/tmp")).await.is_err());
+    }
+    /// The bundle-command refusals, executed — the #1279 review neutralised
+    /// the bin-resident versions with `if false &&` and nothing went red;
+    /// these are the tests that make that mutation fail.
+    #[test]
+    fn bundle_env_refusals_fire_and_the_fs_default_passes() {
+        // fs+store default: both flag spellings pass — no regression.
+        let default = StorageSettings::default();
+        refuse_bundle_env(&default, false).expect("default env, no flag");
+        refuse_bundle_env(&default, true).expect("default env, explicit --home");
+
+        // null refuses in both directions regardless of the flag.
+        let null = StorageSettings {
+            memory_backend: MemoryBackend::Null,
+            ..StorageSettings::default()
+        };
+        for flagged in [false, true] {
+            let err = refuse_bundle_env(&null, flagged)
+                .expect_err("null must refuse")
+                .to_string();
+            assert!(err.contains("OPENCOMPANY_MEMORY=null"), "{err}");
+        }
+
+        // A live environment refuses an explicit --home (two deployments in
+        // one bundle) but proceeds without the flag.
+        let live = StorageSettings {
+            kind: StorageKind::Mongodb,
+            ..StorageSettings::default()
+        };
+        let err = refuse_bundle_env(&live, true)
+            .expect_err("live env + --home must refuse")
+            .to_string();
+        assert!(err.contains("--home"), "{err}");
+        refuse_bundle_env(&live, false).expect("live env without the flag proceeds");
+
+        // Tenant mode refuses on a live env; whitespace does not count as set.
+        let tenant = StorageSettings {
+            kind: StorageKind::Mongodb,
+            tenant_id: Some("acme".into()),
+            ..StorageSettings::default()
+        };
+        let err = refuse_bundle_env(&tenant, false)
+            .expect_err("tenant mode must refuse")
+            .to_string();
+        assert!(err.contains("OPENCOMPANY_TENANT_ID"), "{err}");
+        let blank_tenant = StorageSettings {
+            kind: StorageKind::Mongodb,
+            tenant_id: Some("  ".into()),
+            ..StorageSettings::default()
+        };
+        refuse_bundle_env(&blank_tenant, false).expect("blank tenant id is unset");
     }
 }

--- a/target
+++ b/target
@@ -1,1 +1,0 @@
-/Users/shreyanshsharma/Desktop/Openhuman/opencompany/target

--- a/target
+++ b/target
@@ -1,0 +1,1 @@
+/Users/shreyanshsharma/Desktop/Openhuman/opencompany/target


### PR DESCRIPTION
## Summary

P4 of the memory-surfacing plan: memory stops being trapped wherever it landed. **Stacked on #1273** (review from `0e48f05f`); merge order #1248 → #1273 → this.

### 1. Operator facts travel with the bundle
`export_bundle`/`import_bundle` gain an optional `FactStore`; facts ride `facts.jsonl` at the **bundle root** — the same place the live fs layout keeps them (`paths::Bundle::facts_jsonl`), so exports stay diffable against a live home. Compatibility is explicit in both directions: an old bundle (no file) imports clean; a facts-bearing bundle into a factless target refuses **before anything is written** (the event log is append-only — a late refusal would leave a half-import whose retry duplicates history).

### 2. Export/import read the live engine — one deployment per bundle, enforced
The old arms hardwired fs ports over `--home`, so any deployment running a memory engine (or sqlite/mongodb base) exported the wrong stores silently. Both arms now route through the same env-driven selection `serve` uses — with the invariants that redesign almost broke made explicit: a non-default environment **refuses an explicit `--home`** (a bundle must never mix two deployments), `OPENCOMPANY_MEMORY=null` is refused in both directions (an export of nothing and an import into a black hole both exited 0), shared-single-DB tenant mode is refused (bundle ops write no owner rows), and both arms take the **same exclusive root lock `serve` holds**. Under the fs+store default the environment is inert and `--home` means exactly what it always has.

### 3. `opencompany memory migrate --to <driver>`
The data half of the switch runbook: every record crosses engine-to-engine over the contract's Portability family — paged, resumable (`--resume-cursor`; import is idempotent by `(namespace, key)`, so re-running a failed page cannot duplicate), `--dry-run` touches only the source and labels a resumed count as a remainder. Guards: the boot path's mongodb-ephemeral refusal applies to `--to namespace` (a migration that 'succeeds' into scratch `/data` is data loss with a success message); a mode-aware, normalized same-engine check (the naive version could never fire remote→remote); a stop on a cursor that does not advance; `store`/EngineCortex/`null` refused by name; hosted targets warn about enumeration-based write cost; the no-dual-write precondition (pause first) is printed at start and spelled out in the runbook. Tested against the conformance reference provider on both sides (cross-page copy, idempotent re-run, empty source) plus a failure-injecting double (target error + duplicate-free resume, rejection stop, under-report stop, cursor-echo stop) — the CLI routing and every refusal live in the lib (resolve_migrate_configs / refuse_bundle_env) where the feature lanes execute their tests, and a CI step runs the bin target's tests under the tinymemory lane.

### 4. Runbook grows its real data step
Step 0 pause-first (no dual-write; hosted cursors over mutating stores can skip/repeat), the real command with dry-run/resume semantics, per-tenant-credential and flag-borne-credential cautions.

## Review already applied
A 3-angle review pass ran before this PR was cut; its 10 findings (env split-brain, null black hole, missing lock, ephemeral target, dead same-engine guard, late factless refusal, facts location, dry-run side effects, cursor-echo loop, clippy arg count) are all fixed in `8be262ff`.

## Verification (local, on this exact tree)
- `store::export` 11/11 · `--bin opencompany` 14/14 · `acp,runner,tinymemory` `store::memory` **72/72** · `store::select` 25/25 · fmt · feature-lanes assert (rows unchanged — filters already select the new tests)
- Union lanes + clippy `-D warnings` re-running now on the cold cache; any red lands as a fix-forward commit (per author)

## Known limits (stated, not hidden)
No §A4 typed errors yet, so migrate never retries — it stops with a resume cursor instead. EngineCortex data has no provider seam and cannot migrate through this (use `export`, which now reads it live). `--include-secrets` still copies from the fs bundle only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable memory-engine selection for hosted and embedded deployments.
  - Added a CLI command to migrate memory records between supported engines, with dry runs, progress tracking, verification, and resume support.
  - Added boot-time memory health reporting through `/spec`.
  - Bundle export and import now include optional operator facts.

- **Documentation**
  - Added deployment configuration guidance and an operator runbook for safely switching memory engines.

- **Bug Fixes**
  - Improved safeguards for incompatible storage configurations and migration failures.
  - Fixed data-scrubbing behavior that could corrupt timestamp values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->