### PR TITLE
fix(tour): record the run outcome from joyride's run-level onEvent, not the per-step after hook

### DIFF
--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
-import type { Step, TourData } from "react-joyride";
+import type { EventData, Step, TourData } from "react-joyride";
 
 import type { View } from "@/components/app-shell";
+import { terminalOutcome } from "./events";
 import { TOUR, waitForTarget } from "./steps";
 import { TourTooltip } from "./TourTooltip";
 import { WelcomeDialog } from "./WelcomeDialog";
@@ -46,11 +47,6 @@ const Joyride = lazy(() => importJoyride().then((m) => ({ default: m.Joyride }))
 export function preloadTour(): void {
   void importJoyride().catch(() => {});
 }
-
-// react-joyride status values as string literals, so we don't statically import
-// the runtime `STATUS` enum (which would defeat the lazy load).
-const STATUS_FINISHED = "finished";
-const STATUS_SKIPPED = "skipped";
 
 const STEPS: Step[] = TOUR.map((s) => ({
   target: s.target,
@@ -207,12 +203,14 @@ export function TourController({
     [setView],
   );
 
-  // End the tour (recording completed vs skipped) when joyride reports it done.
-  const after = useCallback(
-    (data: TourData) => {
-      if (data.status === STATUS_FINISHED || data.status === STATUS_SKIPPED) {
-        finish(data.status === STATUS_SKIPPED);
-      }
+  // End the tour (recording completed vs skipped) when joyride reports the RUN
+  // over — `onEvent` + `EVENTS.TOUR_END`, not the per-step `options.after` hook
+  // this used to be registered as. See `./events` for why that distinction is
+  // issue #1408 and why v3 has no `callback` prop to move it to.
+  const onEvent = useCallback(
+    (data: EventData) => {
+      const outcome = terminalOutcome(data);
+      if (outcome) finish(outcome === "skipped");
     },
     [finish],
   );
@@ -262,13 +260,15 @@ export function TourController({
             // the element it points at, which for a full-bleed anchor is
             // unavoidable and strictly better than being unreachable.
             floatingOptions={{ shiftOptions: { crossAxis: true } }}
+            // Run-level. `options.before` below is per-step and stays there;
+            // the terminal handler must not, which is the whole of #1408.
+            onEvent={onEvent}
             options={{
               zIndex: 1200,
               overlayColor: "rgba(0,0,0,0.45)",
               spotlightPadding: 6,
               arrowSize: 0,
               before,
-              after,
             }}
           />
         </Suspense>

--- a/frontend/src/tour/events.ts
+++ b/frontend/src/tour/events.ts
@@ -1,0 +1,65 @@
+// The run-level half of react-joyride's protocol, kept in one small module so
+// the controller's wiring is testable without a browser.
+//
+// # Why these are bare string literals
+//
+// `TourController` lazy-loads react-joyride (most operators never run the
+// tour), so it must not statically `import { EVENTS, STATUS }` — that pulls the
+// runtime module into the main chunk and defeats the split. The literals below
+// are those enums' values, written out.
+//
+// A copied constant can drift from the package it copies, so
+// `test/unit/tour-terminal.test.ts` imports the real `EVENTS`/`STATUS` and
+// asserts each of these still matches. The test is not shipped, so it can
+// import the runtime module freely.
+//
+// # Why `tour:end` and not "watch the status"
+//
+// react-joyride v3 has **no `callback` prop**. The run-level hook is `onEvent`,
+// and the terminal moment it reports is `EVENTS.TOUR_END` — emitted exactly
+// once, when `status` changes into `finished` or `skipped`
+// (`useLifecycleEffect`). joyride then calls `controls.reset()` for an
+// uncontrolled tour, which moves `status` straight back to `ready`; so the
+// event is the only reliable place to read the outcome, and gating on it also
+// stops the same outcome being recorded twice.
+//
+// `options.after` — where this used to live — is joyride's **per-step** hook.
+// It runs around an individual step and its `TourData` never carries a
+// run-level `finished`/`skipped`, which is issue #1408: completing the tour
+// recorded nothing at all.
+
+/** `EVENTS.TOUR_END` — the run is over; `status` says how. */
+export const EVENT_TOUR_END = "tour:end";
+/** `STATUS.FINISHED` — the operator reached the last stop and pressed Done. */
+export const STATUS_FINISHED = "finished";
+/** `STATUS.SKIPPED` — the operator pressed "Skip tour" from inside a run. */
+export const STATUS_SKIPPED = "skipped";
+
+/**
+ * How a tour run ended.
+ *
+ * Both outcomes mean "do not offer this again" — see `terminalOutcome`.
+ */
+export type TourOutcome = "completed" | "skipped";
+
+/**
+ * The outcome to record for a joyride event, or `null` if the run is not over.
+ *
+ * Deliberately structural rather than typed against `EventData`: the shape it
+ * needs is two strings, and keeping it that way is what lets the unit suite
+ * exercise it without constructing a whole joyride step.
+ *
+ * **Completing and skipping record different flags but mean the same thing.**
+ * `tourSeen` is `completed || skipped`, so either one silences the welcome
+ * card. They stay distinguishable because "watched the whole tour" and "bailed
+ * out at step 3" are different facts about an operator, and the day there is a
+ * backend preference to sync (or a "you skipped this — want to finish it?"
+ * nudge) the distinction is the thing that makes it possible. What must never
+ * differ is whether the tour is re-offered.
+ */
+export function terminalOutcome(data: { type: string; status: string }): TourOutcome | null {
+  if (data.type !== EVENT_TOUR_END) return null;
+  if (data.status === STATUS_SKIPPED) return "skipped";
+  if (data.status === STATUS_FINISHED) return "completed";
+  return null;
+}

--- a/frontend/test/e2e/tour-completion-persists.spec.ts
+++ b/frontend/test/e2e/tour-completion-persists.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #1408 — every way of finishing with the tour must be remembered.
+ *
+ * The bug was pure wiring: `TourController` registered its terminal handler as
+ * `options.after`, which is react-joyride's **per-step** hook, so a run that
+ * reached "Done" — or that the operator abandoned with "Skip tour" — recorded
+ * nothing at all. `localStorage` had no `oc-tour:` key, and the welcome card
+ * came back on the next full page load, forever. The only exit that ever
+ * persisted was "Skip for now", because that one never goes through joyride.
+ *
+ * This is the half of the regression cover that a unit test cannot reach.
+ * `test/unit/tour-terminal.test.ts` pins the decision — which event and status
+ * mean "the run is over" — but it would have passed on the broken build,
+ * because on the broken build the decision function was simply never called.
+ * Only a browser can say whether the handler is attached to a prop joyride
+ * actually invokes.
+ *
+ * So all three exits are walked, in a browser, and each is asserted twice: the
+ * key is written, **and** the welcome stays away across a reload. The second
+ * assertion is the one an operator would notice, and it is not implied by the
+ * first — a key written at the wrong scope (a global `oc-tour`, say, instead of
+ * the per-connection-per-company one) writes something and still re-offers.
+ *
+ * NOT a test of #1306, which is a separate, correctly-filed bug: the connection
+ * profile churns on the first loads and can orphan a key written before it
+ * settles. `settleConnectionScope` below waits that out on purpose, so these
+ * specs report on the terminal handler and nothing else.
+ */
+
+type Page = import("@playwright/test").Page;
+
+/**
+ * How many stops `src/tour/steps.ts` declares.
+ *
+ * Hard-coded for the same reason `tour-popover-in-viewport.spec.ts` hard-codes
+ * it — the e2e project has no `@/*` alias — and it rots just as loudly: the
+ * per-step wait below reads the card's own "Step N of M" chip.
+ */
+const TOUR_STOPS = 8;
+
+/** The welcome card's heading; its presence is the whole symptom of #1408. */
+const WELCOME = "Welcome to your company";
+
+/**
+ * Load the console and let the browser-local connection scope stop moving.
+ *
+ * The tour key is scoped per (connection, company) — `oc-tour:<connection>::<company>`
+ * — and issue #1306 has the connection profile still being re-minted for the
+ * first load or two of a fresh profile. A key written before that settles is
+ * orphaned by the next load, which looks exactly like the bug under test here
+ * and is not it. Reloading until `oc.connections.v1` holds still separates the
+ * two, so a failure below is unambiguously the terminal handler.
+ */
+async function settleConnectionScope(page: Page): Promise<void> {
+  const profiles = () =>
+    page.evaluate(() => window.localStorage.getItem("oc.connections.v1") ?? "");
+
+  await page.goto("/#/overview");
+  await expect(page.getByText(WELCOME), "first run should offer the tour").toBeVisible();
+
+  // Two reloads is what the audit needed; poll rather than fix the count so a
+  // slower host does not turn this into a flake.
+  let previous = await profiles();
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await page.reload();
+    await expect(page.getByText(WELCOME)).toBeVisible();
+    const current = await profiles();
+    if (current === previous) return;
+    previous = current;
+  }
+  throw new Error(
+    "the connection profile list never stopped changing across reloads; see issue #1306",
+  );
+}
+
+/** The tour's per-(connection, company) key and its parsed value, from the running app. */
+async function readTourRecord(page: Page): Promise<{ key: string; value: Record<string, unknown> }> {
+  const found = await page.evaluate(() => {
+    const key = Object.keys(window.localStorage).find((k) => k.startsWith("oc-tour:"));
+    return key ? { key, raw: window.localStorage.getItem(key) ?? "" } : null;
+  });
+  expect(found, "the console should have written a tour key").not.toBeNull();
+  return { key: found!.key, value: JSON.parse(found!.raw) as Record<string, unknown> };
+}
+
+/**
+ * Assert the record is scoped, not global.
+ *
+ * `oc-tour` on its own would suppress the tour for every company on every host
+ * an operator has ever opened — which is a *worse* bug than the one being
+ * fixed, and one that would sail past a "the welcome is gone" assertion.
+ */
+function expectScopedKey(key: string): void {
+  expect(key, "the tour key must carry a scope, not be a bare global").not.toBe("oc-tour");
+  expect(key).toMatch(/^oc-tour:.+/);
+}
+
+/** Reload the document and assert the welcome card does not come back. */
+async function expectWelcomeStaysAway(page: Page, exit: string): Promise<void> {
+  // Back to Overview first. A finished tour leaves the console on its last
+  // stop's view, and the liveness check below needs one known anchor for all
+  // three exits. Changing only the fragment is not a document load, so the
+  // `reload()` after it is what makes this the *full page load* the bug was
+  // reported against.
+  await page.goto("/#/overview");
+  await page.reload();
+  // Positively wait for the console to have rendered before concluding the
+  // welcome is absent, otherwise this would pass against a blank page.
+  await expect(page.getByRole("heading", { name: "Overview", level: 1 })).toBeVisible();
+  await expect(
+    page.getByText(WELCOME),
+    `after ${exit}, the welcome must not be re-offered on reload`,
+  ).toHaveCount(0);
+}
+
+/** Advance the running tour from the stop it is on. `"Done"` on the last one. */
+async function advance(page: Page, step: number): Promise<void> {
+  const card = page.getByRole("alertdialog");
+  await expect(
+    card.getByText(`Step ${step} of ${TOUR_STOPS}`),
+    `step ${step} should render (and the tour should still have ${TOUR_STOPS} stops)`,
+  ).toBeVisible();
+  // floating-ui positions the card a frame or two after it mounts; clicking on
+  // the first frame races the move.
+  await page.waitForTimeout(250);
+  // Matched on the rendered label: joyride puts its own locale string on
+  // `primaryProps`' `aria-label`, which would win over the text on an
+  // accessible-name match.
+  await card.locator("button", { hasText: step === TOUR_STOPS ? "Done" : "Next" }).click();
+}
+
+test("completing the tour is remembered across a reload", async ({ page }) => {
+  await settleConnectionScope(page);
+  await page.getByRole("button", { name: "Take the tour" }).click();
+
+  for (let step = 1; step <= TOUR_STOPS; step += 1) {
+    await advance(page, step);
+  }
+
+  // The run ended rather than dead-ending on a stop.
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+
+  const { key, value } = await readTourRecord(page);
+  expectScopedKey(key);
+  // Completing records `completed`, not `skipped`: both silence the welcome,
+  // but "watched the whole tour" and "bailed out at step 3" stay different
+  // facts. See `src/tour/events.ts`.
+  expect(value.completed, "Done should record a completed run").toBe(true);
+  expect(value.skipped).toBeUndefined();
+
+  await expectWelcomeStaysAway(page, "completing the tour");
+});
+
+test("skipping from inside a running tour is remembered across a reload", async ({ page }) => {
+  await settleConnectionScope(page);
+  await page.getByRole("button", { name: "Take the tour" }).click();
+
+  // Part-way in, which is the reported case: the operator accepted the
+  // invitation and then bailed.
+  await advance(page, 1);
+  await advance(page, 2);
+
+  const card = page.getByRole("alertdialog");
+  await expect(card.getByText(`Step 3 of ${TOUR_STOPS}`)).toBeVisible();
+  await page.waitForTimeout(250);
+  // `locator("button", { hasText })` again, not an accessible-name match:
+  // joyride labels `skipProps` with its own locale string ("Skip"), which wins
+  // over the text `TourTooltip` renders.
+  await card.locator("button", { hasText: "Skip tour" }).click();
+
+  await expect(card).toHaveCount(0);
+
+  const { key, value } = await readTourRecord(page);
+  expectScopedKey(key);
+  expect(value.skipped, "Skip tour should record a skipped run").toBe(true);
+  expect(value.completed).toBeUndefined();
+
+  await expectWelcomeStaysAway(page, "skipping mid-run");
+});
+
+test("refusing the tour before it starts is remembered across a reload", async ({ page }) => {
+  // The one exit that already worked. It is here so the three are pinned
+  // together: this path never touches joyride, so a future refactor that moved
+  // all three onto one mechanism would need to keep it working too, and this
+  // is what would say so.
+  await settleConnectionScope(page);
+  await page.getByRole("button", { name: "Skip for now" }).click();
+
+  const { key, value } = await readTourRecord(page);
+  expectScopedKey(key);
+  expect(value.skipped, "Skip for now should record a skipped run").toBe(true);
+
+  await expectWelcomeStaysAway(page, "refusing before the tour starts");
+});

--- a/frontend/test/unit/tour-terminal.test.ts
+++ b/frontend/test/unit/tour-terminal.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { EVENTS, STATUS } from "react-joyride";
+
+import {
+  EVENT_TOUR_END,
+  STATUS_FINISHED,
+  STATUS_SKIPPED,
+  terminalOutcome,
+} from "@/tour/events";
+
+/**
+ * Issue #1408 — the tour recorded nothing when it ended.
+ *
+ * Two separate things had to be true for that bug, and this file covers the
+ * half a fast test can reach. The other half — that the handler is registered
+ * on the RUN-level `onEvent` prop rather than the per-step `options.after`
+ * hook — is only observable in a browser, and is pinned by
+ * `test/e2e/tour-completion-persists.spec.ts`. Neither file is sufficient
+ * alone: this one would have passed on the broken build, and the Playwright
+ * spec cannot say *why* it broke.
+ *
+ * What earns its place here is the copied-constant risk. `src/tour/events.ts`
+ * spells joyride's enum values out as string literals so the controller can
+ * keep lazy-loading the package, and a copied constant is exactly the kind of
+ * thing a minor version bump renames without anyone noticing — the failure
+ * being, again, silence: `terminalOutcome` simply never matches and the tour
+ * goes back to recording nothing. So the assertions below compare against the
+ * real runtime enums, which this test may import freely because it is not
+ * shipped in the bundle.
+ */
+
+describe("the literals copied out of react-joyride", () => {
+  it("still match the package's own EVENTS.TOUR_END", () => {
+    expect(EVENT_TOUR_END).toBe(EVENTS.TOUR_END);
+  });
+
+  it("still match the package's own terminal statuses", () => {
+    expect(STATUS_FINISHED).toBe(STATUS.FINISHED);
+    expect(STATUS_SKIPPED).toBe(STATUS.SKIPPED);
+  });
+});
+
+describe("terminalOutcome", () => {
+  it("records a completed run when the operator presses Done on the last stop", () => {
+    expect(terminalOutcome({ type: EVENTS.TOUR_END, status: STATUS.FINISHED })).toBe("completed");
+  });
+
+  it("records a skipped run when the operator presses Skip tour mid-run", () => {
+    expect(terminalOutcome({ type: EVENTS.TOUR_END, status: STATUS.SKIPPED })).toBe("skipped");
+  });
+
+  it("keeps the two outcomes distinguishable", () => {
+    // They mean the same thing to `tourSeen` (both silence the welcome), but
+    // they are different facts about the operator and the record keeps them
+    // apart. A fix that collapsed both to `{ skipped: true }` would still pass
+    // the Playwright spec — it only asks that the welcome stays away.
+    const done = terminalOutcome({ type: EVENTS.TOUR_END, status: STATUS.FINISHED });
+    const bailed = terminalOutcome({ type: EVENTS.TOUR_END, status: STATUS.SKIPPED });
+    expect(done).not.toBe(bailed);
+  });
+
+  it("ignores the tour ending's own aftermath", () => {
+    // joyride calls `controls.reset()` immediately after TOUR_END for an
+    // uncontrolled tour, which emits TOUR_STATUS with the status already moved
+    // on to `ready`. Nothing to record there.
+    expect(terminalOutcome({ type: EVENTS.TOUR_STATUS, status: STATUS.READY })).toBeNull();
+  });
+
+  it("ignores a terminal status carried on a non-terminal event", () => {
+    // The event is the gate, not the status: the status is still `finished`
+    // for as long as it takes joyride to reset, and a second write would be a
+    // second `seenAt` for one run.
+    expect(terminalOutcome({ type: EVENTS.STEP_AFTER, status: STATUS.FINISHED })).toBeNull();
+  });
+
+  it("ignores every step-level event of a running tour", () => {
+    // The per-step traffic that `options.after` sees — and that a run-level
+    // handler must walk straight past. This is the shape of the bug inverted:
+    // `after` saw only these, so it never recorded anything.
+    for (const type of [
+      EVENTS.TOUR_START,
+      EVENTS.STEP_BEFORE,
+      EVENTS.TOOLTIP,
+      EVENTS.STEP_AFTER,
+    ]) {
+      expect(terminalOutcome({ type, status: STATUS.RUNNING }), `${type}`).toBeNull();
+    }
+  });
+
+  it("does not record a paused run", () => {
+    // `controls.stop()` (what a company switch triggers through `run={false}`)
+    // parks the tour at `paused` and emits no TOUR_END. Recording there would
+    // mark a tour seen that the operator never dismissed.
+    expect(terminalOutcome({ type: EVENTS.TOUR_STATUS, status: STATUS.PAUSED })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1408

## Summary

Completing the product tour recorded nothing, so the welcome card re-offered it on every full page load, forever. The same for "Skip tour" from inside a running tour. Only "Skip for now" — refusing before you start — ever persisted, because that path never goes through react-joyride.

**Root cause confirmed as filed.** `TourController` registered its terminal handler as `options.after`, which is joyride's **per-step** lifecycle hook. Its `TourData` carries the step's own state; it is invoked from `useLifecycleEffect` as the previous step tears down and never observes the run-level `finished` / `skipped` statuses. So `finish()` — and therefore `writeTourState` — was never called. `options.before` sitting right beside it works because a per-step hook is exactly what *that* one is.

## One correction to the issue's proposed fix

The issue suggests moving the handler to a run-level **`callback`** prop. **react-joyride 3.2.0 has no `callback` prop** — that was the v2 API. Checked against the pinned package's own typings (`node_modules/react-joyride/dist/index.d.mts`): `Props` exposes `onEvent?: EventHandler`, and `EventHandler = (data: EventData, controls: Controls) => void`. Adding `callback` would have been a type error, and had it been spelled through an `any` it would have been silently ignored — the same class of failure as the one being fixed.

The issue also asks which of `status` / `action` / `lifecycle` the run-level hook reports on Done vs. Skip. From the 3.2.0 runtime (`useLifecycleEffect`):

- Pressing **Done** on the last stop calls `controls.next()`, which lands `index >= size` with `lifecycle: "complete"`; the effect then sets `status: "finished"`.
- Pressing **Skip tour** calls `controls.skip()`, which sets `status: "skipped"` directly.
- Either transition emits **`EVENTS.TOUR_END` (`"tour:end"`)** exactly once, carrying that status. joyride *then* calls `controls.reset()` for an uncontrolled tour, which moves `status` straight back to `"ready"`.

So the two string literals the old code was built on are still correct — but the status is only readable at that one event, which is why the fix gates on `type === "tour:end"` rather than watching status alone. Gating on the event also stops one run being recorded twice (the status stays `finished` for the events between the transition and the reset).

`controls.stop()` — what a company switch triggers through `run={false}` — parks the tour at `"paused"` and emits no `TOUR_END`, so switching companies still cannot record a tour the operator never dismissed.

## What was wired, and at what scope

- New `frontend/src/tour/events.ts`: the copied joyride literals plus a pure `terminalOutcome(data)`. Small and separate so the wiring is unit-testable and so the controller can keep lazy-loading joyride (a static `import { EVENTS, STATUS }` would pull the runtime module into the main chunk and defeat the code split).
- `TourController` now passes `onEvent={onEvent}` as a run-level prop and drops `after` from `options`. `before` stays in `options` — it genuinely is per-step.

**Scope is unchanged, deliberately.** `finish()` already wrote through `writeTourState(scope, …)`, i.e. the existing per-(connection, company) `oc-tour:<connection>::<company>` key that "Skip for now" uses. Nothing about the key changed; only whether it was ever reached. A fix that wrote a bare global `oc-tour` would suppress the tour for every company on every host at once, so the e2e spec asserts the written key is scoped rather than only asserting the welcome is gone.

**Finished and skipped-mid-run record different flags and mean the same thing** — stated explicitly because it was implicit before. `finish(skipped)` writes `{ completed: true }` or `{ skipped: true }`, and `tourSeen` is `completed || skipped`, so **both silence the welcome permanently**, which is the behaviour the issue asks for. They stay distinguishable because "watched all eight stops" and "bailed out at step 3" are different facts about an operator, and a future backend `UserRecord` preference (or a "you skipped this — want to finish?" nudge) needs that distinction. What must never differ is whether the tour is re-offered, and a unit test pins that they stay different values while the e2e specs pin that both suppress.

## Not #1306

#1306 is a separate, correctly-filed bug: connection-profile churn on the first loads can orphan a key written before the scope settles. **This change does not touch it** and does not fix it — no connection, profile, or scope code is modified. The e2e spec deliberately waits that churn out (`settleConnectionScope`) so a failure there reports on the terminal handler and nothing else; the helper's docblock says so and names #1306. On the harness host the profile was in fact stable from the first load, so the loop is insurance rather than a workaround.

## Verification — behavioural, in a browser

Host on **127.0.0.1:8621**, own `OPENCOMPANY_DATA_DIR` (`target/e2e/data-1408`), `companies/e2e_harness`, freshly built console bundle. Chromium via Playwright, a fresh profile per case. All three exits, `localStorage` dumped, then a full document load:

```
### LS after COMPLETING tour  => {"oc-tour:rptdcx2f9d2r::e2e-harness-co":"{\"completed\":true,\"seenAt\":1787280607473}"}
=> welcome after reload count: 0

### LS after 'Skip tour' mid-run => {"oc-tour:mi01izxv41v2::e2e-harness-co":"{\"skipped\":true,\"seenAt\":1787280608906}"}
=> welcome after reload count: 0

### LS after 'Skip for now'   => {"oc-tour:v67wf8gnn9zw::e2e-harness-co":"{\"skipped\":true,\"seenAt\":1787280609344}"}
=> welcome after reload count: 0
```

(The connection ids differ because each case runs in its own browser profile.)

## Regression cover

`frontend/test/e2e/tour-completion-persists.spec.ts` — the three exits, each asserting a *scoped* key is written **and** that the welcome does not return after a full document load. Picked up automatically by the `console-e2e` lane, which runs `npm run e2e` over the whole `test/e2e` directory.

**Confirmed to catch the bug rather than merely pass.** With `upstream/main`'s `TourController.tsx` restored and the bundle rebuilt:

```
✘ completing the tour is remembered across a reload      → "the console should have written a tour key" (Received: null)
✘ skipping from inside a running tour is remembered ...  → "the console should have written a tour key" (Received: null)
✓ refusing the tour before it starts is remembered ...
```

Exactly the shape the audit reported. With the fix, 3 passed.

`frontend/test/unit/tour-terminal.test.ts` — 9 tests over `terminalOutcome`, and the copied-constant guard the issue asked for: it imports the real `EVENTS` / `STATUS` from react-joyride (a test is not shipped, so it may) and asserts each literal in `events.ts` still equals the package's own value, so a version bump that renames one fails in milliseconds instead of silently going back to recording nothing.

## Commands run locally

```
npm run typecheck          # pass
npm run typecheck:unit     # pass
npm run typecheck:e2e      # pass
npx vitest run             # 171 files, 1645 tests, pass
npx playwright test tour-completion-persists   # 3 passed (against a host on :8621)
```

## Behaviour changes

The tour is now recorded as seen when it is completed or skipped mid-run, so the welcome card stops being re-offered. No API, storage-key, or storage-format change.
