### PR TITLE
console: make a view routable by existing, not by having a nav row (#1311)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -53,6 +53,7 @@ import { useLedgerNav } from "@/hooks/use-ledger-nav";
 import type { WorkspaceEvent } from "@/views/WorkspaceView";
 import { useHashView } from "@/hooks/use-hash-view";
 import { BOARD_LEDGER } from "@/lib/board-columns";
+import { VIEWS, type View } from "@/lib/console-routes";
 import { taskIdFromSegment } from "@/lib/task-route";
 import { toast } from "sonner";
 
@@ -112,23 +113,11 @@ const FinancesView = lazy(() =>
 // as the other heavier, less-visited surfaces.
 const PagesView = lazy(() => import("@/views/PagesView").then((m) => ({ default: m.PagesView })));
 
-export type View =
-  | "overview"
-  | "company"
-  | "chat"
-  | "conversation"
-  | "inbox"
-  | "tasks"
-  | "ledgers"
-  | "team"
-  | "workspace"
-  | "memory"
-  | "approvals"
-  | "workflows"
-  | "pages"
-  | "finances"
-  | "settings"
-  | "feedback";
+// The route table lives in `@/lib/console-routes` — a plain module the unit
+// lane can import, and the single place a surface is declared routable (issue
+// #1311). Re-exported because the console has always imported `View` from the
+// shell that renders those views.
+export type { View };
 
 interface NavItem {
   view: View;
@@ -173,58 +162,22 @@ const NAV: NavItem[] = [
   // Agent-authored internal dashboard pages, rendered in a sandboxed iframe
   // (docs/spec/runtime/pages.md). Placed beside Workflows: both are the
   // "something an agent built" surfaces, as opposed to the fixed views above.
-  // Pages is deliberately not offered in the nav. The view and its `#/pages`
-  // route stay live, so an address or an existing link still resolves — this
-  // is the same treatment `feedback`, `inbox`, `finances`, `conversation`
-  // and `team` already get. Do not "fix" the omission by
-  // adding it back.
+  // Pages is deliberately not offered in the nav (issues #1171, #1172). Do not
+  // "fix" the omission by adding it back. What keeps `#/pages` answering is its
+  // entry in `@/lib/console-routes`, NOT this commented row — a commented row
+  // routes nothing, which is exactly how the address died for four months
+  // (issue #1311). Remove a nav row here and the surface is hidden; remove it
+  // from `console-routes.ts` and the surface is gone.
   // { view: "pages", label: "Pages", icon: AppWindow },
   { view: "settings", label: "Settings", icon: Settings2 },
 ];
 
-/**
- * Routable without a nav entry — reachable by URL, absent from the sidebar.
- *
- * Feedback is linked from the sidebar footer instead. The rest are parked
- * rather than retired (issue #302 for Inbox and Finances — Brain was parked
- * there too and is re-listed above with the memory-engine work; the chat
- * rebuild for Conversation and Team): their host routes, stores and e2e specs
- * are untouched, and re-listing one in `NAV` above is all it takes to bring it
- * back. Conversation and Team are the surfaces the Chat workspace replaces —
- * everything they can do it can do in one screen, including the teammate
- * budget controls `MembersPane` ported from Team (issue #360) — but
- * Conversation keeps answering `#/conversation` until the chat covers the
- * last of what it still does better (a desk's persisted transcript).
- *
- * `team` is here for a narrower reason than it used to be (issue #1141). Bare
- * `#/team` no longer resolves to it at all — `REWRITE_RETIRED` sends that to
- * `#/company`, whose Cards half is the grid it used to draw. What this line
- * keeps alive is `#/team/<agentId>`: the teammate detail page, deliberately a
- * page rather than a modal so it can be linked, and linked to today from the
- * org chart's seats, its "Not on a desk" chips and the chat member pane. Drop
- * `team` from this list and `useHashView` discards the head *and* its sub-page,
- * so every one of those lands on Overview instead of the teammate they named.
- *
- * `tasks` is here for a different reason than the rest, and it is the load-
- * bearing line of issue #1140. The board page is gone, but `#/tasks/<id>` is
- * the card detail — the timeline, the plan brief, the discussion, the attempts,
- * the steer controls — and it is linked from chat, from an approval card, from
- * a workflow run's rows and from every card on the board. Ledgers deliberately
- * does not reproduce any of it. Drop `tasks` from this list and `useHashView`
- * discards the head *and* its sub-page, so every one of those links quietly
- * lands on Overview instead of the card it named.
- *
- */
-const HIDDEN_VIEWS: View[] = [
-  "feedback",
-  "inbox",
-  "finances",
-  "conversation",
-  "team",
-  "tasks",
-];
-
-const VIEWS: View[] = [...NAV.map((i) => i.view), ...HIDDEN_VIEWS];
+// Which views are routable is decided in `@/lib/console-routes`, not here.
+// `NAV` above is presentation: a row means a surface is offered in the sidebar,
+// and its absence means only that the surface is not offered. `VIEWS` is every
+// surface this shell renders, complete by construction, so a view can never be
+// rendered by the block below and unreachable by address at the same time —
+// which is what happened to Pages between #1172 and #1311.
 
 /**
  * Views whose **nav row always means the parent page**, never the sub-page the

--- a/frontend/src/lib/console-routes.ts
+++ b/frontend/src/lib/console-routes.ts
@@ -1,0 +1,134 @@
+/**
+ * The console's route table: every surface `AppShell` can render, and the
+ * allow-list `useHashView` validates a hash against.
+ *
+ * # The rule
+ *
+ * **`NAV` is presentation. `VIEWS` is routing.** A view routes because it is a
+ * member of `View` below and therefore has a `ROUTABLE` entry — never because
+ * it happens to have a sidebar row. Taking a row out of `NAV` (issue #302 for
+ * Inbox and Finances, #1140 for the Tasks board, #1141 for Team, #1172 for
+ * Pages) hides a surface; it does not retire its address. Retiring an address
+ * is a separate, deliberate act: drop the view from the union here, delete its
+ * render block in `app-shell.tsx`, and send the old address somewhere real with
+ * the shell's `REWRITE_RETIRED`.
+ *
+ * # Why this file exists
+ *
+ * Routing used to be `[...NAV.map((i) => i.view), ...HIDDEN_VIEWS]` — the nav
+ * list plus a hand-maintained second list of views deliberately absent from it.
+ * That made "hidden" and "routable" two halves of one treatment that had to be
+ * applied together, and issue #1311 is what happens when only one half lands:
+ * #1172 commented Pages out of `NAV`, wrote a comment promising `#/pages`
+ * "stays live", and never added `pages` to the second list. The address
+ * collapsed onto Overview for four months while the shell's `view === "pages"`
+ * block, the `lazy()` import above it and the whole sandboxed-iframe surface
+ * behind it (`docs/spec/runtime/pages.md`) sat unreachable.
+ *
+ * `ROUTABLE` is a `Record<View, true>`, so it is complete *by construction*:
+ * a view in the union with no entry is a compile error, and `npm run typecheck`
+ * is the first step of every console CI lane. There is no longer a second list
+ * to forget — a surface the shell can render is a surface an address can reach.
+ *
+ * Keeping the table in a plain `.ts` module is also what makes it testable:
+ * the unit lane (`frontend/vitest.config.ts`) collects the `.test.ts` files
+ * under `test/unit` with no React plugin, so `test/unit/task-route.test.ts`
+ * — which needs the shell's route table — had to *duplicate*
+ * the shell's route table verbatim to reach it — which is precisely why nothing
+ * noticed #1311. `test/unit/console-routes.test.ts` imports the real thing.
+ */
+
+export type View =
+  | "overview"
+  | "company"
+  | "chat"
+  | "conversation"
+  | "inbox"
+  | "tasks"
+  | "ledgers"
+  | "team"
+  | "workspace"
+  | "memory"
+  | "approvals"
+  | "workflows"
+  | "pages"
+  | "finances"
+  | "settings"
+  | "feedback";
+
+/**
+ * Every routable view, one entry per member of `View` — the compiler enforces
+ * that, which is the point (see the header).
+ *
+ * The entries with no `NAV` row in `app-shell.tsx` are annotated with why they
+ * have none. They are parked rather than retired: their host routes, stores and
+ * e2e specs are untouched, and re-listing one in `NAV` is all it takes to bring
+ * it back. Issue #1337 is the open question of what a parked surface should
+ * *say* to an operator who arrives on one; this file only decides that they
+ * still answer.
+ */
+const ROUTABLE: Record<View, true> = {
+  overview: true,
+  company: true,
+  chat: true,
+  /**
+   * No nav row: the surface the Chat workspace replaces. Everything it can do
+   * chat can do in one screen — including the teammate budget controls
+   * `MembersPane` ported from Team (issue #360) — but it keeps answering
+   * `#/conversation` until chat covers the last of what it still does better (a
+   * desk's persisted transcript).
+   */
+  conversation: true,
+  /** No nav row: parked by issue #302, host routes and per-agent store intact. */
+  inbox: true,
+  /**
+   * No nav row, and the load-bearing entry of issue #1140. The board page is
+   * gone — bare `#/tasks` is rewritten onto the board's ledger by the shell's
+   * `REWRITE_RETIRED` — but `#/tasks/<id>` is the card detail (the timeline,
+   * the plan brief, the discussion, the attempts, the steer controls), linked
+   * from chat, from an approval card, from a workflow run's rows and from every
+   * card on the board. Ledgers deliberately reproduces none of it. Drop this
+   * entry and `useHashView` discards the head *and* its sub-page, so every one
+   * of those links quietly lands on Overview instead of the card it named.
+   */
+  tasks: true,
+  ledgers: true,
+  /**
+   * No nav row, for a narrower reason than it used to have (issue #1141). Bare
+   * `#/team` is rewritten to `#/company`, whose Cards half is the grid Team
+   * used to draw. What this entry keeps alive is `#/team/<agentId>`: the
+   * teammate detail page, deliberately a page rather than a modal so it can be
+   * linked, and linked to today from the org chart's seats, its "Not on a desk"
+   * chips and the chat member pane.
+   */
+  team: true,
+  workspace: true,
+  memory: true,
+  approvals: true,
+  workflows: true,
+  /**
+   * No nav row (issues #1171, #1172) — and this entry is the half of that
+   * removal which went missing until issue #1311. Pages is the agent-authored
+   * dashboard surface: a sandboxed iframe, a per-document capability and the
+   * `oc:graphql` bridge (`docs/spec/runtime/pages.md`), hardened as recently as
+   * #1122 and #1221. Without an entry here `#/pages` is an unknown hash, so the
+   * shell's `view === "pages"` block is dead code and `nav_visible = false` in a
+   * `page.toml` — documented as keeping a page "reachable only by direct URL" —
+   * has no URL to be reachable by.
+   */
+  pages: true,
+  /** No nav row: parked by issue #302, alongside Inbox. */
+  finances: true,
+  settings: true,
+  /** No nav row: linked from the sidebar footer instead. */
+  feedback: true,
+};
+
+/**
+ * The allow-list `useHashView` validates a hash's first segment against.
+ *
+ * Derived from `ROUTABLE`, so it can never be a subset of the views the shell
+ * renders. Order is irrelevant — the hook only ever asks whether a head is a
+ * member.
+ */
+export const VIEWS: View[] = Object.keys(ROUTABLE) as View[];

--- a/frontend/test/unit/console-routes.test.ts
+++ b/frontend/test/unit/console-routes.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useHashView } from "@/hooks/use-hash-view";
+import { VIEWS, type View } from "@/lib/console-routes";
+
+/**
+ * Every surface the console renders has to answer at its own address.
+ *
+ * Issue #1311: `#/pages` resolved to Overview for four months. #1172 commented
+ * the Pages row out of `NAV` and wrote a comment promising the route "stays
+ * live", but routing was `NAV` plus a second hand-maintained list, and only the
+ * first half of the treatment landed. The shell's `view === "pages"` block, its
+ * `lazy()` import and the entire sandboxed-iframe Pages surface behind them
+ * were unreachable code the whole time, and nothing said so.
+ *
+ * These tests import the REAL table from `@/lib/console-routes` rather than
+ * transcribing it (which is what `task-route.test.ts` has to do for the shell's
+ * `REWRITE_RETIRED`, and why a copy of the route table could rot unobserved).
+ */
+
+describe("the console's route table", () => {
+  /**
+   * The regression itself. Named on its own rather than left to the table below
+   * so a failure reads as "Pages is unreachable again" rather than as one row
+   * of a loop.
+   */
+  it("keeps #/pages routable even though Pages has no nav row (#1311)", () => {
+    expect(VIEWS).toContain("pages");
+  });
+
+  it("has no duplicate entries", () => {
+    expect(new Set(VIEWS).size).toBe(VIEWS.length);
+  });
+});
+
+describe("resolving an address", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let seen: [View, string | null];
+
+  // No `rewrite` argument: this asks what the allow-list alone resolves, which
+  // is the property #1311 broke. The shell's `REWRITE_RETIRED` — which sends
+  // bare `#/tasks` and `#/team` elsewhere before the allow-list is consulted —
+  // is `task-route.test.ts`'s subject, not this file's.
+  function Probe() {
+    const [view, sub] = useHashView<View>(VIEWS, "overview");
+    seen = [view, sub];
+    return null;
+  }
+
+  /**
+   * One render per test: `useHashView` canonicalizes from a mount effect, so a
+   * second `render()` into the same root updates rather than remounts and would
+   * report the first address's answer.
+   */
+  async function visit(hash: string) {
+    window.history.replaceState(null, "", hash);
+    await act(async () => {
+      root.render(createElement(Probe));
+    });
+  }
+
+  beforeEach(() => {
+    (
+      globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  // Every routable view, including the ones with no nav row. A view dropped
+  // from the table lands on Overview silently — a link that quietly shows
+  // Overview looks like a link that worked — so each one is asserted, not just
+  // the one #1311 was filed about.
+  it.each(VIEWS)("resolves #/%s to itself and leaves the address alone", async (view) => {
+    await visit(`#/${view}`);
+    expect(seen).toEqual([view, null]);
+    expect(window.location.hash).toBe(`#/${view}`);
+  });
+
+  it("carries a sub-page through for a hidden view's deep link", async () => {
+    // `#/team/<agentId>` and `#/pages` are hidden for the same reason and would
+    // fail the same way: an unknown head discards its sub-page too.
+    await visit("#/team/agent-1");
+    expect(seen).toEqual(["team", "agent-1"]);
+    expect(window.location.hash).toBe("#/team/agent-1");
+  });
+
+  it("still collapses an address that names nothing onto Overview", async () => {
+    // The fallback is what makes a typo or a genuinely retired address safe;
+    // widening the allow-list must not have widened it into accepting anything.
+    await visit("#/nope");
+    expect(seen).toEqual(["overview", null]);
+    expect(window.location.hash).toBe("#/overview");
+  });
+});


### PR DESCRIPTION
Closes #1311.

`#/pages` did not resolve. Verified against the current tree before touching anything: `pages` is in the `View` union and has a live `{view === "pages" && …}` render block in `app-shell.tsx`, but it is in neither `NAV` (#1172 commented the row out) nor `HIDDEN_VIEWS` — and `VIEWS`, the allow-list `useHashView` validates against, was `[...NAV.map((i) => i.view), ...HIDDEN_VIEWS]`. So the head was unknown, `useHashView` collapsed it to `overview` and canonicalised the URL, and the entire sandboxed-iframe / `oc:graphql` Pages surface was unreachable by any address.

## The decision: restore, not remove

Two coherent outcomes were on the table — restore reachability, or delete the dead branch and the misleading comment. **Restored**, deliberately:

- #1171 and #1172 are explicit that this was a *nav* removal: "Commented, not deleted — `PagesView` and the `#/pages` route stay intact, so an address or an existing link still resolves." Nobody decided to retire the feature; half a change went missing.
- Pages is not parked code. It has a spec (`docs/spec/runtime/pages.md`), four harness tools (`src/harness/pages_tools.rs`), three always-compiled HTTP routes (`src/server/ops/pages.rs`), a `page_builder` agent in `globals/`, a `build:pages-sdk` target in `frontend/package.json` — and two hardening PRs, #1122 (per-document bridge capability) and #1221 (landmark/heading fixes), **landed after** #1172 removed the nav row. Deleting it would retire a feature that is still being worked on, on the strength of a comment nobody meant that way.

## The fix is structural, not a one-line list edit

Adding `"pages"` to `HIDDEN_VIEWS` fixes this instance and leaves the trap armed: routing was the nav list plus a second, hand-maintained list, so "hide a surface" was a two-part treatment that a reviewer could see half of and believe.

The route table now lives in `frontend/src/lib/console-routes.ts`, where `ROUTABLE` is a `Record<View, true>` — **complete by construction**. A view in the union with no entry is a compile error, and `npm run typecheck` is the first step of every console CI lane:

```
src/lib/console-routes.ts(70,7): error TS2741: Property 'pages' is missing in type
'{ overview: true; … }' but required in type 'Record<View, true>'.
```

(that is a real run, with the `pages` entry commented out). There is no second list to forget any more: a surface the shell can render is a surface an address can reach. `NAV` keeps its job — presentation — and its Pages comment now says what actually keeps the route alive instead of the opposite.

Every word of the old `HIDDEN_VIEWS` prose (why `feedback`, `inbox`, `finances`, `conversation`, `team`, `tasks` have no nav row; #302, #360, #1140, #1141) is carried over onto the corresponding entries. `REWRITE_RETIRED` and `NAV_ALWAYS_PARENT` are untouched.

## Regression coverage

`frontend/test/unit/console-routes.test.ts` (20 tests) imports the **real** table rather than transcribing it — the transcription in `task-route.test.ts` is exactly why this rotted unseen:

- `#/pages` is routable, named as its own test so a failure reads as "Pages is unreachable again";
- every member of `VIEWS`, table-driven: `#/<view>` resolves to itself and the address is not rewritten;
- `#/team/agent-1` still carries its sub-page (an unknown head discards the sub-page too — the failure mode #1140/#1141 warn about);
- `#/nope` still collapses onto Overview and is canonicalised, so widening the allow-list did not widen it into accepting anything.

## Relationship to #1338 and #1337

- **#1338** (retired `#/connections`, `#/mcp`, `#/people` collapsing onto Overview) is a different root cause — addresses whose view no longer exists, needing `REWRITE_RETIRED` rules — and a disjoint route set. This PR does **not** subsume it and deliberately does not touch `REWRITE_RETIRED`, to stay out of its way. What it does contribute is the general guard #1338 asks for at the end: the type-level completeness check makes "a surface the shell renders that no address reaches" impossible to reintroduce.
- **#1337** (parked surfaces have no honest "this is parked" state, and six changes produced four treatments) is the design question of what a parked page should *say*. This PR does not answer it and does not preempt it: it decides only that Pages still *answers*, which is what #1172 intended. `console-routes.ts` says so in as many words and points at #1337 for the rest. If #1337 lands on "parked-and-gone" for some surface, the honest removal is now a single, visible edit in one file.

## Verification

VERIFICATION_PLACEHOLDER
