### PR TITLE
fix: pin a teammate card's status line to the bottom of the card (#1373)

### DIFF
--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -607,8 +607,30 @@ function MemberCard({
             {member.description}
           </p>
         )}
-        {workload && <WorkloadLine workload={workload} />}
-        <DailyBudgetLine member={member} setByLabel={setByLabel} />
+        {/*
+          Pinned to the bottom of the card, not left floating under whatever
+          length the description happened to be.
+
+          `CardContent` is a `h-full` column inside a stretched grid row, so
+          every card in a row is the same height — but the content was all
+          top-aligned, and the description is `line-clamp-3`. A one-line
+          description therefore put this block ~36px higher than the two-line
+          card beside it, and the status line is the one thing a roster is
+          scanned for: "who is working, and how much is on them" was on two or
+          three different baselines in every row, with dead space underneath
+          each card.
+
+          `mt-auto` takes the slack instead, so the running facts line up
+          across a row and the card has no empty tail. Wrapped rather than
+          applied to `WorkloadLine` directly because a host that cannot answer
+          the board renders no workload at all (see `IDLE` and the `workload`
+          prop) — the budget line has to inherit the same anchor, or the two
+          shapes of card disagree again.
+        */}
+        <div className="mt-auto space-y-1.5 empty:hidden">
+          {workload && <WorkloadLine workload={workload} />}
+          <DailyBudgetLine member={member} setByLabel={setByLabel} />
+        </div>
         {/*
           The card's footer is gone with the Inbox switch it existed to hold
           (issue #1190).

--- a/frontend/test/e2e/company-cards.spec.ts
+++ b/frontend/test/e2e/company-cards.spec.ts
@@ -185,6 +185,53 @@ test("#1141 a card carries the description, the status and the open count", asyn
   await expect(priya.getByTestId("team-card-tasks")).toHaveText("0 open tasks");
 });
 
+test("the status line sits on one baseline across a row, whatever the description", async ({
+  page,
+}) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+  await expect(card(page, "Maya")).toBeVisible({ timeout: 30_000 });
+
+  // The precondition. This proves nothing unless the descriptions really do
+  // wrap to different heights: Maya's sentence takes two lines at a card's
+  // width, Ravi's takes one. If a future fixture flattens them, this fails
+  // here rather than passing vacuously below.
+  const tall = await card(page, "Maya").getByTestId("team-card-description").boundingBox();
+  const short = await card(page, "Ravi").getByTestId("team-card-description").boundingBox();
+  expect(tall!.height).toBeGreaterThan(short!.height);
+
+  // Same grid row, so the cards are the same height — and the one line an
+  // operator scans a roster *for* has to land in the same place on each. It
+  // used to follow the description, which put "Working · 2 open tasks" a line
+  // higher or lower than its neighbour in every row, with dead space below
+  // each card.
+  const ys = await Promise.all(
+    ["Maya", "Ravi", "Priya"].map(async (name) => {
+      const box = await card(page, name).getByTestId("team-card-status").boundingBox();
+      return Math.round(box!.y);
+    }),
+  );
+  expect(ys[1]).toBe(ys[0]);
+  expect(ys[2]).toBe(ys[0]);
+
+  // And it is the *bottom* they share, not an accident of equal content: the
+  // gap under the status line is the card's own padding on every card.
+  const gaps = await Promise.all(
+    ["Maya", "Ravi", "Priya"].map(async (name) => {
+      const c = await card(page, name).boundingBox();
+      const status = await card(page, name).getByTestId("team-card-status").boundingBox();
+      return Math.round(c!.y + c!.height - (status!.y + status!.height));
+    }),
+  );
+  expect(gaps[1]).toBe(gaps[0]);
+  expect(gaps[2]).toBe(gaps[0]);
+  // Padding, not a void. Measured at 32px against a live host — `CardContent`'s
+  // own `py-4` plus the card's. Bounded generously because the exact figure is
+  // the design system's to change; what this test is about is that the three
+  // agree, which they did not before.
+  expect(gaps[0]).toBeLessThan(48);
+});
+
 test("#1193 the chart is a destination with its own address, not a mode", async ({ page }) => {
   await mockApi(page);
   await page.goto("/#/company");


### PR DESCRIPTION
Closes #1373.

## The failure

`#/company` lays the roster out in a stretched grid, so every card in a row is the same height — but `CardContent` top-aligns everything and the description is `line-clamp-3`. The workload line therefore followed the description: on the seeded company, row 1 at 1440px put `Idle · 2 open tasks` at y=321 on two cards and y=349 on the one whose description wrapped to two lines, with 30–60px of empty card underneath each.

That line is the reason the workload was put on the card at all (#1141). A grid is scannable when a fact sits in the same place on every tile; this one moved.

## The change

The workload line and the daily-budget line move into one `mt-auto` wrapper, so the slack collects above them instead of below. Nothing else moves — the avatar, name, menu and description keep their position.

`empty:hidden` on the wrapper because both children are conditional: a host that cannot answer the board draws no workload (deliberately — `IDLE` vs `undefined`), and an uncapped teammate draws no budget line. Without it those cards would carry a `gap-3` for a wrapper with nothing in it.

## Test

`frontend/test/e2e/company-cards.spec.ts` — "the status line sits on one baseline across a row, whatever the description". It first asserts the fixture's two descriptions really do wrap to different heights (so it cannot pass vacuously), then asserts the three cards' status lines share a `y` **and** share the gap between the status line and the card's bottom edge — bottom-anchored, not accidentally-equal content.

Verified it fails on the parent commit and passes here.

## Commands run locally

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean
- `npx vitest run` — 1596 passed / 167 files
- `scripts/ci/assert-design-tokens.sh` — clean
- `PW_BASE_URL=… npx playwright test test/e2e/company-cards.spec.ts` against a served console — 12 passed
- Browser-verified against a live seeded host at 1440px and 1100px, light and dark: 13 cards, one distinct bottom gap (32px) across all of them, one baseline per grid row.

## Behaviour change

Visual only. No props, no data, no routes.