### PR TITLE
lint: Rust 1.98's result_large_err turned main red — crate-wide allow with reasoning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,17 @@
 //! TinyHumans Rust modules. The default build stays small; enable the `tiny`
 //! feature to compile against the sibling `tiny*` crates.
 
+// Rust 1.98's clippy promoted `result_large_err` into the default set and it
+// fires on ~80 existing Axum handlers: every `Result<_, ApiError>` return,
+// because `ApiError` wraps `OpenCompanyError` by value (>128 bytes). CI runs
+// unpinned stable, so this turned every branch red overnight with no code
+// change. Allowed crate-wide deliberately: the handlers' error path is cold
+// (one construction per failed request, immediately serialized), so boxing
+// ~100 signatures buys latency nothing and costs an allocation on every
+// error. Revisit if OpenCompanyError grows again or a hot path starts
+// returning it.
+#![allow(clippy::result_large_err)]
+
 pub mod app;
 pub mod brain;
 /// Chargebee billing (issue #788): the REST client and the billing operations


### PR DESCRIPTION
CI runs unpinned stable; clippy 1.98 (landed in CI within the last hours — 1290's run at 17:40Z shows `clippy 1.98.0` where earlier runs used 1.97.1) promoted `result_large_err` into the default set, and it fires on **~80 pre-existing handler sites** (`operator.rs` ×19, `users/` ×24, …): every `Result<_, ApiError>` return, because `ApiError` wraps `OpenCompanyError` by value. Every branch — including main on its next run — is red with zero code change.

This is the minimal unblock: a crate-level allow with the reasoning at the attribute (cold error path, one construction per failed request, immediately serialized; boxing ~100 signatures costs an allocation per error and buys latency nothing). The alternative — pinning the CI toolchain — trades this class of surprise for staleness and is a bigger policy call than one lint.

Verified locally on rustc/clippy 1.98.0: `cargo clippy --locked --all-targets -- -D warnings` goes from 80 errors to 0 with only this attribute.

Flagging directly since every open PR is blocked on it: @oxoxDev

🤖 Generated with [Claude Code](https://claude.com/claude-code)