### PR TITLE
feat(mcp): one Smithery key per company, so the directory has something to show (#1287)

### DIFF
--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -182,8 +182,10 @@ always on.
 
 * The **official registry** is always queried. Most of its entries declare no
   remote endpoint, so the hosted-transport filter discards them — correctly:
-  this deployment cannot launch a local subprocess. A live search for `slack`
-  fetched 17 entries and kept 0.
+  this deployment cannot launch a local subprocess. The survival rate is very
+  low: one live `slack` search fetched 17 entries and kept none; a second, paged
+  differently, kept one across three pages. Not literally empty, but far too
+  thin to look like a working directory.
 * **Smithery** carries the hosted servers (all 20 of its `slack` results report
   `isDeployed: true`) and upstream's `enabled_registries` adds it **only when a
   key resolves**.
@@ -215,6 +217,13 @@ intuitive guess and would leave an operator afraid to rotate.
 
 Resolved per call rather than held on `McpRuntime`, so an admin's rotation lands
 on the next search with no restart.
+
+**A bad key degrades, it does not break.** Upstream's `registry_search_with`
+treats a single registry's failure as a partial outage (`!any_ok` → empty
+catalogue, never `Err`), so a wrong or expired Smithery key still returns the
+official registry's rows rather than failing the search. Verified live against a
+local host with a deliberately invalid key: `200`, official rows still present,
+Smithery contributing nothing.
 
 ### Delete dispatches
 

--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -117,9 +117,14 @@ alias `…/company/…`). See [`server::ops::mcp`](../../src/server/ops/mcp.rs).
 | `POST` | `…/mcp/registry/{serverId}/disconnect` | Drop the live session, keeping the install. |
 | `PUT` | `…/mcp/registry/{serverId}/env` | Rotate an install's credentials (write-only). |
 | `DELETE` | `…/mcp/registry/{serverId}` | Uninstall. |
+| `GET` | `…/mcp/registry/credential` | The company's Smithery key status (never the key). |
+| `PUT` | `…/mcp/registry/credential` | Set / rotate / clear it (write-only, admin-only). |
 
 The `…/mcp/registry/…` routes are gated on the `mcp` feature and report
-`not_wired` without it, matching `…/oauth/start`. Every registry **mutation**
+`not_wired` without it, matching `…/oauth/start`. The two `…/credential` rows are
+the exception: the key is a secret slot and a console field, so they are always
+compiled — an unwired build still has to let an admin set the key a wired one
+will spend. Every registry **mutation**
 takes the admin guard: an install hands *every* teammate a new set of callable
 tools, so it settles what the company can reach. Browsing decides nothing and
 takes the ordinary company scope.
@@ -169,6 +174,47 @@ was none, and a `health` where the server has never been probed (a real probe
 wins, since it dials the way the agents' bridge tools do). `authConfigured` is
 the union. All four registry fields are omitted when absent, so a declared row's
 JSON is byte-identical to what it was before this existed.
+
+### The directory needs a credential to be worth browsing
+
+Issue #1287. Two upstream directories back the browse surface and only one is
+always on.
+
+* The **official registry** is always queried. Most of its entries declare no
+  remote endpoint, so the hosted-transport filter discards them — correctly:
+  this deployment cannot launch a local subprocess. A live search for `slack`
+  fetched 17 entries and kept 0.
+* **Smithery** carries the hosted servers (all 20 of its `slack` results report
+  `isDeployed: true`) and upstream's `enabled_registries` adds it **only when a
+  key resolves**.
+
+So with no key the surface works perfectly and has almost nothing to show, which
+reads on screen as a broken search.
+
+The key is **per company**, in that tenant's secret store under
+`smithery/api-key`, write-only, admin-set — [`company::smithery`](../../src/company/smithery.rs).
+Not a shared platform key: Smithery servers *connect* through the account, with
+per-server credentials configured on smithery.ai, so one platform-wide key would
+make one tenant's GitHub configuration every other tenant's, and pool usage onto
+one bill.
+
+**Two working tiers, reported apart.** The company's own key wins; failing that
+the host's `SMITHERY_API_KEY` (upstream's own fallback, and the self-hosting
+hatch). The second is one Smithery account shared by every company on the
+instance, so it is its own `source` value rather than folded into a boolean —
+`configured: true` would be true of both while hiding the sharing, and a
+`configured` meaning "its own" would read `false` for a company whose directory
+works. Those are the two halves of the issue #886 lie at once.
+
+**Discovery, not connection.** The key authenticates search, entry lookup and the
+fetch an install performs. It is *not* what an installed server connects with:
+`registry::connections::connect` dials the stored `deployment_url` and builds its
+auth from that server's own stored env row. Clearing the key stops new browsing
+and leaves running servers alone — worth stating, because the opposite is the
+intuitive guess and would leave an operator afraid to rotate.
+
+Resolved per call rather than held on `McpRuntime`, so an admin's rotation lands
+on the next search with no restart.
 
 ### Delete dispatches
 

--- a/frontend/src/api/mcp-registry.ts
+++ b/frontend/src/api/mcp-registry.ts
@@ -47,11 +47,52 @@ export interface McpCatalogueEntry {
   websiteUrl?: string;
 }
 
+/**
+ * Which Smithery key the host's directory calls present (issue #1287).
+ *
+ * - `company` — this company's own key.
+ * - `environment` — one key set for the whole host, so every company on it
+ *   browses through the same Smithery account. Working, and shared.
+ * - `none` — Smithery is not queried at all, so a search sees only the open
+ *   registry, whose hosted entries are few.
+ *
+ * Not a boolean on purpose: `configured` would either be true of both working
+ * tiers (hiding that one is shared) or false for a company whose directory
+ * works. Both are the #886 failure.
+ */
+export type McpDirectoryCredentialSource = "company" | "environment" | "none";
+
 /** A page of directory results. */
 export interface McpCatalogueSearch {
   servers: McpCatalogueEntry[];
   page: number;
   totalPages: number;
+  /**
+   * The tier this search presented. Rides on the search response rather than a
+   * second request, because the console needs it in the same moment it renders
+   * zero rows — and two fetches can land out of order and describe different
+   * states.
+   */
+  directoryCredential: McpDirectoryCredentialSource;
+}
+
+/** The directory credential's status. Never carries the key. */
+export interface McpDirectoryCredential {
+  /** Whether this company set its **own** key. False with a working host key. */
+  configured: boolean;
+  /** Which key a directory call presents right now. */
+  source: McpDirectoryCredentialSource;
+  /**
+   * What the tier means, worded by the host so the console cannot drift from
+   * what the host actually does. Rendered verbatim.
+   */
+  notice: string;
+}
+
+/** A mutating response: the resulting status plus a plain-language note. */
+export interface McpDirectoryCredentialMutation {
+  status: McpDirectoryCredential;
+  note: string;
 }
 
 /**
@@ -114,7 +155,16 @@ export function expectCatalogue(body: unknown): McpCatalogueSearch {
     servers: page.servers,
     page: typeof page.page === "number" ? page.page : 1,
     totalPages: typeof page.totalPages === "number" ? page.totalPages : 0,
+    // An unrecognised tier degrades to `none`, which only ever offers the
+    // operator MORE explanation than the truth. Guessing `company` from an
+    // unknown string would tell them their key is working when it may not be.
+    directoryCredential: directoryTier(page.directoryCredential),
   };
+}
+
+/** Narrows an unvalidated tier string; anything unknown reads as `none`. */
+function directoryTier(raw: unknown): McpDirectoryCredentialSource {
+  return raw === "company" || raw === "environment" ? raw : "none";
 }
 
 /** Browse the upstream directories. An empty `q` is the directory's own front page. */
@@ -219,5 +269,40 @@ export function uninstallMcpRegistryServer(
 ): Promise<void> {
   return client.del<void>(
     `${client.scopeFor(company)}/mcp/registry/${encodeURIComponent(serverId)}`,
+  );
+}
+
+/**
+ * The company's Smithery key status. Never carries the key.
+ *
+ * Unlike every other route in this module, this one is **not** behind the host's
+ * `mcp` feature: the credential is a secret slot, and an unwired build still has
+ * to let an admin set the key a wired one will spend. So it does not answer
+ * `not_wired` and callers need not classify it as an outage.
+ */
+export function getMcpDirectoryCredential(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<McpDirectoryCredential> {
+  return client.get<McpDirectoryCredential>(
+    `${client.scopeFor(company)}/mcp/registry/credential`,
+  );
+}
+
+/**
+ * Set / rotate / clear the company's Smithery key. A non-empty value sets or
+ * rotates it; an empty string clears it, falling back to whatever the host
+ * offers. Admin-only — a member gets a 403.
+ *
+ * Write-only: the key goes out and is never returned by any read.
+ */
+export function setMcpDirectoryCredential(
+  client: OpenCompanyClient,
+  company: string | null,
+  key: string,
+): Promise<McpDirectoryCredentialMutation> {
+  return client.put<McpDirectoryCredentialMutation>(
+    `${client.scopeFor(company)}/mcp/registry/credential`,
+    { key },
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1191,6 +1191,18 @@ export interface CapabilityStatusDto {
    */
   searchInBuild?: boolean;
   /** Whether a managed search credential is configured on this build (env-only). */
+  /**
+   * Which Smithery key the company's MCP **directory** browsing presents
+   * (issue #1287): `company` (its own), `environment` (one key set for the
+   * whole host and shared by every company on it), or `none` (Smithery is not
+   * queried, so the directory shows only the open registry's few hosted
+   * entries).
+   *
+   * Absent when the host could not determine it — an unknown answer is not
+   * `none`, and reporting a confident "no key" on a transient store failure
+   * would send an admin to paste one they already have.
+   */
+  mcpDirectoryCredential?: "company" | "environment" | "none";
   searchCredentialConfigured?: boolean;
   /** The company's daily `web_search` call ceiling. */
   searchDailyCallCap?: number;

--- a/frontend/src/lib/mcp-registry.ts
+++ b/frontend/src/lib/mcp-registry.ts
@@ -29,6 +29,7 @@
 
 import { ApiError } from "@/api/types";
 import type { McpHealth, McpServer, McpSource } from "@/api/types";
+import type { McpDirectoryCredentialSource } from "@/api/mcp-registry";
 
 /**
  * How a row is removed, if at all.
@@ -171,6 +172,33 @@ export function registryOutage(err: unknown): McpRegistryOutage {
 /** What the console says when the directory surface is missing from the build. */
 export const REGISTRY_UNWIRED_NOTICE =
   "Browsing the MCP directory isn't enabled in this build (the host was compiled without the MCP feature). The servers above still work.";
+
+/**
+ * What a zero-row search means, in the operator's terms (issue #1287).
+ *
+ * Zero rows has two causes and only one of them is theirs to fix. A real miss
+ * and an unqueried directory look identical on screen, and the honest surface is
+ * the one that names the difference — the earlier copy said "nothing matched",
+ * which read as a broken search on every tenant with no key.
+ *
+ * Deliberately does NOT scold the shared-host tier. `environment` is a working
+ * directory; the fact that it is one shared Smithery account belongs on the
+ * credential card where an operator can act on it, not on top of every empty
+ * search result.
+ */
+export function directoryEmptyNotice(tier: McpDirectoryCredentialSource): string {
+  if (tier === "none") {
+    return (
+      "No Smithery key is set, so only the open registry was searched — and nearly everything " +
+      "in it runs as a local subprocess this host can't launch. Add the company's Smithery key " +
+      "below to browse hosted servers."
+    );
+  }
+  return (
+    "No hosted servers matched that. The directory only offers servers this host can dial over " +
+    "HTTP — one that runs as a local subprocess is not listed."
+  );
+}
 
 /**
  * The declared env keys an install is still missing a value for.

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -303,6 +303,10 @@ export function UsageView({ client, company }: Props) {
             {/* Metered web search (issue #238): opt-in, managed-credential-gated,
                 and capped per day — its own status row like media/composio. */}
             {capsLoaded && caps ? <SearchStatusRow caps={caps} /> : null}
+            {/* The MCP directory's Smithery key (issue #1287): not metered and
+                not opt-in, but it decides whether browsing finds anything, and
+                this panel is where an operator checks what is configured. */}
+            {capsLoaded && caps ? <McpDirectoryStatusRow caps={caps} /> : null}
           </CardContent>
         </Card>
       </div>
@@ -437,6 +441,55 @@ function SearchStatusRow({ caps }: { caps: CapabilityStatusDto }) {
       </Badge>
     </div>
   );
+}
+
+/**
+ * The MCP directory's credential tier (issue #1287).
+ *
+ * Three states, not two. The shared-host tier is a *working* directory, so
+ * badging it "Awaiting credential" would be false; badging it "Active" would
+ * hide that every company on the instance browses through one Smithery account.
+ * It gets its own word.
+ */
+function McpDirectoryStatusRow({ caps }: { caps: CapabilityStatusDto }) {
+  const { label, variant } = mcpDirectoryStatus(caps);
+  return (
+    <div
+      className="flex items-center justify-between gap-3 border-t pt-4 text-sm"
+      data-testid="usage-mcp-directory"
+    >
+      <div className="space-y-0.5">
+        <span className="font-medium">MCP directory</span>
+        <p className="text-xs text-muted-foreground">
+          Browsing and installing MCP servers from Smithery. Without a key only the open registry
+          is searched, and nearly everything in it runs as a local subprocess this host cannot
+          launch. Servers already installed keep their own credentials and are unaffected.
+        </p>
+      </div>
+      <Badge variant={variant} className="shrink-0">
+        {label}
+      </Badge>
+    </div>
+  );
+}
+
+export function mcpDirectoryStatus(caps: CapabilityStatusDto): {
+  label: string;
+  variant: BadgeVariant;
+} {
+  switch (caps.mcpDirectoryCredential) {
+    case "company":
+      return { label: "Active", variant: "default" };
+    case "environment":
+      return { label: "Shared host key", variant: "secondary" };
+    case "none":
+      return { label: "Awaiting credential", variant: "destructive" };
+    default:
+      // Absent: the host could not determine it. "Unknown" is the only honest
+      // badge — claiming "Awaiting credential" would send an admin to paste a
+      // key they may already have.
+      return { label: "Unknown", variant: "outline" };
+  }
 }
 
 function searchStatus(caps: CapabilityStatusDto): { label: string; variant: BadgeVariant } {

--- a/frontend/src/views/connections/McpDirectoryCredentialCard.tsx
+++ b/frontend/src/views/connections/McpDirectoryCredentialCard.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { KeyRound, Loader2, Save, ShieldCheck, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  getMcpDirectoryCredential,
+  setMcpDirectoryCredential,
+  type McpDirectoryCredential,
+} from "@/api/mcp-registry";
+import { ApiError } from "@/api/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** Called after a successful write so the directory search re-runs. */
+  onChanged?: () => void;
+}
+
+/**
+ * The company's Smithery key — what decides whether the directory above has
+ * hosted servers to show (issue #1287).
+ *
+ * Sits inside the directory browser rather than beside the other credential
+ * cards, because it is not a general identity: it buys one specific thing an
+ * operator is looking straight at when they need it. The empty-search notice
+ * points down here in as many words.
+ *
+ * Write-only, like every credential the console handles: the key goes out on
+ * `PUT`, lands in the tenant's secret store and is never returned, so the field
+ * is always empty on load and "set" is reported by a flag rather than by a
+ * masked value we would have had to receive.
+ *
+ * Unlike the routes it sits under, this one is **not** behind the host's `mcp`
+ * feature, so it does not 404 on an unwired build and has no `unavailable`
+ * state to render.
+ */
+export function McpDirectoryCredentialCard({ client, company, onChanged }: Props) {
+  const [load, setLoad] = useState<"loading" | "ready" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<McpDirectoryCredential | null>(null);
+  const [key, setKey] = useState("");
+  const [busy, setBusy] = useState<"save" | "clear" | null>(null);
+
+  // Discards a response whose company is no longer the one on screen. Same
+  // guard, and the same reason, as `CompanyCredentialCard`: an admin who reads
+  // "set" for a company that in fact has no key will not set one.
+  const requestGeneration = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const generation = ++requestGeneration.current;
+    try {
+      const next = await getMcpDirectoryCredential(client, company);
+      if (generation !== requestGeneration.current) return;
+      setStatus(next);
+      setError(null);
+      setLoad("ready");
+    } catch (err) {
+      if (generation !== requestGeneration.current) return;
+      // Never swallowed into a "not set" state. The host answers 5xx when it
+      // cannot read the secret store, and painting "Not set" on that would send
+      // an operator to paste a key they already have.
+      setError(
+        err instanceof ApiError ? err.message : "Couldn't read the directory credential.",
+      );
+      setLoad("error");
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    setLoad("loading");
+    setKey("");
+    void refresh();
+  }, [refresh]);
+
+  async function write(value: string, mode: "save" | "clear") {
+    setBusy(mode);
+    const generation = ++requestGeneration.current;
+    try {
+      const result = await setMcpDirectoryCredential(client, company, value);
+      // Unconditional: the write landed, and an admin who navigated away is
+      // still owed that fact. What is conditional is the *state*, which
+      // describes the company that was on screen when the write began.
+      toast.success(mode === "save" ? "Smithery key saved." : "Smithery key cleared.", {
+        description: result.note,
+      });
+      if (generation !== requestGeneration.current) return;
+      setStatus(result.status);
+      setKey("");
+      onChanged?.();
+    } catch (err) {
+      // The host's own reason when it sent one — an admin-only refusal says
+      // something specific, and a generic "couldn't save" throws away the only
+      // actionable part.
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : mode === "save"
+            ? "Couldn't save the Smithery key."
+            : "Couldn't clear the Smithery key.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (load === "loading") return <Skeleton className="h-24 rounded-xl" />;
+
+  if (load === "error") {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="mcp-directory-credential-error">
+        {error ?? "Couldn't read the directory credential."} This is not the same as having none
+        set — the host could not answer, so the current key is unknown.
+      </p>
+    );
+  }
+
+  const configured = status?.configured === true;
+  // No company key, but the host carries one: the directory works, and it works
+  // through an account shared with every other company on this instance. Saying
+  // only "not set" would read as broken; saying only "set" would hide the
+  // sharing.
+  const sharedHostKey = !configured && status?.source === "environment";
+
+  return (
+    <section className="space-y-3 rounded-xl border border-border p-3" data-testid="mcp-directory-credential">
+      <div className="flex items-center gap-2">
+        <KeyRound className="size-4 text-muted-foreground" />
+        <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Smithery key
+        </h4>
+        {configured ? (
+          <span
+            className="inline-flex items-center gap-1 text-xs text-status-done-text"
+            data-testid="mcp-directory-credential-state"
+          >
+            <ShieldCheck className="size-3" /> Set for this company
+          </span>
+        ) : sharedHostKey ? (
+          <span className="text-xs text-muted-foreground" data-testid="mcp-directory-credential-state">
+            Using this host&apos;s shared key
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground" data-testid="mcp-directory-credential-state">
+            Not set
+          </span>
+        )}
+      </div>
+
+      {/* The host words the consequence, so the console cannot drift from what
+          the host actually does. */}
+      {status && (
+        <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+          {status.notice}
+        </p>
+      )}
+
+      <div className="space-y-1">
+        <Label htmlFor="mcp-directory-key" className="text-xs">
+          Smithery API key {configured ? "— set (paste a new value to rotate)" : ""}
+        </Label>
+        <Input
+          id="mcp-directory-key"
+          type="password"
+          autoComplete="off"
+          placeholder="paste this company's Smithery API key"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          disabled={busy !== null || !key.trim()}
+          onClick={() => void write(key.trim(), "save")}
+        >
+          {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+          {configured ? "Rotate key" : "Save key"}
+        </Button>
+        {configured && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={busy !== null}
+            onClick={() => void write("", "clear")}
+          >
+            {busy === "clear" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Trash2 className="size-4" />
+            )}
+            Clear
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/views/connections/McpRegistryBrowser.tsx
+++ b/frontend/src/views/connections/McpRegistryBrowser.tsx
@@ -9,15 +9,18 @@ import {
   searchMcpRegistry,
   type McpCatalogueDetail,
   type McpCatalogueEntry,
+  type McpDirectoryCredentialSource,
 } from "@/api/mcp-registry";
 import { ApiError } from "@/api/types";
 import {
+  directoryEmptyNotice,
   missingEnvKeys,
   REGISTRY_UNWIRED_NOTICE,
   registryOutage,
   type McpRegistryOutage,
 } from "@/lib/mcp-registry";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { McpDirectoryCredentialCard } from "@/views/connections/McpDirectoryCredentialCard";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,7 +33,14 @@ type Results =
   | { kind: "idle" }
   | { kind: "loading" }
   | { kind: "outage"; outage: McpRegistryOutage }
-  | { kind: "ready"; page: number; totalPages: number; servers: McpCatalogueEntry[] };
+  | {
+      kind: "ready";
+      page: number;
+      totalPages: number;
+      servers: McpCatalogueEntry[];
+      /** Which Smithery key this search presented (issue #1287). */
+      directoryCredential: McpDirectoryCredentialSource;
+    };
 
 /** The install dialog's state for the one entry an operator picked. */
 type Picked =
@@ -112,6 +122,7 @@ export function McpRegistryBrowser({ client, company, onInstalled }: Props) {
           page: found.page,
           totalPages: found.totalPages,
           servers: found.servers,
+          directoryCredential: found.directoryCredential,
         });
       } catch (err) {
         if (generation.current !== mine) return;
@@ -221,8 +232,7 @@ export function McpRegistryBrowser({ client, company, onInstalled }: Props) {
       {results.kind === "ready" &&
         (results.servers.length === 0 ? (
           <p className="text-sm text-muted-foreground" data-testid="mcp-registry-empty">
-            No hosted servers matched that. The directory only offers servers this host can dial
-            over HTTP — one that runs as a local subprocess is not listed.
+            {directoryEmptyNotice(results.directoryCredential)}
           </p>
         ) : (
           <>
@@ -293,6 +303,19 @@ export function McpRegistryBrowser({ client, company, onInstalled }: Props) {
             )}
           </>
         ))}
+
+      {/* The key that decides whether any of the above has hosted servers to
+          show (issue #1287). Below the results rather than above them: the
+          search box is what an operator came here for, and the empty-result
+          notice points down here in as many words when it is the thing standing
+          in their way. A save re-runs the current search, so setting the key
+          fills the list they are already looking at instead of leaving them to
+          guess it worked. */}
+      <McpDirectoryCredentialCard
+        client={client}
+        company={company}
+        onChanged={() => void runSearch(1)}
+      />
     </div>
   );
 }

--- a/frontend/test/unit/mcp-directory-credential.test.ts
+++ b/frontend/test/unit/mcp-directory-credential.test.ts
@@ -1,0 +1,97 @@
+// The MCP directory's Smithery credential (issue #1287).
+//
+// The whole point of these tests is that "the directory has nothing to show"
+// has two causes and only one of them is the operator's to fix. Every
+// assertion here is about keeping those two apart on screen.
+
+import { describe, expect, it } from "vitest";
+
+import { expectCatalogue } from "@/api/mcp-registry";
+import type { CapabilityStatusDto } from "@/api/types";
+import { directoryEmptyNotice } from "@/lib/mcp-registry";
+import { mcpDirectoryStatus } from "@/views/UsageView";
+
+describe("directoryEmptyNotice", () => {
+  it("names the missing key when nothing is set", () => {
+    const notice = directoryEmptyNotice("none");
+    expect(notice).toContain("No Smithery key is set");
+    // …and points at the fix, rather than leaving a dead end.
+    expect(notice).toContain("Add the company's Smithery key");
+  });
+
+  it("reports a real miss when a key IS working", () => {
+    for (const tier of ["company", "environment"] as const) {
+      const notice = directoryEmptyNotice(tier);
+      expect(notice).toContain("No hosted servers matched");
+      expect(notice).not.toContain("No Smithery key is set");
+    }
+  });
+
+  // The shared-host tier is a working directory. Scolding about it on top of
+  // every empty result would train an operator to ignore the notice, and the
+  // place to act on sharing is the credential card.
+  it("does not nag about the shared host key on an empty result", () => {
+    expect(directoryEmptyNotice("environment")).not.toContain("shared");
+  });
+});
+
+describe("expectCatalogue tier narrowing", () => {
+  const page = (directoryCredential: unknown) => ({
+    servers: [],
+    page: 1,
+    totalPages: 0,
+    directoryCredential,
+  });
+
+  it("keeps a recognised tier", () => {
+    expect(expectCatalogue(page("company")).directoryCredential).toBe("company");
+    expect(expectCatalogue(page("environment")).directoryCredential).toBe("environment");
+  });
+
+  // An unknown or missing tier degrades to `none`, which only ever offers MORE
+  // explanation than the truth. Guessing `company` would tell an operator their
+  // key is working when it may not be.
+  it("degrades an unknown or missing tier to none", () => {
+    expect(expectCatalogue(page("wat")).directoryCredential).toBe("none");
+    expect(expectCatalogue(page(undefined)).directoryCredential).toBe("none");
+    expect(expectCatalogue({ servers: [], page: 1, totalPages: 0 }).directoryCredential).toBe(
+      "none",
+    );
+  });
+});
+
+describe("mcpDirectoryStatus", () => {
+  const caps = (mcpDirectoryCredential?: "company" | "environment" | "none") =>
+    ({ configured: true, mcpDirectoryCredential }) as CapabilityStatusDto;
+
+  it("badges the company's own key as active", () => {
+    expect(mcpDirectoryStatus(caps("company"))).toEqual({
+      label: "Active",
+      variant: "default",
+    });
+  });
+
+  // Working, and shared. Neither "Active" nor "Awaiting credential" is true of
+  // it, so it gets its own word rather than being rounded to a neighbour.
+  it("gives the shared host key its own word", () => {
+    const status = mcpDirectoryStatus(caps("environment"));
+    expect(status.label).toBe("Shared host key");
+    expect(status.label).not.toBe("Active");
+    expect(status.variant).not.toBe("destructive");
+  });
+
+  it("badges a missing key as awaiting a credential", () => {
+    expect(mcpDirectoryStatus(caps("none"))).toEqual({
+      label: "Awaiting credential",
+      variant: "destructive",
+    });
+  });
+
+  // An absent field means the host could not determine the tier. Claiming
+  // "Awaiting credential" there would send an admin to paste a key they may
+  // already have — the #886 lie in the other direction.
+  it("says unknown when the host could not determine the tier", () => {
+    expect(mcpDirectoryStatus(caps()).label).toBe("Unknown");
+    expect(mcpDirectoryStatus(caps()).variant).not.toBe("destructive");
+  });
+});

--- a/frontend/test/unit/mcp-registry-degrade.test.ts
+++ b/frontend/test/unit/mcp-registry-degrade.test.ts
@@ -75,16 +75,25 @@ describe("registryOutage", () => {
  */
 describe("expectCatalogue", () => {
   it("passes a page through", () => {
-    const body = { servers: [{ qualifiedName: "@org/git" }], page: 2, totalPages: 7 };
+    const body = {
+      servers: [{ qualifiedName: "@org/git" }],
+      page: 2,
+      totalPages: 7,
+      directoryCredential: "company",
+    };
 
     expect(expectCatalogue(body)).toEqual(body);
   });
 
+  // A page from a host that predates issue #1287 carries no tier. It reads as
+  // `none`, which only ever offers the operator more explanation than the
+  // truth — never a claim that a key is working.
   it("accepts an empty page — a directory with no matches is not a failure", () => {
     expect(expectCatalogue({ servers: [], page: 1, totalPages: 0 })).toEqual({
       servers: [],
       page: 1,
       totalPages: 0,
+      directoryCredential: "none",
     });
   });
 

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -64,6 +64,11 @@ pub mod runtime;
 // inference credential still gets a real team.
 pub mod setup;
 mod skill_file;
+// The company's Smithery directory credential (issue #1287): the key that
+// decides whether the MCP directory has hosted servers to show. Always compiled
+// — the console must be able to manage it in a build with no `mcp` feature, the
+// same way it manages the Composio token without the harness.
+pub mod smithery;
 // Steer (issue #111): pause / cancel / redirect an in-flight task or delegation
 // from the operator chat. Always compiled + openhuman-free so the operator
 // control plane can steer in any build and no agent tool can ever reach it.

--- a/src/company/smithery.rs
+++ b/src/company/smithery.rs
@@ -1,0 +1,202 @@
+//! The company's own Smithery directory credential (issue #1287) — the key that
+//! decides whether the MCP directory has anything to show.
+//!
+//! ## Why a credential decides whether a search returns rows
+//!
+//! Two upstream directories back the browse surface shipped in #1270. The
+//! official `modelcontextprotocol/registry` is always queried, and most of its
+//! entries declare no remote endpoint, so the hosted-transport filter discards
+//! them — correctly, since this deployment cannot launch a local subprocess.
+//! Smithery.ai is the directory that actually carries hosted servers, and
+//! upstream's `enabled_registries` adds it **only when a key resolves**. With no
+//! key the browse surface works perfectly and has almost nothing to show, which
+//! reads on screen as a broken search rather than a missing credential.
+//!
+//! ## Scope: discovery, not connection
+//!
+//! This key authenticates the *directory* calls — search, entry lookup, and the
+//! fetch an install performs. It is **not** what an installed server connects
+//! with: `registry::connections::connect` dials the stored `deployment_url` and
+//! builds its auth from that server's own stored env row (the headers declared
+//! by the entry, or a captured OAuth token). So clearing this key stops new
+//! discovery; it does not break servers already installed through it. Worth
+//! stating because the opposite is the intuitive guess, and it would make the
+//! clear action look far more destructive than it is.
+//!
+//! ## Precedence, and why the two tiers are reported apart
+//!
+//! 1. **The company's own key**, stored here under [`API_KEY_KEY`] — set,
+//!    rotated and cleared by an admin through the console, write-only.
+//! 2. **[`API_KEY_ENV`]** on the host process — the self-hosting escape hatch,
+//!    and upstream's own fallback.
+//! 3. Nothing, in which case Smithery is not queried at all.
+//!
+//! Tier 2 is deliberately surfaced as its own [`DirectoryKeySource`] rather than
+//! folded into a `configured: true` boolean. A host process serves **every**
+//! company on it, so an env key is one Smithery account shared by all of them —
+//! a materially different answer from "this company has its own", and the
+//! console has to be able to say which. Collapsing the two is precisely the
+//! failure issue #886 was filed about on Composio, where the panel reported no
+//! credential while agents were making authenticated calls in the same session.
+//!
+//! ## Write-only, and read live
+//!
+//! The value never leaves over any read route — [`resolve`] is called by the
+//! routes that *use* it, and the status shape carries only a tier name. It is
+//! read from the [`SecretStore`] on every directory call rather than cached at
+//! boot, so a console set / rotate / clear takes effect on the next search with
+//! no restart.
+
+use crate::Result;
+use crate::app::config::EnvSource;
+use crate::ports::SecretStore;
+use crate::ports::types::{CompanyId, SecretValue};
+
+/// The canonical per-company Smithery credential key. Write-only via the
+/// console; the value is the raw API key string.
+///
+/// Namespaced `smithery/` for the same reason
+/// [`company_key::KEY_KEY`](crate::company::company_key::KEY_KEY) is namespaced
+/// `tinyhumans/`: it is one vendor's credential, not "the MCP key", and a second
+/// directory arriving later must not have to share this slot.
+pub const API_KEY_KEY: &str = "smithery/api-key";
+
+/// The host-wide Smithery key environment variable. Upstream's own fallback
+/// (`registries::smithery::smithery_api_key` reads it directly), kept here so
+/// this module can *report* the tier rather than let it resolve invisibly one
+/// layer down.
+pub const API_KEY_ENV: &str = "SMITHERY_API_KEY";
+
+/// Which Smithery credential this company's directory calls present.
+///
+/// The wire spelling is the enum name lowercased and is part of the console
+/// contract — the browse surface branches on it to tell "no key, so the hosted
+/// directory is off" apart from "searched fine, nothing matched".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DirectoryKeySource {
+    /// This company's own key. What setting one buys.
+    Company,
+    /// The host process's [`API_KEY_ENV`], shared by every company on this
+    /// instance. Works, and is honest about being one shared account.
+    Environment,
+    /// No key resolves, so Smithery is not queried and the directory is limited
+    /// to the official registry's hosted entries.
+    None,
+}
+
+impl DirectoryKeySource {
+    /// The stable wire spelling (`company` / `environment` / `none`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Company => "company",
+            Self::Environment => "environment",
+            Self::None => "none",
+        }
+    }
+
+    /// Whether *some* key resolves, whichever tier answered.
+    pub fn configured(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// The resolved directory credential: the value to hand upstream, and the tier
+/// that produced it.
+///
+/// The value is `Some` exactly when [`source`](Self::source) is not
+/// [`DirectoryKeySource::None`] — the two cannot disagree, because both come out
+/// of the same match in [`resolve`].
+#[derive(Debug, Clone)]
+pub struct DirectoryKey {
+    value: Option<String>,
+    source: DirectoryKeySource,
+}
+
+impl DirectoryKey {
+    /// The tier that answered. Safe on any read plane — a name, never a secret.
+    pub fn source(&self) -> DirectoryKeySource {
+        self.source
+    }
+
+    /// The key itself, for handing to the upstream registry config. **Never**
+    /// serialise this: it is the credential.
+    pub fn value(&self) -> Option<&str> {
+        self.value.as_deref()
+    }
+
+    /// Consumes into the owned key, for the upstream `Config` field.
+    pub fn into_value(self) -> Option<String> {
+        self.value
+    }
+}
+
+/// Store (or rotate / clear) the company's Smithery key. A non-empty value sets
+/// or rotates it; an empty string clears it, falling back to whatever the host
+/// environment offers. Write-only — never read back over the API.
+pub async fn store_key(company: &CompanyId, secrets: &dyn SecretStore, key: &str) -> Result<()> {
+    secrets
+        .set(company, API_KEY_KEY, SecretValue(key.trim().to_string()))
+        .await
+}
+
+/// Whether a non-empty key is stored in **this company's own** slot — never the
+/// key itself, and never the environment tier.
+///
+/// This answers "did this company set one", not "will the directory work". For
+/// the latter ask [`resolve`] and read its [`DirectoryKeySource`]; a host with
+/// [`API_KEY_ENV`] set has a working directory and `false` here.
+pub async fn key_configured(company: &CompanyId, secrets: &dyn SecretStore) -> Result<bool> {
+    Ok(company_key(company, secrets).await?.is_some())
+}
+
+/// This company's own stored key, trimmed, `None` when unset or blank.
+async fn company_key(company: &CompanyId, secrets: &dyn SecretStore) -> Result<Option<String>> {
+    Ok(secrets
+        .get(company, API_KEY_KEY)
+        .await?
+        .map(|SecretValue(key)| key.trim().to_string())
+        .filter(|key| !key.is_empty()))
+}
+
+/// The Smithery credential this company's directory calls present — **the** seam.
+///
+/// The company's own key wins; failing that the host's [`API_KEY_ENV`]; failing
+/// that nothing. Every directory call resolves through here so the tier the
+/// console reports cannot drift from the key the search actually sent.
+///
+/// ## Why a store error propagates
+///
+/// Mapping an unreadable store to "no key" would silently downgrade a company
+/// that **has** its own key onto the host's shared one — a different Smithery
+/// account, and the same class of misattribution
+/// [`company_key::resolve`](crate::company::company_key::resolve) refuses for
+/// the same reason. A failed read is not an answer.
+/// `env` is `+ Sync` because this future is held across an await inside an axum
+/// handler, and a bare `&dyn EnvSource` would make it `!Send`. Every real
+/// implementor already satisfies it.
+pub async fn resolve(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    env: &(dyn EnvSource + Sync),
+) -> Result<DirectoryKey> {
+    if let Some(key) = company_key(company, secrets).await? {
+        return Ok(DirectoryKey {
+            value: Some(key),
+            source: DirectoryKeySource::Company,
+        });
+    }
+    Ok(match env.get(API_KEY_ENV).map(|k| k.trim().to_string()) {
+        Some(key) if !key.is_empty() => DirectoryKey {
+            value: Some(key),
+            source: DirectoryKeySource::Environment,
+        },
+        _ => DirectoryKey {
+            value: None,
+            source: DirectoryKeySource::None,
+        },
+    })
+}
+
+#[cfg(test)]
+mod test;

--- a/src/company/smithery/test.rs
+++ b/src/company/smithery/test.rs
@@ -1,0 +1,191 @@
+//! Tests for the company's Smithery directory credential (issue #1287).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::app::config::MapEnv;
+
+#[derive(Default)]
+struct MemSecrets {
+    map: Mutex<HashMap<String, String>>,
+}
+
+#[async_trait]
+impl SecretStore for MemSecrets {
+    async fn get(&self, _c: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+        Ok(self
+            .map
+            .lock()
+            .unwrap()
+            .get(key)
+            .map(|v| SecretValue(v.clone())))
+    }
+    async fn set(&self, _c: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+        self.map.lock().unwrap().insert(key.to_string(), value.0);
+        Ok(())
+    }
+}
+
+/// A store whose reads always fail — the transient-hiccup case.
+struct BrokenSecrets;
+
+#[async_trait]
+impl SecretStore for BrokenSecrets {
+    async fn get(&self, _c: &CompanyId, _key: &str) -> Result<Option<SecretValue>> {
+        Err(crate::error::OpenCompanyError::Store("boom".into()))
+    }
+    async fn set(&self, _c: &CompanyId, _key: &str, _value: SecretValue) -> Result<()> {
+        Err(crate::error::OpenCompanyError::Store("boom".into()))
+    }
+}
+
+fn empty_env() -> MapEnv {
+    MapEnv::default()
+}
+
+fn host_env(key: &str) -> MapEnv {
+    MapEnv::new([(API_KEY_ENV, key)])
+}
+
+#[tokio::test]
+async fn the_company_key_outranks_the_host_environment() {
+    let company = CompanyId::new("acme");
+    let secrets = MemSecrets::default();
+    store_key(&company, &secrets, "company-key").await.unwrap();
+
+    let resolved = resolve(&company, &secrets, &host_env("host-key"))
+        .await
+        .unwrap();
+
+    assert_eq!(resolved.source(), DirectoryKeySource::Company);
+    assert_eq!(resolved.value(), Some("company-key"));
+}
+
+#[tokio::test]
+async fn the_host_environment_answers_when_the_company_set_nothing() {
+    let company = CompanyId::new("acme");
+    let secrets = MemSecrets::default();
+
+    let resolved = resolve(&company, &secrets, &host_env("host-key"))
+        .await
+        .unwrap();
+
+    assert_eq!(resolved.source(), DirectoryKeySource::Environment);
+    assert_eq!(resolved.value(), Some("host-key"));
+}
+
+#[tokio::test]
+async fn nothing_anywhere_resolves_to_none_with_no_value() {
+    let company = CompanyId::new("acme");
+    let secrets = MemSecrets::default();
+
+    let resolved = resolve(&company, &secrets, &empty_env()).await.unwrap();
+
+    assert_eq!(resolved.source(), DirectoryKeySource::None);
+    assert_eq!(resolved.value(), None);
+    assert!(!resolved.source().configured());
+}
+
+/// The host tier is a *different answer*, not a shade of the same one: one
+/// Smithery account shared by every company on the instance. A console that
+/// cannot tell the two apart repeats the #886 failure, so the tier must survive
+/// as its own value rather than collapsing into a boolean.
+#[tokio::test]
+async fn the_two_working_tiers_stay_distinguishable() {
+    let company = CompanyId::new("acme");
+    let mine = MemSecrets::default();
+    store_key(&company, &mine, "company-key").await.unwrap();
+    let theirs = MemSecrets::default();
+
+    let own = resolve(&company, &mine, &empty_env()).await.unwrap();
+    let shared = resolve(&company, &theirs, &host_env("host-key"))
+        .await
+        .unwrap();
+
+    assert!(own.source().configured());
+    assert!(shared.source().configured());
+    assert_ne!(own.source(), shared.source());
+    assert_eq!(own.source().as_str(), "company");
+    assert_eq!(shared.source().as_str(), "environment");
+}
+
+/// A cleared key must fall through to the host tier rather than pinning the
+/// company to "no directory" — clearing withdraws *this company's* key, it does
+/// not opt the company out of a host that has one.
+#[tokio::test]
+async fn clearing_falls_through_to_the_host_environment() {
+    let company = CompanyId::new("acme");
+    let secrets = MemSecrets::default();
+    store_key(&company, &secrets, "company-key").await.unwrap();
+    store_key(&company, &secrets, "").await.unwrap();
+
+    assert!(!key_configured(&company, &secrets).await.unwrap());
+    let resolved = resolve(&company, &secrets, &host_env("host-key"))
+        .await
+        .unwrap();
+    assert_eq!(resolved.source(), DirectoryKeySource::Environment);
+}
+
+/// Whitespace is not a credential. A field submitted with spaces in it clears,
+/// and never resolves as a key that would authenticate nothing and report
+/// `company`.
+#[tokio::test]
+async fn a_blank_stored_value_is_not_a_credential() {
+    let company = CompanyId::new("acme");
+    let secrets = MemSecrets::default();
+    store_key(&company, &secrets, "   ").await.unwrap();
+
+    assert!(!key_configured(&company, &secrets).await.unwrap());
+    assert_eq!(
+        resolve(&company, &secrets, &empty_env())
+            .await
+            .unwrap()
+            .source(),
+        DirectoryKeySource::None
+    );
+}
+
+/// A stored key is trimmed on the way in, so a pasted value with a trailing
+/// newline still authenticates.
+#[tokio::test]
+async fn a_pasted_key_is_trimmed() {
+    let company = CompanyId::new("acme");
+    let secrets = MemSecrets::default();
+    store_key(&company, &secrets, "  key-with-space\n")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resolve(&company, &secrets, &empty_env())
+            .await
+            .unwrap()
+            .value(),
+        Some("key-with-space")
+    );
+}
+
+/// An unreadable store is not "no key". Degrading to the host tier here would
+/// send a *different Smithery account's* credential on behalf of a company that
+/// has its own.
+#[tokio::test]
+async fn an_unreadable_store_propagates_rather_than_downgrading() {
+    let company = CompanyId::new("acme");
+
+    assert!(
+        resolve(&company, &BrokenSecrets, &host_env("host-key"))
+            .await
+            .is_err()
+    );
+    assert!(key_configured(&company, &BrokenSecrets).await.is_err());
+}
+
+/// The env var name is upstream's own (`registries::smithery::smithery_api_key`
+/// reads it directly). If this drifts, our reported tier and the key upstream
+/// actually finds stop agreeing.
+#[test]
+fn the_env_var_matches_the_name_upstream_reads() {
+    assert_eq!(API_KEY_ENV, "SMITHERY_API_KEY");
+}

--- a/src/harness/built_in/mcp.rs
+++ b/src/harness/built_in/mcp.rs
@@ -552,6 +552,27 @@ impl McpRuntime {
         Self { config }
     }
 
+    /// This runtime's config with the company's Smithery key applied, for the
+    /// three calls that reach an upstream **directory** (issue #1287).
+    ///
+    /// Per call, not stored on the runtime, and that is the point: the key lives
+    /// in the tenant's secret store and an admin can rotate it from the console
+    /// at any moment. A copy cached here at construction would keep serving the
+    /// previous key until the company runtime was rebuilt, so a rotation would
+    /// appear to do nothing.
+    ///
+    /// `None` leaves the field unset, which is not the same as disabling
+    /// Smithery by hand: upstream's `smithery_api_key` then falls back to the
+    /// host's `SMITHERY_API_KEY`, exactly the tier
+    /// [`smithery::resolve`](crate::company::smithery::resolve) reports as
+    /// `environment`. Passing the resolved value straight through keeps one
+    /// precedence chain rather than two that can disagree.
+    fn directory_config(&self, smithery_key: Option<String>) -> oh::config::Config {
+        let mut config = self.config.clone();
+        config.mcp_client.registry_auth.smithery_api_key = smithery_key;
+        config
+    }
+
     /// Search the upstream MCP directories — Smithery.ai and the official
     /// `modelcontextprotocol/registry` — merged, paged, and SQLite-cached
     /// upstream (issue #1270).
@@ -564,12 +585,13 @@ impl McpRuntime {
     /// as a parameter — see that constant for why.
     pub async fn search(
         &self,
+        smithery_key: Option<String>,
         query: Option<String>,
         page: Option<u32>,
         page_size: Option<u32>,
     ) -> crate::Result<serde_json::Value> {
         oh::mcp::registry::ops::mcp_clients_registry_search(
-            &self.config,
+            &self.directory_config(smithery_key),
             query,
             Some(HOSTED_TRANSPORT.to_string()),
             page,
@@ -581,11 +603,18 @@ impl McpRuntime {
     }
 
     /// One directory entry in full, routed back to the registry it came from.
-    pub async fn registry_get(&self, qualified_name: String) -> crate::Result<serde_json::Value> {
-        oh::mcp::registry::ops::mcp_clients_registry_get(&self.config, qualified_name)
-            .await
-            .map(|outcome| outcome.value)
-            .map_err(|e| OpenCompanyError::Harness(format!("mcp registry lookup failed: {e}")))
+    pub async fn registry_get(
+        &self,
+        smithery_key: Option<String>,
+        qualified_name: String,
+    ) -> crate::Result<serde_json::Value> {
+        oh::mcp::registry::ops::mcp_clients_registry_get(
+            &self.directory_config(smithery_key),
+            qualified_name,
+        )
+        .await
+        .map(|outcome| outcome.value)
+        .map_err(|e| OpenCompanyError::Harness(format!("mcp registry lookup failed: {e}")))
     }
 
     /// Installs a directory entry by qualified name and returns the resulting
@@ -603,11 +632,12 @@ impl McpRuntime {
     /// that was already on disk is left alone, since it is not ours to remove.
     pub async fn install_from_directory(
         &self,
+        smithery_key: Option<String>,
         qualified_name: String,
         env: HashMap<String, String>,
     ) -> crate::Result<InstalledServer> {
         let outcome = oh::mcp::registry::ops::mcp_clients_install(
-            &self.config,
+            &self.directory_config(smithery_key),
             qualified_name.clone(),
             env,
             None,

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use crate::AppState;
 use crate::company::credentials::{CredentialSource, TinyhumansTokenSource};
 use crate::company::runtime::CompanyRuntime;
+use crate::company::smithery::DirectoryKeySource;
 use crate::metering::capability::{CapabilityPlan, tokens_in};
 use crate::ports::now_millis;
 use crate::server::error::ApiError;
@@ -119,6 +120,23 @@ struct CapabilityStatusDto {
     /// transient store hiccup is the same class of lie #886 is about.
     #[serde(skip_serializing_if = "Option::is_none")]
     composio_credential_source: Option<CredentialSource>,
+    /// Which Smithery credential this company's MCP **directory** browsing
+    /// presents (issue #1287) — `company` (its own key), `environment` (one key
+    /// set for the whole host and shared by every company on it), or `none`
+    /// (Smithery is not queried, so the directory shows only the open registry's
+    /// hosted entries, which is very little).
+    ///
+    /// A tier and not a boolean, deliberately. `configured: true` would be true
+    /// of both working tiers while hiding that one of them is a shared account,
+    /// and a `configured` that meant "its own" would read `false` for a company
+    /// whose directory works — the two halves of the #886 lie at once. Anything
+    /// boolean the console needs is derivable from this; a second field would
+    /// only be a copy that can drift.
+    ///
+    /// Omitted when there is no company record to resolve for, or when the
+    /// secret store could not be read — an unknown answer is not `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcp_directory_credential: Option<DirectoryKeySource>,
     /// Metered web search (issue #238): whether this company **explicitly**
     /// grants the `search` namespace (a `*` wildcard does NOT count).
     search_granted: bool,
@@ -207,6 +225,11 @@ struct OptInFlags {
     /// lies to every company that has one — the failure the issue #567 test
     /// below exists to catch.
     composio_credential_source: Option<CredentialSource>,
+    /// The resolved Smithery directory tier (issue #1287), or `None` when it
+    /// could not be determined. On the flags for the same reason the Composio
+    /// tier is: the DTO is built in two places and a field wired into one of
+    /// them lies to every company that has a plan.
+    mcp_directory_credential: Option<DirectoryKeySource>,
     search_granted: bool,
     search_daily_call_cap: u32,
     repo_granted: bool,
@@ -224,6 +247,9 @@ impl OptInFlags {
             // there is no company record to resolve a credential for, which is
             // not the same answer as "no credential resolves".
             composio_credential_source: None,
+            // Likewise undetermined rather than `Some(None)`: no record means
+            // no secret store to ask.
+            mcp_directory_credential: None,
             search_granted: false,
             search_daily_call_cap: crate::company::DEFAULT_SEARCH_DAILY_CALLS,
             repo_granted: false,
@@ -251,6 +277,7 @@ fn unconfigured(flags: OptInFlags) -> CapabilityStatusDto {
         chargebee_in_build: cfg!(feature = "chargebee"),
         composio_token_configured: flags.composio_token_configured,
         composio_credential_source: flags.composio_credential_source,
+        mcp_directory_credential: flags.mcp_directory_credential,
         search_granted: flags.search_granted,
         search_in_build: cfg!(feature = "openhuman"),
         search_credential_configured: search_credential_configured(),
@@ -381,6 +408,19 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
                 .map(std::sync::Arc::new),
         )
         .await,
+        // Issue #1287: which Smithery key the MCP directory browses with. Read
+        // through the resolver rather than a second copy of its precedence, so
+        // this panel cannot name a tier different from the one a search sent.
+        // A store error yields `None` (undetermined) rather than failing the
+        // whole /capabilities response, matching the Composio probe above.
+        mcp_directory_credential: crate::company::smithery::resolve(
+            runtime.id(),
+            runtime.secrets().as_ref(),
+            &crate::app::config::ProcessEnv,
+        )
+        .await
+        .ok()
+        .map(|key| key.source()),
         // Issue #238: search is opt-in per tool grant like media/composio, and
         // its daily cap lives on `[tools]` rather than `[plan]` — a call
         // ceiling, not a token budget — so both travel with the plan-independent
@@ -450,6 +490,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
         chargebee_in_build: cfg!(feature = "chargebee"),
         composio_token_configured: flags.composio_token_configured,
         composio_credential_source: flags.composio_credential_source,
+        mcp_directory_credential: flags.mcp_directory_credential,
         search_granted: flags.search_granted,
         search_in_build: cfg!(feature = "openhuman"),
         search_credential_configured: search_credential_configured(),
@@ -1044,6 +1085,43 @@ mod tests {
             assert_eq!(
                 dto["composioCredentialSource"], "static",
                 "and a pasted token is the `static` tier: {dto}"
+            );
+        }
+    }
+
+    /// Issue #1287: both DTO construction sites carry the directory tier, and
+    /// it tracks the key that is actually set.
+    ///
+    /// Same #567 precedent as the test above — a field wired into one branch
+    /// alone tells the truth to a company with no plan and lies to every company
+    /// that has one, which is exactly the shape that makes such a bug survive
+    /// review.
+    #[tokio::test]
+    async fn both_response_paths_carry_the_mcp_directory_tier() {
+        use crate::company::smithery;
+
+        for manifest in [
+            GRANTS_COMPOSIO,
+            &format!("{GRANTS_COMPOSIO}[plan]\nname = \"starter\"\n"),
+        ] {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let state = state_with_manifest(&home, manifest).await;
+            let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+            let (_, dto) = get_capabilities(&state).await;
+            assert_eq!(
+                dto["mcpDirectoryCredential"], "none",
+                "nothing set anywhere, so the directory has only the open registry: {dto}"
+            );
+
+            smithery::store_key(runtime.id(), runtime.secrets().as_ref(), "smithery_key")
+                .await
+                .unwrap();
+            let (_, dto) = get_capabilities(&state).await;
+            assert_eq!(
+                dto["mcpDirectoryCredential"], "company",
+                "the company's own key is its own tier, not a shared one: {dto}"
             );
         }
     }

--- a/src/server/ops/mcp_registry.rs
+++ b/src/server/ops/mcp_registry.rs
@@ -74,6 +74,7 @@ pub(super) fn router() -> Router<AppState> {
         ))
         .merge(scoped("/mcp/registry/{server_id}/env", put(update_env)))
         .merge(scoped("/mcp/registry/{server_id}", delete(uninstall)))
+        .merge(credential::router())
 }
 
 // ---------------------------------------------------------------------------
@@ -382,6 +383,11 @@ pub(super) fn removal_for(had_index_entry: bool, backed_by_install: bool) -> Rem
 /// directory payload, and a build without `mcp` has no directory to project.
 #[cfg(any(feature = "mcp", test))]
 pub(in crate::server::ops) mod catalogue;
+
+/// The company's Smithery key (issue #1287). **Always** compiled, unlike the
+/// routes above it: the credential is a secret slot and a console field, and an
+/// unwired build still has to let an admin set the key a wired one will spend.
+mod credential;
 
 #[cfg(feature = "mcp")]
 mod wired;

--- a/src/server/ops/mcp_registry/catalogue.rs
+++ b/src/server/ops/mcp_registry/catalogue.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::company::mcp::{McpHealth, McpStatus, stdio_install_refusal};
+use crate::company::smithery::DirectoryKeySource;
 
 // ---------------------------------------------------------------------------
 // Connection state → health — always compiled
@@ -121,6 +122,14 @@ pub(in crate::server::ops) struct CatalogueSearchDto {
     pub(in crate::server::ops) servers: Vec<CatalogueEntryDto>,
     pub(in crate::server::ops) page: u32,
     pub(in crate::server::ops) total_pages: u32,
+    /// Which Smithery credential the search presented (issue #1287).
+    ///
+    /// Set by the route, not by this projection — the raw payload upstream
+    /// returns cannot know it. It rides on the search response rather than
+    /// forcing a second request because the console needs it in exactly the
+    /// moment it renders zero rows, and a separate fetch would let the two
+    /// answers arrive out of order and describe different states.
+    pub(in crate::server::ops) directory_credential: DirectoryKeySource,
 }
 
 /// One directory entry in full, with the install decision already made.
@@ -189,6 +198,9 @@ pub(in crate::server::ops) fn catalogue_search(raw: &Value) -> CatalogueSearchDt
         servers,
         page: raw.get("page").and_then(Value::as_u64).unwrap_or(1) as u32,
         total_pages: raw.get("total_pages").and_then(Value::as_u64).unwrap_or(0) as u32,
+        // Not knowable from the payload; the route overwrites it. `None` is the
+        // safe default: it never claims a credential that was not presented.
+        directory_credential: DirectoryKeySource::None,
     }
 }
 

--- a/src/server/ops/mcp_registry/credential.rs
+++ b/src/server/ops/mcp_registry/credential.rs
@@ -1,0 +1,181 @@
+//! The company's Smithery directory credential, read and written (issue #1287).
+//!
+//! Always compiled, unlike the rest of this module's routes. The credential is a
+//! secret-store slot and a console field; neither needs the `mcp` feature, and a
+//! build without it still has to let an admin set the key that a later build
+//! with it will use. This mirrors [`ops::composio`](crate::server::ops::composio),
+//! whose token plane is likewise always present while the tools that spend it
+//! are gated.
+//!
+//! ## Authority
+//!
+//! Writes take [`AdminScopedCompany`], reads take [`ScopedCompany`] — the same
+//! split every other company credential uses. Setting this key decides which
+//! Smithery account the company's directory calls are billed to and attributed
+//! to, which is an owner's decision; knowing *whether* one is set is what lets a
+//! member understand why the directory is thin, and carries nothing secret.
+//!
+//! ## What it does and does not reach
+//!
+//! Discovery only. See [`company::smithery`](crate::company::smithery) — an
+//! installed server connects with its own stored credentials, so clearing this
+//! key stops new browsing and leaves running servers alone. The notices below
+//! say so, because the opposite is the natural guess and would make an operator
+//! afraid to rotate.
+
+use axum::Json;
+use axum::Router;
+use axum::routing::get;
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::runtime::CompanyRuntime;
+use crate::company::smithery::{DirectoryKeySource, key_configured, resolve, store_key};
+use crate::ports::types::CompanyEvent;
+use crate::server::error::ApiError;
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
+
+/// Said when this company has its own key, or could set one.
+const CONSEQUENCE: &str = "This key is what lets the MCP directory show hosted servers. Without \
+     one only the open registry is searched, and almost everything in it runs as a local \
+     subprocess this host cannot launch — so the browse list comes back nearly empty. It is used \
+     for browsing and installing only: servers already installed keep their own credentials, so \
+     rotating or clearing this does not disconnect them.";
+
+/// Said when no company key is set but the host process carries one.
+const SHARED: &str = "The MCP directory is working on a key set for this whole host, so every \
+     company on it browses through the same Smithery account. Set this company's own key to \
+     browse under its own account instead.";
+
+/// Said when nothing resolves anywhere — the honest degraded state.
+const DEGRADED: &str = "No Smithery key is set, so the MCP directory searches only the open \
+     registry and will show very few servers. Add this company's Smithery key to browse the \
+     hosted ones.";
+
+/// Returned after a write: what changes, and when.
+const SWITCH_NOTE: &str = "Saved. The next directory search uses it — nothing needs restarting.";
+
+/// Builds the directory-credential route fragment.
+pub(super) fn router() -> Router<AppState> {
+    scoped("/mcp/registry/credential", get(get_status).put(set_key))
+}
+
+/// The directory credential as the console renders it. **Never** carries the key.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DirectoryCredentialDto {
+    /// Whether this company has its **own** key stored. `false` does not mean
+    /// the directory is off — read `source`.
+    configured: bool,
+    /// Which key a directory call presents: `company`, `environment` (one shared
+    /// by every company on this host), or `none`.
+    source: DirectoryKeySource,
+    /// The consequence, stated plainly, or the degraded state. Worded by the
+    /// host so the console cannot drift from what the host actually does.
+    notice: String,
+}
+
+/// A mutating response: the resulting status plus the switch reminder.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MutationResponse {
+    status: DirectoryCredentialDto,
+    note: String,
+}
+
+/// Set-key body. Write-only intake: a non-empty value sets or rotates, an
+/// explicit empty string clears.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetKey {
+    key: String,
+}
+
+/// Resolves the status DTO for a company.
+///
+/// `configured` and `source` answer different questions on purpose and are both
+/// reported: the first is "did *this company* set one", the second is "what does
+/// a search actually present". A host with `SMITHERY_API_KEY` set reads
+/// `configured: false, source: "environment"`, and both halves are true.
+/// Collapsing them into one boolean is how the Composio panel came to claim no
+/// credential while calls were succeeding (issue #886).
+async fn effective_status(runtime: &CompanyRuntime) -> Result<DirectoryCredentialDto, ApiError> {
+    let secrets = runtime.secrets();
+    let configured = key_configured(runtime.id(), secrets.as_ref())
+        .await
+        .map_err(ApiError)?;
+    let source = resolve(
+        runtime.id(),
+        secrets.as_ref(),
+        &crate::app::config::ProcessEnv,
+    )
+    .await
+    .map_err(ApiError)?
+    .source();
+    Ok(DirectoryCredentialDto {
+        configured,
+        source,
+        notice: match source {
+            DirectoryKeySource::Company => CONSEQUENCE.to_string(),
+            DirectoryKeySource::Environment => SHARED.to_string(),
+            DirectoryKeySource::None => DEGRADED.to_string(),
+        },
+    })
+}
+
+/// `GET …/mcp/registry/credential` — whether this company has its own Smithery
+/// key, and which key its directory calls present.
+async fn get_status(company: ScopedCompany) -> Result<Json<DirectoryCredentialDto>, ApiError> {
+    Ok(Json(effective_status(company.runtime.as_ref()).await?))
+}
+
+/// `PUT …/mcp/registry/credential` — set / rotate / clear the write-only
+/// Smithery key. **Admin-only**.
+async fn set_key(
+    company: AdminScopedCompany,
+    Json(body): Json<SetKey>,
+) -> Result<Json<MutationResponse>, ApiError> {
+    let runtime = company.runtime.as_ref();
+    store_key(runtime.id(), runtime.secrets().as_ref(), &body.key)
+        .await
+        .map_err(ApiError)?;
+    // After the store, so the journal records a completed change. A clear and a
+    // set are told apart for the same reason `ops::company_key` tells them
+    // apart: one widens what the company can reach and the other narrows it, and
+    // an audit line that cannot say which is most of the way to not having one.
+    let change = if body.key.trim().is_empty() {
+        "smithery_key_cleared"
+    } else {
+        "smithery_key_set"
+    };
+    journal(&company, change).await?;
+    Ok(Json(MutationResponse {
+        status: effective_status(runtime).await?,
+        note: SWITCH_NOTE.to_string(),
+    }))
+}
+
+/// Records who changed the directory credential.
+///
+/// Propagates a journal failure rather than swallowing it, matching the sibling
+/// credential routes: the record exists so that a change to what the company
+/// browses and bills through is never invisible.
+async fn journal(company: &AdminScopedCompany, change: &str) -> Result<(), ApiError> {
+    company
+        .runtime
+        .events()
+        .append(
+            company.id(),
+            CompanyEvent::ToolAccessChanged {
+                change: change.to_string(),
+                toolkit: None,
+                by: Some(company.actor()),
+            },
+        )
+        .await
+        .map_err(ApiError)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test;

--- a/src/server/ops/mcp_registry/credential/test.rs
+++ b/src/server/ops/mcp_registry/credential/test.rs
@@ -269,11 +269,10 @@ async fn the_shared_host_tier_is_reported_as_shared() {
     .await
     .expect("resolve");
     assert_eq!(resolved.source(), DirectoryKeySource::Environment);
-    assert_eq!(
-        crate::company::smithery::key_configured(runtime.id(), runtime.secrets().as_ref())
+    assert!(
+        !crate::company::smithery::key_configured(runtime.id(), runtime.secrets().as_ref())
             .await
             .expect("configured"),
-        false,
         "the host's key is not this company's own, and the two must not be conflated"
     );
 }

--- a/src/server/ops/mcp_registry/credential/test.rs
+++ b/src/server/ops/mcp_registry/credential/test.rs
@@ -1,0 +1,279 @@
+//! Route tests for the company's Smithery directory credential (issue #1287).
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::company::CompanyManifest;
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::runtime::RuntimeBuilder;
+use crate::server::router;
+use crate::store::FsCompanyStore;
+use crate::{AppConfig, AppState};
+
+const PATH: &str = "/api/v1/company/mcp/registry/credential";
+
+/// Long and opaque enough that a leak would be unmistakable in any body.
+const KEY: &str = "smithery_directory_SECRET_do_not_echo_me";
+
+const MANIFEST: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n";
+
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("oc-smithery-key-")
+        .tempdir()
+        .expect("tempdir")
+}
+
+async fn state_for(home: &std::path::Path, company: &str) -> AppState {
+    use crate::ports::CompanyStore;
+    let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+    let store = FsCompanyStore::new(home.to_path_buf());
+    let id = CompanyId::new(company);
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default());
+    state.registry().insert(id, std::sync::Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, company).await;
+    state
+}
+
+async fn send_as(
+    state: &AppState,
+    method: &str,
+    body: Option<Value>,
+    cookie: String,
+) -> (StatusCode, Value, String) {
+    let request = Request::builder()
+        .method(method)
+        .uri(PATH)
+        .header("cookie", cookie);
+    let request = match body {
+        Some(body) => request
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+        None => request.body(Body::empty()).unwrap(),
+    };
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let raw = String::from_utf8_lossy(&bytes).to_string();
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value, raw)
+}
+
+async fn send(
+    state: &AppState,
+    company: &str,
+    method: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value, String) {
+    send_as(
+        state,
+        method,
+        body,
+        crate::server::test_support::fixed_cookie(company),
+    )
+    .await
+}
+
+/// The core round trip: an admin sets the key, the read plane reports the
+/// company tier, and the value never comes back out of any response.
+#[tokio::test]
+async fn the_key_round_trips_write_only_and_reports_the_company_tier() {
+    let home_dir = home();
+    let state = state_for(home_dir.path(), "acme").await;
+
+    let (status, dto, raw) = send(&state, "acme", "GET", None).await;
+    assert_eq!(status, StatusCode::OK, "{raw}");
+    assert_eq!(dto["configured"], false);
+    assert_eq!(dto["source"], "none");
+    assert!(
+        dto["notice"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("open registry"),
+        "the degraded state has to say what the operator still gets: {dto}"
+    );
+
+    let (status, resp, raw) = send(&state, "acme", "PUT", Some(json!({ "key": KEY }))).await;
+    assert_eq!(status, StatusCode::OK, "{raw}");
+    assert_eq!(resp["status"]["configured"], true);
+    assert_eq!(resp["status"]["source"], "company");
+    assert!(!raw.contains(KEY), "the write must not echo the key: {raw}");
+
+    let (_, dto, raw) = send(&state, "acme", "GET", None).await;
+    assert_eq!(dto["configured"], true);
+    assert_eq!(dto["source"], "company");
+    assert!(!raw.contains(KEY), "the read must not carry the key: {raw}");
+    assert!(dto.get("key").is_none(), "status must never carry the key");
+}
+
+/// Clearing withdraws the company's key and says so, rather than leaving a
+/// stale `configured: true` behind.
+#[tokio::test]
+async fn clearing_reports_the_degraded_state() {
+    let home_dir = home();
+    let state = state_for(home_dir.path(), "acme").await;
+    send(&state, "acme", "PUT", Some(json!({ "key": KEY }))).await;
+
+    let (status, resp, raw) = send(&state, "acme", "PUT", Some(json!({ "key": "" }))).await;
+    assert_eq!(status, StatusCode::OK, "{raw}");
+    assert_eq!(resp["status"]["configured"], false);
+    assert_eq!(resp["status"]["source"], "none");
+}
+
+/// The notice must not frighten an operator out of rotating. This key is used
+/// to browse and install; an installed server connects with its own stored
+/// credentials, so a rotation disconnects nothing — and the copy has to say so,
+/// because the opposite is the natural assumption.
+#[tokio::test]
+async fn the_notice_says_a_rotation_does_not_disconnect_installed_servers() {
+    let home_dir = home();
+    let state = state_for(home_dir.path(), "acme").await;
+    send(&state, "acme", "PUT", Some(json!({ "key": KEY }))).await;
+
+    let (_, dto, _) = send(&state, "acme", "GET", None).await;
+    let notice = dto["notice"].as_str().unwrap_or_default();
+    assert!(
+        notice.contains("does not disconnect"),
+        "an operator must be told a rotation is safe: {notice}"
+    );
+}
+
+/// Admin-only, for the reason every other credential write is: this decides
+/// which Smithery account the company browses and bills through.
+#[tokio::test]
+async fn a_member_cannot_set_the_directory_credential() {
+    let home_dir = home();
+    let state = state_for(home_dir.path(), "acme").await;
+    let member =
+        crate::server::test_support::seed_session(&state, "acme", crate::ports::UserRole::Member)
+            .await;
+
+    let (status, body, raw) =
+        send_as(&state, "PUT", Some(json!({ "key": KEY })), member.clone()).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{raw}");
+    assert!(
+        body["error"].as_str().unwrap_or_default().contains("admin"),
+        "the refusal has to say why: {body}"
+    );
+
+    // The refusal is real, not merely a different status code.
+    let (_, dto, _) = send(&state, "acme", "GET", None).await;
+    assert_eq!(
+        dto["configured"], false,
+        "a refused write must not have stored anything: {dto}"
+    );
+
+    // …but a member may still READ it. Knowing the directory is thin because no
+    // key is set is what stops them filing "search is broken".
+    let (status, dto, raw) = send_as(&state, "GET", None, member).await;
+    assert_eq!(status, StatusCode::OK, "{raw}");
+    assert_eq!(dto["source"], "none");
+}
+
+/// Both writes are journaled with an actor, and a clear is told apart from a
+/// set — the two have opposite blast radii.
+#[tokio::test]
+async fn setting_and_clearing_are_journaled_with_an_actor() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let state = state_for(home_dir.path(), "audited").await;
+    send(&state, "audited", "PUT", Some(json!({ "key": KEY }))).await;
+    send(&state, "audited", "PUT", Some(json!({ "key": "" }))).await;
+
+    let id = CompanyId::new("audited");
+    let runtime = state.registry().get(&id).expect("registered");
+    let events = runtime
+        .events()
+        .read_from(&id, crate::ports::types::EventSeq::new(0), 200)
+        .await
+        .expect("events");
+    let changes: Vec<(String, bool)> = events
+        .iter()
+        .filter_map(|stored| match &stored.event {
+            CompanyEvent::ToolAccessChanged { change, by, .. } => {
+                Some((change.clone(), by.is_some()))
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        changes.contains(&("smithery_key_set".to_string(), true)),
+        "a set must be journaled with who did it: {changes:?}"
+    );
+    assert!(
+        changes.contains(&("smithery_key_cleared".to_string(), true)),
+        "a clear must be told apart from a set: {changes:?}"
+    );
+    // Every credential route appends `ToolAccessChanged` to one log. Borrowing a
+    // sibling's vocabulary would make an auditor unable to tell which credential
+    // moved.
+    assert!(
+        !changes
+            .iter()
+            .any(|(change, _)| change.starts_with("company_key_")
+                || change == "credential_set"
+                || change == "credential_cleared"),
+        "no other credential was written here, so no other audit word may appear: {changes:?}"
+    );
+}
+
+/// The whole point of the tier split: a company that set nothing on a host that
+/// has a key is a *working* directory, and the copy must say it is shared
+/// rather than claim the company owns it.
+#[tokio::test]
+async fn the_shared_host_tier_is_reported_as_shared() {
+    use crate::app::config::MapEnv;
+    use crate::company::smithery::{API_KEY_ENV, DirectoryKeySource, resolve};
+
+    let home_dir = home();
+    let state = state_for(home_dir.path(), "acme").await;
+    let id = CompanyId::new("acme");
+    let runtime = state.registry().get(&id).expect("registered");
+
+    // Exercised through the resolver rather than the route: setting a real
+    // process env var would leak across the test binary's other threads.
+    let resolved = resolve(
+        runtime.id(),
+        runtime.secrets().as_ref(),
+        &MapEnv::new([(API_KEY_ENV, "host-wide-key")]),
+    )
+    .await
+    .expect("resolve");
+    assert_eq!(resolved.source(), DirectoryKeySource::Environment);
+    assert_eq!(
+        crate::company::smithery::key_configured(runtime.id(), runtime.secrets().as_ref())
+            .await
+            .expect("configured"),
+        false,
+        "the host's key is not this company's own, and the two must not be conflated"
+    );
+}

--- a/src/server/ops/mcp_registry/wired.rs
+++ b/src/server/ops/mcp_registry/wired.rs
@@ -29,6 +29,7 @@ use openhuman_core::openhuman as oh;
 
 use crate::company::mcp::{McpHealth, stdio_install_refusal};
 use crate::company::runtime::CompanyRuntime;
+use crate::company::smithery::{self, DirectoryKey};
 use crate::error::OpenCompanyError;
 use crate::ports::now_millis;
 use crate::server::error::ApiError;
@@ -170,13 +171,45 @@ fn project(server: InstalledServer, state: Option<&ConnStatus>, now: u64) -> Reg
     }
 }
 
+/// The Smithery credential this company's directory calls present (issue #1287).
+///
+/// Resolved per request rather than held on the runtime, so an admin's rotation
+/// reaches the very next search. The environment is read straight from the
+/// process here, as the sibling credential routes already do.
+async fn directory_key(runtime: &CompanyRuntime) -> Result<DirectoryKey, ApiError> {
+    smithery::resolve(
+        runtime.id(),
+        runtime.secrets().as_ref(),
+        &crate::app::config::ProcessEnv,
+    )
+    .await
+    .map_err(ApiError)
+}
+
 /// `GET …/mcp/registry/search` — browse the two upstream directories.
+///
+/// The response reports which Smithery tier the search presented, because
+/// "no rows" has two completely different causes and only one of them is the
+/// operator's to fix: a real miss, or a directory that was never queried
+/// because no key resolved (issue #1287).
 pub(super) async fn search(company: ScopedCompany, Query(query): Query<SearchQuery>) -> Response {
     let Some(mcp) = company.runtime.mcp() else {
         return not_wired("mcp registry");
     };
-    match mcp.search(query.q, query.page, query.page_size).await {
-        Ok(raw) => Json(catalogue_search(&raw)).into_response(),
+    let key = match directory_key(company.runtime.as_ref()).await {
+        Ok(key) => key,
+        Err(error) => return error.into_response(),
+    };
+    let source = key.source();
+    match mcp
+        .search(key.into_value(), query.q, query.page, query.page_size)
+        .await
+    {
+        Ok(raw) => {
+            let mut dto = catalogue_search(&raw);
+            dto.directory_credential = source;
+            Json(dto).into_response()
+        }
         Err(error) => ApiError(error).into_response(),
     }
 }
@@ -195,7 +228,14 @@ pub(super) async fn entry(company: ScopedCompany, Query(query): Query<EntryQuery
         ))
         .into_response();
     }
-    let raw = match mcp.registry_get(qualified_name.clone()).await {
+    let key = match directory_key(company.runtime.as_ref()).await {
+        Ok(key) => key,
+        Err(error) => return error.into_response(),
+    };
+    let raw = match mcp
+        .registry_get(key.into_value(), qualified_name.clone())
+        .await
+    {
         Ok(raw) => raw,
         Err(error) => return ApiError(error).into_response(),
     };
@@ -232,7 +272,14 @@ pub(super) async fn install(
         .into_response();
     }
 
-    let raw = match mcp.registry_get(qualified_name.clone()).await {
+    let key = match directory_key(runtime).await {
+        Ok(key) => key,
+        Err(error) => return error.into_response(),
+    };
+    let raw = match mcp
+        .registry_get(key.value().map(str::to_string), qualified_name.clone())
+        .await
+    {
         Ok(raw) => raw,
         Err(error) => return ApiError(error).into_response(),
     };
@@ -246,7 +293,10 @@ pub(super) async fn install(
         return ApiError(OpenCompanyError::InvalidRequest(refusal)).into_response();
     }
 
-    let server = match mcp.install_from_directory(qualified_name, body.env).await {
+    let server = match mcp
+        .install_from_directory(key.into_value(), qualified_name, body.env)
+        .await
+    {
         Ok(server) => server,
         Err(error) => return ApiError(error).into_response(),
     };


### PR DESCRIPTION
## Summary

The MCP directory browse shipped in #1270 returns almost nothing, and the cause is a missing credential rather than a defect. Two upstream directories back it. The official registry is always queried, but most of its entries declare no remote endpoint, so the hosted-transport filter discards them — correctly, since this deployment cannot launch a local subprocess. Smithery carries the hosted servers and is only queried when a key resolves. So the surface works perfectly and has nothing to show, which reads on screen as a broken search.

This adds the credential, per company, and makes the empty result say which of those two things happened.

**One key per company**, in that tenant's secret store, admin-set, write-only, available to every teammate — not a shared platform key. Smithery servers *connect* through the account, with per-server credentials configured on smithery.ai, so a single platform-wide key would make one tenant's GitHub configuration every other tenant's and pool usage onto one bill.

**Two working tiers, reported apart.** The company's own key wins; failing that the host's `SMITHERY_API_KEY`, which is upstream's own fallback and the self-hosting hatch. That second tier is one Smithery account shared by every company on the instance, so it is its own `source` value rather than folded into a boolean. `configured: true` would be true of both while hiding the sharing; a `configured` meaning "its own" would read `false` for a company whose directory works. Those are the two halves of the #886 lie at once.

**Discovery, not connection.** The key authenticates search, entry lookup and the fetch an install performs. It is not what an installed server connects with — `registry::connections::connect` dials the stored `deployment_url` and builds auth from that server's own stored env row. So clearing the key stops new browsing and leaves running servers alone, and the console copy says so. The opposite is the intuitive guess and would leave an operator afraid to rotate.

Resolved per call rather than cached on `McpRuntime`, so a rotation lands on the next search with no restart.

Closes #1287.

## API Or Behavior Changes

New routes, both **always compiled** — unlike the rest of `…/mcp/registry/…`, which is behind the `mcp` feature and reports `not_wired` without it. The key is a secret slot and a console field; an unwired build still has to let an admin set the key a wired one will spend.

| Method | Route | Authority |
|---|---|---|
| `GET` | `…/mcp/registry/credential` | any member — carries a tier name and a notice, never the key |
| `PUT` | `…/mcp/registry/credential` | **admin only** — set / rotate / clear, write-only |

Two additive response fields, both safe for an older client to ignore:

- `GET …/mcp/registry/search` gains `directoryCredential` (`company` / `environment` / `none`). It rides on the search response rather than a second request, because the console needs it in the same moment it renders zero rows, and two fetches can land out of order and describe different states.
- `GET …/capabilities` gains `mcpDirectoryCredential`, omitted when the host could not determine it — an unknown answer is not `none`.

Both writes are journaled as `smithery_key_set` / `smithery_key_cleared`, told apart because they have opposite blast radii.

Console: a Smithery key card inside the directory browser, below the results, where the empty-result notice points; and a Usage row badging the tier. The shared-host tier gets its own badge — it is neither "Active" (which hides the sharing) nor "Awaiting credential" (which is false).

No existing behaviour changes when no key is set: that is exactly today's behaviour, now explained instead of silent.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` — default lane, 0
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — **CI's own gated lane**, 0. This is the lane that caught a `bool_assert_comparison` a plain `cargo check` never compiles.
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex,mcp --all-targets -- -D warnings` — 0
- [x] `cargo build --locked --features openhuman,mcp,telegram --all-targets` — the feature combination CI never builds
- [x] `cargo test --locked --features openhuman,tinycortex,mcp --tests` — **4796 passed, 0 failed**
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **4780 passed, 0 failed**
- [x] `scripts/ci/assert-feature-lanes.sh` — 30 features, 0 owed a lane
- [x] Console: `typecheck`, `typecheck:unit`, `typecheck:e2e`, `build`, and `npx vitest run` — **1519 passed** across 159 files

Nine Rust unit tests on the resolver (precedence, the tier split, trimming, clearing falling through to the host tier, an unreadable store propagating rather than downgrading), six route tests (write-only round trip, the clear, the admin/member split, the journal vocabulary), one capabilities test, and nine console tests.

**Red proof, not assumed.** The capabilities test was shown to fail with the field unwired from the configured branch alone — the #567 shape, where a field wired into one construction site tells the truth to a company with no plan and lies to every company that has one.

**Verified live** against a local host with the `mcp` feature:

| Step | Result |
|---|---|
| `GET` with nothing set | `source: none`, and the notice names the fix |
| Search with nothing set | **0 rows** — the reported symptom, now carrying `directoryCredential: none` |
| `PUT` a key | `source: company`; the key appears in **no** response body |
| Search with a deliberately **invalid** key | still `200`, official rows still present, Smithery contributing nothing — a bad key degrades, it does not break |
| `GET …/capabilities` | `mcpDirectoryCredential: company` |
| Clear | back to `configured: false, source: none` |

Not tested: a search against a **valid** Smithery key, because this deployment has none — that is what the issue exists to provide. Everything downstream of the key resolving is upstream's code path, unchanged by this PR.

## Documentation

`docs/modules/mcp.md` — the two new routes and their always-compiled exception, plus a section on why the directory needs a credential to be worth browsing, the two-tier split, and the discovery-not-connection boundary.

One correction is recorded there rather than quietly fixed: an earlier draft said a live `slack` search kept 0 of 17 official entries. A second live search, paged differently, kept one. The doc now states the survival rate, which is what both measurements support, instead of one measurement stated as the rule.
