### PR TITLE
fix(overview): stop knowledge-graph labels rendering under neighbouring node icons

### DIFF
--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -16,7 +16,7 @@ import { ClipboardList, Info, Milestone, Sparkles, User, UserRound, Users, Workf
 import { DERIVED_NOTICE } from './adapter';
 import { orderGraphDepartments, SELF_ID, toolSlugOf, type KGNode, type KGNodeKind, type KnowledgeGraph as KGData } from './model';
 import { branchPath, branchWidth, cyclicDeltaF, edgeArc, focusWheel, radialRestLayout, responsiveRingR, rotateAbout, shortestAngleDelta, treeLayout, wheelPoint, wheelStageGeom, wheelStageSpot, type RestLayoutResult, type TreeLayoutResult, type TreeNodePos } from './tree-layout';
-import { focusLabelIds, LABEL_PRIORITY, planLabels, type LabelCandidate } from './label-plan';
+import { focusLabelIds, LABEL_PRIORITY, planLabels, type LabelCandidate, type LabelIcon } from './label-plan';
 import { rafThrottle } from './raf-throttle';
 import { buildToolWiki, isMcpSlug, prettifySlug } from './agent-wiki';
 import { cameraRect, lerpRect, memoryNodePos, pickRestTier, R_CORE, type MemoryGraph, type Rect } from './memory-core';
@@ -1830,11 +1830,22 @@ export function KnowledgeGraph({
   const selectedOrgId = selectedAgentId ?? selectedHumanId ?? selectedTaskId ?? selectedToolId;
   const focusChildren = focusTree ? focusLabelIds(focusTree.branches, focusId) : null;
   const labelCandidates: LabelCandidate[] = [];
+  // Every circle solid enough to read is a circle solid enough to hide text
+  // (issue #1258), so the declutter gets the icons as obstacles too — not just
+  // the nodes eligible for a label. Tools and SOP tasks are the ones that
+  // matter: numerous, tightly packed, and never named at rest, so they used to
+  // contribute no box at all and a neighbour's label sailed straight over them.
+  // The memory constellation's backdrop disc is deliberately NOT modelled here;
+  // it is a separate, transition-scaled footprint, and feeding a mid-flight
+  // animation into this pass is exactly the flicker the plan measures around.
+  const labelIcons: LabelIcon[] = [];
   for (const n of nodes) {
     const v = visuals.get(n.id)!;
     // a node faded to a whisper has nothing to label, and a label there would
-    // still take a box from a node you can actually see
+    // still take a box from a node you can actually see — the same cut decides
+    // whether its icon is opaque enough to obscure a neighbour's name
     if (v.opacity < 0.3) continue;
+    labelIcons.push({ id: n.id, x: n.x, y: n.y, r: v.r });
     let priority: number | null = null;
     if (hoverId === n.id) priority = LABEL_PRIORITY.hovered;
     else if (selectedOrgId === n.id) priority = LABEL_PRIORITY.selected;
@@ -1861,7 +1872,7 @@ export function KnowledgeGraph({
   // `camK` (state) rather than the live ref: reading it here is what ties the
   // declutter to the zoom, and `camK * W` is the camera width it was published
   // from. x/y come off the ref — they only move every box by a shared vector.
-  const labelSet = planLabels(labelCandidates, { x: camRectRef.current.x, y: camRectRef.current.y, w: camK * W }, W);
+  const labelSet = planLabels(labelCandidates, { x: camRectRef.current.x, y: camRectRef.current.y, w: camK * W }, W, labelIcons);
 
   // ── the graph itself (reused inline + fullscreen) ───────────────────────────
   const graphInner = (

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -1872,7 +1872,9 @@ export function KnowledgeGraph({
   // `camK` (state) rather than the live ref: reading it here is what ties the
   // declutter to the zoom, and `camK * W` is the camera width it was published
   // from. x/y come off the ref — they only move every box by a shared vector.
-  const labelSet = planLabels(labelCandidates, { x: camRectRef.current.x, y: camRectRef.current.y, w: camK * W }, W, labelIcons);
+  // a map, not a set: the plan may mirror a label above its node to get it out
+  // from under a neighbour's icon, so it hands back the `dy` to draw it at
+  const labelPlan = planLabels(labelCandidates, { x: camRectRef.current.x, y: camRectRef.current.y, w: camK * W }, W, labelIcons);
 
   // ── the graph itself (reused inline + fullscreen) ───────────────────────────
   const graphInner = (
@@ -2087,7 +2089,7 @@ export function KnowledgeGraph({
           const color = nodeColor(n);
           const { r, opacity: nodeOpacity, dim, hidden } = visuals.get(n.id)!;
           const selected = selectedAgentId === n.id || selectedToolId === n.id || selectedTaskId === n.id || selectedHumanId === n.id;
-          const showLabel = labelSet.has(n.id);
+          const labelDyPlanned = labelPlan.get(n.id);
           const Icon = cat.Icon;
 
           // the company rendered as its memory: the Notes constellation of real
@@ -2283,10 +2285,10 @@ export function KnowledgeGraph({
               <g style={{ color: n.kind === 'self' ? 'var(--bg)' : color }}>
                 <Icon x={-r * 0.62} y={-r * 0.62} width={r * 1.24} height={r * 1.24} strokeWidth={2} />
               </g>
-              {showLabel && (
+              {labelDyPlanned !== undefined && (
                 <text
                   x={0}
-                  y={r + 11 + (labelDy.get(n.id) ?? 0)}
+                  y={labelDyPlanned}
                   textAnchor="middle"
                   fontFamily="var(--font-mono)"
                   fontWeight={n.kind === 'self' || n.kind === 'team' || hoverId === n.id ? 600 : 400}

--- a/frontend/src/views/overview/kg/label-plan.ts
+++ b/frontend/src/views/overview/kg/label-plan.ts
@@ -12,11 +12,23 @@
  *
  * 1. the component nominates **candidates** with a priority (the roster at
  *    rest, the focused node and its direct children in focus, plus whatever is
- *    hovered or selected);
+ *    hovered or selected), alongside the **icons** — every node circle actually
+ *    drawn, whether or not it is ever named;
  * 2. {@link planLabels} runs a greedy declutter over them — highest priority
- *    placed first, and any later label whose box overlaps one already placed is
- *    dropped. Every node keeps a `<title>`, so a dropped label still has a
- *    native tooltip underneath it.
+ *    placed first, and any later label whose box overlaps one already placed,
+ *    or lands on a node's icon, is dropped. Every node keeps a `<title>`, so a
+ *    dropped label still has a native tooltip underneath it.
+ *
+ * ## Why icons are obstacles too (issue #1258)
+ *
+ * The first cut of this pass only compared a label against other *labels*, and
+ * that is half the picture. The nodes most likely to sit in a text box's path
+ * are tools and SOP tasks — numerous, closely packed, and deliberately left
+ * unnamed at rest, so they contributed no box of their own to collide with. A
+ * label could dodge every other label and still land squarely on a neighbour's
+ * circle avatar, which is how "Portfolio Support" came to render as
+ * `[icon]folio Support`. Icons are circles with a radius, not boxes, so the
+ * test against them is {@link boxHitsCircle}, not {@link overlaps}.
  *
  * ## Why the collision pass measures in SCREEN space
  *
@@ -49,6 +61,23 @@ export type LabelCandidate = {
   fontPx: number;
   /** higher wins a collision; ties break on the order given */
   priority: number;
+};
+
+/**
+ * A node's drawn circle avatar — an obstacle no label may sit on (issue #1258).
+ *
+ * Unlike a label, an icon rides the graph completely: both its centre and its
+ * radius are in graph units, so zooming in makes it cover more pixels. `id`
+ * matches the {@link LabelCandidate} of the same node, which is how a label is
+ * let through its OWN icon; see {@link planLabels}.
+ */
+export type LabelIcon = {
+  id: string;
+  /** the node's centre, in graph units */
+  x: number;
+  y: number;
+  /** the drawn radius, in graph units */
+  r: number;
 };
 
 /**
@@ -112,6 +141,30 @@ const overlaps = (a: LabelBox, b: LabelBox): boolean =>
   a.x0 < b.x1 && b.x0 < a.x1 && a.y0 < b.y1 && b.y0 < a.y1;
 
 /**
+ * Does a label box touch a circle? All four values are screen px.
+ *
+ * An icon is a disc, so the box's bounding square would reject placements that
+ * clear the drawn circle by a comfortable margin at every corner. The exact
+ * test is the cheap one anyway: clamp the centre into the box to get the
+ * nearest point on it, then ask whether that point is inside the radius. A
+ * centre that lands *inside* the box clamps to itself, distance zero, which is
+ * the fully-covered case and reads true as it should.
+ */
+export function boxHitsCircle(
+  box: LabelBox,
+  cx: number,
+  cy: number,
+  r: number,
+): boolean {
+  if (r <= 0) return false;
+  const nx = Math.min(Math.max(cx, box.x0), box.x1);
+  const ny = Math.min(Math.max(cy, box.y0), box.y1);
+  const dx = cx - nx;
+  const dy = cy - ny;
+  return dx * dx + dy * dy < r * r;
+}
+
+/**
  * The ids whose labels survive the declutter, measured in screen px.
  *
  * `canvasW` is the width the camera rect maps onto — the nominal SVG width, so
@@ -119,20 +172,43 @@ const overlaps = (a: LabelBox, b: LabelBox): boolean =>
  * highest priority first; a label that collides with one already placed is
  * dropped rather than nudged, because nudging is what the old two-row stagger
  * did and it only moved the pile-up.
+ *
+ * `icons` are the node circles actually drawn — pass every visible node, not
+ * just the ones eligible for a label, since an unnamed tool hides text exactly
+ * as well as a named agent does. Two rules make them behave:
+ *
+ * - **a label may sit on its own node's icon.** Its box hangs off that very
+ *   node by `dy`, which rides the graph while the font does not, so zoomed far
+ *   enough out every box overlaps its own circle. Blocking on that would drop
+ *   every label at once rather than the one in the way.
+ * - **a label with nowhere clear is dropped, not shrunk or drawn anyway.** That
+ *   is already what an unwinnable label-vs-label collision does, and the node
+ *   still carries a `<title>`, so the name stays one hover away instead of
+ *   being rendered illegibly under an avatar.
  */
 export function planLabels(
   candidates: readonly LabelCandidate[],
   cam: LabelCamera,
   canvasW: number,
+  icons: readonly LabelIcon[] = [],
 ): Set<string> {
   const scale = cam.w > 0 ? canvasW / cam.w : 1;
   const order = candidates.map((c, i) => ({ c, i }));
   order.sort((a, b) => b.c.priority - a.c.priority || a.i - b.i);
+  // icons never move or drop out, so project them once rather than per label
+  const discs = icons.map((n) => ({
+    id: n.id,
+    cx: (n.x - cam.x) * scale,
+    cy: (n.y - cam.y) * scale,
+    // a radius rides the graph, so unlike `fontPx` it scales with the camera
+    r: n.r * scale,
+  }));
   const placed: LabelBox[] = [];
   const kept = new Set<string>();
   for (const { c } of order) {
     const box = labelBoxPx(c, cam, scale);
     if (placed.some((p) => overlaps(p, box))) continue;
+    if (discs.some((d) => d.id !== c.id && boxHitsCircle(box, d.cx, d.cy, d.r))) continue;
     placed.push(box);
     kept.add(c.id);
   }

--- a/frontend/src/views/overview/kg/label-plan.ts
+++ b/frontend/src/views/overview/kg/label-plan.ts
@@ -197,9 +197,14 @@ export type LabelPlan = Map<string, number>;
  * too blunt to ship — measured on a support company it took the company's own
  * name and its pillar's name off the canvas rather than moving them 20px. The
  * mirrored row is checked against labels and icons alike before it is taken, so
- * a moved label is one that genuinely fits, and this can only ever keep a
- * label the icon pass would otherwise have dropped — never add one the pass
- * before #1258 did not already draw.
+ * a moved label is one that genuinely fits.
+ *
+ * Note that this makes the pass **not monotone** in the number of labels: a
+ * label that moves upstairs vacates the row it wanted, and a quieter candidate
+ * that would have lost that row can now have it. So an icon can, indirectly,
+ * add a name rather than remove one. Every placement is still checked, so the
+ * extra name is a legible one — but do not read the survivor count as a
+ * ceiling.
  *
  * `icons` are the node circles actually drawn — pass every visible node, not
  * just the ones eligible for a label, since an unnamed tool hides text exactly

--- a/frontend/src/views/overview/kg/label-plan.ts
+++ b/frontend/src/views/overview/kg/label-plan.ts
@@ -15,9 +15,10 @@
  *    hovered or selected), alongside the **icons** — every node circle actually
  *    drawn, whether or not it is ever named;
  * 2. {@link planLabels} runs a greedy declutter over them — highest priority
- *    placed first, and any later label whose box overlaps one already placed,
- *    or lands on a node's icon, is dropped. Every node keeps a `<title>`, so a
- *    dropped label still has a native tooltip underneath it.
+ *    placed first, dropping any label whose box overlaps one already placed,
+ *    and mirroring above its node (or, failing that, dropping) any label that
+ *    would land on somebody's icon. Every node keeps a `<title>`, so a dropped
+ *    label still has a native tooltip underneath it.
  *
  * ## Why icons are obstacles too (issue #1258)
  *
@@ -121,12 +122,19 @@ export type LabelBox = { x0: number; y0: number; x1: number; y1: number };
 
 /**
  * A candidate's label box in screen px, padded by {@link LABEL_GAP_X}.
- * `scale` is px per graph unit (canvas width ÷ camera width).
+ * `scale` is px per graph unit (canvas width ÷ camera width). `dy` overrides
+ * the candidate's preferred offset, which is how {@link planLabels} costs a
+ * mirrored placement without mutating the candidate.
  */
-export function labelBoxPx(c: LabelCandidate, cam: LabelCamera, scale: number): LabelBox {
+export function labelBoxPx(
+  c: LabelCandidate,
+  cam: LabelCamera,
+  scale: number,
+  dy: number = c.dy,
+): LabelBox {
   const cx = (c.x - cam.x) * scale;
   // `dy` rides the graph, so it scales with the camera; the font does not.
-  const baseline = (c.y - cam.y) * scale + c.dy * scale;
+  const baseline = (c.y - cam.y) * scale + dy * scale;
   const halfW = (c.text.length * MONO_ADVANCE * c.fontPx) / 2 + LABEL_GAP_X;
   return {
     x0: cx - halfW,
@@ -165,13 +173,33 @@ export function boxHitsCircle(
 }
 
 /**
- * The ids whose labels survive the declutter, measured in screen px.
+ * Where each surviving label is drawn: node id → the `dy` to render it at, in
+ * graph units. An id absent from the map is a label the declutter dropped.
+ */
+export type LabelPlan = Map<string, number>;
+
+/**
+ * Which labels survive the declutter and where each one sits, in screen px.
  *
  * `canvasW` is the width the camera rect maps onto — the nominal SVG width, so
  * the px here are the same px `fontPx` is quoted in. Candidates are placed
- * highest priority first; a label that collides with one already placed is
- * dropped rather than nudged, because nudging is what the old two-row stagger
- * did and it only moved the pile-up.
+ * highest priority first.
+ *
+ * **Losing to another label is still final**, exactly as it was: the two rows
+ * are the same width, so moving one of a colliding pair up would relocate the
+ * same contention rather than settle it — that was the old two-row stagger, and
+ * #1104 is the record of it not working.
+ *
+ * **Losing to an icon earns one retry**, on the mirrored row above the node. An
+ * icon is not a party to the negotiation: unlike a rival label it cannot yield,
+ * has no priority to lose on, and is drawn whatever this pass decides, so the
+ * label is the only thing that can move. Without the retry the icon pass is far
+ * too blunt to ship — measured on a support company it took the company's own
+ * name and its pillar's name off the canvas rather than moving them 20px. The
+ * mirrored row is checked against labels and icons alike before it is taken, so
+ * a moved label is one that genuinely fits, and this can only ever keep a
+ * label the icon pass would otherwise have dropped — never add one the pass
+ * before #1258 did not already draw.
  *
  * `icons` are the node circles actually drawn — pass every visible node, not
  * just the ones eligible for a label, since an unnamed tool hides text exactly
@@ -181,9 +209,9 @@ export function boxHitsCircle(
  *   node by `dy`, which rides the graph while the font does not, so zoomed far
  *   enough out every box overlaps its own circle. Blocking on that would drop
  *   every label at once rather than the one in the way.
- * - **a label with nowhere clear is dropped, not shrunk or drawn anyway.** That
- *   is already what an unwinnable label-vs-label collision does, and the node
- *   still carries a `<title>`, so the name stays one hover away instead of
+ * - **a label with no clear row is dropped, not shrunk and not drawn anyway.**
+ *   That is already what an unwinnable label-vs-label collision does, and the
+ *   node still carries a `<title>`, so the name stays one hover away instead of
  *   being rendered illegibly under an avatar.
  */
 export function planLabels(
@@ -191,7 +219,7 @@ export function planLabels(
   cam: LabelCamera,
   canvasW: number,
   icons: readonly LabelIcon[] = [],
-): Set<string> {
+): LabelPlan {
   const scale = cam.w > 0 ? canvasW / cam.w : 1;
   const order = candidates.map((c, i) => ({ c, i }));
   order.sort((a, b) => b.c.priority - a.c.priority || a.i - b.i);
@@ -203,16 +231,32 @@ export function planLabels(
     // a radius rides the graph, so unlike `fontPx` it scales with the camera
     r: n.r * scale,
   }));
+  // a label never blocks on its OWN circle — see the note above
+  const onAnIcon = (box: LabelBox, id: string): boolean =>
+    discs.some((d) => d.id !== id && boxHitsCircle(box, d.cx, d.cy, d.r));
+
   const placed: LabelBox[] = [];
-  const kept = new Set<string>();
+  const plan: LabelPlan = new Map();
   for (const { c } of order) {
-    const box = labelBoxPx(c, cam, scale);
-    if (placed.some((p) => overlaps(p, box))) continue;
-    if (discs.some((d) => d.id !== c.id && boxHitsCircle(box, d.cx, d.cy, d.r))) continue;
+    const under = labelBoxPx(c, cam, scale, c.dy);
+    if (placed.some((p) => overlaps(p, under))) continue;
+    let dy: number | null = onAnIcon(under, c.id) ? null : c.dy;
+    let box = under;
+    if (dy === null) {
+      // only an icon sends a label looking for another row, and only one:
+      // mirrored above the node, where the same name still reads as belonging
+      // to the same circle
+      const over = labelBoxPx(c, cam, scale, -c.dy);
+      if (!placed.some((p) => overlaps(p, over)) && !onAnIcon(over, c.id)) {
+        dy = -c.dy;
+        box = over;
+      }
+    }
+    if (dy === null) continue;
     placed.push(box);
-    kept.add(c.id);
+    plan.set(c.id, dy);
   }
-  return kept;
+  return plan;
 }
 
 /**

--- a/frontend/test/unit/overview-graph-labels.test.ts
+++ b/frontend/test/unit/overview-graph-labels.test.ts
@@ -240,6 +240,23 @@ describe("planLabels vs node icons (issue #1258)", () => {
     expect(planLabels([named], { x: 0, y: 0, w: W * 10 }, W, [above]).size).toBe(0);
   });
 
+  it("frees the row it vacates, so a mirror can let a quieter label in", () => {
+    // Not obvious, and worth pinning rather than discovering: this pass is not
+    // monotone in the number of labels. `loud` would sit at dy 20 and take the
+    // row `quiet` wanted; blocked by an icon it mirrors instead, and `quiet`
+    // now fits the row it just left. Observed on a software company, where the
+    // icon pass cost four names and handed back "QA Engineer".
+    const loud = cand({ id: "loud", x: 0, priority: LABEL_PRIORITY.hovered });
+    const quiet = cand({ id: "quiet", x: 25, priority: LABEL_PRIORITY.worker });
+    // no icon: they contend for one row and the quieter one loses outright
+    expect(ids(planLabels([loud, quiet], { x: 0, y: 0, w: W }, W))).toEqual(["loud"]);
+    // an icon inside `loud`'s row but clear of `quiet`'s sends `loud` upstairs
+    const tool = icon({ id: "tool", x: -10, y: 17, r: 5 });
+    const plan = planLabels([loud, quiet], { x: 0, y: 0, w: W }, W, [tool]);
+    expect(plan.get("loud")).toBe(-20);
+    expect(plan.get("quiet")).toBe(20);
+  });
+
   it("stays pan-invariant, the property that lets the caller cache this", () => {
     // the module only re-runs the pass when the ZOOM changes, on the grounds
     // that a pan moves every box by one shared vector. Icons have to move with

--- a/frontend/test/unit/overview-graph-labels.test.ts
+++ b/frontend/test/unit/overview-graph-labels.test.ts
@@ -240,6 +240,17 @@ describe("planLabels vs node icons (issue #1258)", () => {
     expect(planLabels([named], { x: 0, y: 0, w: W * 10 }, W, [above]).size).toBe(0);
   });
 
+  it("stays pan-invariant, the property that lets the caller cache this", () => {
+    // the module only re-runs the pass when the ZOOM changes, on the grounds
+    // that a pan moves every box by one shared vector. Icons have to move with
+    // them, or a graph you dragged would silently label itself differently.
+    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
+    const panned = planLabels([named], { x: -400, y: 250, w: W }, W, [tool]);
+    // pinned so the comparison cannot pass by both sides dropping everything
+    expect(panned.get("named")).toBe(-20);
+    expect(panned).toEqual(planLabels([named], { x: 0, y: 0, w: W }, W, [tool]));
+  });
+
   it("ignores an icon the caller left out, so hidden nodes never block", () => {
     // the caller only nominates circles it actually draws; a carousel node
     // faded to nothing must not take a name off a node you can see

--- a/frontend/test/unit/overview-graph-labels.test.ts
+++ b/frontend/test/unit/overview-graph-labels.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  boxHitsCircle,
   focusLabelIds,
   LABEL_PRIORITY,
+  labelBoxPx,
   planLabels,
   type LabelCandidate,
+  type LabelIcon,
 } from "@/views/overview/kg/label-plan";
 
 /**
@@ -28,6 +31,14 @@ import {
  *    that matters, because zooming out is what packs nodes together. That
  *    regression would restore the pile-up this issue is about while every unit
  *    of the layout still looked right.
+ * 3. **Node icons are obstacles, not just other labels** (issue #1258). The
+ *    circles most likely to sit on a name belong to tools and SOP tasks, which
+ *    are never named at rest and so contributed no box of their own — a label
+ *    could clear every other label and still render as `[icon]folio Support`.
+ *    The two rules that keep that pass from over-correcting are worth pinning
+ *    down too: a label may sit on its OWN node's icon (it hangs off that very
+ *    circle, so at low zoom it always overlaps it), and a label with nowhere
+ *    clear is dropped rather than drawn illegibly.
  */
 
 const W = 880;
@@ -105,6 +116,118 @@ describe("planLabels", () => {
       cand({ id: "row-1", x: 0, dy: 40, priority: LABEL_PRIORITY.worker }),
     ];
     expect(planLabels(stacked, { x: 0, y: 0, w: W }, W)).toEqual(new Set(["row-0", "row-1"]));
+  });
+});
+
+describe("planLabels vs node icons (issue #1258)", () => {
+  const icon = (over: Partial<LabelIcon> & { id: string }): LabelIcon => ({
+    x: 0,
+    y: 0,
+    r: 7,
+    ...over,
+  });
+
+  // "AAAA" at fontPx 10 hanging on dy 20, at one px per graph unit, is the box
+  // x -15..15, y 12..22 — the numbers every case below is placed against.
+  const named = cand({ id: "named", priority: LABEL_PRIORITY.worker });
+
+  it("drops a label that lands on an unnamed neighbour's icon", () => {
+    // the tool sits squarely in the middle of the word — no other LABEL is
+    // anywhere near, which is exactly why the old pass let this through
+    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [])).toEqual(new Set(["named"]));
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [tool]).size).toBe(0);
+  });
+
+  it("lets a label through its own node's icon", () => {
+    // one circle, two readings: as the label's own node it is exempt, as
+    // anyone else's it blocks. r 18 reaches the box from the node's centre.
+    const own = icon({ id: "named", x: 0, y: 0, r: 18 });
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [own])).toEqual(new Set(["named"]));
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [{ ...own, id: "someone-else" }]).size).toBe(
+      0,
+    );
+  });
+
+  it("keeps the self exemption load-bearing at every depth", () => {
+    // zoomed out, `dy` has shrunk with the graph while the font has not, so
+    // the box straddles its own node whatever that node's radius is. Without
+    // the exemption this would drop every label at once rather than the one in
+    // the way — the failure would read as "labels stopped working when I
+    // zoomed out", not as a collision bug.
+    const own = icon({ id: "named", x: 0, y: 0, r: 7 });
+    expect(planLabels([named], { x: 0, y: 0, w: W * 4 }, W, [own])).toEqual(new Set(["named"]));
+  });
+
+  it("gives no label a way through an icon, however high its priority", () => {
+    // an icon is not a competitor that can lose a tie — it is drawn either
+    // way, so the hovered name would render underneath it
+    const hovered = cand({ id: "hovered", priority: LABEL_PRIORITY.hovered });
+    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
+    expect(planLabels([hovered], { x: 0, y: 0, w: W }, W, [tool]).size).toBe(0);
+  });
+
+  it("drops the blocked label without disturbing the ones that fit", () => {
+    // the no-valid-placement policy is 'drop', and it is local: a name with
+    // nowhere clear costs only itself
+    const blocked = cand({ id: "blocked", x: 0, priority: LABEL_PRIORITY.hovered });
+    const clear = cand({ id: "clear", x: 200, priority: LABEL_PRIORITY.worker });
+    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
+    expect(planLabels([blocked, clear], { x: 0, y: 0, w: W }, W, [tool])).toEqual(
+      new Set(["clear"]),
+    );
+  });
+
+  it("measures icons in screen space too, so zooming out drops what 1:1 kept", () => {
+    // a radius RIDES the graph, unlike the font, so it must be projected
+    // through the camera rather than compared against px as-is. 30 units clear
+    // at 1:1; pulled back to a tenth, the box is still 10px tall while that
+    // gap has collapsed to 3px and the icon is inside the word.
+    const above = icon({ id: "tool", x: 0, y: -30, r: 6 });
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [above])).toEqual(new Set(["named"]));
+    expect(planLabels([named], { x: 0, y: 0, w: W * 10 }, W, [above]).size).toBe(0);
+  });
+
+  it("ignores an icon the caller left out, so hidden nodes never block", () => {
+    // the caller only nominates circles it actually draws; a carousel node
+    // faded to nothing must not take a name off a node you can see
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W)).toEqual(new Set(["named"]));
+  });
+});
+
+describe("boxHitsCircle", () => {
+  const box = { x0: 0, y0: 0, x1: 10, y1: 10 };
+
+  it("is a disc test, not a bounding-box one", () => {
+    // (13,13) is 4.24 from the corner: its bounding SQUARE overlaps the box at
+    // r 4, the circle itself does not. Getting this wrong throws away labels
+    // that clear the drawn avatar with room to spare.
+    expect(boxHitsCircle(box, 13, 13, 4)).toBe(false);
+    expect(boxHitsCircle(box, 13, 13, 5)).toBe(true);
+  });
+
+  it("catches a circle that swallows the box outright", () => {
+    expect(boxHitsCircle(box, 5, 5, 1)).toBe(true);
+    expect(boxHitsCircle(box, 5, 5, 100)).toBe(true);
+  });
+
+  it("treats touching as clear, matching the label-vs-label rule", () => {
+    expect(boxHitsCircle(box, 15, 5, 5)).toBe(false);
+    expect(boxHitsCircle(box, 15, 5, 5.01)).toBe(true);
+  });
+
+  it("says no to a zero or negative radius", () => {
+    expect(boxHitsCircle(box, 5, 5, 0)).toBe(false);
+    expect(boxHitsCircle(box, 5, 5, -3)).toBe(false);
+  });
+
+  it("agrees with the box the planner actually measures", () => {
+    // guards the two staying in the same units: labelBoxPx is px, so the
+    // circle handed to boxHitsCircle has to be projected the same way
+    const b = labelBoxPx(cand({ id: "x" }), { x: 0, y: 0, w: W }, 1);
+    expect(b).toEqual({ x0: -15, x1: 15, y0: 12, y1: 22 });
+    expect(boxHitsCircle(b, 0, 20, 7)).toBe(true);
+    expect(boxHitsCircle(b, 0, 0, 7)).toBe(false);
   });
 });
 

--- a/frontend/test/unit/overview-graph-labels.test.ts
+++ b/frontend/test/unit/overview-graph-labels.test.ts
@@ -8,17 +8,18 @@ import {
   planLabels,
   type LabelCandidate,
   type LabelIcon,
+  type LabelPlan,
 } from "@/views/overview/kg/label-plan";
 
 /**
- * The Overview graph's label declutter (issue #1104).
+ * The Overview graph's label declutter (issues #1104 and #1258).
  *
  * The rule this replaced was one boolean, and it failed at both ends: at rest
  * only the company and its departments were named, so every agent was an
  * anonymous circle; the moment a pillar was focused, every node in the tree was
  * named at once and the names smeared into each other.
  *
- * Two properties are worth guarding here, and neither is visible from a
+ * Four properties are worth guarding here, and none is visible from a
  * screenshot:
  *
  * 1. **Priority decides who survives a collision.** Silent failure: the label
@@ -31,14 +32,19 @@ import {
  *    that matters, because zooming out is what packs nodes together. That
  *    regression would restore the pile-up this issue is about while every unit
  *    of the layout still looked right.
- * 3. **Node icons are obstacles, not just other labels** (issue #1258). The
- *    circles most likely to sit on a name belong to tools and SOP tasks, which
- *    are never named at rest and so contributed no box of their own — a label
- *    could clear every other label and still render as `[icon]folio Support`.
- *    The two rules that keep that pass from over-correcting are worth pinning
- *    down too: a label may sit on its OWN node's icon (it hangs off that very
- *    circle, so at low zoom it always overlaps it), and a label with nowhere
- *    clear is dropped rather than drawn illegibly.
+ * 3. **Node icons are obstacles, not just other labels** (#1258). The circles
+ *    most likely to sit on a name belong to tools and SOP tasks, which are
+ *    never named at rest and so contributed no box of their own — a label could
+ *    clear every other label and still render as `[icon]folio Support`.
+ * 4. **The icon pass does not over-correct.** A label may sit on its OWN node's
+ *    icon (it hangs off that very circle, so at low zoom it always overlaps
+ *    it); a label an icon blocks is offered the mirrored row above its node
+ *    before it is given up on; and one that fits nowhere is dropped rather than
+ *    drawn illegibly. Without the mirror this pass takes a company's own name
+ *    off the canvas rather than moving it 20px — a worse bug than the one it
+ *    fixes. The mirror is offered ONLY against an icon: property 1 is untouched,
+ *    because two labels contending for one row are the same width and moving
+ *    one up relocates the contention rather than settling it.
  */
 
 const W = 880;
@@ -53,9 +59,14 @@ const cand = (over: Partial<LabelCandidate> & { id: string }): LabelCandidate =>
   ...over,
 });
 
+/** the ids a plan kept, in the order it placed them */
+const ids = (plan: LabelPlan): string[] => [...plan.keys()];
+/** the ids a plan kept, order-insensitive */
+const idSet = (plan: LabelPlan): Set<string> => new Set(plan.keys());
+
 describe("planLabels", () => {
   it("drops the lower-priority label of a colliding pair", () => {
-    const kept = planLabels(
+    const plan = planLabels(
       [
         cand({ id: "quiet", x: 0, priority: LABEL_PRIORITY.worker }),
         cand({ id: "hovered", x: 28, priority: LABEL_PRIORITY.hovered }),
@@ -63,11 +74,11 @@ describe("planLabels", () => {
       { x: 0, y: 0, w: W },
       W,
     );
-    expect([...kept]).toEqual(["hovered"]);
+    expect(ids(plan)).toEqual(["hovered"]);
   });
 
   it("keeps both when the boxes clear each other", () => {
-    const kept = planLabels(
+    const plan = planLabels(
       [
         cand({ id: "left", x: 0, priority: LABEL_PRIORITY.worker }),
         cand({ id: "right", x: 32, priority: LABEL_PRIORITY.hovered }),
@@ -75,7 +86,7 @@ describe("planLabels", () => {
       { x: 0, y: 0, w: W },
       W,
     );
-    expect(kept).toEqual(new Set(["left", "right"]));
+    expect(idSet(plan)).toEqual(new Set(["left", "right"]));
   });
 
   it("measures in screen space, so zooming out drops a label the same graph gap kept", () => {
@@ -84,10 +95,10 @@ describe("planLabels", () => {
       cand({ id: "right", x: 32, priority: LABEL_PRIORITY.worker }),
     ];
     // camera width === canvas width: one graph unit is one px, both fit
-    expect(planLabels(pair, { x: 0, y: 0, w: W }, W)).toEqual(new Set(["left", "right"]));
+    expect(idSet(planLabels(pair, { x: 0, y: 0, w: W }, W))).toEqual(new Set(["left", "right"]));
     // pulled back to half scale the nodes are 16px apart while the labels are
     // still 24px wide — in graph units nothing changed at all
-    expect([...planLabels(pair, { x: 0, y: 0, w: W * 2 }, W)]).toEqual(["left"]);
+    expect(ids(planLabels(pair, { x: 0, y: 0, w: W * 2 }, W))).toEqual(["left"]);
   });
 
   it("panning the camera never changes the outcome", () => {
@@ -104,10 +115,10 @@ describe("planLabels", () => {
     const neighbour = cand({ id: "neighbour", x: 100, priority: LABEL_PRIORITY.worker });
     const short = cand({ id: "named", x: 0, text: "A", priority: LABEL_PRIORITY.hovered });
     const long = { ...short, text: "A".repeat(40) };
-    expect(planLabels([short, neighbour], { x: 0, y: 0, w: W }, W)).toEqual(
+    expect(idSet(planLabels([short, neighbour], { x: 0, y: 0, w: W }, W))).toEqual(
       new Set(["named", "neighbour"]),
     );
-    expect([...planLabels([long, neighbour], { x: 0, y: 0, w: W }, W)]).toEqual(["named"]);
+    expect(ids(planLabels([long, neighbour], { x: 0, y: 0, w: W }, W))).toEqual(["named"]);
   });
 
   it("separates labels that share an x but sit on different rows", () => {
@@ -115,7 +126,14 @@ describe("planLabels", () => {
       cand({ id: "row-0", x: 0, dy: 20, priority: LABEL_PRIORITY.hovered }),
       cand({ id: "row-1", x: 0, dy: 40, priority: LABEL_PRIORITY.worker }),
     ];
-    expect(planLabels(stacked, { x: 0, y: 0, w: W }, W)).toEqual(new Set(["row-0", "row-1"]));
+    expect(idSet(planLabels(stacked, { x: 0, y: 0, w: W }, W))).toEqual(
+      new Set(["row-0", "row-1"]),
+    );
+  });
+
+  it("reports where each survivor is drawn, so the renderer cannot guess wrong", () => {
+    const plan = planLabels([cand({ id: "named", dy: 26 })], { x: 0, y: 0, w: W }, W);
+    expect(plan.get("named")).toBe(26);
   });
 });
 
@@ -128,25 +146,35 @@ describe("planLabels vs node icons (issue #1258)", () => {
   });
 
   // "AAAA" at fontPx 10 hanging on dy 20, at one px per graph unit, is the box
-  // x -15..15, y 12..22 — the numbers every case below is placed against.
+  // x -15..15, y 12..22 — the numbers every case below is placed against. Its
+  // mirror is dy -20: the box x -15..15, y -28..-18.
   const named = cand({ id: "named", priority: LABEL_PRIORITY.worker });
 
-  it("drops a label that lands on an unnamed neighbour's icon", () => {
+  it("moves a label off an unnamed neighbour's icon", () => {
     // the tool sits squarely in the middle of the word — no other LABEL is
     // anywhere near, which is exactly why the old pass let this through
     const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
-    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [])).toEqual(new Set(["named"]));
-    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [tool]).size).toBe(0);
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, []).get("named")).toBe(20);
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [tool]).get("named")).toBe(-20);
+  });
+
+  it("drops a label boxed in on both rows", () => {
+    // the whole column is spoken for, so there is no honest place to put the
+    // name: it goes, and the node's <title> carries it instead
+    const below = icon({ id: "below", x: 0, y: 20, r: 7 });
+    const above = icon({ id: "above", x: 0, y: -23, r: 7 });
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [below, above]).size).toBe(0);
   });
 
   it("lets a label through its own node's icon", () => {
     // one circle, two readings: as the label's own node it is exempt, as
-    // anyone else's it blocks. r 18 reaches the box from the node's centre.
-    const own = icon({ id: "named", x: 0, y: 0, r: 18 });
-    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [own])).toEqual(new Set(["named"]));
-    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [{ ...own, id: "someone-else" }]).size).toBe(
-      0,
-    );
+    // anyone else's it blocks. r 30 reaches both rows from the node's centre,
+    // so as a stranger's circle there is nowhere for the name to mirror to.
+    const own = icon({ id: "named", x: 0, y: 0, r: 30 });
+    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [own]).get("named")).toBe(20);
+    expect(
+      planLabels([named], { x: 0, y: 0, w: W }, W, [{ ...own, id: "someone-else" }]).size,
+    ).toBe(0);
   });
 
   it("keeps the self exemption load-bearing at every depth", () => {
@@ -156,42 +184,66 @@ describe("planLabels vs node icons (issue #1258)", () => {
     // the way — the failure would read as "labels stopped working when I
     // zoomed out", not as a collision bug.
     const own = icon({ id: "named", x: 0, y: 0, r: 7 });
-    expect(planLabels([named], { x: 0, y: 0, w: W * 4 }, W, [own])).toEqual(new Set(["named"]));
+    expect(idSet(planLabels([named], { x: 0, y: 0, w: W * 4 }, W, [own]))).toEqual(
+      new Set(["named"]),
+    );
   });
 
   it("gives no label a way through an icon, however high its priority", () => {
     // an icon is not a competitor that can lose a tie — it is drawn either
-    // way, so the hovered name would render underneath it
+    // way, so the hovered name would render underneath it. Priority buys the
+    // first pick of the rows, never a pass through one that is taken.
     const hovered = cand({ id: "hovered", priority: LABEL_PRIORITY.hovered });
-    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
-    expect(planLabels([hovered], { x: 0, y: 0, w: W }, W, [tool]).size).toBe(0);
+    const below = icon({ id: "below", x: 0, y: 20, r: 7 });
+    const above = icon({ id: "above", x: 0, y: -23, r: 7 });
+    expect(planLabels([hovered], { x: 0, y: 0, w: W }, W, [below, above]).size).toBe(0);
   });
 
-  it("drops the blocked label without disturbing the ones that fit", () => {
-    // the no-valid-placement policy is 'drop', and it is local: a name with
-    // nowhere clear costs only itself
+  it("costs a blocked label nothing but itself", () => {
     const blocked = cand({ id: "blocked", x: 0, priority: LABEL_PRIORITY.hovered });
     const clear = cand({ id: "clear", x: 200, priority: LABEL_PRIORITY.worker });
-    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
-    expect(planLabels([blocked, clear], { x: 0, y: 0, w: W }, W, [tool])).toEqual(
+    const below = icon({ id: "below", x: 0, y: 20, r: 7 });
+    const above = icon({ id: "above", x: 0, y: -23, r: 7 });
+    expect(idSet(planLabels([blocked, clear], { x: 0, y: 0, w: W }, W, [below, above]))).toEqual(
       new Set(["clear"]),
     );
   });
 
+  it("offers the mirror only when an icon is the blocker", () => {
+    // #1104's rule is untouched: two labels contending for one row are the same
+    // width, so moving one up relocates the contention instead of settling it.
+    // That was the old two-row stagger, and it is why the loser still just goes.
+    const first = cand({ id: "first", x: 0, priority: LABEL_PRIORITY.hovered });
+    const second = cand({ id: "second", x: 20, priority: LABEL_PRIORITY.worker });
+    expect(ids(planLabels([first, second], { x: 0, y: 0, w: W }, W))).toEqual(["first"]);
+  });
+
+  it("will not mirror onto a label already placed there", () => {
+    // the row above is not a free parking space: the first candidate owns it,
+    // so the second has to give up rather than stack on top of it
+    const tool = icon({ id: "tool", x: 0, y: 20, r: 7 });
+    const first = cand({ id: "first", x: 0, dy: -20, priority: LABEL_PRIORITY.hovered });
+    const second = cand({ id: "second", x: 0, dy: 20, priority: LABEL_PRIORITY.worker });
+    expect(ids(planLabels([first, second], { x: 0, y: 0, w: W }, W, [tool]))).toEqual(["first"]);
+  });
+
   it("measures icons in screen space too, so zooming out drops what 1:1 kept", () => {
     // a radius RIDES the graph, unlike the font, so it must be projected
-    // through the camera rather than compared against px as-is. 30 units clear
-    // at 1:1; pulled back to a tenth, the box is still 10px tall while that
-    // gap has collapsed to 3px and the icon is inside the word.
+    // through the camera rather than compared against px as-is. 30 units above
+    // is clear at 1:1; pulled back to a tenth, the box is still 10px tall while
+    // that gap has collapsed to 3px and the icon is inside the word — on both
+    // rows at once, since at that depth the two rows are 4px apart.
     const above = icon({ id: "tool", x: 0, y: -30, r: 6 });
-    expect(planLabels([named], { x: 0, y: 0, w: W }, W, [above])).toEqual(new Set(["named"]));
+    expect(idSet(planLabels([named], { x: 0, y: 0, w: W }, W, [above]))).toEqual(
+      new Set(["named"]),
+    );
     expect(planLabels([named], { x: 0, y: 0, w: W * 10 }, W, [above]).size).toBe(0);
   });
 
   it("ignores an icon the caller left out, so hidden nodes never block", () => {
     // the caller only nominates circles it actually draws; a carousel node
     // faded to nothing must not take a name off a node you can see
-    expect(planLabels([named], { x: 0, y: 0, w: W }, W)).toEqual(new Set(["named"]));
+    expect(idSet(planLabels([named], { x: 0, y: 0, w: W }, W))).toEqual(new Set(["named"]));
   });
 });
 
@@ -228,6 +280,11 @@ describe("boxHitsCircle", () => {
     expect(b).toEqual({ x0: -15, x1: 15, y0: 12, y1: 22 });
     expect(boxHitsCircle(b, 0, 20, 7)).toBe(true);
     expect(boxHitsCircle(b, 0, 0, 7)).toBe(false);
+  });
+
+  it("mirrors the box when handed the mirrored row", () => {
+    const b = labelBoxPx(cand({ id: "x" }), { x: 0, y: 0, w: W }, 1, -20);
+    expect(b).toEqual({ x0: -15, x1: 15, y0: -28, y1: -18 });
   });
 });
 


### PR DESCRIPTION
Closes #1258

## The bug

On `#/overview`, a node's label renders **underneath a neighbouring node's icon**, hiding the start or middle of the word — `[icon]folio Support`, `Fou[icon]r Sourcer`, `[icon]pport operations desk`.

## Root cause (confirmed against the code, and reproduced)

`planLabels`' declutter pass collected survivors into `placed: LabelBox[]` and tested only `placed.some((p) => overlaps(p, box))`. The node icons — the `<circle r={r}>` avatars drawn from the `visuals` map — were never passed in and never consulted.

The nodes that cause it are precisely the ones the pass could not see: `tool` and `task` circles are the most numerous on the canvas and are deliberately **never nominated for a label at rest**, so they contributed no box of their own to collide with. A label could clear every other label and still land squarely on one.

Reproduced from a local host on both companies the issue names, at rest, both themes, after a reload plus a 10s settle. Measured out of the live SVG rather than eyeballed (every drawn `<text>` box against every drawn icon circle, excluding each label's own node):

| | labels drawn | labels sitting under an icon |
|---|---|---|
| Agentic Venture Capital Firm | 12 | **2** — `Founder Sourcer`, `Portfolio Support` |
| Agentic Customer Support Company | 12 | **5** — incl. `Support operations desk`, `Escalation Manager`, `Bug Reporter` |

A third company not named in the issue, `Agentic Software Company`, turned out to be worse than either: **7 of 16**.

## The fix

`planLabels` now takes the drawn icons as obstacles alongside the placed labels.

**Circle, not box.** An icon is a disc with a radius, so the test is closest-point circle-vs-rect (`boxHitsCircle`), not rect-vs-rect. A bounding-square test would throw away labels that clear the drawn avatar by 4px at every corner.

**Projected through the camera.** A radius *rides the graph*, unlike `fontPx`, which counter-scales to hold a constant on-screen size. So icons are projected (`r * scale`) before being measured, in the same screen px the rest of the pass works in.

**A label may sit on its own node's icon.** It hangs off that very circle by `dy`, and `dy` scales with the camera while the font does not — so zoomed far enough out *every* label overlaps its own icon regardless of radius. Without the exemption this drops every label at once when you zoom out, which would read as "labels stopped working", not as a collision bug.

**No valid placement → mirror once, then drop.** Dropping outright was my first cut and it is too blunt to ship: measured, it took 4 of 12 labels off the customer-support graph, *including the company's own name and its pillar's name*, both of which had only their first letter clipped. So a label an icon blocks is now offered the mirrored row above its node — checked against labels and icons alike before it is taken — and only goes if that is occupied too. The node keeps its `<title>` either way, so a dropped name is still one hover away.

**Losing to another label is still final.** The mirror is offered *only* against an icon. Two labels contending for one row are the same width, so moving one up relocates the contention rather than settling it — that is the old two-row stagger, and #1104 is the record of it not working. An icon is not a party to the negotiation: it cannot yield, has no priority to lose on, and is drawn whatever this pass decides, so the label is the only thing that can move. Every #1104 test passes unchanged.

**The pass is not monotone in the number of labels**, and that surprised me — I had claimed the opposite until a third company disproved it. A label that mirrors upstairs *vacates* the row it wanted, and a quieter candidate that would have lost that row can now have it. So an icon can indirectly **add** a name: on `Agentic Software Company` the icon pass cost four names and handed back `QA Engineer`. Every placement is still checked against labels and icons, so the extra name is a legible one — but the survivor count is not a ceiling. Pinned with a test rather than left to be rediscovered.

`planLabels` consequently returns `Map<id, dy>` rather than `Set<id>`, so the renderer draws each survivor where the plan actually put it.

### Deliberately not modelled
The memory constellation's backdrop disc (`R_CORE + 10`, transition-scaled). It is an animated footprint, and feeding a mid-flight transition into this pass is the flicker class of bug the issue explicitly rules out. Under-reporting it is the conservative direction — it can only fail to drop, never wrongly drop — and the `self` label is placed early at priority 800 either way.

## Browser verification

Local host from this branch, own port and `OPENCOMPANY_DATA_DIR`, side by side against a baseline build of `HEAD~2`. At rest, light and dark, tour dismissed, after a reload and a 10s settle:

| | before | after |
|---|---|---|
| Agentic Venture Capital Firm | 12 labels, **2 obscured** | 10 labels, **0 obscured** |
| Agentic Customer Support Company | 12 labels, **5 obscured** | 8 labels, **0 obscured** |
| Agentic Software Company *(not named in the issue)* | 16 labels, **7 obscured** | 13 labels, **0 obscured** |

Identical in both themes. `Founder Sourcer`, `Support operations desk` and `Bug Reporter` are recovered by the mirror and read cleanly above their nodes; the rest were unreadable before and are now dropped in favour of their tooltip. A focused pillar tree measured byte-identical before and after.

## Commands run

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all clean
- `npx vitest run` — 159 files, 1536 tests, all passing
- `npm run build`

## Tests

`frontend/test/unit/overview-graph-labels.test.ts` gains 15 cases over `label-plan.ts` directly (it is a pure module): the icon collision itself, the own-icon exemption and why it is load-bearing at low zoom, the mirror and its limits (it will not mirror onto a placed label; it is not offered against a label blocker), the drop-when-boxed-in policy, that priority buys no way through an icon, that icons are measured in screen space, pan-invariance (the property that lets the caller only re-run this on zoom), the non-monotonicity above, and `boxHitsCircle` on its own — including the corner case that separates a disc test from a bounding-box one.
