### PR TITLE
perf(mongodb): create indexes concurrently instead of one round trip at a time

### DIFF
--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -356,76 +356,85 @@ impl MongoStore {
                 nonunique(doc! {"company_id": 1, "workflow_id": 1, "created_ms": -1}),
             ),
         ];
-        for (name, index) in plans {
-            self.collection(name)
-                .create_index(index)
-                .await
-                .map_err(mongo_err)?;
-        }
-        self.collection("owners")
-            .create_index(unique(doc! {"company_id": 1}))
-            .await
-            .map_err(mongo_err)?;
-        // Issue #241: the cross-replica arbiter. This unique compound index is
-        // what turns two replicas racing one schedule minute into one winning
-        // `insert_one` and one `E11000` — the case that actually matters, since
-        // hosted replicas share the tenant database. Created outside the array
-        // above so adding it does not disturb that array's fixed length.
-        self.collection("schedule_fires")
-            .create_index(unique(
-                doc! {"company_id": 1, "schedule_id": 1, "scheduled_for": 1},
-            ))
-            .await
-            .map_err(mongo_err)?;
-        // Issue #596: one durable per-node output snapshot per run. The unique
-        // `(company_id, run_id)` index makes the upsert last-write-wins per run;
-        // the recency index backs the newest-N prune. Created outside the fixed
-        // array above so adding it does not disturb that array's length.
-        self.collection("run_outputs")
-            .create_index(unique(doc! {"company_id": 1, "run_id": 1}))
-            .await
-            .map_err(mongo_err)?;
-        self.collection("run_outputs")
-            .create_index(nonunique(doc! {"company_id": 1, "at_ms": -1}))
-            .await
-            .map_err(mongo_err)?;
-        // Issue #726: the runtime journal. `(company_id, seq)` is unique because
-        // two records sharing a sequence would order arbitrarily on replay, and
-        // an at-most-once key replayed before the resolution that consumed it is
-        // the failure the journal exists to prevent. The import receipt is one
-        // document per company. Created outside the fixed array above so adding
-        // them does not disturb its length.
-        self.collection(JOURNAL)
-            .create_index(unique(doc! {"company_id": 1, "seq": 1}))
-            .await
-            .map_err(mongo_err)?;
-        self.collection(JOURNAL_IMPORTS)
-            .create_index(unique(doc! {"company_id": 1}))
-            .await
-            .map_err(mongo_err)?;
-        // Issue #749: durable notifications. The recency index backs the
-        // newest-first feed `NotificationStore::list` returns; the per-person
-        // read marker is unique on `(company_id, user_id, notification_id)` so a
-        // re-mark is a no-op `E11000` and read stays a latch. Created outside the
-        // fixed array above so adding them does not disturb its length.
-        self.collection("notifications")
-            .create_index(nonunique(
-                doc! {"company_id": 1, "created_ms": -1, "id": -1},
-            ))
-            .await
-            .map_err(mongo_err)?;
-        // Unique per (company_id, id): makes `append` idempotent — a duplicate
-        // id within a company is rejected, matching the sqlite primary key.
-        self.collection("notifications")
-            .create_index(unique(doc! {"company_id": 1, "id": 1}))
-            .await
-            .map_err(mongo_err)?;
-        self.collection("notification_reads")
-            .create_index(unique(
-                doc! {"company_id": 1, "user_id": 1, "notification_id": 1},
-            ))
-            .await
-            .map_err(mongo_err)?;
+        // Every index below is issued CONCURRENTLY rather than one at a time.
+        //
+        // Each `create_index` is a round trip, and against a remote cluster the
+        // round trips are the whole cost: measured on staging (MongoDB Atlas),
+        // boot spent ~3.5s in this function — most of an ~8s cold start — and it
+        // was paid on every single boot to re-create indexes that already
+        // existed.
+        //
+        // Safe to parallelise: index creation is independent per index and
+        // idempotent, there is no ordering between any two of these, and
+        // re-creating an existing index is a server-side no-op. Nothing here
+        // reads what another one writes.
+        //
+        // Bounded rather than unbounded because the driver's connection pool is
+        // finite (10 by default); more in flight than that would queue inside
+        // the pool anyway, while making the burst look less deliberate than it
+        // is.
+        const INDEX_CONCURRENCY: usize = 10;
+
+        let extra: [(&str, IndexModel); 9] = [
+            ("owners", unique(doc! {"company_id": 1})),
+            // Issue #241: the cross-replica arbiter. This unique compound index
+            // is what turns two replicas racing one schedule minute into one
+            // winning `insert_one` and one `E11000` — the case that actually
+            // matters, since hosted replicas share the tenant database.
+            (
+                "schedule_fires",
+                unique(doc! {"company_id": 1, "schedule_id": 1, "scheduled_for": 1}),
+            ),
+            // Issue #596: one durable per-node output snapshot per run. The
+            // unique `(company_id, run_id)` index makes the upsert
+            // last-write-wins per run; the recency index backs the newest-N
+            // prune.
+            ("run_outputs", unique(doc! {"company_id": 1, "run_id": 1})),
+            (
+                "run_outputs",
+                nonunique(doc! {"company_id": 1, "at_ms": -1}),
+            ),
+            // Issue #726: the runtime journal. `(company_id, seq)` is unique
+            // because two records sharing a sequence would order arbitrarily on
+            // replay, and an at-most-once key replayed before the resolution
+            // that consumed it is the failure the journal exists to prevent. The
+            // import receipt is one document per company.
+            (JOURNAL, unique(doc! {"company_id": 1, "seq": 1})),
+            (JOURNAL_IMPORTS, unique(doc! {"company_id": 1})),
+            // Issue #749: durable notifications. The recency index backs the
+            // newest-first feed `NotificationStore::list` returns.
+            (
+                "notifications",
+                nonunique(doc! {"company_id": 1, "created_ms": -1, "id": -1}),
+            ),
+            // Unique per (company_id, id): makes `append` idempotent — a
+            // duplicate id within a company is rejected, matching the sqlite
+            // primary key.
+            ("notifications", unique(doc! {"company_id": 1, "id": 1})),
+            // The per-person read marker is unique on
+            // `(company_id, user_id, notification_id)` so a re-mark is a no-op
+            // `E11000` and read stays a latch.
+            (
+                "notification_reads",
+                unique(doc! {"company_id": 1, "user_id": 1, "notification_id": 1}),
+            ),
+        ];
+
+        // Scoped import: the file deliberately avoids a blanket `StreamExt`,
+        // since `map` would then be ambiguous with `Iterator::map`.
+        use futures::StreamExt as _;
+
+        futures::stream::iter(plans.into_iter().chain(extra))
+            .map(|(name, index)| async move {
+                self.collection(name)
+                    .create_index(index)
+                    .await
+                    .map(|_| ())
+                    .map_err(mongo_err)
+            })
+            .buffer_unordered(INDEX_CONCURRENCY)
+            .try_collect::<()>()
+            .await?;
         Ok(())
     }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -424,18 +424,46 @@ impl MongoStore {
         // since `map` would then be ambiguous with `Iterator::map`.
         use futures::StreamExt as _;
 
-        futures::stream::iter(plans.into_iter().chain(extra))
+        // Every operation is allowed to finish before any error is reported.
+        //
+        // `try_collect` would short-circuit, which matches what the old
+        // sequential loop did — but only in appearance. Sequentially there was
+        // never an operation in flight to abandon; here a short-circuit drops up
+        // to `INDEX_CONCURRENCY - 1` futures mid-await, and a driver operation
+        // cancelled after its request is sent but before its reply is read
+        // leaves a connection the pool cannot safely reuse. That hazard is new,
+        // introduced by the concurrency, so it is handled here rather than
+        // inherited.
+        //
+        // Letting them all land is also simply better: a transient failure on
+        // one index no longer decides whether the other forty-three exist.
+        let results: Vec<Result<()>> = futures::stream::iter(plans.into_iter().chain(extra))
             .map(|(name, index)| async move {
                 self.collection(name)
                     .create_index(index)
                     .await
                     .map(|_| ())
-                    .map_err(mongo_err)
+                    .map_err(|err| mongo_err(format!("index on `{name}`: {err}")))
             })
             .buffer_unordered(INDEX_CONCURRENCY)
-            .try_collect::<()>()
-            .await?;
-        Ok(())
+            .collect()
+            .await;
+
+        let failures: Vec<_> = results
+            .into_iter()
+            .filter_map(std::result::Result::err)
+            .collect();
+        let failed = failures.len();
+        match failures.into_iter().next() {
+            // The count matters: one failing index is a different problem from
+            // every index failing, and the first error alone cannot tell them
+            // apart.
+            Some(first) if failed > 1 => Err(mongo_err(format!(
+                "{failed} indexes failed; first: {first}"
+            ))),
+            Some(first) => Err(first),
+            None => Ok(()),
+        }
     }
 
     fn collection(&self, name: &str) -> Collection<Document> {
@@ -4071,6 +4099,75 @@ mod test {
             )
         });
         Some(Arc::new(store))
+    }
+
+    /// One failing index must not stop the other forty-three from being created.
+    ///
+    /// `ensure_indexes` runs concurrently, so a short-circuit would drop
+    /// in-flight driver operations mid-await — and an operation cancelled after
+    /// its request is sent but before its reply is read leaves a connection the
+    /// pool cannot safely reuse. That hazard does not exist in a sequential
+    /// loop; it arrived with the concurrency, so it is pinned here.
+    #[tokio::test]
+    async fn every_index_is_attempted_even_when_one_fails() {
+        let Some(store) = store().await else { return };
+
+        // `store()` has already run `ensure_indexes` once, so the assertion has
+        // to be about something this run RE-creates. Drop a known index first;
+        // if the pipeline short-circuits before reaching it, it stays missing.
+        store
+            .collection("notifications")
+            .drop_index("company_id_1_id_1")
+            .await
+            .expect("drop the index whose return proves the run continued");
+
+        // Induce the failure the way MongoDB actually produces one: an existing
+        // index on the same keys with conflicting options. Replacing the unique
+        // `owners` index with a non-unique one makes `ensure_indexes` collide.
+        store
+            .collection("owners")
+            .drop_index("company_id_1")
+            .await
+            .expect("drop owners index");
+        store
+            .collection("owners")
+            .create_index(IndexModel::builder().keys(doc! {"company_id": 1}).build())
+            .await
+            .expect("seed the conflicting index");
+
+        let err = store
+            .ensure_indexes()
+            .await
+            .expect_err("the conflicting index should make this fail");
+        assert!(
+            format!("{err}").contains("owners"),
+            "the error should name the collection that failed: {err}"
+        );
+
+        // The point: the run continued past the failure and recreated the index
+        // dropped above. A short-circuit would leave it absent.
+        let mut names = Vec::new();
+        let mut cursor = store
+            .collection("notifications")
+            .list_indexes()
+            .await
+            .expect("list notifications indexes");
+        while cursor.advance().await.expect("advance") {
+            if let Some(name) = cursor
+                .deserialize_current()
+                .expect("model")
+                .options
+                .and_then(|o| o.name)
+            {
+                names.push(name);
+            }
+        }
+        assert!(
+            names.iter().any(|n| n == "company_id_1_id_1"),
+            "a failure on `owners` must not stop other indexes being created; got {names:?}"
+        );
+
+        drop_db(&store).await;
     }
 
     async fn drop_db(store: &MongoStore) {


### PR DESCRIPTION
Second of the cold-start reductions. A hosted tenant's wake was measured at ~8s, and **~3.5s of it was here**.

## The measurement

`ensure_indexes` issued **44 `create_index` calls sequentially**, each awaited before the next. Against a local MongoDB that is free. Against a remote one it is 44 round trips, and the round trips are the entire cost.

Staging runs MongoDB Atlas over the internet, and the tenant's own boot log shows exactly where the time goes:

```
20:07:01.018  agent journal, keyring
20:07:04.492  storage backend: Mongodb     ← 3.47s
20:07:04.759  listening on 0.0.0.0:8080
```

That is paid on **every boot**, re-creating indexes that already exist — and every scale-to-zero wake pays it again.

## The change

Issued concurrently, bounded at 10.

Safe because index creation is **independent per index and idempotent**: no ordering between any two, nothing reads what another writes, and re-creating an existing index is a server-side no-op. Bounded rather than unbounded because the driver's connection pool is 10 by default — more in flight would queue inside the pool anyway while making the burst look less deliberate than it is.

The nine indexes that lived after the loop are folded into the same array so they parallelise too, with every issue-referencing comment kept attached to its own entry.

## Verified as a parity refactor, not assumed

**This matters more than usual here.** The MongoDB conformance tests are skipped unless `OPENCOMPANY_TEST_MONGODB_URI` points at a live server — so the 3261 passing tests **did not exercise this code at all**. A green run means very little on its own.

Against a real MongoDB in Docker:

- 43 conformance tests pass
- a temporary probe dumped the resulting index set before and after, sorted by collection and name

```
IDENTICAL — 74 index rows, no difference
```

Same indexes, same names. Different only in how they are issued.

## What is arithmetic rather than measured

The expected saving is 44 sequential round trips collapsing to about five batches. **That is reasoning, not a number I can show**: locally there is no latency to remove, so the improvement is invisible here. The real figure will come from staging, where the 3.5s was measured in the first place, and I will post it once this deploys.

## Verification

```
cargo test --features mongodb,sqlite    3261 + 14 + 1 passed, 0 failed
cargo clippy --all-targets --features mongodb,sqlite -- -D warnings    exit 0
cargo fmt --check (crate-wide)          clean
```

## Context

One of three contributors to the ~8s:

| Phase | Time | Status |
|---|---|---|
| k8s scheduling + container start | ~3.3s | untouched |
| **MongoDB index creation** | **~3.5s** | **this PR** |
| readiness probe lag | ~1.1s | opencompany-microservice#47 |
| rest of app boot | ~0.3s | — |

Sub-1s from a parked tenant stays unreachable regardless — Kubernetes spends ~3.3s before the tenant's code runs. Sub-second wakes remain a question about `IdleResident` and the park timeout rather than about boot speed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * MongoDB index setup now runs concurrently, improving startup efficiency while limiting resource usage.
* **Reliability**
  * Index creation continues to report errors after all configured indexes have been processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->