### PR TITLE
settings: gate the Connected badge on inBuild/granted (Chargebee, PayPal, Vercel)

### DIFF
--- a/frontend/src/views/BillingView.tsx
+++ b/frontend/src/views/BillingView.tsx
@@ -243,9 +243,13 @@ export function BillingView({ client, company }: Props) {
     );
   }
 
-  const connected = status.apiKeyConfigured && !!status.site;
+  const connected =
+    status.inBuild && status.granted && status.apiKeyConfigured && !!status.site;
   const paypalConnected =
-    !!paypal?.clientIdConfigured && !!paypal?.clientSecretConfigured;
+    !!paypal?.inBuild &&
+    !!paypal?.granted &&
+    !!paypal?.clientIdConfigured &&
+    !!paypal?.clientSecretConfigured;
 
   return (
     // `flex-1 overflow-y-auto` is load-bearing, not cosmetic: without it this

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -148,7 +148,7 @@ export function HostingView({ client, company }: Props) {
     );
   }
 
-  const connected = status.apiKeyConfigured;
+  const connected = status.inBuild && status.granted && status.apiKeyConfigured;
 
   return (
     <div className="flex-1 overflow-y-auto" data-testid="hosting-view">

--- a/frontend/test/unit/billing-view-branches.test.ts
+++ b/frontend/test/unit/billing-view-branches.test.ts
@@ -132,6 +132,9 @@ describe("BillingView status surfaces", () => {
     await show(clientWith({ chargebee: { ...CHARGEBEE_OK, granted: false } }));
     expect(at("billing-not-granted")?.textContent).toContain("[tools].allow");
     expect(at("billing-not-in-build")).toBeNull();
+    // Both credentials are configured (CHARGEBEE_OK) and the badge must still
+    // not agree with a page that just said this integration does nothing.
+    expect(at("billing-connected")).toBeNull();
   });
 
   it("says the host lacks the feature, and says only that", async () => {
@@ -145,6 +148,36 @@ describe("BillingView status surfaces", () => {
     );
     expect(at("billing-not-in-build")).not.toBeNull();
     expect(at("billing-not-granted")).toBeNull();
+    expect(at("billing-connected")).toBeNull();
+  });
+
+  it("withholds the connected badges when the host lacks the feature, even with credentials configured", async () => {
+    // The regression this pins: a green badge next to a banner saying the
+    // feature is inert on this build is exactly the disagreement the file's
+    // own doc comment says must not happen.
+    await show(
+      clientWith({
+        chargebee: { ...CHARGEBEE_OK, inBuild: false, granted: false },
+        paypal: { ...PAYPAL_OK, inBuild: false, granted: false },
+      }),
+    );
+    expect(at("billing-not-in-build")).not.toBeNull();
+    expect(at("paypal-not-in-build")).not.toBeNull();
+    expect(at("billing-connected")).toBeNull();
+    expect(at("paypal-connected")).toBeNull();
+  });
+
+  it("withholds the connected badges when the manifest does not grant the tool, even with credentials configured", async () => {
+    await show(
+      clientWith({
+        chargebee: { ...CHARGEBEE_OK, granted: false },
+        paypal: { ...PAYPAL_OK, granted: false },
+      }),
+    );
+    expect(at("billing-not-granted")).not.toBeNull();
+    expect(at("paypal-not-granted")).not.toBeNull();
+    expect(at("billing-connected")).toBeNull();
+    expect(at("paypal-connected")).toBeNull();
   });
 
   it("withholds the connected badge until BOTH the key and the site are stored", async () => {
@@ -197,12 +230,14 @@ describe("BillingView status surfaces", () => {
   it("reports the PayPal grant and build gaps on their own terms", async () => {
     await show(clientWith({ paypal: { ...PAYPAL_OK, granted: false } }));
     expect(at("paypal-not-granted")?.textContent).toContain("[tools].allow");
+    expect(at("paypal-connected")).toBeNull();
 
     await show(
       clientWith({ paypal: { ...PAYPAL_OK, granted: false, inBuild: false } }),
     );
     expect(at("paypal-not-in-build")).not.toBeNull();
     expect(at("paypal-not-granted")).toBeNull();
+    expect(at("paypal-connected")).toBeNull();
   });
 
   it("seeds the site box from what is stored and the environment from PayPal", async () => {

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -83,6 +83,9 @@ describe("HostingView status surfaces", () => {
 
     expect(at("hosting-not-granted")?.textContent).toContain("[tools].allow");
     expect(at("hosting-not-in-build")).toBeNull();
+    // The token is fully configured (HOSTING_OK) and the badge must still not
+    // agree with a page that just said this integration reaches nobody.
+    expect(at("hosting-connected")).toBeNull();
   });
 
   it("says the host lacks the tools, and says only that", async () => {
@@ -93,6 +96,7 @@ describe("HostingView status surfaces", () => {
 
     expect(at("hosting-not-in-build")).not.toBeNull();
     expect(at("hosting-not-granted")).toBeNull();
+    expect(at("hosting-connected")).toBeNull();
   });
 
   it("shows the page-level error when the status cannot be read", async () => {


### PR DESCRIPTION
## Summary

- `BillingView.tsx`'s `connected` (Chargebee) and `paypalConnected` badges, and `HostingView.tsx`'s `connected` (Vercel) badge, were computed from credential fields alone — never from `status.inBuild`/`status.granted`. This let the green "Connected" badge disagree with the page's own warning banner right next to it (e.g. "This host was built without Chargebee support..." next to "✓ Connected"), which each file's doc comment explicitly says must not happen.
- Gate all three badges on `inBuild && granted` in addition to the existing credential checks, so the badge only goes green when the integration is actually live end-to-end.
- Added test coverage in the existing branch-coverage suites asserting the badge is absent whenever `inBuild` or `granted` is false but credentials ARE fully configured (the inverse of what shipped), plus strengthened two existing not-granted/not-in-build tests with the same badge assertion.

Closes #1262

## Changes

- `frontend/src/views/BillingView.tsx`: gate `connected` and `paypalConnected` on `inBuild && granted`.
- `frontend/src/views/HostingView.tsx`: gate `connected` on `inBuild && granted`.
- `frontend/test/unit/billing-view-branches.test.ts`: two new tests plus badge assertions added to two existing tests.
- `frontend/test/unit/hosting-view-branches.test.ts`: badge assertions added to two existing tests.

## Commands run locally

- `npm run typecheck`
- `npm run typecheck:unit`
- `npm run typecheck:e2e`
- `npx vitest run` (full suite — 154 files / 1459 tests, all passing)

## Manual verification

Built the binary with `--features openhuman,tinycortex,mcp` (Chargebee/PayPal deliberately excluded) and ran it against `companies/agentic_software_company`, whose manifest's catch-all `*` grant does not confer `chargebee`/`paypal`/`hosting`. Logged in via a minted magic link and drove the real UI with Playwright:

- Chargebee: saved Site + API key while the "built without Chargebee support" banner was showing — badge stayed absent, description still read "Not connected yet."
- PayPal: saved Client ID + secret while the "built without PayPal support" banner was showing — badge stayed absent.
- Hosting/Vercel: saved an API token while the "does not grant `hosting`" banner was showing — badge stayed absent.

All three now agree with their banners, matching what the doc comments in each file already promised.