### PR TITLE
feat(overview): give the knowledge graph a way out

### DIFF
--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -89,6 +89,32 @@ The console deliberately does **not** intersect a grant against the tool names
 discovered from MCP servers. Deciding what a glob covers is the host's
 `grant_matches`, and a second copy here is exactly the drift issue #264 forbids.
 
+## The way out
+
+Every card ends with one link to the page that names the same record
+(`kg/open-in-console.ts`, issue #1308):
+
+| card | goes to |
+|---|---|
+| AI teammate | `#/team/<agentId>` |
+| SOP task | `#/tasks/<taskId>` |
+| human | `#/settings/people` — there is no per-person address |
+| note | `#/memory` |
+
+A **tool** and a **stage** deliberately get none. A grant is a string in
+`company.toml`, not a record with a page, and pointing at the MCP tab would
+name a server the grant may have nothing to do with — the `grant_matches`
+guesswork this file forbids two sections down. A stage is a node inside a saved
+graph: the flow has an address, the node within it does not.
+
+The destination is read off the **node's own id**, which already carries the
+host's id for the thing it draws (`emp:<agentId>`, `team:desk:<deskId>`), so a
+card cannot link to a different record than the node it was opened from.
+
+It is a real `<a href="#/…">` rather than a click handler, so cmd-click,
+middle-click and copy-link work and the hash router picks it up from
+`hashchange` like every other link in the console.
+
 ## Freshness
 
 The page is a **snapshot**, not a live view, and says so: a "Snapshot HH:MM" chip

--- a/frontend/src/views/overview/kg/KnowledgeDetail.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeDetail.tsx
@@ -2,10 +2,11 @@
 
 // SPDX-License-Identifier: GPL-3.0-or-later
 import {
-  ArrowLeft, ChevronRight, ClipboardList, FileText, ListChecks, Server, User, UserCog, Wrench, X, type LucideIcon,
+  ArrowLeft, ArrowUpRight, ChevronRight, ClipboardList, FileText, ListChecks, Server, User, UserCog, Wrench, X, type LucideIcon,
 } from 'lucide-react';
 import type { ToolWiki } from './agent-wiki';
 import type { MemoryNode } from './memory-core';
+import type { ConsoleDestination } from './open-in-console';
 import type { Person, SopTask } from './schemas';
 
 export type AgentLite = { id: string; name: string; role: string; model: string };
@@ -28,6 +29,36 @@ export function WikiLink({ label, mcp, onClick }: { label: string; mcp?: boolean
     </button>
   ) : (
     <span className="inline-flex items-center gap-1 font-mono text-2xs text-os-accent">{inner}</span>
+  );
+}
+
+/**
+ * The way out of the graph (issue #1308).
+ *
+ * Every card here used to be a dead end: the landing page could tell an
+ * operator that a teammate had never run, and then made them leave through the
+ * sidebar and find that teammate again by hand. This is the one control that
+ * ends the card, in the same place on every card, and it goes to the page that
+ * already names the same record.
+ *
+ * A real `<a href>` rather than a click handler, deliberately: it is a link, so
+ * cmd-click, middle-click and copy-link all have to work, and the console's
+ * hash router picks the address up from `hashchange` exactly as it does for
+ * every other link in the app.
+ *
+ * It mirrors `PanelHeader`'s Back row — same mono caption size, same tracking,
+ * same resting colour — so the card reads as a thing with a top and a bottom
+ * rather than a panel that has grown a button.
+ */
+export function OpenInConsole({ to }: { to: ConsoleDestination }) {
+  return (
+    <a
+      href={to.hash}
+      className="flex shrink-0 items-center justify-between gap-2 border-t border-os-border px-3 py-2 font-mono text-3xs uppercase tracking-[0.14em] text-os-dim transition-colors hover:bg-os-surface hover:text-os-text"
+    >
+      <span className="truncate">{to.label}</span>
+      <ArrowUpRight className="h-3 w-3 shrink-0" aria-hidden />
+    </a>
   );
 }
 
@@ -144,7 +175,7 @@ export function DeptOverviewCard({
  */
 export function AgentHarnessCard({
   agent, task, parentName, parentAgentId, subAgents, lastRun, runLabel, tools,
-  onBack, onClose, onTool, onAgent, onTask,
+  onBack, onClose, onTool, onAgent, onTask, openIn,
 }: {
   /**
    * `tier` is the company's declaration verbatim, `null` when it declared none;
@@ -174,6 +205,8 @@ export function AgentHarnessCard({
   onTool?: (slug: string) => void;
   onAgent?: (agentId: string) => void;
   onTask?: () => void;
+  /** The teammate's own page in the console (issue #1308). */
+  openIn?: ConsoleDestination | null;
 }) {
   return (
     <div className="flex h-full flex-col">
@@ -258,9 +291,15 @@ export function AgentHarnessCard({
             </p>
           </div>
         ) : (
-          <p className="font-mono text-2xs text-os-dim">never run — trigger it from /agents</p>
+          // It used to say "trigger it from /agents" — a route that has never
+          // existed in `VIEWS`, so following the one instruction the card gave
+          // landed the operator back on this same page (issue #1315). The
+          // teammate's real page is one row below now, so this states the fact
+          // and lets the footer carry the way there.
+          <p className="font-mono text-2xs text-os-dim">never run</p>
         )}
       </div>
+      {openIn && <OpenInConsole to={openIn} />}
     </div>
   );
 }
@@ -300,12 +339,14 @@ export function ToolDetailCard({
 
 /** Memory note detail: one note from the company's memory constellation. */
 export function MemoryNoteCard({
-  note, color, onBack, onClose,
+  note, color, onBack, onClose, openIn,
 }: {
   note: MemoryNode;
   color: string;
   onBack?: () => void;
   onClose?: () => void;
+  /** The Brain, which is the surface a note lives on (issue #1308). */
+  openIn?: ConsoleDestination | null;
 }) {
   return (
     <div className="flex h-full flex-col">
@@ -330,13 +371,14 @@ export function MemoryNoteCard({
         <SectionLabel icon={FileText}>source</SectionLabel>
         <WikiLink label={`${note.id}.md`} />
       </div>
+      {openIn && <OpenInConsole to={openIn} />}
     </div>
   );
 }
 
 /** SOP detail: one written-out job — its steps, its single owner, its tools. */
 export function SopTaskDetailCard({
-  task, assigneeName, assigneeKindLabel, assigneeColor, runtime, tools, onBack, onClose, onAssignee, onTool,
+  task, assigneeName, assigneeKindLabel, assigneeColor, runtime, tools, onBack, onClose, onAssignee, onTool, openIn,
 }: {
   task: SopTask;
   assigneeName: string;
@@ -349,6 +391,8 @@ export function SopTaskDetailCard({
   onClose?: () => void;
   onAssignee?: () => void;
   onTool?: (slug: string) => void;
+  /** The board card this SOP is (issue #1308). */
+  openIn?: ConsoleDestination | null;
 }) {
   return (
     <div className="flex h-full flex-col">
@@ -384,13 +428,14 @@ export function SopTaskDetailCard({
           {tools.length === 0 && <span className="font-mono text-2xs text-os-dim">no tools wired</span>}
         </div>
       </div>
+      {openIn && <OpenInConsole to={openIn} />}
     </div>
   );
 }
 
 /** Graph human detail: a person in the process — their one job and tools. */
 export function GraphHumanDetailCard({
-  person, deptName, color, task, tools, onBack, onClose, onTask, onTool,
+  person, deptName, color, task, tools, onBack, onClose, onTask, onTool, openIn,
 }: {
   person: Person;
   deptName: string;
@@ -401,6 +446,8 @@ export function GraphHumanDetailCard({
   onClose?: () => void;
   onTask?: () => void;
   onTool?: (slug: string) => void;
+  /** The console's people list — there is no per-person page (issue #1308). */
+  openIn?: ConsoleDestination | null;
 }) {
   return (
     <div className="flex h-full flex-col">
@@ -424,6 +471,7 @@ export function GraphHumanDetailCard({
           ))}
         </div>
       </div>
+      {openIn && <OpenInConsole to={openIn} />}
     </div>
   );
 }

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -26,6 +26,7 @@ import {
   AgentHarnessCard, GraphHumanDetailCard, MemoryNoteCard, SopTaskDetailCard,
   type DeptLite,
 } from './KnowledgeDetail';
+import { destinationFor, MEMORY_DESTINATION } from './open-in-console';
 import { KnowledgeGraphFullscreen } from './KnowledgeGraphFullscreen';
 
 const W = 880;
@@ -1617,6 +1618,10 @@ export function KnowledgeGraph({
       onTool={selectToolSlug}
       onAgent={(id) => selectAgent(`emp:${id}`)}
       onTask={selectedAgentTaskId ? () => selectTask(selectedAgentTaskId) : undefined}
+      // The way out of the graph (issue #1308). Read off the node's own id, so
+      // the link cannot name a different teammate than the card was opened
+      // from.
+      openIn={selectedAgentId ? destinationFor(selectedAgentId) : null}
     />
   ) : null;
 
@@ -1638,6 +1643,7 @@ export function KnowledgeGraph({
       onClose={clearDetail}
       onAssignee={selectedTaskWorker ? () => selectWorker(selectedTaskWorker) : undefined}
       onTool={selectToolSlug}
+      openIn={selectedTaskId ? destinationFor(selectedTaskId) : null}
     />
   ) : null;
 
@@ -1655,6 +1661,7 @@ export function KnowledgeGraph({
       onClose={clearDetail}
       onTask={selectedHumanTaskId ? () => selectTask(selectedHumanTaskId) : undefined}
       onTool={selectToolSlug}
+      openIn={selectedHumanId ? destinationFor(selectedHumanId) : null}
     />
   ) : null;
 
@@ -1664,6 +1671,9 @@ export function KnowledgeGraph({
       note={selectedMemory}
       color={memColor(selectedMemory)}
       onClose={() => setSelectedMemoryId(null)}
+      // A note's surface is the Brain itself — `#/memory` addresses the page,
+      // not one entry — so this is the constant rather than a per-id lookup.
+      openIn={MEMORY_DESTINATION}
     />
   ) : null;
 

--- a/frontend/src/views/overview/kg/open-in-console.ts
+++ b/frontend/src/views/overview/kg/open-in-console.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Where a node on the graph lives in the rest of the console (issue #1308).
+ *
+ * The Overview graph draws every teammate, every open board card, every
+ * workflow and every desk the company declares — and, until this, linked to
+ * none of them. It was the console's landing page and its only terminal
+ * surface: an operator could learn that a teammate had never run, and then had
+ * to leave through the sidebar and find them again by hand.
+ *
+ * Nothing new is invented here. Every address below already exists and is
+ * already the page that names the same thing; this is the lookup that says
+ * which one, and it is pure so a test can assert the whole table without
+ * rendering a graph.
+ *
+ * ## Why the node id is the input
+ *
+ * A node id already carries the host's own id for the thing it draws —
+ * `emp:<agentId>`, `task:<taskId>`, `team:desk:<deskId>` (`model.ts`,
+ * `adapter.ts`). Reading the destination off the id means the card cannot link
+ * to a different record than the node it was opened from, which a second
+ * id threaded through the component tree could quietly start doing.
+ *
+ * ## What deliberately has no destination
+ *
+ * - **A tool.** A grant is a string in `company.toml` (`mcp:*`, `workspace.*`),
+ *   not a record with a page. The console has no address for one, and
+ *   inventing a link to the MCP tab would point at a server that may have
+ *   nothing to do with the grant — exactly the `grant_matches` guesswork
+ *   `views/overview/README.md` forbids.
+ * - **A workflow stage.** A stage is a node inside a saved graph. The flow has
+ *   an address; the node within it does not.
+ * - **The company core.** It is the page you are already on.
+ */
+
+/** A console address, and the words for the control that goes there. */
+export interface ConsoleDestination {
+  /** The `href` — a real hash link, so cmd-click and copy-link both work. */
+  hash: string;
+  /** What the control says. Names the destination, not the act of leaving. */
+  label: string;
+}
+
+/** `desk:<id>` — the department id the adapter derives from a desk. */
+const DESK_PREFIX = "desk:";
+
+/**
+ * The department id a desk was turned into, back to the desk's own id.
+ *
+ * The inverse of `departmentIdOfDesk` in `adapter.ts`, and it lives here rather
+ * than there so the two are read together: `#/company/<deskId>` wants the id
+ * the host serves, and the graph is holding the prefixed one.
+ */
+function deskIdOf(departmentId: string): string | null {
+  return departmentId.startsWith(DESK_PREFIX)
+    ? departmentId.slice(DESK_PREFIX.length) || null
+    : null;
+}
+
+/**
+ * The console address for a graph node, or `null` where none names it.
+ *
+ * `nodeId` is the graph's own id (`KGNode.id`). Ids are host-supplied, so every
+ * segment is encoded — a desk called `Sales & Ops` or a task id with a slash
+ * would otherwise write a different address than the one it names.
+ */
+export function destinationFor(nodeId: string): ConsoleDestination | null {
+  if (nodeId.startsWith("emp:")) {
+    const id = nodeId.slice("emp:".length);
+    return id ? { hash: `#/team/${encodeURIComponent(id)}`, label: "Open teammate" } : null;
+  }
+  if (nodeId.startsWith("task:")) {
+    const id = nodeId.slice("task:".length);
+    return id ? { hash: `#/tasks/${encodeURIComponent(id)}`, label: "Open card" } : null;
+  }
+  if (nodeId.startsWith("flow:")) {
+    const id = nodeId.slice("flow:".length);
+    return id ? { hash: `#/workflows/${encodeURIComponent(id)}`, label: "Open workflow" } : null;
+  }
+  if (nodeId.startsWith("team:")) {
+    const deskId = deskIdOf(nodeId.slice("team:".length));
+    // A department the adapter did not build from a desk — `UNPLACED`, say —
+    // has no desk behind it and therefore no page. It is not an error; it is
+    // the honest answer, and it is why this returns `null` rather than
+    // guessing at `#/company`.
+    return deskId ? { hash: `#/company/${encodeURIComponent(deskId)}`, label: "Open desk" } : null;
+  }
+  // A human is a person who can sign in, and the console's page for that is the
+  // people list. There is no per-person address to deep-link to, so this names
+  // the list rather than pretending to name the row.
+  if (nodeId.startsWith("person:")) {
+    return { hash: "#/settings/people", label: "Open people" };
+  }
+  return null;
+}
+
+/**
+ * The Brain, where the company's notes live.
+ *
+ * A note on the constellation is a real memory entry, but `#/memory` addresses
+ * the surface rather than one entry, so this is a constant instead of a lookup
+ * over the note's id.
+ */
+export const MEMORY_DESTINATION: ConsoleDestination = {
+  hash: "#/memory",
+  label: "Open Brain",
+};

--- a/frontend/test/unit/overview-open-in-console.test.ts
+++ b/frontend/test/unit/overview-open-in-console.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { departmentIdOfDesk } from "@/views/overview/kg/adapter";
+import { destinationFor, MEMORY_DESTINATION } from "@/views/overview/kg/open-in-console";
+
+/**
+ * Issue #1308: the graph was the console's landing page and its only terminal
+ * surface. It drew every teammate, every open board card, every workflow and
+ * every desk the company declares, and linked to none of them — an operator
+ * could learn that a teammate had never run and then had to leave through the
+ * sidebar and find them again by hand.
+ *
+ * The lookup is pure so the whole table can be asserted without a graph, a
+ * host or a browser. What it is really guarding is the join: a node id carries
+ * the host's own id (`emp:<agentId>`, `team:desk:<deskId>`), and the address
+ * has to be built from *that* id rather than from anything re-derived.
+ */
+describe("where a graph node lives in the console", () => {
+  it("sends a teammate to their own page", () => {
+    expect(destinationFor("emp:frontend_engineer")).toEqual({
+      hash: "#/team/frontend_engineer",
+      label: "Open teammate",
+    });
+  });
+
+  it("sends an SOP task to its board card", () => {
+    expect(destinationFor("task:tsk_01H9")).toEqual({
+      hash: "#/tasks/tsk_01H9",
+      label: "Open card",
+    });
+  });
+
+  it("sends a workflow to the flow it names", () => {
+    expect(destinationFor("flow:nightly-digest")).toEqual({
+      hash: "#/workflows/nightly-digest",
+      label: "Open workflow",
+    });
+  });
+
+  it("sends a human to the people list", () => {
+    // There is no per-person address, so the label names the list rather than
+    // pretending to name the row.
+    expect(destinationFor("person:mithil@example.com")).toEqual({
+      hash: "#/settings/people",
+      label: "Open people",
+    });
+  });
+
+  it("sends a note to the Brain", () => {
+    expect(MEMORY_DESTINATION).toEqual({ hash: "#/memory", label: "Open Brain" });
+  });
+
+  describe("a department", () => {
+    it("unwraps the desk id the adapter wrapped", () => {
+      // The graph holds `team:` + whatever `departmentIdOfDesk` produced.
+      // Building the address from the raw department id would send the
+      // operator to `#/company/desk:eng`, which names no desk. Composing the
+      // id here rather than hardcoding it keeps this honest if the prefix
+      // ever changes.
+      const nodeId = `team:${departmentIdOfDesk("eng")}`;
+      expect(nodeId).toBe("team:desk:eng");
+      expect(destinationFor(nodeId)).toEqual({
+        hash: "#/company/eng",
+        label: "Open desk",
+      });
+    });
+
+    it("has no page when it was not built from a desk", () => {
+      // `UNPLACED` and anything else the adapter did not derive from a desk
+      // has no desk behind it, so there is nothing to open. Answering `null`
+      // is the honest result; guessing at `#/company` would send an operator
+      // to a page that does not contain what they clicked.
+      expect(destinationFor("team:unplaced")).toBeNull();
+    });
+  });
+
+  describe("nodes the console has no address for", () => {
+    it.each([
+      // A grant is a string in `company.toml`, not a record with a page.
+      ["tool:workspace.*", "a tool grant"],
+      ["tool:slack@desk:eng", "a tool split per desk"],
+      // A stage is a node inside a saved graph; the flow has an address, the
+      // node within it does not.
+      ["step:nightly-digest:2", "a workflow stage"],
+      // The company core is the page you are already on.
+      ["self", "the company itself"],
+    ])("answers null for %s (%s)", (nodeId) => {
+      expect(destinationFor(nodeId)).toBeNull();
+    });
+  });
+
+  describe("ids the host supplied", () => {
+    it("encodes a segment that would otherwise change the address", () => {
+      // A desk named with a slash, or an id carrying a `#`, would write a
+      // different address than the one it names.
+      expect(destinationFor("team:desk:sales/ops")?.hash).toBe("#/company/sales%2Fops");
+      expect(destinationFor("task:a#b")?.hash).toBe("#/tasks/a%23b");
+    });
+
+    it("answers null rather than a truncated address for an empty id", () => {
+      expect(destinationFor("emp:")).toBeNull();
+      expect(destinationFor("task:")).toBeNull();
+      expect(destinationFor("flow:")).toBeNull();
+      expect(destinationFor("team:desk:")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1308. Closes #1315.

## The problem

`#/overview` is the console's landing page — `useHashView(VIEWS, "overview", …)` resolves an empty hash, an unknown hash, a typo and a fresh sign-in to it. It draws every teammate, every open board card, every workflow, every stage, every tool and every desk the company declares: about a hundred nodes on the seeded company.

```
$ grep -rn "href\|onNavigate\|window.location\|navigate" frontend/src/views/overview/kg/*.tsx
(nothing)
```

Not one of them linked anywhere. Click a teammate and you learn their tools, their harness tier and that they have never run — and then you leave through the sidebar and find them again by hand.

Every other view in this console is a place you *do* something. Overview was a place you look at something and then use the sidebar anyway. That, more than the force layout or the density, is what made it read as decoration.

## The fix

One link at the foot of every card, in the same place on each, going to the page that already names the same record.

| card | destination |
|---|---|
| AI teammate | `#/team/<agentId>` — "Open teammate" |
| SOP task | `#/tasks/<taskId>` — "Open card" |
| human | `#/settings/people` — "Open people" |
| note | `#/memory` — "Open Brain" |

`kg/open-in-console.ts` is the whole lookup and it is pure, so the table is asserted without a graph, a host or a browser.

**Two decisions worth reviewing.**

*The node id is the input.* A node id already carries the host's own id for the thing it draws — `emp:<agentId>`, `task:<taskId>`, `team:desk:<deskId>`. Reading the destination off that means a card cannot link to a different record than the node it was opened from, which a second id threaded through the component tree could quietly start doing. It also makes `#/company/<deskId>` correct: the graph holds the adapter's prefixed `desk:eng`, and building the address from it unprefixed would send an operator to `#/company/desk:eng`, which names no desk.

*A real `<a href>`, not a click handler.* It is a link, so cmd-click, middle-click and copy-link have to work, and the console's hash router picks the address up from `hashchange` exactly as it does for every other link in the app. No router plumbing into a component this deep.

**What deliberately gets no link**, because the honest answer is that the console has no address for it:

- **a tool** — a grant is a string in `company.toml` (`mcp:*`, `workspace.*`), not a record with a page. Pointing at the MCP tab would name a server the grant may have nothing to do with, which is exactly the `grant_matches` guesswork `views/overview/README.md` forbids.
- **a workflow stage** — a node inside a saved graph. The flow has an address; the node within it does not.
- **the company core** — the page you are already on.
- **a department the adapter did not build from a desk** (`UNPLACED`) — there is no desk behind it, so `destinationFor` answers `null` rather than guessing at `#/company`.

`flow:` is in the table and tested, but no workflow *card* exists yet — clicking a workflow node only focuses it — so nothing renders it today. It is there so the card, when it exists, cannot ship without the link.

## Also: the dead `/agents` route (#1315)

The teammate card's only instruction was:

```
LAST RUN
never run — trigger it from /agents
```

There has never been an `agents` view. It is not in the `View` union, not in `NAV`, not in `HIDDEN_VIEWS` — `useHashView` sends `#/agents` straight back to `#/overview`, the page the operator is already on. It now reads `never run`, and the footer carries the way to the teammate's real page.

## Design note

The footer mirrors `PanelHeader`'s Back row — same mono caption size, same `0.14em` tracking, same resting colour — so the card reads as a thing with a top and a bottom rather than a panel that grew a button. Top of the rail: `← BACK · ENGINEERING`. Bottom: `OPEN TEAMMATE ↗`.

## Tests

`frontend/test/unit/overview-open-in-console.test.ts` — 13 cases covering each kind, the desk-id unwrap (composed through `departmentIdOfDesk` rather than hardcoded, so it stays honest if the prefix changes), the four kinds that must answer `null`, host ids that need encoding (`sales/ops` → `sales%2Fops`), and empty ids answering `null` rather than a truncated address.

## Verified

`npm run typecheck`, `typecheck:unit`, `typecheck:e2e`, `npx vitest run` (168 files / 1609 tests), `scripts/ci/assert-design-tokens.sh`.

In a browser against the seeded `agentic-software-company` host, 1440x900, light **and** dark:

```
agent  -> { href: "#/team/frontend_engineer",              text: "Open teammate" }
task   -> { href: "#/tasks/01a020ad4475-000000000108",     text: "Open card" }
human  -> { href: "#/settings/people",                     text: "Open people" }
following the agent link  ->  #/team/frontend_engineer
```

No console errors.

## Not in this PR

Same audit, filed separately: the chrome buried under the detail rail (#1307, PR #1368), the anonymous pillar dots (#1309), labels under the design system's 10px floor (#1310), and the landing page's own architecture (#1321) — which is the larger question this PR does not try to answer. It is worth doing whether or not that one ever ships.

---
Raised as a draft.

Design audit of `#/overview`; findings are professional judgement — no Figma reference exists for this surface.
