### PR TITLE
fix: one add-teammate control per desk, with the create path inside it (#1424)

### DIFF
--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -42,7 +42,10 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -908,49 +911,93 @@ function DeskNode({
             />
           ))}
 
-          <div className="flex items-center gap-1 pt-1">
+          {/*
+            One control, two ways to staff a desk.
+
+            This was two adjacent controls: a full-width "Add teammate" button
+            that seated somebody already on the roster, and — flush against it,
+            with no label — a `UserPlus` icon that *created* a teammate here.
+            Three problems, all of them the same problem:
+
+            - the labelled one said "Add teammate" and meant "add an existing
+              one", while the page header's "New teammate" wore the identical
+              icon to the unlabelled one beside it. "Add teammate" named two
+              different actions on the same screen;
+            - an icon button with no visible label, touching a button that
+              already says the words, is not discoverable. Nobody looking for
+              "define a new teammate on this desk" finds a bare glyph;
+            - when every roster teammate was already seated, the labelled
+              control went disabled and read "Everyone is on this desk" — so
+              the only remaining way in was the affordance nobody can see.
+
+            Now the button always says "Add teammate", is never disabled, and
+            its menu carries both: whoever is left on the roster, then
+            "New teammate…". "Everyone on the roster is already here" is a
+            piece of information inside the menu rather than a dead trigger.
+          */}
+          <div className="pt-1">
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
                   <Button
                     variant="outline"
                     size="sm"
-                    className="min-w-0 flex-1"
-                    disabled={addable.length === 0 || locked}
+                    className="w-full"
+                    // Only an in-flight write holds this shut. A fully-staffed
+                    // desk does not: creating a teammate here is still a thing
+                    // an operator can do.
+                    disabled={locked}
                   />
                 }
               >
                 <Plus className="size-4" />
-                {addable.length === 0
-                  ? "Everyone is on this desk"
-                  : "Add teammate"}
+                Add teammate
               </DropdownMenuTrigger>
-              {addable.length > 0 && (
-                <DropdownMenuContent
-                  align="start"
-                  className="max-h-64 overflow-y-auto"
+              {/*
+                A fixed width, not the trigger's. The trigger is full-bleed
+                across a desk card — over a thousand pixels at 1440 — and the
+                menu inherited it, so ten short names sat down the left edge of
+                an enormous empty panel.
+              */}
+              <DropdownMenuContent align="start" className="w-64">
+                {addable.length > 0 ? (
+                  // Grouped, because `DropdownMenuLabel` is Base UI's
+                  // `Menu.GroupLabel` and it throws outside a `Menu.Group` —
+                  // a blank page, not a warning.
+                  // The *group* scrolls, not the whole menu. Put the cap on
+                  // the popup and "New teammate…" falls below the fold on any
+                  // company with a roster — which is the one item that had to
+                  // become findable for merging the two controls to be worth
+                  // anything.
+                  <DropdownMenuGroup className="max-h-64 overflow-y-auto">
+                    <DropdownMenuLabel>On the roster</DropdownMenuLabel>
+                    {addable.map((member) => (
+                      <DropdownMenuItem
+                        key={member.id}
+                        onClick={() => onAdd(member.id)}
+                      >
+                        <span className="truncate">{member.name}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
+                ) : (
+                  // Plain text, not a `GroupLabel`: there is no group here to
+                  // label, and this is a statement about the roster rather
+                  // than a heading over items.
+                  <p className="px-1.5 py-1 text-xs text-muted-foreground">
+                    Everyone on the roster is already here.
+                  </p>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={onCreateMember}
+                  aria-label={`Create teammate on ${desk.name}`}
                 >
-                  {addable.map((member) => (
-                    <DropdownMenuItem
-                      key={member.id}
-                      onClick={() => onAdd(member.id)}
-                    >
-                      <span className="truncate">{member.name}</span>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              )}
+                  <UserPlus className="size-4" />
+                  New teammate…
+                </DropdownMenuItem>
+              </DropdownMenuContent>
             </DropdownMenu>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-8 shrink-0"
-              aria-label={`Create teammate on ${desk.name}`}
-              disabled={locked}
-              onClick={onCreateMember}
-            >
-              <UserPlus className="size-4" />
-            </Button>
           </div>
         </div>
       </div>

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -516,8 +516,11 @@ test("#839 creates a teammate on a selected desk and persists it", async ({
   await openChart(page);
 
   const growth = deskNode(page, "Growth");
-  await growth
-    .getByRole("button", { name: "Create teammate on Growth" })
+  // One control per desk now, and "New teammate…" is an item inside its menu
+  // rather than an unlabelled icon button beside it.
+  await growth.getByRole("button", { name: "Add teammate" }).click();
+  await page
+    .getByRole("menuitem", { name: "Create teammate on Growth" })
     .click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Babbage");
@@ -665,6 +668,42 @@ test("#311 the lead can be changed from the chart and survives a reload", async 
   ).toContainText("Ada");
 });
 
+test("a desk offers one add control, and it stays usable when the roster is exhausted", async ({
+  page,
+}) => {
+  await mockApi(page);
+  await openChart(page);
+
+  const engineering = deskNode(page, "Engineering");
+
+  // One control per desk. It used to be two: this button, and — flush against
+  // it, unlabelled — a `UserPlus` icon that created a teammate here. The icon
+  // wore the same glyph as the page header's "New teammate", touching a button
+  // that already said the words, so the create path was invisible.
+  await expect(engineering.getByRole("button", { name: /teammate/i })).toHaveCount(1);
+
+  // Seat everyone the roster has left, through the menu.
+  for (const name of ["Linus", "Hedy", "Turing"]) {
+    await engineering.getByRole("button", { name: "Add teammate" }).click();
+    await page.getByRole("menuitem", { name }).click();
+    await expect(engineering).toContainText(name);
+  }
+
+  // Nobody is left to seat — and the control is still live, because creating a
+  // teammate here is still something an operator can do. It used to go
+  // disabled and read "Everyone is on this desk", which left the unlabelled
+  // icon as the only way in.
+  const add = engineering.getByRole("button", { name: "Add teammate" });
+  await expect(add).toBeEnabled();
+  await add.click();
+
+  const menu = page.getByRole("menu");
+  await expect(menu).toContainText("Everyone on the roster is already here.");
+  await expect(
+    menu.getByRole("menuitem", { name: "Create teammate on Engineering" }),
+  ).toBeVisible();
+});
+
 test("#839 a teammate created but not placed is still on the chart to place by hand", async ({
   page,
 }) => {
@@ -677,8 +716,11 @@ test("#839 a teammate created but not placed is still on the chart to place by h
   await openChart(page);
 
   const growth = deskNode(page, "Growth");
-  await growth
-    .getByRole("button", { name: "Create teammate on Growth" })
+  // One control per desk now, and "New teammate…" is an item inside its menu
+  // rather than an unlabelled icon button beside it.
+  await growth.getByRole("button", { name: "Add teammate" }).click();
+  await page
+    .getByRole("menuitem", { name: "Create teammate on Growth" })
     .click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Hopper");


### PR DESCRIPTION
Closes #1424.

## The failure

Every desk on `#/company/desks` ended with two controls, 4px apart:

- a full-width **"Add teammate"** dropdown that *seated an existing* roster teammate, and
- flush beside it, an **unlabelled** `UserPlus` icon button that *created a new* one.

So "Add teammate" meant "create" on `#/company` and "seat an existing one" here; the icon that actually creates wore the same glyph as the page header's labelled "New teammate"; and when every roster teammate was already seated the labelled control went **disabled** ("Everyone is on this desk"), leaving the invisible affordance as the only way in.

The menu was also the trigger's width — full-bleed across a desk card, so over a thousand pixels at 1440 for ten short names.

## The change

One control per desk. It always says "Add teammate", is disabled only by an in-flight write, and its menu carries both paths:

- `On the roster` — whoever is left to seat, in a group that scrolls
- a separator, then `New teammate…` (`aria-label="Create teammate on <desk>"`, kept so the intent is still nameable)

with `"Everyone on the roster is already here."` as a line **inside** the menu rather than a dead trigger.

Two details worth naming:

- `DropdownMenuLabel` is Base UI's `Menu.GroupLabel` and **throws outside a `Menu.Group`** — a blank page, not a warning. Hence the `DropdownMenuGroup`; the empty-roster line is a plain `<p>` because there is no group there to label.
- The `max-h`/`overflow-y-auto` sits on the **group**, not the popup. On the popup, `New teammate…` falls below the fold on any company with a roster — which is the one item that had to become findable for merging the controls to be worth anything.

Menu width fixed at `w-64`.

## Tests

- `org-tree.spec.ts` — new: "a desk offers one add control, and it stays usable when the roster is exhausted". Asserts exactly one add control per desk, seats every remaining roster teammate through the menu, then asserts the trigger is still **enabled** and the menu still offers `Create teammate on Engineering` alongside "Everyone on the roster is already here.".
- The two existing `#839` create-on-a-desk tests updated to reach the item through the menu.

## Commands run locally

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean
- `npx vitest run` — 1596 passed / 167 files
- `scripts/ci/assert-design-tokens.sh` — clean
- `PW_BASE_URL=… npx playwright test test/e2e/org-tree.spec.ts` against a served console — **25 passed**
- Browser-verified against a live seeded host: 1440px dark, 1440px light, 1100px light — menu at 256px, `New teammate…` pinned below the scrolling roster group.

## Behaviour change

The per-desk create action moves from a bare icon button to a menu item. `aria-label` is unchanged, so anything locating it by accessible name still finds it — as a `menuitem` rather than a `button`.