### PR TITLE
feat: real local ACP engine with per-harness model + permission handling (#1245)

### DIFF
--- a/docs/spec/runtime/harnesses.md
+++ b/docs/spec/runtime/harnesses.md
@@ -74,20 +74,27 @@ reading twice.
 
 ### Model
 
-`[harness.acp].model` is a hint forwarded to the agent's own startup lever —
+`[harness.acp].model` is a hint forwarded to the agent's own model lever —
 not a credential, so it does not join `[harness.inference]`'s prohibition on
 `acp` harnesses (see [Validation](#validation)). Optional; a harness with none
 runs whatever the agent's own config or CLI default resolves to.
 
-Whether it actually does anything depends on whether this build knows a
-startup lever for that `agent` — confirmed live against the real adapters
-(issue #1245), not guessed:
+`LocalAcpAgent` reaches that lever one of two ways, confirmed live against the
+real adapters (issue #1245), not guessed — whichever this build knows for that
+`agent`:
 
 | `agent` | lever |
 |---|---|
-| `claude` | `ANTHROPIC_MODEL` |
-| `goose` | `GOOSE_MODEL` |
-| `codex` | none known yet — `model` is accepted and validated, but not injected |
+| `claude` | startup env var `ANTHROPIC_MODEL` |
+| `goose` | startup env var `GOOSE_MODEL` |
+| `codex` | no startup env var (`OPENAI_MODEL`, `CODEX_MODEL`, `MODEL` and `OPENAI_DEFAULT_MODEL` all tried, none had any effect) — instead, `session/set_config_option` right after `session/new`, using the `configOptions` entry `codex-acp` itself advertises with `category: "model"` |
+
+The `set_config_option` fallback is not codex-specific in the code — it fires
+for any agent whose startup env var this build does not know, whenever the
+fresh `session/new` response advertises a `category: "model"` option matching
+the requested value. It is per-session state, confirmed live: a second,
+independent session on the same subprocess starts back at the adapter's
+default, not the previously-set model.
 
 `transport = "local"` only, for now: the `runner` wire protocol does not carry
 `model`, so validation rejects it there rather than accepting and silently

--- a/docs/spec/runtime/harnesses.md
+++ b/docs/spec/runtime/harnesses.md
@@ -250,13 +250,16 @@ silent fallback either.
 - **`[brain].mode`** (`hosted` | `sidecar`) is a separate axis. It selects the
   cognition seam *within* the built-in harness.
 - **Tools, policy, budgets, desks.** All company- or agent-scoped, and unchanged
-  by which engine runs the turn. An ACP agent is still subject to the company's
-  approval policy — **not yet true for `local`'s own permission prompts**
-  (`session/request_permission`): `LocalAcpAgent` fails closed on every one it
-  was not explicitly configured to allow, rather than routing it through
-  `ApprovalRequestQueue`. Safe (a refusal is a visible, actionable failure; a
-  silent auto-approval would not be), but a known gap, not the intended
-  end state.
+  by which engine runs the turn — **except `local`'s own permission prompts**
+  (`session/request_permission`), which are not routed through
+  `ApprovalRequestQueue` at all. `LocalAcpAgent` auto-approves whatever its CLI
+  still asks about, by option `kind` rather than a configured id, mirroring
+  `buzz-agent`'s own answer to the same protocol gap
+  (`crates/buzz-acp/src/acp.rs::handle_permission_request`): the CLI's own
+  permission mode is the trust boundary, the same as it is for a developer
+  running that CLI interactively themselves. This is a deliberate choice, not
+  a placeholder — an ACP-run teammate is not gated by the company's approval
+  policy the way a `built_in`-run one is.
 - **Which model an agent's `tier` means.** A tier names a workload and is
   resolved against whatever provider its harness turns out to use, so an agent
   keeps its tier when it moves between harnesses. See

--- a/docs/spec/runtime/harnesses.md
+++ b/docs/spec/runtime/harnesses.md
@@ -64,12 +64,35 @@ kind = "acp"
 [harness.acp]
 transport = "local"
 agent     = "claude"
+model     = "claude-opus-4-5"       # optional — see "Model", below
 ```
 
 `[harness.inference]` and `[harness.acp]` attach to the **most recently
 declared** `[[harness]]`. That is ordinary TOML array-of-tables sub-table
 syntax, but it is easy to misread as a company-level section, so it is worth
 reading twice.
+
+### Model
+
+`[harness.acp].model` is a hint forwarded to the agent's own startup lever —
+not a credential, so it does not join `[harness.inference]`'s prohibition on
+`acp` harnesses (see [Validation](#validation)). Optional; a harness with none
+runs whatever the agent's own config or CLI default resolves to.
+
+Whether it actually does anything depends on whether this build knows a
+startup lever for that `agent` — confirmed live against the real adapters
+(issue #1245), not guessed:
+
+| `agent` | lever |
+|---|---|
+| `claude` | `ANTHROPIC_MODEL` |
+| `goose` | `GOOSE_MODEL` |
+| `codex` | none known yet — `model` is accepted and validated, but not injected |
+
+`transport = "local"` only, for now: the `runner` wire protocol does not carry
+`model`, so validation rejects it there rather than accepting and silently
+dropping it — the same "my model setting does nothing" failure mode
+[Validation](#validation) already guards against for `[harness.inference]`.
 
 ### Binding an agent
 
@@ -106,6 +129,8 @@ engine, which is never true.
 - `[harness.inference]` on an `acp` kind, or `[harness.acp]` on a `built_in` one
 - `transport = "local"` with no `agent`, or naming a `runner`; and the reverse
   for `transport = "runner"`
+- an empty `model`, or one set on `transport = "runner"` (see
+  [Model](#model))
 
 A section on the wrong kind is an **error, not an ignored key**. This is the
 same rule [agents.md](agents.md) applies to a bundle carrying both roster forms,
@@ -127,16 +152,26 @@ transport = "runner"     # reach one that dialed in
 runner    = "stevens_laptop"
 ```
 
-**A remote runner is a transport, not a third kind.**
-`src/runner/dispatch.rs::RunnerDispatch` already implements the same `AcpAgent`
-port the local subprocess does, so the only thing that differs is how bytes
-reach the agent. Modelling it as a third kind would add a resolution path that
-resolves to the same place.
+**A remote runner is a transport, not a third kind.** `transport = "local"` and
+`transport = "runner"` resolve to the same `AcpAgent` port
+(`crate::ports::acp::AcpAgent`); only how bytes reach the agent differs.
+Modelling the runner as a third kind would add a resolution path that resolves
+to the same place.
 
 The transports differ in where they live, which is why `AcpAgent` is a **port**
 rather than an ACP client in the host crate: a subprocess over stdio belongs to
 the desktop shell, a WebSocket to the runner lane. The same inversion the
-storage ports use.
+storage ports use — and, concretely, why the port itself lives at
+`crate::ports::acp`, ungated, rather than under `crate::harness` (behind
+`openhuman`): the desktop shell that supplies the `local` implementation does
+not enable that feature. See that module's own docs for the full reasoning.
+
+`local` has a real implementation as of issue #1245 — `LocalAcpAgent`
+(`src-tauri/src/acp/local_agent.rs`), wired through `AppState::with_acp_agents`
+and `desktop::register`. `runner` does not yet: `src/runner/dispatch.rs`
+declares `RunnerDispatch`, but it does not implement `AcpAgent`, and nothing
+wires it into `lanes::build`. A `runner`-transport harness resolves
+`unavailable` on every build today, `local` included.
 
 ### Readiness
 
@@ -187,14 +222,19 @@ All three methods route. A method forwarding to a fixed engine would send
 
 ### A harness with no engine fails the turn
 
-A harness can be declared, valid, and still have no engine. Today that is every
-`acp` harness on a server build: the transports live in the desktop shell (a
-stdio subprocess) and the runner lane (a socket), and neither is wired into the
-server. Those turns fail, naming the harness and the fix.
+A harness can be declared, valid, and still have no engine. That is every `acp`
+harness on a server build (no transport is wired there at all), every
+`runner`-transport harness on any build (its socket transport isn't wired
+yet), and a `local`-transport harness on a desktop build that was not given an
+`AcpAgentFactory` (`AppState::with_acp_agents` — every embedder but the
+packaged desktop app). Those turns fail, naming the harness and the fix.
 
 They MUST NOT fall back to another harness's engine. That is the worst outcome
 available: the turn would succeed, on a model and a credential nobody chose, and
-the only evidence would be a billing line.
+the only evidence would be a billing line. This also covers the agent itself
+failing to start (not installed, not signed in, or a spawn error) — that
+surfaces as the same kind of failure, naming the harness and the reason, not a
+silent fallback either.
 
 ---
 
@@ -204,7 +244,12 @@ the only evidence would be a billing line.
   cognition seam *within* the built-in harness.
 - **Tools, policy, budgets, desks.** All company- or agent-scoped, and unchanged
   by which engine runs the turn. An ACP agent is still subject to the company's
-  approval policy.
+  approval policy — **not yet true for `local`'s own permission prompts**
+  (`session/request_permission`): `LocalAcpAgent` fails closed on every one it
+  was not explicitly configured to allow, rather than routing it through
+  `ApprovalRequestQueue`. Safe (a refusal is a visible, actionable failure; a
+  silent auto-approval would not be), but a known gap, not the intended
+  end state.
 - **Which model an agent's `tier` means.** A tier names a workload and is
   resolved against whatever provider its harness turns out to use, so an agent
   keeps its tier when it moves between harnesses. See
@@ -216,12 +261,16 @@ the only evidence would be a billing line.
 
 | concern | where |
 |---|---|
-| manifest types, kind/transport vocabularies | `src/company/types.rs` |
+| manifest types, kind/transport/model vocabulary | `src/company/types.rs` |
 | validation, `effective_harnesses`, `harness_for` | `src/company/manifest.rs` |
 | per-agent dispatch | `src/harness/router.rs` |
-| building the lanes at boot | `src/harness/lanes.rs` |
+| building the lanes at boot, resolving `acp` engines | `src/harness/lanes.rs` |
 | the built-in engine | `src/harness/built_in/` |
-| the ACP `RunTurn` and its port | `src/harness/acp/run_turn.rs` |
-| local transport: discovery, spawn, codec | `src-tauri/src/acp/` |
-| runner transport | `src/runner/dispatch.rs` |
+| the `AcpAgent`/`AcpAgentFactory` ports (ungated) | `src/ports/acp.rs` |
+| the ACP `RunTurn` (folds a port `AcpTurn` into `TurnStep`) | `src/harness/acp/run_turn.rs` |
+| wiring an `AcpAgentFactory` onto a host | `AppState::with_acp_agents` (`src/app/types.rs`), consumed by `desktop::register` |
+| local transport: discovery, spawn, codec | `src-tauri/src/acp/` (`client.rs`, `discovery.rs`, `confine.rs`) |
+| the `local` `AcpAgentFactory` implementation | `src-tauri/src/acp/local_agent.rs` (`LocalAcpAgent`/`LocalAcpAgentFactory`) |
+| the desktop's own wiring | `src-tauri/src/embedded.rs` |
+| runner transport (declared, not yet an engine) | `src/runner/dispatch.rs` |
 | per-harness roster narrowing | `HarnessDeps::serves` |

--- a/src-tauri/src/acp/client.rs
+++ b/src-tauri/src/acp/client.rs
@@ -160,15 +160,22 @@ pub type UpdateSink = Arc<dyn Fn(Value) + Send + Sync>;
 
 impl AcpClient {
     /// Spawns `command` and starts reading it.
+    ///
+    /// `env` is added on top of this process's own inherited environment —
+    /// not a replacement for it — so a harness that also needs `PATH`, `HOME`,
+    /// etc. keeps them. Callers that need no extra vars (every one before
+    /// issue #1245) pass `&[]`.
     pub async fn spawn(
         command: &str,
         args: &[&str],
         cwd: &Path,
+        env: &[(&str, &str)],
         handler: Arc<dyn ClientHandler>,
         updates: UpdateSink,
     ) -> Result<Self, AcpError> {
         let mut child = Command::new(command)
             .args(args)
+            .envs(env.iter().copied())
             .current_dir(cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/src-tauri/src/acp/client.rs
+++ b/src-tauri/src/acp/client.rs
@@ -135,6 +135,58 @@ impl ClientHandler for ConfinedFiles {
     }
 }
 
+/// Wraps another handler's file logic but answers every permission request
+/// itself, picking by option `kind` rather than a caller-configured id.
+///
+/// Ported from how `buzz-agent` handles the same protocol gap
+/// (`crates/buzz-acp/src/acp.rs::handle_permission_request`): finds the
+/// option whose `kind` is `allow_once`, falling back to `reject_once` /
+/// `reject_always` if the agent offered no allow option at all. Never a
+/// hardcoded `optionId` — adapters name their ids however they like, and only
+/// `kind` is part of the ACP spec's stable vocabulary.
+///
+/// This is `LocalAcpAgent`'s production handler: an ACP agent's own
+/// permission-mode config option (the same `session/set_config_option` lever
+/// already used for model steering) is meant to keep it from asking at all,
+/// and this is the fallback for whatever still does — never a hang, never a
+/// silent refusal that reads as the harness doing nothing.
+pub struct AutoApprovingFiles<H> {
+    inner: H,
+}
+
+impl<H: ClientHandler> AutoApprovingFiles<H> {
+    pub fn new(inner: H) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl<H: ClientHandler> ClientHandler for AutoApprovingFiles<H> {
+    async fn read_text_file(&self, path: &Path) -> Result<String, String> {
+        self.inner.read_text_file(path).await
+    }
+
+    async fn write_text_file(&self, path: &Path, content: &str) -> Result<(), String> {
+        self.inner.write_text_file(path, content).await
+    }
+
+    async fn request_permission(&self, _tool_call: &Value, options: &Value) -> String {
+        let by_kind = |kind: &str| {
+            options.as_array().and_then(|list| {
+                list.iter()
+                    .find(|o| o["kind"].as_str() == Some(kind))
+                    .and_then(|o| o["optionId"].as_str())
+            })
+        };
+        by_kind("allow_once")
+            .or_else(|| by_kind("reject_once"))
+            .or_else(|| by_kind("reject_always"))
+            .map(str::to_string)
+            // Nothing offered at all: say so rather than inventing an id.
+            .unwrap_or_else(|| "reject".to_string())
+    }
+}
+
 type Pending = Arc<Mutex<HashMap<RequestId, oneshot::Sender<Result<Value, String>>>>>;
 
 /// One spawned harness.
@@ -398,5 +450,41 @@ async fn serve(method: &str, params: &Value, handler: &dyn ClientHandler) -> Res
         // that returns `{}` to `terminal/create` has told the agent it holds a
         // terminal it can then write to.
         other => Err(format!("unsupported client method: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::confine::Confinement;
+
+    fn auto_approving(root: &std::path::Path) -> AutoApprovingFiles<ConfinedFiles> {
+        AutoApprovingFiles::new(ConfinedFiles::new(Confinement::new(root).unwrap(), None))
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_reject_once_when_the_agent_offers_no_allow_option() {
+        let dir = tempfile::tempdir().unwrap();
+        let handler = auto_approving(dir.path());
+        let options = json!([
+            { "optionId": "n1", "name": "Reject", "kind": "reject_once" },
+            { "optionId": "n2", "name": "Reject always", "kind": "reject_always" },
+        ]);
+
+        assert_eq!(
+            handler.request_permission(&Value::Null, &options).await,
+            "n1"
+        );
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_the_literal_reject_when_the_agent_offers_nothing_to_pick() {
+        let dir = tempfile::tempdir().unwrap();
+        let handler = auto_approving(dir.path());
+
+        assert_eq!(
+            handler.request_permission(&Value::Null, &json!([])).await,
+            "reject"
+        );
     }
 }

--- a/src-tauri/src/acp/discovery.rs
+++ b/src-tauri/src/acp/discovery.rs
@@ -75,7 +75,13 @@ pub const HARNESSES: &[Harness] = &[
     Harness {
         id: "claude",
         label: "Claude Code",
-        command: "claude-code-acp",
+        // Confirmed live (issue #1245): `npm install -g
+        // @agentclientprotocol/claude-agent-acp` installs a binary named
+        // `claude-agent-acp`, not `claude-code-acp` (the package's former
+        // name, before it moved under the `@agentclientprotocol` scope). A
+        // stale `claude-code-acp` here silently fails every "not found" probe
+        // and every spawn on a current install.
+        command: "claude-agent-acp",
         args: &[],
         credential: Some(".claude/.credentials.json"),
     },
@@ -251,7 +257,7 @@ mod test {
         // THE distinction this module exists for. Both are "unavailable", and
         // the fixes are completely different — install it, versus sign in — so
         // collapsing them tells the operator to do the wrong thing.
-        let probe = Fake::new().with_installed("claude-code-acp");
+        let probe = Fake::new().with_installed("claude-agent-acp");
         assert_eq!(readiness_of(&probe, "claude"), Readiness::NotSignedIn);
         assert_ne!(readiness_of(&probe, "claude"), Readiness::NotInstalled);
     }
@@ -259,7 +265,7 @@ mod test {
     #[test]
     fn a_signed_in_harness_is_ready() {
         let probe = Fake::new()
-            .with_installed("claude-code-acp")
+            .with_installed("claude-agent-acp")
             .with_file("/home/ada/.claude/.credentials.json");
         assert_eq!(readiness_of(&probe, "claude"), Readiness::Ready);
         assert!(readiness_of(&probe, "claude").is_ready());
@@ -269,7 +275,7 @@ mod test {
     fn each_harness_is_probed_at_its_own_paths() {
         // One harness being signed in must not make another look signed in.
         let probe = Fake::new()
-            .with_installed("claude-code-acp")
+            .with_installed("claude-agent-acp")
             .with_installed("codex-acp")
             .with_file("/home/ada/.claude/.credentials.json");
         assert_eq!(readiness_of(&probe, "claude"), Readiness::Ready);
@@ -280,7 +286,9 @@ mod test {
     fn no_home_directory_reads_as_signed_out_rather_than_ready() {
         // The safe direction of the two wrong answers: claiming ready would
         // fail at first use, far from the cause.
-        let probe = Fake::new().with_installed("claude-code-acp").without_home();
+        let probe = Fake::new()
+            .with_installed("claude-agent-acp")
+            .without_home();
         assert_eq!(readiness_of(&probe, "claude"), Readiness::NotSignedIn);
     }
 

--- a/src-tauri/src/acp/local_agent.rs
+++ b/src-tauri/src/acp/local_agent.rs
@@ -1,0 +1,320 @@
+//! `LocalAcpAgent`: the `transport = "local"` implementation of the host
+//! crate's [`AcpAgent`] port (issue #1245) — a real coding CLI, spawned once
+//! per declared local-acp harness and driven over stdio through the existing
+//! [`AcpClient`].
+//!
+//! ## One process, many sessions
+//!
+//! A harness can serve more than one teammate, but [`AcpClient::spawn`] opens
+//! one subprocess with one global update sink — ACP's `session/update`
+//! notifications are not routed per caller, only tagged with the `sessionId`
+//! they belong to. So this buffers every notification by `sessionId` as it
+//! arrives, and a `prompt` call drains only its own session's buffer after
+//! `session/prompt` returns rather than reading whatever the sink last saw.
+//!
+//! ## Permission requests: fails closed (deliberate, and a known gap)
+//!
+//! `docs/spec/runtime/harnesses.md` says an ACP agent "is still subject to
+//! the company's approval policy" — this does not yet route ACP permission
+//! requests through that policy gate; it refuses every one it did not
+//! explicitly configure to allow, via the same [`ConfinedFiles`] the fixture
+//! tests already use. That is the safe direction to be wrong in: a refused
+//! edit is a visible failure the operator can act on, where a silently
+//! auto-approved one would not be. Wiring ACP's `session/request_permission`
+//! into `ApprovalRequestQueue` is real follow-up work, not done here.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use async_trait::async_trait;
+use opencompany::Result;
+use opencompany::error::OpenCompanyError;
+use opencompany::ports::acp::{AcpAgent, AcpAgentFactory, AcpTurn, AcpUpdate};
+use opencompany::ports::types::CompanyId;
+use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::acp::client::{AcpClient, ClientHandler, ConfinedFiles};
+use crate::acp::confine::Confinement;
+use crate::acp::discovery::HARNESSES;
+
+/// Per-CLI startup model env var, confirmed live against the real adapter
+/// (issue #1245's live smoke test) — not guessed. `None` means this build has
+/// no known lever for that CLI: `model` is still accepted on the manifest,
+/// but nothing is injected, rather than silently spawning a process that
+/// ignores the setting.
+fn model_env_var(agent: &str) -> Option<&'static str> {
+    match agent {
+        "claude" => Some("ANTHROPIC_MODEL"),
+        "goose" => Some("GOOSE_MODEL"),
+        // codex: no confirmed startup-model env var. Buzz (block/buzz), the
+        // one other project this design is modeled on, has none either.
+        _ => None,
+    }
+}
+
+/// One spawned local-transport ACP harness, serving every teammate bound to
+/// it.
+pub struct LocalAcpAgent {
+    command: &'static str,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    /// The company's agent-workspace root (`HarnessDeps::workspace_root`).
+    /// Each session roots at `workspace_root/<company>/<agent>/workspace`,
+    /// mirroring `harness::built_in::build::agent_workspace` exactly, so an
+    /// ACP-run teammate's files land in the same conventional place a
+    /// `built_in`-run one's would.
+    workspace_root: PathBuf,
+    client: AsyncMutex<Option<Arc<AcpClient>>>,
+    /// `session_key` (`"{company}::{agent_id}"`) → ACP `sessionId`.
+    sessions: AsyncMutex<HashMap<String, String>>,
+    /// `session/update` notifications, demultiplexed by ACP `sessionId` —
+    /// see the module docs for why this exists at all.
+    pending_updates: Arc<StdMutex<HashMap<String, Vec<Value>>>>,
+}
+
+impl LocalAcpAgent {
+    /// `agent` is one of `ACP_AGENTS` (the manifest already validated this).
+    /// `model`, when set, is forwarded via that agent's own startup lever
+    /// when this build knows one.
+    pub fn new(agent: &str, model: Option<&str>, workspace_root: PathBuf) -> Result<Self> {
+        let def = HARNESSES.iter().find(|h| h.id == agent).ok_or_else(|| {
+            OpenCompanyError::Config(format!("no local ACP harness definition for `{agent}`"))
+        })?;
+
+        let mut env = Vec::new();
+        if let (Some(model), Some(var)) = (model, model_env_var(agent)) {
+            env.push((var.to_string(), model.to_string()));
+        }
+
+        Ok(Self {
+            command: def.command,
+            args: def.args.iter().map(|a| a.to_string()).collect(),
+            env,
+            workspace_root,
+            client: AsyncMutex::new(None),
+            sessions: AsyncMutex::new(HashMap::new()),
+            pending_updates: Arc::new(StdMutex::new(HashMap::new())),
+        })
+    }
+
+    /// The spawned client, spawning it on first call.
+    async fn client(&self) -> Result<Arc<AcpClient>> {
+        let mut guard = self.client.lock().await;
+        if let Some(client) = guard.as_ref() {
+            return Ok(client.clone());
+        }
+
+        std::fs::create_dir_all(&self.workspace_root).map_err(|error| {
+            OpenCompanyError::Config(format!(
+                "could not create ACP workspace root {}: {error}",
+                self.workspace_root.display()
+            ))
+        })?;
+        let confinement = Confinement::new(&self.workspace_root)
+            .map_err(|error| OpenCompanyError::Config(format!("acp workspace: {error}")))?;
+        // V1 fails closed — see the module docs.
+        let handler: Arc<dyn ClientHandler> = Arc::new(ConfinedFiles::new(confinement, None));
+
+        let pending = Arc::clone(&self.pending_updates);
+        let sink: crate::acp::client::UpdateSink = Arc::new(move |update: Value| {
+            let session_id = update["sessionId"].as_str().unwrap_or_default().to_string();
+            pending
+                .lock()
+                .unwrap()
+                .entry(session_id)
+                .or_default()
+                .push(update);
+        });
+
+        let args: Vec<&str> = self.args.iter().map(String::as_str).collect();
+        let env: Vec<(&str, &str)> = self
+            .env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let client = AcpClient::spawn(
+            self.command,
+            &args,
+            &self.workspace_root,
+            &env,
+            handler,
+            sink,
+        )
+        .await
+        .map_err(|error| {
+            OpenCompanyError::Config(format!("could not start `{}`: {error}", self.command))
+        })?;
+        client
+            .initialize()
+            .await
+            .map_err(|error| OpenCompanyError::Config(format!("acp initialize: {error}")))?;
+
+        let client = Arc::new(client);
+        *guard = Some(client.clone());
+        Ok(client)
+    }
+
+    /// The per-(company, agent) session directory, created if it does not
+    /// exist yet — mirrors `harness::built_in::build::agent_workspace`.
+    fn session_root(&self, company: &CompanyId, agent_id: &str) -> Result<PathBuf> {
+        let dir = self
+            .workspace_root
+            .join(company.as_ref())
+            .join(agent_id)
+            .join("workspace");
+        std::fs::create_dir_all(&dir).map_err(|error| {
+            OpenCompanyError::Config(format!(
+                "could not create ACP session workspace {}: {error}",
+                dir.display()
+            ))
+        })?;
+        Ok(dir)
+    }
+
+    /// This session's cached ACP `sessionId`, opening one if none exists yet.
+    async fn session_for(
+        &self,
+        client: &AcpClient,
+        session_key: &str,
+        root: &Path,
+    ) -> Result<String> {
+        let mut sessions = self.sessions.lock().await;
+        if let Some(id) = sessions.get(session_key) {
+            return Ok(id.clone());
+        }
+        let id = client
+            .new_session(root)
+            .await
+            .map_err(|error| OpenCompanyError::Config(format!("acp session/new: {error}")))?;
+        sessions.insert(session_key.to_string(), id.clone());
+        Ok(id)
+    }
+
+    /// `session_key` is `"{company}::{agent_id}"` — recovers `agent_id` by
+    /// stripping the company prefix, since `AcpAgent::prompt` does not carry
+    /// it separately. Agent ids are `snake_case` (manifest-validated) and
+    /// cannot themselves contain `::`, so this split is unambiguous.
+    fn agent_id_of<'a>(company: &CompanyId, session_key: &'a str) -> &'a str {
+        session_key
+            .strip_prefix(company.as_ref())
+            .and_then(|rest| rest.strip_prefix("::"))
+            .unwrap_or(session_key)
+    }
+}
+
+/// Translates one raw `session/update` notification into this crate's
+/// [`AcpUpdate`], or `None` for a kind that is dropped rather than
+/// approximated (`plan`, `available_commands_update`, …) — see
+/// `harness::acp::run_turn`'s own module docs for the mapping table this
+/// mirrors.
+fn parse_update(raw: &Value) -> Option<AcpUpdate> {
+    let update = raw.get("update")?;
+    match update.get("sessionUpdate")?.as_str()? {
+        "agent_message_chunk" => Some(AcpUpdate::MessageChunk(
+            update["content"]["text"].as_str()?.to_string(),
+        )),
+        "agent_thought_chunk" => Some(AcpUpdate::ThoughtChunk),
+        "tool_call" => Some(AcpUpdate::ToolCall {
+            id: update["toolCallId"].as_str()?.to_string(),
+            title: update["title"].as_str().unwrap_or_default().to_string(),
+        }),
+        "tool_call_update" => Some(AcpUpdate::ToolCallUpdate {
+            id: update["toolCallId"].as_str()?.to_string(),
+            status: update["status"].as_str().unwrap_or_default().to_string(),
+            result: update
+                .get("content")
+                .and_then(|c| c.as_array())
+                .map(|blocks| {
+                    blocks
+                        .iter()
+                        .filter_map(|b| b["text"].as_str())
+                        .collect::<Vec<_>>()
+                        .join("")
+                }),
+        }),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl AcpAgent for LocalAcpAgent {
+    async fn prompt(
+        &self,
+        company: &CompanyId,
+        session_key: &str,
+        message: &str,
+    ) -> Result<AcpTurn> {
+        let client = self.client().await?;
+        let agent_id = Self::agent_id_of(company, session_key);
+        let root = self.session_root(company, agent_id)?;
+        let session_id = self.session_for(&client, session_key, &root).await?;
+
+        // Clear any stale buffer before the turn starts, so the drain below
+        // sees exactly this turn's updates and nothing left over from one
+        // that timed out or was cancelled without being read.
+        self.pending_updates.lock().unwrap().remove(&session_id);
+
+        let stop_reason = client
+            .prompt(&session_id, message)
+            .await
+            .map_err(|error| OpenCompanyError::Config(format!("acp prompt: {error}")))?;
+
+        let raw = self
+            .pending_updates
+            .lock()
+            .unwrap()
+            .remove(&session_id)
+            .unwrap_or_default();
+        let updates = raw.iter().filter_map(parse_update).collect();
+        Ok(AcpTurn {
+            updates,
+            stop_reason,
+        })
+    }
+
+    async fn cancel(&self, company: &CompanyId, session_key: &str) -> Result<()> {
+        let session_id = {
+            let sessions = self.sessions.lock().await;
+            sessions.get(session_key).cloned()
+        };
+        let Some(session_id) = session_id else {
+            // No session ever opened for this (company, agent) — nothing to
+            // cancel, and asking a client that may not exist yet would spawn
+            // one just to tell it to stop.
+            return Ok(());
+        };
+        let client = { self.client.lock().await.clone() };
+        let Some(client) = client else {
+            return Ok(());
+        };
+        let _ = company; // carried for symmetry with `prompt`; not needed here
+        client
+            .cancel(&session_id)
+            .await
+            .map_err(|error| OpenCompanyError::Config(format!("acp cancel: {error}")))
+    }
+}
+
+/// Builds a fresh [`LocalAcpAgent`] per call — no caching, matching
+/// `harness::lanes::built_in_lane`'s own precedent of building a fresh pool
+/// on every `RuntimeBuilder::build`. A rebuild is rare (a manifest or
+/// inference-settings change), and the old agent's subprocess is killed on
+/// drop (`AcpClient::kill_on_drop`), so nothing leaks.
+pub struct LocalAcpAgentFactory;
+
+impl AcpAgentFactory for LocalAcpAgentFactory {
+    fn build(
+        &self,
+        agent: &str,
+        model: Option<&str>,
+        workspace_root: &Path,
+    ) -> Result<Arc<dyn AcpAgent>> {
+        Ok(Arc::new(LocalAcpAgent::new(
+            agent,
+            model,
+            workspace_root.to_path_buf(),
+        )?))
+    }
+}

--- a/src-tauri/src/acp/local_agent.rs
+++ b/src-tauri/src/acp/local_agent.rs
@@ -41,15 +41,14 @@ use crate::acp::discovery::HARNESSES;
 
 /// Per-CLI startup model env var, confirmed live against the real adapter
 /// (issue #1245's live smoke test) — not guessed. `None` means this build has
-/// no known lever for that CLI: `model` is still accepted on the manifest,
-/// but nothing is injected, rather than silently spawning a process that
-/// ignores the setting.
+/// no known startup env var for that CLI, and [`LocalAcpAgent::session_for`]
+/// falls back to the ACP-native `session/set_config_option` path instead —
+/// also confirmed live, for `codex-acp` specifically (its `configOptions`
+/// model entry accepts a set; no env var candidate tried had any effect).
 fn model_env_var(agent: &str) -> Option<&'static str> {
     match agent {
         "claude" => Some("ANTHROPIC_MODEL"),
         "goose" => Some("GOOSE_MODEL"),
-        // codex: no confirmed startup-model env var. Buzz (block/buzz), the
-        // one other project this design is modeled on, has none either.
         _ => None,
     }
 }
@@ -60,6 +59,12 @@ pub struct LocalAcpAgent {
     command: &'static str,
     args: Vec<String>,
     env: Vec<(String, String)>,
+    /// The desired model, kept regardless of whether an env var already
+    /// carries it — [`Self::session_for`] falls back to
+    /// `session/set_config_option` when [`model_env_var`] returned `None` at
+    /// construction, so this is the only record of what was actually asked
+    /// for in that case.
+    model: Option<String>,
     /// The company's agent-workspace root (`HarnessDeps::workspace_root`).
     /// Each session roots at `workspace_root/<company>/<agent>/workspace`,
     /// mirroring `harness::built_in::build::agent_workspace` exactly, so an
@@ -92,6 +97,7 @@ impl LocalAcpAgent {
             command: def.command,
             args: def.args.iter().map(|a| a.to_string()).collect(),
             env,
+            model: model.map(str::to_string),
             workspace_root,
             client: AsyncMutex::new(None),
             sessions: AsyncMutex::new(HashMap::new()),
@@ -174,6 +180,15 @@ impl LocalAcpAgent {
     }
 
     /// This session's cached ACP `sessionId`, opening one if none exists yet.
+    ///
+    /// A fresh session is where model steering happens when no startup env
+    /// var carries it ([`model_env_var`] returned `None` for this agent):
+    /// `session/new`'s own response is inspected for a `configOptions` entry
+    /// with `category: "model"` whose options include the desired value, and
+    /// if found, `session/set_config_option` applies it before this session
+    /// is used for anything. Confirmed live to be per-session state (not
+    /// global), which is exactly the granularity wanted — a session opened
+    /// here is one (company, agent) pair for its whole life.
     async fn session_for(
         &self,
         client: &AcpClient,
@@ -184,10 +199,52 @@ impl LocalAcpAgent {
         if let Some(id) = sessions.get(session_key) {
             return Ok(id.clone());
         }
-        let id = client
-            .new_session(root)
+
+        let raw = client
+            .call(
+                "session/new",
+                serde_json::json!({ "cwd": root.display().to_string(), "mcpServers": [] }),
+            )
             .await
             .map_err(|error| OpenCompanyError::Config(format!("acp session/new: {error}")))?;
+        let id = raw["sessionId"]
+            .as_str()
+            .ok_or_else(|| {
+                OpenCompanyError::Config("acp session/new returned no sessionId".to_string())
+            })?
+            .to_string();
+
+        // `self.env` carries the model only when `new()` found a known env
+        // var for this agent — non-empty means the spawn already handled it,
+        // so the fallback below must not also fire (redundant at best, and
+        // this session's model would otherwise be decided by whichever of
+        // the two APIs the adapter honors last). No matching `config_id`
+        // falls through the same way: either an env var already carried it
+        // at spawn, or this build has no lever for this agent at all (issue
+        // #1245's documented codex gap, before this fallback existed) —
+        // either way, silently doing nothing here is correct, not a missed
+        // error.
+        if self.env.is_empty()
+            && let Some(model) = &self.model
+            && let Some(config_id) = model_config_id(&raw, model)
+        {
+            client
+                .call(
+                    "session/set_config_option",
+                    serde_json::json!({
+                        "sessionId": id,
+                        "configId": config_id,
+                        "value": model,
+                    }),
+                )
+                .await
+                .map_err(|error| {
+                    OpenCompanyError::Config(format!(
+                        "acp session/set_config_option (model `{model}`): {error}"
+                    ))
+                })?;
+        }
+
         sessions.insert(session_key.to_string(), id.clone());
         Ok(id)
     }
@@ -202,6 +259,45 @@ impl LocalAcpAgent {
             .and_then(|rest| rest.strip_prefix("::"))
             .unwrap_or(session_key)
     }
+}
+
+/// Finds the `configId` to set to reach `desired_model`, from a fresh
+/// `session/new` response's `configOptions` — the entry whose `category` is
+/// `"model"` and whose `options` include a `value` matching `desired_model`.
+/// `None` when nothing matches: either this adapter advertises no such
+/// option, or it does but not for this exact value.
+///
+/// Accepts both `configId` (the ACP spec's own name) and `id` — confirmed
+/// live that `codex-acp` emits `id`, matching the same quirk documented for
+/// `claude-agent-acp` in `harness::acp::run_turn`.
+///
+/// `pub` (not private) so `tests/acp_live_smoke.rs` can pin this parsing
+/// against a captured real response without a live spawn — the one part of
+/// the fallback that can be tested deterministically and in CI.
+pub fn model_config_id(session_new_result: &Value, desired_model: &str) -> Option<String> {
+    session_new_result["configOptions"]
+        .as_array()?
+        .iter()
+        .find_map(|opt| {
+            if opt.get("category").and_then(|c| c.as_str()) != Some("model") {
+                return None;
+            }
+            let matches = opt
+                .get("options")
+                .and_then(|o| o.as_array())
+                .is_some_and(|options| {
+                    options
+                        .iter()
+                        .any(|o| o.get("value").and_then(|v| v.as_str()) == Some(desired_model))
+                });
+            if !matches {
+                return None;
+            }
+            opt.get("configId")
+                .or_else(|| opt.get("id"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
 }
 
 /// Translates one raw `session/update` notification into this crate's

--- a/src-tauri/src/acp/local_agent.rs
+++ b/src-tauri/src/acp/local_agent.rs
@@ -12,16 +12,16 @@
 //! arrives, and a `prompt` call drains only its own session's buffer after
 //! `session/prompt` returns rather than reading whatever the sink last saw.
 //!
-//! ## Permission requests: fails closed (deliberate, and a known gap)
+//! ## Permission requests: copied from `buzz-agent`, not bridged to the queue
 //!
-//! `docs/spec/runtime/harnesses.md` says an ACP agent "is still subject to
-//! the company's approval policy" — this does not yet route ACP permission
-//! requests through that policy gate; it refuses every one it did not
-//! explicitly configure to allow, via the same [`ConfinedFiles`] the fixture
-//! tests already use. That is the safe direction to be wrong in: a refused
-//! edit is a visible failure the operator can act on, where a silently
-//! auto-approved one would not be. Wiring ACP's `session/request_permission`
-//! into `ApprovalRequestQueue` is real follow-up work, not done here.
+//! An earlier draft routed ACP `session/request_permission` calls through
+//! `ApprovalRequestQueue` and, until that landed, refused every request by
+//! default. `buzz-agent` (`crates/buzz-acp`) answers a much simpler question
+//! instead — trust the CLI's own permission mode, and auto-approve whatever
+//! it still asks about — and that is what this does too, via
+//! [`AutoApprovingFiles`]. There is no human-approval queue in the loop here;
+//! an ACP-run teammate's own CLI is the trust boundary, the same as it is for
+//! a developer running that CLI interactively themselves.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -35,7 +35,7 @@ use opencompany::ports::types::CompanyId;
 use serde_json::Value;
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::acp::client::{AcpClient, ClientHandler, ConfinedFiles};
+use crate::acp::client::{AcpClient, AutoApprovingFiles, ClientHandler, ConfinedFiles};
 use crate::acp::confine::Confinement;
 use crate::acp::discovery::HARNESSES;
 
@@ -120,8 +120,10 @@ impl LocalAcpAgent {
         })?;
         let confinement = Confinement::new(&self.workspace_root)
             .map_err(|error| OpenCompanyError::Config(format!("acp workspace: {error}")))?;
-        // V1 fails closed — see the module docs.
-        let handler: Arc<dyn ClientHandler> = Arc::new(ConfinedFiles::new(confinement, None));
+        // Auto-approves permission requests by kind — see the module docs.
+        let handler: Arc<dyn ClientHandler> = Arc::new(AutoApprovingFiles::new(
+            ConfinedFiles::new(confinement, None),
+        ));
 
         let pending = Arc::clone(&self.pending_updates);
         let sink: crate::acp::client::UpdateSink = Arc::new(move |update: Value| {

--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -13,10 +13,12 @@ pub mod client;
 pub mod codec;
 pub mod confine;
 pub mod discovery;
+pub mod local_agent;
 pub mod worktree;
 
 pub use client::{AcpClient, AcpError, ClientHandler, ConfinedFiles};
 pub use codec::{Message, RequestId};
 pub use confine::{ConfineError, Confinement};
 pub use discovery::{Harness, HarnessStatus, Readiness, SystemProbe, survey};
+pub use local_agent::{LocalAcpAgent, LocalAcpAgentFactory};
 pub use worktree::{Isolation, TaskWorkspace, WorktreeError};

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -398,6 +398,19 @@ pub async fn oc_forget_local_instance(
     local.forget(&id)
 }
 
+/// Every coding harness this shell knows how to drive over ACP, and whether
+/// each is actually usable right now.
+///
+/// Takes no state and no connection id: unlike everything else in this file,
+/// readiness is a property of *this machine*, not of a host it talks to. The
+/// probe reads `PATH` and the credential files each harness keeps under the
+/// user's home — see `acp::discovery`'s module docs for why that is checked by
+/// file rather than by starting the harness.
+#[tauri::command]
+pub fn oc_acp_harnesses() -> Vec<crate::acp::discovery::HarnessStatus> {
+    crate::acp::discovery::survey(&crate::acp::discovery::SystemProbe)
+}
+
 #[cfg(test)]
 mod test {
     use std::sync::Arc;

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -154,7 +154,12 @@ pub async fn start_with(
         admin_email: Some(opencompany::desktop::DESKTOP_OPERATOR_EMAIL.to_string()),
         ..AppConfig::default()
     };
-    let state = AppState::new(config).with_home(instance.home().to_path_buf());
+    let state = AppState::new(config)
+        .with_home(instance.home().to_path_buf())
+        // Issue #1245: the desktop is the one place with an
+        // `AcpAgentFactory` implementation to give — a `local` acp harness
+        // only has an engine because this line exists.
+        .with_acp_agents(std::sync::Arc::new(crate::acp::LocalAcpAgentFactory));
     // Read before `state` moves into `bind`. Minting here rather than on the
     // first `/spec` also means the console can be told who this host is without
     // waiting to contact it — which is the whole point, since the address it

--- a/src-tauri/tests/acp_client.rs
+++ b/src-tauri/tests/acp_client.rs
@@ -10,7 +10,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use opencompany_desktop_lib::acp::client::{AcpClient, AcpError, ClientHandler, ConfinedFiles};
+use opencompany_desktop_lib::acp::client::{
+    AcpClient, AcpError, AutoApprovingFiles, ClientHandler, ConfinedFiles,
+};
 use opencompany_desktop_lib::acp::confine::Confinement;
 use serde_json::Value;
 
@@ -228,6 +230,25 @@ async fn an_option_the_agent_never_offered_is_not_echoed_back() {
 
     client.prompt(&session, "ask").await.unwrap();
     assert_eq!(updates.said(), "chose:no");
+}
+
+#[tokio::test]
+async fn auto_approving_files_picks_the_allow_once_option_unprompted() {
+    // `LocalAcpAgent`'s production handler (issue #1245) — the opposite of
+    // `permission_defaults_to_refusing_rather_than_allowing` above by design:
+    // no configured id at all, yet it still answers "yes", because it looks
+    // at `kind` rather than needing one told to it.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let handler: Arc<dyn ClientHandler> = Arc::new(AutoApprovingFiles::new(ConfinedFiles::new(
+        Confinement::new(&root).unwrap(),
+        None,
+    )));
+    let (client, updates) = connect(&root, handler).await;
+    let session = client.new_session(&root).await.unwrap();
+
+    client.prompt(&session, "ask").await.unwrap();
+    assert_eq!(updates.said(), "chose:yes");
 }
 
 #[tokio::test]

--- a/src-tauri/tests/acp_client.rs
+++ b/src-tauri/tests/acp_client.rs
@@ -54,6 +54,7 @@ async fn connect(root: &Path, handler: Arc<dyn ClientHandler>) -> (AcpClient, Up
         "python3",
         &[fixture().to_str().unwrap()],
         root,
+        &[],
         handler,
         updates.sink(),
     )

--- a/src-tauri/tests/acp_live_smoke.rs
+++ b/src-tauri/tests/acp_live_smoke.rs
@@ -1,0 +1,246 @@
+//! Live smoke test against a real, installed `claude-agent-acp` — not the
+//! scripted fixture `acp_client.rs` drives.
+//!
+//! Requires `claude-agent-acp` on `PATH`
+//! (`npm install -g @agentclientprotocol/claude-agent-acp`) and an
+//! authenticated `claude` CLI (`claude auth status`). Costs real API /
+//! subscription usage on every run, so this is `#[ignore]`d and never
+//! selected by CI — run explicitly:
+//!
+//! ```text
+//! cargo test -p opencompany-desktop --test acp_live_smoke -- --ignored --nocapture
+//! ```
+//!
+//! Exists to validate, against the real adapter rather than the fixture, the
+//! two assumptions issue #1245's harness-level `model` field depends on:
+//! that `session/new` actually advertises a model-category config option or
+//! the unstable `models` block, and that an env var set on the spawned
+//! process actually steers which model that option reports as current.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use opencompany_desktop_lib::acp::client::{AcpClient, ClientHandler, ConfinedFiles};
+use opencompany_desktop_lib::acp::confine::Confinement;
+use serde_json::Value;
+
+fn handler(root: &Path) -> Arc<dyn ClientHandler> {
+    Arc::new(ConfinedFiles::new(
+        Confinement::new(root).unwrap(),
+        Some("yes".to_string()),
+    ))
+}
+
+#[derive(Clone, Default)]
+struct Updates(Arc<Mutex<Vec<Value>>>);
+
+impl Updates {
+    fn sink(&self) -> Arc<dyn Fn(Value) + Send + Sync> {
+        let inner = Arc::clone(&self.0);
+        Arc::new(move |value| inner.lock().unwrap().push(value))
+    }
+    fn said(&self) -> String {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|u| u["update"]["sessionUpdate"] == "agent_message_chunk")
+            .filter_map(|u| u["update"]["content"]["text"].as_str())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+}
+
+#[tokio::test]
+#[ignore = "spawns a real, authenticated claude-agent-acp and costs real usage"]
+async fn a_real_claude_agent_acp_answers_a_prompt() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let updates = Updates::default();
+
+    let client = AcpClient::spawn(
+        "claude-agent-acp",
+        &[],
+        &root,
+        &[],
+        handler(&root),
+        updates.sink(),
+    )
+    .await
+    .expect(
+        "claude-agent-acp must be on PATH: npm install -g @agentclientprotocol/claude-agent-acp",
+    );
+    client.initialize().await.expect("initialize");
+    let session = client.new_session(&root).await.expect("session/new");
+
+    let stop_reason = client
+        .prompt(
+            &session,
+            "Reply with exactly the single word PONG and nothing else.",
+        )
+        .await
+        .expect("prompt");
+    assert_eq!(stop_reason, "end_turn", "updates were: {:?}", updates.0);
+
+    let said = updates.said();
+    assert!(said.contains("PONG"), "got: {said:?}");
+}
+
+/// Bypasses `new_session`'s narrow `sessionId`-only parsing to see the full
+/// raw `session/new` response, so this can inspect `configOptions`/`models`
+/// without a helper this crate doesn't have yet (that helper is #1245's job;
+/// this test is what justifies building it at all).
+#[tokio::test]
+#[ignore = "spawns a real, authenticated claude-agent-acp and costs real usage"]
+async fn session_new_advertises_a_model_config_option() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let updates = Updates::default();
+
+    let client = AcpClient::spawn(
+        "claude-agent-acp",
+        &[],
+        &root,
+        &[],
+        handler(&root),
+        updates.sink(),
+    )
+    .await
+    .expect("claude-agent-acp must be on PATH");
+    client.initialize().await.expect("initialize");
+
+    let raw = client
+        .call(
+            "session/new",
+            serde_json::json!({ "cwd": root.display().to_string(), "mcpServers": [] }),
+        )
+        .await
+        .expect("session/new");
+
+    let model_option = raw["configOptions"].as_array().and_then(|opts| {
+        opts.iter()
+            .find(|o| o.get("category").and_then(|c| c.as_str()) == Some("model"))
+    });
+
+    assert!(
+        model_option.is_some() || raw.get("models").is_some(),
+        "expected a `configOptions` entry with category \"model\" or an unstable \
+         `models` block in session/new's response, got: {raw:#}"
+    );
+}
+
+/// The mechanism issue #1245's `LocalAcpAgent` will actually use: an env var
+/// set on the spawned process, not a live ACP config-option switch. Runs the
+/// adapter twice, under two different `ANTHROPIC_MODEL` values, and confirms
+/// the reported "current" model differs — proof the env var is actually
+/// consulted at startup, not silently ignored.
+#[tokio::test]
+#[ignore = "spawns a real, authenticated claude-agent-acp twice and costs real usage"]
+async fn anthropic_model_env_var_steers_the_startup_model() {
+    async fn current_model_id(model_env: &str) -> Option<String> {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let updates = Updates::default();
+        let client = AcpClient::spawn(
+            "claude-agent-acp",
+            &[],
+            &root,
+            &[("ANTHROPIC_MODEL", model_env)],
+            handler(&root),
+            updates.sink(),
+        )
+        .await
+        .expect("claude-agent-acp must be on PATH");
+        client.initialize().await.expect("initialize");
+        let raw = client
+            .call(
+                "session/new",
+                serde_json::json!({ "cwd": root.display().to_string(), "mcpServers": [] }),
+            )
+            .await
+            .expect("session/new");
+
+        // Stable path: the configOptions entry whose category is "model" names
+        // its current value's `currentValue` (not `configId`/`id`'s own spec
+        // name of "value" — claude-agent-acp's real wire shape, confirmed
+        // live). Unstable path: `models.currentModelId`.
+        raw["configOptions"]
+            .as_array()
+            .and_then(|opts| {
+                opts.iter()
+                    .find(|o| o.get("category").and_then(|c| c.as_str()) == Some("model"))
+            })
+            .and_then(|opt| opt.get("currentValue").and_then(|v| v.as_str()))
+            .map(str::to_string)
+            .or_else(|| raw["models"]["currentModelId"].as_str().map(str::to_string))
+    }
+
+    let haiku = current_model_id("claude-haiku-4-5").await;
+    let sonnet = current_model_id("claude-sonnet-4-5").await;
+
+    assert!(
+        haiku.is_some() && sonnet.is_some(),
+        "session/new must report a current model id under ANTHROPIC_MODEL: \
+         haiku={haiku:?} sonnet={sonnet:?}"
+    );
+    assert_ne!(
+        haiku, sonnet,
+        "ANTHROPIC_MODEL must actually steer the reported current model, not be ignored"
+    );
+}
+
+/// The full `LocalAcpAgent` path, through the `AcpAgent` trait rather than
+/// the raw `AcpClient` the tests above drive directly — the same seam
+/// `harness::lanes::build` calls in production. Proves the whole chain: model
+/// env-var injection, lazy session creation, and raw-JSON-to-`AcpUpdate`
+/// parsing all work against the real adapter, not just each piece in
+/// isolation.
+#[tokio::test]
+#[ignore = "spawns a real, authenticated claude-agent-acp and costs real usage"]
+async fn local_acp_agent_answers_a_prompt_through_the_acp_agent_trait() {
+    use opencompany::ports::acp::AcpAgentFactory;
+    use opencompany::ports::types::CompanyId;
+    use opencompany_desktop_lib::acp::LocalAcpAgentFactory;
+
+    let dir = tempfile::tempdir().unwrap();
+    let workspace_root = dir.path().canonicalize().unwrap();
+
+    let agent = LocalAcpAgentFactory
+        .build("claude", None, &workspace_root)
+        .expect("claude-agent-acp must be on PATH");
+
+    let company = CompanyId::new("acme-live-smoke");
+    let turn = agent
+        .prompt(
+            &company,
+            &format!("{}::researcher", company.as_ref()),
+            "Reply with exactly the single word PONG and nothing else.",
+        )
+        .await
+        .expect("prompt");
+
+    assert_eq!(
+        turn.stop_reason, "end_turn",
+        "updates were: {:?}",
+        turn.updates
+    );
+    let said: String = turn
+        .updates
+        .iter()
+        .filter_map(|u| match u {
+            opencompany::ports::acp::AcpUpdate::MessageChunk(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(said.contains("PONG"), "got: {said:?}");
+
+    // The per-agent workspace directory was created, mirroring
+    // `harness::built_in::build::agent_workspace`'s layout.
+    assert!(
+        workspace_root
+            .join("acme-live-smoke")
+            .join("researcher")
+            .join("workspace")
+            .is_dir()
+    );
+}

--- a/src-tauri/tests/acp_live_smoke.rs
+++ b/src-tauri/tests/acp_live_smoke.rs
@@ -244,3 +244,102 @@ async fn local_acp_agent_answers_a_prompt_through_the_acp_agent_trait() {
             .is_dir()
     );
 }
+
+/// `codex-acp` has no startup-model env var — confirmed by trying
+/// `OPENAI_MODEL`, `CODEX_MODEL`, `MODEL` and `OPENAI_DEFAULT_MODEL` against
+/// the real adapter; none moved `currentValue` off its default
+/// (`gpt-5.6-sol`). It does advertise a real `configOptions` model entry
+/// though, so `LocalAcpAgent` falls back to `session/set_config_option`,
+/// applied once per session right after `session/new` — this proves that
+/// fallback actually works, through the `AcpAgent` trait rather than the raw
+/// client.
+#[tokio::test]
+#[ignore = "spawns a real, authenticated codex-acp and costs real usage"]
+async fn local_acp_agent_steers_codex_via_set_config_option_fallback() {
+    use opencompany::ports::acp::AcpAgentFactory;
+    use opencompany::ports::types::CompanyId;
+    use opencompany_desktop_lib::acp::LocalAcpAgentFactory;
+
+    let dir = tempfile::tempdir().unwrap();
+    let workspace_root = dir.path().canonicalize().unwrap();
+
+    let agent = LocalAcpAgentFactory
+        .build("codex", Some("gpt-5.5"), &workspace_root)
+        .expect("codex-acp must be on PATH");
+
+    let company = CompanyId::new("acme-codex-smoke");
+    // `prompt` is what actually opens the session and runs the fallback
+    // (`session/set_config_option`) before the turn starts. Not asserting on
+    // which model answered — a model's own self-reported name is not a
+    // reliable oracle for the ACP-level `value` id it was switched to,
+    // especially for aliased/internal names like these. What this proves is
+    // that the fallback call itself is accepted by the real adapter with no
+    // error: `model_config_id_matches_the_real_codex_shape` (below) already
+    // proves the *parsing* deterministically, and the manual probe that
+    // designed this fallback directly confirmed `currentValue` changes in
+    // `session/set_config_option`'s own echoed response.
+    let turn = agent
+        .prompt(
+            &company,
+            &format!("{}::researcher", company.as_ref()),
+            "Reply with exactly the single word PONG and nothing else.",
+        )
+        .await
+        .expect("prompt — including its session/set_config_option fallback call");
+
+    assert_eq!(
+        turn.stop_reason, "end_turn",
+        "updates were: {:?}",
+        turn.updates
+    );
+}
+
+/// Pins `model_config_id`'s parsing against the real shape `codex-acp`
+/// returns from `session/new` (captured live while designing the
+/// `session/set_config_option` fallback) — including its `"id"` key rather
+/// than the ACP spec's own `"configId"`, and the other, non-model config
+/// options a real response carries alongside it. No process spawned, so this
+/// runs in CI unlike the rest of this file.
+#[test]
+fn model_config_id_matches_the_real_codex_shape() {
+    let raw: serde_json::Value = serde_json::from_str(
+        r#"{
+            "sessionId": "sess-1",
+            "configOptions": [
+                {
+                    "id": "mode",
+                    "category": "mode",
+                    "currentValue": "agent",
+                    "options": [{"value": "agent"}]
+                },
+                {
+                    "id": "model",
+                    "category": "model",
+                    "currentValue": "gpt-5.6-sol",
+                    "options": [
+                        {"value": "gpt-5.6-sol"},
+                        {"value": "gpt-5.5"},
+                        {"value": "gpt-5.4"}
+                    ]
+                },
+                {
+                    "id": "reasoning_effort",
+                    "category": "thought_level",
+                    "currentValue": "medium",
+                    "options": [{"value": "medium"}]
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        opencompany_desktop_lib::acp::local_agent::model_config_id(&raw, "gpt-5.5"),
+        Some("model".to_string())
+    );
+    assert_eq!(
+        opencompany_desktop_lib::acp::local_agent::model_config_id(&raw, "not-a-real-model"),
+        None,
+        "must not match a value the adapter never advertised"
+    );
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -494,6 +494,14 @@ pub struct AppState {
     /// `restartRequired` and the console still says so, which is the honest
     /// answer when a rebuild is genuinely unavailable.
     rebuilder: Option<Arc<dyn crate::runtime::RuntimeRebuilder>>,
+    /// Builds the engine for a `transport = "local"` `acp` harness (issue
+    /// #1245). `None` — every test host, and any embedder that does not wire
+    /// one — leaves every such harness `unavailable`. Only the desktop shell
+    /// has an implementation to give this; it lives at
+    /// [`crate::ports::acp::AcpAgentFactory`], ungated, for the same reason
+    /// [`rebuilder`](Self::rebuilder) above is: the desktop supplies it, this
+    /// crate only defines the seam.
+    acp_agents: Option<Arc<dyn crate::ports::acp::AcpAgentFactory>>,
     /// The boot-only builder inputs recorded per company at registration, so a
     /// rebuild configures the successor exactly as boot configured its
     /// predecessor. See [`BootInputs`](crate::runtime::BootInputs) for why
@@ -543,6 +551,7 @@ impl AppState {
             #[cfg(feature = "mcp")]
             oauth_pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
             rebuilder: None,
+            acp_agents: None,
             boot_inputs: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -551,6 +560,17 @@ impl AppState {
     pub fn with_rebuilder(mut self, rebuilder: Arc<dyn crate::runtime::RuntimeRebuilder>) -> Self {
         self.rebuilder = Some(rebuilder);
         self
+    }
+
+    /// Wires this host's local-transport ACP agent factory (issue #1245).
+    pub fn with_acp_agents(mut self, factory: Arc<dyn crate::ports::acp::AcpAgentFactory>) -> Self {
+        self.acp_agents = Some(factory);
+        self
+    }
+
+    /// This host's local-transport ACP agent factory, when one is wired.
+    pub fn acp_agents(&self) -> Option<Arc<dyn crate::ports::acp::AcpAgentFactory>> {
+        self.acp_agents.clone()
     }
 
     /// This host's in-place runtime rebuilder, when one is wired.

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -817,8 +817,22 @@ impl CompanyManifest {
                          A runner advertises the harnesses it can drive — this host does not choose one for it."
                     ));
                 }
+                if acp.model.is_some() {
+                    problems.push(format!(
+                        "`[[harness]]` `{id}` uses `transport = \"runner\"` but names a `model`. \
+                         Model overrides aren't supported for a runner yet — the runner wire \
+                         protocol doesn't carry them."
+                    ));
+                }
             }
             _ => unreachable!("transport was checked against ACP_TRANSPORTS above"),
+        }
+
+        if acp.model.as_deref().is_some_and(|m| m.trim().is_empty()) {
+            problems.push(format!(
+                "`[[harness]]` `{id}`'s `[harness.acp].model` is set but empty. Drop the key \
+                 to use the agent's own default, rather than naming an empty one."
+            ));
         }
 
         problems
@@ -2249,6 +2263,43 @@ provider = "openrouter"
                 "`{acp}` should be valid: {:?}",
                 harness_problems(&manifest)
             );
+        }
+    }
+
+    /// Issue #1245: `model` is a hint forwarded to the agent's own startup
+    /// lever, not a credential — so unlike `[harness.inference]` it is
+    /// perfectly valid on a `local` acp harness. It is rejected on `runner`
+    /// (no wire protocol yet) and when set to an empty string (nothing to
+    /// forward, and silently accepting it invites "my model setting does
+    /// nothing").
+    #[test]
+    fn model_is_valid_on_local_rejected_on_runner_and_must_not_be_empty() {
+        let cases: &[(&str, Option<&str>)] = &[
+            (
+                "transport = \"local\"\nagent = \"claude\"\nmodel = \"claude-opus-4-5\"\n",
+                None,
+            ),
+            (
+                "transport = \"runner\"\nrunner = \"laptop\"\nmodel = \"claude-opus-4-5\"\n",
+                Some("but names a `model`"),
+            ),
+            (
+                "transport = \"local\"\nagent = \"claude\"\nmodel = \"   \"\n",
+                Some("is set but empty"),
+            ),
+        ];
+        for (acp, expected) in cases {
+            let manifest = parse(&format!(
+                "{BASE}\n[[harness]]\nid = \"a\"\nkind = \"acp\"\ndefault = true\n\n[harness.acp]\n{acp}"
+            ));
+            let problems = harness_problems(&manifest);
+            match expected {
+                None => assert!(problems.is_empty(), "`{acp}` should be valid: {problems:?}"),
+                Some(msg) => assert!(
+                    problems.iter().any(|p| p.contains(msg)),
+                    "`{acp}` should report {msg:?}, got {problems:?}"
+                ),
+            }
         }
     }
 

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1170,6 +1170,17 @@ pub struct AcpHarness {
     /// Which registered runner holds this scope. `runner` transport only.
     #[serde(default)]
     pub runner: Option<String>,
+    /// A model hint forwarded to the agent's own startup lever, when this
+    /// build knows one for `agent` (issue #1245).
+    ///
+    /// Not a credential — the ACP agent already holds its own, which is the
+    /// whole point of this harness kind — so this does not join
+    /// `[harness.inference]`'s prohibition on `acp` harnesses. `local`
+    /// transport only for now: the `runner` wire protocol does not carry it
+    /// yet, so validation rejects it there rather than accepting and silently
+    /// dropping it.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// `[inference]` — per-tenant Bring-Your-Own-Key inference routing (issue #56).

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -430,6 +430,15 @@ async fn register(
     if let Some(provenance) = provenance {
         builder = builder.with_template_provenance(provenance);
     }
+    // Issue #1245: `with_acp_agents` only exists under `acp` — an
+    // `openhuman`-only build (or one with no `AcpAgentFactory` wired on
+    // `state`, e.g. every non-desktop embedder) leaves the builder's default
+    // `None`, so a `local` acp harness resolves `unavailable` exactly as it
+    // already does.
+    #[cfg(feature = "acp")]
+    if let Some(factory) = state.acp_agents() {
+        builder = builder.with_acp_agents(factory);
+    }
     let runtime = builder.build().await?;
     // The same refusal `serve` applies at boot and provisioning: a `none`-mode
     // company on a routable bind is an unauthenticated admin console. The

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -20,10 +20,14 @@
 //! ## Why a port rather than an ACP client in here
 //!
 //! The transport differs per caller — a subprocess over stdio for the desktop,
-//! a WebSocket for a runner — and neither belongs in the host crate. So this
-//! defines [`AcpAgent`] as a port and folds whatever it reports; the desktop
-//! shell supplies the stdio implementation, and the runner lane will supply the
-//! socket one. The same inversion the storage ports use.
+//! a WebSocket for a runner — and neither belongs in the host crate. The port
+//! itself ([`AcpAgent`], [`AcpAgentFactory`], `AcpTurn`, `AcpUpdate`) lives at
+//! [`crate::ports::acp`], ungated, because the desktop shell that supplies the
+//! stdio implementation deliberately does not enable the `openhuman` feature
+//! this module lives behind — see that module's own docs for why. What
+//! belongs here is [`AcpRunTurn`]: the adapter that folds whatever an
+//! `AcpAgent` reports into this crate's own [`TurnStep`] shape, a genuine
+//! `openhuman` dependency the port itself has none of.
 //!
 //! ## The mapping, and where it is lossy
 //!
@@ -50,64 +54,9 @@ use async_trait::async_trait;
 use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::harness::TurnOutcome;
+pub use crate::ports::acp::{AcpAgent, AcpAgentFactory, AcpTurn, AcpUpdate};
 use crate::ports::types::{CompanyId, TurnStep, TurnStepKind, TurnStepStatus};
 use crate::runtime::delegation::RunTurn;
-
-/// One `session/update` payload, already parsed into what this layer needs.
-///
-/// A narrow enum rather than raw JSON, so the wire-format knowledge stays in
-/// the transport and the folding below stays testable without one.
-#[derive(Clone, Debug, PartialEq)]
-pub enum AcpUpdate {
-    /// Assistant text. Concatenated, in arrival order, into the reply.
-    MessageChunk(String),
-    /// Reasoning. Coalesced into a single step — the console shows "Thinking",
-    /// never the content, matching what the OpenHuman path surfaces.
-    ThoughtChunk,
-    /// A tool call started.
-    ToolCall { id: String, title: String },
-    /// A tool call progressed or finished.
-    ToolCallUpdate {
-        id: String,
-        /// ACP's `pending` / `in_progress` / `completed` / `failed`.
-        status: String,
-        /// A short summary of what came back, already bounded by the transport.
-        result: Option<String>,
-    },
-}
-
-/// What an ACP agent reports for one turn.
-#[derive(Clone, Debug, Default)]
-pub struct AcpTurn {
-    pub updates: Vec<AcpUpdate>,
-    /// ACP's `stopReason`.
-    pub stop_reason: String,
-}
-
-/// An ACP agent this host can run a turn on.
-///
-/// Implemented by the desktop (a subprocess over stdio) and, later, by the
-/// runner lane (a socket). Deliberately says nothing about transport.
-#[async_trait]
-pub trait AcpAgent: Send + Sync {
-    /// Runs one turn and returns everything it produced.
-    ///
-    /// `session_key` is stable for a (company, agent) pair so the agent can
-    /// keep a conversation rather than starting fresh each turn.
-    async fn prompt(
-        &self,
-        company: &CompanyId,
-        session_key: &str,
-        message: &str,
-    ) -> Result<AcpTurn>;
-
-    /// Asks the agent to stop the turn in flight.
-    ///
-    /// Advisory, and the caller must treat it that way: ACP's `session/cancel`
-    /// is a notification, and a harness inside a long tool call notices only
-    /// when that call returns.
-    async fn cancel(&self, company: &CompanyId, session_key: &str) -> Result<()>;
-}
 
 /// [`RunTurn`] over an [`AcpAgent`].
 pub struct AcpRunTurn {

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -9245,6 +9245,7 @@ agent = "claude"
             &brain.deps,
             secrets,
             None,
+            None,
         );
 
         assert!(

--- a/src/harness/lanes.rs
+++ b/src/harness/lanes.rs
@@ -35,6 +35,15 @@
 //! the default the same way as every other harness, in this one place, is what
 //! closes that gap for good instead of leaving a second opinion for a future
 //! caller to reintroduce.
+//!
+//! ## `local` acp harnesses, when a factory is wired (issue #1245)
+//!
+//! `transport = "local"` now has a real engine wherever the caller supplies an
+//! [`AcpAgentFactory`](crate::harness::acp::run_turn::AcpAgentFactory) — the
+//! desktop shell, which owns the only implementation this crate does not
+//! provide itself. A server build, or a desktop build asked to run a `runner`
+//! harness (its socket transport is still unwired), passes `None`/leaves it
+//! `unavailable` exactly as before.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -48,6 +57,16 @@ use crate::ports::SecretStore;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::delegation::RunTurn;
 
+/// The type `build`'s `acp_agents` parameter takes. Real under `acp`
+/// (`crate::harness::acp::run_turn` — the `AcpAgent`/`AcpRunTurn` types — only
+/// exists there); an uninhabited placeholder otherwise, so callers built
+/// under plain `openhuman` (no `acp`) still compile and simply can never pass
+/// `Some`.
+#[cfg(feature = "acp")]
+pub type AcpFactory<'a> = &'a dyn crate::harness::acp::run_turn::AcpAgentFactory;
+#[cfg(not(feature = "acp"))]
+pub type AcpFactory<'a> = &'a std::convert::Infallible;
+
 /// Why a declared harness of `kind` has no engine on this host — the one
 /// message both the default-harness path and the named-harness loop use, so
 /// they cannot drift into saying different things about the same gap.
@@ -58,6 +77,55 @@ fn unavailable_reason(kind: &str) -> String {
             .to_string(),
         other => format!("`{other}` is not a harness kind this build knows how to run"),
     }
+}
+
+/// Resolves one `kind = "acp"` harness to an engine, or records why it has
+/// none. Shared by the default-harness resolution and the named-harness loop
+/// so the two cannot describe the same gap differently.
+#[cfg(feature = "acp")]
+fn resolve_acp_engine(
+    harness: &Harness,
+    acp_agents: Option<AcpFactory<'_>>,
+    workspace_root: &std::path::Path,
+) -> std::result::Result<Arc<dyn RunTurn>, String> {
+    // Validation guarantees `acp` is `Some` and `transport` is one of
+    // `ACP_TRANSPORTS` on every harness that reaches here — this crate's own
+    // `CompanyManifest::validate`, not a caller-supplied invariant.
+    let acp = harness
+        .acp
+        .as_ref()
+        .ok_or_else(|| unavailable_reason("acp"))?;
+
+    if acp.transport != "local" {
+        // `runner` (a remote socket dispatch) has no engine on any build yet —
+        // a materially different, larger piece of work than the local
+        // subprocess case, and out of scope here.
+        return Err(
+            "it uses `transport = \"runner\"` and this build has no runner transport wired yet"
+                .to_string(),
+        );
+    }
+
+    let factory = acp_agents.ok_or_else(|| unavailable_reason("acp"))?;
+    let agent_id = acp.agent.as_deref().unwrap_or_default();
+    factory
+        .build(agent_id, acp.model.as_deref(), workspace_root)
+        .map(|agent| {
+            Arc::new(crate::harness::acp::run_turn::AcpRunTurn::new(agent)) as Arc<dyn RunTurn>
+        })
+        .map_err(|error| format!("`{agent_id}` could not be started: {error}"))
+}
+
+/// The `openhuman`-without-`acp` build: unconditionally unavailable, exactly
+/// as every `acp` harness was before issue #1245 — `acp_agents` can only ever
+/// be `None` here (its type is uninhabited), so there is nothing to build.
+#[cfg(not(feature = "acp"))]
+fn resolve_acp_engine(
+    _harness: &Harness,
+    _acp_agents: Option<AcpFactory<'_>>,
+    _workspace_root: &std::path::Path,
+) -> std::result::Result<Arc<dyn RunTurn>, String> {
+    Err(unavailable_reason("acp"))
 }
 
 /// The engines a company's declared harnesses resolve to on this host.
@@ -116,6 +184,7 @@ pub fn build(
     base: &HarnessDeps,
     secrets: Arc<dyn SecretStore>,
     env_default: Option<EnvDefault>,
+    acp_agents: Option<AcpFactory<'_>>,
 ) -> Lanes {
     let declared = record.manifest.effective_harnesses();
     let default_harness = record.manifest.default_harness();
@@ -131,6 +200,13 @@ pub fn build(
         "built_in" => {
             Some(Arc::new(HarnessRunTurn::new(pool, Arc::new(base.clone()))) as Arc<dyn RunTurn>)
         }
+        "acp" => match resolve_acp_engine(&default_harness, acp_agents, &base.workspace_root) {
+            Ok(engine) => Some(engine),
+            Err(reason) => {
+                unavailable.push((default_harness_id.clone(), reason));
+                None
+            }
+        },
         kind => {
             unavailable.push((default_harness_id.clone(), unavailable_reason(kind)));
             None
@@ -150,6 +226,10 @@ pub fn build(
                     &default_harness_id,
                 ),
             )),
+            "acp" => match resolve_acp_engine(harness, acp_agents, &base.workspace_root) {
+                Ok(engine) => lanes.push((harness.id.clone(), engine)),
+                Err(reason) => unavailable.push((harness.id.clone(), reason)),
+            },
             kind => unavailable.push((harness.id.clone(), unavailable_reason(kind))),
         }
     }

--- a/src/ports/acp.rs
+++ b/src/ports/acp.rs
@@ -1,0 +1,124 @@
+//! The [`AcpAgent`]/[`AcpAgentFactory`] ports: running a company's turn on an
+//! external agent over the Agent Client Protocol, instead of the embedded
+//! OpenHuman harness (issue #1245).
+//!
+//! ## Why these live here, not under `harness`
+//!
+//! Everything under `crate::harness` is gated behind the `openhuman` feature
+//! — the embedded engine and its dependency tree. The desktop shell, which is
+//! the whole reason ACP exists (an operator's own coding CLI, no credential
+//! from us at all), deliberately does **not** enable that feature: pulling in
+//! the entire vendored OpenHuman runtime just to reach two trait definitions
+//! would be exactly backwards for "the operator's own subscription, nothing
+//! to configure."
+//!
+//! So the port — what an ACP agent *is*, and what builds one — lives here,
+//! ungated, alongside every other cross-cutting port
+//! ([`SecretStore`](crate::ports::SecretStore),
+//! [`ContextStore`](crate::ports::ContextStore), …). `crate::harness::acp`
+//! (openhuman-gated) re-exports these and adds
+//! [`AcpRunTurn`](crate::harness::acp::run_turn::AcpRunTurn) — the
+//! `RunTurn` adapter that folds an [`AcpTurn`] into the embedded engine's own
+//! [`TurnStep`](crate::ports::types::TurnStep) shape — because *that* piece
+//! genuinely needs the embedded engine's types.
+//!
+//! ## What this unlocks
+//!
+//! - **A desktop company with no key.** The embedded host runs a turn on the
+//!   operator's own `claude-agent-acp`, against their existing subscription.
+//! - **Reverse dispatch.** A cloud host hands a task to a runner on someone's
+//!   machine; the runner is an ACP agent as far as this is concerned.
+//! - **Any other harness.** Codex, goose, and anything else that speaks ACP.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+
+/// One `session/update` payload, already parsed into what this layer needs.
+///
+/// A narrow enum rather than raw JSON, so the wire-format knowledge stays in
+/// the transport and the folding downstream stays testable without one.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AcpUpdate {
+    /// Assistant text. Concatenated, in arrival order, into the reply.
+    MessageChunk(String),
+    /// Reasoning. Coalesced into a single step — the console shows "Thinking",
+    /// never the content, matching what the OpenHuman path surfaces.
+    ThoughtChunk,
+    /// A tool call started.
+    ToolCall { id: String, title: String },
+    /// A tool call progressed or finished.
+    ToolCallUpdate {
+        id: String,
+        /// ACP's `pending` / `in_progress` / `completed` / `failed`.
+        status: String,
+        /// A short summary of what came back, already bounded by the transport.
+        result: Option<String>,
+    },
+}
+
+/// What an ACP agent reports for one turn.
+#[derive(Clone, Debug, Default)]
+pub struct AcpTurn {
+    pub updates: Vec<AcpUpdate>,
+    /// ACP's `stopReason`.
+    pub stop_reason: String,
+}
+
+/// An ACP agent this host can run a turn on.
+///
+/// Implemented by the desktop (a subprocess over stdio) and, later, by the
+/// runner lane (a socket). Deliberately says nothing about transport.
+#[async_trait]
+pub trait AcpAgent: Send + Sync {
+    /// Runs one turn and returns everything it produced.
+    ///
+    /// `session_key` is stable for a (company, agent) pair so the agent can
+    /// keep a conversation rather than starting fresh each turn.
+    async fn prompt(
+        &self,
+        company: &CompanyId,
+        session_key: &str,
+        message: &str,
+    ) -> Result<AcpTurn>;
+
+    /// Asks the agent to stop the turn in flight.
+    ///
+    /// Advisory, and the caller must treat it that way: ACP's `session/cancel`
+    /// is a notification, and a harness inside a long tool call notices only
+    /// when that call returns.
+    async fn cancel(&self, company: &CompanyId, session_key: &str) -> Result<()>;
+}
+
+/// Builds an [`AcpAgent`] for one declared `transport = "local"` harness.
+///
+/// A port, exactly like [`AcpAgent`] itself: only the desktop shell can
+/// actually spawn a subprocess, so this crate defines the seam and the
+/// desktop supplies the implementation. `lanes::build` receives this as
+/// `Option<&dyn AcpAgentFactory>` — `None` on a server build, which is why a
+/// `local` acp harness there still resolves to `unavailable` rather than a
+/// broken or panicking build attempt.
+///
+/// Synchronous and infallible-to-call-lazily on purpose: building the value
+/// (a struct holding the command/args/env to spawn) does no I/O — the actual
+/// subprocess spawns lazily, on the agent's first `prompt` — so `lanes::build`
+/// itself never blocks on process startup or a harness that is slow to boot.
+pub trait AcpAgentFactory: Send + Sync {
+    /// `agent` is one of `ACP_AGENTS` (the manifest already validated this).
+    /// `model`, when set, is forwarded to that agent's own startup lever
+    /// where this build knows one — see the implementation's own docs for
+    /// which agents that currently covers. `workspace_root` is the same root
+    /// the embedded engine roots a company's agent workspaces under
+    /// (`HarnessDeps::workspace_root`) — the factory has no other way to
+    /// learn it, since it is built once and shared across every company the
+    /// host runs, not constructed fresh per company.
+    fn build(
+        &self,
+        agent: &str,
+        model: Option<&str>,
+        workspace_root: &std::path::Path,
+    ) -> Result<Arc<dyn AcpAgent>>;
+}

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -8,6 +8,7 @@
 
 mod ids;
 
+pub mod acp;
 pub mod approvals;
 pub mod artifacts;
 pub mod brain;
@@ -40,6 +41,7 @@ pub mod workflow_runner;
 pub mod workflow_verdict;
 pub mod workspace;
 
+pub use acp::{AcpAgent, AcpAgentFactory, AcpTurn, AcpUpdate};
 pub use approvals::ApprovalGate;
 pub use artifacts::{
     ArtifactAuthor, ArtifactDiff, ArtifactKind, ArtifactRecord, ArtifactStore, ArtifactVersion,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -472,6 +472,16 @@ pub struct RuntimeBuilder {
     /// consumed when a company **explicitly** grants the `search` namespace.
     #[cfg(feature = "openhuman")]
     search_backend: Option<crate::harness::search::SearchBackend>,
+    /// Issue #1245: builds the engine for a `transport = "local"` `acp`
+    /// harness. `None` — the default — leaves every such harness
+    /// `unavailable`, exactly as before this existed; only the desktop shell
+    /// (the only implementation this crate does not itself provide) sets it.
+    ///
+    /// Gated on `acp` specifically, not `openhuman` — `AcpAgentFactory` lives
+    /// behind the narrower feature (`acp = ["openhuman"]`), so an
+    /// `openhuman`-only build (no `acp`) does not have the type to name here.
+    #[cfg(feature = "acp")]
+    acp_agents: Option<Arc<dyn crate::harness::acp::run_turn::AcpAgentFactory>>,
     /// Issue #290: the live state of the runtime this build is *replacing*.
     ///
     /// Present only on a rebuild. It supplies the per-instance pieces a second
@@ -551,6 +561,8 @@ impl RuntimeBuilder {
             media_backend: None,
             #[cfg(feature = "openhuman")]
             search_backend: None,
+            #[cfg(feature = "acp")]
+            acp_agents: None,
             handover: None,
         }
     }
@@ -964,6 +976,21 @@ impl RuntimeBuilder {
         model_override: Option<String>,
     ) -> Self {
         self.harness_inference = Some((config, model_override));
+        self
+    }
+
+    /// Issue #1245: sets the factory that builds the engine for a
+    /// `transport = "local"` `acp` harness. Only the desktop shell has an
+    /// implementation to give this — a server build leaves it unset, so
+    /// `lanes::build` records every such harness `unavailable` instead of
+    /// having anything to spawn a subprocess with. Feature-gated on `acp`
+    /// specifically; see the field's own doc for why.
+    #[cfg(feature = "acp")]
+    pub fn with_acp_agents(
+        mut self,
+        factory: Arc<dyn crate::harness::acp::run_turn::AcpAgentFactory>,
+    ) -> Self {
+        self.acp_agents = Some(factory);
         self
     }
 
@@ -2651,12 +2678,23 @@ impl RuntimeBuilder {
                             // `serves`) could build the whole roster on the
                             // default provider regardless of which agents it
                             // actually serves.
+                            //
+                            // `self.acp_agents` only exists under `acp`
+                            // (narrower than this whole block's `openhuman`
+                            // gate) — an `openhuman`-only build has nothing to
+                            // pass, so every `local` acp harness resolves to
+                            // `unavailable` there, same as before issue #1245.
+                            #[cfg(feature = "acp")]
+                            let acp_agents = self.acp_agents.as_deref();
+                            #[cfg(not(feature = "acp"))]
+                            let acp_agents = None;
                             let lanes = crate::harness::lanes::build(
                                 &record,
                                 pool.clone(),
                                 &deps,
                                 secrets.clone(),
                                 env_default,
+                                acp_agents,
                             );
                             if !lanes.lanes.is_empty() || !lanes.unavailable.is_empty() {
                                 tracing::info!(


### PR DESCRIPTION
## Summary

Builds a real `transport = "local"` ACP engine so a teammate bound to an `acp`-kind harness actually runs turns on a real external CLI (claude / codex / goose), instead of the manifest field being decorative. Includes per-harness model selection and permission-request handling — both live-verified against real, authenticated CLIs.

- `LocalAcpAgent` (`src-tauri/src/acp/local_agent.rs`): spawns a declared local-ACP harness lazily, drives it over the existing `AcpClient`, and implements the `AcpAgent` port. One process per harness, sessions keyed per `(company, agent)`.
- `AcpAgentFactory`/`AcpAgent` port relocated to `src/ports/acp.rs` (ungated) so `src-tauri` — which enables neither the `openhuman` nor `acp` Cargo feature on its dependency — can implement it. `src/harness/acp/run_turn.rs` re-exports the same types for the gated engine-fold path.
- **Model steering**, verified live against real adapters:
  - `claude` → `ANTHROPIC_MODEL` env var at spawn.
  - `goose` → `GOOSE_MODEL` env var at spawn.
  - `codex` → no working startup env var exists; falls back to the ACP-native `session/set_config_option` call, using the `configId`/`id` discovered from `session/new`'s own `configOptions` response.
- `AcpHarness.model: Option<String>` added to the manifest, validated (rejected on `transport = "runner"`, must be non-empty when set).
- **Permission requests**: `AutoApprovingFiles` (`src-tauri/src/acp/client.rs`) auto-approves whatever the CLI still asks about, by option `kind` (`allow_once` → `reject_once` → `reject_always`), mirroring `buzz-agent`'s own `handle_permission_request`. No human-approval queue — the CLI's own permission mode is the trust boundary, same as running it interactively. Replaces the earlier fail-closed default.
- `oc_acp_harnesses` Tauri command exposing `acp::discovery::survey()` — not yet wired into `generate_handler!` or called by the frontend; groundwork for the IPC/UI phase.
- Fixed a legacy binary name in `discovery.rs` (`claude-code-acp` → `claude-agent-acp`), found via a live spawn failure.
- `docs/spec/runtime/harnesses.md` updated: model steering, the permission-handling design, and corrected claims about what the ACP port actually implements.

Out of scope (unchanged): `transport = "runner"` (remote dispatch — separate wire-protocol work), and the frontend UI for selecting harness/model.

## Test plan

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` (root and `src-tauri`)
- `cargo test --features acp --lib` / `cargo test --features openhuman --lib` — full suite green
- `cargo test --lib` / `cargo test --test acp_client` in `src-tauri` — full suite green, including new fixture and unit tests for `AutoApprovingFiles`
- `src-tauri/tests/acp_live_smoke.rs` (`#[ignore]`d, run manually with `--ignored --nocapture`): model steering verified live for claude (env var), codex (`session/set_config_option`); prompt round-trip through the `AcpAgent` trait verified live
- Deterministic unit test (`model_config_id_matches_the_real_codex_shape`) pins the codex `configOptions` parsing against a captured real response, so the fallback path is covered in CI without a live spawn

Co-Authored-By: Claude <noreply@anthropic.com>