### PR TITLE
fix(overview): keep the right-edge chrome clear of the detail rail

### DIFF
--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -240,6 +240,59 @@ export function Overview({ client, company, companyName }: Props) {
 
   const memoryGraph = useMemo(() => buildMemoryGraph(sources.memories), [sources.memories]);
 
+  /**
+   * The snapshot line: what the page is, when it was taken, and the way to
+   * take another. The graph is not live, and says so rather than leaving an
+   * operator to assume a stale wheel is the current company.
+   *
+   * Handed to the graph as a slot rather than positioned here (issue #1307).
+   * This used to be an `absolute right-3 top-3 z-10` corner of its own, which
+   * put it squarely underneath the graph's `z-30` detail rail: opening any
+   * node's card hid the staleness signal, the Refresh control *and* the
+   * outage alert, and left them unclickable behind an opaque panel. Only the
+   * graph's shell knows how much of the right edge the rail is using, so the
+   * shell is what places this.
+   */
+  const statusSlot = (
+    <>
+      {/* Every source failed at once (issue #1219): a host that could not be
+          reached, said out loud, in the same corner that already owns the
+          staleness signal — rather than a graph redrawn empty with no
+          explanation. */}
+      {loadError && (
+        <div
+          role="alert"
+          className="max-w-64 rounded-md border border-destructive/40 bg-destructive/10 px-2 py-1 text-2xs text-destructive shadow-sm backdrop-blur"
+        >
+          {loadError}
+        </div>
+      )}
+      <div className="flex items-center gap-1.5 rounded-md border bg-background/90 px-2 py-1 text-2xs text-muted-foreground shadow-sm backdrop-blur">
+        <span className="truncate">
+          {sources.fetchedAt === null
+            ? loading
+              ? "Loading…"
+              : "No snapshot yet"
+            : `Snapshot ${new Date(sources.fetchedAt).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}`}
+        </span>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          title="This page is a snapshot, not a live view. Re-read the company."
+          aria-label="Refresh the graph"
+          className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-muted disabled:opacity-50"
+        >
+          <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} aria-hidden />
+          Refresh
+        </button>
+      </div>
+    </>
+  );
+
   return (
     // The whole viewport: the shell hides its top bar for this view, so there
     // is nothing above to subtract.
@@ -254,49 +307,17 @@ export function Overview({ client, company, companyName }: Props) {
           #1221) — this names it for a screen reader the same way every other
           view's title does. */}
       <h1 className="sr-only">Company overview</h1>
-      {/* The snapshot line: what the page is, when it was taken, and the way to
-          take another. The graph is not live, and says so rather than leaving an
-          operator to assume a stale wheel is the current company. */}
-      <div className="absolute right-3 top-3 z-10 flex flex-col items-end gap-1.5">
-        {/* Every source failed at once (issue #1219): a host that could not be
-            reached, said out loud, in the same corner that already owns the
-            staleness signal — rather than a graph redrawn empty with no
-            explanation. */}
-        {loadError && (
-          <div
-            role="alert"
-            className="max-w-64 rounded-md border border-destructive/40 bg-destructive/10 px-2 py-1 text-2xs text-destructive shadow-sm backdrop-blur"
-          >
-            {loadError}
-          </div>
-        )}
-        <div className="flex items-center gap-1.5 rounded-md border bg-background/90 px-2 py-1 text-2xs text-muted-foreground shadow-sm backdrop-blur">
-          <span className="truncate">
-            {sources.fetchedAt === null
-              ? loading
-                ? "Loading…"
-                : "No snapshot yet"
-              : `Snapshot ${new Date(sources.fetchedAt).toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}`}
-          </span>
-          <button
-            type="button"
-            onClick={refresh}
-            disabled={loading}
-            title="This page is a snapshot, not a live view. Re-read the company."
-            aria-label="Refresh the graph"
-            className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-muted disabled:opacity-50"
-          >
-            <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} aria-hidden />
-            Refresh
-          </button>
-        </div>
-      </div>
       <Suspense
         fallback={
+          // The graph's chunk is still in flight, so there is no shell to slot
+          // the snapshot line into yet — and no detail rail for it to dodge
+          // either. It is drawn here at the same inset the shell will use, so
+          // a cold load still says "Loading…" and the line does not appear to
+          // pop into existence once the physics arrives.
           <div className="grid h-full place-items-center text-sm text-muted-foreground">
+            <div className="absolute right-5 top-5 z-40 flex flex-col items-end gap-1.5">
+              {statusSlot}
+            </div>
             Drawing the graph…
           </div>
         }
@@ -309,6 +330,7 @@ export function Overview({ client, company, companyName }: Props) {
           tasks={adapted.tasks}
           memory={memoryGraph}
           toolLabels={adapted.toolLabels}
+          statusSlot={statusSlot}
         />
       </Suspense>
     </div>

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -214,11 +214,24 @@ type SimLink = { source: SimNode | string; target: SimNode | string; kind: strin
  */
 export function KnowledgeGraph({
   graph, agents = [], departments = [], people = [], tasks = [], memory, runsByAgent = {}, toolLabels = {},
+  statusSlot,
   repelDefault = 150, linkDistDefault = 60, centerDefault = 0.32,
 }: {
   graph: KGData; agents?: Agent[]; departments?: Department[]; people?: Person[]; tasks?: SopTask[];
   /** the distilled memory constellation drawn at the core */
   memory?: MemoryGraph;
+  /**
+   * The snapshot line — when this picture was read, and the control that reads
+   * it again — owned by `Overview` and positioned by the shell (issue #1307).
+   *
+   * It is a slot rather than something `Overview` positions itself because the
+   * detail rail is the only thing that knows how much of the right edge is
+   * still visible, and `Overview` cannot see it. Positioned separately, the
+   * chip sat at `right-3` under a `z-30` rail: the staleness signal, the
+   * Refresh control and the outage alert all vanished behind the first card an
+   * operator opened.
+   */
+  statusSlot?: React.ReactNode;
   /** latest run per agent id, for the harness card */
   runsByAgent?: Record<string, AgentRun>;
   /** Tool slug → display name, so a card can name a tool as its source does. */
@@ -2396,6 +2409,7 @@ export function KnowledgeGraph({
         onCollapseCore={clearAll}
         searchSlot={vaultSearchInput}
         legendSlot={compactLegend}
+        statusSlot={statusSlot}
         onNavDept={navDept}
         onBack={clearDetail}
       >

--- a/frontend/src/views/overview/kg/KnowledgeGraphFullscreen.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraphFullscreen.tsx
@@ -16,7 +16,7 @@ import { ToolDetailCard, type DeptLite } from './KnowledgeDetail';
  */
 export function KnowledgeGraphFullscreen({
   deptList, currentTeamId, currentDept,
-  toolWiki, extraDetail, coreOpen = false, onCollapseCore, searchSlot, legendSlot,
+  toolWiki, extraDetail, coreOpen = false, onCollapseCore, searchSlot, legendSlot, statusSlot,
   onNavDept, onBack, children,
 }: {
   deptList: DeptLite[];
@@ -34,6 +34,8 @@ export function KnowledgeGraphFullscreen({
   searchSlot?: React.ReactNode;
   /** compact kind legend, rendered bottom-left */
   legendSlot?: React.ReactNode;
+  /** the snapshot line and its Refresh control, rendered top-right */
+  statusSlot?: React.ReactNode;
   onNavDept: (teamId: string) => void;
   onBack: () => void;
   children: React.ReactNode;
@@ -41,6 +43,32 @@ export function KnowledgeGraphFullscreen({
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   const hasDetail = !!(toolWiki || extraDetail);
+  /**
+   * How the right-edge chrome gets out of the detail rail's way (issue #1307).
+   *
+   * The rail is an absolute overlay on purpose — resizing the canvas under it
+   * reflowed the graph on every open and close, which is the glitch the
+   * comment on the `<aside>` below is about. So the canvas keeps its size and
+   * the two controls that live on the right edge move instead: `right-2` is
+   * inside the 300px rail, and the rail is `z-30`, so without this they are
+   * both covered *and* unclickable rather than merely obscured.
+   *
+   * Above 820px the rail is that 300px column, and the offset is its width
+   * plus the inset the control already had. At or below it the rail is a
+   * bottom sheet (`max-h-[62vh]`, anchored bottom) — the right edge is clear
+   * again, so the offset is reverted and the paddles rise into the band the
+   * sheet leaves instead of staying centred underneath it.
+   */
+  const clearOfRail = hasDetail ? 'right-[316px] max-[820px]:right-2' : 'right-2';
+  /**
+   * Mid-height normally; in the band above the bottom sheet when there is one.
+   *
+   * The sheet is `max-h-[62vh]` anchored to the bottom, so its top edge sits at
+   * 38vh and a paddle centred at 50vh is underneath it. 19vh is the middle of
+   * what is left. Only applies at or below 820px, because that is the only
+   * width where the rail becomes a sheet.
+   */
+  const paddleTop = hasDetail ? 'top-1/2 max-[820px]:top-[19vh]' : 'top-1/2';
   const idx = deptList.findIndex((d) => d.teamId === currentTeamId);
   const step = (dir: number) => {
     if (deptList.length === 0) return;
@@ -123,19 +151,36 @@ export function KnowledgeGraphFullscreen({
           </div>
         )}
 
+        {/* the snapshot line — top-right, clear of the detail rail (issue
+            #1307). `z-40` so it stays above the rail even when the offset
+            above puts it beside rather than behind it, and `top-5`/`right-5`
+            so it sits on the same 20px inset as the pillar selector and the
+            legend rather than the 12px one it used to carry alone. */}
+        {statusSlot && (
+          <div
+            className={`absolute top-5 z-40 flex flex-col items-end gap-1.5 transition-[right] duration-200 ease-standard ${
+              hasDetail ? 'right-[316px] max-[820px]:right-5' : 'right-5'
+            }`}
+          >
+            {statusSlot}
+          </div>
+        )}
+
         {/* compact legend — bottom-left, always on */}
         {legendSlot && <div className="absolute bottom-5 left-5 z-10">{legendSlot}</div>}
 
         {/* side paddles: slim, hugging the canvas edges at mid-height — you
             turn the wheel from where you're already looking, never the top.
-            The right paddle steps aside when the detail panel is open. */}
+            The right paddle steps aside when the detail panel is open — see
+            `clearOfRail`, which is what finally made that sentence true
+            (issue #1307). */}
         {!coreOpen && (
           <>
             <button
               onClick={() => step(-1)}
               aria-label="Previous department"
               title="Previous pillar (←)"
-              className="absolute left-2 top-1/2 z-20 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-colors hover:border-os-border-strong hover:text-os-text"
+              className={`absolute left-2 z-40 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-all duration-200 ease-standard hover:border-os-border-strong hover:text-os-text ${paddleTop}`}
             >
               <ChevronLeft className="h-7 w-7" />
             </button>
@@ -143,7 +188,7 @@ export function KnowledgeGraphFullscreen({
               onClick={() => step(1)}
               aria-label="Next department"
               title="Next pillar (→)"
-              className="absolute right-2 top-1/2 z-20 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-colors hover:border-os-border-strong hover:text-os-text"
+              className={`absolute z-40 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-all duration-200 ease-standard hover:border-os-border-strong hover:text-os-text ${clearOfRail} ${paddleTop}`}
             >
               <ChevronRight className="h-7 w-7" />
             </button>

--- a/frontend/test/unit/overview-detail-rail-clearance.test.ts
+++ b/frontend/test/unit/overview-detail-rail-clearance.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import type { DeptLite } from "@/views/overview/kg/KnowledgeDetail";
 import { KnowledgeGraphFullscreen } from "@/views/overview/kg/KnowledgeGraphFullscreen";
 
 /**
@@ -31,27 +32,28 @@ let root: Root;
 
 const RAIL_CLEARANCE = "right-[316px]";
 
+const DESKS: DeptLite[] = [
+  { deptId: "desk:eng", teamId: "team:desk:eng", name: "Engineering", tagline: "", color: "var(--accent)" },
+  { deptId: "desk:gtm", teamId: "team:desk:gtm", name: "Go-to-Market", tagline: "", color: "var(--ok)" },
+];
+
 /** The shell, with or without a detail card in the rail. */
 function render(detail: boolean) {
   act(() => {
     root.render(
-      createElement(
-        KnowledgeGraphFullscreen,
-        {
-          deptList: [
-            { teamId: "eng", name: "Engineering", color: "var(--accent)" },
-            { teamId: "gtm", name: "Go-to-Market", color: "var(--ok)" },
-          ],
-          currentTeamId: "eng",
-          currentDept: { teamId: "eng", name: "Engineering", color: "var(--accent)" },
-          toolWiki: null,
-          extraDetail: detail ? createElement("div", { "data-testid": "card" }, "a card") : undefined,
-          statusSlot: createElement("div", { "data-testid": "snapshot" }, "Snapshot 09:41"),
-          onNavDept: () => {},
-          onBack: () => {},
-        },
-        createElement("svg"),
-      ),
+      createElement(KnowledgeGraphFullscreen, {
+        deptList: DESKS,
+        currentTeamId: DESKS[0].teamId,
+        currentDept: DESKS[0],
+        toolWiki: null,
+        extraDetail: detail ? createElement("div", { "data-testid": "card" }, "a card") : undefined,
+        statusSlot: createElement("div", { "data-testid": "snapshot" }, "Snapshot 09:41"),
+        onNavDept: () => {},
+        onBack: () => {},
+        // `children` is a required prop here, not a JSX convenience — passing
+        // it positionally to `createElement` satisfies React and not the type.
+        children: createElement("svg"),
+      }),
     );
   });
 }

--- a/frontend/test/unit/overview-detail-rail-clearance.test.ts
+++ b/frontend/test/unit/overview-detail-rail-clearance.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { KnowledgeGraphFullscreen } from "@/views/overview/kg/KnowledgeGraphFullscreen";
+
+/**
+ * Issue #1307: the detail rail buried the chrome on the right edge.
+ *
+ * The rail is an absolute `z-30` overlay 300px wide, on purpose — resizing the
+ * canvas under it reflowed the graph on every open and close. The two controls
+ * that live on the right edge were left at `right-2` / `right-3` and `z-20` /
+ * `z-10` underneath it, so opening any node's card hid the "Next pillar"
+ * paddle, the snapshot clock, the Refresh button and the total-outage alert,
+ * and made every one of them unclickable behind an opaque panel.
+ *
+ * What makes this worth a test rather than a fix is that the shell already
+ * *claimed* the behaviour — "The right paddle steps aside when the detail panel
+ * is open" sat in a comment above a paddle nailed to `right-2` with nothing
+ * implementing it. A sentence is not a guard.
+ *
+ * jsdom does no layout, so this asserts the class contract rather than
+ * measured geometry: with a card open, both controls carry the offset that
+ * clears the rail's width; with no card open, neither does.
+ */
+
+let host: HTMLElement;
+let root: Root;
+
+const RAIL_CLEARANCE = "right-[316px]";
+
+/** The shell, with or without a detail card in the rail. */
+function render(detail: boolean) {
+  act(() => {
+    root.render(
+      createElement(
+        KnowledgeGraphFullscreen,
+        {
+          deptList: [
+            { teamId: "eng", name: "Engineering", color: "var(--accent)" },
+            { teamId: "gtm", name: "Go-to-Market", color: "var(--ok)" },
+          ],
+          currentTeamId: "eng",
+          currentDept: { teamId: "eng", name: "Engineering", color: "var(--accent)" },
+          toolWiki: null,
+          extraDetail: detail ? createElement("div", { "data-testid": "card" }, "a card") : undefined,
+          statusSlot: createElement("div", { "data-testid": "snapshot" }, "Snapshot 09:41"),
+          onNavDept: () => {},
+          onBack: () => {},
+        },
+        createElement("svg"),
+      ),
+    );
+  });
+}
+
+/** The element that positions the snapshot line — the slot's parent. */
+function statusColumn(): HTMLElement {
+  const slot = host.querySelector('[data-testid="snapshot"]');
+  expect(slot, "the shell must render the status slot it is given").not.toBeNull();
+  return slot!.parentElement as HTMLElement;
+}
+
+function nextPillar(): HTMLElement {
+  const el = host.querySelector('[aria-label="Next department"]');
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+}
+
+beforeEach(() => {
+  // React only treats `act` as authoritative when the environment says so;
+  // without this every render logs "not configured to support act(...)".
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+describe("the right-edge chrome and the detail rail", () => {
+  it("sits at the canvas edge while no card is open", () => {
+    render(false);
+    expect(statusColumn().className).toContain("right-5");
+    expect(statusColumn().className).not.toContain(RAIL_CLEARANCE);
+    expect(nextPillar().className).toContain("right-2");
+    expect(nextPillar().className).not.toContain(RAIL_CLEARANCE);
+  });
+
+  it("steps clear of the rail when a card opens", () => {
+    render(true);
+    expect(host.querySelector('[data-testid="card"]')).not.toBeNull();
+    expect(statusColumn().className).toContain(RAIL_CLEARANCE);
+    expect(nextPillar().className).toContain(RAIL_CLEARANCE);
+  });
+
+  it("stays above the rail rather than merely beside it", () => {
+    // Belt and braces: the offset is what makes them visible, but the rail is
+    // `z-30` and both of these used to be below it. If a future change moves
+    // the rail rather than the controls, the stacking order must not be the
+    // thing that re-buries them.
+    render(true);
+    expect(statusColumn().className).toContain("z-40");
+    expect(nextPillar().className).toContain("z-40");
+  });
+
+  it("returns to the edge when the card closes", () => {
+    render(true);
+    render(false);
+    expect(statusColumn().className).not.toContain(RAIL_CLEARANCE);
+    expect(nextPillar().className).not.toContain(RAIL_CLEARANCE);
+  });
+});

--- a/frontend/test/unit/overview-unreachable-host.test.ts
+++ b/frontend/test/unit/overview-unreachable-host.test.ts
@@ -25,7 +25,11 @@ import type { DeskDto, TeamMemberDto } from "@/api/types";
  */
 
 vi.mock("@/views/overview/kg/KnowledgeGraph", () => ({
-  KnowledgeGraph: () => null,
+  // The snapshot corner is a slot the graph's shell positions (issue #1307),
+  // because only the shell knows how wide the detail rail is. The stand-in
+  // therefore has to render that slot — a mock that dropped it would take the
+  // whole surface under test with it and pass by drawing nothing.
+  KnowledgeGraph: ({ statusSlot }: { statusSlot?: unknown }) => statusSlot ?? null,
 }));
 
 const { Overview } = await import("@/views/Overview");


### PR DESCRIPTION
Closes #1307.

## The bug

The graph's detail rail is a 300px `z-30` overlay. Two controls live on the right edge underneath it:

| control | was | rail |
|---|---|---|
| Next pillar paddle | `right-2 z-20` | `right-0 w-[300px] z-30` |
| Snapshot / Refresh / outage alert | `right-3 z-10` (owned by `Overview`) | same |

Measured at 1440x900 against a seeded host, with a teammate card open:

```
nextPaddle   [1384, 386, 48, 128]      aside  [1140, 0, 300, 900]
refreshChip  [1356,  17, 63,  20]
elementFromPoint(paddle centre)  -> the aside's scroll body
elementFromPoint(refresh centre) -> the aside's Back button
```

The rail is opaque (`bg-os-bg/95`), so both were **unclickable**, not merely obscured. Clicking a node — the primary interaction on this page — silently revoked the page's own freshness contract: an operator inspecting a card could not see that the snapshot was stale and could not refresh it. The total-outage alert from #1219 went with them.

`KnowledgeGraphFullscreen.tsx:129-131` already claimed the behaviour —

> The right paddle steps aside when the detail panel is open

— above a paddle nailed to `right-2` with nothing implementing it.

## The fix

The rail stays an overlay. Resizing the canvas under it reflowed the graph on every open and close, which is the glitch the `<aside>`'s own comment is about, so the controls move instead of the canvas.

- `clearOfRail` / `paddleTop` in the shell hold the offsets, so the rail-awareness is in one place rather than spread across two components.
- The snapshot line becomes a **slot** (`statusSlot`) the shell positions. `Overview` cannot see the rail; only the shell knows how much of the right edge is left. It also moves from a lone `right-3 top-3` inset onto the `top-5 / right-5` inset the pillar selector and legend already share.
- Both controls go to `z-40`, so a future change that moves the rail rather than the controls cannot re-bury them by stacking order.
- Below 820px the rail is a bottom sheet (`max-h-[62vh]`, anchored bottom), which buried *both* paddles at `top-1/2`. The offset reverts there and the paddles rise to `top-[19vh]` — the middle of the band the sheet leaves.
- The Suspense fallback keeps drawing the line at the shell's inset, so a cold load still says "Loading…" and it does not appear to pop into place when the physics chunk lands.

## Tests

`frontend/test/unit/overview-detail-rail-clearance.test.ts` — 4 cases. jsdom does no layout, so it asserts the class contract: at rest neither control carries the clearance; with a card open both do, and both are `z-40`; closing the card returns them. The point of the test is that this behaviour was previously a *sentence*, and a sentence is not a guard.

`overview-unreachable-host.test.ts`'s `KnowledgeGraph` stand-in now renders the slot it is handed — a mock that dropped it would take the surface under test with it and pass by drawing nothing.

## Verified

`npm run typecheck`, `typecheck:unit`, `typecheck:e2e`, `npx vitest run` (168 files / 1600 tests), `scripts/ci/assert-design-tokens.sh`.

In a browser against the seeded `agentic-software-company` host, at 1440x900 light **and** dark and at 1100x800, opening a teammate card:

```
light 1440  nextPaddle [1076,386,48,128] reachable=true   refresh [1052,25,63,20] reachable=true
dark  1440  nextPaddle [1076,386,48,128] reachable=true   refresh [1052,25,63,20] reachable=true
light 1100  nextPaddle [ 736,336,48,128] reachable=true   refresh [ 712,25,63,20] reachable=true
```

No console errors.

## Not in this PR

Found in the same audit, filed separately: the graph has no outbound navigation at all (#1308), the pillar selector shows anonymous dots (#1309), labels are drawn under the design system's 10px floor (#1310), and the legend is clipped by the rail at narrow widths (#1316).

---
Raised as a draft.

Design audit of `#/overview`; findings are professional judgement — no Figma reference exists for this surface.
