### PR TITLE
fix: set canvas minZoom so fit-view can show full pipelines

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2797,6 +2797,13 @@ export function WorkflowsView({
                 colorMode={resolvedTheme === "dark" ? "dark" : "light"}
                 fitView
                 fitViewOptions={{ padding: 0.2 }}
+                // Issue #1261: the library default (0.5) is above the scale
+                // most shipped templates need to fit — an 8-10 node single-row
+                // pipeline needs roughly 0.3. Left at the default, `fitView`
+                // clamps to 0.5 and permanently crops the first/last node,
+                // and the canvas's own Zoom Out control is disabled from
+                // load because the viewport is already pinned at the floor.
+                minZoom={0.1}
                 nodesDraggable={false}
                 nodesConnectable={false}
                 elementsSelectable


### PR DESCRIPTION
## Summary
- `WorkflowsView.tsx`'s `<ReactFlow>` canvas never set `minZoom`, so it inherited the library default of `0.5`.
- Shipped company workflow templates are 8-10 node single-row pipelines needing roughly 0.3x zoom to fit the pane, so `fitView` clamped to the 0.5 floor, the Zoom Out control was disabled from load, and the first/last node were permanently cropped.
- Adds `minZoom={0.1}` to the `<ReactFlow>` mount — a conservative floor with headroom well beyond the confirmed worst case, that doesn't change `fitView`'s computed scale for any graph that already fit within 0.5.

Closes #1261

## Test plan
- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (full suite, 1457 tests passed)
- [x] Manual browser verification: built and ran the host locally (`agentic_software_company` company, "Feature pipeline" workflow, 10 nodes), confirmed via Playwright against the real running app:
  - Transform after mount (`fitView`): `scale(0.352941)` — below the old 0.5 floor
  - Zoom Out control `disabled` attribute: `null` (previously disabled from load)
  - Manual zoom-out clicks work, reaching `scale(0.219427)`
  - Screenshot confirms both the first ("Feature requested") and last ("Ship and report") nodes are fully visible on screen, no longer cropped