### PR TITLE
fix(console): let a dialog that asks to be wide actually be wide

### DIFF
--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -989,7 +989,7 @@ export function LedgersView({
 
       {rendered !== null && ledger && (
         <Dialog open onOpenChange={() => setRendered(null)}>
-          <DialogContent className="max-h-[80vh] max-w-3xl overflow-y-auto">
+          <DialogContent className="max-h-[80vh] sm:max-w-3xl overflow-y-auto">
             <DialogHeader>
               <DialogTitle>{ledger.derived}</DialogTitle>
               <DialogDescription>
@@ -1242,7 +1242,7 @@ function ComposeDialog({
 
   return (
     <Dialog open onOpenChange={onCancel}>
-      <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[85vh] sm:max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {composeDialogTitle(ledger, composing, existingIds)}

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -156,7 +156,7 @@ export function TaskEditDialog({
 
   return (
     <Dialog open={!!task} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Edit task</DialogTitle>
           <DialogDescription>

--- a/frontend/src/views/company/DeclareListWizard.tsx
+++ b/frontend/src/views/company/DeclareListWizard.tsx
@@ -146,7 +146,7 @@ export function DeclareListWizard({
 
   return (
     <Dialog open onOpenChange={onCancel}>
-      <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[85vh] sm:max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>New list</DialogTitle>
           <DialogDescription>

--- a/frontend/test/unit/dialog-width-override.test.ts
+++ b/frontend/test/unit/dialog-width-override.test.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A `DialogContent` that asks to be wide has to ask at the `sm:` breakpoint.
+ *
+ * `DialogContent`'s own base carries `sm:max-w-sm`. `tailwind-merge` dedupes
+ * conflicting utilities, but `max-w-2xl` and `sm:max-w-sm` are different
+ * *variants*, so both survive the merge and the responsive one wins on every
+ * screen ≥640px. A caller writing `max-w-3xl` therefore gets 384px and no
+ * warning — the class is present in the DOM, it simply loses.
+ *
+ * Four dialogs were shipping that way, all on the Work surface: the rendered
+ * file viewer (a *document*, in a 40-character measure), the compose form, the
+ * declare wizard — where the 384px width was also what wrapped its five-step
+ * indicator and left a connector dangling into empty space — and Edit task.
+ *
+ * This is a source guard rather than a render test on purpose. The failure is
+ * invisible at every level below pixels: the component renders, the class is
+ * there, the type checks, and only a browser at ≥640px shows the wrong width.
+ * A grep is the level the mistake actually lives at.
+ */
+const SRC = new URL("../../src", import.meta.url).pathname;
+
+/** Every `.tsx` under `src/`. */
+function sources(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) sources(path, out);
+    else if (name.endsWith(".tsx")) out.push(path);
+  }
+  return out;
+}
+
+/** `max-w-*` that is not behind a breakpoint, inside a `DialogContent` tag. */
+const BARE_MAX_W = /<DialogContent[^>]*className="([^"]*)"/g;
+
+describe("DialogContent width overrides", () => {
+  it("are all responsive, so none of them silently loses to the base", () => {
+    const offenders: string[] = [];
+    for (const path of sources(SRC)) {
+      const source = readFileSync(path, "utf8");
+      for (const [, classes] of source.matchAll(BARE_MAX_W)) {
+        const bare = classes
+          .split(/\s+/)
+          .filter((held) => /^max-w-/.test(held) && !held.startsWith("max-w-["));
+        if (bare.length > 0) {
+          offenders.push(`${relative(SRC, path)}: ${bare.join(" ")}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1353.

Found while auditing the **Work** surface: three dialogs on one screen at two apparent widths, one of them a *document* squeezed into a forty-character measure. The cause turned out to be one line in `DialogContent`.

## The bug

`DialogContent`'s base class list carries `sm:max-w-sm`. `tailwind-merge` dedupes conflicting utilities, but `max-w-3xl` and `sm:max-w-sm` are different **variants**, so both survive the merge — and the responsive one wins on every screen at or above 640px.

A caller writing `max-w-3xl` therefore gets **384px**, with no warning of any kind: the class is present in the DOM, the types check, the component renders. Fourteen call sites in the console use `sm:max-w-*` and work correctly. Four did not, and all four are on the Work surface:

| dialog | asked for | got |
|---|---|---|
| `derived/TASKS.md` viewer | 768px | 384px |
| Compose / amend a row | 672px | 384px |
| Declare-list wizard | 672px | 384px |
| Edit task | 512px | 384px |

## The second symptom

The wizard's five-step indicator wrapped 2 + 3 inside its 384px, which left the connector after step 2 — `② Name it —` — pointing into empty space at the end of the first line. At the 672px it had been asking for all along, the stepper is one line and the dangling connector is simply gone.

That is why this PR does not touch `Stepper`. The wrap was a symptom.

## The guard

`test/unit/dialog-width-override.test.ts` fails on any `DialogContent` whose `max-w-*` is not behind a breakpoint.

A source test rather than a render test, on purpose: this failure is invisible at every level below pixels, so a grep is the level the mistake actually lives at. Verified negative — reintroducing `max-w-lg` on `TaskEditDialog` fails it by name.

## Commands run

- `npm run typecheck` / `typecheck:unit` / `typecheck:e2e`
- `npx vitest run` — 1637 passed, 171 files
- `scripts/ci/assert-design-tokens.sh`
- `npx playwright test board-columns list-switcher manage-lists-wizard` against a real host — 16 passed
- Browser-verified at 1440px and 1100px on all four dialogs
- `upstream/main` merged before push