### PR TITLE
fix(workspace): say where the open note lives, and reveal it in the tree

### DIFF
--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -94,6 +94,50 @@ export function pathOf(nodes: FsNode[], id: string | null): FsNode[] {
   return path;
 }
 
+/**
+ * One step of a note's location, for the header breadcrumb (issue #1371).
+ *
+ * `null` is the elided middle — a crumb the trail could not fit, rendered as an
+ * ellipsis rather than dropped, so the operator can see that the path is longer
+ * than what is shown instead of reading a shortened path as the whole truth.
+ */
+export type Crumb = FsNode | null;
+
+/**
+ * The folders a note sits inside, shortened to at most `max` of them.
+ *
+ * The note itself is **not** in the trail: its name is already the heading beside
+ * it, and repeating it would spend the widest crumb saying what the operator is
+ * looking straight at.
+ *
+ * When the trail is too long, the **root and the last two folders** survive and
+ * the middle collapses. That split is the useful one: the root says which part
+ * of the company this belongs to, and the last two say what it sits next to.
+ * Truncating the string instead — which is what `truncate` on a single span did
+ * — ellipsises the *tail*, so every note under `Standards/Engineering/…` renders
+ * the identical prefix and the discriminating end is exactly what is thrown away.
+ */
+export function breadcrumbOf(nodes: FsNode[], id: string | null, max = 3): Crumb[] {
+  const folders = pathOf(nodes, id).slice(0, -1);
+  if (folders.length <= max) return folders;
+  // `max - 2` leading crumbs, the ellipsis, then the final two.
+  return [...folders.slice(0, Math.max(max - 2, 1)), null, ...folders.slice(-2)];
+}
+
+/**
+ * The ids of every folder a node is nested in — what has to be expanded for the
+ * node's own row to exist in the tree (issue #1371).
+ *
+ * Excludes the node itself even when it is a folder: revealing a folder means
+ * showing its row, not opening it.
+ */
+export function ancestorFolderIds(nodes: FsNode[], id: string | null): string[] {
+  return pathOf(nodes, id)
+    .slice(0, -1)
+    .filter((node) => node.kind === "folder")
+    .map((node) => node.id);
+}
+
 /** Ids of a node and all its descendants (for delete / move guards). */
 export function subtreeIds(nodes: FsNode[], id: string): Set<string> {
   const ids = new Set<string>([id]);

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -88,7 +88,9 @@ import { rosterDisplayName, rosterNameMap, type RosterNames } from "@/lib/roster
 import { fromDto } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import {
+  ancestorFolderIds,
   applyRepair,
+  breadcrumbOf,
   childrenOf,
   clearLegacyLocal,
   ensureMdExt,
@@ -97,7 +99,6 @@ import {
   hasLegacyLocal,
   isDerivedNode,
   nodeById,
-  pathOf,
   readLegacyLocalNodes,
   subtreeCounts,
   subtreeIds,
@@ -396,6 +397,16 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   const [searchError, setSearchError] = useState<string | null>(null);
 
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  /**
+   * The node the explorer should bring into view next (issue #1371).
+   *
+   * Separate from `openId` because revealing is a one-shot *event*, not a piece
+   * of state: scrolling on every render that happens to have a note open would
+   * yank the tree back under an operator who had deliberately scrolled away
+   * from it to look at something else.
+   */
+  const [revealId, setRevealId] = useState<string | null>(null);
+  const onRevealed = useCallback(() => setRevealId(null), []);
   const [prompt, setPrompt] = useState<PromptState | null>(null);
   const [moving, setMoving] = useState<FsNode | null>(null);
   const [showExplorer, setShowExplorer] = useState(true);
@@ -832,6 +843,25 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialNodeId]);
 
+  /* ---- reveal the open note in the tree (#1371) ---- */
+
+  // Expanding runs off `nodes` as well as `openId`, and that is the whole
+  // point: on the deep-link route the note is opened before the tree has
+  // loaded, so the first pass has no ancestors to find and the second — once
+  // the nodes arrive — is the one that does the work. Expanding is idempotent,
+  // so re-running it costs nothing.
+  useEffect(() => {
+    if (!openId) return;
+    const ancestors = ancestorFolderIds(nodes, openId);
+    if (ancestors.length > 0) {
+      setExpanded((prev) => {
+        if (ancestors.every((id) => prev.has(id))) return prev;
+        return new Set([...prev, ...ancestors]);
+      });
+    }
+    setRevealId(openId);
+  }, [openId, nodes]);
+
   /* ---- migration off the retired localStorage scratchpad ---- */
 
   useEffect(() => {
@@ -903,11 +933,11 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     setSaveState("idle");
     setOpenFile(null);
     setFileError(null);
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      for (const a of pathOf(nodes, id)) if (a.kind === "folder") next.add(a.id);
-      return next;
-    });
+    // The ancestors are expanded by the reveal effect below rather than here.
+    // Doing it here read `nodes` out of this closure, and on the deep-link route
+    // (`#/workspace/<id>`) that closure runs before the tree has arrived — so
+    // `pathOf` walked an empty array, expanded nothing, and the note the
+    // operator had just been sent to was nowhere in the explorer (issue #1371).
     // A payload has no text body to fetch, and the host refuses the text read
     // for one — asking anyway would put an error in `fileError` for a file that
     // is perfectly fine (issue #553). `BinaryNodeView` fetches the bytes it
@@ -933,15 +963,24 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   async function openHit(hit: SearchHit) {
     if (hit.kind === "folder") {
       setSearchInput("");
-      setExpanded((prev) => {
-        const next = new Set(prev);
-        for (const a of pathOf(nodes, hit.id)) if (a.kind === "folder") next.add(a.id);
-        next.add(hit.id);
-        return next;
-      });
+      setExpanded((prev) => new Set([...prev, ...ancestorFolderIds(nodes, hit.id), hit.id]));
+      setRevealId(hit.id);
       return;
     }
     await open(hit.id);
+  }
+
+  /**
+   * Show a folder in the tree, from a breadcrumb crumb (issue #1371).
+   *
+   * Expands it as well as its ancestors — clicking the folder you are inside of
+   * means "show me what else is in here", and revealing it collapsed would
+   * answer a question nobody asked.
+   */
+  function revealFolder(id: string) {
+    setSearchInput("");
+    setExpanded((prev) => new Set([...prev, ...ancestorFolderIds(nodes, id), id]));
+    setRevealId(id);
   }
 
   function toggle(id: string) {
@@ -1350,6 +1389,8 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               depth={0}
               expanded={expanded}
               openId={openId}
+              revealId={revealId}
+              onRevealed={onRevealed}
               rosterNames={rosterNames}
               onToggle={toggle}
               onOpen={(id) => void open(id)}
@@ -1423,7 +1464,16 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               <IconBtn label="Toggle explorer" onClick={() => setShowExplorer((s) => !s)}>
                 <PanelLeft className="size-4" />
               </IconBtn>
-              <span className="truncate text-sm font-medium">{titleOf(openNode)}</span>
+              <span className="flex min-w-0 items-baseline gap-1.5">
+                {/* Where this note lives (issue #1371). The header used to name
+                    the file and nothing else, which in a tree five deep with
+                    three notes called README answered neither "which one is
+                    this?" nor "what sits beside it?". Search already knew — it
+                    returns a `path` on every hit — and threw the answer away at
+                    exactly the moment it became useful. */}
+                <Breadcrumb nodes={nodes} nodeId={openNode.id} onOpenFolder={revealFolder} />
+                <span className="truncate text-sm font-medium">{titleOf(openNode)}</span>
+              </span>
               <Authorship
                 createdBy={openFile?.createdBy ?? openNode.createdBy}
                 updatedBy={openFile?.updatedBy ?? openNode.updatedBy}
@@ -1580,6 +1630,57 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   );
 }
 
+/**
+ * Where the open note lives, above its name (issue #1371).
+ *
+ * Rendered as separate clickable crumbs rather than one path string, because a
+ * path is only half an answer: the operator who has just discovered that this
+ * note is the one under `Rust/API design` almost always wants to see what else
+ * is in there, and a string cannot be clicked. Each crumb expands that folder
+ * and scrolls the tree to it.
+ *
+ * Nothing renders at the workspace root — a note with no folders above it has no
+ * location worth stating, and an empty crumb rail would be a line of chrome that
+ * says "top level" in the space where a real path would go.
+ */
+function Breadcrumb({
+  nodes,
+  nodeId,
+  onOpenFolder,
+}: {
+  nodes: FsNode[];
+  nodeId: string;
+  onOpenFolder: (id: string) => void;
+}) {
+  const crumbs = breadcrumbOf(nodes, nodeId);
+  if (crumbs.length === 0) return null;
+  return (
+    <span
+      className="hidden min-w-0 shrink items-baseline gap-1 text-xs text-muted-foreground sm:flex"
+      data-testid="workspace-breadcrumb"
+    >
+      {crumbs.map((crumb, i) =>
+        crumb === null ? (
+          <span key={`gap-${i}`} aria-hidden="true">
+            …/
+          </span>
+        ) : (
+          <span key={crumb.id} className="flex min-w-0 items-baseline">
+            <button
+              type="button"
+              onClick={() => onOpenFolder(crumb.id)}
+              className="truncate rounded-sm hover:text-foreground hover:underline"
+            >
+              {crumb.name}
+            </button>
+            <span aria-hidden="true">/</span>
+          </span>
+        ),
+      )}
+    </span>
+  );
+}
+
 /** The editor's save indicator: quiet when idle, explicit when it matters. */
 function SaveStatus({ state }: { state: SaveState }) {
   if (state === "idle") return null;
@@ -1607,6 +1708,10 @@ interface TreeProps {
   depth: number;
   expanded: Set<string>;
   openId: string | null;
+  /** The node to scroll into view once its row exists (issue #1371). */
+  revealId: string | null;
+  /** Called by the row that scrolled itself, so the reveal fires once. */
+  onRevealed: () => void;
   /** id -> display name for roster ids (issue #973). See {@link isAgentsFolder}. */
   rosterNames: RosterNames;
   onToggle: (id: string) => void;
@@ -1707,7 +1812,19 @@ function sameOrigin(a: WorkspaceOrigin, b: WorkspaceOrigin): boolean {
 }
 
 function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
-  const { depth, expanded, openId, onToggle, onOpen, nodes, rosterNames } = props;
+  const { depth, expanded, openId, onToggle, onOpen, nodes, rosterNames, revealId, onRevealed } =
+    props;
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  // Scrolling belongs to the row rather than to the pane because only the row
+  // knows when it exists: the ancestors expand first, and the row this reveal
+  // is about is mounted by that render, not the one that asked for it
+  // (issue #1371). `block: "nearest"` so a row already on screen — the ordinary
+  // case, a click in the tree — does not move at all.
+  useEffect(() => {
+    if (revealId !== node.id) return;
+    rowRef.current?.scrollIntoView({ block: "nearest" });
+    onRevealed();
+  }, [revealId, node.id, onRevealed]);
   const isFolder = node.kind === "folder";
   const isOpen = expanded.has(node.id);
   const active = node.id === openId;
@@ -1722,6 +1839,7 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
   return (
     <>
       <div
+        ref={rowRef}
         className={cn(
           "group flex items-center gap-1 rounded-md px-1.5 py-1 text-sm",
           active ? "bg-accent font-medium" : "hover:bg-accent/50",

--- a/frontend/test/unit/workspace-breadcrumb.test.ts
+++ b/frontend/test/unit/workspace-breadcrumb.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Where an open note says it lives (issue #1371).
+ *
+ * The header used to name the file and nothing else, and the tree did not
+ * expand or scroll to reveal it — so a note reached from a search hit, a
+ * wikilink or an `#/workspace/<id>` deep link appeared with no location at all.
+ * In a tree five levels deep, with three notes called `README`, that answers
+ * neither "which one is this?" nor "what sits beside it?".
+ *
+ * Two pure pieces carry the fix, and both are pinned here: which folders make
+ * up the trail, and which ones have to be expanded for the row to exist.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FsNode } from "@/api/workspace";
+import { ancestorFolderIds, breadcrumbOf } from "@/lib/workspace";
+
+function node(partial: Partial<FsNode> & { id: string; name: string }): FsNode {
+  return { kind: "file", parentId: null, updatedAt: 0, ...partial } as FsNode;
+}
+
+// The shape that motivated the issue: Standards/Engineering/Backend/Rust/API
+// design/Pagination.md, five folders deep.
+const TREE: FsNode[] = [
+  node({ id: "std", name: "Standards", kind: "folder" }),
+  node({ id: "eng", name: "Engineering", kind: "folder", parentId: "std" }),
+  node({ id: "be", name: "Backend", kind: "folder", parentId: "eng" }),
+  node({ id: "rust", name: "Rust", kind: "folder", parentId: "be" }),
+  node({ id: "api", name: "API design", kind: "folder", parentId: "rust" }),
+  node({ id: "page", name: "Pagination.md", parentId: "api" }),
+  node({ id: "root-note", name: "README.md" }),
+  node({ id: "pb", name: "Playbooks", kind: "folder" }),
+  node({ id: "shallow", name: "Release checklist.md", parentId: "pb" }),
+];
+
+describe("breadcrumbOf", () => {
+  it("says nothing for a note at the workspace root", () => {
+    // An empty crumb rail would be chrome that says "top level" in the space a
+    // real path would occupy.
+    expect(breadcrumbOf(TREE, "root-note")).toEqual([]);
+  });
+
+  it("leaves the note itself out of its own trail", () => {
+    // Its name is the heading right beside the trail; repeating it would spend
+    // the widest crumb saying what the operator is looking straight at.
+    const names = breadcrumbOf(TREE, "shallow").map((c) => c?.name);
+    expect(names).toEqual(["Playbooks"]);
+  });
+
+  it("keeps the root and the last two folders when the trail is too long", () => {
+    // The half that matters. Truncating a path *string* ellipsises the tail, so
+    // every note under Standards/Engineering/… renders an identical prefix and
+    // the discriminating end is exactly what is thrown away.
+    const crumbs = breadcrumbOf(TREE, "page");
+    expect(crumbs.map((c) => c?.name ?? "…")).toEqual(["Standards", "…", "Rust", "API design"]);
+  });
+
+  it("elides with an explicit gap rather than by dropping folders", () => {
+    // A shortened path that does not admit it is shortened reads as the whole
+    // truth. The `null` is what the ellipsis crumb is rendered from.
+    expect(breadcrumbOf(TREE, "page")).toContain(null);
+  });
+
+  it("does not elide a trail that already fits", () => {
+    expect(breadcrumbOf(TREE, "page", 5).map((c) => c?.name)).toEqual([
+      "Standards",
+      "Engineering",
+      "Backend",
+      "Rust",
+      "API design",
+    ]);
+  });
+});
+
+describe("ancestorFolderIds", () => {
+  it("names every folder that must be expanded for the row to exist", () => {
+    expect(ancestorFolderIds(TREE, "page")).toEqual(["std", "eng", "be", "rust", "api"]);
+  });
+
+  it("excludes the node itself, even when it is a folder", () => {
+    // Revealing a folder means showing its row, not opening it.
+    expect(ancestorFolderIds(TREE, "api")).toEqual(["std", "eng", "be", "rust"]);
+  });
+
+  it("expands nothing for a root node", () => {
+    expect(ancestorFolderIds(TREE, "root-note")).toEqual([]);
+  });
+
+  it("finds nothing when the tree has not loaded yet", () => {
+    // The deep-link bug in one line: `open()` ran before the tree arrived, so
+    // this walked an empty array and expanded nothing. The reveal now re-runs
+    // when `nodes` changes, and this is the first pass it has to survive.
+    expect(ancestorFolderIds([], "page")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1371.

## What was wrong

The note-pane header read `Pagination · Aug 21, 1:13 AM` and that was the entire location information the operator got. The explorer beside it stayed exactly where it was — `Standards` collapsed, the open note nowhere on screen.

The ancestor expansion in `open()` looked like it should have handled this, but it was dead on the route that needs it most. It read `nodes` out of its own closure, and on the deep-link route (`#/workspace/<id>`, which the Artifacts tab's "Open in workspace" uses) that closure runs **before the tree has loaded** — so `pathOf` walked an empty array and expanded nothing. Measured against a live host:

```
deep note reveal: {"rowCount":32,"activeLabel":null,"activeInView":null,"scrollTop":0}
```

32 rows rendered, and the row for the note the operator had just been sent to was not one of them.

## What changed

**Reveal** is now an effect keyed on `[openId, nodes]`, so the pass that runs once the tree arrives is the one that does the work. Expanding is idempotent, so re-running costs nothing; the effect bails early when every ancestor is already open, so it does not churn state.

**Scrolling** belongs to the row, not the pane — only the row knows when it exists, since the ancestors expand on one render and the row mounts on the next. `block: "nearest"`, so a row already on screen (the ordinary tree click) does not move at all. `revealId` is a one-shot event cleared by the row that consumed it, so an operator who scrolls the tree away from the open note is not yanked back on the next render.

**Breadcrumb**: `breadcrumbOf` elides the **middle**, keeping the root and the last two folders — `Standards / … / Rust / API design`. Truncating a path *string* (which is what `truncate` on a single span does) ellipsises the tail, so every note under `Standards/Engineering/…` renders an identical prefix and the discriminating end is exactly what gets thrown away. Each crumb is clickable and reveals that folder.

The note's own name is deliberately not in the trail — it is the heading immediately beside it.

## Verified

Against a real host, deep link and search-hit routes, 1440px and 1100px, light and dark:

```
deep-link reveal: {"rowCount":41,"activeLabel":"Pagination","activeInView":true,"scrollTop":314}
breadcrumb:       Standards/…/Rust/API design/

search-hit reveal:{"rowCount":48,"activeLabel":"Refund after chargeback","activeInView":true,"scrollTop":26}
breadcrumb:       Product/Billing/Edge cases/
```

## Commands run

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean
- `npx vitest run` — 168 files, 1605 tests, all passing (9 new)
- `scripts/ci/assert-design-tokens.sh` — clean
- Browser-verified light and dark, 1440px and 1100px, against a live host

Found during a design audit of the Workspace surface.