### PR TITLE
fix: make first-run company setup reachable, and give it a lane that cannot skip itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1665,80 +1665,6 @@ jobs:
           path: frontend/test-results/
           retention-days: 7
 
-  # Issue #1404. First-run company setup gets its OWN lane because it needs its
-  # own host: the flow opens only on a company nobody has staffed, and every
-  # company under `companies/` except `companies/e2e_setup` declares a roster of
-  # its own — including `companies/e2e_harness`, which the lane above serves. One
-  # host cannot satisfy both, so this is a second run rather than a matrix leg.
-  #
-  # Before this lane existed, `company-setup.spec.ts` was covered by NOTHING. Its
-  # own header said so. It carried a `test.skip` for a host serving the wrong
-  # company, no job ever set the variable that would have un-skipped it, and once
-  # the global baseline began merging four undeletable teammates into every
-  # company the guard fired on every run — so the console lane stayed green while
-  # the entire first-run experience was unreachable in the shipped product. That
-  # is `CLAUDE.md`'s "builds, runs and reports zero without failing anything", in
-  # a browser suite.
-  #
-  # Which is why the step below is a SCRIPT and not `npm run e2e:first-run`.
-  # `assert-e2e-spec-ran.sh` reads the run's own reported count and fails on
-  # zero, the same way `assert-integration-targets-run.sh` does for the Rust
-  # targets. A lane whose only guarantee is its configuration can be silently
-  # vacuous; a lane that asserts a number cannot.
-  console-e2e-first-run:
-    needs: [changes, rust]
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
-    name: Console E2E (first run)
-    runs-on: ubuntu-latest
-    # One spec with two tests, each of which builds a real team. Well inside
-    # this; the cap is a wedged-browser backstop.
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          # No `submodules`: the binary arrives prebuilt from the `rust` job and
-          # nothing here resolves a cargo manifest, same as the lane above.
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: frontend/.nvmrc
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - run: npm ci
-        working-directory: frontend
-
-      - name: Download the host binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: opencompany-debug-binary
-          path: target/debug
-
-      # `upload-artifact` does not preserve the executable bit; `host.sh` tests
-      # for `-x` and would answer with a build instruction.
-      - name: Restore the executable bit
-        run: chmod +x target/debug/opencompany
-
-      - name: Install Chromium
-        run: npx playwright install --with-deps chromium
-        working-directory: frontend
-
-      # `PW_FIRST_RUN=1` (set by the npm script this calls) is what makes
-      # `playwright.config.ts` serve `companies/e2e_setup` on a data root of its
-      # own AND select the first-run spec and only it. The script then asserts
-      # the run reported a non-zero count — see its header.
-      - name: Run the first-run lane and assert it executed
-        run: scripts/ci/assert-e2e-spec-ran.sh
-
-      - name: Upload failure artifacts
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: playwright-first-run-failures
-          path: frontend/test-results/
-          retention-days: 7
-
   # Issue #467. The lane above is the DEFAULT feature set, and four of the
   # suite's specs cannot pass against it — not because they are wrong, but
   # because the thing they test is not compiled in. They skip themselves through
@@ -1835,6 +1761,83 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-live-brain-failures
+          path: frontend/test-results/
+          retention-days: 7
+
+  # Issue #1404. First-run company setup gets its OWN lane because it needs its
+  # own host: the flow opens only on a company nobody has staffed, and every
+  # company under `companies/` except `companies/e2e_setup` declares a roster of
+  # its own — including `companies/e2e_harness`, which both `Console E2E` lanes
+  # serve. One host cannot satisfy both, so this is a third run rather than a
+  # matrix leg of either. It needs only the DEFAULT binary: nothing here runs an
+  # agent turn, and the design pass falls back to a curated team with no model
+  # reachable (decision D3), which is a path worth exercising in its own right.
+  #
+  # Before this lane existed, `company-setup.spec.ts` was covered by NOTHING. Its
+  # own header said so. It carried a `test.skip` for a host serving the wrong
+  # company, no job ever set the variable that would have un-skipped it, and once
+  # the global baseline began merging four undeletable teammates into every
+  # company the guard fired on every run — so the console lane stayed green while
+  # the entire first-run experience was unreachable in the shipped product. That
+  # is `CLAUDE.md`'s "builds, runs and reports zero without failing anything", in
+  # a browser suite.
+  #
+  # Which is why the step below is a SCRIPT and not `npm run e2e:first-run`.
+  # `assert-e2e-spec-ran.sh` reads the run's own reported count and fails on
+  # zero, the same way `assert-integration-targets-run.sh` does for the Rust
+  # targets. A lane whose only guarantee is its configuration can be silently
+  # vacuous; a lane that asserts a number cannot.
+  console-e2e-first-run:
+    needs: [changes, rust]
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
+    name: Console E2E (first run)
+    runs-on: ubuntu-latest
+    # One spec with two tests, each of which builds a real team. Well inside
+    # this; the cap is a wedged-browser backstop.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # No `submodules`: the binary arrives prebuilt from the `rust` job and
+          # nothing here resolves a cargo manifest, same as the lane above.
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+        working-directory: frontend
+
+      - name: Download the host binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: opencompany-debug-binary
+          path: target/debug
+
+      # `upload-artifact` does not preserve the executable bit; `host.sh` tests
+      # for `-x` and would answer with a build instruction.
+      - name: Restore the executable bit
+        run: chmod +x target/debug/opencompany
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      # `PW_FIRST_RUN=1` (set by the npm script this calls) is what makes
+      # `playwright.config.ts` serve `companies/e2e_setup` on a data root of its
+      # own AND select the first-run spec and only it. The script then asserts
+      # the run reported a non-zero count — see its header.
+      - name: Run the first-run lane and assert it executed
+        run: scripts/ci/assert-e2e-spec-ran.sh
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-first-run-failures
           path: frontend/test-results/
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1665,6 +1665,80 @@ jobs:
           path: frontend/test-results/
           retention-days: 7
 
+  # Issue #1404. First-run company setup gets its OWN lane because it needs its
+  # own host: the flow opens only on a company nobody has staffed, and every
+  # company under `companies/` except `companies/e2e_setup` declares a roster of
+  # its own — including `companies/e2e_harness`, which the lane above serves. One
+  # host cannot satisfy both, so this is a second run rather than a matrix leg.
+  #
+  # Before this lane existed, `company-setup.spec.ts` was covered by NOTHING. Its
+  # own header said so. It carried a `test.skip` for a host serving the wrong
+  # company, no job ever set the variable that would have un-skipped it, and once
+  # the global baseline began merging four undeletable teammates into every
+  # company the guard fired on every run — so the console lane stayed green while
+  # the entire first-run experience was unreachable in the shipped product. That
+  # is `CLAUDE.md`'s "builds, runs and reports zero without failing anything", in
+  # a browser suite.
+  #
+  # Which is why the step below is a SCRIPT and not `npm run e2e:first-run`.
+  # `assert-e2e-spec-ran.sh` reads the run's own reported count and fails on
+  # zero, the same way `assert-integration-targets-run.sh` does for the Rust
+  # targets. A lane whose only guarantee is its configuration can be silently
+  # vacuous; a lane that asserts a number cannot.
+  console-e2e-first-run:
+    needs: [changes, rust]
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
+    name: Console E2E (first run)
+    runs-on: ubuntu-latest
+    # One spec with two tests, each of which builds a real team. Well inside
+    # this; the cap is a wedged-browser backstop.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # No `submodules`: the binary arrives prebuilt from the `rust` job and
+          # nothing here resolves a cargo manifest, same as the lane above.
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+        working-directory: frontend
+
+      - name: Download the host binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: opencompany-debug-binary
+          path: target/debug
+
+      # `upload-artifact` does not preserve the executable bit; `host.sh` tests
+      # for `-x` and would answer with a build instruction.
+      - name: Restore the executable bit
+        run: chmod +x target/debug/opencompany
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      # `PW_FIRST_RUN=1` (set by the npm script this calls) is what makes
+      # `playwright.config.ts` serve `companies/e2e_setup` on a data root of its
+      # own AND select the first-run spec and only it. The script then asserts
+      # the run reported a non-zero count — see its header.
+      - name: Run the first-run lane and assert it executed
+        run: scripts/ci/assert-e2e-spec-ran.sh
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-first-run-failures
+          path: frontend/test-results/
+          retention-days: 7
+
   # Issue #467. The lane above is the DEFAULT feature set, and four of the
   # suite's specs cannot pass against it — not because they are wrong, but
   # because the thing they test is not compiled in. They skip themselves through

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -246,6 +246,15 @@ write. See [runtime/tools.md](tools.md).
 "orchestrator"` agent, else the first declared) rather than read off `tier`, so
 a company that tags nobody still names its orchestrator.
 
+`global` marks the teammates the [global baseline](globals.md) merged in — the
+ones every company has whichever vertical it started from, and the ones
+`DELETE …/team/{agentId}` refuses. It is sent on every row because a client
+cannot otherwise tell a company somebody staffed from one nobody has: the
+baseline is on every roster, so `length === 0` is a question with one answer.
+The console's first-run gate turns on it
+([company-setup.md](company-setup.md)); before the field existed that gate could
+never open.
+
 `PATCH …/team/{agentId}` edits an **overlay** teammate's `name`, `role` and
 `description`. It is a patch: an omitted key is left alone, and `"description":
 null` clears it — the two must stay apart or every partial save would erase an

--- a/docs/spec/runtime/company-setup.md
+++ b/docs/spec/runtime/company-setup.md
@@ -373,7 +373,11 @@ Two related problems surfaced in the same run, both fixed:
 - The Team page fabricated a twelve-agent starter roster whenever the host
   answered with nobody, so "this company has no team yet" rendered directly above
   twelve agents that did not exist on the host. A genuinely empty company now
-  shows an honest empty state.
+  shows an honest empty state. The same sentence had to go for the mirror-image
+  reason once the gate started opening again: the prompt renders above the
+  baseline's teammates, who *do* exist on the host, so it now reads "this company
+  hasn't been set up yet" — true whether the roster below it holds nobody or the
+  baseline's four.
 - The product tour is held not only while the dialog is open but for as long as
   the company is unstaffed. Otherwise skipping setup popped the tour's welcome
   straight over an empty console — the first impression this document exists to

--- a/docs/spec/runtime/company-setup.md
+++ b/docs/spec/runtime/company-setup.md
@@ -322,11 +322,25 @@ For setup it is not fine, because setup *creates things*. Someone who clears
 their browser data or signs in from their phone would run it again and get a
 second team stacked on the first.
 
-**Decision D4: no flag. We ask a question we already know the answer to — does
-this company have any staff yet?** Empty team means setup has not run. A team
-with people on it means it has. This survives a cleared browser, a new laptop,
+**Decision D4: no flag. We ask a question we already know the answer to — has
+anybody staffed this company yet?** Nobody staffed means setup has not run.
+People on the team means it has. This survives a cleared browser, a new laptop,
 and a second person joining the same company, with no stored flag to drift out
 of step with reality.
+
+**"Staffed" is narrower than "has a roster", and the difference is load-bearing.**
+The [global baseline](globals.md) merges a fixed set of teammates into *every*
+company whatever its manifest says, and they cannot be deleted — `DELETE
+…/team/{id}` answers `409` on each. So "is the roster empty?" is false on every
+company this product can serve. Asked that way, as it was until issue #1404, the
+gate never opened anywhere: not on a fresh tenant, not on `companies/e2e_setup`,
+which exists for no other purpose than to reach it.
+
+The question the console asks is therefore *has this company any teammate that
+is not part of the baseline every company gets*. It reads that from the roster
+itself — `GET …/team` carries `global` on each row, the same `Agent::global`
+marker the merge sets — rather than from a list of the baseline's ids copied
+into the console, which would break silently the next time a global is added.
 
 It also happens to be exactly the signal Phase 2 needs, so nothing here has to
 change later.
@@ -341,6 +355,18 @@ so none of them can ever reach the flow — there is no way to demo or test setu
 against the shipped examples. `companies/e2e_setup` exists for exactly that
 reason: a company that ships with nobody on it, which the end-to-end lane runs
 against.
+
+And the lane has to actually run it. It did not, for as long as the flow was
+broken: `frontend/test/e2e/company-setup.spec.ts` carried a `test.skip` written
+for a host serving the wrong company, no CI job set the variable that would have
+selected the right one, and once the baseline landed the guard fired on every
+run. The console lane was green over a feature that could not open. The spec now
+**asserts** its host instead of skipping, `playwright.config.ts` selects it only
+in a first-run run (`npm run e2e:first-run`, which serves `companies/e2e_setup`
+on a data root of its own), and `Console E2E (first run)` runs it through
+`scripts/ci/assert-e2e-spec-ran.sh` — which fails on a reported count of zero,
+because a lane whose only guarantee is its configuration can be silently
+vacuous.
 
 Two related problems surfaced in the same run, both fixed:
 
@@ -395,6 +421,7 @@ most likely to go stale — trust the code over this list.
 | Create an agent | `POST …/team` (`add_member`, `src/server/ops/team.rs`) | exists |
 | Set an agent's role/description | `PATCH …/team/{agent_id}` (`src/server/ops/team_agent.rs`) | exists |
 | Read the roster (first-run check, D4) | `GET …/team` (`list_team`) | exists |
+| Tell baseline teammates from staffed ones | `TeamMemberDto.global` (`list_team`, `team_agent::is_global`) | exists |
 | Desk and agent folders | `ensure_workspace_scaffold`, `ensure_agent_folder`, `ensure_desk_folder` (`src/company/workspace_scaffold.rs`) | exists |
 | Talk to an agent afterwards | existing chat surface | exists |
 | Answers → proposed roster | — | **new** |

--- a/docs/spec/runtime/globals.md
+++ b/docs/spec/runtime/globals.md
@@ -103,6 +103,15 @@ rather than a bare `toml::from_str`: a company is provisioned once and read
 thereafter, so a baseline applied only where bundles are parsed would reach new
 companies and no existing one.
 
+`Agent::global` also travels to the console, on every `GET …/team` row. That is
+not decoration: because the baseline is merged into every company, "is this
+roster empty?" is false everywhere, and the console's first-run gate asked
+exactly that — so [company setup](company-setup.md) could not open on any
+company, including the fixture built to reach it (issue #1404). The gate now
+asks whether any teammate is *not* from the baseline, which is a question only
+the provenance marker can answer. A console re-deriving it from a copied list of
+global ids would break on the next global added, silently.
+
 ## Adding to the baseline
 
 1. Add the file under `globals/agents/` or `globals/workflows/`, or the slug to

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed",
     "e2e:live": "PW_LIVE_BRAIN=1 playwright test",
+    "e2e:first-run": "PW_FIRST_RUN=1 playwright test",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import {
   COMPOSIO,
   COMPOSIO_FIXTURE_BIND,
+  FIRST_RUN,
+  FIRST_RUN_COMPANY,
   LIVE_BRAIN,
   MCP_FIXTURE_BIND,
   MOCK_BRAIN_BIND,
@@ -62,6 +64,14 @@ const here = dirname(fileURLToPath(import.meta.url));
  * reconfigure a host it did not launch.
  */
 
+/**
+ * The one spec that needs a host serving a company nobody has staffed
+ * (`companies/e2e_setup`), and which therefore cannot share a host with the
+ * rest of the suite. See `FIRST_RUN` in `test/e2e/capabilities.ts` for why this
+ * is a second run rather than a skip inside the spec — issue #1404.
+ */
+const FIRST_RUN_SPEC = /company-setup\.spec\.ts$/;
+
 const providedBaseURL = process.env.PW_BASE_URL;
 
 /** Whether this config is responsible for the host, as opposed to driving yours. */
@@ -77,7 +87,16 @@ const baseURL = providedBaseURL || "http://127.0.0.1:8080";
  */
 const storageState =
   process.env.PW_STORAGE_STATE ||
-  (managesHost ? resolve(here, "../target/e2e/storage-state.json") : undefined);
+  (managesHost
+    ? resolve(
+        here,
+        // A path of its own for the first-run run: it signs into a different
+        // company on a different data root, so a shared file would hand one run
+        // the other's session — which reads as a mysterious sign-in loop rather
+        // than as the collision it is.
+        FIRST_RUN ? "../target/e2e/first-run-storage-state.json" : "../target/e2e/storage-state.json",
+      )
+    : undefined);
 
 // `global-setup.ts` writes that file but does not create its directory, and
 // `target/e2e/` does not exist on a clean checkout.
@@ -122,10 +141,31 @@ const composioEnv: Record<string, string> = managesComposio
   ? { OPENCOMPANY_COMPOSIO_BACKEND_URL: `http://${COMPOSIO_FIXTURE_BIND}` }
   : {};
 
+/**
+ * What a first-run run tells `test/e2e/host.sh` to serve.
+ *
+ * The company is the whole point: `companies/e2e_setup` declares no `[[agent]]`,
+ * so it is the only company this repository ships that first-run setup can open
+ * on. The data root is separate for the same reason it is wiped — the spec
+ * creates a team, and a second run against a root still holding the first one's
+ * team would find the company already staffed and the gate correctly shut.
+ *
+ * Both are read by `host.sh` itself rather than by the host binary, so they do
+ * not go through `PW_HOST_PASSTHROUGH`.
+ */
+const firstRunEnv: Record<string, string> =
+  managesHost && FIRST_RUN
+    ? {
+        PW_HOST_COMPANY: resolve(here, "..", FIRST_RUN_COMPANY),
+        PW_HOST_DATA_DIR: resolve(here, "../target/e2e/first-run-data"),
+      }
+    : {};
+
 const passthrough = [...Object.keys(inferenceEnv), ...Object.keys(composioEnv)];
 const hostEnv: Record<string, string> = {
   ...inferenceEnv,
   ...composioEnv,
+  ...firstRunEnv,
   ...(passthrough.length > 0 ? { PW_HOST_PASSTHROUGH: passthrough.join(" ") } : {}),
 };
 
@@ -175,6 +215,14 @@ const fixtureServers = [
 
 export default defineConfig({
   testDir: "./test/e2e",
+  // The two runs are disjoint **by selection**, not by a guard inside a spec.
+  // A first-run run drives a host serving an unstaffed company and can only run
+  // the first-run spec; every other run drives the harness company, against
+  // which that spec is unpassable. Expressing it here means neither run can be
+  // pointed at a host it cannot pass against, and — because Playwright exits
+  // non-zero when a selection matches nothing — an empty selection is a
+  // failure rather than a silent zero (issue #1404).
+  ...(FIRST_RUN ? { testMatch: FIRST_RUN_SPEC } : { testIgnore: FIRST_RUN_SPEC }),
   globalSetup: storageState ? "./test/e2e/global-setup.ts" : undefined,
   fullyParallel: false,
   workers: 1,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -727,6 +727,26 @@ export interface TeamMemberDto {
   /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
   budgetSetAtMillis?: number;
   /**
+   * Whether this teammate came from the **global baseline** — the agents,
+   * workflows and skills every company gets whichever vertical it started from
+   * (`docs/spec/runtime/globals.md`) — rather than from this company's own
+   * roster or from an operator.
+   *
+   * Provenance, and the field first-run setup is gated on (issue #1404). The
+   * baseline is merged into every company whatever its manifest says, so
+   * `roster.length === 0` is never true and the gate that used it could never
+   * open — including on `companies/e2e_setup`, the fixture that exists solely
+   * to reach that flow. Read this rather than testing ids against a hard-coded
+   * list of baseline agents, which re-breaks the moment the baseline changes.
+   *
+   * **Optional on the type, not on the wire**: a host predating the field omits
+   * it, and `undefined` means "this host cannot say". The setup gate reads that
+   * as *not* baseline, which is the conservative answer — counting an unknown
+   * row as baseline would offer setup to a company that already has a team and
+   * stack a second one on it.
+   */
+  global?: boolean;
+  /**
    * The declared cognition-tier hint (`[[agent]].tier`) verbatim, from the same
    * host-side helper that answers `GET .../team/{agentId}` (issue #643).
    *

--- a/frontend/src/lib/company-setup.ts
+++ b/frontend/src/lib/company-setup.ts
@@ -132,29 +132,64 @@ export function draftIsSubmittable(draft: SetupDraft): boolean {
 }
 
 /**
- * Whether this company still has nobody on it.
+ * The teammates this company was actually staffed with — everyone on the roster
+ * bar the global baseline.
  *
- * The literal condition, kept as its own named function because the decision to
- * define first-run this way is a product choice rather than an implementation
- * detail — see {@link shouldOfferSetup}.
+ * ## Why the roster is not the answer on its own (issue #1404)
+ *
+ * The **global baseline** (`docs/spec/runtime/globals.md`) merges a fixed set of
+ * teammates into *every* company at boot, whatever its manifest says, and they
+ * cannot be deleted — `DELETE …/team/{id}` answers `409` on each. So
+ * `roster.length === 0`, which is what this gate used to ask, is false on every
+ * company this product can serve. First-run setup could not open anywhere,
+ * including on `companies/e2e_setup` — a company whose whole reason to exist is
+ * to reach it.
+ *
+ * The fix is not to subtract the four ids the baseline ships today. That is a
+ * copy of a list which is meant to grow, held somewhere the baseline's authors
+ * will never look, and the gate would break silently on the next addition. The
+ * host marks provenance on each row instead (`TeamMemberDto.global`, from the
+ * same `Agent::global` the merge sets), and this reads it.
+ *
+ * A host predating that field sends nothing, and `undefined` is read as "not
+ * baseline". That is the safe direction: it restores the old behaviour — no
+ * offer — rather than offering setup to a company that already has a team.
  */
-export function teamIsEmpty(roster: TeamMemberDto[]): boolean {
-  return roster.length === 0;
+export function staffedTeam(roster: TeamMemberDto[]): TeamMemberDto[] {
+  return roster.filter((member) => member.global !== true);
+}
+
+/**
+ * Whether nobody has staffed this company yet.
+ *
+ * Kept as its own named function because the decision to define first-run this
+ * way is a product choice rather than an implementation detail — see
+ * {@link shouldOfferSetup}. It is deliberately *not* "the roster is empty": see
+ * {@link staffedTeam} for why that question can no longer be asked.
+ */
+export function teamIsUnstaffed(roster: TeamMemberDto[]): boolean {
+  return staffedTeam(roster).length === 0;
 }
 
 /**
  * Whether to open setup unprompted.
  *
- * **An empty team is the signal**, not a stored "has run" flag. A flag in the
- * browser would re-fire after cleared storage or on a second device and build a
+ * **The team is the signal**, not a stored "has run" flag. A flag in the browser
+ * would re-fire after cleared storage or on a second device and build a
  * duplicate team; asking the host who is on the roster cannot drift, because it
  * is the same thing setup changes.
  *
- * The cost of this rule, accepted deliberately: a company whose manifest already
- * names agents — which is every company under `companies/` — never sees the
- * offer, because it was never unstaffed. Those companies came with a team, so
- * there is nothing for setup to do. Reaching it by hand stays possible at
- * `#/setup`, which is also how someone who skipped comes back.
+ * Decision D4 is intact and the question is narrower: not "does this company
+ * have any staff" but "does it have any staff *somebody chose for it*". The
+ * global baseline is what every company has by definition, so it is evidence of
+ * nothing — counting it is what made this gate answer `no` on every company
+ * (issue #1404).
+ *
+ * The cost of this rule, accepted deliberately: a company whose manifest names
+ * agents of its own — which is every company under `companies/` except
+ * `companies/e2e_setup` — never sees the offer, because it was never unstaffed.
+ * Those companies came with a team, so there is nothing for setup to do. The
+ * Team page's in-place prompt is how someone who skipped comes back.
  *
  * `skipped` suppresses only the *unprompted* open. It is browser-local and that
  * is safe precisely because it can only ever hide an offer, never cause a
@@ -167,7 +202,7 @@ export function shouldOfferSetup({
   roster: TeamMemberDto[];
   skipped: boolean;
 }): boolean {
-  return teamIsEmpty(roster) && !skipped;
+  return teamIsUnstaffed(roster) && !skipped;
 }
 
 /**
@@ -175,10 +210,10 @@ export function shouldOfferSetup({
  *
  * The other half of "blocking but skippable": skipping must not be a dead end,
  * so an unstaffed company keeps a visible way back in even after the dialog has
- * been dismissed. Same emptiness test, minus the skip suppression.
+ * been dismissed. Same test, minus the skip suppression.
  */
 export function shouldPromptSetup(roster: TeamMemberDto[]): boolean {
-  return teamIsEmpty(roster);
+  return teamIsUnstaffed(roster);
 }
 
 /** Progress copy for the build-out screen: `Creating your team… 2 of 5`. */

--- a/frontend/src/setup/SetupController.tsx
+++ b/frontend/src/setup/SetupController.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { OpenCompanyClient } from "@/api/client";
 import type { TeamMemberDto } from "@/api/types";
 import { useLocalScope } from "@/connections/ConnectionContext";
-import { shouldOfferSetup, teamIsEmpty } from "@/lib/company-setup";
+import { shouldOfferSetup, teamIsUnstaffed } from "@/lib/company-setup";
 import { SetupDialog } from "./SetupDialog";
 import { clearSetupSkipped, markSetupSkipped, setupSkipped } from "./state";
 
@@ -19,14 +19,20 @@ import { clearSetupSkipped, markSetupSkipped, setupSkipped } from "./state";
  *
  * ## The gate
  *
- * Open when the roster is empty and the operator has not skipped. The emptiness
- * test is the host's answer, not a stored flag, so it cannot drift from the thing
- * setup changes — see `shouldOfferSetup` for why a browser flag would be unsafe
- * for this and is fine for the skip.
+ * Open when nobody has staffed this company and the operator has not skipped.
+ * The test is the host's answer, not a stored flag, so it cannot drift from the
+ * thing setup changes — see `shouldOfferSetup` for why a browser flag would be
+ * unsafe for this and is fine for the skip.
  *
- * A company whose manifest already names agents therefore never sees the offer.
- * That is deliberate: it came with a team, so there is nothing to set up. `force`
- * is how the Team page's in-place prompt reopens it anyway.
+ * "Staffed" is narrower than "has a roster", and the difference is the whole of
+ * issue #1404: the global baseline puts undeletable teammates on **every**
+ * company, so an emptiness test never answered `true` anywhere and this dialog
+ * could not open in the shipped product. `teamIsUnstaffed` reads the host's
+ * per-row provenance instead.
+ *
+ * A company whose manifest names agents of its own therefore never sees the
+ * offer. That is deliberate: it came with a team, so there is nothing to set up.
+ * `force` is how the Team page's in-place prompt reopens it anyway.
  */
 export function SetupController({
   client,
@@ -78,7 +84,10 @@ export function SetupController({
    * staffed company or fail to open over an empty one until the fetch landed.
    */
   const [checked, setChecked] = useState(false);
-  /** Whether the host's roster is empty, independent of the skip flag. */
+  /**
+   * Whether the host says nobody has staffed this company, independent of the
+   * skip flag. The global baseline does not count — see `teamIsUnstaffed`.
+   */
   const [unstaffed, setUnstaffed] = useState(false);
   /**
    * Whether the gate has already been evaluated once in this mount.
@@ -127,7 +136,7 @@ export function SetupController({
       if (cancelled) return;
       const first = !evaluatedOnce.current;
       evaluatedOnce.current = true;
-      setUnstaffed(teamIsEmpty(roster));
+      setUnstaffed(teamIsUnstaffed(roster));
       // Only the first evaluation may open the dialog by itself; see
       // `evaluatedOnce`. Later switches still report `unstaffed`, so the tour
       // keeps holding and the Team page keeps prompting.

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -30,6 +30,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { emptyDraft, type AgentDraft, type AgentFieldKey } from "@/lib/agent";
 import { fetchBoardColumns } from "@/lib/board-columns";
+import { shouldPromptSetup } from "@/lib/company-setup";
 import {
   addMemberFailure,
   addOutcome,
@@ -89,12 +90,18 @@ export function TeamView({
   const [load, setLoad] = useState<Load>("loading");
   const [fromHost, setFromHost] = useState(false);
   /**
-   * The host answered the roster read **and** answered with nobody
+   * The host answered the roster read **and** nobody has staffed this company
    * (`docs/spec/runtime/company-setup.md`).
    *
    * Distinct from `!fromHost`, which also covers a host with no `…/team` surface
    * at all. Only the first case is a company waiting to be set up; offering
    * setup on the second would open a dialog whose first call 404s.
+   *
+   * Also distinct from "the host answered with nobody", which is what this used
+   * to mean and is a state no company can be in: the global baseline puts
+   * undeletable teammates on every roster (issue #1404). `shouldPromptSetup`
+   * discounts those, so this is `true` on a company that has the baseline and
+   * nothing else — which is exactly the company that needs the prompt.
    */
   const [hostEmpty, setHostEmpty] = useState(false);
   const [members, setMembers] = useState<TeamMember[]>([]);
@@ -151,10 +158,15 @@ export function TeamView({
   const boot = useCallback(async (): Promise<boolean> => {
     try {
       const roster = await client.listTeam(company);
+      // Every row the host holds is rendered, baseline teammates included: they
+      // are real agents an operator can open, brief and cap. The setup prompt is
+      // gated on a *different* question — whether anyone has been staffed here —
+      // so the two are read separately rather than one inferred from the other
+      // (issue #1404).
+      setHostEmpty(shouldPromptSetup(roster));
       if (roster.length) {
         setMembers(roster.map(fromDto));
         setFromHost(true);
-        setHostEmpty(false);
       } else {
         // NOT `starterTeam()`. The host answered, and answered with nobody — so
         // fabricating twelve agents here would put "Ops Lead", "Front Desk" and
@@ -164,7 +176,6 @@ export function TeamView({
         // (`docs/spec/runtime/company-setup.md`).
         setMembers([]);
         setFromHost(false);
-        setHostEmpty(true);
       }
       return true;
     } catch {
@@ -383,11 +394,16 @@ export function TeamView({
         </div>
 
         {/*
-          The other half of "blocking but skippable": while nobody is on this
-          company, keep a visible way back into setup. Skipping the dialog leaves
-          an operator on an empty page, and burying the offer would make that a
-          dead end. Gated on `fromHost` too, so the pre-connection fabricated
-          starter roster — which is not a real team — cannot hide the prompt.
+          The other half of "blocking but skippable": until somebody has staffed
+          this company, keep a visible way back into setup. Skipping the dialog
+          leaves an operator on a page with nothing of theirs on it, and burying
+          the offer would make that a dead end.
+
+          The copy says "not been set up" rather than "has no team", and that is
+          load-bearing: this prompt now renders directly above the global
+          baseline's teammates, who are real agents on the host (issue #1404).
+          Claiming there is nobody here, over four cards, would be the same lie
+          the fabricated starter roster was deleted for — pointing the other way.
         */}
         {load === "ready" && onRunSetup && hostEmpty && (
           <div
@@ -395,7 +411,7 @@ export function TeamView({
             data-testid="setup-prompt"
           >
             <div className="space-y-0.5">
-              <p className="text-sm font-medium">This company has no team yet</p>
+              <p className="text-sm font-medium">This company hasn't been set up yet</p>
               <p className="text-sm text-muted-foreground">
                 Answer three questions and we'll build you a starting team.
               </p>

--- a/frontend/test/e2e/capabilities.ts
+++ b/frontend/test/e2e/capabilities.ts
@@ -112,3 +112,42 @@ export const LIVE_BRAIN_REASON =
   "needs a --features openhuman,tinycortex,mcp host plus an inference backend; " +
   "set PW_LIVE_BRAIN=1 to run. The `Console E2E (live brain)` CI lane does " +
   "(issue #467).";
+
+/**
+ * Whether this run's host serves the **unstaffed first-run fixture**
+ * (`companies/e2e_setup`) rather than the suite's usual harness company.
+ *
+ * Set `PW_FIRST_RUN=1`, or run `npm run e2e:first-run`, which sets it and — when
+ * this config manages the host — points that host at the fixture and at a data
+ * root of its own.
+ *
+ * ## Why this is a separate run and not a skip inside the spec
+ *
+ * First-run setup opens only on a company nobody has staffed, and every company
+ * under `companies/` except this fixture declares a roster of its own. So
+ * `company-setup.spec.ts` cannot pass against the harness company and the
+ * harness company cannot serve the rest of the suite — two hosts, therefore two
+ * runs.
+ *
+ * It used to be one run with a `test.skip` inside the spec, and that is the
+ * shape issue #1404 was half about: the guard read the roster, found the global
+ * baseline on it, and skipped **every time**, so the lane reported green over a
+ * feature that could not open at all. `CLAUDE.md` names this exact pathology for
+ * Rust targets — "builds, runs and reports zero without failing anything".
+ *
+ * The replacement has three parts, and all three are needed:
+ *
+ *   1. {@link playwright.config.ts} selects the first-run spec **only** in a
+ *      first-run run, and every other spec **only** outside one, so neither can
+ *      be pointed at a host it cannot pass against;
+ *   2. the spec asserts its host is the right one instead of skipping, so a
+ *      mispointed run fails loudly on the first line rather than quietly on all
+ *      of them;
+ *   3. `Console E2E (first run)` in CI runs it, through
+ *      `scripts/ci/assert-e2e-spec-ran.sh`, which fails on a reported count of
+ *      zero — a number, because a configuration can look right and be vacuous.
+ */
+export const FIRST_RUN = process.env.PW_FIRST_RUN === "1";
+
+/** The company a first-run run must be serving, relative to the repository root. */
+export const FIRST_RUN_COMPANY = "companies/e2e_setup";

--- a/frontend/test/e2e/company-setup.spec.ts
+++ b/frontend/test/e2e/company-setup.spec.ts
@@ -1,57 +1,91 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 
+import { FIRST_RUN_COMPANY } from "./capabilities";
+
 /**
  * First-run company setup, end to end
  * (`docs/spec/runtime/company-setup.md`).
  *
  * Three questions asked once, then a team created on the host. This spec covers
- * the half only a browser proves: that the dialog opens by itself on an
- * unstaffed company, that the build-out screen names each teammate as its write
+ * the half only a browser proves: that the dialog opens by itself on a company
+ * nobody has staffed, that the build-out screen names each teammate as its write
  * lands, and that the roster the operator is left looking at came from the
  * **host** rather than from the console's fabricated starter team.
  *
  * A unit test pins the decisions (`test/unit/company-setup.test.ts`); this pins
  * that they are wired to a real host.
  *
- * # This lane needs its own company
+ * # This lane needs its own company, and now has its own run
  *
- * Setup opens only when the roster is empty, and every company under
- * `companies/` declares agents in its manifest — including
- * `companies/e2e_harness`, this suite's default. So a company that came with a
- * team can never reach the flow, and running this spec against the default host
- * would fail on a dialog that correctly never appears.
- *
- * Run it against the fixture that ships with nobody on it:
+ * Setup opens only on a company nobody has staffed, and every company under
+ * `companies/` except one declares agents of its own — including
+ * `companies/e2e_harness`, which the rest of the suite drives. So this spec
+ * needs a different host, which is why it is a separate run:
  *
  * ```sh
- * PW_HOST_COMPANY=companies/e2e_setup npx playwright test company-setup
+ * npm run e2e:first-run
  * ```
  *
- * The guard below skips rather than fails when that is missing, so an ordinary
- * `npx playwright test` stays green — and so a reader of the skip reason learns
- * what to set. **It is therefore not covered by any lane that does not set
- * `PW_HOST_COMPANY`**; a CI job wanting this must set it, the same trap
- * `CLAUDE.md` describes for Rust integration targets.
+ * That sets `PW_FIRST_RUN=1`, and `playwright.config.ts` does the rest: it
+ * serves `companies/e2e_setup` on a data root of its own, and selects this spec
+ * and only this spec. An ordinary `npx playwright test` does not run it at all —
+ * not by skipping it, by not selecting it.
+ *
+ * # Why the guard below fails instead of skipping (issue #1404)
+ *
+ * What stood here was:
+ *
+ * ```ts
+ * test.skip(left.length > 0, "this company ships with N manifest agents ...");
+ * ```
+ *
+ * It was written for a host serving the wrong company. What it actually did,
+ * once the global baseline began merging four undeletable teammates into
+ * **every** company, was fire on every run — including the right one. So the
+ * lane went green while first-run setup could not open anywhere in the shipped
+ * product, and nothing said a word. That is `CLAUDE.md`'s "builds, runs and
+ * reports zero without failing anything", one level up from the Rust targets it
+ * describes.
+ *
+ * A first-run lane that skips itself is worse than no lane, so the guard is now
+ * an assertion. A run pointed at the wrong host fails on its first line, naming
+ * the command to use, rather than passing vacuously.
  */
 
 const COMPANY_SCOPE = "/api/v1/company";
 
-/** The roster the host actually holds. */
-async function hostRoster(request: APIRequestContext): Promise<Array<{ role: string }>> {
+/** One row of the host's roster, as this spec reads it. */
+type RosterRow = { id?: string; role: string; global?: boolean };
+
+/** The roster the host actually holds — baseline teammates included. */
+async function hostRoster(request: APIRequestContext): Promise<RosterRow[]> {
   const res = await request.get(`${COMPANY_SCOPE}/team`);
   expect(res.ok()).toBeTruthy();
-  return (await res.json()) as Array<{ role: string }>;
+  return (await res.json()) as RosterRow[];
+}
+
+/**
+ * The teammates somebody staffed this company with — the roster minus the global
+ * baseline (`docs/spec/runtime/globals.md`), which is merged into every company
+ * and is therefore evidence of nothing.
+ *
+ * This is the quantity the whole spec is about. `hostRoster().length` is never
+ * zero on any company this host can serve, which is exactly the confusion
+ * issue #1404 was filed over; asserting on it would put the bug back.
+ */
+function staffed(roster: RosterRow[]): RosterRow[] {
+  return roster.filter((member) => member.global !== true);
 }
 
 /**
  * Removes every operator-added teammate, so a re-run starts from a first run
- * again. A manifest teammate 409s and is left alone — the fixture company has
- * none, which is the point of it.
+ * again. A manifest or baseline teammate 409s and is left alone.
  */
 async function unstaffCompany(request: APIRequestContext) {
   for (const member of await hostRoster(request)) {
-    const id = (member as { id?: string }).id;
-    if (id) await request.delete(`${COMPANY_SCOPE}/team/${id}`).catch(() => undefined);
+    if (member.id) {
+      await request.delete(`${COMPANY_SCOPE}/team/${member.id}`).catch(() => undefined);
+    }
   }
 }
 
@@ -64,15 +98,16 @@ async function answer(page: Page, field: string, text: string) {
 
 test.beforeEach(async ({ request }) => {
   await unstaffCompany(request);
-  // A company that still has people on it after unstaffing declares them in its
-  // manifest, so setup can never open. Say so, rather than failing on a missing
-  // dialog thirty lines later.
-  const left = await hostRoster(request);
-  test.skip(
-    left.length > 0,
-    `this company ships with ${left.length} manifest agents, so first-run setup ` +
-      "cannot open — run with PW_HOST_COMPANY=companies/e2e_setup",
-  );
+  // Anyone still here after unstaffing is declared in the manifest and cannot be
+  // deleted, so setup can never open on this host. Fail now, naming the command
+  // that fixes it — a skip here is what made this whole spec vacuous (#1404).
+  const left = staffed(await hostRoster(request));
+  expect(
+    left.map((member) => member.role),
+    `this host serves a company that ships with ${left.length} teammate(s) of its ` +
+      "own, so first-run setup cannot open against it. Run this spec with " +
+      `\`npm run e2e:first-run\`, which serves ${FIRST_RUN_COMPANY}.`,
+  ).toEqual([]);
 });
 
 test("first-run setup builds a real team from three answers", async ({ page, request }) => {
@@ -120,13 +155,17 @@ test("first-run setup builds a real team from three answers", async ({ page, req
   await page.getByTestId("setup-finish").click();
   await expect(dialog).toBeHidden();
 
-  // 5. The host really holds them — not the console's fabricated starter team.
-  const roster = await hostRoster(request);
-  expect(roster.length).toBeGreaterThanOrEqual(4);
+  // 5. The host really holds them — not the console's fabricated starter team,
+  //    and not the global baseline every company already had.
+  const designed = staffed(await hostRoster(request));
+  expect(
+    designed.length,
+    "the teammates setup created, over and above the baseline every company gets",
+  ).toBeGreaterThanOrEqual(4);
 
   // 6. And the Team page shows that roster, refreshed without a reload.
   await page.goto("/#/company");
-  for (const member of roster.slice(0, 3)) {
+  for (const member of designed.slice(0, 3)) {
     await expect(page.getByText(member.role, { exact: false }).first()).toBeVisible();
   }
 
@@ -156,8 +195,9 @@ test("skipping setup leaves a way back in", async ({ page, request }) => {
   await page.goto("/#/company");
   await expect(page.getByTestId("setup-prompt")).toBeVisible({ timeout: 20_000 });
 
-  // And nothing was created by skipping.
-  expect(await hostRoster(request)).toHaveLength(0);
+  // And nothing was created by skipping. The baseline is still there — it always
+  // is — so this asks the only question that distinguishes the two states.
+  expect(staffed(await hostRoster(request))).toHaveLength(0);
 
   // The prompt reopens the same dialog.
   await page.getByTestId("setup-prompt-run").click();

--- a/frontend/test/unit/company-setup.test.ts
+++ b/frontend/test/unit/company-setup.test.ts
@@ -14,8 +14,9 @@ import {
   emptySetupDraft,
   shouldOfferSetup,
   shouldPromptSetup,
+  staffedTeam,
   stepProblem,
-  teamIsEmpty,
+  teamIsUnstaffed,
   type SetupDraft,
 } from "@/lib/company-setup";
 
@@ -26,10 +27,27 @@ import {
  * offering it twice would stack a second team on the first — the failure this
  * feature would be judged on. It is a pure function of the roster and the skip
  * flag precisely so it can be pinned here rather than left to an effect.
+ *
+ * Since issue #1404 it has a second failure mode of equal weight, in the other
+ * direction: offering it *never*. The global baseline puts undeletable
+ * teammates on every company, so a rule that counts them can no longer answer
+ * "is this a first run?" at all — which is how the whole flow came to be
+ * unreachable in the shipped product while every test here stayed green.
  */
 
 const member = (id: string): TeamMemberDto =>
   ({ id, role: "Analyst", inboxEnabled: false }) as TeamMemberDto;
+
+/**
+ * A teammate from the global baseline (`docs/spec/runtime/globals.md`) — the set
+ * merged into every company whatever its manifest says, and undeletable
+ * (`DELETE …/team/{id}` answers 409).
+ */
+const baseline = (id: string): TeamMemberDto =>
+  ({ id, role: "Analyst", inboxEnabled: false, global: true }) as TeamMemberDto;
+
+/** The baseline as a fresh company actually receives it: nothing else on the roster. */
+const BASELINE_ONLY = ["operations", "page_builder", "researcher", "writer"].map(baseline);
 
 const draft = (over: Partial<SetupDraft> = {}): SetupDraft => ({
   ...emptySetupDraft(),
@@ -95,6 +113,50 @@ describe("shouldOfferSetup", () => {
   });
 
   /**
+   * **The regression this gate was broken by (issue #1404).**
+   *
+   * `companies/e2e_setup` declares no `[[agent]]` at all and exists solely to
+   * reach first-run setup, yet `GET …/team` answers it with the four baseline
+   * teammates — none of which can be deleted. Under the old `roster.length === 0`
+   * rule that was indistinguishable from a staffed company, so the dialog could
+   * not open on the one fixture built for it, or anywhere else.
+   */
+  it("offers to a company that has the baseline and nothing else", () => {
+    expect(shouldOfferSetup({ roster: BASELINE_ONLY, skipped: false })).toBe(true);
+  });
+
+  /**
+   * And it must not be a subtraction of today's four ids. The baseline is
+   * documented as a thing that grows (`docs/spec/runtime/globals.md`), so a
+   * fifth global has to fall out of the gate the same way — which it does only
+   * because the rule reads provenance rather than a copied list.
+   */
+  it("keeps offering when the baseline gains a teammate", () => {
+    const grown = [...BASELINE_ONLY, baseline("scheduler")];
+    expect(shouldOfferSetup({ roster: grown, skipped: false })).toBe(true);
+  });
+
+  /**
+   * The moment setup creates the first teammate the gate closes, which is what
+   * stops a reload building a second team on top of the first.
+   */
+  it("stops offering as soon as one non-baseline teammate exists", () => {
+    const staffed = [...BASELINE_ONLY, member("meta-ads-specialist")];
+    expect(shouldOfferSetup({ roster: staffed, skipped: false })).toBe(false);
+  });
+
+  /**
+   * A host predating `global` sends no such field, and `undefined` must read as
+   * "not baseline" — the old behaviour, no offer. The other reading would offer
+   * setup to a company that already has a team, which is the expensive
+   * direction: it stacks a second team on the first.
+   */
+  it("treats a roster from a host that cannot say as staffed", () => {
+    const legacy = ["operations", "page_builder"].map(member);
+    expect(shouldOfferSetup({ roster: legacy, skipped: false })).toBe(false);
+  });
+
+  /**
    * The duplicate-team guard. Whatever else changes, a company that already has
    * people on it must never be offered setup unprompted.
    */
@@ -132,12 +194,34 @@ describe("shouldPromptSetup", () => {
   it("stops once the company is staffed", () => {
     expect(shouldPromptSetup([member("a")])).toBe(false);
   });
+
+  /**
+   * The Team page's way back in has the same blind spot as the dialog, and had
+   * it for the same reason (issue #1404): a company holding only the baseline
+   * read as staffed, so skipping the dialog really was a dead end.
+   */
+  it("keeps prompting a company that has the baseline and nothing else", () => {
+    expect(shouldPromptSetup(BASELINE_ONLY)).toBe(true);
+  });
 });
 
-describe("teamIsEmpty", () => {
-  it("is emptiness and nothing else", () => {
-    expect(teamIsEmpty([])).toBe(true);
-    expect(teamIsEmpty([member("a")])).toBe(false);
+describe("staffedTeam", () => {
+  it("is the roster minus the global baseline", () => {
+    const roster = [...BASELINE_ONLY, member("meta-ads-specialist")];
+    expect(staffedTeam(roster).map((m) => m.id)).toEqual(["meta-ads-specialist"]);
+  });
+
+  it("keeps a row whose host does not report provenance", () => {
+    expect(staffedTeam([member("a")]).map((m) => m.id)).toEqual(["a"]);
+  });
+});
+
+describe("teamIsUnstaffed", () => {
+  it("asks whether anyone was staffed here, not whether the roster is empty", () => {
+    expect(teamIsUnstaffed([])).toBe(true);
+    expect(teamIsUnstaffed(BASELINE_ONLY)).toBe(true);
+    expect(teamIsUnstaffed([member("a")])).toBe(false);
+    expect(teamIsUnstaffed([...BASELINE_ONLY, member("a")])).toBe(false);
   });
 });
 

--- a/scripts/ci/assert-e2e-spec-ran.sh
+++ b/scripts/ci/assert-e2e-spec-ran.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+#
+# Run the first-run end-to-end lane and assert it actually executed something.
+# Issue #1404.
+#
+# The trap this closes is the one `assert-integration-targets-run.sh` closes for
+# Rust targets, in a browser suite. `frontend/test/e2e/company-setup.spec.ts` —
+# the only proof first-run company setup works at all — opened with:
+#
+#   test.skip(left.length > 0, "this company ships with N manifest agents ...")
+#
+# written for a host serving the wrong company. Once the global baseline began
+# merging four undeletable teammates into EVERY company, that guard fired on
+# every run, including the right one. Playwright reported `2 skipped`, exited 0,
+# and the lane was green over a feature that could not open anywhere in the
+# shipped product.
+#
+# So this checks a NUMBER. The spec's own guard now fails rather than skips, and
+# `playwright.config.ts` selects it only in a first-run run — but both of those
+# are configuration, and configuration can look right and be vacuous. A count
+# cannot.
+#
+# Usage:
+#   scripts/ci/assert-e2e-spec-ran.sh
+#
+# Run from anywhere; it resolves the repository root itself. It expects a host
+# binary at `target/debug/opencompany` (or `PW_HOST_BINARY`), exactly as
+# `npm run e2e` does — see `frontend/test/e2e/host.sh`.
+#
+# Requires `jq` (present on `ubuntu-latest`; `brew install jq` locally).
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+if ! command -v jq > /dev/null 2>&1; then
+  echo "assert-e2e-spec-ran: jq is required but not installed" >&2
+  exit 1
+fi
+
+REPORT="${REPO_ROOT}/target/e2e/first-run-report.json"
+mkdir -p "$(dirname "${REPORT}")"
+rm -f "${REPORT}"
+
+cd "${REPO_ROOT}/frontend"
+
+# `list` keeps the human-readable output in the log; `json` is what this script
+# reads. Playwright writes the JSON to PLAYWRIGHT_JSON_OUTPUT_NAME rather than
+# stdout when that variable is set, which is what keeps the two from colliding.
+set +e
+PLAYWRIGHT_JSON_OUTPUT_NAME="${REPORT}" \
+  npm run e2e:first-run -- --reporter=list,json
+run_status=$?
+set -e
+
+if [ ! -f "${REPORT}" ]; then
+  cat >&2 << EOF
+No JSON report at ${REPORT}.
+
+Playwright did not get far enough to write one, so the run failed before any
+test was selected — a host that never bound, a missing binary, or a config
+error. Its output is above.
+EOF
+  exit 1
+fi
+
+expected=$(jq -r '.stats.expected // 0' "${REPORT}")
+unexpected=$(jq -r '.stats.unexpected // 0' "${REPORT}")
+skipped=$(jq -r '.stats.skipped // 0' "${REPORT}")
+flaky=$(jq -r '.stats.flaky // 0' "${REPORT}")
+
+echo
+echo "first-run lane: ${expected} passed, ${unexpected} failed, ${flaky} flaky, ${skipped} skipped"
+
+if [ "${expected}" -eq 0 ]; then
+  cat >&2 << EOF
+
+The first-run lane executed no tests.
+
+A lane that selects nothing reports success having proved nothing, which is the
+exact defect this lane was added to fix. Something is wrong with the WIRING, not
+with the spec:
+
+  * \`playwright.config.ts\` selects \`company-setup.spec.ts\` only when
+    PW_FIRST_RUN=1 — check that \`npm run e2e:first-run\` still sets it;
+  * the spec may have been renamed out of the FIRST_RUN_SPEC pattern;
+  * every test in it may be skipped. Do NOT restore a \`test.skip\` to make this
+    pass — a first-run lane that skips itself is worse than no lane, and is what
+    issue #1404 was filed about.
+EOF
+  exit 1
+fi
+
+if [ "${skipped}" -ne 0 ]; then
+  cat >&2 << EOF
+
+${skipped} test(s) in the first-run lane skipped themselves.
+
+This lane brings up the host the spec needs, so nothing in it has a legitimate
+reason to skip. A skip here is the silent-green shape all over again: fix the
+condition, or fail on it, but do not leave it reporting nothing.
+EOF
+  exit 1
+fi
+
+exit "${run_status}"

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -158,6 +158,17 @@ struct TeamMemberDto {
     /// When that cap was set (epoch millis). Paired with `budgetSetBy`.
     #[serde(skip_serializing_if = "Option::is_none")]
     budget_set_at_millis: Option<u64>,
+    /// Whether this teammate came from the **global baseline**
+    /// (`docs/spec/runtime/globals.md`) rather than from this company — the
+    /// same `Agent::global` marker the merge itself sets (issue #1404).
+    ///
+    /// Always sent, never skipped. The console's first-run gate asks "has
+    /// anybody staffed this company?", and the baseline is appended to every
+    /// company whatever its manifest says, so a row that omitted this would be
+    /// counted as staff and first-run setup could never open. Absence has to
+    /// mean "this host predates the field", which the console reads as the old
+    /// behaviour; it must not also mean "not global".
+    global: bool,
 }
 
 /// The add-teammate body.
@@ -341,6 +352,10 @@ fn member_row(
         spent_today_usd: cap.and_then(|_| spent(agent_id)),
         budget_set_by: attribution.map(|entry| entry.set_by.id.clone()),
         budget_set_at_millis: attribution.map(|entry| entry.at_millis),
+        // Through the same helper as the four above, for the same reason: the
+        // roster read is what the first-run gate is decided on, so a second
+        // copy of the provenance rule here is a second thing to forget.
+        global: super::team_agent::is_global(record, agent_id),
     }
 }
 
@@ -493,6 +508,10 @@ async fn add_member(
         spent_today_usd: body.budget_usd_daily.map(|_| 0.0),
         budget_set_by: attribution.as_ref().map(|entry| entry.set_by.id.clone()),
         budget_set_at_millis: attribution.as_ref().map(|entry| entry.at_millis),
+        // An operator just created this one, so it is by construction not from
+        // the baseline — the merge only ever appends to the manifest roster.
+        // It is also exactly the write that closes the first-run gate.
+        global: false,
     }))
 }
 
@@ -816,7 +835,22 @@ mod tests {
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
-        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        state_with(home, toml::from_str(manifest_toml).unwrap()).await
+    }
+
+    /// As above, but with the **global baseline merged in** — the roster every
+    /// company actually boots with (`docs/spec/runtime/globals.md`).
+    ///
+    /// Kept apart from `state_with_manifest` on purpose: most tests here are
+    /// about one hand-written teammate and are clearer without four extra rows,
+    /// while the provenance tests are meaningless without them.
+    async fn state_with_globals(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        let mut manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        manifest.apply_globals();
+        state_with(home, manifest).await
+    }
+
+    async fn state_with(home: &std::path::Path, manifest: CompanyManifest) -> AppState {
         let store = FsCompanyStore::new(home.to_path_buf());
         let id = CompanyId::new("acme");
         store
@@ -1806,6 +1840,121 @@ mod tests {
             row["isOrchestrator"], false,
             "an empty manifest roster names nobody, so it does not fall through \
              to the overlay half: {row}"
+        );
+    }
+
+    // --- Baseline provenance, and the first-run gate (issue #1404) ----------
+
+    /// The roster says which of its rows came from the global baseline.
+    ///
+    /// This is the field the console's first-run gate turns on. `apply_globals`
+    /// appends `globals/agents/*.toml` to **every** company whatever its
+    /// manifest says, so a company nobody has ever staffed still answers this
+    /// route with a non-empty list — and "is the roster empty?" therefore
+    /// answered `no` everywhere, which is what made first-run setup unreachable
+    /// in the shipped product.
+    ///
+    /// Asserted as "at least one row, all of them global" rather than against a
+    /// count or the four current ids: the baseline is meant to grow, and a test
+    /// that pins its contents here would fail for the wrong reason.
+    #[tokio::test]
+    async fn a_company_with_no_declared_roster_answers_with_the_baseline_only() {
+        let home_dir = home();
+        let state = state_with_globals(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (status, body) = get_team(&state).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let rows = body.as_array().unwrap();
+        assert!(
+            !rows.is_empty(),
+            "the baseline is merged into every company, so this is never empty: {body}"
+        );
+        assert!(
+            rows.iter().all(|row| row["global"] == true),
+            "a company declaring no `[[agent]]` has nothing but baseline \
+             teammates, and every one of them must say so: {body}"
+        );
+    }
+
+    /// A teammate the company wrote, and one the operator adds, are both
+    /// `global: false` — beside a baseline that is `true` on the same read.
+    ///
+    /// Both halves are the point. The gate must stay shut for a company that
+    /// shipped with a roster (`docs/spec/runtime/company-setup.md`), and it must
+    /// close the moment setup creates the first teammate.
+    #[tokio::test]
+    async fn a_declared_or_operator_added_teammate_is_never_marked_global() {
+        let home_dir = home();
+        let state = state_with_globals(home_dir.path(), ROSTER).await;
+
+        let declared = team_row(&state, "analyst").await;
+        assert_eq!(
+            declared["global"], false,
+            "a `[[agent]]` the company wrote is the company's own: {declared}"
+        );
+
+        let (status, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Nova", "role": "Researcher"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        assert_eq!(
+            created["global"], false,
+            "the create response answers the same way the read does: {created}"
+        );
+        let id = created["id"].as_str().unwrap().to_string();
+        assert_eq!(team_row(&state, &id).await["global"], false);
+
+        // …and the baseline on the same roster still says otherwise, so the two
+        // are distinguishable rather than uniformly false.
+        let (_, body) = get_team(&state).await;
+        assert!(
+            body.as_array()
+                .unwrap()
+                .iter()
+                .any(|row| row["global"] == true),
+            "the baseline rows are on this roster too: {body}"
+        );
+    }
+
+    /// A baseline teammate cannot be deleted — the 409 that made "just delete
+    /// them to reach first-run" impossible. Pinned beside the marker so the two
+    /// answers to the same question stay together.
+    #[tokio::test]
+    async fn a_baseline_teammate_refuses_deletion() {
+        let home_dir = home();
+        let state = state_with_globals(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (_, body) = get_team(&state).await;
+        let id = body.as_array().unwrap()[0]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let (status, _) = send(
+            &state,
+            "DELETE",
+            &format!("/api/v1/company/team/{id}"),
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "a baseline teammate is part of the blueprint; the console must not \
+             be able to empty the roster to reach first-run setup"
         );
     }
 }

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -263,6 +263,31 @@ pub(super) fn is_orchestrator(record: &CompanyRecord, agent_id: &str) -> bool {
     crate::company::orchestrator_id(&record.manifest.agents) == Some(agent_id)
 }
 
+/// Whether `agent_id` came from the **global baseline**
+/// ([`crate::globals`]) rather than from this company.
+///
+/// Provenance, and the one question first-run setup turns on (issue #1404).
+/// `apply_globals` appends `globals/agents/*.toml` to *every* company's roster
+/// whatever its manifest says, so "is the roster empty?" is answered `no` on a
+/// company nobody has ever staffed — which is how the whole first-run flow came
+/// to be unreachable in the shipped product. The console needs to tell the
+/// baseline apart from a team, and it must not do that by hard-coding the
+/// baseline's ids: the next global added would silently re-break the gate.
+///
+/// Read from [`Agent::global`](crate::company::Agent::global), the marker the
+/// merge itself sets, so this answer moves with the baseline rather than
+/// alongside it. An overlay teammate is never global — the merge only ever
+/// touches the manifest roster — so an id this does not find is `false`, which
+/// is also the right answer for an id that is not on the roster at all.
+pub(super) fn is_global(record: &CompanyRecord, agent_id: &str) -> bool {
+    record
+        .manifest
+        .agents
+        .iter()
+        .find(|agent| agent.id == agent_id)
+        .is_some_and(|agent| agent.global)
+}
+
 /// One agent's grants at all three levels — the single constructor for
 /// [`AgentToolsDto`].
 ///


### PR DESCRIPTION
Closes #1404.

First-run company setup could not open on any company this host can serve — including `companies/e2e_setup`, the fixture that exists solely to reach it — and the lane that was supposed to catch that skipped itself, so CI stayed green over a dead feature.

## What the gate is now, and why

The gate was `roster.length === 0`. The global baseline merges four **undeletable** teammates (`operations`, `page_builder`, `researcher`, `writer`) into every company whatever its manifest says, so that expression is false everywhere. All four `409` on `DELETE …/team/{id}`, so there is no route back to an empty roster either.

The gate now asks the narrower question **"has anybody staffed this company?"** — is there any teammate that is *not* part of the baseline every company gets.

Deliberately **not** a subtraction of the four ids the baseline ships today. `docs/spec/runtime/globals.md` documents the baseline as a thing that grows; a copy of its id list held in the console would break the gate silently on the next global added. Instead the host reports provenance per row: `GET …/team` now carries `global`, read from the same `Agent::global` marker `apply_globals` sets, through a shared `team_agent::is_global` helper so the roster list and the create response cannot disagree.

Decision D4 is intact — no stored flag, the answer still comes from the host and still cannot drift from the thing setup changes. Only the question narrowed. A host predating the field sends nothing, and `undefined` reads as *not* baseline: that restores the old behaviour (no offer) rather than risking a second team stacked on a company that already has one.

The Team page's in-place prompt follows the same rule, and its copy moved from "This company has no team yet" to **"This company hasn't been set up yet"**. That is load-bearing, not cosmetic: the prompt now renders directly above the baseline's four real teammate cards, and the old line would have been the fabricated-starter-roster lie pointing the other way.

## How the spec was stopped from self-skipping

`company-setup.spec.ts` opened with `test.skip(left.length > 0, …)`, written for a host serving the wrong company. Once the baseline landed it fired on **every** run, including a correct one — and no CI job ever set the variable that would have selected the right host anyway. The spec's own header said it was covered by nothing.

Three changes, and all three are needed:

1. **The guard asserts instead of skipping.** A run pointed at the wrong host now fails on its first line naming `npm run e2e:first-run`, rather than passing vacuously.
2. **The two runs are disjoint by selection, in config.** `playwright.config.ts` selects `company-setup.spec.ts` only when `PW_FIRST_RUN=1`, and every other spec only when it is unset — so neither run can be pointed at a host it cannot pass against. A first-run run also serves `companies/e2e_setup` on a data root and storage state of its own, so `npm run e2e:first-run` is the whole command.
3. **A lane runs it, and asserts a number.** `Console E2E (first run)` calls `scripts/ci/assert-e2e-spec-ran.sh`, which fails on a reported count of zero — and on any skip — the way `assert-integration-targets-run.sh` does for Rust targets. Configuration can look right and be vacuous; a count cannot.

## Verification

Host on `127.0.0.1:8607`, own `OPENCOMPANY_DATA_DIR`, `--company companies/e2e_setup`, walked in Chromium at 1440x900:

- `GET …/team` answers 4 rows, every one `"global": true`.
- Landing on `#/overview` **opens the dialog unprompted**; the tour is held (no "Take the tour" button).
- The empty first question is blocked ("Tell us a little about the company first."); questions 2 and 3 are skippable.
- The build-out named 5 teammates one at a time and finished on "Your team is ready", honestly attributing the curated fallback ("we couldn't reach a model to tailor it to your answers") — this host has no inference credential.
- After finish, `GET …/team` holds 9 rows: the 4 baseline plus `meta_ads`, `seo`, `logistics`, `ops`, `accounts`. The Company page shows all nine; the setup prompt is gone; a reload does not re-offer.
- Skip path, fresh data dir: skipping leaves the tour still held, the Company page shows "This company hasn't been set up yet" above the four baseline cards, and its button reopens the dialog.

Spec, against that host: **2 passed, 0 skipped** (`{"expected": 2, "skipped": 0, "unexpected": 0}` in the JSON report). Against a `companies/e2e_harness` host on 8608 both tests **fail** with the new message, which is the point. Selection is disjoint: `--list` reports 247 tests / 65 files by default (company-setup absent) and 2 tests / 1 file with `PW_FIRST_RUN=1`.

Regression sweep against the harness host: `company-cards`, `team-budget`, `team-budget-edit`, `org-tree`, `agent-detail` — 41 passed.

## Commands run

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 3191 passed, 0 failed
- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e`
- `npx vitest run` — 1643 passed (170 files)
- `scripts/ci/assert-feature-lanes.sh`, `scripts/ci/assert-md-line-cap.sh`

## API and behaviour changes

- `GET …/team` and `POST …/team` gain `global: boolean` on every row. Additive; existing clients are unaffected.
- First-run setup now opens on a company holding only the baseline. Everything downstream of the gate becomes reachable for the first time: the three questions, the build-out, the Team-page prompt, and the tour's `hold` (which really was dead code).

## Not fixed here

`#/setup` still redirects to `#/overview` — it is not in `useHashView`'s valid list. That is **#1417** and is left alone; the Team page's in-place prompt is the way back in that this PR verifies. Also observable now that the gate opens, and each tracked separately: #1409 (post-setup Overview staleness), #1415 (no model gate in `SetupDialog`), #1421 (build-out reveal pacing). None are touched here.
