### PR TITLE
fix(chat): make the top of an empty channel readable

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -329,6 +329,22 @@
        surface. Not a substitute for the focus ring — an addition to it. */
     --shadow-brand: 0 2px 8px -2px color-mix(in oklab, var(--brand-500) 32%, transparent);
 
+    /* A soft brand glow bleeding from a card's lower-left corner, for the
+       standing invitations on an otherwise empty surface — the "create a
+       teammate" / "add people" pair on a channel with no transcript.
+
+       A token rather than a gradient written at the call site because a glow
+       is a *colour*, and a colour that cannot theme is wrong in one of the two
+       modes: the value below is barely there against a light canvas, and the
+       `.dark` counterpart has to work several times harder to lift a card off
+       near-black. One utility, two tunings, no call site that has to know
+       which mode it is in. */
+    --glow-brand-card: radial-gradient(
+        120% 108% at 14% 112%,
+        color-mix(in oklab, var(--brand-500) 13%, transparent) 0%,
+        transparent 62%
+    );
+
     /*
      * Third-party brand colours.
      *
@@ -463,6 +479,13 @@
     --shadow-xl: 0 8px 16px -8px hsl(var(--shadow-color) / 0.55),
         0 24px 56px -12px hsl(var(--shadow-color) / 0.6), inset 0 1px 0 0 oklch(1 0 0 / 7%);
     --shadow-brand: 0 2px 12px -2px color-mix(in oklab, var(--brand-400) 40%, transparent);
+    /* The light value is invisible here — `--brand-400` at roughly twice the
+       mix is what actually separates the card from the canvas. See `:root`. */
+    --glow-brand-card: radial-gradient(
+        120% 108% at 14% 112%,
+        color-mix(in oklab, var(--brand-400) 22%, transparent) 0%,
+        transparent 62%
+    );
 }
 
 /* ============================================================================
@@ -579,6 +602,11 @@
     --shadow-lg: var(--shadow-lg);
     --shadow-xl: var(--shadow-xl);
     --shadow-brand: var(--shadow-brand);
+
+    /* `--background-image-*` is the namespace that generates a `bg-*` utility
+       for a gradient, the way `--color-*` does for a flat fill. Gives
+       `bg-glow-brand-card`. */
+    --background-image-glow-brand-card: var(--glow-brand-card);
 
     --radius-sm: calc(var(--radius) * 0.6);
     --radius-md: calc(var(--radius) * 0.8);

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { Bot, UserPlus } from "lucide-react";
+import { Bot, CircleDot, Hash, Lock, UserPlus } from "lucide-react";
 
 import type { ApprovalSummary, GrantScope, TurnStep, Verdict } from "@/api/types";
 import { TeammateAvatar } from "@/components/teammate-avatar";
@@ -9,7 +9,13 @@ import { ApprovalRow } from "./ApprovalRow";
 import { MessageRow } from "./MessageRow";
 import { StepTimeline } from "./StepTimeline";
 import { WorkingIndicator } from "./WorkingIndicator";
-import { channelIntroSentence, channelTitle, type Channel, type TimelineItem } from "./model";
+import {
+  channelIntroSentence,
+  channelTitle,
+  dmFace,
+  type Channel,
+  type TimelineItem,
+} from "./model";
 
 interface Props {
   channel: Channel;
@@ -110,6 +116,14 @@ export function MessageTimeline({
   // the *claim of emptiness* that has to wait.
   const loading = historyPending && items.length === 0;
   /**
+   * The channel has answered and has nothing in it.
+   *
+   * Distinct from `loading`: both have no rows, but only this one is a *claim*
+   * that there are none. It drives the intro's copy, its action cards, and —
+   * since #1323 — which end of the pane the whole block settles against.
+   */
+  const empty = items.length === 0 && !loading;
+  /**
    * Is the view parked at the bottom, and therefore still following?
    *
    * A ref rather than state on purpose: it is read inside effects and written
@@ -181,13 +195,35 @@ export function MessageTimeline({
 
   return (
     <div ref={scroller} onScroll={trackFollowing} className="flex-1 overflow-y-auto">
-      <div className="flex min-h-full flex-col justify-end pb-4">
+      {/*
+       * Which end short content settles against (issue #1323).
+       *
+       * `justify-end` is right for a *transcript* shorter than the viewport:
+       * three messages should sit above the composer the way every chat client
+       * puts them, not float in the middle of the pane. It is wrong for a
+       * channel with no transcript at all, because then the only thing being
+       * bottom-pinned is the intro — a heading, a sentence, and the two action
+       * cards that are the whole point of an empty channel — and they end up
+       * crushed against the composer under most of a screen of dead canvas.
+       * The cards are the primary invitation and they were the last thing the
+       * eye reached.
+       *
+       * So an empty channel reads downward from the top, as the design
+       * reference draws it. `empty` is the same value `ChannelIntro` gets, and
+       * it is lifted here rather than recomputed so the two cannot disagree
+       * about what "empty" means — a channel whose intro claimed emptiness
+       * while the wrapper anchored for content would jump on every load.
+       */}
+      <div className={cn("flex min-h-full flex-col pb-4", empty ? "justify-start" : "justify-end")}>
         {/* `empty` only drives the top padding, and the skeleton fills the
             same space real rows will — so a loading channel is spaced like a
-            full one and the intro does not jump down and back up. */}
+            full one and the intro does not jump down and back up. That is also
+            why `loading` keeps the *bottom* anchor above: flipping to the top
+            while history is in flight would move the intro up and then drop it
+            back down the moment the rows land. */}
         <ChannelIntro
           channel={channel}
-          empty={items.length === 0 && !loading}
+          empty={empty}
           loading={loading}
           onAddPeople={onAddPeople}
         />
@@ -297,13 +333,7 @@ function ChannelIntro({
 }) {
   return (
     <div className={cn("px-4 pb-3", empty ? "pt-16" : "pt-6")}>
-      <TeammateAvatar
-        name={channel.voice ?? channel.name}
-        tone={channel.tone}
-        avatar={channel.member?.avatar}
-        company={channel.kind === "channel" && channel.id === "main"}
-        className="mb-3 size-12 rounded-lg text-base"
-      />
+      <IntroMark channel={channel} />
       <h2 className="text-xl font-semibold tracking-tight">{channelTitle(channel)}</h2>
       {/* Both of these sentences are positive claims that the channel has no
           history — "the start of", "the very beginning of". Neither may render
@@ -321,6 +351,72 @@ function ChannelIntro({
         <ActionCards onAddPeople={onAddPeople} />
       )}
     </div>
+  );
+}
+
+/**
+ * What the intro draws above the channel's name (issue #1327).
+ *
+ * The same rule the header settled in #1170, at the intro's larger size: a DM
+ * has exactly one person on the other end and wears their face; a channel has
+ * nobody behind it and wears its kind.
+ *
+ * Before this, every channel but `main` fell through to `TeammateAvatar` seeded
+ * on the channel *name*, so `#engineering` grew an arbitrary mascot — a face
+ * belonging to no one, at the largest avatar size on the surface, as the first
+ * thing in the pane — while the header eighteen pixels above drew `#` for the
+ * same channel. Two marks for one thing, disagreeing on screen.
+ *
+ * `dmFace` is the shared seed, so the mark here and the rail row and the header
+ * cannot drift about who a DM is with.
+ */
+function IntroMark({ channel }: { channel: Channel }) {
+  // The geometry is fixed across all three branches so the copy beneath never
+  // shifts with the kind of channel being opened.
+  const box = "mb-3 size-12 rounded-lg";
+
+  if (channel.kind === "dm") {
+    const face = dmFace(channel);
+    // A DM with no roster entry has nobody to draw. The header falls back to a
+    // glyph rather than inventing a mascot for a stranger; so does this.
+    return face ? (
+      <TeammateAvatar {...face} className={cn(box, "text-base")} />
+    ) : (
+      <MarkTile icon={CircleDot} className={box} />
+    );
+  }
+
+  // The company's own line keeps the brand mark it has always had.
+  if (channel.id === "main") {
+    return (
+      <TeammateAvatar
+        name={channel.voice ?? channel.name}
+        tone={channel.tone}
+        company
+        className={cn(box, "text-base")}
+      />
+    );
+  }
+
+  return <MarkTile icon={channel.private ? Lock : Hash} className={box} />;
+}
+
+/**
+ * A channel's kind on a tile, matching the treatment `ActionCard` gives its own
+ * icon — `--surface-icon`, the rung the brand guide names for an icon ground —
+ * so the two blocks on an empty channel read as one system rather than two.
+ */
+function MarkTile({ icon: Icon, className }: { icon: typeof Hash; className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex items-center justify-center bg-surface-icon text-muted-foreground",
+        className,
+      )}
+      aria-hidden
+    >
+      <Icon className="size-5" />
+    </span>
   );
 }
 
@@ -376,8 +472,13 @@ function ActionCard({
       </span>
     </>
   );
+  // `bg-glow-brand-card` is a background *image* and `bg-card` a background
+  // *colour*, so the two compose rather than collide: the glow sits over the
+  // card's fill and under its content, and `hover:bg-accent` still swaps the
+  // fill beneath it. See `--glow-brand-card` in `index.css` for why the tint is
+  // a token.
   const cls =
-    "flex h-33 w-60 flex-col items-start rounded-xl border bg-card p-4 text-left transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none";
+    "flex h-33 w-60 flex-col items-start rounded-xl border bg-card bg-glow-brand-card p-4 text-left transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none";
 
   // A navigation is an anchor and an in-page action is a button, so the card
   // keeps the affordance its behaviour actually has.

--- a/frontend/test/unit/chat-channel-intro.test.ts
+++ b/frontend/test/unit/chat-channel-intro.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { avatarFor, type TeamMember } from "@/lib/team";
+import { MessageTimeline } from "@/views/chat/MessageTimeline";
+import type { Channel } from "@/views/chat/model";
+
+/**
+ * What the channel intro draws above a channel's name (issue #1327).
+ *
+ * The rule the header settled in #1170, applied one block lower: a DM has
+ * exactly one person on the other end and wears their face; a channel has
+ * nobody behind it and wears its kind.
+ *
+ * The bug this pins is silent in exactly the way #1170's was. Every channel but
+ * `main` fell through to `TeammateAvatar` seeded on the channel *name*, so
+ * `#engineering` grew a mascot belonging to no one — at the largest avatar size
+ * on the surface, as the first thing in the pane — while the header a few
+ * pixels above drew `#` for the same channel. Nothing throws and nothing fails
+ * to render; the two marks simply disagree on screen, and only an assertion
+ * about *which* mark was drawn catches it.
+ *
+ * The marks are told apart by what they are made of rather than by a class
+ * name: only `TeammateAvatar`'s mascot branch renders an `<img>`, so its
+ * presence is the whole question here.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+function member(id: string, name: string): TeamMember {
+  return {
+    id,
+    name,
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    avatar: avatarFor(id),
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+  };
+}
+
+// `createElement` rather than JSX because the unit suite's vitest `include` is
+// `*.test.ts` — a `.tsx` file is silently not collected, which reads as a
+// passing suite.
+function render(channel: Channel) {
+  act(() => {
+    root.render(
+      createElement(MessageTimeline, {
+        channel,
+        items: [],
+        historyPending: false,
+        openThreadId: null,
+        typing: false,
+        onOpenThread: () => {},
+        onReact: () => {},
+        onDismissCard: () => {},
+        dismissingCardId: null,
+      }),
+    );
+  });
+}
+
+/**
+ * The intro's mark: the first element inside the intro block.
+ *
+ * Reached structurally rather than by test id because the point of the change
+ * is *which element type* is rendered there — a query that named one of them
+ * would pass by construction.
+ */
+function mark(): HTMLElement {
+  const intro = container.firstElementChild!.firstElementChild!.firstElementChild!;
+  return intro.firstElementChild as HTMLElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the channel intro's mark", () => {
+  it("draws a DM's teammate, face and all", () => {
+    render({
+      id: "dm:agent_ada",
+      name: "Ada",
+      kind: "dm",
+      purpose: "",
+      tone: "violet",
+      member: member("agent_ada", "Ada"),
+    });
+
+    const img = mark().querySelector("img");
+    expect(img).not.toBeNull();
+    // Seeded through `dmFace`, so the intro cannot disagree with the rail row
+    // or the header about who this DM is with.
+    expect(img!.getAttribute("src")).toContain(avatarFor("agent_ada"));
+  });
+
+  it("draws no face for a channel — there is no one person behind it", () => {
+    render({ id: "engineering", name: "engineering", kind: "channel", purpose: "" });
+
+    expect(mark().querySelector("img")).toBeNull();
+    // The kind mark instead, on the icon ground the action cards below it use.
+    expect(mark().className).toContain("bg-surface-icon");
+    expect(mark().querySelector("svg")).not.toBeNull();
+  });
+
+  it("draws no face for a private channel either — the lock speaks for it", () => {
+    render({ id: "ops", name: "ops", kind: "channel", purpose: "", private: true });
+
+    expect(mark().querySelector("img")).toBeNull();
+    expect(mark().className).toContain("bg-surface-icon");
+  });
+
+  it("keeps the company's own brand mark on the main line", () => {
+    // `main` is the one channel that legitimately has a voice behind it, and it
+    // wears the company mark rather than a mascot or a hash.
+    render({ id: "main", name: "general", voice: "Acme", kind: "channel", purpose: "" });
+
+    expect(mark().querySelector("img")).toBeNull();
+    expect(mark().className).toContain("bg-primary");
+  });
+
+  it("falls back to a glyph for a DM the roster cannot name", () => {
+    // No `member`, so `dmFace` answers null. Inventing a mascot for a stranger
+    // is exactly what the header refuses to do here.
+    render({ id: "dm:gone", name: "Gone", kind: "dm", purpose: "" });
+
+    expect(mark().querySelector("img")).toBeNull();
+    expect(mark().querySelector("svg")).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/chat-scroll-anchor.test.ts
+++ b/frontend/test/unit/chat-scroll-anchor.test.ts
@@ -356,3 +356,54 @@ describe("a transcript that arrives after mount", () => {
     expect(scrollTop).toBe(100);
   });
 });
+
+/**
+ * Which end short content settles against (issue #1323).
+ *
+ * Separate from the scroll rules above, and deliberately so: `scrollTop` cannot
+ * express this. A pane whose content is shorter than its viewport has no scroll
+ * range at all, so every anchoring call in this file is a no-op there and the
+ * only thing deciding where the block sits is the flex alignment on the inner
+ * wrapper. That is what these assert.
+ *
+ * The bug: an empty channel's intro — a heading, a sentence, and the two action
+ * cards that are the entire point of an empty channel — was bottom-pinned by
+ * `justify-end`, so it rendered crushed against the composer under most of a
+ * screen of dead canvas, with the primary invitation as the last thing the eye
+ * reached.
+ */
+describe("where an empty channel's intro sits", () => {
+  /** The inner wrapper, whose flex alignment is the whole subject here. */
+  function wrapper(): HTMLElement {
+    return scroller().firstElementChild as HTMLElement;
+  }
+
+  it("reads from the top when the channel has answered and is empty", () => {
+    const ch = channel("engineering");
+    render(ch, [], false);
+
+    expect(wrapper().className).toContain("justify-start");
+    expect(wrapper().className).not.toContain("justify-end");
+  });
+
+  it("keeps the bottom anchor once there is a transcript", () => {
+    // A short transcript still belongs above the composer, the way every chat
+    // client puts it. This is the behaviour #1323 must not disturb.
+    const ch = channel("engineering");
+    render(ch, items(3, ch), false);
+
+    expect(wrapper().className).toContain("justify-end");
+    expect(wrapper().className).not.toContain("justify-start");
+  });
+
+  it("keeps the bottom anchor while history is still on the wire", () => {
+    // `loading` renders the skeleton, which fills the space the real rows will.
+    // Flipping to the top here would lift the intro and then drop it back the
+    // moment the transcript landed — the jump the skeleton exists to prevent.
+    const ch = channel("engineering");
+    render(ch, [], true);
+
+    expect(wrapper().className).toContain("justify-end");
+    expect(wrapper().className).not.toContain("justify-start");
+  });
+});


### PR DESCRIPTION
Design audit of the Chat surface, driven against a running seeded host at 1440px and 1100px in both themes. Three faults in one block — the intro above a channel's transcript.

## 1. It was pinned to the bottom of an empty screen (#1323)

`justify-end` on a `min-h-full` flex column bottom-pins content shorter than the viewport. Right for a short *transcript* — three messages belong above the composer, as every chat client puts them — wrong for a channel with no transcript, where the only thing bottom-pinned is the intro. The two action cards that are the entire point of an empty channel rendered crushed against the composer under roughly 850px of dead canvas, so the primary invitation was the last thing the eye reached.

An empty channel now reads downward from the top. Two behaviours deliberately unchanged:
- a channel **with rows** keeps the bottom anchor;
- a channel **still loading** keeps it too, because the skeleton fills the space the real rows will — flipping to the top there would lift the intro and drop it back the moment history landed, which is the jump the skeleton exists to prevent.

## 2. It drew a face for a thing with no face (#1327)

Every channel but `main` fell through to `TeammateAvatar` seeded on the channel *name*, so `#engineering` grew an arbitrary mascot belonging to nobody — at the largest avatar size on the surface, as the first thing in the pane — while `ChatHeader` a few pixels above drew `#` for the same channel. Two marks for one thing, disagreeing on screen.

`IntroMark` now applies the rule the header settled in #1170: a DM wears its teammate's face (seeded through the shared `dmFace`, so the intro, the rail row and the header cannot drift about who a DM is with); `main` keeps the company brand mark; every other channel wears its kind (`#`, or the lock when private).

## 3. The action cards did not lift off the canvas (#1339)

`rounded-xl border bg-card` and nothing else read as two empty boxes against near-black. `--glow-brand-card` adds the soft radial brand glow the design reference gives them.

Tokenised, beside `--shadow-brand` and built the same way (`color-mix(in oklab, var(--brand-N) …)`): a glow is a colour, and a colour that cannot theme is wrong in one of the two modes — the light value is barely there, and dark needs `--brand-400` at roughly twice the mix to separate a card from the canvas. Exposed through `--background-image-*`, which is the namespace that generates a `bg-*` utility for a gradient; **verified against the emitted CSS**, not assumed:

```
.bg-glow-brand-card{background-image:var(--glow-brand-card)}
```

## Tests

- `frontend/test/unit/chat-scroll-anchor.test.ts` — a new block for which end short content settles against. Deliberately separate from the scroll rules already in that file: a pane shorter than its viewport has no scroll range, so every anchoring call is a no-op there and only the flex alignment decides. Covers empty, has-rows, and still-loading.
- `frontend/test/unit/chat-channel-intro.test.ts` (new) — which mark the intro draws, told apart by what the element is made of rather than by a class name (only the mascot branch renders an `<img>`), so a query cannot pass by construction. Covers DM, plain channel, private channel, `main`, and a DM with no roster entry.
- No unit test for the glow — it is pure CSS, covered by `assert-design-tokens.sh` and the build check above.

## Gates run locally

| gate | result |
|---|---|
| `npm run typecheck` | pass |
| `npm run typecheck:unit` | pass |
| `npm run typecheck:e2e` | pass |
| `npx vitest run` | 168 files, 1604 tests, all pass |
| `scripts/ci/assert-design-tokens.sh` | pass |
| `npx playwright test chat-` (own host on :8473 serving this build) | 28 passed, 3 skipped (live-brain gated) |
| `npm run build` | pass (and used to verify the utility above) |

Browser-verified in **both themes** at 1440px against a real host: the empty DM, the empty channel with its cards, and a channel with a transcript to confirm the bottom anchor is undisturbed.

Closes #1323, closes #1327, closes #1339.