### PR TITLE
fix: resolve ledger byline to the author's email

### DIFF
--- a/src/server/ops/ledgers.rs
+++ b/src/server/ops/ledgers.rs
@@ -219,13 +219,40 @@ fn ctx(scope: &ScopedCompany) -> ledgers::Ledgers {
 /// becomes a system author, which the service refuses every deletion from. That
 /// is deliberate and not an oversight: the platform credential is a tenant, not
 /// a person, and *only a person deletes* has to mean a person.
-fn author(scope: &ScopedCompany) -> LedgerAuthor {
+async fn author(scope: &ScopedCompany) -> LedgerAuthor {
     match &scope.actor {
         Some(actor) if matches!(actor.kind, ActorKind::Operator | ActorKind::User) => {
-            LedgerAuthor::human(actor.id.clone(), actor.id.clone())
+            LedgerAuthor::human(actor.id.clone(), human_label(scope, &actor.id).await)
         }
         Some(actor) => LedgerAuthor::agent(actor.id.clone()),
         None => LedgerAuthor::system("platform"),
+    }
+}
+
+/// A person's byline, resolved through the same user store the admin-only
+/// `GET …/users` route reads (`src/server/users/admin.rs::list_users`) — but
+/// called directly here, with no `require_admin` gate, so every signed-in
+/// member sees a real name rather than only admins.
+///
+/// Falls back to the raw id on any lookup failure — a deleted user, a store
+/// error — because a display-name lookup must never fail the write it is
+/// merely decorating.
+async fn human_label(scope: &ScopedCompany, actor_id: &str) -> String {
+    match scope
+        .runtime
+        .users()
+        .get_user(scope.runtime.id(), actor_id)
+        .await
+    {
+        Ok(Some(user)) => {
+            let display_name = user.display_name.as_deref().unwrap_or("").trim();
+            if display_name.is_empty() {
+                user.email
+            } else {
+                display_name.to_string()
+            }
+        }
+        Ok(None) | Err(_) => actor_id.to_string(),
     }
 }
 
@@ -321,7 +348,8 @@ async fn record_entry(
     if let Some(reason) = body.reason {
         fields.insert(crate::ledger::REASON_FIELD.to_string(), Some(reason));
     }
-    let entry = ledgers::record(&ctx(&scope), spec, &author(&scope), &body.id, fields).await?;
+    let entry =
+        ledgers::record(&ctx(&scope), spec, &author(&scope).await, &body.id, fields).await?;
     Ok(Json(EntryRow::of(&entry, spec)))
 }
 
@@ -332,7 +360,7 @@ async fn delete_entry(
     let registry = ledgers::registry(&ctx(&scope)).await?;
     let spec = registry.require(&path.slug)?;
     let removed =
-        ledgers::delete_entry(&ctx(&scope), spec, &author(&scope), &path.entry_id).await?;
+        ledgers::delete_entry(&ctx(&scope), spec, &author(&scope).await, &path.entry_id).await?;
     Ok(if removed {
         StatusCode::NO_CONTENT
     } else {
@@ -345,7 +373,7 @@ async fn retire_ledger(
     Path(path): Path<LedgerPath>,
     Query(query): Query<RetireQuery>,
 ) -> Result<StatusCode, ApiError> {
-    ledgers::retire(&ctx(&scope), &author(&scope), &path.slug, query.purge).await?;
+    ledgers::retire(&ctx(&scope), &author(&scope).await, &path.slug, query.purge).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/src/server/ops/ledgers_test.rs
+++ b/src/server/ops/ledgers_test.rs
@@ -425,3 +425,44 @@ async fn the_derived_file_appears_in_the_workspace_and_is_read_only() {
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
     assert!(format!("{body}").contains("risks"), "{body}");
 }
+
+/// A row's byline names the signed-in person, not their opaque id (issue
+/// #1263). `seed_fixed_admin` seeds a user whose id is a generated internal
+/// id but whose email is `harness-admin@example.test` — exactly the id/email
+/// split the console needs to show something a reader recognizes.
+#[tokio::test]
+async fn a_row_s_byline_names_the_person_by_email_not_id() {
+    let (state, _home) = state().await;
+    send(&state, "POST", "/api/v1/company/ledgers", Some(risks())).await;
+
+    let (status, entry) = send(
+        &state,
+        "POST",
+        "/api/v1/company/ledgers/risks/entries",
+        Some(json!({
+            "id": "vendor-slip",
+            "fields": { "risk": "the vendor misses the date" },
+            "status": "open"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{entry}");
+    assert_eq!(entry["updatedBy"]["kind"], "human");
+    assert_eq!(entry["updatedBy"]["label"], "harness-admin@example.test");
+    let id = entry["updatedBy"]["id"]
+        .as_str()
+        .expect("updatedBy carries an id");
+    assert!(!id.is_empty());
+    assert_ne!(
+        id, "harness-admin@example.test",
+        "the id and the label must no longer be the same opaque value"
+    );
+    assert_eq!(entry["openedBy"]["label"], "harness-admin@example.test");
+
+    let (status, read) = send(&state, "GET", "/api/v1/company/ledgers/risks", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        read["entries"][0]["updatedBy"]["label"],
+        "harness-admin@example.test"
+    );
+}


### PR DESCRIPTION
## Summary
- A ledger row's "Last recorded by" byline showed the operator's opaque internal id (e.g. `01a01e95992a-000000000042 (human)`) instead of a readable identity, because `author()` in `src/server/ops/ledgers.rs` passed `actor.id` as both the `id` and the `label` of `LedgerAuthor::human`.
- Resolves the label through `UserStore::get_user()` — the same store method the admin-only `GET …/users` route (`src/server/users/admin.rs::list_users`, used by Settings → People) reads from — but called directly against the store with no `require_admin` gate, so every signed-in member gets a readable byline, not just admins.
- Label preference mirrors what Settings → People already shows for the same `UserRecord`: `display_name` if set, else `email`. Falls back to the raw id on any lookup failure (deleted user, store error) so a display-name miss never blocks the underlying write.
- No frontend changes: `byline()` in `frontend/src/api/ledgers.ts` already preferred `label` over `id` — the bug was purely that the backend never populated a real label.
- Known, deliberate limitation: entries recorded before this fix keep `label == id` baked into their persisted `LedgerAuthor` (there is no ledger-entry backfill/migration in scope here — the fold is append-only).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — full suite, 3128 passed, 0 failed (includes a new regression test, `a_row_s_byline_names_the_person_by_email_not_id`, in `src/server/ops/ledgers_test.rs`)
- [x] `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all clean
- [x] `npx vitest run` — full suite, 154 files / 1457 tests passed
- [x] Verified live in a browser: signed in as a real person, recorded a ledger entry through the console, and confirmed the row now reads `Last recorded by mithil@vezures.xyz (human) · 1 write` instead of the raw id

Closes #1263