### PR TITLE
fix(workflows): cut the run-history page by seq so a clock regression cannot hide a run (#1012)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -281,6 +281,11 @@ undelivered report is its own reading rather than a failure, and why it is
 derived on the read rather than journaled (issue #981) — has its own focused
 page: [run-verdict.md](run-verdict.md).
 
+How the run history is **paged** — why the page is cut by `seq` but displayed
+by `(atMillis, seq)`, why the cursor is server-issued rather than derived from
+the last row, and what a console must do when an older host omits it (issue
+#1012) — likewise: [run-history-paging.md](run-history-paging.md).
+
 ### Pausing a workflow, and the disarm rule (issue #276)
 
 The pause switch, what it does **not** stop, why it lives in

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -283,8 +283,8 @@ page: [run-verdict.md](run-verdict.md).
 
 How the run history is **paged** — why the page is cut by `seq` but displayed
 by `(atMillis, seq)`, why the cursor is server-issued rather than derived from
-the last row, and what a console must do when an older host omits it (issue
-#1012) — likewise: [run-history-paging.md](run-history-paging.md).
+the last row, and what a console must do when an older host omits it
+(issue #1012) — likewise: [run-history-paging.md](run-history-paging.md).
 
 ### Pausing a workflow, and the disarm rule (issue #276)
 

--- a/docs/modules/server/run-history-paging.md
+++ b/docs/modules/server/run-history-paging.md
@@ -1,0 +1,55 @@
+# Paging the workflow run history (issue #1012)
+
+How `GET …/workflows/runs` cuts a page, orders it, and hands back the
+cursor for the page behind it. Split out of
+[workflow-routes.md](workflow-routes.md), which links here.
+
+```text
+GET …/workflows/runs?workflow=<wid>&limit=<n>&before_seq=<cursor>
+→ { "runs": [ … ], "hasMore": true, "nextBeforeSeq": 41 }
+```
+
+The page is **cut by `seq` and displayed by `(atMillis, seq)`** — two different
+keys, on purpose.
+
+`seq` is the journal's append position: monotonic, and the only key the backward
+read (`EventLog::read_before`) can be bounded by. `atMillis` is wall-clock and
+is *not* monotonic in storage order — a clock step backwards (NTP correction, a
+VM resume, an operator setting the date) writes a row whose time precedes the
+row before it. Cutting the page on the display pair and then paging off the
+boundary row's `seq` therefore used to lose runs outright: a run appended after
+the boundary but timestamped before it sorts below the cut (dropped from this
+page) and sits at or above the cursor (excluded from the next), and because the
+cursor only descends, from every later page too. It became permanently
+unreachable while `hasMore` still counted it.
+
+Cutting on `seq` makes the two pages a **partition**: this response is exactly
+`{ seq >= nextBeforeSeq }` of the candidates and the next request asks for
+`{ seq < nextBeforeSeq }`. That is a structural guarantee, not a bound on how
+far a clock may drift.
+
+The accepted trade: under a clock regression a run is served on the page its
+`seq` puts it on — correctly ordered *within* that page, possibly out of order
+against the adjacent one. Under a monotonic clock the two keys agree and the
+behaviour is identical to cutting on the pair. The degradation fires only on the
+anomaly that previously caused permanent loss, and it degrades to "wrong order
+at one seam", never to "the run is gone".
+
+**`nextBeforeSeq` is server-issued, and clients must not derive it.** Under this
+cut the boundary is the page's *lowest* `seq`, which no ordering of the returned
+rows exposes as "the last one" — so `runs.at(-1).seq` is a different run
+whenever the clock regressed. It is **omitted when `hasMore` is `false`**: there
+is no page behind the last one.
+
+A client talking to a host predating the field must fall back to the old
+`runs.at(-1).seq` derivation — such a host still cuts its pages in display
+order, so its last row genuinely is the boundary. Reading the absent field as
+"there are no more pages" would re-ship this fix as a fresh silent truncation,
+which is #1012's own symptom. `hasMore` remains the only thing that says whether
+to keep going.
+
+`limit` counts **runs**, not journal rows — a run is a group (`Started`, N node
+rows, `Finished`) and a page of raw events is not a page of runs. `?workflow=`
+is applied before the cut, so asking for one graph returns *its* most recent N
+rather than whichever of the last N happen to match.
+

--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -147,6 +147,16 @@ rides the create body and the read shape under the same key, and the model
 type is reused verbatim in both directions (`kind` / `target` are single words,
 so there is no camelCase mirror to drift from).
 
+### Paging the run history (issue #1012)
+
+`GET …/workflows/runs` is paged: `?limit=` counts **runs** (not journal rows),
+`hasMore` says whether an older page exists, and `nextBeforeSeq` is the cursor
+to pass back as `?before_seq=`. The page is cut by `seq` and displayed by
+`(atMillis, seq)` — two different keys, because `atMillis` is wall-clock and
+cutting on it loses runs when the clock steps backwards. Clients must **not**
+derive the cursor. Full contract, the partition argument, and the
+version-skew fallback: [run-history-paging.md](run-history-paging.md).
+
 ### Destinations that can never deliver are refused at save (issue #981)
 
 Two of delivery's refusals are decided by facts that hold for *every* run of the

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -72,6 +72,16 @@ run is then followed through the `workflow_run_started` / `workflow_node_finishe
 / `workflow_run_finished` frames it already keys by that `runId`, and read back
 from `GET …/workflows/runs`, whose fold reports `running: true` until it settles.
 
+That read is **paged** (issue #1012): `{ runs, hasMore, nextBeforeSeq }`, where
+`nextBeforeSeq` is the cursor to pass back as `?before_seq=` and is omitted once
+`hasMore` is `false`. The page is cut by `seq` and only then sorted for display
+by `(atMillis, seq)`, so the cursor is the page's *lowest* `seq` rather than its
+last row — clients must send back what the host issued rather than deriving it,
+and a client talking to a host that omits the field falls back to the old
+`runs.at(-1).seq` derivation, never to "no more pages". Why the two keys differ,
+and the partition argument that makes paging lossless under a clock regression:
+[server/run-history-paging.md](../../modules/server/run-history-paging.md).
+
 **Clients must discriminate on the response shape, not on what they sent.** A
 host predating this ignores the unknown `detach` field and answers the full
 synchronous `200`, so `output` present means "already settled" and `detached`

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -825,13 +825,31 @@ export function cancelWorkflowRun(
 /**
  * One page of {@link listWorkflowRuns} (issue #1012).
  *
- * `hasMore` says whether an older page exists behind `beforeSeq` — the run
+ * `hasMore` says whether an older page exists behind `nextBeforeSeq` — the run
  * history drawer's "Load older" affordance is gated on it, so a truncated
  * history never silently reads as the whole thing.
  */
 export interface WorkflowRunsPage {
   runs: WorkflowRunOutcome[];
   hasMore: boolean;
+  /**
+   * The cursor to pass back as `beforeSeq` for the page behind this one — the
+   * page's **lowest** `seq`, which is not in general the last row in display
+   * order.
+   *
+   * Server-issued rather than derived here, and that is the point. The host
+   * cuts a page by `seq` (monotonic, and the key its journal read is bounded
+   * by) and then sorts it for display by `(atMillis, seq)`; `atMillis` is
+   * wall-clock, so a clock regression makes the two orders disagree and
+   * `runs.at(-1)!.seq` is no longer the boundary. Paging off the last
+   * displayed row then skips runs permanently — the very bug #1012 is about.
+   *
+   * **Absent on a host predating this field.** That must fall back to the old
+   * `runs.at(-1)?.seq` derivation, never to "there are no more pages": the
+   * latter would ship this fix as a fresh silent truncation. `hasMore` remains
+   * the only thing that says whether to keep going.
+   */
+  nextBeforeSeq?: number;
 }
 
 /**
@@ -841,10 +859,10 @@ export interface WorkflowRunsPage {
  *
  * `workflow` narrows to one graph's runs; `limit` caps the page (the host
  * defaults to a short recent list and clamps a large ask). `beforeSeq` pages
- * further back: pass the `seq` of the oldest run already held to fetch the
- * page before it (issue #1012) — `hasMore` on the returned page says whether
- * one exists. A host predating this route answers 404 — callers should treat
- * that as "no history yet" rather than an error, since the console still works
+ * further back: pass the previous page's {@link WorkflowRunsPage.nextBeforeSeq}
+ * to fetch the page before it (issue #1012) — `hasMore` says whether one
+ * exists. A host predating this route answers 404 — callers should treat that
+ * as "no history yet" rather than an error, since the console still works
  * without it.
  */
 export function listWorkflowRuns(
@@ -855,7 +873,10 @@ export function listWorkflowRuns(
   const params = new URLSearchParams();
   if (options?.workflow) params.set("workflow", options.workflow);
   if (options?.limit) params.set("limit", String(options.limit));
-  if (options?.beforeSeq) params.set("before_seq", String(options.beforeSeq));
+  // `!== undefined`, not truthiness: `0` is a legitimate cursor (the journal's
+  // first row) and a truthy check drops it, silently asking for the newest
+  // page again and looping the caller on the same rows.
+  if (options?.beforeSeq !== undefined) params.set("before_seq", String(options.beforeSeq));
   const query = params.toString();
   return client.get<WorkflowRunsPage>(
     `${client.scopeFor(company)}/workflows/runs${query ? `?${query}` : ""}`,

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -414,6 +414,27 @@ export function WorkflowsView({
   // newest-page fetch has not yet learned this), and updated by both that
   // effect and `loadOlderRuns` from each fetch's own `hasMore`.
   const [runsHasMore, setRunsHasMore] = useState(false);
+  // Issue #1012 follow-up: the cursor the HOST issued for the page behind the
+  // rows currently held. Not derivable here any more — the host cuts a page by
+  // `seq` and displays it by `(atMillis, seq)`, so the boundary is the page's
+  // lowest `seq` rather than its last row, and a clock regression makes those
+  // two different runs. `undefined` means either "no older page" (`hasMore`
+  // says which) or "host predates the field", which `loadOlderRuns` handles by
+  // falling back to the old derivation rather than by stopping.
+  const [runsNextBeforeSeq, setRunsNextBeforeSeq] = useState<number | undefined>(undefined);
+  // The rows currently held, readable from `loadOlderRuns` without listing
+  // `runs` as one of its dependencies — which would rebuild the callback on
+  // every history refresh and, worse, capture a generation that has already
+  // moved. Only the pre-#1012-host fallback reads it.
+  const runsRef = useRef<WorkflowRunOutcome[]>(runs);
+  runsRef.current = runs;
+  // Which "generation" of the history list is on screen. Bumped at every ENTRY
+  // of the first-page effect below, which replaces `runs` wholesale on all of
+  // its paths — so an older page fetched against the previous list can tell it
+  // is answering a question nobody is asking any more. Identity fields
+  // (company, workflow) cannot see this case: a refresh within one company
+  // changes neither.
+  const historyGenRef = useRef(0);
   // A "Load older" fetch in flight, so the drawer can disable the control and
   // avoid a second click racing the first for the same older page.
   const [loadingOlderRuns, setLoadingOlderRuns] = useState(false);
@@ -995,16 +1016,22 @@ export function WorkflowsView({
     // no history to ask for, and asking unfiltered is the bug described above.
     // `historySupported` is deliberately left alone — nothing was learned about
     // whether the host serves this route.
+    // Issue #1012 follow-up: bumped at ENTRY, before the early return, because
+    // every path out of this effect replaces the list — including this one.
+    // Any "Load older" response still in flight is now answering a superseded
+    // list and must be dropped rather than appended.
+    historyGenRef.current += 1;
     if (!selectedId) {
       setRuns([]);
       setRunsHasMore(false);
+      setRunsNextBeforeSeq(undefined);
       setRunsFor(null);
       return;
     }
     let live = true;
     (async () => {
       try {
-        const { runs: rows, hasMore } = await listWorkflowRuns(client, company, {
+        const { runs: rows, hasMore, nextBeforeSeq } = await listWorkflowRuns(client, company, {
           workflow: selectedId,
           limit: 50,
         });
@@ -1016,6 +1043,7 @@ export function WorkflowsView({
         // starts back over from this fresh newest page's own answer rather
         // than carrying forward whatever the appended state last said.
         setRunsHasMore(hasMore);
+        setRunsNextBeforeSeq(nextBeforeSeq);
         setRunsFor(selectedId);
         setHistorySupported(true);
         // Issue #371, the no-live-stream fallback. If the run we just POSTed is
@@ -1039,6 +1067,7 @@ export function WorkflowsView({
         console.debug("[WorkflowsView] run history unavailable", e);
         setRuns([]);
         setRunsHasMore(false);
+        setRunsNextBeforeSeq(undefined);
         // Still THIS workflow's answer — "the host has no history for it" — so
         // the pair agrees and the copilot may proceed, told via `runsKnown`
         // that nothing is known about runs rather than that there were none.
@@ -1058,33 +1087,71 @@ export function WorkflowsView({
 
   // Issue #1012: "Load older", the run-history drawer's pagination affordance.
   // APPENDS to `runs` rather than replacing it — unlike the effect above,
-  // which always starts over from the newest page. Paged off the `seq` of the
-  // oldest run currently held, matching the host's `?before_seq=` cursor
-  // semantics (issue #1012's ordering fix made `seq` the field every row's
-  // own display agrees with, which is what makes it a stable paging key).
+  // which always starts over from the newest page.
   const loadOlderRuns = useCallback(() => {
     if (!selectedId || loadingOlderRuns) return;
-    const oldest = runs.at(-1)?.seq;
-    if (oldest === undefined) return;
+    // The boundary comes from the HOST (issue #1012 follow-up). It is the
+    // page's lowest `seq`, which stopped being its last displayed row once the
+    // cut moved to `seq` while the display stayed on `(atMillis, seq)` — under
+    // a clock regression those are two different runs, and paging off the last
+    // row skips the ones in between, permanently.
+    //
+    // The fallback is version skew, and it must be the OLD derivation rather
+    // than "stop here": a host predating the field still cuts its pages in
+    // display order, so its last row genuinely is the boundary. Reading an
+    // absent cursor as "no more pages" would re-ship this fix as a fresh
+    // silent truncation — #1012's own symptom. Gated on `hasMore` so a
+    // finished history never asks for a page behind its last row.
+    const cursor = runsNextBeforeSeq ?? (runsHasMore ? runsRef.current.at(-1)?.seq : undefined);
+    if (cursor === undefined) return;
+    // Everything this response is allowed to land on, captured BEFORE the
+    // await — the same pattern the Resume handler uses for its company guard.
+    const forCompany = companyRef.current;
+    const forWorkflow = selectedId;
+    const forGeneration = historyGenRef.current;
     setLoadingOlderRuns(true);
     (async () => {
       try {
-        const { runs: older, hasMore } = await listWorkflowRuns(client, company, {
+        const { runs: older, hasMore, nextBeforeSeq } = await listWorkflowRuns(client, company, {
           workflow: selectedId,
           limit: 50,
-          beforeSeq: oldest,
+          beforeSeq: cursor,
         });
+        // Three checks, because no two of them are enough.
+        //
+        // * Company: a workflow id is NOT unique across companies —
+        //   `create_company_workflow` checks it only within the requesting
+        //   company — so two companies genuinely share one (a seed workflow
+        //   shipped identically to both is the common case). Company A's older
+        //   page would otherwise append onto company B's history.
+        // * Workflow: the ordinary switch-while-in-flight.
+        // * Generation: the first-page effect can have replaced the list
+        //   without either identity field changing — a run finished, the 2s
+        //   poll ticked, an explicit refresh. Appending an older page onto a
+        //   list that has already started over duplicates rows and corrupts
+        //   the cursor.
+        if (
+          companyRef.current !== forCompany ||
+          selectedIdRef.current !== forWorkflow ||
+          historyGenRef.current !== forGeneration
+        ) {
+          return;
+        }
         setRuns((prev) => [...prev, ...older]);
         setRunsHasMore(hasMore);
+        setRunsNextBeforeSeq(nextBeforeSeq);
       } catch (e) {
         // Same quiet degradation as the newest-page fetch — leave what is
         // already shown in place rather than losing it to a failed page.
         console.debug("[WorkflowsView] loading older run history failed", e);
       } finally {
+        // Deliberately OUTSIDE the guard above. The flag belongs to the click,
+        // not to the list the answer turned out to be for: skipping it on a
+        // superseded response would wedge "Load older" as permanently busy.
         setLoadingOlderRuns(false);
       }
     })();
-  }, [client, company, selectedId, runs, loadingOlderRuns]);
+  }, [client, company, selectedId, runsNextBeforeSeq, runsHasMore, loadingOlderRuns]);
 
   // Issue #303: the run page the index's health readings are folded from.
   //

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -291,6 +291,7 @@ export function RunHistoryPanel({
                 variant="ghost"
                 size="sm"
                 className="w-full"
+                data-testid="workflow-run-load-older"
                 disabled={loadingOlder}
                 onClick={onLoadOlder}
               >

--- a/frontend/test/unit/workflow-history-cross-company-race.test.ts
+++ b/frontend/test/unit/workflow-history-cross-company-race.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph, WorkflowRunOutcome, WorkflowRunsPage } from "@/api/workflows";
+
+/**
+ * A "Load older" page that answers a question nobody is asking any more must be
+ * dropped, not appended (issue #1012 follow-up).
+ *
+ * `loadOlderRuns` awaits a page and then unconditionally does
+ * `setRuns(prev => [...prev, ...older])`. It has no staleness guard at all —
+ * not even the workflow id — and a `useCallback` has no cleanup, so nothing
+ * invalidates a request already in flight. Two ways that lands the wrong rows:
+ *
+ * * **Across companies.** `create_company_workflow` checks workflow-id
+ *   uniqueness only *within* the requesting company (`src/company/workflow_create.rs`),
+ *   so two companies genuinely share an id — a seed workflow shipped identically
+ *   to both is the ordinary case. An older page started against company A and
+ *   held in flight while the operator switches to B appends A's runs onto B's
+ *   history, and A's cursor overwrites B's pagination state.
+ * * **Within one company.** The first-page effect replaces `runs` wholesale on
+ *   a refresh (a run finished, the 2s poll ticked, the client was swapped).
+ *   Neither the company nor the workflow id changes, so identity fields cannot
+ *   see it — the second case below fails against a guard built from those alone.
+ *
+ * These render the view, the way `workflow-run-failure.test.ts` earns its
+ * exception to the pure-function rule: the claim is about what ends up in the
+ * DOM after two overlapping fetches race, which no pure helper can pin.
+ */
+
+vi.mock("sonner", () => {
+  const noop = vi.fn();
+  const toast = Object.assign(noop, { success: noop, error: noop, warning: noop, info: noop });
+  return { toast };
+});
+
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+
+// React Flow measures its container on mount; jsdom has no layout and no
+// `ResizeObserver`, so these stubs are what let the view render at all. None is
+// under test. (Same three as `workflow-run-failure.test.ts`.)
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, {
+  ResizeObserver: NoopResizeObserver,
+  DOMMatrixReadOnly: class {
+    m22 = 1;
+  },
+});
+Object.defineProperties(globalThis.HTMLElement.prototype, {
+  offsetHeight: { get: () => 400 },
+  offsetWidth: { get: () => 800 },
+});
+
+const { WorkflowsView } = await import("@/views/WorkflowsView");
+
+/** The id both companies' workflow happen to share — e.g. an identical seed. */
+const WF_ID = "shared-wf";
+
+const GRAPH: WorkflowGraph = {
+  id: WF_ID,
+  name: "Shared workflow",
+  version: null,
+  nodes: [{ id: "start", kind: "trigger", name: "Start" }],
+  edges: [],
+};
+
+function run(seq: number, runId: string): WorkflowRunOutcome {
+  return {
+    seq,
+    atMillis: seq * 1_000,
+    workflowId: WF_ID,
+    scheduled: false,
+    runId,
+    deliveries: [],
+    pendingApprovals: [],
+  };
+}
+
+/** A resolver the test controls, so a fetch can be held open across renders. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const EMPTY: WorkflowRunsPage = { runs: [], hasMore: false };
+
+/**
+ * A client whose run-history reads are scripted per company slug.
+ *
+ * `first` answers the newest-page fetch (no `before_seq`); `older` is the single
+ * held-open "Load older" response for `acme`, which the test resolves when it
+ * chooses. Everything else answers the inert shape the view needs to render.
+ */
+function makeClient(script: {
+  first: Record<string, WorkflowRunsPage>;
+  older?: Promise<WorkflowRunsPage>;
+}): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/${company ?? "company"}`,
+    get: async (path: string) => {
+      if (path.endsWith("/workflows")) return [{ id: WF_ID, name: GRAPH.name }];
+      if (path.includes("/workflows/tool-slugs")) return { slugs: [], unwired: [] };
+      if (path.includes("/workflows/wired-channels")) return { channels: [] };
+      if (path.includes("/workflows/runs")) {
+        const url = new URL(path, "http://test");
+        const slug = path.split("/")[3];
+        const workflow = url.searchParams.get("workflow");
+        const beforeSeq = url.searchParams.get("before_seq");
+        // The company-wide index fetch is inert here — the view stays on the
+        // detail page throughout.
+        if (workflow !== WF_ID) return EMPTY;
+        if (beforeSeq !== null) {
+          return slug === "acme" && script.older ? script.older : EMPTY;
+        }
+        return script.first[slug] ?? EMPTY;
+      }
+      if (/\/workflows\/[^/?]+$/.test(path)) return GRAPH;
+      return null;
+    },
+    post: async () => ({}),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function rows(): NodeListOf<Element> {
+  return container.querySelectorAll('[data-testid="workflow-run-row"]');
+}
+
+function loadOlderButton(): HTMLButtonElement | null {
+  return container.querySelector('[data-testid="workflow-run-load-older"]');
+}
+
+async function openHistory() {
+  await act(async () => {
+    (container.querySelector('[data-testid="workflow-history-toggle"]') as HTMLButtonElement).click();
+  });
+}
+
+describe("run history pagination races", () => {
+  it("drops a superseded company's stale older page instead of appending it", async () => {
+    const older = deferred<WorkflowRunsPage>();
+    const client = makeClient({
+      first: {
+        acme: { runs: [run(20, "acme-r2"), run(10, "acme-r1")], hasMore: true, nextBeforeSeq: 10 },
+        beta: { runs: [run(5, "beta-r1")], hasMore: false },
+      },
+      older: older.promise,
+    });
+
+    await act(async () => {
+      root.render(createElement(WorkflowsView, { client, company: "acme", sub: WF_ID }));
+    });
+
+    await openHistory();
+    expect(rows()).toHaveLength(2);
+    expect(loadOlderButton()).not.toBeNull();
+
+    // Fire "Load older" for acme. Nothing resolves it until the test does.
+    await act(async () => {
+      loadOlderButton()!.click();
+    });
+
+    // The operator switches to `beta`, which happens to have a workflow of the
+    // SAME id already selected (`sub` unchanged — `WorkflowsView` never resets
+    // `selectedId` on a company prop change, and the deep-link-apply effect
+    // will not reselect an id it already applied). Beta's own first page
+    // answers immediately: one run, nothing older.
+    await act(async () => {
+      root.render(createElement(WorkflowsView, { client, company: "beta", sub: WF_ID }));
+    });
+    expect(rows()).toHaveLength(1);
+    expect(loadOlderButton()).toBeNull();
+
+    // Now let acme's stale older-page answer land.
+    await act(async () => {
+      older.resolve({ runs: [run(1, "acme-older")], hasMore: false });
+    });
+
+    // Pre-fix: appended unconditionally — 1 + 1 = 2 rows, one of them acme's,
+    // and the stale response's cursor would overwrite beta's pagination state
+    // too. Post-fix: the company guard rejects it and beta's page is untouched.
+    expect(rows()).toHaveLength(1);
+  });
+
+  it("drops an older page superseded by a refresh of the SAME company's history", async () => {
+    const older = deferred<WorkflowRunsPage>();
+    const before = makeClient({
+      first: {
+        acme: { runs: [run(20, "acme-r2"), run(10, "acme-r1")], hasMore: true, nextBeforeSeq: 10 },
+      },
+      older: older.promise,
+    });
+
+    await act(async () => {
+      root.render(createElement(WorkflowsView, { client: before, company: "acme", sub: WF_ID }));
+    });
+
+    await openHistory();
+    expect(rows()).toHaveLength(2);
+
+    await act(async () => {
+      loadOlderButton()!.click();
+    });
+
+    // The history refreshes while that page is in flight — same company, same
+    // workflow, so nothing about the request's IDENTITY has changed. Modelled
+    // by swapping the client, which is one of the first-page effect's own
+    // dependencies, exactly as a `runsTick`/`runEventTick` bump would be.
+    // The fresh page says the history is complete.
+    const after = makeClient({
+      first: {
+        acme: { runs: [run(20, "acme-r2"), run(10, "acme-r1")], hasMore: false },
+      },
+    });
+    await act(async () => {
+      root.render(createElement(WorkflowsView, { client: after, company: "acme", sub: WF_ID }));
+    });
+    expect(rows()).toHaveLength(2);
+    expect(loadOlderButton()).toBeNull();
+
+    await act(async () => {
+      older.resolve({ runs: [run(1, "acme-older")], hasMore: false });
+    });
+
+    // A guard built from company + workflow alone passes here: both still
+    // match. Only the generation counter can tell that the list this answer
+    // was for has already been replaced.
+    expect(rows()).toHaveLength(2);
+  });
+});

--- a/frontend/test/unit/workflow-runs-cursor-zero.test.ts
+++ b/frontend/test/unit/workflow-runs-cursor-zero.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { listWorkflowRuns } from "@/api/workflows";
+
+/**
+ * `beforeSeq: 0` is a real cursor and must reach the wire (issue #1012
+ * follow-up).
+ *
+ * The host issues the page's lowest `seq` as its pagination boundary, and a
+ * journal's first row is `seq` 0 — so 0 is exactly the cursor a company whose
+ * history reaches the beginning gets handed. A truthy check drops it, the
+ * request goes out with no `before_seq` at all, and the host answers the
+ * NEWEST page: the drawer appends the rows it already has, "Load older" stays
+ * enabled, and every further click repeats the same page forever.
+ */
+describe("listWorkflowRuns cursor", () => {
+  function spy(): { calls: string[]; client: OpenCompanyClient } {
+    const calls: string[] = [];
+    const client = {
+      scopeFor: () => "/api/v1/company",
+      get: async (path: string) => {
+        calls.push(path);
+        return { runs: [], hasMore: false };
+      },
+    } as unknown as OpenCompanyClient;
+    return { calls, client };
+  }
+
+  it("sends before_seq=0 rather than dropping it as falsy", async () => {
+    const { calls, client } = spy();
+    await listWorkflowRuns(client, null, { workflow: "wf", limit: 50, beforeSeq: 0 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("before_seq=0");
+  });
+
+  it("still omits before_seq when no cursor was given", async () => {
+    const { calls, client } = spy();
+    await listWorkflowRuns(client, null, { workflow: "wf", limit: 50 });
+    expect(calls[0]).not.toContain("before_seq");
+  });
+});

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2366,11 +2366,18 @@ struct RunsQuery {
     limit: Option<usize>,
     /// Opaque pagination cursor (issue #1012): only runs whose displayed
     /// `seq` is strictly less than this are considered. Absent reads the
-    /// newest page. The console walks backward through history by passing the
-    /// `seq` of the oldest run it already holds — the same `before_seq` shape
+    /// newest page. Same `before_seq` shape
     /// [`chat_history`](crate::server::chat_history)'s `?before=` and
     /// `TaskDetailQuery`'s `?discussionBefore=` already use for the same
     /// problem.
+    ///
+    /// **What to pass is the boundary the previous response issued** —
+    /// [`WorkflowRunsResponse::next_before_seq`] — not "the `seq` of the oldest
+    /// run you hold". Those two coincided while the page was cut in display
+    /// order; they no longer do, because the cut is keyed on `seq` and the
+    /// display is keyed on `(at_millis, seq)`. Deriving the cursor from the
+    /// last displayed row re-opens the hole this parameter's own page cut
+    /// closes: see [`select_run_page`].
     before_seq: Option<u64>,
 }
 
@@ -2835,6 +2842,83 @@ fn fold_run_events(rows: Vec<StoredEvent>, wanted: Option<&str>) -> (Vec<Workflo
     (runs, read_through)
 }
 
+/// Cuts one page out of the folded run set and issues the cursor the *next*
+/// page must be asked for (issue #1012).
+///
+/// Three quantities the page needs, kept apart because they are not the same
+/// number:
+///
+/// * the **cut** — which `limit` runs this page carries,
+/// * the **display order** — how those runs are listed,
+/// * the **cursor** — the boundary the next request pages before.
+///
+/// # Why the cut is keyed on `seq` and the display is not
+///
+/// The page is cut by `seq` descending, and only then sorted for display by
+/// `(at_millis, seq)` descending — issue #228's ordering, kept verbatim, just
+/// applied *after* the cut rather than as the cut.
+///
+/// `seq` is the journal's own append position: monotonic, and the only key
+/// [`EventLog::read_before`](crate::ports::EventLog::read_before) can bound a
+/// read by. `at_millis` is wall-clock and is **not** monotonic in storage
+/// order — a clock step backwards (NTP correction, a VM resume, an operator
+/// setting the date) writes a row whose time is older than the row before it.
+///
+/// Cutting on `(at_millis, seq)` and then paging off the cut's boundary loses
+/// runs outright. Take a run `R` appended after this page's boundary run `B`
+/// under a regressed clock, so `R.seq > B.seq` but `R.at_millis < B.at_millis`.
+/// `R` sorts *below* `B`, so the truncate drops it from this page; the next
+/// request asks `before_seq = B.seq`, which excludes every row at or above
+/// `B.seq` — `R` among them. `R` is on neither page, and because the boundary
+/// only ever descends, on no later page either. It is permanently unreachable,
+/// and `has_more` may well be `true` *because* of it — a page the caller can
+/// see exists and can never fetch.
+///
+/// Cutting on `seq` closes that by construction rather than by any argument
+/// about how large a clock step can be: the set served here is exactly
+/// `{ seq >= next_before_seq }` of the candidates, and the next request asks
+/// for `{ seq < next_before_seq }`. The two partition the run set on the same
+/// key the read is bounded by, so nothing can fall between them.
+///
+/// The accepted cost, stated plainly: under a clock regression a run is served
+/// on the page its `seq` puts it on — correctly ordered *within* that page, but
+/// possibly out of order against the adjacent one. Under a monotonic clock
+/// `seq` and `at_millis` order identically and this is indistinguishable from
+/// cutting on the tuple. So the degradation fires only on the exact anomaly
+/// that previously caused permanent loss, and it degrades to "wrong order at
+/// one seam", never to "the run is gone".
+///
+/// Returns the page, whether an older page exists, and the cursor to ask for it
+/// with — `None` when there is no older page, so a caller is never handed a
+/// cursor for a page that does not exist.
+fn select_run_page(
+    mut runs: Vec<WorkflowRunOutcome>,
+    limit: usize,
+) -> (Vec<WorkflowRunOutcome>, bool, Option<u64>) {
+    // The backward-paged read stopped once it had settled at least `limit + 1`
+    // runs (or ran out of journal), precisely so this count is known here — one
+    // more than fits on the page means there is a page after this one.
+    let has_more = runs.len() > limit;
+    // The cut: the `limit` highest-`seq` runs.
+    runs.sort_by_key(|run| std::cmp::Reverse(run.seq));
+    runs.truncate(limit);
+    // The cursor: this page's low-water `seq`, which under the cut above is its
+    // minimum and NOT the last row in display order — which is why the client
+    // can no longer derive it and the host has to say it. Issued only when
+    // something is actually behind it.
+    let next_before_seq = if has_more {
+        runs.iter().map(|run| run.seq).min()
+    } else {
+        None
+    };
+    // The display order (issue #228 / #1012): newest FINISH first, on the very
+    // pair every row shows. Preserved exactly as merged; it only moves below
+    // the cut, and neither the cut nor this sort touches a single field of a
+    // row.
+    runs.sort_by_key(|run| std::cmp::Reverse((run.at_millis, run.seq)));
+    (runs, has_more, next_before_seq)
+}
+
 /// `GET …/workflows/runs?workflow=&limit=&before_seq=` — the company's
 /// finished workflow runs, **newest first** (issue #228), a page at a time
 /// (issue #1012).
@@ -3191,13 +3275,15 @@ async fn list_runs(
     // a single field of a row — they reorder and drop whole rows — so the
     // invariant the verdict pass is placed on ("derive after everything that
     // can still change its inputs") is not weakened by running them first.
-    runs.sort_by_key(|r| std::cmp::Reverse((r.at_millis, r.seq)));
-    // Issue #1012: the backward-paged read above stopped once it had settled
-    // at least `limit + 1` runs (or ran out of journal), precisely so this
-    // count is known here — one more than fit on the page means there is a
-    // page after this one.
-    let has_more = runs.len() > limit;
-    runs.truncate(limit);
+    //
+    // Issue #1012 follow-up: the sort above and the `limit` cut are no longer
+    // the same operation. The cut is keyed on `seq` alone and the sort — which
+    // is exactly the one described above — runs after it, because a cursor
+    // derived from a non-monotonic key cannot partition the run set and
+    // silently loses runs under a clock regression. The whole argument lives on
+    // [`select_run_page`], which now owns both steps plus the cursor this page
+    // hands back.
+    let (mut runs, has_more, next_before_seq) = select_run_page(runs, limit);
 
     // Issues #1143 + #1189. A run's record of what it stopped for is a receipt
     // and cannot go stale — but the *question* it points at can. `ApprovalParked`
@@ -3266,7 +3352,11 @@ async fn list_runs(
         run.verdict = run.derive_verdict();
     }
 
-    Ok(Json(WorkflowRunsResponse { runs, has_more }))
+    Ok(Json(WorkflowRunsResponse {
+        runs,
+        has_more,
+        next_before_seq,
+    }))
 }
 
 /// The `GET …/workflows/runs` response body (issue #1012).
@@ -3279,9 +3369,22 @@ async fn list_runs(
 #[serde(rename_all = "camelCase")]
 struct WorkflowRunsResponse {
     runs: Vec<WorkflowRunOutcome>,
-    /// Whether a further, older page exists behind `?before_seq=<oldest
-    /// returned run's seq>`.
+    /// Whether a further, older page exists behind [`next_before_seq`](Self::next_before_seq).
     has_more: bool,
+    /// The cursor to pass as `?before_seq=` to fetch the page behind this one —
+    /// this page's **lowest** `seq`, which is not in general the last row in
+    /// display order (see [`select_run_page`]).
+    ///
+    /// Server-issued rather than client-derived. The console used to take
+    /// `runs.at(-1)?.seq`, which was the same number only while the cut and the
+    /// display order shared a key; they no longer do, and the page cut is the
+    /// only place the boundary is known. Absent exactly when `has_more` is
+    /// `false` — nothing older to ask for.
+    ///
+    /// A console predating this field falls back to its old derivation, which
+    /// is why the field is omitted rather than sent as `null`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_before_seq: Option<u64>,
 }
 
 /// Relabels a run's node rows for the nodes it blocked on a human (issue #881).
@@ -4226,7 +4329,10 @@ mod tests {
         use axum::http::{Request, StatusCode};
         use tower::ServiceExt;
 
-        use super::super::{CompanyEvent, DEFAULT_RUN_LIMIT, WorkflowNodeStatus};
+        use super::super::{
+            CompanyEvent, DEFAULT_RUN_LIMIT, WorkflowNodeStatus, WorkflowRunOutcome,
+            WorkflowRunVerdict, select_run_page,
+        };
         use crate::company::CompanyManifest;
         use crate::ports::CompanyStore;
         use crate::ports::types::{CompanyId, CompanyRecord};
@@ -7284,6 +7390,277 @@ mod tests {
             assert!(
                 body["runs"].is_array(),
                 "graph read shadowed the history: {body}"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Page cut / cursor partition (issue #1012 follow-up)
+        //
+        // `select_run_page` is exercised directly because the anomaly these
+        // tests are about — a run journaled with an `at_millis` OLDER than the
+        // row before it, after the clock stepped backwards — cannot be staged
+        // through the router at all: `FileStore::append` stamps
+        // `at_millis: now_millis()` itself, and `journal_start`/`journal_finish`
+        // hand it only a `CompanyEvent`. There is no seam to fake a clock
+        // regression end-to-end, so the cut is tested where it lives and the
+        // route is tested for the one thing the pure function cannot carry —
+        // the serialized field.
+        // -------------------------------------------------------------------
+
+        /// A settled run at `(seq, at_millis)`, with every other field at its
+        /// nothing-happened value. Only the two keys `select_run_page` reads
+        /// matter here.
+        fn page_run(seq: u64, at_millis: u64) -> WorkflowRunOutcome {
+            WorkflowRunOutcome {
+                seq,
+                at_millis,
+                workflow_id: "wf".to_string(),
+                scheduled: false,
+                run_id: Some(format!("run-{seq}")),
+                deliveries: Vec::new(),
+                pending_approvals: Vec::new(),
+                error: None,
+                nodes: Vec::new(),
+                started_nodes: Vec::new(),
+                started_at_millis: Some(at_millis),
+                running: false,
+                cancelled: false,
+                notices: Vec::new(),
+                board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
+                stranded_approvals: 0,
+                verdict: WorkflowRunVerdict::Ok,
+            }
+        }
+
+        /// One request's worth of the read, as the route performs it: everything
+        /// strictly older than the cursor is a candidate (that is exactly what
+        /// `EventLog::read_before` bounds by), and the cut runs over it.
+        ///
+        /// Handing the whole candidate set in is a faithful superset of what the
+        /// backward walk accumulates — it stops once it has settled `limit + 1`
+        /// runs, and because it walks by descending `seq` those are the highest
+        /// `seq`s among the candidates, which is precisely the set the cut keeps.
+        fn page(
+            journal: &[(u64, u64)],
+            before_seq: Option<u64>,
+            limit: usize,
+        ) -> (Vec<WorkflowRunOutcome>, bool, Option<u64>) {
+            let candidates: Vec<WorkflowRunOutcome> = journal
+                .iter()
+                .filter(|(seq, _)| before_seq.is_none_or(|bound| *seq < bound))
+                .map(|(seq, at_millis)| page_run(*seq, *at_millis))
+                .collect();
+            select_run_page(candidates, limit)
+        }
+
+        /// A journal whose clock stepped backwards: `seq` 40 was appended after
+        /// 30 but carries a wall-clock time older than both 30 and 20. Every
+        /// other row is well-behaved.
+        const REGRESSED: [(u64, u64); 5] = [
+            (10, 1_000),
+            (20, 2_000),
+            (30, 3_000),
+            // NTP correction / VM resume / an operator setting the date: the
+            // append order is unchanged, the timestamp goes backwards.
+            (40, 1_500),
+            (50, 5_000),
+        ];
+
+        /// **The issue #1012 follow-up pin.** Paging must reach every run, and
+        /// a run whose `at_millis` regressed below the page boundary's is the
+        /// one that used to be lost.
+        ///
+        /// Pre-fix (cut on `(at_millis, seq)`, cursor derived from the last
+        /// displayed row) the first `limit=2` page is `[50, 30]` — run 40 sorts
+        /// below 30 on time and is truncated away — and the cursor is 30, which
+        /// excludes everything at or above `seq` 30. Run 40 is on neither page,
+        /// and since the boundary only descends, on no later page either.
+        #[test]
+        fn a_clock_regressed_run_is_reachable_on_a_later_page() {
+            let mut seen: Vec<u64> = Vec::new();
+            let mut cursor: Option<u64> = None;
+            // Bounded so a cursor that fails to advance fails the test instead
+            // of hanging it.
+            for _ in 0..10 {
+                let (rows, has_more, next) = page(&REGRESSED, cursor, 2);
+                seen.extend(rows.iter().map(|run| run.seq));
+                if !has_more {
+                    assert!(next.is_none(), "a last page must issue no cursor");
+                    break;
+                }
+                let next = next.expect("a page with more behind it must issue a cursor");
+                assert!(
+                    cursor.is_none_or(|previous| next < previous),
+                    "the cursor must descend, or the walk cannot terminate"
+                );
+                cursor = Some(next);
+            }
+
+            seen.sort_unstable();
+            assert_eq!(
+                seen,
+                vec![10, 20, 30, 40, 50],
+                "every journaled run must be reachable by paging; \
+                 40 is the clock-regressed one"
+            );
+        }
+
+        /// The property the design rests on, asserted directly rather than
+        /// inferred from a walk: the page and the cursor **partition** the
+        /// candidate set. Everything served is at or above the cursor,
+        /// everything withheld is strictly below it — so the next request,
+        /// which asks for `seq < cursor`, gets exactly the remainder with no
+        /// overlap and no gap.
+        #[test]
+        fn the_page_cursor_partitions_the_run_set() {
+            let (rows, has_more, next) = page(&REGRESSED, None, 2);
+            assert!(has_more);
+            let cursor = next.expect("cursor");
+
+            let served: Vec<u64> = rows.iter().map(|run| run.seq).collect();
+            assert!(
+                served.iter().all(|seq| *seq >= cursor),
+                "a served run below the cursor would be served twice: {served:?} vs {cursor}"
+            );
+            let withheld: Vec<u64> = REGRESSED
+                .iter()
+                .map(|(seq, _)| *seq)
+                .filter(|seq| !served.contains(seq))
+                .collect();
+            assert!(
+                withheld.iter().all(|seq| *seq < cursor),
+                "a withheld run at or above the cursor is unreachable forever: \
+                 {withheld:?} vs {cursor}"
+            );
+            assert_eq!(
+                served.len() + withheld.len(),
+                REGRESSED.len(),
+                "the two halves must account for every run"
+            );
+        }
+
+        /// Issue #228 / #1272's ordering is untouched: the cut is keyed on
+        /// `seq`, but what comes back is still sorted newest **finish** first,
+        /// on the very `(at_millis, seq)` pair each row displays.
+        #[test]
+        fn a_page_is_still_displayed_newest_finish_first() {
+            // Within one page, `seq` order and finish order disagree: 40 was
+            // appended last but finished (by the clock) before 30.
+            let (rows, _, _) = page(&[(30, 3_000), (40, 1_500), (50, 5_000)], None, 3);
+            let order: Vec<u64> = rows.iter().map(|run| run.seq).collect();
+            assert_eq!(
+                order,
+                vec![50, 30, 40],
+                "the page must be listed by finish time, not by the key it was cut on"
+            );
+        }
+
+        /// No older page, no cursor. A cursor for a page that does not exist
+        /// invites a caller to ask for it, and an absent field is also what
+        /// tells an older console to fall back to its own derivation.
+        #[test]
+        fn next_before_seq_is_absent_when_there_is_no_older_page() {
+            let (rows, has_more, next) = page(&REGRESSED, None, 50);
+            assert_eq!(rows.len(), 5);
+            assert!(!has_more);
+            assert_eq!(next, None);
+
+            // Exactly `limit` runs is still "no older page" — the read stops at
+            // `limit + 1` precisely so this case is knowable.
+            let (rows, has_more, next) = page(&REGRESSED, None, 5);
+            assert_eq!(rows.len(), 5);
+            assert!(!has_more);
+            assert_eq!(next, None);
+        }
+
+        /// The one part the pure function cannot cover: the cursor reaches the
+        /// console, under the camelCase name the client reads, and feeding it
+        /// back gets the next page with no repeat and no gap.
+        #[tokio::test]
+        async fn run_history_issues_the_page_cursor_on_the_wire() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            for _ in 0..5 {
+                journal_run(&state, &id, "digest", false, Vec::new(), None).await;
+            }
+
+            let fetch = |uri: String| {
+                let state = state.clone();
+                async move {
+                    json_body(
+                        router(state)
+                            .oneshot(request("GET", &uri, None))
+                            .await
+                            .unwrap(),
+                    )
+                    .await
+                }
+            };
+            let seqs = |body: &serde_json::Value| -> Vec<u64> {
+                body["runs"]
+                    .as_array()
+                    .expect("array")
+                    .iter()
+                    .map(|row| row["seq"].as_u64().expect("seq"))
+                    .collect()
+            };
+
+            let first =
+                fetch("/api/v1/company/workflows/runs?workflow=digest&limit=2".to_string()).await;
+            assert_eq!(first["hasMore"], true, "{first}");
+            let cursor = first["nextBeforeSeq"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("nextBeforeSeq must be on the wire: {first}"));
+            let page_one = seqs(&first);
+            assert_eq!(page_one.len(), 2, "{first}");
+            assert_eq!(
+                cursor,
+                *page_one.iter().min().expect("min"),
+                "the cursor is the page's low-water seq: {first}"
+            );
+
+            let second = fetch(format!(
+                "/api/v1/company/workflows/runs?workflow=digest&limit=2&before_seq={cursor}"
+            ))
+            .await;
+            let page_two = seqs(&second);
+            assert!(
+                page_two.iter().all(|seq| *seq < cursor),
+                "the next page must be strictly below the cursor: {second}"
+            );
+            assert!(
+                page_two.iter().all(|seq| !page_one.contains(seq)),
+                "no run may appear on two pages: {page_one:?} then {page_two:?}"
+            );
+
+            let last_cursor = second["nextBeforeSeq"]
+                .as_u64()
+                .expect("a third page exists");
+            let third = fetch(format!(
+                "/api/v1/company/workflows/runs?workflow=digest&limit=2&before_seq={last_cursor}"
+            ))
+            .await;
+            let page_three = seqs(&third);
+            assert_eq!(third["hasMore"], false, "{third}");
+            assert!(
+                third.get("nextBeforeSeq").is_none(),
+                "the last page must omit the cursor entirely: {third}"
+            );
+
+            // No gap: the three pages are the whole history, once each.
+            let mut walked: Vec<u64> = page_one;
+            walked.extend(page_two);
+            walked.extend(page_three);
+            walked.sort_unstable();
+            walked.dedup();
+            assert_eq!(
+                walked.len(),
+                5,
+                "paging must reach all five runs: {walked:?}"
             );
         }
 


### PR DESCRIPTION
## Summary

Two follow-ups to #1272, which landed run-history ordering, cursor pagination and the bounded read for #1012. Both were found reviewing #1090 (the parallel implementation of the same issue, now closed as superseded) and are the only things from that branch worth carrying forward.

**1. A run could fall out of the history permanently.** #1272 pages the journal with `read_before`, which bounds strictly by `seq`, but cuts each page by the display sort on `(at_millis, seq)`. `seq` is monotonic; `at_millis` is wall-clock and is not. Under a clock regression a run R can satisfy `R.seq > boundary.seq` while `R.at_millis < boundary.at_millis` — so R sorts below the page and `truncate` drops it, and the next request's `before_seq` (the *displayed* boundary, which is lower than `R.seq`) makes `read_before` skip R's events. R is on no page, and since the boundary only descends, no later page reaches it either. `hasMore` can even be `true` *because* of R and then not contain it.

The fix separates the two jobs the page cut was doing: **cut by `seq`, display by finish time.** `select_run_page` takes the `limit` highest-`seq` runs, issues `min(seq)` over that cut as the cursor, then applies #1272's sort to the cut. The served set is exactly `{seq >= nextBeforeSeq}` and the next request asks `seq < nextBeforeSeq` — a partition on the key `read_before` actually bounds by, so no regression of any magnitude can skip a run. This is structural, not a bound on how far clocks may drift.

The cursor now has to travel on the wire: under this cut it is the page's *minimum* `seq`, which no ordering of the served rows exposes as "the last one", so the console can no longer derive it.

**2. "Load older" had no staleness guard at all.** It awaited and unconditionally appended to whatever list was on screen. Workflow ids are unique only *within* a company — `create_company_workflow` checks against the requesting company's own seed/overlay/manifest ids and never across companies, so two companies genuinely share ids, an identically-seeded workflow being the common case. Switching companies mid-flight appended one company's runs to another's panel. A same-company refresh that moved the page boundary slipped through too. The response is now rejected unless company, selection and a generation counter all still match.

Also fixes `if (options?.beforeSeq)` in the API client, which silently dropped a cursor of `0`.

### On #1272's code

Nothing is reverted, weakened or simplified. The cut key moves from the tuple to `seq`; the sort is preserved **verbatim** and only relocated below the cut; the block moves into a pure function because `at_millis` is stamped inside `append` (`src/store/fs.rs`) and cannot be controlled through the router, so a clock regression is not reproducible end-to-end — an extractable pure function is the only way to test the regression at all. `run_history_orders_by_finish_not_start` and `run_history_limit_counts_runs_not_journal_rows` pass unchanged. The read loop, `RUN_EVENT_PAGE`, `read_before`, `exhausted`, `retain(is_settled)`, the #1009 gate, the #1189 reconciliation join and the verdict pass are untouched.

### The trade-off, stated plainly

Cross-page finish-time ordering is given up under a clock regression: R is served on the page its `seq` puts it on, ordered correctly *within* that page but possibly out of order across the seam. Under a monotonic clock the two orders agree and behaviour is identical to today. The degradation fires only on the exact anomaly that currently causes permanent loss, and it degrades to "out of order at one boundary" rather than "the run is gone". Not claimed as a clean win.

Alternatives rejected, with their actual failures: resuming from the previous low-water mark still skips R (R sits *above* it); a composite `(at_millis, seq)` cursor is correct only if the bounded read is thrown away for an unbounded fold, which is what #1090 did; bounded-overlap re-read is not actually bounded, since a badly-regressed run is re-read and re-truncated on every page and pins the resume point at its `seq` forever; a time-bounded port read is unsound, because `at_millis` is not monotonic in storage order — that *is* the bug — so `{at_millis < X}` is a scattered subset rather than a suffix.

## API Or Behavior Changes

- `GET …/workflows/runs` gains `nextBeforeSeq` in the response (omitted when no older page exists). `before_seq` is unchanged in shape; its meaning is now "the boundary the previous response issued", not "the oldest run you hold".
- Page membership changes only under a clock regression, where it changes from "this run is unreachable" to "this run is on an adjacent page".
- **Version skew:** a newer console against an older host falls back to deriving the cursor from the last row, gated on `hasMore` — it must not read a missing `nextBeforeSeq` as "no more pages", which would ship this fix as a fresh silent truncation.
- Console: "Load older" discards a response whose company, selection or list generation has changed since the request went out.

## Tests

Every new behaviour test was shown red against pre-fix semantics before being accepted, one shim at a time:

- `a_clock_regressed_run_is_reachable_on_a_later_page` — `left: [10, 20, 30, 50] right: [10, 20, 30, 40, 50]`; run 40 appears on no page.
- `the_page_cursor_partitions_the_run_set` — `a withheld run at or above the cursor is unreachable forever: [10, 20, 40] vs 30`.
- `run_history_issues_the_page_cursor_on_the_wire` — `nextBeforeSeq must be on the wire`.
- `workflow-history-cross-company-race.test.ts` case 1 (cross-company) — `expected … to have a length of 1 but got 2`.
- case 2 (same-company generation) — `expected … to have a length of 2 but got 3`. Deleting only the generation check from the finished fix reds case 2 while case 1 still passes, so the two checks are independently load-bearing.
- `workflow-runs-cursor-zero.test.ts` — `expected … to contain 'before_seq=0'`.

`a_page_is_still_displayed_newest_finish_first` and `next_before_seq_is_absent_when_there_is_no_older_page` pass under both old and new code deliberately — they are guards on merged behaviour, not new behaviour.

Gates, each read unpiped: `cargo fmt --all -- --check`; `cargo clippy --locked --all-targets --no-deps -- -D warnings`; the same with `--features openhuman,tinycortex`; `cargo test --locked` (3165 passed, 1 ignored, 0 failed); `assert-md-line-cap`, `assert-feature-lanes`, `assert-toolchain-pin`, `assert-design-tokens`; console `typecheck` / `typecheck:unit` / `typecheck:e2e`, `vitest run` (167 files, 1578 tests), `build`.

Manual, host: built with `--features openhuman,tinycortex,mcp`, served `companies/e2e_harness` against the repo's mock brain, fired five real detached runs and walked `?limit=2` with curl. On every page the cursor equals the page's low-water `seq`, boundaries strictly descend, every row is strictly below the cursor it was fetched with, no `seq` appears on two pages, the cursor is absent on the last page, and the settled runs the walk yields match the single-page set in the same order.

**Not done:** a real browser click-through of "Load older". The two jsdom tests render the actual `WorkflowsView` and were red-proved against unmodified main, but that is not the same thing and is not claimed as one.

## Documentation

New `docs/modules/server/run-history-paging.md` carries the contract and the partition argument, linked from `docs/modules/server/workflow-routes.md` and the server `README.md`; `docs/spec/runtime/api.md` documents `nextBeforeSeq` and the version-skew rule.

## Related

Part of #1012. Follows #1272. Supersedes #1090 (closed), whose review threads hold the original analysis.

Separately found while verifying this on a live host, **not addressed here and not caused by this change**: paging past a run's finish resurfaces its *start* row as a phantom entry reporting `running: true`, so a five-run history walked at `?limit=2` yields ten rows, five of them duplicates that spin forever. This is the bracket-split orphan shape already documented in `fold_run_events`. It is structurally independent of this diff — `fold_run_events` and the `before_seq` window are untouched, and under a monotonic clock `Reverse(seq)` and `Reverse((at_millis, seq))` induce the same permutation, so main produces identical pages here. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added paginated workflow run history with “Load older” support.
  - Added server-provided cursors and indicators showing whether more history is available.
  - Improved ordering and retrieval consistency when run timestamps change unexpectedly.
  - Preserved compatibility with older hosts that do not provide cursors.

- **Bug Fixes**
  - Prevented outdated responses from overwriting refreshed or switched workflow history.
  - Preserved valid pagination when the cursor value is zero.

- **Documentation**
  - Documented pagination behavior, cursor usage, ordering, limits, and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->