### PR TITLE
fix(chat): give a thread's summary row faces and an age

### DIFF
--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -4,6 +4,7 @@ import { Markdown } from "@/components/markdown";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
 import { isHostMessageId, type ChatMessage } from "@/lib/chat";
+import { timeAgo } from "@/lib/language";
 import { cn } from "@/lib/utils";
 import {
   formatTime,
@@ -125,10 +126,16 @@ export function MessageRow({
             onClick={() => onOpenThread(message.id)}
             className="mt-1 flex w-fit items-center gap-2 rounded-md px-1.5 py-1 text-xs font-medium text-primary transition-colors hover:bg-accent"
           >
-            <ReplyFacepile replies={replies} />
+            <ReplyFacepile senders={entry.replySenders} />
             {replies.length} {replies.length === 1 ? "reply" : "replies"}
+            {/* "Last reply" asks how long a thread has been quiet, and a
+                wall-clock time is the one form that does not answer it: on a
+                transcript older than a day it is ambiguous without the date,
+                and inside one day it makes the reader do the subtraction. The
+                day divider above already carries "Today", so the absolute time
+                was doubly redundant on the common case (issue #1328). */}
             <span className="font-normal text-muted-foreground">
-              Last reply {formatTime(replies[replies.length - 1].at)}
+              · Last reply {timeAgo(replies[replies.length - 1].at, Date.now())}
             </span>
           </button>
         )}
@@ -283,18 +290,36 @@ function ActionBar({
   );
 }
 
-function ReplyFacepile({ replies }: { replies: ChatMessage[] }) {
+/**
+ * Who is in this thread, as faces (issue #1324).
+ *
+ * This used to seed each tile on `message.channel` and draw it `markOnly` —
+ * and both halves defeated it. Every reply in a thread carries the same
+ * channel, so all three tiles hashed to one tone; and `markOnly` renders an
+ * *empty* tile by design, because 16px is below the size at which initials or
+ * a mascot can be read. The result was three identical featureless grey
+ * squares that read as a loading skeleton, carrying no information at all.
+ *
+ * Both are fixed by the same change. The senders arrive already resolved and
+ * deduped from {@link TimelineEntry.replySenders}, so the tiles are genuinely
+ * different people; and at 20px — the size the rail already draws a DM's face
+ * at, legibly — the real mascot fits, so there is nothing left for `markOnly`
+ * to apologise for.
+ */
+function ReplyFacepile({ senders }: { senders: Sender[] }) {
   // At most three faces — beyond that the count carries the information.
-  const shown = replies.slice(0, 3);
+  const shown = senders.slice(0, 3);
+  if (shown.length === 0) return null;
   return (
     <span className="flex -space-x-1.5" aria-hidden>
-      {shown.map((r) => (
+      {shown.map((s) => (
         <TeammateAvatar
-          key={r.id}
-          name={r.from === "you" ? "You" : (r.channel ?? "Company")}
-          tone={r.channel}
-          markOnly
-          className="size-4 rounded-[3px] ring-1 ring-background"
+          key={s.key}
+          name={s.name}
+          tone={s.tone}
+          avatar={s.avatar}
+          company={s.kind === "company"}
+          className="size-5 rounded-[4px] text-3xs ring-1 ring-background"
         />
       ))}
     </span>

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -519,6 +519,38 @@ export interface TimelineEntry {
   dayLabel?: string;
   /** Replies hanging off this row, oldest first. */
   replies: ChatMessage[];
+  /**
+   * The distinct voices in those replies, in the order they first spoke
+   * (issue #1324).
+   *
+   * Resolved here rather than in the row because resolving a sender needs the
+   * channel and the roster, and neither reaches the renderer. Without it the
+   * summary row could only seed a face on `message.channel` — one value shared
+   * by every reply in a thread — so a three-face pile drew one colour three
+   * times and said nothing at all.
+   *
+   * Deduped by `Sender.key`: a pile is a list of *people*, and someone who
+   * replied four times is still one face.
+   */
+  replySenders: Sender[];
+}
+
+/**
+ * The distinct voices in a run of messages, in first-spoken order.
+ *
+ * Goes through the same {@link senderOf} every rendered row does, so a face in
+ * a thread's summary pile is the same face that thread shows when it is opened.
+ * A system line is dropped: it has no voice to draw, and a pile that counted it
+ * would claim one more participant than the thread has.
+ */
+function distinctSenders(messages: ChatMessage[], channel: Channel, members: TeamMember[]): Sender[] {
+  const byKey = new Map<string, Sender>();
+  for (const m of messages) {
+    if (m.from === "system") continue;
+    const sender = senderOf(m, channel, members);
+    if (!byKey.has(sender.key)) byKey.set(sender.key, sender);
+  }
+  return [...byKey.values()];
 }
 
 /**
@@ -558,12 +590,14 @@ export function buildTimeline(
       // otherwise sit between two lines that read as one utterance.
       prev.replies.length === 0;
 
+    const own = replies.get(m.id) ?? [];
     const entry: TimelineEntry = {
       message: m,
       sender,
       continuation,
       dayLabel: newDay ? formatDay(m.at) : undefined,
-      replies: replies.get(m.id) ?? [],
+      replies: own,
+      replySenders: distinctSenders(own, channel, members),
     };
     entries.push(entry);
     prev = entry;

--- a/frontend/test/unit/chat-timeline.test.ts
+++ b/frontend/test/unit/chat-timeline.test.ts
@@ -157,3 +157,89 @@ describe("buildTimeline", () => {
     expect(entries[1].continuation).toBe(false);
   });
 });
+
+/**
+ * Who a thread's summary pile draws (issue #1324).
+ *
+ * The facepile under a threaded row used to seed each tile on the *message's*
+ * channel, and every reply in a thread carries the same channel — so a
+ * three-face pile hashed to one tone and drew one colour three times. Combined
+ * with `markOnly`, which renders a deliberately empty tile, the row showed
+ * three identical featureless squares: not faces, and not information.
+ *
+ * Resolving the senders here is what makes the pile able to say anything. It
+ * goes through the same `senderOf` every rendered row uses, so a face in the
+ * summary is the same face the thread shows when it is opened — the agreement
+ * #1170 and #1185 established for DMs, extended to threads.
+ */
+describe("buildTimeline: the voices behind a thread", () => {
+  it("tells apart voices the message channel alone could not", () => {
+    // Both replies are `from: "company"` on the same parent. Before, both
+    // seeded on `channel` and collapsed to one tone; the *originating* channel
+    // is what actually distinguishes them.
+    const entries = buildTimeline(
+      [
+        message({ id: "a", text: "who can take this?" }),
+        message({ id: "b", from: "company", channel: "agent_ada", parentId: "a", at: T0 + 1 }),
+        message({ id: "c", from: "company", channel: "agent_bo", parentId: "a", at: T0 + 2 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries[0].replySenders.map((s) => s.key)).toEqual(["agent:agent_ada", "agent:agent_bo"]);
+  });
+
+  it("counts a person once however often they replied — a pile is people, not messages", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a" }),
+        message({ id: "b", parentId: "a", at: T0 + 1 }),
+        message({ id: "c", parentId: "a", at: T0 + 2 }),
+        message({ id: "d", parentId: "a", at: T0 + 3 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries[0].replies).toHaveLength(3);
+    expect(entries[0].replySenders.map((s) => s.key)).toEqual(["you"]);
+  });
+
+  it("keeps the voices in the order they first spoke", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a" }),
+        message({ id: "b", from: "company", channel: "agent_bo", parentId: "a", at: T0 + 1 }),
+        message({ id: "c", parentId: "a", at: T0 + 2 }),
+        // Bo again — already seen, so this must not move them down the pile.
+        message({ id: "d", from: "company", channel: "agent_bo", parentId: "a", at: T0 + 3 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries[0].replySenders.map((s) => s.key)).toEqual(["agent:agent_bo", "you"]);
+  });
+
+  it("draws no face for a system line — it has no voice to draw", () => {
+    // A pile that counted this would claim one more participant than the
+    // thread has.
+    const entries = buildTimeline(
+      [
+        message({ id: "a" }),
+        message({ id: "b", from: "system", text: "approved", parentId: "a", at: T0 + 1 }),
+      ],
+      CHANNEL,
+      [],
+    );
+
+    expect(entries[0].replies).toHaveLength(1);
+    expect(entries[0].replySenders).toEqual([]);
+  });
+
+  it("leaves a row with no replies with no voices", () => {
+    const entries = buildTimeline([message({ id: "a" })], CHANNEL, []);
+    expect(entries[0].replySenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Design audit of the Chat surface. The summary row under a threaded message was carrying two pieces of information and getting both wrong.

Before / after, same thread, same host:

| | |
|---|---|
| before | `▪▪▪  6 replies  Last reply 1:08 AM` |
| after | `🟢🟣  6 replies · Last reply 26m ago` |

## 1. The facepile said nothing (#1324)

Each tile was seeded on the *message's* channel and drawn `markOnly`. Both halves defeated it:

- every reply in a thread carries the same channel, so all three tiles hashed to **one tone**;
- `markOnly` renders a deliberately **empty** tile, because 16px is below the size at which initials or a mascot can be read.

So the row drew three identical featureless grey squares. They read as a loading skeleton, and they carried no information — a facepile that cannot distinguish anybody is worse than no facepile.

Both halves are fixed by resolving the senders properly. `TimelineEntry` gains `replySenders`: the distinct voices behind a row's replies, deduped by `Sender.key`, in first-spoken order, resolved through **the same `senderOf` every rendered row uses** — so a face in the summary is the same face the thread shows when opened. That is the agreement #1170 and #1185 established for DMs, extended to threads.

Resolving it in the model rather than the row is what makes it possible at all: a sender needs the channel and the roster, and neither reaches the renderer. It also puts the logic somewhere a pure unit test can reach.

With genuinely different people to draw, the tile goes to **20px** — the size the rail already draws a DM's face at, legibly — so the real mascot fits and there is nothing left for `markOnly` to apologise for.

A system line among the replies draws no face: it has no voice, and counting it would claim one more participant than the thread has.

## 2. "Last reply 1:08 AM" answered the wrong question (#1328)

"Last reply" asks how long a thread has been quiet, and a wall-clock time is the one form that does not say it: on a transcript older than a day it is ambiguous without the date, and inside one day it makes the reader do the subtraction — while the day divider above already carries "Today", so it was doubly redundant on the common case.

Now `timeAgo`, the helper `ApprovalsView`, `TaskCard` and `FeedbackView` already share (reused rather than added — the point of that module is that two surfaces cannot drift into two vocabularies for one idea), plus the `·` that was missing between the count and the age.

## Tests

`frontend/test/unit/chat-timeline.test.ts` — the model change is pure, so it is tested as one. Five cases: two company voices the message channel alone could not tell apart; one person who replied three times counting once (a pile is people, not messages); first-spoken ordering held when someone replies again; a system line drawing nothing; and a row with no replies having no voices.

## Gates run locally

| gate | result |
|---|---|
| `npm run typecheck` | pass |
| `npm run typecheck:unit` | pass |
| `npm run typecheck:e2e` | pass |
| `npx vitest run` | 167 files, 1601 tests, all pass |
| `scripts/ci/assert-design-tokens.sh` | pass |
| `npx playwright test chat-` (own host on :8473 serving this build) | 28 passed, 3 skipped (live-brain gated) |
| `npm run build` | pass |

Browser-verified in **both themes** at 1440px against a real host, on a six-reply thread.

Closes #1324, closes #1328.