### PR TITLE
design: give the Work page a header about the list, and a row about the view

### DIFF
--- a/frontend/src/lib/inline-code.tsx
+++ b/frontend/src/lib/inline-code.tsx
@@ -1,0 +1,46 @@
+// Backtick code spans in a one-line string, rendered rather than printed.
+//
+// A ledger's `purpose` and `writtenBy` are authored as Markdown — the derived
+// file renders them, and the strings lean on it: *"this ledger is written
+// through the board — not with `record_entry`"*. The console printed them as
+// plain text, so every surface that showed one showed the backticks: the Work
+// page subtitle, its Details disclosure, and every row of Manage lists.
+//
+// Deliberately not the full `Markdown` component. These are single-line labels
+// sitting inside an `h1`'s subtitle or a table row, and that component brings a
+// block layout — paragraphs, headings, lists, its own vertical rhythm — to a
+// place with room for none of it. Code spans are the only Markdown these
+// strings actually use, so this handles exactly that and leaves everything else
+// as the literal characters the author typed.
+
+import { Fragment, type ReactNode } from "react";
+
+/** Splits on paired backticks. An unpaired one is a literal backtick. */
+const SPAN = /`([^`]+)`/g;
+
+/**
+ * `text` with its `code spans` rendered.
+ *
+ * Returns the string unchanged when it holds none, so the overwhelmingly common
+ * case costs one regex test and no extra elements.
+ */
+export function inlineCode(text: string): ReactNode {
+  if (!text.includes("`")) return text;
+  const out: ReactNode[] = [];
+  let last = 0;
+  for (const match of text.matchAll(SPAN)) {
+    const at = match.index ?? 0;
+    if (at > last) out.push(text.slice(last, at));
+    out.push(
+      <code
+        key={`${at}-${match[1]}`}
+        className="rounded bg-muted px-1 py-0.5 font-mono text-xs"
+      >
+        {match[1]}
+      </code>,
+    );
+    last = at + match[0].length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out.map((piece, n) => <Fragment key={n}>{piece}</Fragment>);
+}

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -91,6 +91,7 @@ import {
   type LedgerRead,
   type LedgerSummary,
 } from "@/api/ledgers";
+import { inlineCode } from "@/lib/inline-code";
 import { Markdown } from "@/components/markdown";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -222,7 +223,10 @@ export const MANAGE_SEGMENT = "manage";
 export const NEW_LIST_FLAG = "new";
 
 /** Slugs a declared list may not take — reserved for routing, not data. */
-export const RESERVED_SEGMENTS: readonly string[] = [MANAGE_SEGMENT, NEW_LIST_FLAG];
+export const RESERVED_SEGMENTS: readonly string[] = [
+  MANAGE_SEGMENT,
+  NEW_LIST_FLAG,
+];
 
 /**
  * A stable empty default for `approvals`.
@@ -555,7 +559,8 @@ export function LedgersView({
       restage(was);
       const label = labelFor(columnsOf(ledger), status);
       toast.error(`Could not move "${entry.title || entry.id}" to ${label}.`, {
-        description: e instanceof Error ? e.message : "the host refused the move",
+        description:
+          e instanceof Error ? e.message : "the host refused the move",
       });
     }
   };
@@ -613,7 +618,10 @@ export function LedgersView({
               affordance is the `<button>` inside it, not the heading itself,
               so a screen reader still announces "heading level 1: Goals"
               rather than losing the page's landmark structure to a button. */}
-          <h1 className="text-xl font-semibold">
+          {/* A flex row, because the trigger inside is a flex button: as
+              ordinary inline content the count badge wrapped to a line of its
+              own and cost back the space this header just saved. */}
+          <h1 className="flex flex-wrap items-center gap-2 text-xl font-semibold">
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
@@ -627,7 +635,10 @@ export function LedgersView({
                   </button>
                 }
               />
-              <DropdownMenuContent align="start" className="max-h-[60vh] w-56 overflow-y-auto">
+              <DropdownMenuContent
+                align="start"
+                className="max-h-[60vh] w-56 overflow-y-auto"
+              >
                 {ledgers.map((held) => (
                   <DropdownMenuItem
                     key={held.slug}
@@ -637,7 +648,9 @@ export function LedgersView({
                     <Check
                       className={cn(
                         "size-4",
-                        held.slug === ledger?.slug ? "opacity-100" : "opacity-0",
+                        held.slug === ledger?.slug
+                          ? "opacity-100"
+                          : "opacity-0",
                       )}
                     />
                     <span className="flex-1 truncate">{held.title}</span>
@@ -646,7 +659,9 @@ export function LedgersView({
                         count information" for the zero case, not as "zero" —
                         the same ambiguity `filteredEmptyNotice` exists to
                         rule out elsewhere in this file. */}
-                    <span className="text-xs text-muted-foreground">{held.open}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {held.open}
+                    </span>
                   </DropdownMenuItem>
                 ))}
                 <DropdownMenuSeparator />
@@ -673,44 +688,103 @@ export function LedgersView({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            {/* How much is live here, beside the name — the one fact about a
+                list that changes, and the one the switcher already shows for
+                every *other* list while saying nothing about the open one. */}
+            {ledger && (
+              <span
+                title={`${ledger.open} open`}
+                className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium tabular-nums text-muted-foreground"
+              >
+                {ledger.open}
+              </span>
+            )}
           </h1>
-          <p className="text-sm text-muted-foreground">
-            {ledger
-              ? ledger.purpose
-              : "This list does not exist, or was retired. Pick another from the title menu."}
-          </p>
+          {!ledger && (
+            <p className="text-sm text-muted-foreground">
+              This list does not exist, or was retired. Pick another from the
+              title menu.
+            </p>
+          )}
           {ledger && (
+            // The purpose lives in here now (issue #1349). It is a fixed
+            // sentence about the engine — "this ledger is written through the
+            // board, not with `record_entry`" — written for whoever declares a
+            // list, not for the operator working one, and it was holding two
+            // permanent lines above the board on the console's most-visited
+            // screen. Read once, then never again; a disclosure is what that
+            // shape of text is for.
             <details className="text-xs text-muted-foreground">
-              <summary className="cursor-pointer select-none">Details</summary>
-              <div className="mt-1 space-y-1">
+              <summary className="w-fit cursor-pointer select-none rounded px-1 py-0.5 hover:bg-accent/50 hover:text-foreground">
+                About this list
+              </summary>
+              <div className="mt-1 max-w-prose space-y-1 px-1">
+                <p>{inlineCode(ledger.purpose)}</p>
                 <p>
                   Renders into <code>{ledger.derived}</code>
                 </p>
                 {!isWritable(ledger) && (
                   <p className="flex items-start gap-1.5">
                     <Lock className="mt-0.5 size-3 shrink-0" />
-                    Rows here are opened elsewhere: {ledger.writtenBy}. You can
-                    still move one between columns — that goes through the
-                    board, which is what makes it start work.
+                    <span>
+                      Rows here are opened elsewhere:{" "}
+                      {inlineCode(ledger.writtenBy)}. You can still move one
+                      between columns — that goes through the board, which is
+                      what makes it start work.
+                    </span>
                   </p>
                 )}
               </div>
             </details>
           )}
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            void refreshRead();
-            // The board's cards are decorated from a second read, and this
-            // button is the whole manual fallback on a screen with no timer.
-            void refreshTasks();
-          }}
-        >
-          <RefreshCw className="mr-2 size-4" />
-          Refresh
-        </Button>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void refreshRead();
+              // The board's cards are decorated from a second read, and this
+              // button is the whole manual fallback on a screen with no timer.
+              void refreshTasks();
+            }}
+          >
+            <RefreshCw className="mr-2 size-4" />
+            Refresh
+          </Button>
+          {/* The primary action sits on the title row, not in the filter bar
+              below it (issue #1349). Down there it was the fourth of four
+              buttons in one flat row, at the same weight as a view toggle and
+              a file viewer — three different kinds of control, one of which
+              opens work and two of which change how you are looking at it. The
+              reference puts it here, beside the name and the count, and it is
+              right: this is the row about the list, that one is about the
+              view. */}
+          {ledger &&
+            (isWritable(ledger) ? (
+              <Button
+                size="sm"
+                onClick={() =>
+                  setComposing({
+                    id: "",
+                    fields: {},
+                    status: ledger.statuses[0]?.name ?? "",
+                    closing: false,
+                  })
+                }
+              >
+                <Plus className="mr-2 size-4" />
+                Record
+              </Button>
+            ) : (
+              ledger.slug === BOARD_LEDGER && (
+                <Button size="sm" onClick={() => setCreatingCard(true)}>
+                  <Plus className="mr-2 size-4" />
+                  Add task
+                </Button>
+              )
+            ))}
+        </div>
       </header>
 
       {error && (
@@ -736,7 +810,9 @@ export function LedgersView({
                 </div>
                 <Select
                   value={statusFilter}
-                  onValueChange={(value) => setStatusFilter(value ?? EVERY_STATUS)}
+                  onValueChange={(value) =>
+                    setStatusFilter(value ?? EVERY_STATUS)
+                  }
                 >
                   {/* Explicit trigger text, for the reason issue #813 gave the
                       destination picker its own: base-ui renders the stored
@@ -745,7 +821,9 @@ export function LedgersView({
                       status", and a chosen board column read `in_progress`
                       beside columns headed "In progress". */}
                   <SelectTrigger className="w-[12rem]">
-                    <SelectValue>{statusFilterLabel(ledger, statusFilter)}</SelectValue>
+                    <SelectValue>
+                      {statusFilterLabel(ledger, statusFilter)}
+                    </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={EVERY_STATUS}>Every status</SelectItem>
@@ -773,33 +851,16 @@ export function LedgersView({
                   )}
                   {mode === "board" ? "List" : "Board"}
                 </Button>
-                <Button variant="outline" size="sm" onClick={() => void showRendered()}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void showRendered()}
+                >
                   <FileText className="mr-2 size-4" />
                   Rendered file
                 </Button>
-                {isWritable(ledger) ? (
-                  <Button
-                    size="sm"
-                    onClick={() =>
-                      setComposing({
-                        id: "",
-                        fields: {},
-                        status: ledger.statuses[0]?.name ?? "",
-                        closing: false,
-                      })
-                    }
-                  >
-                    <Plus className="mr-2 size-4" />
-                    Record
-                  </Button>
-                ) : (
-                  ledger.slug === BOARD_LEDGER && (
-                    <Button size="sm" onClick={() => setCreatingCard(true)}>
-                      <Plus className="mr-2 size-4" />
-                      Add task
-                    </Button>
-                  )
-                )}
+                {/* The primary action moved up to the title row (issue
+                    #1349): this row is the view, that one is the list. */}
                 {/* Retiring a list moved to Manage Lists (issue #1284),
                     reached from the Company page — the same place it is
                     declared. This screen is about a list's rows now, never
@@ -817,8 +878,10 @@ export function LedgersView({
                   indistinguishably — the read is filtered server-side. The two
                   are not the same claim, and saying the stronger one over a
                   ledger the nav is counting 14 rows for is simply false. */}
-              {read && read.entries.length === 0 && !reading && (
-                emptyNotice ? (
+              {read &&
+                read.entries.length === 0 &&
+                !reading &&
+                (emptyNotice ? (
                   <div
                     className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
                     data-testid="ledger-filtered-empty"
@@ -829,11 +892,13 @@ export function LedgersView({
                     </Button>
                   </div>
                 ) : (
-                  <p className="text-sm text-muted-foreground" data-testid="ledger-empty">
+                  <p
+                    className="text-sm text-muted-foreground"
+                    data-testid="ledger-empty"
+                  >
                     Nothing recorded here yet.
                   </p>
-                )
-              )}
+                ))}
 
               {mode === "board" && read ? (
                 <BoardMode
@@ -842,7 +907,9 @@ export function LedgersView({
                   onMove={(entry, status) => void move(entry, status)}
                   // A drop on dead board pixels. Saying so is the whole fix:
                   // silence here is indistinguishable from a frozen app.
-                  onMiss={() => toast.error("Drop the card on a column to move it.")}
+                  onMiss={() =>
+                    toast.error("Drop the card on a column to move it.")
+                  }
                   onOpen={(entry) =>
                     ledger.source === "native" && onOpenCard
                       ? onOpenCard(entry.id)
@@ -855,7 +922,9 @@ export function LedgersView({
                   }
                   // The `Task` behind a native board row, when there is one.
                   // Absent for every declared ledger, whose rows are rows.
-                  taskFor={isBoard ? (entry) => taskById.get(entry.id) : undefined}
+                  taskFor={
+                    isBoard ? (entry) => taskById.get(entry.id) : undefined
+                  }
                   approvals={approvals}
                   now={clock}
                   // Resume is a move, not a second write path: back into In
@@ -907,12 +976,34 @@ export function LedgersView({
                 </p>
               )}
 
-              {read?.faults?.map((fault) => (
-                <Alert key={fault}>
+              {/* One row, not one per fault (issue #1347).
+                  
+                  A ledger whose rows are written by agents produces faults in
+                  batches — a required field one pass forgot is missing from
+                  every row that pass wrote — so this was seven full-width
+                  alerts, 364px of the same sentence with a different id in it,
+                  stacked below the board and out-weighing the content they are
+                  about. The count is the whole headline; the ids are what you
+                  open when you go looking. */}
+              {read?.faults && read.faults.length > 0 && (
+                <Alert data-testid="ledger-faults">
                   <AlertTriangle className="size-4" />
-                  <AlertDescription>{fault}</AlertDescription>
+                  <AlertDescription>
+                    <details>
+                      <summary className="w-fit cursor-pointer select-none">
+                        {read.faults.length === 1
+                          ? "1 row could not be read"
+                          : `${read.faults.length} rows could not be read`}
+                      </summary>
+                      <ul className="mt-2 space-y-1">
+                        {read.faults.map((fault) => (
+                          <li key={fault}>{inlineCode(fault)}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  </AlertDescription>
                 </Alert>
-              ))}
+              )}
             </>
           )}
         </section>
@@ -1293,7 +1384,9 @@ function ComposeDialog({
               <Label htmlFor={`ledger-field-${field.name}`}>
                 {field.name}
                 {field.required && " *"}
-                {field.name === "reason" && needsReason && " — required to close"}
+                {field.name === "reason" &&
+                  needsReason &&
+                  " — required to close"}
               </Label>
               {field.role === "prose" ? (
                 <Textarea

--- a/frontend/src/views/company/ManageListsView.tsx
+++ b/frontend/src/views/company/ManageListsView.tsx
@@ -22,6 +22,7 @@ import { useEffect, useState } from "react";
 import { AlertTriangle, ArrowLeft, Lock, Plus } from "lucide-react";
 import { toast } from "sonner";
 
+import { inlineCode } from "@/lib/inline-code";
 import type { OpenCompanyClient } from "@/api/client";
 import { retireLedger, type LedgerSummary } from "@/api/ledgers";
 import {
@@ -53,7 +54,9 @@ interface Props {
 
 export function ManageListsView({ client, company, ledgerNav, onBack }: Props) {
   const [declaring, setDeclaring] = useState(false);
-  const [confirmRetire, setConfirmRetire] = useState<LedgerSummary | null>(null);
+  const [confirmRetire, setConfirmRetire] = useState<LedgerSummary | null>(
+    null,
+  );
   const [retiring, setRetiring] = useState(false);
 
   const { ledgers, faults, remaining, loading, refresh } = ledgerNav;
@@ -115,9 +118,9 @@ export function ManageListsView({ client, company, ledgerNav, onBack }: Props) {
           <div>
             <h1 className="text-xl font-semibold">Manage lists</h1>
             <p className="text-sm text-muted-foreground">
-              Every list this company tracks — its own board, plus whatever
-              else it records. Reach any of them from the switcher on its own
-              title; retire one here.
+              Every list this company tracks — its own board, plus whatever else
+              it records. Reach any of them from the switcher on its own title;
+              retire one here.
             </p>
           </div>
           <Button
@@ -140,7 +143,9 @@ export function ManageListsView({ client, company, ledgerNav, onBack }: Props) {
         <Alert>
           <AlertTriangle className="size-4" />
           <AlertDescription>
-            <p className="font-medium">Some declarations could not be loaded:</p>
+            <p className="font-medium">
+              Some declarations could not be loaded:
+            </p>
             <ul className="mt-1 list-disc pl-4">
               {faults.map((fault) => (
                 <li key={fault}>{fault}</li>
@@ -170,19 +175,26 @@ export function ManageListsView({ client, company, ledgerNav, onBack }: Props) {
                       />
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">{held.purpose}</p>
+                  <p className="max-w-prose text-xs text-muted-foreground">
+                    {inlineCode(held.purpose)}
+                  </p>
                   <p className="text-xs text-muted-foreground">
                     {held.open} open · {held.closed} closed
                   </p>
                 </div>
                 {held.builtin ? (
-                  <span className="text-xs text-muted-foreground" title="Built into every company">
+                  <span
+                    className="text-xs text-muted-foreground"
+                    title="Built into every company"
+                  >
                     Built in
                   </span>
                 ) : (
                   <AlertDialog
                     open={confirmRetire?.slug === held.slug}
-                    onOpenChange={(open) => setConfirmRetire(open ? held : null)}
+                    onOpenChange={(open) =>
+                      setConfirmRetire(open ? held : null)
+                    }
                   >
                     <AlertDialogTrigger
                       render={
@@ -197,7 +209,9 @@ export function ManageListsView({ client, company, ledgerNav, onBack }: Props) {
                     />
                     <AlertDialogContent>
                       <AlertDialogHeader>
-                        <AlertDialogTitle>Retire “{held.title}”?</AlertDialogTitle>
+                        <AlertDialogTitle>
+                          Retire “{held.title}”?
+                        </AlertDialogTitle>
                         <AlertDialogDescription>
                           This list leaves the switcher's menu and its{" "}
                           <code>{held.derived}</code> file stops being

--- a/frontend/test/unit/inline-code.test.ts
+++ b/frontend/test/unit/inline-code.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { inlineCode } from "@/lib/inline-code";
+
+/**
+ * A ledger's `purpose` is authored as Markdown and was printed as plain text,
+ * so every console surface that showed one showed its backticks: the Work
+ * page's subtitle, its disclosure, and every row of Manage lists.
+ *
+ * The strings this has to get right are the real ones — the `tasks` purpose is
+ * the sentence the operator meets first on the console's most-visited screen.
+ */
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+async function render(text: string) {
+  await act(async () =>
+    root.render(createElement("p", null, inlineCode(text))),
+  );
+}
+
+describe("inlineCode", () => {
+  it("renders a code span as a <code>, not as backticks", async () => {
+    await render("written through the board — not with `record_entry`.");
+
+    const code = container.querySelectorAll("code");
+    expect(code).toHaveLength(1);
+    expect(code[0].textContent).toBe("record_entry");
+    expect(container.textContent).not.toContain("`");
+    expect(container.textContent).toBe(
+      "written through the board — not with record_entry.",
+    );
+  });
+
+  it("handles several spans in one sentence", async () => {
+    // The `writtenBy` string on the tasks ledger, which carries three.
+    await render(
+      "the board — `spawn_task` to open a card, `assign_task` to hand it over. `record_entry` does not write it",
+    );
+
+    expect(
+      Array.from(container.querySelectorAll("code")).map((c) => c.textContent),
+    ).toEqual(["spawn_task", "assign_task", "record_entry"]);
+  });
+
+  it("passes an ordinary sentence straight through", async () => {
+    await render("Every candidate in flight, and where each one sits.");
+
+    expect(container.querySelectorAll("code")).toHaveLength(0);
+    expect(container.textContent).toBe(
+      "Every candidate in flight, and where each one sits.",
+    );
+  });
+
+  it("leaves an unpaired backtick as the character it is", async () => {
+    // Better a literal backtick than swallowing the rest of the sentence into
+    // a code span that was never closed.
+    await render("a stray ` and then some words");
+
+    expect(container.querySelectorAll("code")).toHaveLength(0);
+    expect(container.textContent).toBe("a stray ` and then some words");
+  });
+});


### PR DESCRIPTION
Closes #1347, closes #1348, closes #1349.

From a design audit of the **Work** surface. Three findings, all above the board.

## 1. 190px of preamble, written for an agent author (#1349)

The board began 190px down the page, behind an `h1`, a two-line purpose paragraph, a `Details` disclosure and a toolbar.

The purpose is engine documentation:

> Cards dispatch when they enter In progress, so this ledger is written through the board — not with `record_entry`.

That is written for whoever *declares* a list, not for the operator *working* one. It never changes, it is read once, and it was holding two permanent lines on the console's most-visited screen. It moves into the disclosure — which gains a name ("About this list" rather than "Details") and a real hover affordance, instead of being an 11px unstyled `<summary>`.

**The primary action moves up beside the title**, where the reference (`927:2643`) puts it: `Board` + count + `+ Add task` on one row. In the filter row it was the fourth of four buttons at identical weight — a view toggle, a file viewer, and the control that *opens work*, all reading as peers. Now the title row is about the **list** (name, open count, Refresh, Record/Add task) and the row below is about the **view** (search, status, Board/List, Rendered file).

The open count also joins the title. The switcher already showed a count for every list *except* the one you are looking at.

Board top edge: **190px → 158px**, and the hierarchy is right.

## 2. Backticks printed literally (#1348)

`purpose` and `writtenBy` are authored as Markdown — the derived file renders them — but every console surface printed them raw: the subtitle, the disclosure, and every row of Manage lists.

`inlineCode` renders code spans and nothing else. Deliberately **not** the full `Markdown` component: these are single-line labels inside an `h1`'s subtitle or a table row, and that component brings paragraphs, headings and its own vertical rhythm to a place with room for none of it.

Manage lists also gains `max-w-prose` — its descriptions were running the full 1160px, roughly 180 characters per line.

## 3. Read faults, one full-width alert each (#1347)

An agent-written ledger produces faults in batches — a required field one pass forgot is missing from every row that pass wrote. A live Goals list rendered **seven** identical full-width alerts: 364px of the same sentence with a different id in it, stacked below the board and out-weighing the content they are about.

Now one row that opens to the list. That also gives the board back the height the stack was taking — the `Active` column's fourth card was being clipped by it.

## Not in this PR

The fault alert's glyph is still the neutral `Alert` variant, so it reads grey rather than amber in dark. Left on #1347. Manage lists' row density and its `Retire` affordance are #1352.

## Tests

`test/unit/inline-code.test.ts` — four cases over the real strings, including the `tasks` purpose and the three-span `writtenBy`, plus an unpaired backtick (left as the character it is, rather than swallowing the rest of the sentence).

## Commands run

- `npm run typecheck` / `typecheck:unit` / `typecheck:e2e`
- `npx vitest run` — 1640 passed, 171 files
- `scripts/ci/assert-design-tokens.sh`
- Browser-verified at 1440px and 1100px, light and dark, against a live seeded host, on Tasks, Goals and Manage lists
- `upstream/main` merged before push