### PR TITLE
fix: only say Amend once a ledger row's id actually exists

### DIFF
--- a/frontend/src/api/ledgers.ts
+++ b/frontend/src/api/ledgers.ts
@@ -343,6 +343,38 @@ export function filteredEmptyNotice(
   return `No rows with status ${statusFilterLabel(ledger, statusFilter)}.`;
 }
 
+/**
+ * The compose dialog's title (issue #1264).
+ *
+ * The id field is editable in every non-closing dialog — "Record" opens it
+ * empty, "Amend" opens it prefilled but still editable — so whether this says
+ * "Amend" cannot be "is `composing.id` non-empty" (that flips true on the
+ * first keystroke of a row that has never been saved, before it exists). It
+ * has to ask whether the *current* typed id names a row this ledger already
+ * has, checked against whatever is currently loaded (`existingIds`) the same
+ * way `save()` treats the id — trimmed.
+ */
+export function composeDialogTitle(
+  ledger: LedgerSummary,
+  composing: { id: string; closing: boolean },
+  existingIds: ReadonlySet<string>,
+): string {
+  if (composing.closing) return `Close ${composing.id}`;
+  return existingIds.has(composing.id.trim())
+    ? `Amend ${composing.id}`
+    : `New row on ${ledger.title}`;
+}
+
+/** The compose dialog's description — the same "does this id exist" read as the title. */
+export function composeDialogDescription(
+  composing: { id: string },
+  existingIds: ReadonlySet<string>,
+): string {
+  return existingIds.has(composing.id.trim())
+    ? "Only what you change is written; everything else on the row is left alone."
+    : "Give it a short, readable id — it is how anybody names this row later.";
+}
+
 /** Whether this status ends a row's life on this ledger. */
 export function isClosingStatus(ledger: LedgerSummary, status: string): boolean {
   return ledger.statuses.some(

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -71,6 +71,8 @@ import { taskApprovalBlock } from "@/lib/task-approvals";
 import {
   byline,
   composableFields,
+  composeDialogDescription,
+  composeDialogTitle,
   defineLedger,
   deleteEntry,
   EVERY_STATUS,
@@ -263,6 +265,21 @@ export function LedgersView({
   const taskById = useMemo(
     () => new Map(tasks.map((task) => [task.id, task])),
     [tasks],
+  );
+
+  /**
+   * Ids the compose dialog can currently confirm exist (issue #1264).
+   *
+   * `read.entries` is server-filtered by the search box and status filter, so
+   * this can under-report — a row hidden by the current filter or truncated
+   * past the fetched page reads as "does not exist" here. Accepted: this is a
+   * display-copy fix for the dialog title, not a data-fetching change, and the
+   * common case (a brand-new row's id typed for the first time) never matches
+   * anything anyway.
+   */
+  const existingIds = useMemo(
+    () => new Set((read?.entries ?? []).map((entry) => entry.id)),
+    [read],
   );
 
   /** The clock the "blocked since" labels measure against (issue #883). */
@@ -953,6 +970,7 @@ export function LedgersView({
         <ComposeDialog
           ledger={ledger}
           composing={composing}
+          existingIds={existingIds}
           saving={saving}
           onChange={setComposing}
           onCancel={() => setComposing(null)}
@@ -1254,6 +1272,7 @@ function EntryCard({
 function ComposeDialog({
   ledger,
   composing,
+  existingIds,
   saving,
   onChange,
   onCancel,
@@ -1261,6 +1280,7 @@ function ComposeDialog({
 }: {
   ledger: LedgerSummary;
   composing: Composing;
+  existingIds: ReadonlySet<string>;
   saving: boolean;
   onChange: (next: Composing) => void;
   onCancel: () => void;
@@ -1277,16 +1297,10 @@ function ComposeDialog({
       <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
-            {composing.closing
-              ? `Close ${composing.id}`
-              : composing.id
-                ? `Amend ${composing.id}`
-                : `New row on ${ledger.title}`}
+            {composeDialogTitle(ledger, composing, existingIds)}
           </DialogTitle>
           <DialogDescription>
-            {composing.id
-              ? "Only what you change is written; everything else on the row is left alone."
-              : "Give it a short, readable id — it is how anybody names this row later."}
+            {composeDialogDescription(composing, existingIds)}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/test/unit/ledger-compose-title.test.ts
+++ b/frontend/test/unit/ledger-compose-title.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  composeDialogDescription,
+  composeDialogTitle,
+  type LedgerSummary,
+} from "@/api/ledgers";
+
+/**
+ * Issue #1264: the compose dialog's title flipping to "Amend <id>" the moment
+ * an operator types the first character of a brand-new row's id — before the
+ * row is saved, before it exists, while the submit button still correctly
+ * reads "Record".
+ *
+ * The bug was branching on `composing.id` being non-empty rather than on
+ * whether the typed id names a row this ledger already has. Both branches are
+ * pure, which is why they live in `api/ledgers.ts` rather than inside the view
+ * — the decision is the whole bug and it should be assertable without a
+ * render (the reasoning `filteredEmptyNotice` uses for issue #1217).
+ */
+
+const PROMISES = {
+  slug: "customer-promises",
+  title: "Customer promises",
+  purpose: "",
+  source: "events",
+  derived: "derived/CUSTOMER_PROMISES.md",
+  writtenBy: "",
+  builtin: false,
+  fields: [],
+  statuses: [
+    { name: "open" },
+    { name: "kept", closed: true },
+    { name: "broken", closed: true },
+  ],
+  sections: [],
+  open: 9,
+  closed: 5,
+} as unknown as LedgerSummary;
+
+const EXISTING_IDS = new Set(["promise-shipped-dark-mode", "promise-refund"]);
+
+describe("the compose dialog's title", () => {
+  it("reads 'New row on <ledger>' for a brand-new, untouched row", () => {
+    expect(
+      composeDialogTitle(PROMISES, { id: "", closing: false }, EXISTING_IDS),
+    ).toBe("New row on Customer promises");
+  });
+
+  it("stays 'New row' while typing an id that names no existing row (#1264)", () => {
+    // This is the exact bug: `composing.id` is non-empty the instant the
+    // operator types, but the row still does not exist.
+    expect(
+      composeDialogTitle(
+        PROMISES,
+        { id: "promise-test-dark-mode", closing: false },
+        EXISTING_IDS,
+      ),
+    ).toBe("New row on Customer promises");
+  });
+
+  it("switches to 'Amend <id>' once the typed id names a row that exists", () => {
+    expect(
+      composeDialogTitle(
+        PROMISES,
+        { id: "promise-shipped-dark-mode", closing: false },
+        EXISTING_IDS,
+      ),
+    ).toBe("Amend promise-shipped-dark-mode");
+  });
+
+  it("trims the typed id before checking existence, like save() does", () => {
+    expect(
+      composeDialogTitle(
+        PROMISES,
+        { id: "  promise-refund  ", closing: false },
+        EXISTING_IDS,
+      ),
+    ).toBe("Amend   promise-refund  ");
+  });
+
+  it("always reads 'Close <id>' while closing, regardless of existingIds", () => {
+    expect(
+      composeDialogTitle(
+        PROMISES,
+        { id: "promise-refund", closing: true },
+        EXISTING_IDS,
+      ),
+    ).toBe("Close promise-refund");
+    expect(
+      composeDialogTitle(
+        PROMISES,
+        { id: "not-in-the-set", closing: true },
+        new Set<string>(),
+      ),
+    ).toBe("Close not-in-the-set");
+  });
+});
+
+describe("the compose dialog's description", () => {
+  it("gives the new-row hint when the id names no existing row", () => {
+    expect(composeDialogDescription({ id: "" }, EXISTING_IDS)).toBe(
+      "Give it a short, readable id — it is how anybody names this row later.",
+    );
+    expect(
+      composeDialogDescription(
+        { id: "promise-test-dark-mode" },
+        EXISTING_IDS,
+      ),
+    ).toBe(
+      "Give it a short, readable id — it is how anybody names this row later.",
+    );
+  });
+
+  it("gives the amend hint once the id names a row that exists", () => {
+    expect(
+      composeDialogDescription({ id: "promise-refund" }, EXISTING_IDS),
+    ).toBe(
+      "Only what you change is written; everything else on the row is left alone.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- The ledger compose dialog's title/description branched on `composing.id` being non-empty, so typing the first character of a brand-new row's id flipped the header to `Amend <id>` before anything was saved — even though the row does not exist yet and the submit button correctly still read `Record`.
- Added two pure helpers, `composeDialogTitle` and `composeDialogDescription`, in `frontend/src/api/ledgers.ts` (following the existing `statusFilterLabel`/`filteredEmptyNotice` pattern from issue #1217) that decide the copy by checking whether the *current, trimmed* typed id names a row currently loaded for this ledger (`existingIds`, a `Set` built from `read.entries` in `LedgersView`), not merely whether the id field is non-empty.
- `ComposeDialog` now renders through these helpers and takes `existingIds` as a new prop.
- Known, accepted limitation (documented in a code comment): `read.entries` can be a filtered/truncated page (search box, status filter, or the "Showing X of Y" case), so `existingIds` may under-report for a row hidden by the current filter. This is a display-copy fix, not a data-fetching change.

Closes #1264

## Test plan
- [x] Added `frontend/test/unit/ledger-compose-title.test.ts` covering: empty id, a typed id that names no existing row (the exact bug), a typed id that does name an existing row, `closing: true` (always "Close"), and trimming behavior matching `save()`.
- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (155 files / 1464 tests passing)
- [x] Verified in a real browser (own port + `OPENCOMPANY_DATA_DIR`, dev server pointed at the host via `OC_API_TARGET`): declared a ledger, recorded one row, opened Record for a new row, typed an id that doesn't exist (title stayed "New row on Customer promises"), then typed the existing row's id (title switched to "Amend promise-refund"); confirmed in both light and dark themes.