### PR TITLE
feat(mcp): browse and install from the MCP directory, in one merged server list (#1270)

### DIFF
--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -244,8 +244,9 @@ builds with `mcp` (`TENANT_FEATURES` in `deploy-staging.yml`); the default
 
 One component reads these routes —
 [`McpServersSection`](../../frontend/src/views/connections/McpServersSection.tsx),
-over the standalone functions in `frontend/src/api/mcp.ts` — rendered from two
-places: inline on Connections, and as the whole of Settings, MCP Servers.
+over the standalone functions in `frontend/src/api/mcp.ts` (List A) and
+`frontend/src/api/mcp-registry.ts` (the directory) — rendered from two places:
+inline on Connections, and as the whole of Settings, MCP Servers.
 
 There is deliberately no MCP method on `OpenCompanyClient`. A second set used to
 sit there, declaring a `{ servers }` wrapper around this table's bare array,
@@ -253,6 +254,48 @@ sit there, declaring a `{ servers }` wrapper around this table's bare array,
 Settings page built on it crashed on open (issue #414). The client casts an
 unparsed body to the declared type, so a second surface is never caught by the
 compiler — only by whoever opens the page.
+
+### Browsing the directory
+
+[`McpRegistryBrowser`](../../frontend/src/views/connections/McpRegistryBrowser.tsx)
+sits inside the same card as the add-a-URL form, under the same manage gate
+(issue #403 — an install hands every teammate a new set of tools). What it
+installs lands in the list above it with a `registry` badge; there is no second
+section, for the reason the whole merge exists.
+
+An entry's install form is exactly the `requiredEnvKeys` the host derived from
+the connection the install will use, as password fields. Those values are
+write-only in both directions: nothing sends one back, and the merged row
+reports only `authConfigured`.
+
+Its failures are its own. Both upstream directories are network hops and either
+can be down, and on a build without the `mcp` feature every `…/mcp/registry/…`
+route answers `404 not_wired` — so `registryOutage` in
+`frontend/src/lib/mcp-registry.ts` turns *every* rejection into one of two
+notices rendered inside the panel, and never rethrows. A dead directory is an
+empty result with a reason; a missing feature is a sentence about the build. The
+company's installed servers keep rendering through both.
+
+### Provenance picks the routes, not just the badge
+
+A row's `source` decides which half of the API it may call. List A's Switch,
+`Test` and `Tools` resolve the row's `name` against the declared list; a
+directory install has no declaration and its `name` is a slug the merge minted,
+so all three answer `no MCP server named …` on it. The registry's
+connect / disconnect stand in their place, its delete is
+`DELETE …/mcp/registry/{serverId}`, and its credentials rotate through
+`PUT …/mcp/registry/{serverId}/env` rather than List A's single token field.
+
+`mcpRowControls` in `frontend/src/lib/mcp-registry.ts` is the one place that
+decides all four, and it reads `source` — never the presence of `serverId`. A
+reconciled row carries a `serverId` and is still a manifest server: it keeps
+List A's controls, keeps its badge, and keeps its refusal to be deleted.
+
+One wire gap worth knowing: `GET …/mcp/servers` reports *that* a credential is
+stored, never which keys hold it, so the rotation form re-reads the field names
+from the catalogue entry. A directory outage therefore costs the rotation form
+its fields even though `PUT …/env` is healthy — the form says so rather than
+guessing.
 
 ### Opening one server
 
@@ -264,7 +307,11 @@ the paragraph above one level up: two surfaces describing the same idea acquire
 two vocabularies and then drift.
 
 The panel is read-only. Enable, `Test`, `Tools` and `Remove` stay on the row;
-what it adds is what the row cannot say —
+what it adds is what the row cannot say. Its provenance and removal prose are
+`mcpProvenanceNote` / `mcpRemovalNote` — one sentence per source, because the
+panel used to read `manifest` against everything-else and told a directory
+install it "was added from the console and lives in this company's runtime
+store", true of neither half of it.
 
 - **Connected, and as what.** MCP has no connection object, so this is assembled
   from two facts a single badge would collapse: `enabled` (whether any agent

--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -6,14 +6,16 @@ An agent granted a server reaches it through the generic bridge tools
 `mcp_client` registry, its HTTP transport, and its prompt-injection safety
 filter over remote tool metadata.
 
-Hosted v1 boundary: **HTTP transport only**. Out of scope for v1: stdio /
-subprocess servers (rejected with a clear error), Smithery browsing,
-MCP-server OAuth, and live pool invalidation.
+Hosted v1 boundary: **HTTP transport only**. Stdio / subprocess servers are
+rejected with a clear error — the tenant image ships no Node, Python or package
+manager to launch one with. Still out of scope: live pool invalidation.
+
+Directory browsing landed in issue #1270; see [The directory](#the-directory).
 
 ## Where servers come from
 
-A company's *effective* MCP servers are the union of two sources, merged by
-name (a runtime entry overrides a manifest server of the same name but keeps
+A company's *effective* MCP servers are the union of the sources below, merged
+by name (a runtime entry overrides a manifest server of the same name but keeps
 its `manifest` badge):
 
 1. **Manifest** — `[[mcp_server]]` entries in `company.toml`
@@ -32,6 +34,14 @@ its `manifest` badge):
 2. **Runtime** — servers the operator adds through the console, persisted as a
    single JSON index in the [`SecretStore`](../../src/ports/secrets.rs) under
    `mcp/servers`.
+
+3. **Default** — `[[default_mcp_server]]` in the instance `config.toml`
+   (issue #527): shipped by the install, present for every company, and badged
+   `default` so it is never mistaken for something this operator added.
+
+4. **Registry** — installed from an upstream MCP directory (issue #1270), badged
+   `registry`. Keyed by a stable `serverId` rather than by name; see
+   [The directory](#the-directory).
 
 Validation (manifest + API): unique names, an `http(s)://` endpoint, and no
 stdio `command`. See [`company::mcp`](../../src/company/mcp.rs).
@@ -98,12 +108,108 @@ alias `…/company/…`). See [`server::ops::mcp`](../../src/server/ops/mcp.rs).
 | `GET` | `…/mcp/servers` | Effective servers (`authConfigured`, never the token). |
 | `POST` | `…/mcp/servers` | Add a runtime server (+ optional write-only `token`). |
 | `PUT` | `…/mcp/servers/{name}` | Enable/disable, edit tool lists/endpoint, rotate token. A manifest server gets a runtime override entry. |
-| `DELETE` | `…/mcp/servers/{name}` | Remove a runtime server. `409` for a manifest server (disable it instead). |
+| `DELETE` | `…/mcp/servers/{name}` | Remove a server, dispatching on where it lives. `409` for a manifest or default server (disable it instead). |
 | `GET` | `…/mcp/servers/{name}/tools` | Live tool discovery through the registry. |
+| `GET` | `…/mcp/registry/search?q=&page=&pageSize=` | Browse the upstream directories. |
+| `GET` | `…/mcp/registry/entry?qualifiedName=` | One entry, with the install decision already made. |
+| `POST` | `…/mcp/registry/install` | Install an entry (+ write-only `env` values) and connect it. |
+| `POST` | `…/mcp/registry/{serverId}/connect` | Dial an installed server. |
+| `POST` | `…/mcp/registry/{serverId}/disconnect` | Drop the live session, keeping the install. |
+| `PUT` | `…/mcp/registry/{serverId}/env` | Rotate an install's credentials (write-only). |
+| `DELETE` | `…/mcp/registry/{serverId}` | Uninstall. |
+
+The `…/mcp/registry/…` routes are gated on the `mcp` feature and report
+`not_wired` without it, matching `…/oauth/start`. Every registry **mutation**
+takes the admin guard: an install hands *every* teammate a new set of callable
+tools, so it settles what the company can reach. Browsing decides nothing and
+takes the ordinary company scope.
 
 Discovery is gated on the `openhuman` feature (the MCP transport lives there);
 without it the route reports `not_wired` and the console falls back to the
 declared tool lists. Every mutating response carries a `note` reminder.
+
+## The directory
+
+Issue #1270. Before it, the tab could only contain what somebody already knew
+the address of: an operator arrived with a URL or the list stayed empty. Nothing
+in `src/server/` reached `McpRuntime`
+([`harness::mcp`](../../src/harness/built_in/mcp.rs)), the wrapper over
+OpenHuman's own MCP registry — two upstream directories (Smithery.ai and
+`modelcontextprotocol/registry`), a SQLite store of installs, named write-only
+env credentials, boot-time connect and a supervisor — even though it is
+constructed for every company.
+
+[`server::ops::mcp_registry`](../../src/server/ops/mcp_registry.rs) is that
+routing layer.
+
+### One list, not two sections
+
+`GET …/mcp/servers` returns declared servers **and** directory installs as one
+list, each row badged with its provenance. A server present in both — installed
+from the directory *and* typed in by URL — is **one reconciled row**, matched on
+the normalised endpoint: lowercased scheme and host, default port dropped, query
+and fragment stripped, trailing slash dropped.
+
+The query string has to go, because a declared server may carry its credential
+as a query parameter; a comparison that kept it would never match, and the
+operator would get the same server twice with two credentials and two health
+badges disagreeing.
+
+**The declared side wins the provenance.** `source` decides the badge and
+whether the console offers a delete, and both must answer to the declared list: a
+manifest server cannot be deleted, only disabled, so an install must not be able
+to capture that row and relabel it deletable. The deeper reason is that the
+declared list is what the *agents* reach — `registry_for_agent` builds each
+agent's registry from it and scopes it by `mcp:<name>` grants. Nothing is lost:
+`serverId` rides on the reconciled row, so the registry routes still address it.
+
+The registry contributes only what the declared side has no field for —
+`serverId`, `qualifiedName`, `iconUrl`, `transport`, a `description` where there
+was none, and a `health` where the server has never been probed (a real probe
+wins, since it dials the way the agents' bridge tools do). `authConfigured` is
+the union. All four registry fields are omitted when absent, so a declared row's
+JSON is byte-identical to what it was before this existed.
+
+### Delete dispatches
+
+`DELETE …/mcp/servers/{name}` removes what the row actually has: the
+runtime-index entry, the upstream install, or **both** for a reconciled row.
+Dropping only the index row there would leave the install connected with its
+tools still on every belt — a delete the operator watches fail. Manifest and
+default rows stay `409`.
+
+### Hosted transport only
+
+Directory search is pinned to the hosted-transport filter, so a stdio-only entry
+never reaches the operator's screen; the install route refuses one again by name,
+because a caller can POST a qualified name search never offered. The blocker is
+not the read-only root filesystem — tenants mount a writable `/data` — but that
+the runtime image is `debian:bookworm-slim` plus `ca-certificates`, `curl`,
+`libssl3` and X11 libs. A stdio install would fail on `npx: not found`.
+
+### Nothing crosses the wire blind
+
+Env values are write-only exactly like a declared server's `token`. Upstream's
+catalogue DTOs end in a flattened `extra` map that round-trips every key the
+registries emit, so each projection names the fields it forwards. An install's
+raw `last_error` is **dropped**, not scrubbed: the scrubber's redaction pass
+needs the credential values to replace, and this surface deliberately never
+loads them — only the stable `auth_hint` code and a fixed sentence per status
+cross the wire.
+
+### A failing registry does not break the read
+
+An unreadable store or a directory that will not answer resolves to "no
+installs", and `GET …/mcp/servers` still returns the declared list. The declared
+half is what governs what the agents reach, so it is the half that must survive.
+
+### Per-agent scoping does not apply to installs
+
+`harness::built_in::build` pushes the registry bridge tools onto **every**
+agent's belt with no grant check, so every teammate can call every installed
+server. Issue #1270 leaves that in place deliberately and makes it visible: a
+registry row's `reachableBy` lists the whole roster (and nobody when the install
+is disabled) rather than claiming a scope the harness does not apply.
 
 ## Which builds can honour a server (issue #567)
 

--- a/frontend/src/api/mcp-registry.ts
+++ b/frontend/src/api/mcp-registry.ts
@@ -1,0 +1,223 @@
+// The MCP **directory** routes (issue #1270): browse the two upstream registries
+// the host federates (Smithery.ai and `modelcontextprotocol/registry`), install
+// an entry, and drive an install's lifecycle and credentials.
+//
+// Sibling of `api/mcp.ts`, which serves List A — the company's `[[mcp_server]]`
+// manifest entries and the URLs an operator typed in. The two lists come back
+// merged from one read (`listMcpServers`); this module is only the write and
+// browse half that List A structurally cannot do.
+//
+// ## Two keys, and they are not interchangeable
+//
+// List A addresses a server by `name`. A directory install is addressed by its
+// `serverId` — a stable id in OpenHuman's own store — and its `name` is a
+// display slug the host mints for the merged row. Sending one where the other
+// belongs deletes or rotates the wrong server, so every function here takes a
+// `serverId` and none takes a name.
+//
+// ## Credentials are write-only in both directions
+//
+// An entry declares the env keys it needs; their values go out on install and on
+// rotation and never come back. Nothing in this module returns one, and the
+// merged row reports only a non-secret `authConfigured` boolean.
+//
+// ## `not_wired`
+//
+// Every route here is behind the host's `mcp` Cargo feature. A build without it
+// registers the same routes and answers `404 not_wired` — a fact about the
+// build, not a failure. Callers classify that with
+// [`registryOutage`](@/lib/mcp-registry) rather than showing the raw error.
+
+import type { OpenCompanyClient } from "./client";
+import { ApiError } from "./types";
+import type { McpHealth, McpServer } from "./types";
+
+/** One directory listing, as `GET …/mcp/registry/search` returns it. */
+export interface McpCatalogueEntry {
+  /** The directory's stable identity (`@org/server`) — what an install is keyed on. */
+  qualifiedName: string;
+  displayName: string;
+  description?: string;
+  iconUrl?: string;
+  /** Which upstream directory this row came from (`smithery` / `mcp_official`). */
+  source: string;
+  /** Upstream's canonical-first-party badge. */
+  official: boolean;
+  useCount: number;
+  websiteUrl?: string;
+}
+
+/** A page of directory results. */
+export interface McpCatalogueSearch {
+  servers: McpCatalogueEntry[];
+  page: number;
+  totalPages: number;
+}
+
+/**
+ * One directory entry in full, with the install decision already made by the
+ * host so the console never offers an install that would be refused.
+ */
+export interface McpCatalogueDetail {
+  qualifiedName: string;
+  displayName: string;
+  description?: string;
+  iconUrl?: string;
+  source: string;
+  /** The hosted endpoint an install would dial. Absent ⇒ nothing dialable here. */
+  endpoint?: string;
+  /**
+   * The env keys the install form must collect, as the host derived them from
+   * the connection the install will actually use. Values are write-only.
+   */
+  requiredEnvKeys: string[];
+  /** Whether `POST …/mcp/registry/install` would accept this entry. */
+  installable: boolean;
+  /** Why not, when it would not. Present iff `installable` is false. */
+  refusal?: string;
+}
+
+/**
+ * A registry mutation's answer: the resulting **merged** row and the connection
+ * state right after the change.
+ *
+ * `server` is re-read from the merged list, so an install that reconciles onto
+ * a manifest or runtime row comes back badged as that row — the same one a
+ * following `GET …/mcp/servers` will show.
+ */
+export interface McpRegistryMutation {
+  server: McpServer;
+  note: string;
+  /**
+   * The connection state after the mutation. A refused connection is **not** a
+   * rollback: an install that lands "needs a credential" is at a valid resting
+   * state, the same way `POST …/mcp/servers` treats a `needs_config` probe.
+   */
+  test?: McpHealth;
+}
+
+/**
+ * A search body, or a stated failure.
+ *
+ * Same guard as [`expectList`](./mcp.ts) and for the same reason: `client.get<T>`
+ * casts an unparsed body straight to `T`, so a declared type is a claim about
+ * the host and never a check on it. A body whose `servers` is not an array would
+ * otherwise reach the render and throw on `.map` several frames from the fetch.
+ */
+export function expectCatalogue(body: unknown): McpCatalogueSearch {
+  const page = body as Partial<McpCatalogueSearch> | null | undefined;
+  if (!page || typeof page !== "object" || !Array.isArray(page.servers)) {
+    // Status 0: nothing was refused, the answer was unusable.
+    throw new ApiError(0, "unexpected_shape", "the host's MCP directory results weren't a list");
+  }
+  return {
+    servers: page.servers,
+    page: typeof page.page === "number" ? page.page : 1,
+    totalPages: typeof page.totalPages === "number" ? page.totalPages : 0,
+  };
+}
+
+/** Browse the upstream directories. An empty `q` is the directory's own front page. */
+export async function searchMcpRegistry(
+  client: OpenCompanyClient,
+  company: string | null,
+  query: { q?: string; page?: number; pageSize?: number },
+): Promise<McpCatalogueSearch> {
+  const params = new URLSearchParams();
+  if (query.q?.trim()) params.set("q", query.q.trim());
+  if (query.page !== undefined) params.set("page", String(query.page));
+  if (query.pageSize !== undefined) params.set("pageSize", String(query.pageSize));
+  const suffix = params.toString();
+  const body = await client.get<unknown>(
+    `${client.scopeFor(company)}/mcp/registry/search${suffix ? `?${suffix}` : ""}`,
+  );
+  return expectCatalogue(body);
+}
+
+/** One directory entry in full — the env keys an install must collect live here. */
+export function getMcpRegistryEntry(
+  client: OpenCompanyClient,
+  company: string | null,
+  qualifiedName: string,
+): Promise<McpCatalogueDetail> {
+  return client.get<McpCatalogueDetail>(
+    `${client.scopeFor(company)}/mcp/registry/entry?qualifiedName=${encodeURIComponent(qualifiedName)}`,
+  );
+}
+
+/**
+ * Install a directory entry and connect it.
+ *
+ * `env` carries the values for the entry's declared keys and is write-only — the
+ * host persists them into OpenHuman's env table and no route here reads one
+ * back.
+ */
+export function installMcpRegistryEntry(
+  client: OpenCompanyClient,
+  company: string | null,
+  body: { qualifiedName: string; env: Record<string, string> },
+): Promise<McpRegistryMutation> {
+  return client.post<McpRegistryMutation>(
+    `${client.scopeFor(company)}/mcp/registry/install`,
+    body,
+  );
+}
+
+/** Dial an installed server. Keyed by `serverId`, never by the row's name. */
+export function connectMcpRegistryServer(
+  client: OpenCompanyClient,
+  company: string | null,
+  serverId: string,
+): Promise<McpRegistryMutation> {
+  return client.post<McpRegistryMutation>(
+    `${client.scopeFor(company)}/mcp/registry/${encodeURIComponent(serverId)}/connect`,
+    {},
+  );
+}
+
+/** Drop the live session, keeping the install and its stored credentials. */
+export function disconnectMcpRegistryServer(
+  client: OpenCompanyClient,
+  company: string | null,
+  serverId: string,
+): Promise<McpRegistryMutation> {
+  return client.post<McpRegistryMutation>(
+    `${client.scopeFor(company)}/mcp/registry/${encodeURIComponent(serverId)}/disconnect`,
+    {},
+  );
+}
+
+/**
+ * Rotate an install's credentials (write-only).
+ *
+ * The host merges the supplied keys over the stored ones and reconnects, so a
+ * form that sends only the field the operator retyped does not erase the rest.
+ */
+export function updateMcpRegistryEnv(
+  client: OpenCompanyClient,
+  company: string | null,
+  serverId: string,
+  env: Record<string, string>,
+): Promise<McpRegistryMutation> {
+  return client.put<McpRegistryMutation>(
+    `${client.scopeFor(company)}/mcp/registry/${encodeURIComponent(serverId)}/env`,
+    { env },
+  );
+}
+
+/**
+ * Uninstall a directory install and drop its stored env values.
+ *
+ * This is the **only** delete a `registry`-badged row may use.
+ * `DELETE …/mcp/servers/{name}` is List A's, keyed on a declaration a registry
+ * row does not have.
+ */
+export function uninstallMcpRegistryServer(
+  client: OpenCompanyClient,
+  company: string | null,
+  serverId: string,
+): Promise<void> {
+  return client.del<void>(
+    `${client.scopeFor(company)}/mcp/registry/${encodeURIComponent(serverId)}`,
+  );
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -971,16 +971,44 @@ export interface RosterAgent {
 }
 
 /**
+ * How a server got into the company's effective set.
+ *
+ * - `manifest` — committed in `company.toml`'s `[[mcp_server]]`.
+ * - `runtime` — typed into the console by URL.
+ * - `default` — shipped enabled by the packaged install (issue #527). Nobody
+ *   wrote it into *this* company, so it is not "operator-added".
+ * - `registry` — installed from an upstream MCP directory through the browse
+ *   surface (issue #1270). Keyed by {@link McpServer.serverId}, not by name,
+ *   and addressed by the `…/mcp/registry/…` routes rather than List A's.
+ */
+export type McpSource = "manifest" | "runtime" | "default" | "registry";
+
+/**
  * One effective MCP tool server (issue #50), as `.../mcp/servers` returns it.
  * The credential is never present — only the non-secret `authConfigured` flag
  * and the last (scrubbed) probe `health`.
+ *
+ * Since issue #1270 this one list carries directory installs too. The four
+ * registry fields below are all optional and omitted by the host on a row with
+ * no install behind it, so a manifest / runtime / default row arrives exactly
+ * as it always did.
  */
 export interface McpServer {
   name: string;
   endpoint: string;
   description?: string;
-  /** `manifest` (committed in company.toml) or `runtime` (console-added). */
-  source: "manifest" | "runtime";
+  /**
+   * Where this row came from. **The console's single source of provenance** —
+   * it decides the badge, the delete guard, and which set of routes the row's
+   * controls may call.
+   *
+   * A row that is *both* a directory install and a List A declaration is one
+   * reconciled row carrying List A's provenance, not `registry` (issue #1270).
+   * Never re-derive provenance from {@link McpServer.serverId} being present:
+   * a manifest server that was also installed from the directory carries a
+   * `serverId` and must still badge `manifest` and still refuse a delete.
+   */
+  source: McpSource;
   enabled: boolean;
   allowedTools: string[];
   disallowedTools: string[];
@@ -1002,6 +1030,22 @@ export interface McpServer {
   reachableBy?: RosterAgent[];
   /** The last recorded (scrubbed) probe outcome, when the server has been probed. */
   health?: McpHealth;
+  /**
+   * The stable install id, present only on a row backed by a directory install
+   * (issue #1270). Every `…/mcp/registry/{serverId}/…` route keys on this;
+   * `name` is a display slug the host mints for the row and addresses nothing
+   * in the registry's own store.
+   *
+   * Present does **not** mean `source === "registry"` — a reconciled row is a
+   * List A server that also has an install. See {@link McpServer.source}.
+   */
+  serverId?: string;
+  /** The directory's qualified name (`@org/server`), when this row came from one. */
+  qualifiedName?: string;
+  /** The directory's icon, when this row came from one. */
+  iconUrl?: string;
+  /** How an install is dialled — `http_remote` or `stdio`. Absent on a List A-only row. */
+  transport?: string;
 }
 
 /**

--- a/frontend/src/lib/mcp-registry.ts
+++ b/frontend/src/lib/mcp-registry.ts
@@ -1,0 +1,222 @@
+// What a merged MCP row is allowed to do, and how a directory failure reads
+// (issue #1270).
+//
+// ## Why these are functions and not conditions in the row
+//
+// `GET …/mcp/servers` now returns two structurally different things in one list.
+// A List A row — manifest, default, or an operator-typed runtime entry — is
+// addressed by `name`, and every control the row has ever offered writes to a
+// `…/mcp/servers/{name}/…` route that resolves that name against List A's
+// declarations. A directory install has no such declaration: its `name` is a
+// display slug the host mints for the merged view, so the *same* Switch, the
+// same Test and the same Tools button answer `no MCP server named …` on it.
+//
+// So provenance does not merely pick a badge — it picks which half of the API
+// the row may talk to at all. One function answering that for the whole row is
+// what keeps the four decisions (toggle, probe, lifecycle, delete) from drifting
+// apart into four inline conditions that each get it right on a different day.
+//
+// ## Provenance comes from `source`, never from `serverId`
+//
+// A server can be both: declared in `company.toml` *and* installed from the
+// directory. The host reconciles those into **one row** carrying List A's
+// provenance, because List A is the half the agents actually reach and the half
+// whose delete guard is real — a manifest declaration cannot be deleted, only
+// disabled, and a delete that uninstalled the directory copy would leave the
+// declared server exactly where it was while reporting success. Such a row
+// carries a `serverId`, so reading "has a serverId" as "is a registry row" is
+// precisely the mistake that removes the wrong thing.
+
+import { ApiError } from "@/api/types";
+import type { McpHealth, McpServer, McpSource } from "@/api/types";
+
+/**
+ * How a row is removed, if at all.
+ *
+ * - `none` — a manifest or install-wide default. The declaration outlives any
+ *   delete, so the row offers a disable instead.
+ * - `index` — `DELETE …/mcp/servers/{name}`. The host removes the runtime index
+ *   row *and* any directory install reconciled onto it, so one call is the whole
+ *   removal even on a reconciled row.
+ * - `install` — `DELETE …/mcp/registry/{serverId}`. The only delete a
+ *   registry-badged row may use.
+ */
+export type McpRemoval =
+  | { kind: "none" }
+  | { kind: "index"; name: string }
+  | { kind: "install"; serverId: string };
+
+/**
+ * Which connection control a row offers, and which way it points.
+ *
+ * Scoped to `registry` rows on purpose. A reconciled row *has* an install and
+ * the connect routes would accept its `serverId`, but what the company's agents
+ * reach through that row is List A's half — so a Disconnect there would drop a
+ * session the row does not represent while its tools kept working. The row
+ * already has the control that governs its own half: the Switch.
+ */
+export type McpLifecycle = "none" | "connect" | "disconnect";
+
+/** Everything a merged row's right edge is entitled to offer. */
+export interface McpRowControls {
+  /** List A's enable/disable Switch (`PUT …/mcp/servers/{name}`). */
+  toggle: boolean;
+  /**
+   * List A's on-demand probe and live tool discovery
+   * (`…/mcp/servers/{name}/test` and `/tools`). Both resolve the name against
+   * List A's declarations, which a registry install has none of.
+   */
+  probe: boolean;
+  lifecycle: McpLifecycle;
+  removal: McpRemoval;
+}
+
+/** Whether this row has a List A declaration behind its `name`. */
+function declaredInListA(source: McpSource): boolean {
+  return source !== "registry";
+}
+
+/**
+ * How this row is removed.
+ *
+ * Reads `source` and only then `serverId`: the guard on a manifest or default
+ * row holds whether or not a directory install reconciled onto it.
+ */
+export function mcpRemoval(server: McpServer): McpRemoval {
+  switch (server.source) {
+    case "manifest":
+    case "default":
+      return { kind: "none" };
+    case "runtime":
+      return { kind: "index", name: server.name };
+    case "registry":
+      // A `registry` row with no id is a host we cannot address. Offering a
+      // delete we have no key for would remove nothing and report success.
+      return server.serverId ? { kind: "install", serverId: server.serverId } : { kind: "none" };
+  }
+}
+
+/**
+ * Which way a registry row's connection control points.
+ *
+ * `ok` is the only state that means a live session exists; every other state —
+ * refused for a credential, failed, disabled, connecting, never dialled — is one
+ * a Connect is the right offer for.
+ */
+export function mcpLifecycle(server: McpServer, health: McpHealth | undefined): McpLifecycle {
+  if (server.source !== "registry" || !server.serverId) return "none";
+  return health?.status === "ok" ? "disconnect" : "connect";
+}
+
+/**
+ * The whole control set for one merged row.
+ *
+ * `health` is the row's *effective* health — a live Test result this session
+ * where there is one, else the persisted probe — so the connection control
+ * agrees with the badge beside it.
+ */
+export function mcpRowControls(
+  server: McpServer,
+  health: McpHealth | undefined,
+): McpRowControls {
+  const listA = declaredInListA(server.source);
+  return {
+    toggle: listA,
+    probe: listA,
+    lifecycle: mcpLifecycle(server, health),
+    removal: mcpRemoval(server),
+  };
+}
+
+/** The source badge: the host's own word for the provenance, and its weight. */
+export function mcpSourceBadge(source: McpSource): {
+  label: McpSource;
+  variant: "secondary" | "outline";
+} {
+  // The label is the host's vocabulary verbatim — the tab has badged `manifest`
+  // and `runtime` since issue #50 and an operator reads them as the words they
+  // are, so a fourth provenance joins as its own word rather than being folded
+  // into one of the three.
+  return { label: source, variant: source === "manifest" ? "secondary" : "outline" };
+}
+
+/**
+ * Why the directory surface is not answering.
+ *
+ * - `unwired` — this build has no `mcp` feature, so the registry routes answer
+ *   `404 not_wired`. A fact about the deployment, not a failure: the console
+ *   says the feature is not in this build rather than showing an error.
+ * - `error` — anything else. The directories are federated over the network and
+ *   either of them can be down; that is an empty result with a reason, never a
+ *   broken tab.
+ *
+ * **Total by construction.** Every failure the browse surface can see resolves
+ * to one of these two, including a rejection that is not an `ApiError` at all,
+ * because the one outcome this must never produce is an exception escaping into
+ * the section that renders the company's server list. A directory being down
+ * cannot be allowed to take List A's rows off the screen with it.
+ */
+export type McpRegistryOutage = { kind: "unwired" } | { kind: "error"; message: string };
+
+export function registryOutage(err: unknown): McpRegistryOutage {
+  if (err instanceof ApiError) {
+    if (err.code === "not_wired") return { kind: "unwired" };
+    // The host's own sentence when it sent one; its envelope is prose meant for
+    // an operator. A network failure carries our sentence instead.
+    if (err.message.trim()) return { kind: "error", message: err.message };
+  }
+  return { kind: "error", message: "The MCP directory didn't answer." };
+}
+
+/** What the console says when the directory surface is missing from the build. */
+export const REGISTRY_UNWIRED_NOTICE =
+  "Browsing the MCP directory isn't enabled in this build (the host was compiled without the MCP feature). The servers above still work.";
+
+/**
+ * The declared env keys an install is still missing a value for.
+ *
+ * Trimmed, because a key whose value is whitespace is a key the operator has
+ * not filled in — and an install that silently stores it would come back
+ * `unauthorized` with a credential the console reports as configured.
+ */
+export function missingEnvKeys(
+  requiredKeys: readonly string[],
+  values: Readonly<Record<string, string>>,
+): string[] {
+  return requiredKeys.filter((key) => !(values[key] ?? "").trim());
+}
+
+/**
+ * What a row's provenance means, for the detail panel (issue #821).
+ *
+ * Four provenances, four sentences: the panel used to read `manifest` against
+ * everything-else, which told an operator that a directory install "was added
+ * from the console and lives in this company's runtime store" — true of neither
+ * half of it.
+ */
+export function mcpProvenanceNote(source: McpSource): string {
+  switch (source) {
+    case "manifest":
+      return "Declared in this company's company.toml, so it comes back on every boot — it can be turned off here but not deleted.";
+    case "default":
+      return "Shipped enabled by this installation rather than by this company, so it is present for every company here — it can be turned off but not deleted.";
+    case "registry":
+      return "Installed from an upstream MCP directory, so it lives in this host's registry store rather than in company.toml — it is connected and disconnected here, and uninstalling removes it.";
+    case "runtime":
+      return "Added from the console, so it lives in this company's runtime store rather than in company.toml.";
+  }
+}
+
+/** What a removal reaches, for the detail panel. Mirrors {@link mcpRemoval}. */
+export function mcpRemovalNote(source: McpSource): string {
+  switch (source) {
+    case "manifest":
+      return "This server is declared in company.toml, so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn, and it returns on the next boot unless the manifest changes.";
+    case "default":
+      return "This server ships with the installation, so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn.";
+    case "registry":
+      return "Uninstalling it removes the install from this host's registry store, closes its session and deletes the credential values stored for it.";
+    case "runtime":
+      return "Removing it drops it from every teammate's tool belt on the next turn and deletes the credential stored here for it.";
+  }
+}

--- a/frontend/src/views/connections/McpRegistryBrowser.tsx
+++ b/frontend/src/views/connections/McpRegistryBrowser.tsx
@@ -1,0 +1,461 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertTriangle, Info, Loader2, Search } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  getMcpRegistryEntry,
+  installMcpRegistryEntry,
+  searchMcpRegistry,
+  type McpCatalogueDetail,
+  type McpCatalogueEntry,
+} from "@/api/mcp-registry";
+import { ApiError } from "@/api/types";
+import {
+  missingEnvKeys,
+  REGISTRY_UNWIRED_NOTICE,
+  registryOutage,
+  type McpRegistryOutage,
+} from "@/lib/mcp-registry";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/** How many directory rows one page asks for. */
+const PAGE_SIZE = 10;
+
+type Results =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "outage"; outage: McpRegistryOutage }
+  | { kind: "ready"; page: number; totalPages: number; servers: McpCatalogueEntry[] };
+
+/** The install dialog's state for the one entry an operator picked. */
+type Picked =
+  | { kind: "loading"; qualifiedName: string }
+  | { kind: "failed"; qualifiedName: string; outage: McpRegistryOutage }
+  | { kind: "ready"; detail: McpCatalogueDetail };
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** Called after a successful install so the merged server list re-reads. */
+  onInstalled: () => void;
+}
+
+/**
+ * Browse the upstream MCP directories and install from them (issue #1270).
+ *
+ * The MCP tab could not discover anything: an operator had to arrive already
+ * knowing a server's URL and type it in, so the tab stayed empty until someone
+ * pasted something into it. This is the catalogue half — the host federates
+ * Smithery.ai and `modelcontextprotocol/registry`, and an entry installed here
+ * lands in the **same** list above with a `registry` badge, not in a second
+ * section.
+ *
+ * ## It cannot take the server list down with it
+ *
+ * Everything here is fenced inside this component's own state. The directories
+ * are two network hops away and either can be down; the host itself may be
+ * built without the `mcp` feature, in which case these routes answer
+ * `404 not_wired`. Both are rendered as a notice *inside this panel* — an empty
+ * result with a reason — while the company's installed servers above go on
+ * rendering. A dead directory is not a broken tab.
+ *
+ * ## Credentials
+ *
+ * An entry declares the env keys it needs, and those are the only fields the
+ * install form has. Their values are write-only: they go out with the install
+ * and no route ever sends one back, so nothing here reads or renders one.
+ */
+export function McpRegistryBrowser({ client, company, onInstalled }: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Results>({ kind: "idle" });
+  const [picked, setPicked] = useState<Picked | null>(null);
+  const [env, setEnv] = useState<Record<string, string>>({});
+  const [installing, setInstalling] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+  // Only the newest search may write its answer. Two searches issued quickly —
+  // a fresh query while a page turn is in flight — can land out of order, and
+  // the older answer arriving last would paint results for a query the operator
+  // has already replaced. Bumped on every scope change too, so an answer for
+  // the company just left cannot repaint this panel.
+  const generation = useRef(0);
+
+  // Switching company re-keys everything this panel shows. Without the reset,
+  // one company's directory page and a half-filled install form stay on screen
+  // under another company's heading.
+  useEffect(() => {
+    generation.current += 1;
+    setResults({ kind: "idle" });
+    setPicked(null);
+    setEnv({});
+    setInstallError(null);
+  }, [client, company]);
+
+  const runSearch = useCallback(
+    async (page: number) => {
+      generation.current += 1;
+      const mine = generation.current;
+      setResults({ kind: "loading" });
+      try {
+        const found = await searchMcpRegistry(client, company, {
+          q: query,
+          page,
+          pageSize: PAGE_SIZE,
+        });
+        if (generation.current !== mine) return;
+        setResults({
+          kind: "ready",
+          page: found.page,
+          totalPages: found.totalPages,
+          servers: found.servers,
+        });
+      } catch (err) {
+        if (generation.current !== mine) return;
+        // Classified, never rethrown: see the component doc.
+        setResults({ kind: "outage", outage: registryOutage(err) });
+      }
+    },
+    [client, company, query],
+  );
+
+  async function pick(entry: McpCatalogueEntry) {
+    setInstallError(null);
+    setEnv({});
+    setPicked({ kind: "loading", qualifiedName: entry.qualifiedName });
+    try {
+      const detail = await getMcpRegistryEntry(client, company, entry.qualifiedName);
+      setPicked({ kind: "ready", detail });
+    } catch (err) {
+      setPicked({
+        kind: "failed",
+        qualifiedName: entry.qualifiedName,
+        outage: registryOutage(err),
+      });
+    }
+  }
+
+  async function install(detail: McpCatalogueDetail) {
+    if (installing) return;
+    const missing = missingEnvKeys(detail.requiredEnvKeys, env);
+    if (missing.length > 0) {
+      setInstallError(
+        `This server needs a value for ${missing.join(", ")} before it can be installed.`,
+      );
+      return;
+    }
+    setInstalling(true);
+    setInstallError(null);
+    try {
+      const res = await installMcpRegistryEntry(client, company, {
+        qualifiedName: detail.qualifiedName,
+        env,
+      });
+      // An install that lands "needs a credential" is NOT a rollback — the host
+      // says so explicitly — so it is reported where the operator can act on it
+      // rather than dressed up as a failed install.
+      if (res.test && res.test.status !== "ok") {
+        setInstallError(res.test.message);
+      } else {
+        toast.success(`Installed ${detail.displayName}. ${res.note}`);
+        setPicked(null);
+      }
+      setEnv({});
+      onInstalled();
+    } catch (err) {
+      setInstallError(
+        err instanceof ApiError ? err.message : "Couldn't install that server.",
+      );
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 border-t border-border pt-3" data-testid="mcp-registry-browser">
+      <div className="space-y-1">
+        <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Add from the MCP directory
+        </h4>
+        <p className="text-xs text-muted-foreground">
+          Search Smithery and the official MCP registry. An installed server joins the list above
+          and every teammate can call it.
+        </p>
+      </div>
+
+      <form
+        className="flex items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void runSearch(1);
+        }}
+      >
+        <div className="flex-1 space-y-1">
+          <Label htmlFor="mcp-registry-q" className="text-xs">
+            Search the directory
+          </Label>
+          <Input
+            id="mcp-registry-q"
+            data-testid="mcp-registry-search"
+            value={query}
+            placeholder="github, linear, postgres…"
+            autoComplete="off"
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+        <Button type="submit" variant="secondary" disabled={results.kind === "loading"}>
+          {results.kind === "loading" ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Search className="size-4" />
+          )}{" "}
+          Search
+        </Button>
+      </form>
+
+      {results.kind === "outage" && <OutageNotice outage={results.outage} />}
+
+      {results.kind === "ready" &&
+        (results.servers.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="mcp-registry-empty">
+            No hosted servers matched that. The directory only offers servers this host can dial
+            over HTTP — one that runs as a local subprocess is not listed.
+          </p>
+        ) : (
+          <>
+            <ul className="divide-y divide-border" data-testid="mcp-registry-results">
+              {results.servers.map((entry) => (
+                <li key={entry.qualifiedName} className="space-y-2 py-2 first:pt-0">
+                  <div className="flex items-start gap-2">
+                    <CatalogueIcon entry={entry} />
+                    <div className="min-w-0 flex-1 space-y-0.5">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="text-sm font-medium">{entry.displayName}</span>
+                        {entry.official && <Badge variant="secondary">official</Badge>}
+                        <Badge variant="outline">{entry.source}</Badge>
+                      </div>
+                      <p className="truncate font-mono text-xs text-muted-foreground">
+                        {entry.qualifiedName}
+                      </p>
+                      {entry.description && (
+                        <p className="text-xs text-muted-foreground">{entry.description}</p>
+                      )}
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      data-testid="mcp-registry-pick"
+                      disabled={installing}
+                      onClick={() => void pick(entry)}
+                    >
+                      Install
+                    </Button>
+                  </div>
+                  {isPicked(picked, entry.qualifiedName) && (
+                    <InstallForm
+                      picked={picked}
+                      env={env}
+                      setEnv={setEnv}
+                      installing={installing}
+                      error={installError}
+                      onCancel={() => setPicked(null)}
+                      onInstall={install}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+            {results.totalPages > 1 && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={results.page <= 1}
+                  onClick={() => void runSearch(results.page - 1)}
+                >
+                  Previous
+                </Button>
+                <span>
+                  Page {results.page} of {results.totalPages}
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={results.page >= results.totalPages}
+                  onClick={() => void runSearch(results.page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        ))}
+    </div>
+  );
+}
+
+/** Whether the open install dialog belongs to this row. */
+function isPicked(picked: Picked | null, qualifiedName: string): picked is Picked {
+  if (picked === null) return false;
+  const of = picked.kind === "ready" ? picked.detail.qualifiedName : picked.qualifiedName;
+  return of === qualifiedName;
+}
+
+/**
+ * The directory is not answering.
+ *
+ * A missing build feature is said as a missing build feature — an operator can
+ * do nothing about it and it is not a fault of theirs or of the network — while
+ * a real failure carries the host's own sentence. Neither is a toast: both are
+ * facts that stay true while the panel is open.
+ */
+function OutageNotice({ outage }: { outage: McpRegistryOutage }) {
+  if (outage.kind === "unwired") {
+    return (
+      <Alert data-testid="mcp-registry-unwired">
+        <Info className="size-4" />
+        <AlertTitle>The MCP directory isn&apos;t in this build</AlertTitle>
+        <AlertDescription>{REGISTRY_UNWIRED_NOTICE}</AlertDescription>
+      </Alert>
+    );
+  }
+  return (
+    <Alert variant="destructive" data-testid="mcp-registry-error">
+      <AlertTriangle className="size-4" />
+      <AlertTitle>Couldn&apos;t search the MCP directory</AlertTitle>
+      <AlertDescription>
+        {outage.message} The servers above are unaffected — this is the catalogue, not your
+        installed set.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/**
+ * The install form for one picked entry.
+ *
+ * Its fields are exactly the env keys the entry declared, and they are password
+ * inputs with no value ever read back: an install credential is write-only in
+ * both directions, the same rule List A's token field follows.
+ */
+function InstallForm({
+  picked,
+  env,
+  setEnv,
+  installing,
+  error,
+  onCancel,
+  onInstall,
+}: {
+  picked: Picked;
+  env: Record<string, string>;
+  setEnv: (next: Record<string, string>) => void;
+  installing: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onInstall: (detail: McpCatalogueDetail) => void;
+}) {
+  if (picked.kind === "loading") {
+    return (
+      <p className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" /> Reading what this server needs…
+      </p>
+    );
+  }
+  if (picked.kind === "failed") {
+    return (
+      <p className="text-xs text-destructive" data-testid="mcp-registry-entry-error">
+        {picked.outage.kind === "unwired"
+          ? REGISTRY_UNWIRED_NOTICE
+          : `${picked.outage.message} Nothing was installed.`}
+      </p>
+    );
+  }
+
+  const detail = picked.detail;
+  if (!detail.installable) {
+    return (
+      <p className="text-xs text-destructive" data-testid="mcp-registry-refusal">
+        {detail.refusal ?? "This host can't install that server."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-md bg-muted/40 p-2" data-testid="mcp-registry-install-form">
+      {detail.endpoint && (
+        <p className="font-mono text-xs break-all text-muted-foreground">{detail.endpoint}</p>
+      )}
+      {detail.requiredEnvKeys.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          This server asks for no credentials — installing connects it straight away.
+        </p>
+      ) : (
+        detail.requiredEnvKeys.map((key) => (
+          <div key={key} className="space-y-1">
+            <Label htmlFor={`mcp-env-${key}`} className="font-mono text-xs">
+              {key}
+            </Label>
+            <Input
+              id={`mcp-env-${key}`}
+              data-testid="mcp-registry-env-field"
+              type="password"
+              autoComplete="new-password"
+              placeholder="write-only"
+              value={env[key] ?? ""}
+              onChange={(e) => setEnv({ ...env, [key]: e.target.value })}
+            />
+          </div>
+        ))
+      )}
+      {error && (
+        <p className="text-xs text-destructive" data-testid="mcp-registry-install-error">
+          {error}
+        </p>
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          data-testid="mcp-registry-install"
+          disabled={installing}
+          onClick={() => onInstall(detail)}
+        >
+          {installing ? <Loader2 className="size-4 animate-spin" /> : null} Install
+        </Button>
+        <Button size="sm" variant="ghost" disabled={installing} onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** A catalogue icon, falling back to an initial when the remote image dies. */
+function CatalogueIcon({ entry }: { entry: McpCatalogueEntry }) {
+  const [failed, setFailed] = useState(false);
+  useEffect(() => setFailed(false), [entry.iconUrl]);
+
+  if (!entry.iconUrl || failed) {
+    return (
+      <span
+        aria-hidden="true"
+        className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground"
+      >
+        {entry.displayName.charAt(0).toUpperCase()}
+      </span>
+    );
+  }
+  return (
+    <img
+      src={entry.iconUrl}
+      alt=""
+      aria-hidden="true"
+      loading="lazy"
+      className="size-6 shrink-0 rounded-md object-contain"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Server,
   Trash2,
+  Unplug,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -26,8 +27,29 @@ import {
   testMcpServer,
   updateMcpServer,
 } from "@/api/mcp";
-import { ApiError, type McpHealth, type McpServer, type McpToolInfo } from "@/api/types";
+import {
+  connectMcpRegistryServer,
+  disconnectMcpRegistryServer,
+  getMcpRegistryEntry,
+  uninstallMcpRegistryServer,
+  updateMcpRegistryEnv,
+} from "@/api/mcp-registry";
+import {
+  ApiError,
+  type McpHealth,
+  type McpServer,
+  type McpSource,
+  type McpStatus,
+  type McpToolInfo,
+} from "@/api/types";
 import { type McpBridgeState, mcpAddedMessage, mcpBridgeState } from "@/lib/mcp-bridge";
+import {
+  missingEnvKeys,
+  mcpRowControls,
+  mcpSourceBadge,
+  REGISTRY_UNWIRED_NOTICE,
+  registryOutage,
+} from "@/lib/mcp-registry";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -36,21 +58,42 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { McpRegistryBrowser } from "@/views/connections/McpRegistryBrowser";
 import { ProviderDetail } from "@/views/connections/ProviderDetail";
 
 /**
- * What a server's health entitles its row to offer (issue #1260).
+ * What a server's health entitles its row to offer (issues #1260, #1270).
  *
- * A rule rather than two inline conditions, because the two OAuth states differ
- * by exactly one thing an operator cannot see: whether the server advertises
+ * A rule rather than inline conditions, because the two OAuth states differ by
+ * exactly one thing an operator cannot see: whether the server advertises
  * dynamic client registration. `oauth_required` means the server asked for
  * OAuth; only the host knows whether this console can complete one, and it says
  * so by sending `static_token_required` instead. Reading them as the same state
  * is what put a Sign in button on a Slack row that could never sign in.
+ *
+ * Issue #1270 added a third control and a reason the hint alone cannot decide
+ * between them. A **directory install** keeps its credentials as named env
+ * values in the host's registry store, and its row's `name` is a display slug
+ * addressing no List A declaration — so both List A controls are wrong for it
+ * twice over: `POST …/oauth/start` and `PUT …/mcp/servers/{name}` answer *no
+ * MCP server named …*, and the value they collect would be written to a store
+ * this server is not dialled from. Such a row gets `rotate_env`, which is
+ * `PUT …/mcp/registry/{serverId}/env`.
+ *
+ * `row.status` is consulted only for that case, and it has to be: the host's
+ * registry projection emits a stable `authHint` only when the upstream
+ * connection reported one, so a directory install refused for want of a
+ * credential can arrive as `needs_config` with no hint at all. List A's
+ * mapping below is untouched — it is still a function of the hint and nothing
+ * else.
  */
 export function credentialAffordance(
   authHint: string | undefined,
-): "sign_in" | "add_token" | "none" {
+  row?: { source: McpSource; status?: McpStatus },
+): "sign_in" | "add_token" | "rotate_env" | "none" {
+  if (row?.source === "registry") {
+    return row.status === "needs_config" ? "rotate_env" : "none";
+  }
   switch (authHint) {
     case "oauth_required":
       return "sign_in";
@@ -65,6 +108,20 @@ export function credentialAffordance(
 }
 
 type McpLoad = "loading" | "ready" | "unavailable" | "error";
+/**
+ * The fields a directory install's credential rotation is asking for.
+ *
+ * They come from the *directory*, not from the row: `GET …/mcp/servers` reports
+ * only whether a credential is stored (`authConfigured`), never which keys hold
+ * it, so the names have to be re-read from the catalogue entry the install came
+ * from. That is also why this can fail while the rotation route itself is
+ * perfectly healthy — a directory outage costs the field names, so the form
+ * says so instead of guessing at them.
+ */
+type EnvFields =
+  | { kind: "loading" }
+  | { kind: "failed"; message: string }
+  | { kind: "ready"; keys: string[] };
 type ToolsState =
   | { kind: "idle" }
   | { kind: "loading" }
@@ -92,10 +149,19 @@ interface Props {
 }
 
 /**
- * Manage the company's MCP tool servers (issue #50). Lists the effective set
- * (manifest + runtime), adds runtime servers with a **write-only** token field,
- * toggles/removes them, and live-discovers each server's tools. A manifest
- * server can be disabled but not deleted.
+ * Manage the company's MCP tool servers (issue #50). Lists the effective set,
+ * adds runtime servers with a **write-only** token field, toggles/removes them,
+ * and live-discovers each server's tools. A manifest server can be disabled but
+ * not deleted.
+ *
+ * Since issue #1270 the effective set is four provenances, not two: manifest
+ * and default declarations, operator-typed runtime entries, and installs from
+ * the upstream MCP directories that [`McpRegistryBrowser`](./McpRegistryBrowser.tsx)
+ * below the form adds. They are **one list** with a provenance badge, not two
+ * sections — but a row's provenance decides more than its badge, because a
+ * directory install has no List A declaration behind its name and so cannot use
+ * List A's routes at all. That dispatch is
+ * [`mcpRowControls`](@/lib/mcp-registry)'s.
  *
  * This is the console's **only** MCP surface, reached from two places: the
  * Connections page renders it `inline`, Settings, MCP Servers renders it
@@ -134,6 +200,22 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
    */
   const [credentialFor, setCredentialFor] = useState<string | null>(null);
   const [credentialDraft, setCredentialDraft] = useState("");
+  /**
+   * The registry row whose credential-rotation form is open, and the fields it
+   * is showing (issue #1270).
+   *
+   * Separate state from `credentialFor` because the two collect different
+   * things for different stores: List A's is one bearer token written to this
+   * company's secret store, a directory install's is a set of *named* env
+   * values written to the host's registry store. Which of the two a row offers
+   * is `credentialAffordance`'s decision and nothing else's.
+   *
+   * The field names are not on the row — see `openEnvRotation`.
+   */
+  const [envFor, setEnvFor] = useState<string | null>(null);
+  const [envFields, setEnvFields] = useState<EnvFields>({ kind: "loading" });
+  const [envDraft, setEnvDraft] = useState<Record<string, string>>({});
+  const [envError, setEnvError] = useState<string | null>(null);
   // Set by the unmount cleanup below. A sign-in poll that is mid-`await` when
   // this component goes away has already removed its own timer entry, so the
   // cleanup has nothing left to cancel — it checks this instead of re-arming.
@@ -389,15 +471,148 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     }
   }
 
+  /**
+   * Remove a server through whichever route owns it (issue #1270).
+   *
+   * The dispatch is [`mcpRowControls`](@/lib/mcp-registry)'s, not a condition
+   * here, because the two routes key on different things and neither accepts
+   * the other's key: List A deletes by `name`, a directory install by its
+   * `serverId`. A registry row's `name` is a slug the host mints for the merged
+   * view — sending it to `DELETE …/mcp/servers/{name}` addresses a declaration
+   * that does not exist, and on an unlucky slug collision would address someone
+   * else's.
+   *
+   * The `index` arm covers a *reconciled* runtime row on purpose: the host
+   * removes the index row and uninstalls the directory half in the same call,
+   * so one delete is the whole removal.
+   */
   async function remove(server: McpServer) {
     if (busy) return;
+    const removal = mcpRowControls(server, tested[server.name] ?? server.health).removal;
+    if (removal.kind === "none") return;
     setBusy(server.name);
     try {
-      await removeMcpServer(client, company, server.name);
+      if (removal.kind === "install") {
+        await uninstallMcpRegistryServer(client, company, removal.serverId);
+      } else {
+        await removeMcpServer(client, company, removal.name);
+      }
       toast.success(`Removed ${server.name}.`);
       await refresh();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Couldn't remove the server.");
+      if (err instanceof ApiError && err.code === "not_wired") {
+        toast.message(REGISTRY_UNWIRED_NOTICE);
+      } else {
+        toast.error(err instanceof ApiError ? err.message : "Couldn't remove the server.");
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  /**
+   * Dial or drop a directory install's session (issue #1270).
+   *
+   * The registry's answer to the Switch. A disconnect keeps the install and its
+   * stored credentials — it closes the session, it does not uninstall — so the
+   * two are separate controls rather than one destructive toggle.
+   *
+   * The response carries the connection state right after the change, which is
+   * recorded as this row's live health so the badge moves without a second
+   * round trip. A refused connection is **not** an error: the host says so, and
+   * a server that answers "needs a credential" has told the operator exactly
+   * what to do next.
+   */
+  async function lifecycle(server: McpServer, direction: "connect" | "disconnect") {
+    if (busy || !server.serverId) return;
+    setBusy(server.name);
+    try {
+      const res =
+        direction === "connect"
+          ? await connectMcpRegistryServer(client, company, server.serverId)
+          : await disconnectMcpRegistryServer(client, company, server.serverId);
+      const after = res.test;
+      if (after) setTested((t) => ({ ...t, [server.name]: after }));
+      // No state came back: drop any stale override so the row falls back to
+      // the health the refresh below is about to bring.
+      else setTested(({ [server.name]: _dropped, ...rest }) => rest);
+      await refresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "not_wired") {
+        toast.message(REGISTRY_UNWIRED_NOTICE);
+      } else {
+        toast.error(
+          err instanceof ApiError
+            ? err.message
+            : `Couldn't ${direction} ${server.name}.`,
+        );
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  /**
+   * Open a directory install's credential rotation, reading its field names
+   * from the catalogue entry it was installed from.
+   *
+   * The row cannot supply them: the merged read reports only that *a*
+   * credential is stored. See {@link EnvFields}.
+   */
+  async function openEnvRotation(server: McpServer) {
+    setEnvDraft({});
+    setEnvError(null);
+    setEnvFor(server.name);
+    if (!server.qualifiedName) {
+      setEnvFields({
+        kind: "failed",
+        message: "This install doesn't name a directory entry, so its credential fields are unknown.",
+      });
+      return;
+    }
+    setEnvFields({ kind: "loading" });
+    try {
+      const detail = await getMcpRegistryEntry(client, company, server.qualifiedName);
+      setEnvFields({ kind: "ready", keys: detail.requiredEnvKeys });
+    } catch (err) {
+      const outage = registryOutage(err);
+      setEnvFields({
+        kind: "failed",
+        message:
+          outage.kind === "unwired"
+            ? REGISTRY_UNWIRED_NOTICE
+            : `${outage.message} Its credential fields are named in the directory, so they can't be read right now.`,
+      });
+    }
+  }
+
+  /**
+   * Rotate a directory install's credentials.
+   *
+   * Write-only in both directions, exactly like List A's token: the values go
+   * to `PUT …/mcp/registry/{serverId}/env` and come back only as the row's
+   * `authConfigured` flag. The host merges the supplied keys over the stored
+   * ones and reconnects, so the post-write connection state is the answer to
+   * "was that the right credential" and is recorded as this row's live health.
+   */
+  async function saveEnvRotation(server: McpServer, keys: string[]) {
+    if (busy || !server.serverId) return;
+    const missing = missingEnvKeys(keys, envDraft);
+    if (missing.length > 0) {
+      setEnvError(`Fill in ${missing.join(", ")} before saving.`);
+      return;
+    }
+    setBusy(server.name);
+    setEnvError(null);
+    try {
+      const res = await updateMcpRegistryEnv(client, company, server.serverId, envDraft);
+      const after = res.test;
+      if (after) setTested((t) => ({ ...t, [server.name]: after }));
+      setEnvFor(null);
+      setEnvDraft({});
+      await refresh();
+    } catch (err) {
+      setEnvError(err instanceof ApiError ? err.message : "Couldn't save those credentials.");
     } finally {
       setBusy(null);
     }
@@ -503,6 +718,22 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
               <ul className="divide-y divide-border">
                 {servers.map((server) => {
                   const health = tested[server.name] ?? server.health;
+                  // Which half of the API this row may talk to at all — not
+                  // merely which badge it prints (issue #1270). A directory
+                  // install has no List A declaration behind its name, so the
+                  // Switch, Test and Tools that every row used to carry answer
+                  // `no MCP server named …` on it, and the registry's own
+                  // connect/disconnect stand in their place.
+                  const controls = mcpRowControls(server, health);
+                  // Hoisted out of the JSX so the direction stays narrowed:
+                  // there is one place that decides connect-or-disconnect, and
+                  // the button below reads it rather than re-testing it.
+                  const dial = controls.lifecycle === "none" ? null : controls.lifecycle;
+                  const badge = mcpSourceBadge(server.source);
+                  const credential = credentialAffordance(health?.authHint, {
+                    source: server.source,
+                    status: health?.status,
+                  });
                   return (
                     <li
                       key={server.name}
@@ -532,17 +763,19 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           {server.name}
                           <ChevronRight className="size-3.5 text-muted-foreground" />
                         </button>
-                        <Badge variant={server.source === "manifest" ? "secondary" : "outline"}>
-                          {server.source}
+                        <Badge variant={badge.variant} data-testid="mcp-source-badge">
+                          {badge.label}
                         </Badge>
                         <McpHealthBadge health={health} authConfigured={server.authConfigured} />
                         <span className="ml-auto flex items-center gap-2">
-                          <Switch
-                            checked={server.enabled}
-                            disabled={busy === server.name || !canManage}
-                            onCheckedChange={(v) => void toggle(server, v)}
-                            aria-label={`Enable ${server.name}`}
-                          />
+                          {controls.toggle && (
+                            <Switch
+                              checked={server.enabled}
+                              disabled={busy === server.name || !canManage}
+                              onCheckedChange={(v) => void toggle(server, v)}
+                              aria-label={`Enable ${server.name}`}
+                            />
+                          )}
                           {/* Issue #1260: `oauth_required` means the server asked for
                               OAuth; it does NOT mean this console can complete one. A
                               server advertising no dynamic client registration — Slack's
@@ -552,7 +785,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               error naming something the operator cannot act on, which is
                               the same trade `hub_providers` already refuses to make for
                               the Google and GitHub buttons. */}
-                          {credentialAffordance(health?.authHint) === "add_token" &&
+                          {credential === "add_token" &&
                             canManage &&
                             credentialFor !== server.name && (
                               <Button
@@ -568,7 +801,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                                 <KeyRound className="size-4" /> Add token
                               </Button>
                             )}
-                          {credentialAffordance(health?.authHint) === "sign_in" && canManage && (
+                          {credential === "sign_in" && canManage && (
                             <Button
                               variant="default"
                               size="sm"
@@ -583,28 +816,73 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               Sign in
                             </Button>
                           )}
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            disabled={busy === server.name}
-                            onClick={() => void test(server)}
-                          >
-                            {busy === server.name ? (
-                              <Loader2 className="size-4 animate-spin" />
-                            ) : (
-                              <Plug className="size-4" />
-                            )}{" "}
-                            Test
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            disabled={busy === server.name}
-                            onClick={() => void discover(server)}
-                          >
-                            <ChevronDown className="size-4" /> Tools
-                          </Button>
-                          {server.source === "runtime" && canManage && (
+                          {/* Issue #1270: a directory install's credentials are
+                              named env values in the host's registry store, so
+                              the control it gets is a rotation of those, not
+                              List A's single bearer-token field. */}
+                          {credential === "rotate_env" &&
+                            canManage &&
+                            envFor !== server.name && (
+                              <Button
+                                variant="default"
+                                size="sm"
+                                data-testid="mcp-rotate-env"
+                                disabled={busy === server.name}
+                                onClick={() => void openEnvRotation(server)}
+                              >
+                                <KeyRound className="size-4" /> Credentials
+                              </Button>
+                            )}
+                          {dial !== null && canManage && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              data-testid="mcp-lifecycle"
+                              disabled={busy === server.name}
+                              onClick={() => void lifecycle(server, dial)}
+                            >
+                              {busy === server.name ? (
+                                <Loader2 className="size-4 animate-spin" />
+                              ) : dial === "connect" ? (
+                                <Plug className="size-4" />
+                              ) : (
+                                <Unplug className="size-4" />
+                              )}{" "}
+                              {dial === "connect" ? "Connect" : "Disconnect"}
+                            </Button>
+                          )}
+                          {/* Test and Tools resolve the row's `name` against
+                              List A's declarations, which a directory install
+                              has none of — offering them there would spend a
+                              click to reach `no MCP server named …`. Connect
+                              above is that row's equivalent: its answer carries
+                              the connection state and the tool count. */}
+                          {controls.probe && (
+                            <>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                disabled={busy === server.name}
+                                onClick={() => void test(server)}
+                              >
+                                {busy === server.name ? (
+                                  <Loader2 className="size-4 animate-spin" />
+                                ) : (
+                                  <Plug className="size-4" />
+                                )}{" "}
+                                Test
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                disabled={busy === server.name}
+                                onClick={() => void discover(server)}
+                              >
+                                <ChevronDown className="size-4" /> Tools
+                              </Button>
+                            </>
+                          )}
+                          {controls.removal.kind !== "none" && canManage && (
                             <Button
                               variant="ghost"
                               size="sm"
@@ -691,6 +969,72 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           >
                             Cancel
                           </Button>
+                        </div>
+                      )}
+                      {envFor === server.name && canManage && (
+                        <div className="space-y-2 rounded-md bg-muted/40 p-2" data-testid="mcp-env-inline">
+                          {envFields.kind === "loading" ? (
+                            <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                              <Loader2 className="size-3 animate-spin" /> Reading this
+                              server&apos;s credential fields…
+                            </p>
+                          ) : envFields.kind === "failed" ? (
+                            <p className="text-xs text-destructive" data-testid="mcp-env-unavailable">
+                              {envFields.message}
+                            </p>
+                          ) : envFields.keys.length === 0 ? (
+                            <p className="text-xs text-muted-foreground">
+                              This server asks for no credentials.
+                            </p>
+                          ) : (
+                            envFields.keys.map((key) => (
+                              <div key={key} className="space-y-1">
+                                <Label
+                                  htmlFor={`mcp-env-${server.name}-${key}`}
+                                  className="font-mono text-xs"
+                                >
+                                  {key}
+                                </Label>
+                                <Input
+                                  id={`mcp-env-${server.name}-${key}`}
+                                  type="password"
+                                  autoComplete="new-password"
+                                  placeholder="write-only"
+                                  value={envDraft[key] ?? ""}
+                                  onChange={(e) =>
+                                    setEnvDraft({ ...envDraft, [key]: e.target.value })
+                                  }
+                                />
+                              </div>
+                            ))
+                          )}
+                          {envError && <p className="text-xs text-destructive">{envError}</p>}
+                          <div className="flex items-center gap-2">
+                            {envFields.kind === "ready" && envFields.keys.length > 0 && (
+                              <Button
+                                size="sm"
+                                data-testid="mcp-env-save"
+                                disabled={busy === server.name}
+                                onClick={() => void saveEnvRotation(server, envFields.keys)}
+                              >
+                                {busy === server.name ? (
+                                  <Loader2 className="size-4 animate-spin" />
+                                ) : (
+                                  "Save"
+                                )}
+                              </Button>
+                            )}
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={busy === server.name}
+                              onClick={() => setEnvFor(null)}
+                            >
+                              {envFields.kind === "ready" && envFields.keys.length > 0
+                                ? "Cancel"
+                                : "Close"}
+                            </Button>
+                          </div>
                         </div>
                       )}
                       <McpToolsList state={tools[server.name] ?? { kind: "idle" }} />
@@ -800,6 +1144,25 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                   </Button>
                 </div>
               </div>
+            )}
+
+            {/* Issue #1270: the tab could not discover anything — an operator
+                had to arrive already knowing a URL to paste. The directory
+                browser sits inside the same card, under the same manage gate as
+                the form above it (an install hands every teammate a new set of
+                tools), and what it installs lands in the list above with a
+                `registry` badge rather than in a section of its own.
+
+                Its failures are its own: it renders a notice inside itself and
+                never touches `load`, so a directory that is down — or a host
+                built without the MCP feature, which 404s these routes — costs
+                the catalogue and not the company's server list. */}
+            {canManage && (
+              <McpRegistryBrowser
+                client={client}
+                company={company}
+                onInstalled={() => void refresh()}
+              />
             )}
           </CardContent>
         </Card>

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -22,6 +22,7 @@ import {
   probedOn,
 } from "@/lib/connection-detail";
 import { toolkitSlug } from "@/lib/connections";
+import { mcpProvenanceNote, mcpRemovalNote } from "@/lib/mcp-registry";
 import { accountSummary, tallyAccounts } from "@/lib/provider-grid";
 import type { GridProvider } from "@/lib/provider-grid";
 
@@ -451,10 +452,12 @@ function McpBody({
                 to open the panel rather than a detail to hide again. */}
             <p className="font-mono text-xs break-all">{server.endpoint}</p>
           </div>
-          <p className="text-xs text-muted-foreground">
-            {server.source === "manifest"
-              ? "Declared in this company's company.toml, so it comes back on every boot — it can be turned off here but not deleted."
-              : "Added from the console, so it lives in this company's runtime store rather than in company.toml."}
+          {/* One sentence per provenance (issue #1270). This read `manifest`
+              against everything-else, which told an operator that a directory
+              install "was added from the console and lives in this company's
+              runtime store" — true of neither half of it. */}
+          <p className="text-xs text-muted-foreground" data-testid="mcp-detail-provenance">
+            {mcpProvenanceNote(server.source)}
           </p>
           <p className="text-xs text-muted-foreground" data-testid="mcp-detail-probe">
             {standing.probe}
@@ -470,7 +473,10 @@ function McpBody({
             {/* The same answer the native path gets, for the same reason: there
                 is no connect to record. Said rather than left blank, which
                 reads as "never". */}
-            {connectedOn(undefined)} — MCP has no connect step to record one.
+            {connectedOn(undefined)} —{" "}
+            {server.source === "registry"
+              ? "this host does connect a directory install, but records no date for it."
+              : "MCP has no connect step to record one."}
           </p>
         </section>
 
@@ -533,9 +539,7 @@ function McpBody({
             What a disconnect reaches
           </h4>
           <p className="text-xs text-muted-foreground" data-testid="mcp-detail-disconnect-scope">
-            {server.source === "manifest"
-              ? "This server is declared in company.toml, so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn, and it returns on the next boot unless the manifest changes."
-              : "Removing it drops it from every teammate's tool belt on the next turn and deletes the credential stored here for it."}{" "}
+            {mcpRemovalNote(server.source)}{" "}
             Nothing is revoked at the server&apos;s own end: no token it issued is invalidated and no
             session there is closed. Revoke those where they were issued.
           </p>

--- a/frontend/test/unit/mcp-credential-affordance.test.ts
+++ b/frontend/test/unit/mcp-credential-affordance.test.ts
@@ -41,4 +41,70 @@ describe("credentialAffordance", () => {
     expect(credentialAffordance("token_rejected")).toBe("none");
     expect(credentialAffordance("some_code_added_later")).toBe("none");
   });
+
+  it("leaves every List A provenance on the hint alone", () => {
+    // Issue #1270 added a second parameter. The rule for a row that has a List
+    // A declaration is unchanged — it is still a function of the hint and
+    // nothing else, whether or not the caller passes the row.
+    for (const source of ["manifest", "runtime", "default"] as const) {
+      expect(credentialAffordance("oauth_required", { source, status: "needs_config" })).toBe(
+        "sign_in",
+      );
+      expect(credentialAffordance("static_token_required", { source, status: "needs_config" })).toBe(
+        "add_token",
+      );
+      expect(credentialAffordance(undefined, { source, status: "ok" })).toBe("none");
+    }
+  });
+});
+
+/**
+ * Issue #1270. A directory install keeps its credentials as *named env values*
+ * in the host's registry store, and its row's `name` is a display slug that
+ * addresses no List A declaration. So both of List A's controls are wrong for
+ * it twice over: `POST …/oauth/start` and `PUT …/mcp/servers/{name}` answer
+ * `no MCP server named …`, and the value they collect would be written to a
+ * store this server is not dialled from.
+ */
+describe("credentialAffordance — directory installs", () => {
+  it("routes a registry row to its own env rotation", () => {
+    expect(credentialAffordance(undefined, { source: "registry", status: "needs_config" })).toBe(
+      "rotate_env",
+    );
+  });
+
+  it("does not need a hint to know a registry row wants a credential", () => {
+    // The reason `status` is consulted at all. The host's registry projection
+    // emits a stable `authHint` only when the upstream connection reported one,
+    // so an install refused for want of a credential can arrive as
+    // `needs_config` with no hint — and a rule keyed on the hint alone would
+    // offer that row nothing at all.
+    expect(credentialAffordance(undefined, { source: "registry", status: "needs_config" })).not.toBe(
+      "none",
+    );
+  });
+
+  it("never offers a registry row a control that writes to the wrong store", () => {
+    for (const hint of [
+      undefined,
+      "oauth_required",
+      "static_token_required",
+      "credential_required",
+      "token_rejected",
+    ]) {
+      const offered = credentialAffordance(hint, {
+        source: "registry",
+        status: "needs_config",
+      });
+      expect(offered).not.toBe("sign_in");
+      expect(offered).not.toBe("add_token");
+    }
+  });
+
+  it("offers nothing to a registry row that is not asking for one", () => {
+    for (const status of ["ok", "error", "unknown"] as const) {
+      expect(credentialAffordance(undefined, { source: "registry", status })).toBe("none");
+    }
+    expect(credentialAffordance(undefined, { source: "registry" })).toBe("none");
+  });
 });

--- a/frontend/test/unit/mcp-registry-degrade.test.ts
+++ b/frontend/test/unit/mcp-registry-degrade.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { expectCatalogue } from "@/api/mcp-registry";
+import { ApiError } from "@/api/types";
+import { missingEnvKeys, REGISTRY_UNWIRED_NOTICE, registryOutage } from "@/lib/mcp-registry";
+
+/**
+ * Issue #1270 — the directory half must not be able to take the tab down with
+ * it.
+ *
+ * The catalogue is two network hops away (the host federates Smithery and the
+ * official MCP registry) and the routes serving it are behind the host's `mcp`
+ * Cargo feature, so a build without it answers `404 not_wired` on every one of
+ * them. Neither is a reason for the company's installed servers to stop
+ * rendering: a dead directory is an empty search result with a reason, and a
+ * missing build feature is a sentence about the build.
+ *
+ * The property that makes that structural is that classification is **total** —
+ * every rejection the browse surface can see becomes a notice, and nothing
+ * escapes as an exception into the section rendering List A.
+ */
+describe("registryOutage", () => {
+  it("reads not_wired as a missing feature, not an error", () => {
+    const outage = registryOutage(new ApiError(404, "not_wired", "mcp registry is not wired"));
+
+    expect(outage).toEqual({ kind: "unwired" });
+    // The operator gets a sentence about the build. Nothing here is their fault
+    // and nothing here is actionable from the console.
+    expect(REGISTRY_UNWIRED_NOTICE).toContain("isn't enabled in this build");
+    // …and it says the rest of the tab is fine, because it is.
+    expect(REGISTRY_UNWIRED_NOTICE).toContain("servers above still work");
+  });
+
+  it("keeps a not_wired 404 distinct from any other 404", () => {
+    // The section already treats a bare 404 on `GET …/mcp/servers` as "this
+    // host has no MCP surface". A directory 404 that is not `not_wired` is a
+    // failure of this route, and saying "the feature isn't in this build" would
+    // be a claim about the deployment we cannot make.
+    expect(registryOutage(new ApiError(404, "not_found", "no such entry"))).toEqual({
+      kind: "error",
+      message: "no such entry",
+    });
+  });
+
+  it("carries the host's own sentence when it sent one", () => {
+    const outage = registryOutage(new ApiError(502, "upstream", "Smithery didn't answer."));
+
+    expect(outage).toEqual({ kind: "error", message: "Smithery didn't answer." });
+  });
+
+  it("classifies every failure, including ones that are not ApiErrors", () => {
+    // Totality is the point: whatever a rejected fetch hands back becomes a
+    // notice inside the browse panel. A throw escaping from here is the one
+    // outcome that would blank the server list.
+    for (const thrown of [undefined, null, "boom", new Error("boom"), { status: 500 }, 0]) {
+      const outage = registryOutage(thrown);
+      expect(outage.kind).toBe("error");
+      expect(outage.kind === "error" && outage.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("falls back to its own sentence when the host's envelope was blank", () => {
+    expect(registryOutage(new ApiError(500, "boom", "   "))).toEqual({
+      kind: "error",
+      message: "The MCP directory didn't answer.",
+    });
+  });
+});
+
+/**
+ * `client.get<T>` casts an unparsed body straight to `T`, so a declared type is
+ * a claim about the host and never a check on it. Issue #414 is what that costs
+ * when the claim is wrong: the bad value flows on and throws at render, several
+ * frames from the fetch that caused it.
+ */
+describe("expectCatalogue", () => {
+  it("passes a page through", () => {
+    const body = { servers: [{ qualifiedName: "@org/git" }], page: 2, totalPages: 7 };
+
+    expect(expectCatalogue(body)).toEqual(body);
+  });
+
+  it("accepts an empty page — a directory with no matches is not a failure", () => {
+    expect(expectCatalogue({ servers: [], page: 1, totalPages: 0 })).toEqual({
+      servers: [],
+      page: 1,
+      totalPages: 0,
+    });
+  });
+
+  it("defaults the paging numbers rather than putting NaN on the screen", () => {
+    const page = expectCatalogue({ servers: [] });
+
+    expect(page.page).toBe(1);
+    expect(page.totalPages).toBe(0);
+  });
+
+  it("rejects a body whose servers are not a list", () => {
+    for (const body of [undefined, null, [], {}, { servers: null }, { servers: "git" }]) {
+      expect(() => expectCatalogue(body)).toThrow(ApiError);
+    }
+  });
+
+  it("marks a bad shape as not the host refusing", () => {
+    try {
+      expectCatalogue({ servers: {} });
+      expect.unreachable();
+    } catch (err) {
+      const api = err as ApiError;
+      expect(api.code).toBe("unexpected_shape");
+      // Nothing was refused — the answer was unusable.
+      expect(api.status).toBe(0);
+      expect(api.fromHost).toBe(false);
+    }
+  });
+});
+
+/**
+ * An entry declares the env keys it needs and the install form's fields are
+ * exactly those. A key left blank is a key the operator has not filled in — and
+ * an install that stored it anyway would come back `unauthorized` while the row
+ * reported a credential as configured.
+ */
+describe("missingEnvKeys", () => {
+  it("names every key still without a value", () => {
+    expect(missingEnvKeys(["GITHUB_TOKEN", "GITHUB_ORG"], { GITHUB_ORG: "acme" })).toEqual([
+      "GITHUB_TOKEN",
+    ]);
+  });
+
+  it("treats whitespace as unfilled", () => {
+    expect(missingEnvKeys(["TOKEN"], { TOKEN: "   " })).toEqual(["TOKEN"]);
+  });
+
+  it("is satisfied by every key having a value", () => {
+    expect(missingEnvKeys(["TOKEN"], { TOKEN: "abc" })).toEqual([]);
+  });
+
+  it("asks for nothing when the entry declared nothing", () => {
+    // A directory entry with no credentials installs straight through.
+    expect(missingEnvKeys([], {})).toEqual([]);
+    // …and a value for a key the entry never declared does not make it required.
+    expect(missingEnvKeys([], { STRAY: "x" })).toEqual([]);
+  });
+});

--- a/frontend/test/unit/mcp-registry-row.test.ts
+++ b/frontend/test/unit/mcp-registry-row.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import type { McpHealth, McpServer, McpSource } from "@/api/types";
+import {
+  mcpLifecycle,
+  mcpProvenanceNote,
+  mcpRemoval,
+  mcpRemovalNote,
+  mcpRowControls,
+  mcpSourceBadge,
+} from "@/lib/mcp-registry";
+
+/**
+ * Issue #1270. `GET …/mcp/servers` now returns two structurally different
+ * things in one list: List A rows (manifest / default / operator-typed
+ * runtime), addressed by `name` against a declaration the host resolves, and
+ * directory installs, addressed by a `serverId` in the host's registry store.
+ *
+ * The row cannot tell them apart by looking at what it has, because a server
+ * can be **both** — declared in `company.toml` *and* installed from the
+ * directory — and the host reconciles those into one row that keeps List A's
+ * provenance. That row carries a `serverId`. So "has a serverId" is not "is a
+ * registry row", and reading it as one is exactly how a delete removes the
+ * wrong thing: it would uninstall the directory copy of a manifest server,
+ * report success, and leave the declared server exactly where it was.
+ *
+ * These pin the dispatch: provenance comes from `source`, and `source` decides
+ * which half of the API the row may call at all.
+ */
+
+const health = (status: McpHealth["status"], authHint?: string): McpHealth => ({
+  status,
+  message: "",
+  toolCount: 0,
+  checkedAtMillis: 1,
+  authHint,
+});
+
+/** A merged row. Defaults to a plain List A runtime server. */
+function row(over: Partial<McpServer> & { source: McpSource }): McpServer {
+  return {
+    name: "notion",
+    endpoint: "https://mcp.notion.com/mcp",
+    enabled: true,
+    allowedTools: [],
+    disallowedTools: [],
+    timeoutSecs: 30,
+    authConfigured: false,
+    ...over,
+  };
+}
+
+describe("mcpRemoval — which route owns this row", () => {
+  it("sends a registry row to the install route, keyed by serverId", () => {
+    const server = row({ source: "registry", name: "org-git", serverId: "srv_9fa1" });
+
+    // The `name` here is a display slug the host minted for the merged view. It
+    // addresses no List A declaration, and on an unlucky collision would
+    // address someone else's.
+    expect(mcpRemoval(server)).toEqual({ kind: "install", serverId: "srv_9fa1" });
+  });
+
+  it("keeps a manifest server's delete guard even when it also has an install", () => {
+    // The reconciliation case. The host adopted the install onto the manifest
+    // row, so the row carries a `serverId` — and must still refuse a delete,
+    // because the declaration in company.toml outlives any uninstall and the
+    // next read merges it straight back.
+    const reconciled = row({ source: "manifest", serverId: "srv_9fa1" });
+
+    expect(mcpRemoval(reconciled)).toEqual({ kind: "none" });
+    expect(mcpRemoval(row({ source: "manifest" }))).toEqual({ kind: "none" });
+  });
+
+  it("refuses a delete on an install-wide default, with or without an install", () => {
+    expect(mcpRemoval(row({ source: "default" }))).toEqual({ kind: "none" });
+    expect(mcpRemoval(row({ source: "default", serverId: "srv_9fa1" }))).toEqual({ kind: "none" });
+  });
+
+  it("deletes a reconciled runtime row by name, not by its install id", () => {
+    // One call is the whole removal: the host drops the runtime index row and
+    // uninstalls the directory half together. Routing this to the registry
+    // instead would uninstall one half and leave the typed-in URL behind.
+    const reconciled = row({ source: "runtime", name: "linear", serverId: "srv_44" });
+
+    expect(mcpRemoval(reconciled)).toEqual({ kind: "index", name: "linear" });
+  });
+
+  it("offers no delete for a registry row the host gave no id", () => {
+    // A delete with no key would remove nothing and report success.
+    expect(mcpRemoval(row({ source: "registry" }))).toEqual({ kind: "none" });
+  });
+});
+
+describe("mcpLifecycle — connect/disconnect belongs to registry rows only", () => {
+  it("offers a disconnect only while a session is live", () => {
+    const server = row({ source: "registry", serverId: "srv_1" });
+
+    expect(mcpLifecycle(server, health("ok"))).toBe("disconnect");
+  });
+
+  it("offers a connect for every state that is not a live session", () => {
+    const server = row({ source: "registry", serverId: "srv_1" });
+
+    for (const state of [undefined, health("needs_config"), health("error"), health("unknown")]) {
+      expect(mcpLifecycle(server, state)).toBe("connect");
+    }
+  });
+
+  it("offers neither on a reconciled row, whose live half is List A's", () => {
+    // The connect route would accept this `serverId`, which is the trap: what
+    // the company's agents reach through this row is the List A half, so a
+    // Disconnect here would drop a session the row does not represent while its
+    // tools went on working. The row already governs its own half with the
+    // Switch.
+    expect(mcpLifecycle(row({ source: "manifest", serverId: "srv_1" }), health("ok"))).toBe("none");
+    expect(mcpLifecycle(row({ source: "runtime", serverId: "srv_1" }), health("ok"))).toBe("none");
+    expect(mcpLifecycle(row({ source: "runtime" }), health("ok"))).toBe("none");
+  });
+});
+
+describe("mcpRowControls — which half of the API a row may call", () => {
+  it("withholds List A's controls from a directory install", () => {
+    // The Switch, Test and Tools all resolve the row's `name` against List A's
+    // declarations. A directory install has none, so all three answer `no MCP
+    // server named …` — a click spent to reach an error about a name the
+    // operator never chose.
+    const controls = mcpRowControls(
+      row({ source: "registry", name: "org-git", serverId: "srv_9fa1" }),
+      health("needs_config"),
+    );
+
+    expect(controls.toggle).toBe(false);
+    expect(controls.probe).toBe(false);
+    expect(controls.lifecycle).toBe("connect");
+    expect(controls.removal).toEqual({ kind: "install", serverId: "srv_9fa1" });
+  });
+
+  it("leaves a reconciled manifest row with exactly the controls it always had", () => {
+    const controls = mcpRowControls(
+      row({ source: "manifest", serverId: "srv_9fa1" }),
+      health("ok"),
+    );
+
+    expect(controls.toggle).toBe(true);
+    expect(controls.probe).toBe(true);
+    expect(controls.lifecycle).toBe("none");
+    expect(controls.removal).toEqual({ kind: "none" });
+  });
+
+  it("leaves a plain runtime row unchanged", () => {
+    const controls = mcpRowControls(row({ source: "runtime" }), undefined);
+
+    expect(controls).toEqual({
+      toggle: true,
+      probe: true,
+      lifecycle: "none",
+      removal: { kind: "index", name: "notion" },
+    });
+  });
+});
+
+describe("mcpSourceBadge", () => {
+  it("badges a directory install as its own provenance", () => {
+    expect(mcpSourceBadge("registry").label).toBe("registry");
+  });
+
+  it("badges a reconciled row by its source, so provenance is never re-derived", () => {
+    // The badge is a pure function of `source` — a row carrying a `serverId`
+    // cannot reach this at all, which is the property that keeps a manifest
+    // server from being relabelled by an install that landed on it.
+    expect(mcpSourceBadge("manifest")).toEqual({ label: "manifest", variant: "secondary" });
+  });
+
+  it("gives every provenance a badge rather than defaulting a new one", () => {
+    for (const source of ["manifest", "runtime", "default", "registry"] as const) {
+      expect(mcpSourceBadge(source).label).toBe(source);
+    }
+  });
+});
+
+describe("detail-panel prose", () => {
+  it("stops describing a directory install as console-added", () => {
+    // The panel read `manifest` against everything-else, so a registry row was
+    // told it "lives in this company's runtime store" — true of neither half.
+    const note = mcpProvenanceNote("registry");
+
+    expect(note).toContain("directory");
+    expect(note).not.toContain("runtime store");
+    expect(note).not.toBe(mcpProvenanceNote("runtime"));
+  });
+
+  it("gives each provenance its own removal sentence", () => {
+    const notes = (["manifest", "runtime", "default", "registry"] as const).map(mcpRemovalNote);
+
+    expect(new Set(notes).size).toBe(4);
+    // The two undeletable provenances say so; the two deletable ones do not.
+    expect(mcpRemovalNote("manifest")).toContain("cannot be removed");
+    expect(mcpRemovalNote("default")).toContain("cannot be removed");
+    expect(mcpRemovalNote("registry")).not.toContain("cannot be removed");
+    expect(mcpRemovalNote("runtime")).not.toContain("cannot be removed");
+  });
+});

--- a/src/company/mcp.rs
+++ b/src/company/mcp.rs
@@ -72,6 +72,35 @@ pub enum McpSource {
     /// flavour of [`Self::Manifest`] — nobody wrote it into *this* company, and
     /// the console must not label it as operator-added.
     Default,
+    /// Installed from an upstream MCP directory — Smithery.ai or the official
+    /// `modelcontextprotocol/registry` — through the console's browse surface
+    /// (issue #1270).
+    ///
+    /// Distinct from [`Self::Runtime`] because the two are keyed differently and
+    /// deleted differently: a runtime server is addressed by `name` and lives in
+    /// this company's runtime index, while a registry install is addressed by a
+    /// stable `server_id` and lives in OpenHuman's own store, so removing one
+    /// means uninstalling it there rather than dropping an index row.
+    Registry,
+}
+
+/// The operator-facing refusal for a directory entry that can only run as a
+/// local stdio subprocess (issue #1270).
+///
+/// Says *why* rather than "unsupported": the blocker is not the read-only root
+/// filesystem (tenants mount a writable `/data` and an emptyDir `/tmp`) but that
+/// the tenant image carries no Node, Python or package manager to launch one
+/// with — a stdio install would fail on `npx: not found`. One function so the
+/// two places that can refuse an install — the catalogue pre-check at the route
+/// and the post-install belt in
+/// [`McpRuntime`](crate::harness::mcp::McpRuntime) — say the same sentence, and
+/// so the day a sidecar makes stdio runnable there is one message to retire.
+pub fn stdio_install_refusal(qualified_name: &str) -> String {
+    format!(
+        "`{qualified_name}` offers no hosted HTTP endpoint — it can only run as a local \
+         subprocess, and this deployment ships no Node, Python or package manager to launch \
+         one. Pick a server with a hosted endpoint, or add it by URL if you host it yourself."
+    )
 }
 
 /// Resolved outbound auth material for one MCP server.

--- a/src/harness/built_in/mcp.rs
+++ b/src/harness/built_in/mcp.rs
@@ -31,7 +31,7 @@ use oh::security::{SecurityPolicy, ToolOperation};
 use oh::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 
 use crate::company::Agent as ManifestAgent;
-use crate::company::mcp::{AuthMaterial, McpServerDecl};
+use crate::company::mcp::{AuthMaterial, McpServerDecl, stdio_install_refusal};
 use crate::error::OpenCompanyError;
 use crate::harness::mcp_probe::{
     McpFailure, McpFailureQueue, classify_mcp_error, operator_message, scrub, strip_endpoint,
@@ -522,6 +522,21 @@ fn required_string_arg(args: &Value, key: &str) -> anyhow::Result<String> {
 // Company-scoped MCP lifecycle (McpRuntime)
 // ---------------------------------------------------------------------------
 
+/// The transport filter every directory search is pinned to — upstream's
+/// vocabulary for "has a hosted HTTP endpoint" (`registry::apply_transport`
+/// keeps `is_deployed` rows for `"hosted"`, drops them for `"stdio"`).
+///
+/// **Hardcoded, not a parameter the console may set.** A stdio entry launches a
+/// local subprocess through `npx` / `uvx`, and the tenant image is
+/// `debian:bookworm-slim` plus `ca-certificates`, `curl`, `libssl3` and X11 —
+/// no Node, no Python, no package manager (issue #1270). So there is no caller
+/// for whom `"stdio"` or `"all"` would produce an installable row, and offering
+/// the knob would only let the console show an operator servers that fail at
+/// install time. Widening it is one edit here, on the day a sidecar that can
+/// actually run stdio servers exists; until then the honest surface is the one
+/// that cannot express the broken request.
+const HOSTED_TRANSPORT: &str = "hosted";
+
 /// Company-home-scoped persistence and access to OpenHuman's live MCP registry.
 pub struct McpRuntime {
     config: oh::config::Config,
@@ -535,6 +550,102 @@ impl McpRuntime {
             ..Default::default()
         };
         Self { config }
+    }
+
+    /// Search the upstream MCP directories — Smithery.ai and the official
+    /// `modelcontextprotocol/registry` — merged, paged, and SQLite-cached
+    /// upstream (issue #1270).
+    ///
+    /// The console's only way to answer "what could I add?". The static server
+    /// list cannot: an operator has to arrive already knowing an endpoint, so
+    /// that surface is empty until somebody pastes a URL into it.
+    ///
+    /// The transport filter is fixed at [`HOSTED_TRANSPORT`] rather than exposed
+    /// as a parameter — see that constant for why.
+    pub async fn search(
+        &self,
+        query: Option<String>,
+        page: Option<u32>,
+        page_size: Option<u32>,
+    ) -> crate::Result<serde_json::Value> {
+        oh::mcp::registry::ops::mcp_clients_registry_search(
+            &self.config,
+            query,
+            Some(HOSTED_TRANSPORT.to_string()),
+            page,
+            page_size,
+        )
+        .await
+        .map(|outcome| outcome.value)
+        .map_err(|e| OpenCompanyError::Harness(format!("mcp registry search failed: {e}")))
+    }
+
+    /// One directory entry in full, routed back to the registry it came from.
+    pub async fn registry_get(&self, qualified_name: String) -> crate::Result<serde_json::Value> {
+        oh::mcp::registry::ops::mcp_clients_registry_get(&self.config, qualified_name)
+            .await
+            .map(|outcome| outcome.value)
+            .map_err(|e| OpenCompanyError::Harness(format!("mcp registry lookup failed: {e}")))
+    }
+
+    /// Installs a directory entry by qualified name and returns the resulting
+    /// record. Idempotent upstream: re-installing a server already present
+    /// refreshes its env/config onto the existing row rather than writing a
+    /// second one.
+    ///
+    /// **Refuses a stdio install.** Upstream's picker already prefers a hosted
+    /// HTTP connection over a local subprocess, so this only fires for an entry
+    /// that offers *nothing but* stdio — which this deployment cannot launch
+    /// (see [`stdio_install_refusal`]). The search filter above keeps such
+    /// entries off the operator's screen in the first place; this is the belt to
+    /// that braces, because a caller can POST a qualified name the search never
+    /// offered. A refused install that we ourselves created is rolled back; one
+    /// that was already on disk is left alone, since it is not ours to remove.
+    pub async fn install_from_directory(
+        &self,
+        qualified_name: String,
+        env: HashMap<String, String>,
+    ) -> crate::Result<InstalledServer> {
+        let outcome = oh::mcp::registry::ops::mcp_clients_install(
+            &self.config,
+            qualified_name.clone(),
+            env,
+            None,
+        )
+        .await
+        .map_err(|e| OpenCompanyError::Harness(format!("mcp install failed: {e}")))?;
+        let already_installed = outcome
+            .value
+            .get("already_installed")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let record = outcome.value.get("server").cloned().ok_or_else(|| {
+            OpenCompanyError::Harness("mcp install returned no server record".to_string())
+        })?;
+        let server: InstalledServer = serde_json::from_value(record).map_err(|e| {
+            OpenCompanyError::Harness(format!("mcp install record is unreadable: {e}"))
+        })?;
+        if server.transport.deployment_url().is_none() {
+            if !already_installed {
+                let _ = self.uninstall(&server.server_id).await;
+            }
+            return Err(OpenCompanyError::InvalidRequest(stdio_install_refusal(
+                &qualified_name,
+            )));
+        }
+        Ok(server)
+    }
+
+    /// Rotate an install's environment values (write-only, never read back).
+    pub async fn update_env(
+        &self,
+        server_id: String,
+        env: HashMap<String, String>,
+    ) -> crate::Result<()> {
+        oh::mcp::registry::ops::mcp_clients_update_env(&self.config, server_id, env)
+            .await
+            .map(|_| ())
+            .map_err(|e| OpenCompanyError::Harness(format!("mcp env update failed: {e}")))
     }
 
     /// Reconnects enabled installed servers. Failures are logged by OpenHuman

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -34,13 +34,14 @@ use crate::ports::types::CompanyRecord;
 use crate::runtime::builder::agent_effective_grants;
 use crate::runtime::tools::grants_cover_server;
 use crate::server::error::ApiError;
-use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, mcp_registry, scoped};
 
 /// The reminder attached to every mutating response: the effective MCP set is
 /// re-resolved and fingerprinted on every harness cycle (`HarnessPool::ensure`),
 /// so an edit reaches agents on the company's next turn with no restart. The
 /// `mcp_fingerprint` staleness term is what makes this a property of the design.
-const NEXT_TURN_NOTE: &str = "Agents pick up this change on their next turn — no restart needed.";
+pub(super) const NEXT_TURN_NOTE: &str =
+    "Agents pick up this change on their next turn — no restart needed.";
 
 /// Builds the MCP server management route fragment.
 pub fn router() -> Router<AppState> {
@@ -57,24 +58,59 @@ pub fn router() -> Router<AppState> {
 /// One effective MCP server as the console renders it. **Never** carries a
 /// credential — only a non-secret `authConfigured` flag and the last (scrubbed)
 /// probe `health`.
+///
+/// Since issue #1270 this shape also carries a registry install. The four
+/// registry-only fields are all `Option` + `skip_serializing_if`, so a
+/// manifest / default / runtime row serializes **byte-identically** to what it
+/// did before — the console's existing readers cannot tell the change happened.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct McpServerDto {
-    name: String,
-    endpoint: String,
-    description: Option<String>,
-    /// `manifest` (committed), `runtime` (console-added), or `default`
-    /// (shipped by the install — issue #527). The console renders this as the
-    /// source badge, so the three stay distinguishable: a shipped default is
-    /// not something this operator added, and must not be labelled as if it
-    /// were.
-    source: McpSource,
-    enabled: bool,
-    allowed_tools: Vec<String>,
-    disallowed_tools: Vec<String>,
-    timeout_secs: u64,
+pub(super) struct McpServerDto {
+    pub(super) name: String,
+    pub(super) endpoint: String,
+    pub(super) description: Option<String>,
+    /// `manifest` (committed), `runtime` (console-added), `default` (shipped by
+    /// the install — issue #527), or `registry` (installed from an upstream MCP
+    /// directory — issue #1270). The console renders this as the source badge,
+    /// so the four stay distinguishable: a shipped default is not something this
+    /// operator added, and must not be labelled as if it were.
+    ///
+    /// On a **reconciled** row — one server that is both installed from the
+    /// directory and declared/typed in List A — this is the List A provenance.
+    /// See [`mcp_registry::merge_installs`](super::mcp_registry::merge_installs)
+    /// for why that side wins.
+    pub(super) source: McpSource,
+    pub(super) enabled: bool,
+    pub(super) allowed_tools: Vec<String>,
+    pub(super) disallowed_tools: Vec<String>,
+    pub(super) timeout_secs: u64,
     /// Whether an outbound credential is stored — never the credential itself.
-    auth_configured: bool,
+    ///
+    /// On a reconciled row this is the **union**: either List A's token slot or
+    /// the registry install's env values counts. The two are separate stores
+    /// dialled by separate transports, and there is no merging them; what the
+    /// field claims — "a credential is stored for this server" — stays true
+    /// either way, and the alternative (reporting only List A's slot) would
+    /// print "no credential" over a server that authenticates fine.
+    pub(super) auth_configured: bool,
+    /// The stable install id, present only on a row backed by a registry
+    /// install. Registry rows are keyed by this and **not** by `name`: `name` is
+    /// a display slug this surface mints, while `serverId` is what every
+    /// `…/mcp/registry/{serverId}/…` route and OpenHuman's own store address.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) server_id: Option<String>,
+    /// The directory's qualified name (`@org/server`), when this row came from
+    /// one. The catalogue's stable identity, and what an install is re-keyed on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) qualified_name: Option<String>,
+    /// The directory's icon, when this row came from one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) icon_url: Option<String>,
+    /// How a registry install is dialled — `http_remote` or `stdio`. Absent on
+    /// a List A-only row, which is always HTTP by construction (`command` is a
+    /// validation error there).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) transport: Option<String>,
     /// The company's agents whose effective tool grants cover this server — who
     /// can actually call it (issue #568). Computed over the same roster the
     /// harness builds (manifest agents + promoted overlay teammates), through the
@@ -86,10 +122,16 @@ struct McpServerDto {
     /// — the harness hands out no tool for it whatever the grants say — so the
     /// console reads the empty case against `enabled` and stays quiet there.
     /// Always serialized (even when empty).
-    reachable_by: Vec<RosterAgentDto>,
+    ///
+    /// A **registry** row lists the whole roster: `build.rs` pushes the registry
+    /// bridge tools into every agent's toolbelt with no grant check, so every
+    /// teammate really can call every installed server. Issue #1270 leaves that
+    /// asymmetry in place deliberately and makes it operator-visible here rather
+    /// than inventing a grant filter the harness does not apply.
+    pub(super) reachable_by: Vec<RosterAgentDto>,
     /// The last recorded probe outcome (scrubbed), or `None` when never probed.
     #[serde(skip_serializing_if = "Option::is_none")]
-    health: Option<McpHealth>,
+    pub(super) health: Option<McpHealth>,
 }
 
 /// One roster agent named on a coverage line, carried as an id **and** the label
@@ -275,6 +317,12 @@ fn dto_from_decl(
         disallowed_tools: decl.disallowed_tools.clone(),
         timeout_secs: decl.timeout_secs,
         auth_configured: decl.auth.is_configured(),
+        // A List A decl knows nothing about a directory install; the merge pass
+        // fills these in when one reconciles onto this row.
+        server_id: None,
+        qualified_name: None,
+        icon_url: None,
+        transport: None,
         reachable_by,
         health,
     }
@@ -370,10 +418,17 @@ fn reachers_of(
         .collect()
 }
 
-/// `GET …/mcp/servers` — the company's effective MCP servers, each with its last
-/// recorded (scrubbed) probe health.
-async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>, ApiError> {
-    let runtime = company.runtime.as_ref();
+/// The company's whole MCP surface as one list: the declared servers (manifest ∪
+/// install defaults ∪ runtime index) with the directory installs folded in.
+///
+/// Issue #1270. Every reader of this list — the `GET`, the List A mutation
+/// response, the delete dispatch, and the registry mutation responses — goes
+/// through here, so no two of them can disagree about a row's name, badge or
+/// health. That matters most for the reconciled case: a server that is both
+/// installed and declared has exactly one identity, and it has to be the same
+/// identity in the response to the write that created it as in the read that
+/// follows.
+pub(super) async fn merged_rows(runtime: &CompanyRuntime) -> Result<Vec<McpServerDto>, ApiError> {
     // One record load feeds both the manifest servers (merged into the effective
     // set) and the roster used for reachability (issue #568), rather than loading
     // it twice. The install-wide defaults (issue #527) are the layer *underneath*
@@ -401,7 +456,17 @@ async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>,
             .map_err(ApiError)?;
         out.push(dto_from_decl(decl, reachers_of(&grants, decl), health));
     }
-    Ok(Json(out))
+    // The directory half. A registry that cannot be read yields nothing and the
+    // declared servers stand on their own — see `mcp_registry::installs`.
+    let roster: Vec<RosterAgentDto> = grants.iter().map(|(agent, _)| agent.clone()).collect();
+    mcp_registry::merge_installs(&mut out, mcp_registry::installs(runtime).await, &roster);
+    Ok(out)
+}
+
+/// `GET …/mcp/servers` — the company's effective MCP servers, each with its last
+/// recorded (scrubbed) probe health.
+async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>, ApiError> {
+    merged_rows(company.runtime.as_ref()).await.map(Json)
 }
 
 /// `POST …/mcp/servers` — add a runtime MCP server (+ optional token).
@@ -559,8 +624,17 @@ async fn update_server(
     mutation_response(runtime, &name, warning).await
 }
 
-/// `DELETE …/mcp/servers/{name}` — remove a runtime server (409 for a manifest
-/// server, which can only be disabled).
+/// `DELETE …/mcp/servers/{name}` — remove a server (409 for a manifest or
+/// default server, which can only be disabled).
+///
+/// **Dispatches on where the row actually lives** (issue #1270). Dropping a
+/// runtime-index row is the right removal for a server an operator typed in, and
+/// the wrong one for a directory install: the install lives in OpenHuman's own
+/// store, keyed by `server_id`, and it stays connected — with its tools on every
+/// agent's belt — no matter what this company's index says. So a row backed by
+/// an install is uninstalled there, and a **reconciled** row (typed in *and*
+/// installed) has both halves removed, because a delete that leaves the server
+/// callable is not a delete.
 async fn delete_server(
     company: AdminScopedCompany,
     Path(NamePath { name }): Path<NamePath>,
@@ -589,28 +663,49 @@ async fn delete_server(
         ))));
     }
 
+    // Which halves this row has. Read from the same merged list the console
+    // rendered, so the delete targets the row the operator actually saw.
+    let install_id = merged_rows(runtime)
+        .await?
+        .into_iter()
+        .find(|row| row.name == name)
+        .and_then(|row| row.server_id);
+
     let mut index = load_runtime_index(runtime.id(), runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
     let before = index.len();
     index.retain(|s| s.name.trim() != name);
-    if index.len() == before {
+    let removal = mcp_registry::removal_for(index.len() != before, install_id.is_some());
+    if removal == mcp_registry::Removal::NotFound {
         return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
             "no runtime MCP server named `{name}`."
         ))));
     }
-    save_runtime_index(runtime.id(), runtime.secrets().as_ref(), &index)
-        .await
-        .map_err(ApiError)?;
-    // Best-effort credential + health wipe (the store has no delete; an empty
-    // value reads as unset, so a later server of the same name never inherits a
-    // stale credential or badge).
-    clear_auth(runtime.id(), &name, runtime.secrets().as_ref())
-        .await
-        .map_err(ApiError)?;
-    clear_health(runtime.id(), &name, runtime.secrets().as_ref())
-        .await
-        .map_err(ApiError)?;
+    if matches!(
+        removal,
+        mcp_registry::Removal::IndexRow | mcp_registry::Removal::Both
+    ) {
+        save_runtime_index(runtime.id(), runtime.secrets().as_ref(), &index)
+            .await
+            .map_err(ApiError)?;
+        // Best-effort credential + health wipe (the store has no delete; an empty
+        // value reads as unset, so a later server of the same name never inherits a
+        // stale credential or badge).
+        clear_auth(runtime.id(), &name, runtime.secrets().as_ref())
+            .await
+            .map_err(ApiError)?;
+        clear_health(runtime.id(), &name, runtime.secrets().as_ref())
+            .await
+            .map_err(ApiError)?;
+    }
+    if matches!(
+        removal,
+        mcp_registry::Removal::Install | mcp_registry::Removal::Both
+    ) && let Some(install_id) = install_id
+    {
+        mcp_registry::remove_install(runtime, &install_id).await?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -628,39 +723,22 @@ async fn mutation_response(
     // DTO so the response and a later `GET` agree.
     let test = probe_and_persist(runtime, name).await;
 
-    // One record load: the manifest servers merged into the effective set, and
-    // the roster the mutated server's reachability is computed against (#568).
-    // Install-wide defaults (#527) sit under the manifest and come off the
-    // runtime, so the mutation response reflects the same three-layer merge a
-    // later `GET` will.
-    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
-    let manifest = record
-        .as_ref()
-        .map(|r| r.manifest.mcp_servers.clone())
-        .unwrap_or_default();
-    let decls = resolve_effective(
-        runtime.id(),
-        runtime.default_mcp_servers(),
-        &manifest,
-        runtime.secrets().as_ref(),
-    )
-    .await
-    .map_err(ApiError)?;
-    let decl = decls.iter().find(|d| d.name == name).ok_or_else(|| {
-        ApiError(OpenCompanyError::InvalidRequest(format!(
-            "`{name}` not found"
-        )))
-    })?;
-    let reachable_by = record
-        .as_ref()
-        .map(roster_grants)
-        .map(|grants| reachers_of(&grants, decl))
-        .unwrap_or_default();
-    let health = load_health(runtime.id(), name, runtime.secrets().as_ref())
-        .await
-        .map_err(ApiError)?;
+    // Re-read the same merged list a later `GET` will serve — the three declared
+    // layers (defaults under manifest under runtime) plus any directory install
+    // that reconciles onto this endpoint. Projecting the decl alone would answer
+    // an add-by-URL of an already-installed server with a row missing the
+    // `serverId` the very next read shows (issue #1270).
+    let server = merged_rows(runtime)
+        .await?
+        .into_iter()
+        .find(|row| row.name == name)
+        .ok_or_else(|| {
+            ApiError(OpenCompanyError::InvalidRequest(format!(
+                "`{name}` not found"
+            )))
+        })?;
     Ok(Json(MutationResponse {
-        server: dto_from_decl(decl, reachable_by, health),
+        server,
         note: NEXT_TURN_NOTE.to_string(),
         test,
         warning,

--- a/src/server/ops/mcp_registry.rs
+++ b/src/server/ops/mcp_registry.rs
@@ -1,0 +1,465 @@
+//! The MCP **directory** surface (issue #1270): browse two upstream registries,
+//! install from them, and fold those installs into the one server list the
+//! console already renders.
+//!
+//! ## Why this module exists
+//!
+//! There were two MCP server lists in every tenant and only one of them was
+//! reachable. [`mcp`](super::mcp) serves **List A** — `company.toml`'s
+//! `[[mcp_server]]` entries, the install-wide `[[default_mcp_server]]` layer
+//! (issue #527), and the runtime index an operator types URLs into. List A can
+//! only ever contain what somebody already knew the address of, so the tab is
+//! empty until it is pasted into.
+//!
+//! **List B** is [`McpRuntime`](crate::harness::mcp::McpRuntime), a wrapper over
+//! OpenHuman's own MCP registry: two upstream directories (Smithery.ai and
+//! `modelcontextprotocol/registry`), a SQLite store of installs, named
+//! write-only env credentials, and a boot-time connect + supervisor. It is
+//! constructed for every company and, before this module, called by nothing in
+//! `src/server/`.
+//!
+//! ## One list, not two sections
+//!
+//! `GET …/mcp/servers` returns both, each row badged with its provenance. A
+//! server present in both — installed from the directory *and* typed in by URL —
+//! is **one reconciled row**; see [`merge_installs`] for the matching rule and
+//! for which side's provenance survives.
+//!
+//! ## What never crosses the wire
+//!
+//! Env values are write-only exactly like List A's `token`: they go in through
+//! install / `PUT …/env` and come back only as an `authConfigured` bool. Nothing
+//! upstream hands back is forwarded blind — the search, entry and status
+//! projections below name every field they emit, so a new key appearing in an
+//! upstream payload (both DTOs carry a `#[serde(flatten)] extra` map) cannot
+//! reach a response by default. [`health_from_status`] explains why an install's
+//! `last_error` is dropped rather than scrubbed.
+//!
+//! ## Feature gate
+//!
+//! Everything that touches the registry is `#[cfg(feature = "mcp")]`, matching
+//! `…/mcp/servers/{name}/oauth/start`. A build without it registers the same
+//! routes and answers `not_wired`, and List A is served unchanged.
+
+use std::collections::{HashMap, HashSet};
+
+use axum::Router;
+use axum::routing::{delete, get, post, put};
+
+use crate::AppState;
+use crate::company::mcp::{McpHealth, McpSource};
+use crate::server::ops::mcp::{McpServerDto, RosterAgentDto};
+use crate::server::ops::scoped;
+
+/// The per-request timeout a registry row reports.
+///
+/// OpenHuman's install record has no timeout of its own — the connection map
+/// owns that — so the row reports the same 30s `POST …/mcp/servers` defaults to,
+/// rather than inventing a second number the console would have to explain.
+const REGISTRY_TIMEOUT_SECS: u64 = 30;
+
+/// Builds the registry route fragment. Merged into [`super::mcp::router`] so the
+/// whole MCP surface is registered from one place.
+pub(super) fn router() -> Router<AppState> {
+    scoped("/mcp/registry/search", get(search))
+        .merge(scoped("/mcp/registry/entry", get(entry)))
+        .merge(scoped("/mcp/registry/install", post(install)))
+        .merge(scoped(
+            "/mcp/registry/{server_id}/connect",
+            post(connect_server),
+        ))
+        .merge(scoped(
+            "/mcp/registry/{server_id}/disconnect",
+            post(disconnect_server),
+        ))
+        .merge(scoped("/mcp/registry/{server_id}/env", put(update_env)))
+        .merge(scoped("/mcp/registry/{server_id}", delete(uninstall)))
+}
+
+// ---------------------------------------------------------------------------
+// Projection of one install — always compiled
+// ---------------------------------------------------------------------------
+
+/// One registry install, projected out of OpenHuman's store into the shape the
+/// merged read needs.
+///
+/// Deliberately a plain struct rather than the upstream `InstalledServer`: the
+/// upstream type lives behind the `mcp` feature, and every rule worth testing
+/// here — endpoint matching, name minting, which side of a reconciled row wins —
+/// is arithmetic over these fields. Keeping them feature-free means the
+/// reconciliation tests run in the ungated lane instead of only in the filtered
+/// belt lane, where a gated test can sit compiled and unexecuted (issue #770).
+#[derive(Debug, Clone)]
+pub(super) struct RegistryInstall {
+    /// The stable install id — how every registry route addresses this server.
+    pub(super) server_id: String,
+    /// The directory's qualified name, e.g. `@modelcontextprotocol/server-git`.
+    pub(super) qualified_name: String,
+    /// The directory's display name; the seed for the row's `name` slug.
+    pub(super) display_name: String,
+    pub(super) description: Option<String>,
+    pub(super) icon_url: Option<String>,
+    /// The install's `deployment_url`. `None` for a stdio install — which this
+    /// deployment refuses to create, but which a store written by an older build
+    /// or by OpenHuman's own setup agent can still contain.
+    pub(super) endpoint: Option<String>,
+    /// `http_remote` or `stdio`.
+    pub(super) transport: String,
+    pub(super) enabled: bool,
+    /// Whether env values were supplied for this install. Derived from the
+    /// install's `env_keys`, which upstream populates from the keys whose values
+    /// were persisted — so this answers "is a credential stored" without ever
+    /// reading one.
+    pub(super) auth_configured: bool,
+    /// The live connection state, already mapped by [`health_from_status`].
+    pub(super) health: Option<McpHealth>,
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint reconciliation — always compiled
+// ---------------------------------------------------------------------------
+
+/// Normalises an MCP endpoint to the identity two lists are compared on:
+/// lowercased scheme and host, default port dropped, query and fragment
+/// stripped, trailing slash dropped.
+///
+/// **The query string must go.** A List A server can carry its credential as a
+/// query parameter (the BrowserBase style — see
+/// [`AuthMaterial::QueryParam`](crate::company::mcp::AuthMaterial::QueryParam)),
+/// so `…/mcp?token=abc` and `…/mcp` are the same server reached two ways. A
+/// comparison that kept the query would never match them and the operator would
+/// get the duplicate row this whole rule exists to prevent — with two
+/// credentials and two health badges disagreeing about one server.
+///
+/// Returns `None` for a blank endpoint, which is what a stdio install has: no
+/// address means nothing to reconcile *on*, not "reconciles with everything".
+pub(super) fn normalize_endpoint(endpoint: &str) -> Option<String> {
+    let raw = endpoint.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (scheme, rest) = match raw.split_once("://") {
+        Some((scheme, rest)) => (scheme.to_ascii_lowercase(), rest),
+        // Not a URL we can decompose. Compare it case-insensitively as a whole
+        // rather than guessing at a shape — a wrong split would merge two
+        // unrelated rows, which is worse than leaving a duplicate.
+        None => return Some(raw.to_ascii_lowercase()),
+    };
+    // `?` and `#` cannot legally appear in an authority, so cutting them off the
+    // whole remainder first is safe and handles `https://host?q` too.
+    let cut = rest.find(['?', '#']).unwrap_or(rest.len());
+    let rest = &rest[..cut];
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    let mut authority = authority.to_ascii_lowercase();
+    for (default_scheme, port) in [("http", ":80"), ("https", ":443")] {
+        if scheme == default_scheme
+            && let Some(host) = authority.strip_suffix(port)
+        {
+            authority = host.to_string();
+            break;
+        }
+    }
+    let path = path.trim_end_matches('/');
+    if authority.is_empty() && path.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{authority}{path}"))
+}
+
+/// A display slug for a registry row, derived from its qualified name.
+///
+/// Registry installs are keyed by `server_id`, not by name, so this is purely
+/// the label the console prints and the `DELETE …/mcp/servers/{name}` path
+/// segment. It still has to be **unique within the list**: the console keys rows
+/// by `name`, and two rows sharing one would render as a single flickering row
+/// and delete the wrong server. Collisions fall back to a server-id suffix,
+/// which is stable across reads rather than positional.
+pub(super) fn registry_row_name(install: &RegistryInstall, taken: &HashSet<String>) -> String {
+    let base = slugify(&install.qualified_name)
+        .or_else(|| slugify(&install.display_name))
+        .unwrap_or_else(|| "mcp-server".to_string());
+    if !taken.contains(&base) {
+        return base;
+    }
+    let suffix: String = install
+        .server_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect();
+    let with_id = format!("{base}-{suffix}");
+    if !taken.contains(&with_id) {
+        return with_id;
+    }
+    // Two installs of the same service whose ids also share a prefix. Vanishingly
+    // unlikely, but a duplicate name is a wrong-row delete, so it is not left to
+    // chance.
+    (2..)
+        .map(|n| format!("{with_id}-{n}"))
+        .find(|candidate| !taken.contains(candidate))
+        .unwrap_or(with_id)
+}
+
+/// Lowercase, alphanumeric-and-dashes. `None` when nothing survives.
+fn slugify(raw: &str) -> Option<String> {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Folds registry installs into the List A rows, in place.
+///
+/// # The reconciliation rule
+///
+/// An install matches a List A row when their [`normalize_endpoint`] values are
+/// equal. A match **adopts** — the registry's identity fields are attached to
+/// the existing row and no second row is pushed. Everything else stays List A's.
+///
+/// ## Why List A's provenance wins
+///
+/// `source` decides two things the console acts on: which badge it prints, and
+/// whether it offers a delete. Both have to answer to List A.
+///
+/// A manifest or default server **cannot be deleted**, only disabled — the
+/// declaration lives in `company.toml` or the instance config, so dropping the
+/// row would not remove it and the next read would merge it straight back. If a
+/// directory install could capture that row and relabel it `registry`, the
+/// console would offer a delete that uninstalls the directory copy and leaves
+/// the declared server exactly where it was.
+///
+/// The deeper reason is that List A is what the *agents* actually reach.
+/// `registry_for_agent` builds each agent's MCP registry from the List A decls
+/// and scopes it by `mcp:<name>` grants; the row's `name`, `enabled`, tool lists
+/// and credential all govern that path. A row relabelled `registry` would stop
+/// offering the controls that decide what the company's agents can call.
+///
+/// Nothing is lost by adopting: the install is still addressable — `serverId` is
+/// on the row, and every `…/mcp/registry/…` route keys on it — and
+/// [`super::mcp::delete_server`] uninstalls both halves when the reconciled row
+/// is a deletable one.
+///
+/// ## What the registry contributes to a reconciled row
+///
+/// Only what List A structurally has no field for: `serverId`, `qualifiedName`,
+/// `iconUrl`, `transport`; a `description` when List A carries none; a `health`
+/// when List A has never probed. Health prefers List A's probe because that
+/// probe dials the endpoint the way the agents' bridge tools do, credential
+/// included.
+pub(super) fn merge_installs(
+    rows: &mut Vec<McpServerDto>,
+    installs: Vec<RegistryInstall>,
+    roster: &[RosterAgentDto],
+) {
+    let mut by_endpoint: HashMap<String, usize> = HashMap::new();
+    for (index, row) in rows.iter().enumerate() {
+        if let Some(key) = normalize_endpoint(&row.endpoint) {
+            by_endpoint.entry(key).or_insert(index);
+        }
+    }
+    let mut taken: HashSet<String> = rows.iter().map(|row| row.name.clone()).collect();
+
+    for install in installs {
+        let key = install.endpoint.as_deref().and_then(normalize_endpoint);
+        if let Some(key) = &key
+            && let Some(&index) = by_endpoint.get(key)
+        {
+            adopt(&mut rows[index], install);
+            continue;
+        }
+        let name = registry_row_name(&install, &taken);
+        taken.insert(name.clone());
+        rows.push(row_from_install(install, name, roster));
+        if let Some(key) = key {
+            by_endpoint.entry(key).or_insert(rows.len() - 1);
+        }
+    }
+}
+
+/// Attaches an install's identity to a List A row it reconciles with.
+fn adopt(row: &mut McpServerDto, install: RegistryInstall) {
+    row.server_id = Some(install.server_id);
+    row.qualified_name = Some(install.qualified_name);
+    row.transport = Some(install.transport);
+    if row.icon_url.is_none() {
+        row.icon_url = install.icon_url;
+    }
+    if row.description.is_none() {
+        row.description = install.description;
+    }
+    if row.health.is_none() {
+        row.health = install.health;
+    }
+    // The union, per `McpServerDto::auth_configured`.
+    row.auth_configured = row.auth_configured || install.auth_configured;
+}
+
+/// Projects an install that reconciled with nothing into its own row.
+fn row_from_install(
+    install: RegistryInstall,
+    name: String,
+    roster: &[RosterAgentDto],
+) -> McpServerDto {
+    McpServerDto {
+        name,
+        endpoint: install.endpoint.unwrap_or_default(),
+        description: install.description,
+        source: McpSource::Registry,
+        enabled: install.enabled,
+        // The directory does not express per-tool allow/deny, and OpenHuman's
+        // bridge tools do not consult one. Empty is the truthful projection, not
+        // a placeholder.
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
+        timeout_secs: REGISTRY_TIMEOUT_SECS,
+        auth_configured: install.auth_configured,
+        server_id: Some(install.server_id),
+        qualified_name: Some(install.qualified_name),
+        icon_url: install.icon_url,
+        transport: Some(install.transport),
+        // Every teammate, or nobody when the install is off — see
+        // `McpServerDto::reachable_by`.
+        reachable_by: if install.enabled {
+            roster.to_vec()
+        } else {
+            Vec::new()
+        },
+        health: install.health,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Delete dispatch — always compiled
+// ---------------------------------------------------------------------------
+
+/// What `DELETE …/mcp/servers/{name}` has to remove for a row (issue #1270).
+///
+/// The two lists are removed from in completely different ways — a runtime
+/// server is a row in this company's secret-store index, a directory install is
+/// a row in OpenHuman's SQLite store keyed by `server_id` with a live connection
+/// attached — so "delete" is a dispatch, not one operation. Written as a value
+/// rather than a chain of `if`s because the case that gets forgotten is
+/// [`Self::Both`]: dropping only the index row leaves the install connected and
+/// its tools on every agent's belt, which is a delete the operator watches fail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Removal {
+    /// No such row — the caller named something that does not exist.
+    NotFound,
+    /// A typed-in server: drop the runtime-index row and wipe its credential.
+    IndexRow,
+    /// A directory install and nothing else: uninstall it upstream.
+    Install,
+    /// Both halves of a reconciled row.
+    Both,
+}
+
+/// Decides [`Removal`] from what each side holds.
+///
+/// Manifest and default rows never reach here — they are refused earlier, and
+/// must stay refused: their declaration lives in `company.toml` or the instance
+/// config, so no removal here would make them go away.
+pub(super) fn removal_for(had_index_entry: bool, backed_by_install: bool) -> Removal {
+    match (had_index_entry, backed_by_install) {
+        (true, true) => Removal::Both,
+        (true, false) => Removal::IndexRow,
+        (false, true) => Removal::Install,
+        (false, false) => Removal::NotFound,
+    }
+}
+
+/// Directory-payload projections and the connection-state badge, split out so
+/// the parent keeps only what every build needs (the merge). Compiled for the
+/// wired build and for tests: nothing but the registry routes projects a
+/// directory payload, and a build without `mcp` has no directory to project.
+#[cfg(any(feature = "mcp", test))]
+pub(in crate::server::ops) mod catalogue;
+
+#[cfg(feature = "mcp")]
+mod wired;
+#[cfg(feature = "mcp")]
+use wired::{connect_server, disconnect_server, entry, install, search, uninstall, update_env};
+#[cfg(feature = "mcp")]
+pub(super) use wired::{installs, remove_install};
+
+// ---------------------------------------------------------------------------
+// Unwired build
+// ---------------------------------------------------------------------------
+
+/// Without the `mcp` feature there is no registry store and no directory client,
+/// so every route reports `not_wired` and the console's browse surface degrades
+/// the same way its Sign in button does.
+#[cfg(not(feature = "mcp"))]
+mod unwired {
+    use axum::response::Response;
+
+    use super::*;
+    use crate::server::ops::{AdminScopedCompany, ScopedCompany};
+
+    /// No registry in this build, so nothing to merge — List A is the whole list.
+    pub(in crate::server::ops) async fn installs(
+        _runtime: &crate::company::runtime::CompanyRuntime,
+    ) -> Vec<RegistryInstall> {
+        Vec::new()
+    }
+
+    /// No installs exist, so no row can be backed by one and the delete
+    /// dispatch never reaches here.
+    pub(in crate::server::ops) async fn remove_install(
+        _runtime: &crate::company::runtime::CompanyRuntime,
+        _server_id: &str,
+    ) -> Result<(), crate::server::error::ApiError> {
+        Ok(())
+    }
+
+    pub(super) async fn search(company: ScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+
+    pub(super) async fn entry(company: ScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+
+    pub(super) async fn install(company: AdminScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+
+    pub(super) async fn connect_server(company: AdminScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+
+    pub(super) async fn disconnect_server(company: AdminScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+
+    pub(super) async fn update_env(company: AdminScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+
+    pub(super) async fn uninstall(company: AdminScopedCompany) -> Response {
+        let _ = company;
+        crate::server::ops::not_wired("mcp registry")
+    }
+}
+
+#[cfg(not(feature = "mcp"))]
+use unwired::{connect_server, disconnect_server, entry, install, search, uninstall, update_env};
+#[cfg(not(feature = "mcp"))]
+pub(super) use unwired::{installs, remove_install};
+
+#[cfg(test)]
+mod tests;

--- a/src/server/ops/mcp_registry/catalogue.rs
+++ b/src/server/ops/mcp_registry/catalogue.rs
@@ -1,0 +1,252 @@
+//! Projections of what the two upstream directories hand back, and of a live
+//! connection's state.
+//!
+//! Split from the parent so that module keeps only the merge — the part every
+//! build runs. Everything here is a pure `Value` / `&str` → DTO function with no
+//! feature-gated type in its signature, which is what lets the parent's tests
+//! exercise it in the ungated lane (issue #770).
+//!
+//! **Nothing upstream sends is forwarded blind.** Both of upstream's catalogue
+//! DTOs end in a `#[serde(flatten)] extra` map that round-trips every key the
+//! registries emit, so each projection below names the fields it emits and drops
+//! the rest. That is what keeps an upstream payload change from silently
+//! becoming an OpenCompany API change.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::company::mcp::{McpHealth, McpStatus, stdio_install_refusal};
+
+// ---------------------------------------------------------------------------
+// Connection state → health — always compiled
+// ---------------------------------------------------------------------------
+
+/// Maps OpenHuman's connection status onto the health badge the console already
+/// renders for List A, so one server does not get two vocabularies.
+///
+/// # Why `last_error` is dropped, not scrubbed
+///
+/// Upstream's `ConnStatus` carries a raw `last_error` from the transport. List A
+/// runs its equivalent through [`scrub`](crate::harness::mcp_probe::scrub),
+/// whose redaction pass needs **the credential values** to replace them with
+/// `•••`. A registry install's credentials are its env values, which this
+/// surface deliberately never loads — so there is no known-secret set to scrub
+/// against, and the pass would degrade to stripping query strings and hoping.
+/// An env value can be interpolated into a header or a URL by the server's own
+/// config schema, so "hoping" is not a security posture. The stable `auth_hint`
+/// code, which upstream documents as never carrying the raw challenge, plus a
+/// fixed sentence per status, is the whole safe surface.
+///
+/// `checked_at_millis` is a parameter rather than a clock read so the mapping
+/// stays a pure function.
+pub(in crate::server::ops) fn health_from_status(
+    status: &str,
+    tool_count: u32,
+    auth_hint: Option<&str>,
+    checked_at_millis: u64,
+) -> Option<McpHealth> {
+    let (status, message) = match status {
+        "connected" => (
+            McpStatus::Ok,
+            match tool_count {
+                1 => "Connected — 1 tool available.".to_string(),
+                n => format!("Connected — {n} tools available."),
+            },
+        ),
+        "unauthorized" => (
+            McpStatus::NeedsConfig,
+            match auth_hint {
+                Some("oauth_required") => {
+                    "This server needs a browser sign-in — a pasted token will not work."
+                }
+                Some("token_rejected") => "The stored credential was rejected by this server.",
+                _ => "This server needs a credential before it can be used.",
+            }
+            .to_string(),
+        ),
+        "error" => (
+            McpStatus::Error,
+            "The last connection attempt to this server failed. Reconnect to retry.".to_string(),
+        ),
+        "disabled" => (
+            McpStatus::Unknown,
+            "Disabled — this server is not connected and its tools are hidden.".to_string(),
+        ),
+        "connecting" => (McpStatus::Unknown, "Connecting…".to_string()),
+        "disconnected" => (McpStatus::Unknown, "Not connected.".to_string()),
+        // A status string this build does not know is not a badge we can render
+        // honestly.
+        _ => return None,
+    };
+    Some(McpHealth {
+        status,
+        message,
+        tool_count,
+        checked_at_millis,
+        auth_hint: auth_hint.map(str::to_string),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Catalogue projections — always compiled
+// ---------------------------------------------------------------------------
+
+/// One directory listing, projected field by field out of upstream's summary.
+///
+/// Upstream's `SmitheryServerSummary` ends in `#[serde(flatten)] extra`, so it
+/// round-trips every key the two registries emit. Naming what we forward is what
+/// keeps an upstream payload change from becoming an OpenCompany API change.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::server::ops) struct CatalogueEntryDto {
+    pub(in crate::server::ops) qualified_name: String,
+    pub(in crate::server::ops) display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) icon_url: Option<String>,
+    /// Which upstream directory this row came from (`smithery` / `mcp_official`).
+    pub(in crate::server::ops) source: String,
+    /// Upstream's canonical-first-party badge.
+    pub(in crate::server::ops) official: bool,
+    pub(in crate::server::ops) use_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) website_url: Option<String>,
+}
+
+/// A page of directory results.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::server::ops) struct CatalogueSearchDto {
+    pub(in crate::server::ops) servers: Vec<CatalogueEntryDto>,
+    pub(in crate::server::ops) page: u32,
+    pub(in crate::server::ops) total_pages: u32,
+}
+
+/// One directory entry in full, with the install decision already made.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::server::ops) struct CatalogueDetailDto {
+    pub(in crate::server::ops) qualified_name: String,
+    pub(in crate::server::ops) display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) icon_url: Option<String>,
+    pub(in crate::server::ops) source: String,
+    /// The hosted endpoint an install would dial. `None` ⇒ nothing dialable here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) endpoint: Option<String>,
+    /// The env keys the install dialog must collect, as upstream derived them
+    /// from the connection the install will actually use.
+    pub(in crate::server::ops) required_env_keys: Vec<String>,
+    /// Whether `POST …/mcp/registry/install` would accept this entry.
+    pub(in crate::server::ops) installable: bool,
+    /// Why not, when it would not. Present iff `installable` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::server::ops) refusal: Option<String>,
+}
+
+/// The connection kinds that mean "dial an HTTPS endpoint". Mirrors upstream's
+/// `ConnectionKind::transport_kind`, which is `pub(super)` to its own crate and
+/// so cannot be called from here.
+const HTTP_CONNECTION_KINDS: [&str; 3] = ["http", "http_remote", "sse"];
+
+/// The endpoint an install of this entry would dial, or `None` when the entry
+/// offers only a local subprocess.
+///
+/// Published connections win, matching upstream's picker, so the entry detail
+/// names the URL the install will actually use rather than an unpublished one.
+pub(in crate::server::ops) fn http_deployment_url(server: &Value) -> Option<String> {
+    let connections = server.get("connections")?.as_array()?;
+    let dialable = |conn: &&Value| -> Option<String> {
+        let kind = conn.get("type").and_then(Value::as_str).unwrap_or_default();
+        if !HTTP_CONNECTION_KINDS.contains(&kind) {
+            return None;
+        }
+        let url = conn
+            .get("deployment_url")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|url| !url.is_empty())?;
+        Some(url.to_string())
+    };
+    connections
+        .iter()
+        .filter(|conn| conn.get("published").and_then(Value::as_bool) == Some(true))
+        .find_map(|conn| dialable(&conn))
+        .or_else(|| connections.iter().find_map(|conn| dialable(&conn)))
+}
+
+/// Projects `{ servers, page, total_pages }` as upstream's search returns it.
+pub(in crate::server::ops) fn catalogue_search(raw: &Value) -> CatalogueSearchDto {
+    let servers = raw
+        .get("servers")
+        .and_then(Value::as_array)
+        .map(|rows| rows.iter().filter_map(catalogue_entry).collect())
+        .unwrap_or_default();
+    CatalogueSearchDto {
+        servers,
+        page: raw.get("page").and_then(Value::as_u64).unwrap_or(1) as u32,
+        total_pages: raw.get("total_pages").and_then(Value::as_u64).unwrap_or(0) as u32,
+    }
+}
+
+/// One summary row. A row without a qualified name cannot be installed and is
+/// dropped rather than rendered as an un-actionable card.
+fn catalogue_entry(raw: &Value) -> Option<CatalogueEntryDto> {
+    let qualified_name = text(raw, "qualified_name")?;
+    Some(CatalogueEntryDto {
+        display_name: text(raw, "display_name").unwrap_or_else(|| qualified_name.clone()),
+        qualified_name,
+        description: text(raw, "description"),
+        icon_url: text(raw, "icon_url"),
+        source: text(raw, "source").unwrap_or_default(),
+        official: raw
+            .get("official")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        use_count: raw.get("use_count").and_then(Value::as_u64).unwrap_or(0),
+        website_url: text(raw, "website_url"),
+    })
+}
+
+/// Projects `{ server: … }` as upstream's `registry_get` returns it, deciding
+/// installability from the connections it lists.
+pub(in crate::server::ops) fn catalogue_detail(raw: &Value) -> Option<CatalogueDetailDto> {
+    let server = raw.get("server")?;
+    let qualified_name = text(server, "qualified_name")?;
+    let endpoint = http_deployment_url(server);
+    let refusal = endpoint
+        .is_none()
+        .then(|| stdio_install_refusal(&qualified_name));
+    Some(CatalogueDetailDto {
+        display_name: text(server, "display_name").unwrap_or_else(|| qualified_name.clone()),
+        qualified_name,
+        description: text(server, "description"),
+        icon_url: text(server, "icon_url"),
+        source: text(server, "source").unwrap_or_default(),
+        installable: endpoint.is_some(),
+        endpoint,
+        required_env_keys: server
+            .get("required_env_keys")
+            .and_then(Value::as_array)
+            .map(|keys| {
+                keys.iter()
+                    .filter_map(Value::as_str)
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        refusal,
+    })
+}
+
+/// A non-blank string field.
+fn text(raw: &Value, key: &str) -> Option<String> {
+    raw.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}

--- a/src/server/ops/mcp_registry/tests.rs
+++ b/src/server/ops/mcp_registry/tests.rs
@@ -1,0 +1,609 @@
+//! Reconciliation, row naming, status mapping and catalogue projection.
+//!
+//! None of these are feature-gated. That is the point: the `mcp` feature's own
+//! CI lane is filtered to two modules (`scripts/ci/feature-lanes.txt`), so a
+//! test written behind `#[cfg(feature = "mcp")]` here would compile in that lane
+//! and be selected by nothing — the exact silence issue #770 exists to catch.
+//! Every rule worth asserting was therefore written against feature-free inputs.
+
+use super::catalogue::*;
+use super::*;
+use crate::company::mcp::{McpStatus, stdio_install_refusal};
+
+/// A List A row as `dto_from_decl` produces one.
+fn declared(name: &str, endpoint: &str, source: McpSource) -> McpServerDto {
+    McpServerDto {
+        name: name.to_string(),
+        endpoint: endpoint.to_string(),
+        description: None,
+        source,
+        enabled: true,
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
+        timeout_secs: 30,
+        auth_configured: false,
+        server_id: None,
+        qualified_name: None,
+        icon_url: None,
+        transport: None,
+        reachable_by: Vec::new(),
+        health: None,
+    }
+}
+
+fn install(server_id: &str, qualified_name: &str, endpoint: Option<&str>) -> RegistryInstall {
+    RegistryInstall {
+        server_id: server_id.to_string(),
+        qualified_name: qualified_name.to_string(),
+        display_name: qualified_name.to_string(),
+        description: None,
+        icon_url: None,
+        endpoint: endpoint.map(str::to_string),
+        transport: if endpoint.is_some() {
+            "http_remote".to_string()
+        } else {
+            "stdio".to_string()
+        },
+        enabled: true,
+        auth_configured: false,
+        health: None,
+    }
+}
+
+fn agent(id: &str) -> RosterAgentDto {
+    RosterAgentDto {
+        id: id.to_string(),
+        name: id.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+/// The requirement the whole merge exists for: a server the operator typed in by
+/// URL **and** installed from the directory is one row, not two.
+///
+/// Two rows is not a cosmetic duplicate — each carries its own credential slot
+/// and its own health badge, so the tab would show one server twice with
+/// contradictory status and no way to tell which one the agents are using.
+#[test]
+fn a_server_in_both_lists_reconciles_to_one_row() {
+    let mut rows = vec![declared(
+        "browserbase",
+        "https://api.browserbase.com/mcp",
+        McpSource::Runtime,
+    )];
+    merge_installs(
+        &mut rows,
+        vec![install(
+            "id-1",
+            "@browserbasehq/mcp",
+            Some("https://api.browserbase.com/mcp"),
+        )],
+        &[],
+    );
+
+    assert_eq!(rows.len(), 1, "one server, one row");
+    assert_eq!(rows[0].name, "browserbase", "List A keeps the row's name");
+    assert_eq!(
+        rows[0].source,
+        McpSource::Runtime,
+        "List A's provenance survives — it is what governs delete and what the \
+         harness builds each agent's registry from"
+    );
+    assert_eq!(
+        rows[0].server_id.as_deref(),
+        Some("id-1"),
+        "the install is still addressable on the reconciled row"
+    );
+    assert_eq!(
+        rows[0].qualified_name.as_deref(),
+        Some("@browserbasehq/mcp")
+    );
+    assert_eq!(rows[0].transport.as_deref(), Some("http_remote"));
+}
+
+/// The match is on the *normalised* endpoint, so the credential a List A server
+/// carries in its query string cannot hide the duplicate.
+#[test]
+fn reconciliation_ignores_query_strings_ports_and_trailing_slashes() {
+    let mut rows = vec![declared(
+        "parallel",
+        "HTTPS://MCP.Parallel.AI:443/search/?token=sekrit",
+        McpSource::Runtime,
+    )];
+    merge_installs(
+        &mut rows,
+        vec![install(
+            "id-1",
+            "@parallel/search",
+            Some("https://mcp.parallel.ai/search"),
+        )],
+        &[],
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "same server despite case, port, slash, query"
+    );
+}
+
+/// A manifest row must not become deletable by being installed over.
+#[test]
+fn a_manifest_row_keeps_its_badge_when_an_install_reconciles_onto_it() {
+    let mut rows = vec![declared(
+        "deepwiki",
+        "https://mcp.deepwiki.com/mcp",
+        McpSource::Manifest,
+    )];
+    merge_installs(
+        &mut rows,
+        vec![install(
+            "id-1",
+            "@deepwiki/mcp",
+            Some("https://mcp.deepwiki.com/mcp"),
+        )],
+        &[],
+    );
+    assert_eq!(rows[0].source, McpSource::Manifest);
+}
+
+/// Two servers that share nothing must stay two rows — the matching rule has to
+/// be able to say "no".
+#[test]
+fn distinct_endpoints_stay_distinct_rows() {
+    let mut rows = vec![declared(
+        "deepwiki",
+        "https://mcp.deepwiki.com/mcp",
+        McpSource::Manifest,
+    )];
+    merge_installs(
+        &mut rows,
+        vec![install("id-1", "@exa/exa", Some("https://mcp.exa.ai/mcp"))],
+        &[],
+    );
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[1].source, McpSource::Registry);
+}
+
+/// A stdio install has no endpoint. "No address" must mean "matches nothing",
+/// not "matches the first row" — a blank key colliding would silently graft an
+/// install onto an unrelated server.
+#[test]
+fn an_install_without_an_endpoint_reconciles_with_nothing() {
+    let mut rows = vec![declared(
+        "exa",
+        "https://mcp.exa.ai/mcp",
+        McpSource::Runtime,
+    )];
+    merge_installs(
+        &mut rows,
+        vec![install("id-1", "@old/stdio-server", None)],
+        &[],
+    );
+    assert_eq!(rows.len(), 2);
+    assert!(rows[0].server_id.is_none(), "the http row is untouched");
+    assert_eq!(rows[1].transport.as_deref(), Some("stdio"));
+    assert_eq!(rows[1].endpoint, "", "nothing to dial");
+}
+
+/// A credential on either side means one is stored. Reporting only List A's slot
+/// would print "no credential" over a server that authenticates fine.
+#[test]
+fn auth_configured_is_the_union_on_a_reconciled_row() {
+    let mut rows = vec![declared(
+        "exa",
+        "https://mcp.exa.ai/mcp",
+        McpSource::Runtime,
+    )];
+    let mut with_env = install("id-1", "@exa/exa", Some("https://mcp.exa.ai/mcp"));
+    with_env.auth_configured = true;
+    merge_installs(&mut rows, vec![with_env], &[]);
+    assert!(rows[0].auth_configured);
+}
+
+/// List A's probe wins: it dials the endpoint the way the agents' bridge tools
+/// do, credential included, so it is the more truthful badge when both exist.
+#[test]
+fn list_a_health_wins_and_registry_health_fills_a_gap() {
+    let probed = McpHealth {
+        status: McpStatus::Ok,
+        message: "probed".to_string(),
+        tool_count: 7,
+        checked_at_millis: 1,
+        auth_hint: None,
+    };
+    let mut rows = vec![
+        declared("exa", "https://mcp.exa.ai/mcp", McpSource::Runtime),
+        declared("linear", "https://mcp.linear.app/mcp", McpSource::Runtime),
+    ];
+    rows[0].health = Some(probed.clone());
+
+    let from_registry = health_from_status("error", 0, None, 99);
+    let mut a = install("id-1", "@exa/exa", Some("https://mcp.exa.ai/mcp"));
+    a.health = from_registry.clone();
+    let mut b = install("id-2", "@linear/linear", Some("https://mcp.linear.app/mcp"));
+    b.health = from_registry.clone();
+
+    merge_installs(&mut rows, vec![a, b], &[]);
+    assert_eq!(
+        rows[0].health,
+        Some(probed),
+        "List A's probe is not replaced"
+    );
+    assert_eq!(
+        rows[1].health, from_registry,
+        "and fills a row that has none"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Row shape
+// ---------------------------------------------------------------------------
+
+/// The two halves of the DTO contract: a registry row carries the id its routes
+/// key on, and a List A row's JSON is byte-identical to what it was before the
+/// registry fields existed.
+#[test]
+fn a_registry_row_carries_its_server_id_and_a_declared_row_is_unchanged() {
+    let mut rows = vec![declared(
+        "exa",
+        "https://mcp.exa.ai/mcp",
+        McpSource::Runtime,
+    )];
+    let before = serde_json::to_value(&rows[0]).expect("serializes");
+
+    merge_installs(
+        &mut rows,
+        vec![install(
+            "id-1",
+            "@modelcontextprotocol/server-git",
+            Some("https://git.example.test/mcp"),
+        )],
+        &[agent("ceo")],
+    );
+
+    let declared_json = serde_json::to_value(&rows[0]).expect("serializes");
+    assert_eq!(
+        declared_json, before,
+        "a non-registry row gains no key — every registry field is \
+         skip_serializing_if = Option::is_none"
+    );
+    for key in ["serverId", "qualifiedName", "iconUrl", "transport"] {
+        assert!(
+            declared_json.get(key).is_none(),
+            "`{key}` must not appear on a declared row"
+        );
+    }
+
+    let registry = &rows[1];
+    assert_eq!(registry.server_id.as_deref(), Some("id-1"));
+    assert_eq!(
+        registry.name, "modelcontextprotocol-server-git",
+        "the row's name is a display slug; `serverId` is the key"
+    );
+    assert_eq!(registry.source, McpSource::Registry);
+    assert_eq!(
+        registry.reachable_by.len(),
+        1,
+        "every teammate reaches an installed server — the harness pushes the \
+         registry bridge tools with no grant check"
+    );
+}
+
+/// A disabled install hands out no tools, so it reaches nobody — the same rule
+/// `reachers_of` applies to a disabled List A server.
+#[test]
+fn a_disabled_install_reaches_nobody() {
+    let mut rows = Vec::new();
+    let mut off = install("id-1", "@exa/exa", Some("https://mcp.exa.ai/mcp"));
+    off.enabled = false;
+    merge_installs(&mut rows, vec![off], &[agent("ceo"), agent("cto")]);
+    assert!(rows[0].reachable_by.is_empty());
+    assert!(!rows[0].enabled);
+}
+
+/// The console keys rows by `name`. Two rows sharing one would render as a
+/// single flickering row and delete the wrong server, so a collision has to
+/// resolve — deterministically, not positionally.
+#[test]
+fn a_colliding_row_name_falls_back_to_the_server_id() {
+    let mut rows = vec![declared(
+        "modelcontextprotocol-server-git",
+        "https://elsewhere.example.test/mcp",
+        McpSource::Runtime,
+    )];
+    merge_installs(
+        &mut rows,
+        vec![
+            install(
+                "aaaaaaaa-1111",
+                "@modelcontextprotocol/server-git",
+                Some("https://one.example.test/mcp"),
+            ),
+            install(
+                "bbbbbbbb-2222",
+                "@modelcontextprotocol/server-git",
+                Some("https://two.example.test/mcp"),
+            ),
+        ],
+        &[],
+    );
+    let names: Vec<&str> = rows.iter().map(|row| row.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "modelcontextprotocol-server-git",
+            "modelcontextprotocol-server-git-aaaaaaaa",
+            "modelcontextprotocol-server-git-bbbbbbbb",
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint normalisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn endpoint_normalisation_rules() {
+    let same = |a: &str, b: &str| {
+        assert_eq!(
+            normalize_endpoint(a),
+            normalize_endpoint(b),
+            "`{a}` and `{b}` are one endpoint"
+        );
+    };
+    same("https://Host.Example/mcp", "https://host.example/mcp/");
+    same("https://host.example:443/mcp", "https://host.example/mcp");
+    same("http://host.example:80/mcp", "http://host.example/mcp");
+    same(
+        "https://host.example/mcp?k=v#frag",
+        "https://host.example/mcp",
+    );
+    same("https://host.example", "https://host.example/");
+
+    assert_ne!(
+        normalize_endpoint("https://host.example/mcp"),
+        normalize_endpoint("http://host.example/mcp"),
+        "scheme is part of the identity"
+    );
+    assert_ne!(
+        normalize_endpoint("https://host.example/a"),
+        normalize_endpoint("https://host.example/b"),
+        "path is part of the identity"
+    );
+    assert_eq!(normalize_endpoint("   "), None);
+    assert_eq!(normalize_endpoint(""), None);
+}
+
+// ---------------------------------------------------------------------------
+// Status → health
+// ---------------------------------------------------------------------------
+
+#[test]
+fn connection_status_maps_onto_the_console_badge() {
+    let health = |status: &str, hint: Option<&str>| health_from_status(status, 3, hint, 42);
+
+    let ok = health("connected", None).expect("mapped");
+    assert_eq!(ok.status, McpStatus::Ok);
+    assert_eq!(ok.tool_count, 3);
+    assert_eq!(ok.checked_at_millis, 42);
+
+    assert_eq!(
+        health("unauthorized", Some("oauth_required"))
+            .expect("mapped")
+            .status,
+        McpStatus::NeedsConfig,
+        "a 401 is a resting state to act on, not a failure"
+    );
+    assert_eq!(
+        health("error", None).expect("mapped").status,
+        McpStatus::Error
+    );
+    assert_eq!(
+        health("disconnected", None).expect("mapped").status,
+        McpStatus::Unknown
+    );
+    assert_eq!(
+        health("something-upstream-added", None),
+        None,
+        "a status this build cannot read is no badge, not a wrong one"
+    );
+}
+
+/// The reason a raw `last_error` is not in [`RegistryInstall`] at all: there is
+/// no known-secret set to scrub an install's error against, because its env
+/// values are deliberately never loaded. Pinned so a later "let's surface the
+/// error" change has to confront it.
+#[test]
+fn no_upstream_error_text_reaches_the_badge() {
+    let hint = "token_rejected";
+    let health = health_from_status("unauthorized", 0, Some(hint), 1).expect("mapped");
+    assert!(
+        !health.message.contains("http"),
+        "no URL can ride out in the message: {}",
+        health.message
+    );
+    assert_eq!(
+        health.auth_hint.as_deref(),
+        Some(hint),
+        "only the stable reason code crosses the wire"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Catalogue projection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_results_forward_only_named_fields() {
+    let raw = serde_json::json!({
+        "servers": [{
+            "qualified_name": "@exa/exa",
+            "display_name": "Exa",
+            "description": "Search",
+            "icon_url": "https://icons.example/exa.png",
+            "source": "smithery",
+            "official": true,
+            "use_count": 12,
+            "internal_admin_token": "sekrit",
+        }, {
+            "display_name": "No identity"
+        }],
+        "page": 2,
+        "total_pages": 5,
+    });
+    let projected = catalogue_search(&raw);
+    assert_eq!(projected.page, 2);
+    assert_eq!(projected.total_pages, 5);
+    assert_eq!(
+        projected.servers.len(),
+        1,
+        "a row with no qualified name cannot be installed and is dropped"
+    );
+    let json = serde_json::to_value(&projected.servers[0]).expect("serializes");
+    assert!(
+        json.get("internal_admin_token").is_none(),
+        "upstream's flattened extras do not ride through"
+    );
+    assert_eq!(json["qualifiedName"], "@exa/exa");
+    assert!(projected.servers[0].official);
+}
+
+/// The entry projection makes the install decision so the console never offers
+/// a button that would be refused — and names the reason when it must refuse.
+#[test]
+fn a_stdio_only_entry_is_refused_with_a_reason_that_names_why() {
+    let raw = serde_json::json!({
+        "server": {
+            "qualified_name": "@modelcontextprotocol/server-filesystem",
+            "display_name": "Filesystem",
+            "source": "mcp_official",
+            "required_env_keys": ["ROOT"],
+            "connections": [{
+                "type": "stdio",
+                "published": true,
+                "example_config": { "command": "npx" }
+            }]
+        }
+    });
+    let detail = catalogue_detail(&raw).expect("projected");
+    assert!(!detail.installable);
+    assert_eq!(detail.endpoint, None);
+    let refusal = detail.refusal.expect("a refusal says why");
+    assert!(
+        refusal.contains("@modelcontextprotocol/server-filesystem"),
+        "names the entry: {refusal}"
+    );
+    for reason in ["Node", "Python", "hosted HTTP endpoint"] {
+        assert!(
+            refusal.contains(reason),
+            "names why ({reason} missing): {refusal}"
+        );
+    }
+}
+
+/// The same refusal is what the install route raises, so the two surfaces cannot
+/// disagree about the reason.
+#[test]
+fn the_entry_refusal_is_the_install_refusal() {
+    let raw = serde_json::json!({
+        "server": { "qualified_name": "@a/b", "connections": [{ "type": "stdio" }] }
+    });
+    let detail = catalogue_detail(&raw).expect("projected");
+    assert_eq!(detail.refusal, Some(stdio_install_refusal("@a/b")));
+}
+
+#[test]
+fn a_hosted_entry_is_installable_and_names_the_url_the_install_will_dial() {
+    let raw = serde_json::json!({
+        "server": {
+            "qualified_name": "@exa/exa",
+            "display_name": "Exa",
+            "source": "smithery",
+            "required_env_keys": ["EXA_API_KEY"],
+            "connections": [
+                { "type": "stdio", "published": true },
+                { "type": "http", "published": false, "deployment_url": "https://draft.exa.ai/mcp" },
+                { "type": "http", "published": true, "deployment_url": "https://mcp.exa.ai/mcp" }
+            ]
+        }
+    });
+    let detail = catalogue_detail(&raw).expect("projected");
+    assert!(detail.installable);
+    assert_eq!(
+        detail.endpoint.as_deref(),
+        Some("https://mcp.exa.ai/mcp"),
+        "the published hosted connection wins, matching upstream's picker"
+    );
+    assert_eq!(detail.required_env_keys, vec!["EXA_API_KEY".to_string()]);
+    assert_eq!(detail.refusal, None);
+    let json = serde_json::to_value(&detail).expect("serializes");
+    assert!(
+        json.get("connections").is_none() && json.get("exampleConfig").is_none(),
+        "raw connection metadata is not forwarded"
+    );
+}
+
+/// `sse` is one of the wire names upstream routes into the HTTP install path.
+#[test]
+fn an_sse_connection_counts_as_hosted() {
+    let raw = serde_json::json!({
+        "connections": [{ "type": "sse", "deployment_url": "https://host.example/sse" }]
+    });
+    assert_eq!(
+        http_deployment_url(&raw).as_deref(),
+        Some("https://host.example/sse")
+    );
+}
+
+/// An http connection that declares no URL is not dialable — treating it as one
+/// would install a server with an empty endpoint.
+#[test]
+fn an_http_connection_without_a_url_is_not_dialable() {
+    let raw = serde_json::json!({
+        "connections": [{ "type": "http", "published": true, "deployment_url": "  " }]
+    });
+    assert_eq!(http_deployment_url(&raw), None);
+}
+
+// ---------------------------------------------------------------------------
+// Delete dispatch
+// ---------------------------------------------------------------------------
+
+/// `DELETE …/mcp/servers/{name}` dispatches on where the row actually lives.
+///
+/// The case this pins is `Both`. A reconciled row that only drops its
+/// runtime-index entry leaves the directory install connected, with its tools
+/// still on every agent's belt — a delete the operator watches fail. Manifest
+/// and default rows never reach this decision; they are refused before it.
+#[test]
+fn delete_dispatches_on_where_the_row_lives() {
+    assert_eq!(removal_for(true, false), Removal::IndexRow, "typed in only");
+    assert_eq!(removal_for(false, true), Removal::Install, "installed only");
+    assert_eq!(
+        removal_for(true, true),
+        Removal::Both,
+        "typed in AND installed — removing one half leaves the server callable"
+    );
+    assert_eq!(removal_for(false, false), Removal::NotFound, "no such row");
+}
+
+/// The degraded contract's other half: when the registry yields nothing — an
+/// unreadable store, a directory that will not answer, a build with no `mcp` —
+/// the merged read is List A, byte for byte.
+#[test]
+fn no_installs_leaves_the_declared_list_untouched() {
+    let mut rows = vec![
+        declared(
+            "deepwiki",
+            "https://mcp.deepwiki.com/mcp",
+            McpSource::Manifest,
+        ),
+        declared("exa", "https://mcp.exa.ai/mcp", McpSource::Runtime),
+    ];
+    let before = serde_json::to_value(&rows).expect("serializes");
+    merge_installs(&mut rows, Vec::new(), &[agent("ceo")]);
+    assert_eq!(serde_json::to_value(&rows).expect("serializes"), before);
+}

--- a/src/server/ops/mcp_registry/wired.rs
+++ b/src/server/ops/mcp_registry/wired.rs
@@ -1,0 +1,384 @@
+//! The registry routes and the store read behind them — compiled only with the
+//! `mcp` feature.
+//!
+//! Everything here is a thin adapter: it resolves the company's
+//! [`McpRuntime`](crate::harness::mcp::McpRuntime), calls one of its wrappers,
+//! and hands the result to a projection from the parent module. The rules worth
+//! testing (endpoint reconciliation, row naming, status mapping, catalogue
+//! projection, the stdio refusal) all live in the parent and compile without
+//! this feature, so they are exercised by the ungated lane rather than only by
+//! the filtered belt lane (issue #770).
+//!
+//! **Authority.** Every mutation takes [`AdminScopedCompany`]: installing a
+//! server hands *every* teammate a new set of callable tools (`build.rs` pushes
+//! the registry bridge tools with no grant check), so it settles what the
+//! company can reach — the same question `POST …/mcp/servers` already answers
+//! under the same guard. Browsing the directory decides nothing and takes
+//! [`ScopedCompany`], matching `GET …/mcp/servers`.
+
+use std::collections::HashMap;
+
+use axum::Json;
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+use oh::mcp::registry::types::{ConnStatus, InstalledServer};
+use openhuman_core::openhuman as oh;
+
+use crate::company::mcp::{McpHealth, stdio_install_refusal};
+use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
+use crate::ports::now_millis;
+use crate::server::error::ApiError;
+use crate::server::ops::mcp::{McpServerDto, NEXT_TURN_NOTE, merged_rows};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, not_wired};
+
+use super::RegistryInstall;
+use super::catalogue::{catalogue_detail, catalogue_search, health_from_status};
+
+// ---------------------------------------------------------------------------
+// Request and response bodies
+// ---------------------------------------------------------------------------
+
+/// `GET …/mcp/registry/search` query.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SearchQuery {
+    #[serde(default)]
+    q: Option<String>,
+    #[serde(default)]
+    page: Option<u32>,
+    #[serde(default)]
+    page_size: Option<u32>,
+}
+
+/// `GET …/mcp/registry/entry` query.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct EntryQuery {
+    qualified_name: String,
+}
+
+/// `POST …/mcp/registry/install` body — the entry to install and the values for
+/// the env keys it declared. Values are write-only: they are persisted into
+/// OpenHuman's env table and never read back by any route here.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct InstallBody {
+    qualified_name: String,
+    #[serde(default)]
+    env: HashMap<String, String>,
+}
+
+/// `PUT …/mcp/registry/{server_id}/env` body — a credential rotation.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct EnvBody {
+    #[serde(default)]
+    env: HashMap<String, String>,
+}
+
+/// The `{server_id}` path segment.
+#[derive(Debug, Deserialize)]
+pub(super) struct ServerIdPath {
+    server_id: String,
+}
+
+/// A registry mutation's response: the resulting row, the rebuild reminder, and
+/// the connection state right after the change.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RegistryMutationResponse {
+    server: McpServerDto,
+    note: String,
+    /// The connection state after the mutation. A failed connect is **never** a
+    /// rollback — a needs-credential resting state is valid here for exactly the
+    /// reason it is on `POST …/mcp/servers`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    test: Option<McpHealth>,
+}
+
+/// Every registry install for this company, already projected.
+///
+/// **Degrades, never fails.** A missing runtime, an unreadable store, or a
+/// registry that will not answer all resolve to "no installs", so
+/// `GET …/mcp/servers` still returns List A. The MCP tab going blank because a
+/// directory was down is a worse outcome than a tab that is briefly missing the
+/// rows it cannot read, and List A is the half that governs what the agents
+/// reach — so it is the half that must survive.
+pub(in crate::server::ops) async fn installs(runtime: &CompanyRuntime) -> Vec<RegistryInstall> {
+    let Some(mcp) = runtime.mcp() else {
+        return Vec::new();
+    };
+    let servers = match mcp.list() {
+        Ok(servers) => servers,
+        Err(error) => {
+            tracing::warn!(
+                "[mcp-registry] company `{}`: install list unavailable, serving the declared \
+                 servers only: {error}",
+                runtime.id()
+            );
+            return Vec::new();
+        }
+    };
+    if servers.is_empty() {
+        return Vec::new();
+    }
+    let status: HashMap<String, ConnStatus> = mcp
+        .status()
+        .await
+        .into_iter()
+        .map(|state| (state.server_id.clone(), state))
+        .collect();
+    let now = now_millis();
+    servers
+        .into_iter()
+        .map(|server| {
+            let state = status.get(&server.server_id);
+            project(server, state, now)
+        })
+        .collect()
+}
+
+/// One store record plus its live connection state.
+fn project(server: InstalledServer, state: Option<&ConnStatus>, now: u64) -> RegistryInstall {
+    let endpoint = server.transport.deployment_url().map(str::to_string);
+    let transport = server.transport.dispatch_kind().to_string();
+    let health = state.and_then(|state| {
+        health_from_status(
+            state.status.as_str(),
+            state.tool_count,
+            state.auth_hint.as_deref(),
+            now,
+        )
+    });
+    RegistryInstall {
+        server_id: server.server_id,
+        qualified_name: server.qualified_name,
+        display_name: server.display_name,
+        description: server.description,
+        icon_url: server.icon_url,
+        endpoint,
+        transport,
+        enabled: server.enabled,
+        // `env_keys` is the set of keys whose values upstream persisted, so this
+        // answers "is a credential stored" without ever loading one.
+        auth_configured: !server.env_keys.is_empty(),
+        health,
+    }
+}
+
+/// `GET …/mcp/registry/search` — browse the two upstream directories.
+pub(super) async fn search(company: ScopedCompany, Query(query): Query<SearchQuery>) -> Response {
+    let Some(mcp) = company.runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    match mcp.search(query.q, query.page, query.page_size).await {
+        Ok(raw) => Json(catalogue_search(&raw)).into_response(),
+        Err(error) => ApiError(error).into_response(),
+    }
+}
+
+/// `GET …/mcp/registry/entry?qualifiedName=…` — one directory entry in full,
+/// with the install decision already made so the console never offers an
+/// install that would be refused.
+pub(super) async fn entry(company: ScopedCompany, Query(query): Query<EntryQuery>) -> Response {
+    let Some(mcp) = company.runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    let qualified_name = query.qualified_name.trim().to_string();
+    if qualified_name.is_empty() {
+        return ApiError(OpenCompanyError::InvalidRequest(
+            "a directory lookup needs a `qualifiedName`.".to_string(),
+        ))
+        .into_response();
+    }
+    let raw = match mcp.registry_get(qualified_name.clone()).await {
+        Ok(raw) => raw,
+        Err(error) => return ApiError(error).into_response(),
+    };
+    match catalogue_detail(&raw) {
+        Some(detail) => Json(detail).into_response(),
+        None => ApiError(OpenCompanyError::McpServerNotFound(qualified_name)).into_response(),
+    }
+}
+
+/// `POST …/mcp/registry/install` — install a directory entry and connect it.
+///
+/// Refuses a stdio-only entry before writing anything: the tenant image has no
+/// Node, Python or package manager to launch one with. The search filter keeps
+/// such entries off the operator's screen; this check is what makes the refusal
+/// true for a caller that POSTs a qualified name search never offered.
+///
+/// The connect that follows is **not** a gate. A server that installs and then
+/// asks for a credential is at a valid resting state — the same rule
+/// `POST …/mcp/servers` follows when its probe comes back `needs_config` — so
+/// the install stands and the connection state rides back in `test`.
+pub(super) async fn install(
+    company: AdminScopedCompany,
+    Json(body): Json<InstallBody>,
+) -> Response {
+    let runtime = company.runtime.as_ref();
+    let Some(mcp) = runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    let qualified_name = body.qualified_name.trim().to_string();
+    if qualified_name.is_empty() {
+        return ApiError(OpenCompanyError::InvalidRequest(
+            "an install needs a `qualifiedName`.".to_string(),
+        ))
+        .into_response();
+    }
+
+    let raw = match mcp.registry_get(qualified_name.clone()).await {
+        Ok(raw) => raw,
+        Err(error) => return ApiError(error).into_response(),
+    };
+    let Some(detail) = catalogue_detail(&raw) else {
+        return ApiError(OpenCompanyError::McpServerNotFound(qualified_name)).into_response();
+    };
+    if !detail.installable {
+        let refusal = detail
+            .refusal
+            .unwrap_or_else(|| stdio_install_refusal(&qualified_name));
+        return ApiError(OpenCompanyError::InvalidRequest(refusal)).into_response();
+    }
+
+    let server = match mcp.install_from_directory(qualified_name, body.env).await {
+        Ok(server) => server,
+        Err(error) => return ApiError(error).into_response(),
+    };
+    // A connect failure is recorded as connection state, not raised: see above.
+    let _ = mcp.connect(&server.server_id).await;
+    mutation_response(runtime, &server.server_id).await
+}
+
+/// `POST …/mcp/registry/{server_id}/connect` — dial an installed server.
+pub(super) async fn connect_server(
+    company: AdminScopedCompany,
+    Path(ServerIdPath { server_id }): Path<ServerIdPath>,
+) -> Response {
+    let runtime = company.runtime.as_ref();
+    let Some(mcp) = runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    if let Err(error) = mcp.get(&server_id) {
+        return ApiError(error).into_response();
+    }
+    // Same posture as install: a refused connection is a state to report, not an
+    // error that hides the server.
+    let _ = mcp.connect(&server_id).await;
+    mutation_response(runtime, &server_id).await
+}
+
+/// `POST …/mcp/registry/{server_id}/disconnect` — drop the live session,
+/// keeping the install and its stored credentials.
+pub(super) async fn disconnect_server(
+    company: AdminScopedCompany,
+    Path(ServerIdPath { server_id }): Path<ServerIdPath>,
+) -> Response {
+    let runtime = company.runtime.as_ref();
+    let Some(mcp) = runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    if let Err(error) = mcp.disconnect(&server_id).await {
+        return ApiError(error).into_response();
+    }
+    mutation_response(runtime, &server_id).await
+}
+
+/// `PUT …/mcp/registry/{server_id}/env` — rotate an install's credentials.
+///
+/// Write-only in both directions: the values go into OpenHuman's env table and
+/// the response carries an `authConfigured` bool, never a value. Upstream merges
+/// the supplied keys over the stored ones and reconnects, so a form that sends
+/// only the field the operator retyped does not erase the rest.
+pub(super) async fn update_env(
+    company: AdminScopedCompany,
+    Path(ServerIdPath { server_id }): Path<ServerIdPath>,
+    Json(body): Json<EnvBody>,
+) -> Response {
+    let runtime = company.runtime.as_ref();
+    let Some(mcp) = runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    if body.env.is_empty() {
+        return ApiError(OpenCompanyError::InvalidRequest(
+            "a credential rotation needs at least one `env` value.".to_string(),
+        ))
+        .into_response();
+    }
+    // Establish membership before writing: upstream's update persists first and
+    // reads the install record afterwards, so an unknown id would leave orphaned
+    // env rows behind before failing.
+    if let Err(error) = mcp.get(&server_id) {
+        return ApiError(error).into_response();
+    }
+    if let Err(error) = mcp.update_env(server_id.clone(), body.env).await {
+        return ApiError(error).into_response();
+    }
+    mutation_response(runtime, &server_id).await
+}
+
+/// `DELETE …/mcp/registry/{server_id}` — disconnect, then drop the install and
+/// its stored env values.
+pub(super) async fn uninstall(
+    company: AdminScopedCompany,
+    Path(ServerIdPath { server_id }): Path<ServerIdPath>,
+) -> Response {
+    let Some(mcp) = company.runtime.mcp() else {
+        return not_wired("mcp registry");
+    };
+    match mcp.uninstall(&server_id).await {
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => ApiError(error).into_response(),
+    }
+}
+
+/// Builds a mutation response by re-reading the **merged** list and picking out
+/// the row this install now occupies.
+///
+/// Re-reading rather than projecting the record in hand is what keeps the
+/// response and a following `GET …/mcp/servers` from disagreeing: if the install
+/// reconciles onto a manifest or runtime row, that is the row the operator will
+/// see, and it is the row that comes back here — badge, name and all.
+async fn mutation_response(runtime: &CompanyRuntime, server_id: &str) -> Response {
+    let rows = match merged_rows(runtime).await {
+        Ok(rows) => rows,
+        Err(error) => return error.into_response(),
+    };
+    let Some(server) = rows
+        .into_iter()
+        .find(|row| row.server_id.as_deref() == Some(server_id))
+    else {
+        return ApiError(OpenCompanyError::McpServerNotFound(server_id.to_string()))
+            .into_response();
+    };
+    // The row's health *is* the post-mutation connection state — `installs`
+    // reads it from the live connection map on this very call. Echoing it as
+    // `test` matches the shape `POST …/mcp/servers` already returns.
+    let test = server.health.clone();
+    Json(RegistryMutationResponse {
+        server,
+        note: NEXT_TURN_NOTE.to_string(),
+        test,
+    })
+    .into_response()
+}
+
+/// Removes a directory install on behalf of `DELETE …/mcp/servers/{name}`.
+///
+/// A runtime already missing its registry is not an error here: there is then no
+/// install to remove and the index-row delete that preceded this call was the
+/// whole removal.
+pub(in crate::server::ops) async fn remove_install(
+    runtime: &CompanyRuntime,
+    server_id: &str,
+) -> Result<(), ApiError> {
+    let Some(mcp) = runtime.mcp() else {
+        return Ok(());
+    };
+    mcp.uninstall(server_id).await.map(|_| ()).map_err(ApiError)
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -37,6 +37,7 @@ pub mod ledgers;
 pub mod mail;
 pub mod mailer;
 pub mod mcp;
+pub mod mcp_registry;
 pub mod memory;
 pub mod pages;
 pub mod policy;
@@ -196,6 +197,7 @@ pub fn router() -> Router<AppState> {
         .merge(pages::router())
         .merge(skills::router())
         .merge(mcp::router())
+        .merge(mcp_registry::router())
         .merge(read_state::router())
         .merge(repos::router())
         .merge(inference::router())

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3406,6 +3406,65 @@ async fn mcp_servers_crud_round_trips_and_token_is_write_only() {
     assert_eq!(list.as_array().unwrap().len(), 0);
 }
 
+/// Issue #1270: a build without the `mcp` feature must serve List A exactly as
+/// before and answer the directory routes `not_wired`.
+///
+/// Gated on the absence of the feature rather than written once for both builds:
+/// with `mcp` on, these routes reach a live registry and two upstream
+/// directories over the network, which is not a thing a unit test may do. The
+/// default `cargo test --locked` lane is what runs this, and it is the lane that
+/// compiles the unwired half in the first place.
+#[cfg(not(feature = "mcp"))]
+#[tokio::test]
+async fn without_the_mcp_feature_the_directory_is_not_wired_and_list_a_is_unchanged() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers",
+        Some(json!({ "name": "notion", "endpoint": "https://notion.example/mcp" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // List A is served, and carries none of the registry-only keys.
+    let (status, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(list.as_array().unwrap().len(), 1);
+    assert_eq!(list[0]["source"], "runtime");
+    for key in ["serverId", "qualifiedName", "iconUrl", "transport"] {
+        assert!(
+            list[0].get(key).is_none(),
+            "`{key}` must not appear without a registry install"
+        );
+    }
+
+    // Every directory route answers the console's degrade signal.
+    for (method, uri) in [
+        ("GET", "/api/v1/company/mcp/registry/search?q=git"),
+        (
+            "GET",
+            "/api/v1/company/mcp/registry/entry?qualifiedName=@a/b",
+        ),
+        ("POST", "/api/v1/company/mcp/registry/install"),
+        ("POST", "/api/v1/company/mcp/registry/sid/connect"),
+        ("POST", "/api/v1/company/mcp/registry/sid/disconnect"),
+        ("PUT", "/api/v1/company/mcp/registry/sid/env"),
+        ("DELETE", "/api/v1/company/mcp/registry/sid"),
+    ] {
+        let (status, body) = send(&state, method, uri, None).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{method} {uri}");
+        assert_eq!(body["code"], "not_wired", "{method} {uri}");
+    }
+
+    // And the List A delete still works with no install behind the row.
+    let (status, _) = send(&state, "DELETE", "/api/v1/company/mcp/servers/notion", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+}
+
 #[tokio::test]
 async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
     let home_dir = home();


### PR DESCRIPTION
## Summary

The MCP Servers tab could not discover anything. An operator had to arrive already knowing a server's URL and type it in, so the tab stayed empty until somebody pasted something into it.

Meanwhile OpenHuman's MCP registry was already vendored, already wrapped in `McpRuntime`, and already constructed inside every running tenant — and **nothing in `src/server/` had ever called `runtime.mcp()`**. It was dead weight in every pod.

This wires it up. The tab now browses two upstream directories, installs an entry with its declared credentials, and shows every server — manifest, default, runtime and directory install — as **one list**.

## API Or Behavior Changes

**`GET …/mcp/servers` is now a merged read.** Manifest + default + runtime + directory installs, one row each. A server present in more than one source is **one reconciled row**, matched on normalised endpoint (lowercased scheme+host, default port dropped, query and fragment stripped, trailing slash dropped) — not the same server twice with separate credentials and disagreeing health.

**A reconciled row keeps List A's provenance**, deliberately. `source` decides the badge *and* whether a delete is offered, and both must answer to List A: a manifest server can only be disabled, so an install must not be able to capture that row and relabel it deletable. Underneath, List A is also what the agents actually reach.

**`McpSource` gains a fourth value, `registry`.** `McpServerDto` gains four optional fields — `serverId`, `qualifiedName`, `iconUrl`, `transport` — all `skip_serializing_if`, so **a non-registry row's JSON is byte-identical to before**.

**Seven new routes** under `…/mcp/registry/`: search, entry lookup, install, connect, disconnect, env rotation, uninstall. Every mutation is admin-scoped, matching the existing write routes — installing a server hands every agent new tools.

**`DELETE …/mcp/servers/{name}` now dispatches four ways** (`NotFound` / `IndexRow` / `Install` / `Both`). `Both` is the case worth naming: dropping only the index row would leave the install connected with its tools still on every belt.

**Directory results are filtered to hosted transports.** Nothing in the tenant image can launch a stdio server — the runtime stage is `debian:bookworm-slim` plus `ca-certificates`, `curl`, `libssl3` and X11 libs, with no Node and no Python — so a stdio install would fail on `npx: not found`. Filtering at search means those entries are never offered, with a refusal on the install path as the belt to that braces.

**A build without the `mcp` feature** registers the same routes and answers `not_wired`, and List A is unaffected.

**Not in scope, tracked separately:** stdio transport, and MCP tools in workflows (`WORKFLOW_TOOL_NAMESPACES` is untouched).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex,mcp --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex,mcp --tests` — **4781 passed, 0 failed**
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **4765 passed, 0 failed** (the CI lane's own feature set, which omits `mcp`)
- [x] `scripts/ci/assert-feature-lanes.sh` — 30 features, 0 owed a lane
- [x] `npm run typecheck && npm run typecheck:unit && npm run typecheck:e2e`
- [x] `npx vitest run` — **1492 passed** across 156 files (+35 over baseline)

22 backend tests and 35 frontend tests, covering: reconciliation to a single row; delete dispatch across all four cases; a stdio entry refused with a reason; a registry failure degrading the merged read to List A rather than erroring; the unwired build; and the console's row-control dispatch.

The backend tests run in **both** lanes deliberately. The `mcp` row in `feature-lanes.txt` is `partial` and filtered, so a test behind `#[cfg(feature = "mcp")]` would compile there and be selected by nothing.

**Verified against a live host** (`companies/e2e_harness`, real magic-link sign-in): `GET …/mcp/registry/search` answers **HTTP 200 in 1.4s** with real upstream data.

One thing that live run established, and it is worth knowing before anyone reads the search as broken: **the hosted catalogue is currently thin** — a handful of rows, and zero for common queries. That is correct behaviour, not a defect. Only the official registry is queried today, and most of its entries declare no remote endpoint, so the hosted filter discards them accurately. The directory that carries hosted servers needs a credential this deployment does not have; that is a deployment decision with its own issue, and no code change here.

## Documentation

`docs/modules/mcp.md` gains "Browsing the directory" and "Provenance picks the routes". The reconciliation rule and the four-way delete dispatch are documented where they are implemented.

Closes #1270
