### PR TITLE
fix: make the sticky dialog footer opaque (#1359)

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -102,7 +102,18 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "sticky bottom-[-1rem] -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        // `bg-muted`, not `bg-muted/50`. This footer is `sticky`, so on any
+        // dialog whose body scrolls — the desk creator's roster picker is the
+        // one with thirteen rows in it — the content underneath keeps running
+        // past the bottom of the popup. At 50% opacity that content reads
+        // *through* the footer: teammate names sit legibly behind Cancel and
+        // the submit button, which looks like a rendering fault and makes both
+        // harder to read. A sticky bar has to be opaque to do its job.
+        //
+        // `--muted` still differs from the popup's own `--popover` in both
+        // themes (lighter in light, darker in dark), so the tonal separation
+        // the translucency was reaching for survives the change.
+        "sticky bottom-[-1rem] -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/frontend/test/unit/dialog-footer-opaque.test.ts
+++ b/frontend/test/unit/dialog-footer-opaque.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
+
+/**
+ * The dialog footer is opaque, because it is `sticky`.
+ *
+ * `DialogContent` is `max-h-[85vh] overflow-y-auto` and `DialogFooter` is
+ * `sticky bottom-[-1rem]`, so on any dialog whose body outgrows the viewport
+ * the body keeps scrolling underneath the footer rather than pushing it down.
+ * That is the intended behaviour — the submit button stays reachable — and it
+ * only works if the bar the content passes behind is actually opaque.
+ *
+ * It was `bg-muted/50`. The desk creator (`DeskCreateDialog`) renders one
+ * bordered row per roster teammate, so a company with a dozen agents scrolls,
+ * and the rows that ran under the footer stayed legible *through* Cancel and
+ * Create desk: teammate names printed across both buttons. It read as a
+ * rendering fault, and it made the two controls the dialog exists for harder
+ * to read than the list behind them.
+ *
+ * Asserted on the mounted node rather than by reading the source, so a future
+ * `className` override that reintroduces a translucency modifier is caught
+ * too — the class list is what the browser sees.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function footer(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-slot="dialog-footer"]');
+}
+
+function mount() {
+  act(() => {
+    root.render(
+      createElement(
+        Dialog,
+        { open: true },
+        createElement(
+          DialogContent,
+          { showCloseButton: false },
+          createElement(DialogFooter, null, "Create desk"),
+        ),
+      ),
+    );
+  });
+}
+
+describe("dialog footer", () => {
+  it("is sticky, so content scrolls behind it", () => {
+    mount();
+    expect(footer()?.className).toContain("sticky");
+  });
+
+  it("paints an opaque background", () => {
+    mount();
+    const classes = footer()?.className.split(/\s+/) ?? [];
+    expect(classes).toContain("bg-muted");
+  });
+
+  it("carries no alpha modifier on its background", () => {
+    mount();
+    // `bg-muted/50` and friends: a slash on the background utility is what let
+    // the scrolled roster read through the buttons.
+    const translucent = (footer()?.className.split(/\s+/) ?? []).filter((c) =>
+      /^bg-.+\/\d+$/.test(c),
+    );
+    expect(translucent).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1359.

## The failure

`DialogContent` is `max-h-[85vh] overflow-y-auto`; `DialogFooter` is `sticky bottom-[-1rem] … bg-muted/50`. On a dialog whose body outgrows the popup the body scrolls *behind* the footer — intended — but at 50% opacity it stays legible through it.

**New desk** on `#/company/desks` is the visible case: one bordered row per roster teammate, thirteen on the seeded company, so "Page Builder" and "Researcher" print across `Cancel` and `Create desk` in both themes.

## The change

One utility: `bg-muted/50` → `bg-muted`, with the reasoning recorded at the site. `--muted` still differs from the popup's `--popover` in both themes (lighter in light, darker in dark), so the tonal separation the translucency reached for is unchanged — only the bleed-through goes.

## Test

`frontend/test/unit/dialog-footer-opaque.test.ts` — a jsdom render asserting the mounted footer is `sticky`, carries `bg-muted`, and carries **no** `bg-*/nn` alpha modifier at all. Asserted on the class list the browser sees rather than on the source, so a later `className` override that reintroduces translucency is caught too.

## Commands run locally

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean
- `npx vitest run test/unit/dialog-footer-opaque.test.ts` — 3 passed
- `scripts/ci/assert-design-tokens.sh` — clean
- Browser-verified against a live seeded host, **New desk** dialog, light and dark at 1440px: rows now clip cleanly at the footer edge.

## Behaviour change

Purely visual, and it applies to every dialog with a scrolling body — that is the point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dialog footers to use a fully opaque background, improving visual consistency and readability.

* **Tests**
  * Added coverage to verify the footer remains sticky and does not apply unintended transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->