### PR TITLE
fix(approvals): render each card's batch position, not a hardcoded "1 of N" (#1289)

### DIFF
--- a/frontend/src/lib/approval-wording.ts
+++ b/frontend/src/lib/approval-wording.ts
@@ -54,3 +54,44 @@ export function approvedByRuntimeLine(stillAwaiting: StillAwaiting, detail?: str
     stillAwaiting === 1 ? "" : "s"
   } before it runs${suffix}`;
 }
+
+/** This card's place in its turn's batch: 1-based `index` of `total` (#1289). */
+export interface BatchPosition {
+  index: number;
+  total: number;
+}
+
+/**
+ * Each batched approval's position within its own turn's batch (#1289).
+ *
+ * The "N of M from the same turn" line on the Approvals page needs both halves,
+ * and they must come from one walk of one list: computing the numerator over a
+ * focus-narrowed view and the denominator over the whole queue would print a
+ * card as "1 of 5" when it is the third. So `index` and `total` are derived
+ * here together, in `approvals` order, and every sibling of a batch gets a
+ * distinct `index` — which is what the old hardcoded `1` never did, leaving a
+ * two-card turn with two "1 of 2"s and no "2 of 2".
+ *
+ * `total` is counted over the approvals passed in — the caller passes the still
+ * pending set (#842), so the count shrinks as rows are decided rather than
+ * promising a sibling that has already been signed off. Approvals with no
+ * `batch` are absent from the map; their line is not shown.
+ */
+export function batchPositions(
+  approvals: readonly { id: string; batch?: string | null }[],
+): Map<string, BatchPosition> {
+  const total = new Map<string, number>();
+  for (const a of approvals) {
+    if (!a.batch) continue;
+    total.set(a.batch, (total.get(a.batch) ?? 0) + 1);
+  }
+  const seen = new Map<string, number>();
+  const positions = new Map<string, BatchPosition>();
+  for (const a of approvals) {
+    if (!a.batch) continue;
+    const index = (seen.get(a.batch) ?? 0) + 1;
+    seen.set(a.batch, index);
+    positions.set(a.id, { index, total: total.get(a.batch) ?? index });
+  }
+  return positions;
+}

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
-import { approvedByRuntimeLine, approvedLine } from "@/lib/approval-wording";
+import { approvedByRuntimeLine, approvedLine, batchPositions } from "@/lib/approval-wording";
 import { approvalSummary, grantHeadline, timeAgo, toolAction, untilLabel } from "@/lib/language";
 import { approvalsForTask } from "@/lib/task-approvals";
 import { startVisiblePolling } from "@/lib/visible-poll";
@@ -165,15 +165,14 @@ export function ApprovalsView({
    * Counted over what is still pending rather than over the whole batch, so the
    * number shrinks as rows are decided instead of promising a fourth row that
    * has already been signed off.
+   *
+   * Both halves of "N of M" come from one walk of that pending list (#1289): a
+   * per-card `index` as well as the batch `total`, so a two-card turn reads
+   * "1 of 2" then "2 of 2" rather than the hardcoded "1 of 2" twice, and a
+   * focus-narrowed view cannot count the position over a subset and the total
+   * over the whole.
    */
-  const batchTotals = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const a of approvals) {
-      if (!a.batch) continue;
-      counts.set(a.batch, (counts.get(a.batch) ?? 0) + 1);
-    }
-    return counts;
-  }, [approvals]);
+  const batchPos = useMemo(() => batchPositions(approvals), [approvals]);
 
   const markInFlight = (id: string, verdict: Verdict | null) =>
     setInFlight((prev) => {
@@ -335,7 +334,8 @@ export function ApprovalsView({
                   now={now}
                   askerNames={askerNames}
                   deciding={inFlight.get(a.id) ?? null}
-                  batchTotal={batchTotals.get(a.batch ?? "") ?? 1}
+                  batchIndex={batchPos.get(a.id)?.index ?? 1}
+                  batchTotal={batchPos.get(a.id)?.total ?? 1}
                   onDecide={(verdict, scope) => void decide(a, verdict, scope)}
                 />
               ))}
@@ -562,6 +562,7 @@ function ApprovalCard({
   now,
   askerNames,
   deciding,
+  batchIndex,
   batchTotal,
   onDecide,
 }: {
@@ -570,6 +571,12 @@ function ApprovalCard({
   askerNames: Map<string, string>;
   /** The verdict this card is waiting on, or `null` when it is idle (#373). */
   deciding: Verdict | null;
+  /**
+   * This card's 1-based position within its turn's batch — the numerator of
+   * "N of M from the same turn" (#1289). `1` is the default for an approval
+   * with no batch, where the line is not shown at all.
+   */
+  batchIndex: number;
   /**
    * How many rows this turn's batch still has waiting, including this one
    * (#842). `1` — the default for an approval with no batch — says nothing.
@@ -659,7 +666,7 @@ function ApprovalCard({
                   // here, on its own, and pointing at the others would imply a
                   // batch decision this page does not offer. The conversation's
                   // card is where one Approve covers all of them (#842).
-                  `1 of ${batchTotal} from the same turn`
+                  `${batchIndex} of ${batchTotal} from the same turn`
                 : undefined
           }
         />

--- a/frontend/test/unit/approval-batch-position.test.ts
+++ b/frontend/test/unit/approval-batch-position.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { batchPositions } from "@/lib/approval-wording";
+
+/**
+ * "N of M from the same turn" on the Approvals page (#1289).
+ *
+ * The line used to hardcode its numerator: every sibling of a batch read
+ * "1 of M", so a two-card turn showed two "1 of 2"s and never a "2 of 2".
+ * These pin the numerator to the card's real place in the batch, and pin index
+ * and total to one walk of one list so a focus-narrowed view cannot count them
+ * over different sets.
+ */
+
+type Row = { id: string; batch?: string | null };
+
+describe("batchPositions (#1289)", () => {
+  it("numbers each card 1..M within its turn's batch, not 1 every time", () => {
+    const rows: Row[] = [
+      { id: "a1", batch: "turn-1" },
+      { id: "a2", batch: "turn-1" },
+    ];
+
+    const pos = batchPositions(rows);
+
+    // The bug: both were "1 of 2". Now the second is "2 of 2".
+    expect(pos.get("a1")).toEqual({ index: 1, total: 2 });
+    expect(pos.get("a2")).toEqual({ index: 2, total: 2 });
+  });
+
+  it("counts each turn's batch independently and interleaved", () => {
+    const rows: Row[] = [
+      { id: "a1", batch: "turn-1" },
+      { id: "b1", batch: "turn-2" },
+      { id: "a2", batch: "turn-1" },
+      { id: "a3", batch: "turn-1" },
+      { id: "b2", batch: "turn-2" },
+    ];
+
+    const pos = batchPositions(rows);
+
+    expect(pos.get("a1")).toEqual({ index: 1, total: 3 });
+    expect(pos.get("a2")).toEqual({ index: 2, total: 3 });
+    expect(pos.get("a3")).toEqual({ index: 3, total: 3 });
+    expect(pos.get("b1")).toEqual({ index: 1, total: 2 });
+    expect(pos.get("b2")).toEqual({ index: 2, total: 2 });
+  });
+
+  it("omits approvals with no batch — their line is not shown", () => {
+    const rows: Row[] = [
+      { id: "solo" },
+      { id: "none", batch: null },
+      { id: "a1", batch: "turn-1" },
+    ];
+
+    const pos = batchPositions(rows);
+
+    expect(pos.has("solo")).toBe(false);
+    expect(pos.has("none")).toBe(false);
+    // A batch of one is still a real position — the caller only renders the
+    // line when total > 1, so a lone batched row carries { index: 1, total: 1 }.
+    expect(pos.get("a1")).toEqual({ index: 1, total: 1 });
+  });
+
+  it("index and total share the pending list, so both shrink together", () => {
+    // #842: the caller passes only what is still pending, so a decided sibling
+    // is simply absent — the survivors renumber over the smaller set rather
+    // than one half counting the decided row and the other not.
+    const afterOneDecided: Row[] = [
+      { id: "a2", batch: "turn-1" },
+      { id: "a3", batch: "turn-1" },
+    ];
+
+    const pos = batchPositions(afterOneDecided);
+
+    expect(pos.get("a2")).toEqual({ index: 1, total: 2 });
+    expect(pos.get("a3")).toEqual({ index: 2, total: 2 });
+  });
+});


### PR DESCRIPTION
## Summary

The Approvals page's "N of M from the same turn" line hardcoded its numerator to `1`, so every sibling of a same-turn batch read **"1 of M"** — a two-card turn showed two "1 of 2"s and never a "2 of 2" (screenshot in #1289). `batchTotal` was counted correctly; the card's ordinal was simply never computed.

This adds a pure helper `batchPositions(approvals)` (`frontend/src/lib/approval-wording.ts`) that walks the pending approvals once and returns each batched card's `{ index, total }` — both from the same walk of the same list, so a focus-narrowed view (#883) cannot count the position over a subset and the total over the whole and print a card as "1 of 5" when it is the third. `ApprovalsView` consumes it, replacing the two near-identical count loops and the literal `1` with `` `${batchIndex} of ${batchTotal} from the same turn` ``.

The existing intent is preserved: it stays a **count, not a link** — the row is still decided on its own here, and the total still counts only what is still pending (#842), so it shrinks as rows are decided.

Closes #1289.

## API Or Behavior Changes

Console-only. A batched approval card now shows its true position (`1 of 2`, `2 of 2`, …) instead of `1 of N` on every card. No API, wire-type, or decision-path change; single-card approvals are unaffected (the line only renders when the batch total > 1).

## Tests

Frontend-only change — the Rust boxes below are N/A. Run from `frontend/`:

- [x] `npm run typecheck` · `typecheck:unit` · `typecheck:e2e` — all green
- [x] `npx vitest run` — 1479/1479 across 157 files (new `approval-batch-position.test.ts`, +4)
- [x] `npm run build` — green
- [x] Red-proofed: forcing the numerator back to a literal `1` reds 3 of the 4 new cases
- [ ] `cargo fmt --all -- --check` — N/A (no Rust touched)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A
- [ ] `cargo build --all-targets` — N/A
- [ ] `cargo test` — N/A

## Documentation

None needed — the behaviour is self-evident in the label, and the rationale (one walk for both halves; count-not-link) lives in the helper's and the call site's doc comments.