### PR TITLE
fix: unblock CI on rustc 1.98 and pin the Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,17 @@ env:
 # Dependabot is unlikely to bump. Re-resolve it from the `stable` branch by
 # hand; never copy a SHA from another repo or another toolchain branch.
 #
+# Issue #1298: that input is a VERSION, not `stable`. It used to be `stable`,
+# which resolved at run time — so when rustc 1.98.0 shipped on 2026-08-18 and
+# brought a newly-enforced `clippy::result_large_err` with it, every open PR in
+# the repo went red at once, including PRs touching no Rust. The action was
+# pinned; the compiler it installed was not. A version here turns the next
+# stable release into a reviewable bump PR instead of a repo-wide outage that
+# no diff explains. `rust-toolchain.toml` carries the same version and the
+# reasoning in full; `scripts/ci/assert-toolchain-pin.sh` (run in the `rust`
+# job) fails if any call site below disagrees with it, so bumping one and
+# forgetting the others is caught rather than shipped.
+#
 # Pins rot: an unbumped pin is a frozen, eventually-unpatched action, which
 # trades one supply-chain risk for another. The `github-actions` ecosystem entry
 # in `.github/dependabot.yml` is the other half of this — it turns each upstream
@@ -378,9 +389,16 @@ jobs:
             echo "::warning title=Vendored openhuman drift::pin $pin is $behind commits behind openhuman main. Past ~25 the catch-up stops being a pointer move — see issue #499, where it reached 102 and the reorg in between turned the bump into a migration."
           fi
 
+      # Issue #1298. Runs BEFORE the toolchain install, and needs no toolchain
+      # of its own: it is a check on this repo's config, and a drifted pin
+      # should fail here in one legible line rather than as a lint difference
+      # between two lanes twenty minutes later.
+      - name: Assert toolchain pins agree
+        run: scripts/ci/assert-toolchain-pin.sh
+
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0"
           components: rustfmt, clippy
 
       # Issue #1118. This job had NO build cache, which the comment above
@@ -665,7 +683,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0"
 
       # Issue #1118: save the cache on a red run too — see the `rust` job.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -799,7 +817,7 @@ jobs:
       # covered by the `rust` job and re-running it here would buy nothing.
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0"
           components: clippy
 
       # Issue #1118: save the cache on a red run too — see the `rust` job.
@@ -1273,7 +1291,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0"
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -1813,6 +1831,14 @@ jobs:
             src-tauri
             frontend/src-tauri
 
+      # Issue #1298. This lane installs no toolchain of its own — unlike the
+      # four `dtolnay/rust-toolchain` call sites elsewhere in this file — and
+      # does not need to: `src-tauri` has no `rust-toolchain.toml`, so rustup
+      # walks up to the repo root's and the cargo steps below run on the same
+      # pinned version every other Rust lane uses. That is why
+      # `assert-toolchain-pin.sh` finds nothing to check here; the pin still
+      # applies. If this job ever grows an explicit install, it must pass the
+      # same version, and the script will start covering it automatically.
       - name: Format
         run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
+          toolchain: "1.98.0"
 
       # `--locked` for the same reason issue #251 requires it throughout
       # `ci.yml`: both commands resolve a dependency graph, and without the flag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,23 @@ dedicated `test.rs` file when they grow.
 Run commands from the repository root unless a future workspace layout changes
 the module location.
 
+`rust-toolchain.toml` pins an **explicit** Rust version (issue #1298), and
+every `dtolnay/rust-toolchain` call site in `.github/workflows/` passes that
+same version. Do not change either back to `stable`. Both said `stable` until
+rustc 1.98.0 shipped on 2026-08-18 with a newly-enforced
+`clippy::result_large_err`, at which point every open PR in the repo went red
+at once — including PRs touching no Rust — while everyone still on 1.97.x
+passed `cargo clippy` locally and could not reproduce it. A pin turns the next
+stable release into one reviewable bump PR instead.
+
+To bump: edit `rust-toolchain.toml`, then run
+`scripts/ci/assert-toolchain-pin.sh`, which fails and names any workflow call
+site still on the old version. That script runs in the `rust` job, so a
+half-finished bump is caught rather than shipped. Because the pin is in
+`rust-toolchain.toml`, a plain `cargo` in this checkout already uses it — you
+do not need `cargo +<version>`, and if your `rustup` lacks the toolchain it
+will fetch it.
+
 `.cargo/config.toml` sets `RUST_MIN_STACK = 8388608` for every cargo-invoked
 process (issue #895). Do not drop it. The gated suite exceeds libtest's 2 MiB
 default thread stack, and when it does the failure is a `SIGABRT` that aborts

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,21 @@
+# Issue #1298. An EXPLICIT version, never "stable".
+#
+# This file used to say `channel = "stable"`, and CI installed `stable` too, so
+# both resolved to whatever stable happened to be at run time. On 2026-08-18
+# rustc 1.98.0 shipped, `clippy::result_large_err` started firing across
+# `src/server/**`, and every open PR in the repo went red — including PRs that
+# touched no Rust at all. Nothing in the tree changed; the compiler did. Anyone
+# still on 1.97.x passed `cargo clippy` locally and could not reproduce it.
+#
+# A floating channel makes an upstream release a repo-wide outage with nothing
+# in any diff to explain it. A pin makes the same release a PR: one that bumps
+# this number, absorbs whatever new lints came with it, and is reviewed on its
+# own — which is where that work belongs.
+#
+# `scripts/ci/assert-toolchain-pin.sh` asserts that every
+# `dtolnay/rust-toolchain` call site in `.github/workflows/` passes this exact
+# version, so the workflows and this file cannot drift apart. Bump here, run
+# that script, and it will name any call site you missed.
 [toolchain]
-channel = "stable"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]

--- a/scripts/ci/assert-toolchain-pin.sh
+++ b/scripts/ci/assert-toolchain-pin.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Fail if any `dtolnay/rust-toolchain` call site in `.github/workflows/`
+# installs a toolchain other than the one `rust-toolchain.toml` pins.
+#
+# Issue #1298. Both used to say `stable`, which is not a version but a promise
+# to resolve one later. rustc 1.98.0 shipped on 2026-08-18 carrying a
+# newly-enforced `clippy::result_large_err`, every lane picked it up on its next
+# run, and every open PR in the repo went red — on diffs that touched no Rust.
+# Local checkouts on 1.97.x stayed green, so the first read of it was "CI is
+# broken", not "the compiler moved".
+#
+# Pinning fixes that, but only while the pins agree. Four call sites in `ci.yml`
+# and one in `release.yml` each name the version separately, because the
+# workflow comment there wants the selection visible to a reader at the call
+# site rather than hidden behind an action ref. Five copies of a version is five
+# chances to bump four. A partial bump is worse than no bump: the lanes split,
+# some lint under the new compiler and some under the old, and which of them is
+# authoritative is a question nobody can answer from the diff.
+#
+# So `rust-toolchain.toml` is the single source of truth and this script is what
+# makes the copies obey it. To bump: change `rust-toolchain.toml`, run this
+# script, and fix whatever it names.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+pinned="$(
+  sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+    rust-toolchain.toml | head -1
+)"
+
+if [ -z "$pinned" ]; then
+  echo "assert-toolchain-pin: could not read [toolchain].channel from rust-toolchain.toml" >&2
+  exit 1
+fi
+
+case "$pinned" in
+  stable | beta | nightly | *-*)
+    echo "assert-toolchain-pin: rust-toolchain.toml pins '$pinned'." >&2
+    echo "  Expected an explicit version such as 1.98.0. A floating channel is" >&2
+    echo "  what issue #1298 was about: it makes an upstream release red every" >&2
+    echo "  open PR at once, with nothing in any diff to explain it." >&2
+    exit 1
+    ;;
+esac
+
+echo "rust-toolchain.toml pins $pinned."
+
+# Every `toolchain:` input in the workflows, with its file and line, so a
+# failure names the exact call site to edit.
+status=0
+found=0
+while IFS=: read -r file line value; do
+  found=$((found + 1))
+  # Strip surrounding quotes and trailing comment/whitespace.
+  value="$(printf '%s' "$value" | sed 's/#.*//; s/[[:space:]]*$//; s/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')"
+  if [ "$value" = "$pinned" ]; then
+    echo "  ok  $file:$line -> $value"
+  else
+    echo "  BAD $file:$line -> '$value' (rust-toolchain.toml pins '$pinned')" >&2
+    status=1
+  fi
+done < <(
+  grep -rn '^[[:space:]]*toolchain:[[:space:]]*' .github/workflows/ \
+    | sed 's/^\([^:]*\):\([0-9]*\):[[:space:]]*toolchain:[[:space:]]*/\1:\2:/'
+)
+
+# A grep that matches nothing exits 0 and would pass this check silently — the
+# same shape of hole `assert-integration-targets-run.sh` exists to close.
+if [ "$found" -eq 0 ]; then
+  echo "assert-toolchain-pin: found no 'toolchain:' inputs in .github/workflows/." >&2
+  echo "  Either the call sites stopped passing one explicitly (see the comment" >&2
+  echo "  at the top of ci.yml for why they should), or this script's pattern is" >&2
+  echo "  stale. Both need a human." >&2
+  exit 1
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "assert-toolchain-pin: bump every call site to '$pinned', or change" >&2
+  echo "  rust-toolchain.toml if the workflows are the ones that are right." >&2
+  exit 1
+fi
+
+echo "All $found toolchain call site(s) agree with rust-toolchain.toml."

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,28 @@
+// Issue #1298: a deliberate deferral, not a disagreement with the lint.
+//
+// `clippy::result_large_err` began firing across this module on rustc 1.98.0
+// (released 2026-08-18) with no change to this tree. Every finding names the
+// same foreign type — 80 of them on the default feature set, and not one names
+// `ApiError` or `OpenCompanyError`, both of which are well under the limit.
+// `axum::http::Response<Body>` is exactly 128 bytes, which is exactly clippy's
+// default `large-error-threshold`, and handlers here return
+// `Result<T, Response>` — the pre-rendered-rejection shape.
+//
+// The lint is correct. `Result<T, E>` is as large as its larger arm, so those
+// 128 bytes are moved on the success path too, on every one of these handlers.
+//
+// It is allowed rather than fixed because `Response` is axum's type, so there
+// is no variant of ours to box. `Result<T, Box<Response>>` does not work
+// directly — axum requires the `Err` type to implement `IntoResponse`, which
+// `Box<Response>` does not — so the real fix is a newtype or a move onto
+// `ApiError`, threaded through 80 signatures in 16 files. That is a reviewable
+// refactor of the whole server surface, not a CI unblock.
+//
+// Tracked in #1299, which also records the per-module plan for narrowing this
+// allow back down as handlers are converted. Scoped to `server` on purpose:
+// the rest of the crate stays covered by the lint.
+#![allow(clippy::result_large_err)]
+
 #[cfg(feature = "tinyplace")]
 pub mod a2a;
 /// The Agent Client Protocol surface (the `acp` feature).


### PR DESCRIPTION
Closes #1298.

## Summary

Nothing in this repo changed. The compiler did.

`rustc 1.98.0` shipped on **2026-08-18**. CI installed its toolchain with
`dtolnay/rust-toolchain` passing `toolchain: stable`, and `rust-toolchain.toml`
also said `channel = "stable"` — both of which resolve at *run time*, not at pin
time. So the first CI run after that release silently swapped compilers:

```
stable-x86_64-unknown-linux-gnu updated - rustc 1.98.0 (88d9e12ae 2026-08-18) (from rustc 1.97.1)
```

1.98 enforces `clippy::result_large_err`, which our `-D warnings` turns into 80
hard errors in `src/server/**`. Every open PR whose Rust lane ran went red,
including PRs touching no Rust at all, and `Console E2E` (`needs: rust`) was
*skipped* rather than run — so a second lane quietly stopped providing coverage
too.

**If you are reading this because your PR is red: it is not your diff.** Rebase
on top of this once it lands. And if you tried to reproduce locally and
couldn't, that's expected — anyone still on 1.97.x passes `cargo clippy`
cleanly, because the lint doesn't exist there.

### One correction to the issue's diagnosis

#1298 attributes this to "one shared `Response`-based error type being large",
which reads as though it's *our* error type. It isn't. `OpenCompanyError` and
`ApiError` are both comfortably under the threshold and neither is named once.
All 80 findings name the same **foreign** type:

```
= help: try reducing the size of `axum::http::Response<axum::body::Body>`
  the `Err`-variant is at least 128 bytes
```

`axum::http::Response<Body>` is exactly 128 bytes — exactly clippy's default
`large-error-threshold` — and handlers across the server surface return
`Result<T, Response>`, the pre-rendered-rejection shape. That distinction is
what decides part 1, so it's worth stating plainly.

### Part 1 — unblock: a scoped `allow`, not a box

The issue offered "box the large variants **or** allow". Boxing isn't available
in the form that phrase implies: `Response` is axum's type, so there is no
variant of ours to box. The real options are wider than they sound:

- `Result<T, Box<Response>>` doesn't work directly — axum requires the `Err`
  type to implement `IntoResponse`, and `Box<Response>` does not. It needs a
  newtype threaded through every signature and every `?`/`map_err` feeding it.
- Moving these handlers onto `ApiError` is the better end state, but several of
  these rejections genuinely aren't `OpenCompanyError`-shaped (auth redirects,
  cookie-setting responses, setup-flow HTML), so it's a per-handler judgement
  call, not a mechanical rewrite.

Either way it's **80 signatures across 16 files** — a reviewable refactor of the
whole server surface, which is exactly the thing #1298 argues shouldn't be
buried in an unrelated diff. So it gets the same treatment: its own PR, tracked
in **#1299**, which carries the per-file counts and a suggested per-module plan.

What this PR does instead is one line in `src/server/mod.rs`:

```rust
#![allow(clippy::result_large_err)]
```

Scoped to the `server` module, **not** crate-level — the lint keeps covering the
rest of the crate, and it will start covering each server module again as #1299
converts them. The comment above it says outright that the lint is *correct*
(`Result<T, E>` is as large as its larger arm, so those 128 bytes ride along on
the success path too), that this is a deferral, and where the deferred work
lives.

### Part 2 — stop it recurring: pin the toolchain

An action pinned to a SHA that installs a floating compiler isn't pinned. Every
Rust lane is now on an explicit version:

- `rust-toolchain.toml`: `channel = "stable"` → `"1.98.0"`.
- All five `dtolnay/rust-toolchain` call sites — four in `ci.yml` (`rust`,
  `rust-mongodb`, `rust-gated`, `rust-gated-binary`) and one in `release.yml` —
  pass `toolchain: "1.98.0"`.

Pinning to 1.98.0 rather than back to 1.97.1 is deliberate: dodging the lint by
freezing on the old compiler just moves the same wall further out.

**The five copies can't drift.** `ci.yml`'s existing comment explains why each
call site names its toolchain *explicitly* rather than inheriting it from the
action ref, and I kept that convention. But five copies of a version is five
chances to bump four — and a partial bump is worse than none, because the lanes
split across two compilers with nothing in the diff to say which is
authoritative. So `rust-toolchain.toml` is the single source of truth, and
`scripts/ci/assert-toolchain-pin.sh` (new, run early in the `rust` job before
the toolchain install) fails if any call site disagrees with it, naming the
exact `file:line`. It also rejects a floating `channel` outright, and fails if
it matches *zero* call sites rather than passing silently on a stale pattern —
the same hole `assert-integration-targets-run.sh` exists to close.

To bump Rust in future: edit `rust-toolchain.toml`, run
`scripts/ci/assert-toolchain-pin.sh`, fix whatever it names.

**The sixth lane.** `Desktop` also runs cargo but installs no toolchain of its
own. It needs none: `src-tauri/` has no `rust-toolchain.toml`, so rustup walks
up to the root one and that lane is now pinned too, implicitly. There's a
comment there saying so, so nobody reads the absence as an oversight — and if it
ever grows an explicit install, the assert script picks it up automatically.

`.cargo/config.toml`'s `RUST_MIN_STACK` (issue #895) is untouched.

## API Or Behavior Changes

**None.** This is a zero-behaviour-change diff. No signature, no error path and
no rendered response is touched — only whether clippy reports on them, and which
compiler CI installs. The `allow` route was chosen partly *because* it keeps it
that way; the reshaping that would touch error paths is deferred to #1299.

## Tests

All of the below on **1.98.0 specifically** — verifying on 1.97.x would prove
nothing, since the lint doesn't exist there. I reproduced the failure first (80
errors on the default feature set), then confirmed each check goes red → green.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --locked -- -D warnings` — **80 errors → clean** (this is the plain `Rust` lane)
- [x] `cargo build --locked --all-targets`
- [x] `cargo test --locked`

Beyond the template:

- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean (the exact `Rust (openhuman, tinycortex)` invocation)
- [x] same with `,mcp` added — clean
- [x] `cargo fmt`/`cargo clippy` on `src-tauri` (the `Desktop` lane) — clean on 1.98
- [x] `scripts/ci/assert-toolchain-pin.sh` — passes; **and** fails correctly when I deliberately broke one call site, and again when I reverted the channel to `stable`
- [x] `scripts/ci/assert-feature-lanes.sh` — unchanged (no feature added)
- [x] `scripts/ci/assert-md-line-cap.sh` — pass

## Documentation

`AGENTS.md` (which `CLAUDE.md` symlinks to) gains a short section under the
build commands: the pin exists, don't revert it to `stable`, here's how to bump
it, and you don't need `cargo +<version>` because `rust-toolchain.toml` already
selects it for a plain `cargo` in this checkout.

`rust-toolchain.toml`, the `ci.yml` toolchain-policy comment, the new script and
the `src/server/mod.rs` allow each carry their own rationale inline, in the
style the surrounding comments already use.
