### PR TITLE
feat(overview): name the pillars instead of numbering them

### DIFF
--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -141,6 +141,11 @@ the two board predicates the adapter needs. Theme tokens live under `.oc-kg`
 in `src/index.css`.
 
 The graph is the whole page, so its chrome stays minimal: a pillar selector, a
-kind legend, the side paddles, and the detail card. The docked directory index
+kind legend, the side paddles, and the detail card. The selector names every
+desk rather than numbering them (issue #1309) — it used to draw one anonymous
+dot per desk under the words "Pick a pillar", so the control that exists to
+choose a desk said which was which only on hover, and said nothing at all to a
+touch device. The chips wrap rather than scroll or clip; each carries the
+colour its pillar's node and label already carry. The docked directory index
 and the entity/function/action lenses were removed — with nothing else on the
 page competing for attention, they covered more of the graph than they earned.

--- a/frontend/src/views/overview/kg/KnowledgeGraphFullscreen.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraphFullscreen.tsx
@@ -80,46 +80,59 @@ export function KnowledgeGraphFullscreen({
         {/* vault search — top-left while the Notes core is open */}
         {searchSlot && <div className="absolute left-5 top-5 z-10">{searchSlot}</div>}
 
-        {/* pillar selector — compact, TOP-LEFT: convenient, not in
-            the graph's way): current pillar + one dot per pillar to jump */}
+        {/* pillar selector — compact, TOP-LEFT: convenient, not in the
+            graph's way. One named chip per desk (issue #1309).
+
+            It used to be three 10px dots at 50% opacity under the words "Pick
+            a pillar", and the names existed only in each dot's `title` — so
+            the control that exists to choose a desk refused to say which desk
+            was which, while the graph named all three in their own colours a
+            few inches away. You had to click a blind dot to learn what it was.
+
+            The chips wrap rather than scroll or truncate the row: a company
+            with ten desks gets three short lines in the corner, which is a
+            legible answer, where a clipped row is not. The colour is the same
+            one the desk's node and label carry, so the chip and the pillar are
+            visibly the same thing. */}
         {!coreOpen && (
-          <div className="absolute left-5 top-5 z-20 flex items-center gap-2.5 rounded-sm-t border border-os-border-strong bg-os-bg/85 px-2.5 py-1.5 backdrop-blur">
-            <div className="flex flex-col">
-              <span
-                className="max-w-[150px] truncate text-xs font-bold leading-tight transition-colors duration-300"
-                style={currentDept ? { color: currentDept.color } : undefined}
-              >
-                {currentDept?.name ?? 'Pick a pillar'}
-              </span>
-              <span className="font-mono text-3xs uppercase tracking-[0.14em] text-os-dim">
-                {idx >= 0 ? `${idx + 1} / ${deptList.length}` : `${deptList.length} pillars`}
-              </span>
-            </div>
-            <div className="flex items-center gap-0.5 border-l border-os-border pl-2">
-              {deptList.map((d) => {
-                const active = d.teamId === currentTeamId;
-                return (
-                  <button
-                    key={d.teamId}
-                    onClick={() => onNavDept(d.teamId)}
-                    title={d.name}
-                    aria-label={d.name}
-                    aria-current={active ? 'true' : undefined}
-                    className="group grid h-6 w-5 place-items-center"
-                  >
-                    <span
-                      className={`rounded-full transition-all duration-200 group-hover:scale-125 ${
-                        active ? 'h-3 w-3' : 'h-2.5 w-2.5 opacity-50 group-hover:opacity-100'
+          <div className="absolute left-5 top-5 z-20 flex max-w-[min(34rem,45vw)] flex-col gap-1 rounded-sm-t border border-os-border-strong bg-os-bg/85 px-2.5 py-1.5 backdrop-blur">
+            <span className="font-mono text-3xs uppercase tracking-[0.14em] text-os-dim">
+              {/* Names the group rather than instructing. "Pick a pillar" was
+                  an imperative with no visible object, and at zero desks it
+                  asked for something the page made impossible. */}
+              {deptList.length > 0 ? 'Pillars' : 'No desks yet'}
+            </span>
+            {deptList.length > 0 && (
+              <div className="flex flex-wrap items-center gap-x-1 gap-y-0.5">
+                {deptList.map((d) => {
+                  const active = d.teamId === currentTeamId;
+                  return (
+                    <button
+                      key={d.teamId}
+                      onClick={() => onNavDept(d.teamId)}
+                      title={`${d.name} — bring this pillar forward`}
+                      aria-current={active ? 'true' : undefined}
+                      className={`flex items-center gap-1.5 rounded-sm-t px-1.5 py-0.5 text-2xs leading-tight transition-colors duration-200 ease-standard hover:bg-os-surface hover:text-os-text ${
+                        active ? 'font-bold' : 'text-os-muted'
                       }`}
-                      style={{
-                        background: active ? d.color : 'var(--text-3)',
-                        boxShadow: active ? `0 0 8px ${d.color}` : undefined,
-                      }}
-                    />
-                  </button>
-                );
-              })}
-            </div>
+                      style={active ? { color: d.color } : undefined}
+                    >
+                      <span
+                        aria-hidden
+                        className={`h-2 w-2 shrink-0 rounded-full transition-all duration-200 ${
+                          active ? '' : 'opacity-60'
+                        }`}
+                        style={{
+                          background: d.color,
+                          boxShadow: active ? `0 0 8px ${d.color}` : undefined,
+                        }}
+                      />
+                      <span className="max-w-[12rem] truncate">{d.name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/test/unit/overview-pillar-selector.test.ts
+++ b/frontend/test/unit/overview-pillar-selector.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DeptLite } from "@/views/overview/kg/KnowledgeDetail";
+import { KnowledgeGraphFullscreen } from "@/views/overview/kg/KnowledgeGraphFullscreen";
+
+/**
+ * Issue #1309: the pillar selector would not say which pillar was which.
+ *
+ * It drew one 10px dot per desk at 50% opacity under the words "Pick a
+ * pillar", and each desk's name existed only in that dot's `title` — a hover
+ * away on a pointer and unreachable on touch. So the control whose whole
+ * purpose is choosing a desk named none of them at rest, while the graph
+ * labelled all of them in their own colours a few inches away. You had to
+ * click a blind dot to learn what it was.
+ *
+ * The caption is also under test, because "Pick a pillar / 0 PILLARS" was an
+ * imperative the page made impossible to follow on a company that has not
+ * seated a desk yet.
+ */
+
+let host: HTMLElement;
+let root: Root;
+
+const DESKS: DeptLite[] = [
+  { deptId: "desk:eng", teamId: "team:desk:eng", name: "Engineering", tagline: "", color: "var(--chart-1)" },
+  { deptId: "desk:pd", teamId: "team:desk:pd", name: "Product & Design", tagline: "", color: "var(--chart-2)" },
+  { deptId: "desk:gtm", teamId: "team:desk:gtm", name: "Go-to-Market", tagline: "", color: "var(--chart-3)" },
+];
+
+function render(deptList: DeptLite[], currentTeamId: string | null, onNavDept: (id: string) => void = () => {}) {
+  const currentDept = deptList.find((d) => d.teamId === currentTeamId) ?? null;
+  act(() => {
+    root.render(
+      createElement(KnowledgeGraphFullscreen, {
+        deptList,
+        currentTeamId,
+        currentDept,
+        toolWiki: null,
+        onNavDept,
+        onBack: () => {},
+        // `children` is a required prop here, not a JSX convenience — passing
+        // it positionally to `createElement` satisfies React and not the type.
+        children: createElement("svg"),
+      }),
+    );
+  });
+}
+
+/** The pillar chips, in the order they are drawn. */
+function chips(): HTMLButtonElement[] {
+  return [...host.querySelectorAll("button")].filter((b) =>
+    (b.getAttribute("title") ?? "").includes("bring this pillar forward"),
+  ) as HTMLButtonElement[];
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+describe("the pillar selector", () => {
+  it("names every desk, at rest, with nothing focused", () => {
+    render(DESKS, null);
+    expect(chips().map((b) => b.textContent)).toEqual([
+      "Engineering",
+      "Product & Design",
+      "Go-to-Market",
+    ]);
+  });
+
+  it("names them in the host's own desk order", () => {
+    // The order is the company's, never re-sorted here — the same rule ring 1
+    // follows. A selector that alphabetised would disagree with the wheel.
+    render([...DESKS].reverse(), null);
+    expect(chips().map((b) => b.textContent)).toEqual([
+      "Go-to-Market",
+      "Product & Design",
+      "Engineering",
+    ]);
+  });
+
+  it("marks the focused desk, and only that one", () => {
+    render(DESKS, "team:desk:pd");
+    expect(chips().map((b) => b.getAttribute("aria-current"))).toEqual([null, "true", null]);
+  });
+
+  it("marks nothing when the wheel is at rest", () => {
+    render(DESKS, null);
+    expect(chips().every((b) => b.getAttribute("aria-current") === null)).toBe(true);
+  });
+
+  it("brings a desk forward when its chip is clicked", () => {
+    const seen: string[] = [];
+    render(DESKS, null, (id) => seen.push(id));
+    act(() => {
+      chips()[2].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(seen).toEqual(["team:desk:gtm"]);
+  });
+
+  it("says a company has no desks rather than instructing it to pick one", () => {
+    // "Pick a pillar / 0 PILLARS" asked for something impossible, next to
+    // nothing to pick — which is the first screen a newly provisioned company
+    // sees.
+    render([], null);
+    expect(chips()).toHaveLength(0);
+    expect(host.textContent).toContain("No desks yet");
+    expect(host.textContent).not.toContain("Pick a pillar");
+  });
+});


### PR DESCRIPTION
Closes #1309.

## The problem

At rest the pillar control read:

```
Pick a pillar
3 PILLARS          ● ● ●
```

Three 10px dots at 50% opacity. The company's three desks — *Engineering*, *Product & Design*, *Go-to-Market* — are named right there on the graph, in their own colours, a few inches away. The control that exists to choose one of them refused to say which was which.

Each name lived only in its dot's `title` / `aria-label`: a second of hover on a 24x20 target with a pointer, and unreachable on touch. Once you picked one it finally said the name — so you had to click a blind dot to learn what it was.

Three smaller failures rode along:

- `Pick a pillar` is an imperative with no visible object.
- `3 PILLARS` is redundant next to three visible dots, and becomes actively wrong at `0 PILLARS` — an instruction the page makes impossible to follow, on the first screen a newly provisioned company sees.
- The text block was inert: not a button, not a menu, no cursor change. The only hit targets were the dots.

## The fix

One named chip per desk, in the host's own desk order — never re-sorted, the same rule ring 1 follows, so the selector cannot disagree with the wheel.

Each chip carries the colour its pillar's node and label already carry, so the chip and the pillar are visibly the same object. The active one takes that colour and goes bold; the rest sit in `--os-muted`. `aria-current` marks the focused desk.

The caption names the group (`PILLARS`) instead of instructing, and answers `No desks yet` when the company has seated none — which also gives the empty state one honest sentence where it had an impossible instruction.

**They wrap, rather than scroll or truncate the row.** Ten desks become three short lines in the top-left corner, which is a legible answer; a clipped row is not. Each name still truncates at `12rem` on its own so one very long desk name cannot push the others off.

The `←` / `→` paddles and `Escape` are untouched.

## What this gives up

The `1 / 3` position readout. Names replace it: knowing you are on *Go-to-Market* and that the others are *Engineering* and *Product & Design* is strictly more than knowing you are on the second of three.

## Tests

`frontend/test/unit/overview-pillar-selector.test.ts` — 6 cases: every desk named at rest with nothing focused; the host's order preserved (a selector that alphabetised would disagree with the wheel); `aria-current` on the focused desk and only that one; nothing marked at rest; a click bringing that desk forward; and the empty company saying `No desks yet` rather than `Pick a pillar`.

## Verified

`npm run typecheck`, `typecheck:unit`, `typecheck:e2e`, `npx vitest run` (168 files / 1602 tests), `scripts/ci/assert-design-tokens.sh`.

In a browser against the seeded `agentic-software-company` host:

```
light 1440  [Engineering, Product & Design, Go-to-Market]  none current
dark  1100  [Engineering, Product & Design, Go-to-Market]  Go-to-Market current
```

No console errors. Colours confirmed matching the pillar nodes in both themes.

## Not in this PR

Same audit, filed separately: the chrome buried under the detail rail (#1307, PR #1368), the graph having no way out (#1308, PR #1398), labels under the design system's 10px floor (#1310), the empty state generally (#1313), and `pillar` / `department` / `desk` being three words for one concept (#1320) — this PR keeps saying "pillar" rather than pre-empting that decision.

---
Raised as a draft.

Design audit of `#/overview`; findings are professional judgement — no Figma reference exists for this surface.
