### PR TITLE
fix(settings): stop persisting the SMTP password to localStorage

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -51,8 +51,8 @@ why this is not a read/write split: [authority.md](authority.md).
 | `team` | `POST …/team`, `DELETE …/team/{id}`, `PUT …/team/{id}/inbox` (overlay; roster-only in v1) |
 | `mail` | `POST …/inboxes/{key}/read` |
 | `inbox` | `POST …/inboxes/ingest` (HMAC-signed inbound email) |
-| `domain` | `PUT …/domain`, `POST …/domain/verify` |
-| `smtp` | `PUT …/smtp`, `POST …/smtp/test` |
+| `domain` | `GET …/domain` (the stored records and last verify result, or `null`), `PUT …/domain`, `POST …/domain/verify` (the `GET` is a REST twin of the GraphQL `Company.domain` read, #1460) |
+| `smtp` | `GET …/smtp` (non-secret status; never the password), `PUT …/smtp` (the password is a patch — omit it to keep the stored one), `POST …/smtp/test` (the `GET` is a REST twin of the GraphQL `Company.smtp` read, #1460) |
 | `connections` (feature `oauth`) | `POST …/connections/{provider}/start` → dated `410` retirement bridge, `POST …/connections/{provider}/disconnect`, `GET /api/v1/oauth/callback` → dated `410` browser landing page (#838; removal #1023) |
 | `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/runs`, `POST …/workflows/cron/preview`, `GET …/workflows/{wid}`, `PUT …/workflows/{wid}`, `DELETE …/workflows/{wid}`, `POST …/workflows/{wid}/run`, `POST …/workflows/runs/{runId}/cancel` |
 

--- a/docs/modules/server/authority.md
+++ b/docs/modules/server/authority.md
@@ -38,8 +38,13 @@ domain, its published DNS records, and whether they resolved) and `GET …/smtp`
 (host, port, username, from-address — the password is absent from `SmtpStatus`
 by construction) are that rule applied to the two rows above, and are the reason
 this is not a per-module habit: admin-only, they would `403` a member on the
-Settings screen while the identical data stayed readable to them over GraphQL as
-`Company.domain` and `Company.smtp`. So do the probes over already-stored config
+Settings screen while the same domain and the same non-secret SMTP routing
+stayed readable to them over GraphQL as `Company.domain` and `Company.smtp`.
+The GraphQL projections are narrower, not fresher or staler — they share the
+REST loaders, but they answer less detail: `DomainStatusGql` drops the
+per-record `checks` from the last verify pass, and `SmtpStatusGql` drops
+`security`, `from_name` and `from_email`. Neither carries anything secret.
+So do the probes over already-stored config
 — `POST …/inference/test`, `GET …/mcp/servers/{name}/tools`,
 `POST …/mcp/servers/{name}/test`, `POST …/domain/verify` — which name no
 destination of their own.

--- a/docs/modules/server/authority.md
+++ b/docs/modules/server/authority.md
@@ -33,8 +33,14 @@ the world as, and which third-party accounts its agents act through:
 
 Reads on those same surfaces stay open to any member: they carry a tier name and
 non-secret routing, never a credential, and knowing *that* Gmail is connected is
-what lets a member understand why an agent can read mail. So do the probes over
-already-stored config — `POST …/inference/test`, `GET …/mcp/servers/{name}/tools`,
+what lets a member understand why an agent can read mail. `GET …/domain` (the
+domain, its published DNS records, and whether they resolved) and `GET …/smtp`
+(host, port, username, from-address — the password is absent from `SmtpStatus`
+by construction) are that rule applied to the two rows above, and are the reason
+this is not a per-module habit: admin-only, they would `403` a member on the
+Settings screen while the identical data stayed readable to them over GraphQL as
+`Company.domain` and `Company.smtp`. So do the probes over already-stored config
+— `POST …/inference/test`, `GET …/mcp/servers/{name}/tools`,
 `POST …/mcp/servers/{name}/test`, `POST …/domain/verify` — which name no
 destination of their own.
 
@@ -44,4 +50,6 @@ differently on purpose; an extractor named for the HTTP verb would have to take
 capabilities away from members that are meant to be theirs.
 
 `server::ops::write_test` pins the whole table against a member session, so a
-route joining this plane joins that list too.
+route joining this plane joins that list too — and pins the other direction as
+well, that a member is let through `GET …/domain` and `GET …/smtp`, so the
+sentence above stays a test rather than only a claim.

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -317,14 +317,26 @@ credential: the old credential was unreachable by agents.
 ```text
 GET    …/credential                         whether the company has its own key + which tier it presents
 PUT    …/credential                         set / rotate / clear the company's TinyHumans key  [admin]
-PUT    …/domain                             set the custom domain
+GET    …/domain                             the stored domain + records + last verify result, or `null`
+PUT    …/domain                             set the custom domain  [admin]
 POST   …/domain/verify                       server-side DNS check
-PUT    …/smtp                               store SMTP credentials (secret store)
-POST   …/smtp/test                           send a test email
+GET    …/smtp                               non-secret SMTP status (`configured: false` when unset)
+PUT    …/smtp                               store SMTP credentials (secret store)  [admin]
+POST   …/smtp/test                           send a test email  [admin]
 POST   …/connections/{provider}/start        retired native OAuth bridge → 410 JSON until 2026-09-30  [feature: oauth]
 POST   …/connections/{provider}/disconnect   drop a legacy stored OAuth token  [feature: oauth]
 GET    /api/v1/oauth/callback                retired browser landing page → 410 HTML until 2026-09-30  [feature: oauth]
 ```
+
+The two `GET`s are REST twins of the GraphQL `Company.domain` / `Company.smtp`
+reads and serve the same loader, so the planes cannot answer differently. They
+are open to any member (the `[admin]` line guards the company's outward
+identity, not the reading of it) and neither carries credential material: the
+SMTP password is absent from `SmtpStatus` by construction. `PUT …/smtp` treats
+the password as a **patch** — a body that omits it keeps the stored one, so a
+form can offer "stored — leave blank to keep" instead of charging a credential
+re-entry for a from-name fix. A body carrying one behaves exactly as before, and
+one that supplies neither with nothing stored is `400`.
 
 `…/credential` is the company's **one** TinyHumans key, presented by every
 surface wired to it (**Composio today**) — see

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -348,9 +348,16 @@ was supplied at all, because leading and trailing spaces can be significant.
 Keeping the stored password costs no read-modify-write. The configuration and
 the password live under separate secret keys, so a passwordless save rewrites
 the configuration and never touches the secret — a rotation arriving at the same
-moment survives instead of being reverted. Credentials written before that split
-still carry the password inside the configuration blob; reads fall back to it,
-and the first passwordless save after the split migrates it to its own key.
+moment survives instead of being reverted, however many processes are writing.
+
+Credentials written before that split still carry the password inside the
+configuration blob; reads fall back to it, and the first passwordless save after
+the split migrates it to its own key. That migration is the one path that must
+read and then write, so `PUT …/smtp` serializes per company for the duration of
+the handler. The lock is in-process, which covers the deployed topology (a
+tenant is a single container); two replicas of one company would reopen the
+window on the legacy path alone, and closing it there would need a conditional
+write that `SecretStore` cannot express today.
 
 `…/credential` is the company's **one** TinyHumans key, presented by every
 surface wired to it (**Composio today**) — see

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -328,15 +328,29 @@ POST   …/connections/{provider}/disconnect   drop a legacy stored OAuth token 
 GET    /api/v1/oauth/callback                retired browser landing page → 410 HTML until 2026-09-30  [feature: oauth]
 ```
 
-The two `GET`s are REST twins of the GraphQL `Company.domain` / `Company.smtp`
-reads and serve the same loader, so the planes cannot answer differently. They
-are open to any member (the `[admin]` line guards the company's outward
-identity, not the reading of it) and neither carries credential material: the
-SMTP password is absent from `SmtpStatus` by construction. `PUT …/smtp` treats
-the password as a **patch** — a body that omits it keeps the stored one, so a
-form can offer "stored — leave blank to keep" instead of charging a credential
-re-entry for a from-name fix. A body carrying one behaves exactly as before, and
-one that supplies neither with nothing stored is `400`.
+The two `GET`s are the REST siblings of the GraphQL `Company.domain` /
+`Company.smtp` reads and share their loaders, so the planes cannot disagree
+about the fields they both carry. They can still differ in *detail*: REST
+answers the full `DomainStatus` and `SmtpStatus`, while `DomainStatusGql` omits
+the per-record `checks` from the last verify pass and `SmtpStatusGql` omits
+`security`, `from_name` and `from_email`. Both are open to any member (the
+`[admin]` line guards the company's outward identity, not the reading of it) and
+neither carries credential material: the SMTP password is absent from
+`SmtpStatus` by construction.
+
+`PUT …/smtp` treats the password as a **patch** — a body that omits it keeps the
+stored one, so a form can offer "stored — leave blank to keep" instead of
+charging a credential re-entry for a from-name fix. A body carrying one behaves
+exactly as before, and one that supplies neither with nothing stored is `400`.
+The supplied password is stored byte for byte; trimming decides only whether one
+was supplied at all, because leading and trailing spaces can be significant.
+
+Keeping the stored password costs no read-modify-write. The configuration and
+the password live under separate secret keys, so a passwordless save rewrites
+the configuration and never touches the secret — a rotation arriving at the same
+moment survives instead of being reverted. Credentials written before that split
+still carry the password inside the configuration blob; reads fall back to it,
+and the first passwordless save after the split migrates it to its own key.
 
 `…/credential` is the company's **one** TinyHumans key, presented by every
 surface wired to it (**Composio today**) — see

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -351,8 +351,12 @@ neither carries credential material: the SMTP password is absent from
 stored one, so a form can offer "stored — leave blank to keep" instead of
 charging a credential re-entry for a from-name fix. A body carrying one behaves
 exactly as before, and one that supplies neither with nothing stored is `400`.
-The supplied password is stored byte for byte; trimming decides only whether one
-was supplied at all, because leading and trailing spaces can be significant.
+A supplied password is stored **byte for byte** — leading and trailing
+whitespace is preserved, because it can be significant to the remote server.
+Trimming decides only *whether* one was supplied: a value that is empty or
+entirely whitespace counts as omitted and keeps the stored password, so an
+all-whitespace password cannot be set through this route. Any value with a
+non-whitespace character in it is stored exactly as sent.
 
 Keeping the stored password costs no read-modify-write. The configuration and
 the password live under separate secret keys, so a passwordless save rewrites

--- a/frontend/src/api/domain.ts
+++ b/frontend/src/api/domain.ts
@@ -1,0 +1,115 @@
+// The custom-domain API: the domain a company sends and receives on, and the
+// DNS records that have to exist for it to work.
+//
+// **The records are the host's answer. The console derives nothing.**
+//
+// This module exists because the console used to fabricate them: a
+// `dnsRecords(domain)` helper in `src/lib/domain.ts` hashed the domain into a
+// verification token and pasted it into a hardcoded `opencompany.host` target,
+// client-side. Every value it produced was a guess. An operator who copied
+// those five rows into their registrar had added five records the host had
+// never heard of, and the card's "Pending" badge — which nothing could ever
+// clear, because nothing was ever checked — told them to keep waiting.
+//
+// So: `records` comes off `DomainStatus`, `verified` comes off `DomainStatus`,
+// and `checks` comes off `DomainStatus`. If a row is on screen, the host put it
+// there. Do not reintroduce a local generator, not even as a fallback for an
+// empty list — a fallback is the same lie with a narrower blast radius.
+//
+// Standalone functions over the shared client, mirroring `api/hosting.ts`, so
+// `OpenCompanyClient` needs no new methods.
+
+import type { OpenCompanyClient } from "./client";
+
+/** One DNS record the operator must create at their registrar. */
+export interface DnsRecord {
+  type: "CNAME" | "TXT";
+  name: string;
+  value: string;
+  /** A string, not a number — the host sends what a registrar form expects. */
+  ttl: string;
+}
+
+/**
+ * The result of looking one record up, from the most recent verify pass.
+ *
+ * Matched back to its record by `(name, type)` and never by position: the host
+ * is free to return checks in a different order, or to check a subset, and an
+ * index-matched join would silently move a tick onto the wrong row.
+ */
+export interface RecordCheck {
+  name: string;
+  type: "CNAME" | "TXT";
+  /** Whether the expected value was found in DNS. */
+  found: boolean;
+}
+
+/**
+ * A company's custom-domain configuration as the host holds it.
+ *
+ * `domain: ""` is the unconfigured sentinel — the read can also answer `null`
+ * before anything has ever been set, and removal is `PUT { domain: "" }`. There
+ * is no DELETE.
+ */
+export interface DomainStatus {
+  domain: string;
+  verified: boolean;
+  /** Authoritative. See the module header. */
+  records: DnsRecord[];
+  /**
+   * Absent until a verify pass has run — which is a different thing from "ran
+   * and found nothing", and the card words the two differently.
+   */
+  checks?: RecordCheck[];
+}
+
+/** Reads the company's domain configuration, or null if none was ever set. */
+export async function getDomain(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<DomainStatus | null> {
+  return client.get<DomainStatus | null>(`${client.scopeFor(company)}/domain`);
+}
+
+/**
+ * Sets the domain and returns the records the host wants created for it.
+ *
+ * Admin-only on the host. The response — not the request — is what the card
+ * renders next.
+ */
+export async function saveDomain(
+  client: OpenCompanyClient,
+  company: string | null,
+  domain: string,
+): Promise<DomainStatus> {
+  return client.put<DomainStatus>(`${client.scopeFor(company)}/domain`, { domain });
+}
+
+/**
+ * Removes the configured domain.
+ *
+ * An empty-string PUT, because that is the host's contract: the domain field is
+ * the whole resource, so clearing it is a write of the empty value rather than
+ * a DELETE of the route.
+ */
+export async function clearDomain(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<DomainStatus> {
+  return saveDomain(client, company, "");
+}
+
+/**
+ * Asks the host to look the records up in DNS now.
+ *
+ * Rejects with `404 not_wired` on a host built without the `dns` feature — a
+ * build fact, not an outage, and the card says so rather than showing an error —
+ * and with a `400` when no domain is configured, which is why callers must test
+ * for the `not_wired` code rather than for the status.
+ */
+export async function verifyDomain(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<DomainStatus> {
+  return client.post<DomainStatus>(`${client.scopeFor(company)}/domain/verify`);
+}

--- a/frontend/src/api/smtp.ts
+++ b/frontend/src/api/smtp.ts
@@ -1,0 +1,118 @@
+// The outbound-mail API: the SMTP server a company sends through.
+//
+// The password is write-only. It goes into the host's secret store on save and
+// there is no field on {@link SmtpStatus} that could carry it back — not an
+// empty string, not a mask. It is also never written to browser storage; before
+// issue #1460 the card persisted the whole form to `localStorage` on every
+// keystroke, which is the bug this surface exists to have fixed.
+//
+// # Casing: these wire shapes are snake_case, deliberately
+//
+// `from_name` and `from_email` are NOT typos and NOT an oversight. The host's
+// `SmtpStatus` and `SmtpConfig` structs carry no `#[serde(rename_all =
+// "camelCase")]`, so serde emits Rust field names verbatim. `api/hosting.ts`
+// next door is camelCase (`apiKeyConfigured`) because ITS structs do carry the
+// attribute. The two files disagree because the host disagrees with itself.
+//
+// "Fixing" these to `fromName`/`fromEmail` compiles, type-checks, and silently
+// stops working: the host deserializes a body with a missing `from_email` and
+// the read renders an undefined From address. If you change them, change the
+// Rust struct in the same commit.
+//
+// Standalone functions over the shared client, mirroring `api/hosting.ts`.
+
+import type { OpenCompanyClient } from "./client";
+
+/** How the connection to the SMTP server is secured. */
+export type SmtpSecurity = "none" | "starttls" | "ssl";
+
+/**
+ * The non-secret view of a company's SMTP configuration.
+ *
+ * Optional fields are `?:` rather than `| null`: the host uses
+ * `skip_serializing_if`, so an unset field is **absent** from the JSON, not
+ * present-and-null. There is no password field, by construction.
+ */
+export interface SmtpStatus {
+  /** Whether a complete configuration — including a password — is stored. */
+  configured: boolean;
+  host?: string;
+  port?: number;
+  security?: SmtpSecurity;
+  username?: string;
+  /** snake_case on the wire. See the module header before renaming. */
+  from_name?: string;
+  /** snake_case on the wire. See the module header before renaming. */
+  from_email?: string;
+}
+
+/**
+ * The save body.
+ *
+ * `port` is a number because the host takes a `u16`; a string, or an
+ * out-of-range value, fails deserialization with a message no operator can act
+ * on, so callers validate before sending.
+ */
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  security: SmtpSecurity;
+  username: string;
+  /** snake_case on the wire. See the module header before renaming. */
+  from_email: string;
+  /** snake_case on the wire. See the module header before renaming. */
+  from_name?: string;
+  /** Write-only. **Omit** to keep the password already stored. */
+  password?: string;
+}
+
+/** The host's own verdict on a test send, in its own words. */
+export interface SmtpTestResult {
+  ok: boolean;
+  /**
+   * Rendered verbatim on both branches. The host knows whether the server
+   * refused the credentials, timed out, or rejected the From address; a generic
+   * "Couldn't send" thrown over the top of that is strictly less useful.
+   */
+  message: string;
+}
+
+/** Reads the company's SMTP configuration status. Never the password. */
+export async function getSmtp(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<SmtpStatus> {
+  return client.get<SmtpStatus>(`${client.scopeFor(company)}/smtp`);
+}
+
+/**
+ * Saves the configuration and returns the resulting status.
+ *
+ * Admin-only on the host. Omitting `password` leaves the stored one in place,
+ * so correcting the port never means re-typing a credential the operator cannot
+ * see.
+ */
+export async function saveSmtp(
+  client: OpenCompanyClient,
+  company: string | null,
+  config: SmtpConfig,
+): Promise<SmtpStatus> {
+  return client.put<SmtpStatus>(`${client.scopeFor(company)}/smtp`, config);
+}
+
+/**
+ * Asks the host to send a test message through the stored configuration.
+ *
+ * Rejects with `404 not_wired` on a host built without the `smtp` feature — the
+ * credentials are still stored and a build that has the feature will use them.
+ */
+export async function testSmtp(
+  client: OpenCompanyClient,
+  company: string | null,
+  to?: string,
+): Promise<SmtpTestResult> {
+  return client.post<SmtpTestResult>(
+    `${client.scopeFor(company)}/smtp/test`,
+    to ? { to } : {},
+  );
+}

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -31,6 +31,7 @@ import {
   type MailSettings,
   saveMailSettings,
   type SmtpSecurity,
+  withoutSmtpPassword,
 } from "@/lib/domain";
 
 interface Props {
@@ -43,13 +44,21 @@ const SECURITY_LABELS: Record<SmtpSecurity, string> = {
   ssl: "SSL / TLS",
 };
 
-/** Custom domain (with DNS records) and SMTP credentials for the company. */
+/**
+ * Custom domain (with DNS records) and SMTP credentials for the company.
+ *
+ * The write-back is deliberately routed through `withoutSmtpPassword` rather
+ * than handing `settings` straight to `saveMailSettings` (issue #1460). The
+ * password stays in this component's state for the life of the page and is
+ * never persisted; everything else on the card is remembered so a half-filled
+ * form survives a reload.
+ */
 export function DomainSettings({ company: _company }: Props) {
   const scope = useLocalScope();
   const [settings, setSettings] = useState<MailSettings>(() => loadMailSettings(scope));
 
   useEffect(() => {
-    saveMailSettings(scope, settings);
+    saveMailSettings(scope, withoutSmtpPassword(settings));
   }, [scope, settings]);
 
   return (
@@ -257,7 +266,11 @@ function SmtpCard({
           <Field label="Username" id="smtp-user">
             <Input id="smtp-user" value={s.username} onChange={(e) => set({ username: e.target.value })} placeholder="apikey" autoComplete="off" />
           </Field>
-          <Field label="Password" id="smtp-pass">
+          <Field
+            label="Password"
+            id="smtp-pass"
+            hint="Held on this page only — never written to browser storage, and cleared when you reload."
+          >
             <Input id="smtp-pass" type="password" value={s.password} onChange={(e) => set({ password: e.target.value })} placeholder="••••••••" autoComplete="off" />
           </Field>
           <Field label="From name" id="smtp-fromname">
@@ -271,8 +284,9 @@ function SmtpCard({
         <Alert>
           <Info className="size-4" />
           <AlertDescription>
-            Saved to this browser as a draft. When the host is connected, credentials are stored in
-            its secret store and used per tenant — never handed to the workload directly.
+            Nothing on this card is sent to the host yet, so filling it in does not configure
+            outbound mail. The password is held on this page only and is gone when you reload;
+            the remaining fields are remembered in this browser as a draft.
           </AlertDescription>
         </Alert>
 
@@ -297,11 +311,23 @@ function SmtpCard({
   );
 }
 
-function Field({ label, id, children }: { label: string; id: string; children: React.ReactNode }) {
+function Field({
+  label,
+  id,
+  hint,
+  children,
+}: {
+  label: string;
+  id: string;
+  /** Rendered under the control. Use it to state what happens to what is typed. */
+  hint?: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className={cn("grid gap-2")}>
       <Label htmlFor={id}>{label}</Label>
       {children}
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
     </div>
   );
 }

--- a/frontend/src/lib/domain.ts
+++ b/frontend/src/lib/domain.ts
@@ -1,7 +1,24 @@
-// Custom domain + SMTP setup for a company. Persisted per company in
-// localStorage; the console has no provisioning API yet, so DNS verification
-// and SMTP tests are host-side once wired. Secrets live here only as a local
-// draft until the host stores them securely.
+// Custom domain + SMTP setup for a company.
+//
+// The NON-SECRET half of the form is remembered per company in localStorage so
+// a half-filled card survives a reload. The SMTP **password** never is, and
+// this module is the single place that guarantees it (issue #1460).
+//
+// It used to be: the card held the whole `MailSettings` in one `useState` and
+// an effect wrote all of it back on every change, so the password landed in
+// browser storage keystroke by keystroke — readable by any script on the
+// origin, and still there after sign-out. A sending credential does not belong
+// in a store with no expiry and no encryption; every other credential on this
+// surface (Billing, Hosting, MCP, the company credential) goes write-only into
+// the host's secret store instead.
+//
+// So the persisted shape is `StoredMailSettings`, which structurally has no
+// `password` field. `saveMailSettings` cannot write one because it does not
+// receive one, and `loadMailSettings` always hands back an empty password. The
+// password lives in React state for the life of the page and nowhere else.
+//
+// `purgeStoredSmtpPasswords` cleans up after the old behaviour on the way in —
+// see its docstring.
 
 import { type LocalScope, scopedKeyAdoptingLegacy } from "@/connections/types";
 
@@ -25,6 +42,29 @@ export interface SmtpConfig {
 export interface MailSettings {
   domain: DomainConfig;
   smtp: SmtpConfig;
+}
+
+/**
+ * The subset of {@link MailSettings} that is allowed into localStorage.
+ *
+ * `password` is omitted **structurally**, not by convention: `saveMailSettings`
+ * takes this type, so a future caller that tries to persist a credential does
+ * not compile. That is the point — a comment saying "don't store the password"
+ * rots, a type does not.
+ */
+export interface StoredMailSettings {
+  domain: DomainConfig;
+  smtp: Omit<SmtpConfig, "password"> & {
+    /**
+     * Never present. Typed `never` rather than simply omitted because omission
+     * alone would not stop anything: TypeScript is structural, so a full
+     * {@link MailSettings} — which has every field this shape asks for, plus a
+     * password — is assignable to a plain `Omit<…>` by width subtyping, and the
+     * old leaking call would still compile. `password?: never` rejects it,
+     * because `string` is not assignable to `never`.
+     */
+    password?: never;
+  };
 }
 
 export function emptyMailSettings(): MailSettings {
@@ -72,20 +112,106 @@ export function isValidDomain(domain: string): boolean {
 const KEY = (scope: LocalScope) =>
   scopedKeyAdoptingLegacy("oc-mail", scope, `oc-mail:${scope.company ?? "single"}`);
 
+/**
+ * Reads the remembered non-secret half back, with an empty password.
+ *
+ * The empty password is unconditional and deliberate: even if a stored blob
+ * still carries one — a key written by an older build, in a tab that has not
+ * reloaded since the purge ran — it is not read back into the form. Nothing
+ * downstream of this function can resurrect a credential from storage.
+ */
 export function loadMailSettings(scope: LocalScope): MailSettings {
   try {
     const raw = localStorage.getItem(KEY(scope));
-    if (raw) return { ...emptyMailSettings(), ...(JSON.parse(raw) as MailSettings) };
+    if (raw) {
+      const stored = JSON.parse(raw) as Partial<MailSettings>;
+      const merged = { ...emptyMailSettings(), ...stored };
+      return { ...merged, smtp: { ...merged.smtp, password: "" } };
+    }
   } catch {
     /* fall through */
   }
   return emptyMailSettings();
 }
 
-export function saveMailSettings(scope: LocalScope, settings: MailSettings): void {
+/**
+ * Strips the password off a full settings object, yielding the storable shape.
+ *
+ * Destructuring rather than deleting a key, so the result never transiently
+ * holds the credential and `JSON.stringify` has nothing to find.
+ */
+export function withoutSmtpPassword(settings: MailSettings): StoredMailSettings {
+  const { password: _password, ...smtp } = settings.smtp;
+  return { domain: settings.domain, smtp };
+}
+
+/**
+ * Persists the non-secret half of the card.
+ *
+ * Takes {@link StoredMailSettings}, so there is no password to write. Callers
+ * holding a full {@link MailSettings} pass it through
+ * {@link withoutSmtpPassword} first.
+ */
+export function saveMailSettings(scope: LocalScope, settings: StoredMailSettings): void {
   try {
     localStorage.setItem(KEY(scope), JSON.stringify(settings));
   } catch {
     /* storage unavailable */
   }
+}
+
+/** Every localStorage key this module has ever written a password under. */
+const MAIL_KEY_PREFIX = "oc-mail";
+
+/**
+ * Removes SMTP passwords left in localStorage by the pre-#1460 console.
+ *
+ * Stopping new writes only half-solves it: an operator who typed a password
+ * before upgrading still has it sitting in their browser, and it stays there
+ * until something deletes it. This runs once at boot (see `main.tsx`) and
+ * sweeps **every** `oc-mail*` key — scoped and legacy, every connection and
+ * company, not just the scope the current page happens to be looking at,
+ * because the operator is not required to visit Settings for the credential to
+ * need to be gone.
+ *
+ * It rewrites rather than deletes: host, port, security, username and the from
+ * fields are not secret and are work the operator did, so they survive. Only
+ * the password is dropped. A key holding unparseable JSON is removed outright —
+ * it cannot be shown to be password-free, and this function's contract is that
+ * afterwards no password remains.
+ *
+ * Returns the number of keys it rewrote or removed, which is what the
+ * regression test asserts on.
+ */
+export function purgeStoredSmtpPasswords(): number {
+  let cleaned = 0;
+  try {
+    const store = window.localStorage;
+    const keys: string[] = [];
+    for (let i = 0; i < store.length; i++) {
+      const key = store.key(i);
+      if (key !== null && key.startsWith(MAIL_KEY_PREFIX)) keys.push(key);
+    }
+    for (const key of keys) {
+      const raw = store.getItem(key);
+      if (raw === null) continue;
+      if (!raw.includes('"password"')) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        // Unreadable, but it contains the word. Cannot be proven clean, so it
+        // goes — a stale draft is a far smaller loss than a retained secret.
+        store.removeItem(key);
+        cleaned++;
+        continue;
+      }
+      const settings = { ...emptyMailSettings(), ...(parsed as Partial<MailSettings>) };
+      store.setItem(key, JSON.stringify(withoutSmtpPassword(settings)));
+      cleaned++;
+    }
+  } catch {
+    /* storage unavailable — nothing was ever stored to clean */
+  }
+  return cleaned;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "next-themes";
 import { App } from "./App";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
+import { purgeStoredSmtpPasswords } from "@/lib/domain";
 import { startScrollActivity } from "@/lib/scroll-activity";
 import "./index.css";
 
@@ -39,5 +40,12 @@ function mount(): void {
 // mark the themed scrollbars in `index.css` lift on. Outside React on purpose,
 // so StrictMode's double-invoked effects cannot arm it twice.
 startScrollActivity();
+
+// Deletes SMTP passwords the pre-#1460 console wrote to localStorage, before
+// the first render and therefore before anything can read one back. At boot
+// rather than in the Settings card because the operator is not obliged to open
+// Settings again, and the credential has to be gone either way. A no-op on any
+// browser that never stored one.
+purgeStoredSmtpPasswords();
 
 mount();

--- a/frontend/test/unit/smtp-password-never-stored.test.ts
+++ b/frontend/test/unit/smtp-password-never-stored.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { scopedKey } from "@/connections/types";
+import {
+  emptyMailSettings,
+  loadMailSettings,
+  purgeStoredSmtpPasswords,
+  saveMailSettings,
+  withoutSmtpPassword,
+} from "@/lib/domain";
+
+/**
+ * The SMTP password must never reach `localStorage` (issue #1460).
+ *
+ * The pre-fix console held the whole card in one `useState` and wrote all of it
+ * back on every change, so a live sending credential was persisted to browser
+ * storage character by character as it was typed — readable by any script on
+ * the origin, surviving sign-out, with no expiry.
+ *
+ * The assertions below are deliberately written against **the whole store**
+ * rather than against a known key. A test that checks `oc-mail:…` for a missing
+ * `password` field passes the day someone adds a second key, or renames the
+ * prefix, or stores a draft somewhere new — and the credential leaks again with
+ * a green suite. So: type a password, do the things the card does, then read
+ * every value in `localStorage` and assert the secret appears in none of them.
+ * That is the property the fix exists to hold, and it cannot rot into a weaker
+ * one without the assertion visibly changing.
+ */
+
+const SCOPE = { connection: "conn-a", company: "acme" };
+const OTHER_SCOPE = { connection: "conn-b", company: "globex" };
+const LEGACY_KEY = "oc-mail:acme";
+
+/** Distinctive enough that a substring search over the store is meaningful. */
+const SECRET = "pw-3f9a1c-do-not-persist";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+/** Every value currently in `localStorage`, concatenated. */
+function entireStore(): string {
+  const parts: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key === null) continue;
+    parts.push(key, localStorage.getItem(key) ?? "");
+  }
+  return parts.join("\n");
+}
+
+/** A full settings object with a password typed into it. */
+function settingsWithPassword() {
+  const settings = emptyMailSettings();
+  settings.domain = { domain: "mail.acme.com", verified: false };
+  settings.smtp = {
+    host: "smtp.postmarkapp.com",
+    port: "587",
+    security: "starttls",
+    username: "apikey",
+    password: SECRET,
+    fromName: "Acme",
+    fromEmail: "hello@mail.acme.com",
+  };
+  return settings;
+}
+
+describe("saving the card", () => {
+  it("puts no part of the password anywhere in localStorage", () => {
+    saveMailSettings(SCOPE, withoutSmtpPassword(settingsWithPassword()));
+
+    expect(entireStore()).not.toContain(SECRET);
+  });
+
+  it("still remembers the non-secret fields", () => {
+    saveMailSettings(SCOPE, withoutSmtpPassword(settingsWithPassword()));
+
+    const raw = localStorage.getItem(scopedKey("oc-mail", SCOPE)) ?? "";
+    expect(raw).toContain("smtp.postmarkapp.com");
+    expect(raw).toContain("apikey");
+    expect(raw).toContain("mail.acme.com");
+    // The key itself is absent, not merely empty: `withoutSmtpPassword`
+    // destructures it away rather than blanking it.
+    expect(raw).not.toContain("password");
+  });
+
+  it("survives the per-keystroke write pattern the card actually uses", () => {
+    // The regression was a `useEffect` firing once per character. Replaying it
+    // is what proves no intermediate write leaks a prefix of the secret.
+    const settings = settingsWithPassword();
+    for (let i = 0; i <= SECRET.length; i++) {
+      saveMailSettings(SCOPE, withoutSmtpPassword({
+        ...settings,
+        smtp: { ...settings.smtp, password: SECRET.slice(0, i) },
+      }));
+    }
+
+    expect(entireStore()).not.toContain(SECRET.slice(0, 8));
+  });
+});
+
+describe("the persisted shape", () => {
+  it("will not accept a full settings object", () => {
+    // The load-bearing guard, and the one that cannot rot: if `saveMailSettings`
+    // ever becomes willing to take a password again, this `@ts-expect-error`
+    // stops being an error and `npm run typecheck:unit` fails on the unused
+    // directive. A reviewer has to delete this line on purpose to reintroduce
+    // the bug.
+    // @ts-expect-error a full MailSettings carries `password` and must not be storable
+    saveMailSettings(SCOPE, settingsWithPassword());
+
+    // Belt and braces: even having forced the call through, the value written
+    // is whatever the caller passed, so this is the assertion that would catch
+    // a runtime regression the type system was talked out of.
+    expect(entireStore()).toContain(SECRET);
+    purgeStoredSmtpPasswords();
+    expect(entireStore()).not.toContain(SECRET);
+  });
+});
+
+describe("reading the card back", () => {
+  it("returns an empty password even when storage still holds one", () => {
+    // A key written by an older build, in a tab that has not reloaded since the
+    // purge ran. It must not flow back into the form.
+    localStorage.setItem(
+      scopedKey("oc-mail", SCOPE),
+      JSON.stringify({ ...settingsWithPassword() }),
+    );
+
+    expect(loadMailSettings(SCOPE).smtp.password).toBe("");
+  });
+
+  it("keeps the non-secret fields it reads back", () => {
+    saveMailSettings(SCOPE, withoutSmtpPassword(settingsWithPassword()));
+
+    const loaded = loadMailSettings(SCOPE);
+    expect(loaded.smtp.host).toBe("smtp.postmarkapp.com");
+    expect(loaded.smtp.username).toBe("apikey");
+    expect(loaded.domain.domain).toBe("mail.acme.com");
+  });
+});
+
+describe("purging what the old console already stored", () => {
+  it("clears passwords from every scope, not just the one on screen", () => {
+    const stored = JSON.stringify(settingsWithPassword());
+    localStorage.setItem(scopedKey("oc-mail", SCOPE), stored);
+    localStorage.setItem(scopedKey("oc-mail", OTHER_SCOPE), stored);
+    localStorage.setItem(LEGACY_KEY, stored);
+
+    expect(purgeStoredSmtpPasswords()).toBe(3);
+    expect(entireStore()).not.toContain(SECRET);
+  });
+
+  it("keeps the operator's non-secret work", () => {
+    localStorage.setItem(scopedKey("oc-mail", SCOPE), JSON.stringify(settingsWithPassword()));
+
+    purgeStoredSmtpPasswords();
+
+    const loaded = loadMailSettings(SCOPE);
+    expect(loaded.smtp.host).toBe("smtp.postmarkapp.com");
+    expect(loaded.smtp.username).toBe("apikey");
+    expect(loaded.smtp.fromEmail).toBe("hello@mail.acme.com");
+    expect(loaded.domain.domain).toBe("mail.acme.com");
+  });
+
+  it("removes a key whose JSON cannot be parsed but mentions a password", () => {
+    // Cannot be shown to be clean, so it cannot be left in place.
+    localStorage.setItem(scopedKey("oc-mail", SCOPE), `{"smtp":{"password":"${SECRET}"`);
+
+    expect(purgeStoredSmtpPasswords()).toBe(1);
+    expect(localStorage.getItem(scopedKey("oc-mail", SCOPE))).toBeNull();
+    expect(entireStore()).not.toContain(SECRET);
+  });
+
+  it("leaves unrelated keys alone and reports nothing to clean", () => {
+    localStorage.setItem("oc-tour:conn-a::acme", '{"step":3}');
+    localStorage.setItem(scopedKey("oc-mail", SCOPE), JSON.stringify(withoutSmtpPassword(emptyMailSettings())));
+
+    expect(purgeStoredSmtpPasswords()).toBe(0);
+    expect(localStorage.getItem("oc-tour:conn-a::acme")).toBe('{"step":3}');
+  });
+
+  it("is idempotent", () => {
+    localStorage.setItem(scopedKey("oc-mail", SCOPE), JSON.stringify(settingsWithPassword()));
+
+    expect(purgeStoredSmtpPasswords()).toBe(1);
+    expect(purgeStoredSmtpPasswords()).toBe(0);
+    expect(entireStore()).not.toContain(SECRET);
+  });
+});

--- a/src/server/graphql/connections.rs
+++ b/src/server/graphql/connections.rs
@@ -8,12 +8,7 @@ use async_graphql::SimpleObject;
 
 use crate::company::dns::DomainStatus;
 use crate::company::runtime::CompanyRuntime;
-use crate::server::ops::smtp::{SmtpCredentials, SmtpStatus};
-
-/// The reserved SecretStore key holding the JSON domain status.
-const DOMAIN_KEY: &str = "__domain";
-/// The reserved SecretStore key holding the JSON SMTP credentials.
-const SMTP_KEY: &str = "__smtp";
+use crate::server::ops::smtp::SmtpStatus;
 
 /// One third-party connection's state: manifest intent plus live OAuth status.
 #[derive(SimpleObject)]
@@ -134,29 +129,37 @@ pub(crate) async fn resolve_connections(
 }
 
 /// Resolves `Company.domain`, returning null when no domain is configured.
+///
+/// Delegates to [`ops::domain::load_domain`](crate::server::ops::domain::load_domain),
+/// the same read `GET …/domain` serves, for the reason
+/// [`resolve_connections`] documents: two copies of one decision are free to
+/// drift, and a domain that read as verified on one plane and not the other
+/// would be exactly that drift (issue #316).
 pub(crate) async fn resolve_domain(
     runtime: &Arc<CompanyRuntime>,
 ) -> async_graphql::Result<Option<DomainStatusGql>> {
-    let Some(value) = runtime.secrets().get(runtime.id(), DOMAIN_KEY).await? else {
-        return Ok(None);
-    };
-    let status: DomainStatus = serde_json::from_str(value.expose())
+    let stored = crate::server::ops::domain::load_domain(runtime.as_ref())
+        .await
         .map_err(|e| async_graphql::Error::new(format!("stored domain status is invalid: {e}")))?;
-    Ok(Some(status.into()))
+    Ok(stored.map(DomainStatusGql::from))
 }
 
 /// Resolves `Company.smtp`: the non-secret SMTP projection (never the password).
+///
+/// Reads through [`ops::smtp::load_credentials`](crate::server::ops::smtp::load_credentials)
+/// — the same load `GET …/smtp` and the test send use — and projects it here.
+/// The projection is [`SmtpStatus::from_credentials`], which is what drops the
+/// password; this resolver never sees a shape that could carry one onward.
 pub(crate) async fn resolve_smtp(
     runtime: &Arc<CompanyRuntime>,
 ) -> async_graphql::Result<SmtpStatusGql> {
-    let status = match runtime.secrets().get(runtime.id(), SMTP_KEY).await? {
-        Some(value) => {
-            let creds: SmtpCredentials = serde_json::from_str(value.expose()).map_err(|e| {
-                async_graphql::Error::new(format!("stored SMTP credentials are invalid: {e}"))
-            })?;
-            SmtpStatus::from_credentials(&creds)
-        }
-        None => SmtpStatus::unconfigured(),
-    };
+    let stored = crate::server::ops::smtp::load_credentials(runtime.as_ref())
+        .await
+        .map_err(|e| {
+            async_graphql::Error::new(format!("stored SMTP credentials are invalid: {e}"))
+        })?;
+    let status = stored
+        .as_ref()
+        .map_or_else(SmtpStatus::unconfigured, SmtpStatus::from_credentials);
     Ok(status.into())
 }

--- a/src/server/ops/domain.rs
+++ b/src/server/ops/domain.rs
@@ -82,8 +82,14 @@ pub(crate) async fn load_domain(
 /// whether they resolved — so it stays open to any member, exactly as
 /// `POST …/domain/verify` and `GET …/hosting` already are
 /// (`docs/modules/server/authority.md`). Making it admin-only would `403` a
-/// member on the Settings screen while the identical data stayed readable to
-/// them over GraphQL as `Company.domain`.
+/// member on the Settings screen while the same domain, its records and its
+/// verified flag stayed readable to them over GraphQL as `Company.domain`.
+///
+/// "The same", not "identical". Both surfaces read through [`load_domain`], so
+/// neither can be staler than the other, but they do not answer the same
+/// detail: this route returns the whole [`DomainStatus`], and `DomainStatusGql`
+/// projects only `domain`, `verified` and `records`. The per-record `checks`
+/// from the last verify pass are REST-only.
 ///
 /// `null` rather than a synthesized empty status, matching the nullability
 /// `Company.domain` already reports.

--- a/src/server/ops/domain.rs
+++ b/src/server/ops/domain.rs
@@ -14,20 +14,22 @@ use std::sync::Arc;
 
 use axum::extract::State;
 use axum::response::Response;
-use axum::routing::{post, put};
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 
 use crate::AppState;
 use crate::company::dns::{self, DomainStatus};
 use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
 use crate::ports::types::SecretValue;
 use crate::server::error::ApiError;
 use crate::server::ops::{AdminScopedCompany, DOMAIN_KEY, ScopedCompany, scoped};
 
 /// Builds the domain route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/domain", put(put_domain)).merge(scoped("/domain/verify", post(verify_domain)))
+    scoped("/domain", get(get_domain).put(put_domain))
+        .merge(scoped("/domain/verify", post(verify_domain)))
 }
 
 /// The set-domain request body.
@@ -58,11 +60,35 @@ async fn persist(runtime: &CompanyRuntime, status: &DomainStatus) -> Result<(), 
 }
 
 /// Loads the stored domain config, if any.
-async fn load_domain(runtime: &CompanyRuntime) -> Result<Option<DomainStatus>, ApiError> {
+///
+/// `pub(crate)` and carrying the crate error rather than [`ApiError`] so the
+/// GraphQL resolver for `Company.domain` can serve the same read instead of
+/// keeping a second copy of it (issue #316) — an `ApiError` is an HTTP
+/// response, and a resolver has nowhere to put one.
+pub(crate) async fn load_domain(
+    runtime: &CompanyRuntime,
+) -> Result<Option<DomainStatus>, OpenCompanyError> {
     let Some(value) = runtime.secrets().get(runtime.id(), DOMAIN_KEY).await? else {
         return Ok(None);
     };
     Ok(Some(serde_json::from_str(value.expose())?))
+}
+
+/// `GET …/domain` (both scope forms) — the stored domain status, or `null`.
+///
+/// `ScopedCompany`, not `AdminScopedCompany`, and deliberately: the admin line
+/// on this plane is the company's outward *identity*, which is the write. The
+/// read carries no credential — a domain, its published DNS records, and
+/// whether they resolved — so it stays open to any member, exactly as
+/// `POST …/domain/verify` and `GET …/hosting` already are
+/// (`docs/modules/server/authority.md`). Making it admin-only would `403` a
+/// member on the Settings screen while the identical data stayed readable to
+/// them over GraphQL as `Company.domain`.
+///
+/// `null` rather than a synthesized empty status, matching the nullability
+/// `Company.domain` already reports.
+async fn get_domain(company: ScopedCompany) -> Result<Json<Option<DomainStatus>>, ApiError> {
+    Ok(Json(load_domain(&company.runtime).await?))
 }
 
 /// `PUT …/domain` (both scope forms).
@@ -88,7 +114,7 @@ async fn run_verify(
     };
     let stored = load_domain(&runtime)
         .await
-        .map_err(IntoResponse::into_response)?;
+        .map_err(|e| ApiError(e).into_response())?;
     let Some(stored) = stored else {
         return Err(ApiError(crate::error::OpenCompanyError::InvalidRequest(
             "no domain configured".to_string(),

--- a/src/server/ops/mailer.rs
+++ b/src/server/ops/mailer.rs
@@ -430,6 +430,7 @@ impl TenantMailboxConfig {
 #[derive(Clone, Default)]
 pub struct RecordingMailSender {
     sent: Arc<Mutex<Vec<(String, OutboundEmail)>>>,
+    presented: Arc<Mutex<Vec<MailCredentials>>>,
 }
 
 impl RecordingMailSender {
@@ -441,6 +442,17 @@ impl RecordingMailSender {
     /// Every `(from_email, email)` sent so far.
     pub fn sent(&self) -> Vec<(String, OutboundEmail)> {
         self.sent.lock().expect("mail sender poisoned").clone()
+    }
+
+    /// The credentials each send actually presented, in order.
+    ///
+    /// Recorded alongside [`sent`](Self::sent) rather than folded into it, so
+    /// existing callers keep their tuple. It exists because "which password
+    /// reached the transport" is otherwise unobservable from a test, and that
+    /// is precisely the question a patching `PUT …/smtp` has to answer: a save
+    /// that omitted the password must still send under the stored one.
+    pub fn presented(&self) -> Vec<MailCredentials> {
+        self.presented.lock().expect("mail sender poisoned").clone()
     }
 }
 
@@ -455,6 +467,10 @@ impl MailSender for RecordingMailSender {
             .lock()
             .expect("mail sender poisoned")
             .push((creds.from_email().to_string(), email.clone()));
+        self.presented
+            .lock()
+            .expect("mail sender poisoned")
+            .push(creds.clone());
         Ok(())
     }
 }

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -95,8 +95,19 @@ use crate::server::ops::mailer::{MailCredentials, MailSender};
 
 /// SecretStore key holding the JSON [`DomainStatus`](crate::company::dns::DomainStatus).
 pub(crate) const DOMAIN_KEY: &str = "__domain";
-/// SecretStore key holding the JSON SMTP credentials.
+/// SecretStore key holding the JSON SMTP configuration — everything but the
+/// password. See [`SMTP_PASSWORD_KEY`].
 pub(crate) const SMTP_KEY: &str = "__smtp";
+/// SecretStore key holding the SMTP password on its own.
+///
+/// Split out of [`SMTP_KEY`] so that "keep the stored password" is the
+/// *absence* of a write rather than a read-modify-write: `PUT …/smtp` without a
+/// password rewrites only the configuration blob and never touches this key, so
+/// it cannot write a stale secret back over a concurrent rotation. Credentials
+/// written before the split still carry the password inside the `SMTP_KEY`
+/// blob; reads fall back to it, and the first write after the split migrates it
+/// here. See `src/server/ops/smtp.rs`.
+pub(crate) const SMTP_PASSWORD_KEY: &str = "__smtp_password";
 /// SecretStore key holding the shared secret the inbound ingest HMAC is verified against.
 pub(crate) const INGEST_SECRET_KEY: &str = "ingest_secret";
 

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -32,7 +32,7 @@ use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::inbox::EmailRecord;
-use crate::ports::types::SecretValue;
+use crate::ports::types::{CompanyId, SecretValue};
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
@@ -294,13 +294,19 @@ struct SmtpConfigBody {
 /// blob and leaves the secret untouched. A rotation landing concurrently is
 /// therefore preserved rather than reverted. The one exception is credentials
 /// written before the split, whose password still sits inside the blob: the
-/// first passwordless save after the split migrates it to its own key, and that
-/// single migration is a genuine read-modify-write. It is no worse than the
-/// behaviour it replaces, and it can only ever happen once per company.
+/// first passwordless save after the split has to read it and write it to its
+/// own key, which is a genuine read-modify-write. That one path is serialized
+/// by [`write_lock`] so a rotation cannot interleave with it.
 async fn put_smtp(
     company: AdminScopedCompany,
     Json(body): Json<SmtpConfigBody>,
 ) -> Result<Json<SmtpStatus>, ApiError> {
+    // Held across the whole handler, so the legacy migration below and any
+    // rotation racing it cannot interleave. The steady-state path needs no lock
+    // — it is raceless by construction — but taking it unconditionally keeps
+    // the ordering rule in one place rather than in each branch.
+    let lock = write_lock(company.runtime.id());
+    let _guard = lock.lock().await;
     match body.password.filter(|password| !password.trim().is_empty()) {
         // A rotation. Write the secret before the configuration blob: the blob
         // is what makes the company read as `configured`, so this order can
@@ -320,6 +326,34 @@ async fn put_smtp(
         from_email: body.from_email,
     };
     store_config(company.runtime, config).await
+}
+
+/// Per-company serialization for `PUT …/smtp`.
+///
+/// The split-key layout already makes the steady-state passwordless save
+/// raceless without any lock, because it writes no password at all. This exists
+/// for the one path that must still read and then write — migrating a pre-split
+/// password out of the configuration blob — where a rotation landing in between
+/// would otherwise be overwritten by the migration.
+///
+/// **In-process only, and deliberately so.** A tenant runs as a single
+/// container ([`docs/spec/runtime/storage.md`]), so one process is the whole
+/// population of concurrent writers in the deployed topology. Two replicas of
+/// one company would reopen the window on the legacy path alone; closing it
+/// there would need a conditional write in
+/// [`SecretStore`](crate::ports::SecretStore), which the port cannot express
+/// today. The steady-state path stays correct under any number of replicas.
+fn write_lock(company: &CompanyId) -> Arc<tokio::sync::Mutex<()>> {
+    static LOCKS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<CompanyId, Arc<tokio::sync::Mutex<()>>>>,
+    > = std::sync::OnceLock::new();
+    let locks = LOCKS.get_or_init(Default::default);
+    let mut locks = locks.lock().expect("smtp write locks poisoned");
+    Arc::clone(
+        locks
+            .entry(company.clone())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+    )
 }
 
 /// Confirms a password is stored ahead of a passwordless save, and refuses the

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use axum::extract::State;
 use axum::response::Response;
-use axum::routing::{post, put};
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +32,7 @@ use crate::ports::types::SecretValue;
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
-use crate::server::ops::{AdminScopedCompany, SMTP_KEY, scoped};
+use crate::server::ops::{AdminScopedCompany, SMTP_KEY, ScopedCompany, scoped};
 
 /// The SMTP security mode. Mirrors the console's `SmtpSecurity`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -126,7 +126,33 @@ impl SmtpStatus {
 
 /// Builds the SMTP route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/smtp", put(put_smtp)).merge(scoped("/smtp/test", post(test_smtp)))
+    scoped("/smtp", get(get_smtp).put(put_smtp)).merge(scoped("/smtp/test", post(test_smtp)))
+}
+
+// -- GET smtp ---------------------------------------------------------------
+
+/// `GET …/smtp` (both scope forms) — the non-secret status of what is stored.
+///
+/// `ScopedCompany`, and the asymmetry with its neighbours is deliberate. The
+/// admin line on this plane guards the company's outward identity: `PUT …/smtp`
+/// sets the credentials its mail goes out under, and `POST …/smtp/test` sends
+/// real mail to a recipient the caller names in the body. This read does
+/// neither — [`SmtpStatus`] is host, port, username and from-address, with the
+/// password absent by construction — so it stays open to any member, the same
+/// rule `docs/modules/server/authority.md` already states for reads on these
+/// surfaces. Admin-only, it would `403` a member on the Settings screen while
+/// the identical projection stayed readable to them over GraphQL as
+/// `Company.smtp`.
+///
+/// [`SmtpStatus::unconfigured`] rather than `null` when nothing is stored: the
+/// type already carries a `configured` flag to say so, and the GraphQL field is
+/// the non-null `SmtpStatus!`.
+async fn get_smtp(company: ScopedCompany) -> Result<Json<SmtpStatus>, ApiError> {
+    let stored = load_credentials(&company.runtime).await?;
+    Ok(Json(stored.as_ref().map_or_else(
+        SmtpStatus::unconfigured,
+        SmtpStatus::from_credentials,
+    )))
 }
 
 // -- PUT smtp ---------------------------------------------------------------
@@ -144,14 +170,80 @@ async fn store_credentials(
     Ok(Json(SmtpStatus::from_credentials(&creds)))
 }
 
+/// The save-credentials body: [`SmtpCredentials`], except that the password is
+/// a **patch**.
+///
+/// Same shape and same field names on the wire — a body carrying a password
+/// behaves exactly as it always did. What is new is that a body *without* one
+/// keeps the stored password, mirroring the patch semantics
+/// [`hosting`](super::hosting) already uses for its API key. The reason is the
+/// same: the password is write-only, so a form can never render it back, and
+/// without this every correction to a from-name would cost the operator a
+/// credential they would have to go and look up again.
+///
+/// Field names stay `snake_case` (`from_name`, `from_email`) because
+/// [`SmtpCredentials`] has no `rename_all` and the console mirrors it as-is.
+#[derive(Debug, Deserialize)]
+struct SmtpConfigBody {
+    /// SMTP server host.
+    host: String,
+    /// SMTP server port.
+    port: u16,
+    /// Transport security mode.
+    #[serde(default)]
+    security: SmtpSecurity,
+    /// Login username.
+    username: String,
+    /// Login password. Omit (or send empty) to keep the stored one.
+    #[serde(default)]
+    password: Option<String>,
+    /// Display name on the `From` header.
+    #[serde(default)]
+    from_name: String,
+    /// Envelope/from address.
+    from_email: String,
+}
+
 /// `PUT …/smtp` (both scope forms).
 ///
 /// Requires authority over the company (issue #403): these credentials are the
 /// address the company's mail goes out as.
+///
+/// Every field but the password replaces what is stored. The password is kept
+/// when the body omits it, so "stored — leave blank to keep" is a save the
+/// console can actually offer; with nothing supplied and nothing stored, the
+/// request is refused rather than persisting credentials that could never
+/// authenticate.
 async fn put_smtp(
     company: AdminScopedCompany,
-    Json(creds): Json<SmtpCredentials>,
+    Json(body): Json<SmtpConfigBody>,
 ) -> Result<Json<SmtpStatus>, ApiError> {
+    let supplied = body
+        .password
+        .as_deref()
+        .map(str::trim)
+        .filter(|password| !password.is_empty())
+        .map(str::to_string);
+    let password = match supplied {
+        Some(password) => password,
+        None => load_credentials(&company.runtime)
+            .await?
+            .map(|stored| stored.password)
+            .ok_or_else(|| {
+                ApiError(OpenCompanyError::InvalidRequest(
+                    "an SMTP password is required".to_string(),
+                ))
+            })?,
+    };
+    let creds = SmtpCredentials {
+        host: body.host,
+        port: body.port,
+        security: body.security,
+        username: body.username,
+        password,
+        from_name: body.from_name,
+        from_email: body.from_email,
+    };
     store_credentials(company.runtime, creds).await
 }
 

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -168,8 +168,8 @@ async fn get_smtp(company: ScopedCompany) -> Result<Json<SmtpStatus>, ApiError> 
 /// still falls back to it; nothing writes it, because
 /// `skip_serializing_if = "Option::is_none"` and every construction site leaves
 /// it `None`.
-#[derive(Debug, Serialize, Deserialize)]
-struct StoredConfig {
+#[derive(Serialize, Deserialize)]
+pub(super) struct StoredConfig {
     /// SMTP server host.
     host: String,
     /// SMTP server port.
@@ -187,6 +187,27 @@ struct StoredConfig {
     from_name: String,
     /// Envelope/from address.
     from_email: String,
+}
+
+impl std::fmt::Debug for StoredConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never the legacy password: a derived Debug would print it, and this
+        // struct is the one place a password can still ride along inside
+        // otherwise non-secret configuration. Same rule as
+        // [`TenantMailboxConfig`](super::mailer::TenantMailboxConfig).
+        f.debug_struct("StoredConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("security", &self.security)
+            .field("username", &self.username)
+            .field("from_name", &self.from_name)
+            .field("from_email", &self.from_email)
+            .field(
+                "legacy_password",
+                &self.password.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl StoredConfig {

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -4,8 +4,12 @@
 //! adapter it plugs into lives in [`mailer`](super::mailer).
 //!
 //! `PUT …/smtp` stores credentials in [`SecretStore`](crate::ports::SecretStore)
-//! under [`SMTP_KEY`](super::SMTP_KEY) and returns a non-secret
-//! [`SmtpStatus`] — the password never appears in any response. `POST …/smtp/test`
+//! and returns a non-secret [`SmtpStatus`] — the password never appears in any
+//! response. They are stored under two keys, not one: the configuration under
+//! [`SMTP_KEY`](super::SMTP_KEY) and the password under
+//! [`SMTP_PASSWORD_KEY`](super::SMTP_PASSWORD_KEY). That split is what lets a
+//! save that omits the password keep the stored one without reading it first —
+//! see [`put_smtp`]. `POST …/smtp/test`
 //! sends a test email through the mockable
 //! [`MailSender`](super::mailer::MailSender) seam, pulling the stored
 //! credentials per send, and records the sent mail in the company's
@@ -32,7 +36,7 @@ use crate::ports::types::SecretValue;
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
-use crate::server::ops::{AdminScopedCompany, SMTP_KEY, ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, SMTP_KEY, SMTP_PASSWORD_KEY, ScopedCompany, scoped};
 
 /// The SMTP security mode. Mirrors the console's `SmtpSecurity`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -148,26 +152,89 @@ pub fn router() -> Router<AppState> {
 /// type already carries a `configured` flag to say so, and the GraphQL field is
 /// the non-null `SmtpStatus!`.
 async fn get_smtp(company: ScopedCompany) -> Result<Json<SmtpStatus>, ApiError> {
-    let stored = load_credentials(&company.runtime).await?;
-    Ok(Json(stored.as_ref().map_or_else(
-        SmtpStatus::unconfigured,
-        SmtpStatus::from_credentials,
-    )))
+    let stored = load_config(&company.runtime).await?;
+    Ok(Json(
+        stored.map_or_else(SmtpStatus::unconfigured, |config| config.status()),
+    ))
 }
 
 // -- PUT smtp ---------------------------------------------------------------
 
-/// Persists credentials and returns the non-secret status.
-async fn store_credentials(
+/// What lives under [`SMTP_KEY`]: the credentials minus the password, which has
+/// its own key ([`SMTP_PASSWORD_KEY`]).
+///
+/// `password` is a **legacy read path only**. Blobs written before the split
+/// embedded it here, so [`load_config`] still parses it and [`load_credentials`]
+/// still falls back to it; nothing writes it, because
+/// `skip_serializing_if = "Option::is_none"` and every construction site leaves
+/// it `None`.
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredConfig {
+    /// SMTP server host.
+    host: String,
+    /// SMTP server port.
+    port: u16,
+    /// Transport security mode.
+    #[serde(default)]
+    security: SmtpSecurity,
+    /// Login username.
+    username: String,
+    /// The pre-split password location. Read, never written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    password: Option<String>,
+    /// Display name on the `From` header.
+    #[serde(default)]
+    from_name: String,
+    /// Envelope/from address.
+    from_email: String,
+}
+
+impl StoredConfig {
+    /// Projects the stored configuration to its non-secret status.
+    fn status(&self) -> SmtpStatus {
+        SmtpStatus {
+            configured: true,
+            host: Some(self.host.clone()),
+            port: Some(self.port),
+            security: Some(self.security),
+            username: Some(self.username.clone()),
+            from_name: Some(self.from_name.clone()),
+            from_email: Some(self.from_email.clone()),
+        }
+    }
+}
+
+/// Reads the stored configuration blob, if any.
+async fn load_config(runtime: &CompanyRuntime) -> Result<Option<StoredConfig>, OpenCompanyError> {
+    let Some(value) = runtime.secrets().get(runtime.id(), SMTP_KEY).await? else {
+        return Ok(None);
+    };
+    Ok(Some(serde_json::from_str(value.expose())?))
+}
+
+/// Writes the password to its own key.
+async fn store_password(runtime: &CompanyRuntime, password: &str) -> Result<(), OpenCompanyError> {
+    runtime
+        .secrets()
+        .set(
+            runtime.id(),
+            SMTP_PASSWORD_KEY,
+            SecretValue(password.to_string()),
+        )
+        .await
+}
+
+/// Persists the configuration blob and returns the non-secret status.
+async fn store_config(
     runtime: Arc<CompanyRuntime>,
-    creds: SmtpCredentials,
+    config: StoredConfig,
 ) -> Result<Json<SmtpStatus>, ApiError> {
-    let json = serde_json::to_string(&creds)?;
+    let json = serde_json::to_string(&config)?;
     runtime
         .secrets()
         .set(runtime.id(), SMTP_KEY, SecretValue(json))
         .await?;
-    Ok(Json(SmtpStatus::from_credentials(&creds)))
+    Ok(Json(config.status()))
 }
 
 /// The save-credentials body: [`SmtpCredentials`], except that the password is
@@ -214,37 +281,73 @@ struct SmtpConfigBody {
 /// console can actually offer; with nothing supplied and nothing stored, the
 /// request is refused rather than persisting credentials that could never
 /// authenticate.
+///
+/// The password is taken **byte for byte** as supplied. Trimming is only ever
+/// used to decide whether the caller supplied one at all: an SMTP password may
+/// legitimately open or close with a space, and silently storing `" hunter2 "`
+/// as `"hunter2"` would fail authentication with nothing in any response or log
+/// to explain why.
+///
+/// Keeping the stored password is the *absence* of a write, not a
+/// read-modify-write: the two live under separate keys ([`SMTP_KEY`] and
+/// [`SMTP_PASSWORD_KEY`]), so a passwordless save rewrites the configuration
+/// blob and leaves the secret untouched. A rotation landing concurrently is
+/// therefore preserved rather than reverted. The one exception is credentials
+/// written before the split, whose password still sits inside the blob: the
+/// first passwordless save after the split migrates it to its own key, and that
+/// single migration is a genuine read-modify-write. It is no worse than the
+/// behaviour it replaces, and it can only ever happen once per company.
 async fn put_smtp(
     company: AdminScopedCompany,
     Json(body): Json<SmtpConfigBody>,
 ) -> Result<Json<SmtpStatus>, ApiError> {
-    let supplied = body
-        .password
-        .as_deref()
-        .map(str::trim)
-        .filter(|password| !password.is_empty())
-        .map(str::to_string);
-    let password = match supplied {
-        Some(password) => password,
-        None => load_credentials(&company.runtime)
-            .await?
-            .map(|stored| stored.password)
-            .ok_or_else(|| {
-                ApiError(OpenCompanyError::InvalidRequest(
-                    "an SMTP password is required".to_string(),
-                ))
-            })?,
-    };
-    let creds = SmtpCredentials {
+    match body.password.filter(|password| !password.trim().is_empty()) {
+        // A rotation. Write the secret before the configuration blob: the blob
+        // is what makes the company read as `configured`, so this order can
+        // never leave a configured company pointing at no password.
+        Some(password) => store_password(&company.runtime, &password).await?,
+        // A passwordless save. Confirm a password exists — migrating a
+        // pre-split one to its own key — and otherwise leave it alone.
+        None => ensure_password_stored(&company.runtime).await?,
+    }
+    let config = StoredConfig {
         host: body.host,
         port: body.port,
         security: body.security,
         username: body.username,
-        password,
+        password: None,
         from_name: body.from_name,
         from_email: body.from_email,
     };
-    store_credentials(company.runtime, creds).await
+    store_config(company.runtime, config).await
+}
+
+/// Confirms a password is stored ahead of a passwordless save, and refuses the
+/// save when none is.
+///
+/// In the steady state this reads one key and writes nothing, which is what
+/// keeps the passwordless save free of a read-modify-write. It writes only to
+/// migrate a pre-split password out of the configuration blob, because the
+/// blob is about to be rewritten without it.
+async fn ensure_password_stored(runtime: &CompanyRuntime) -> Result<(), ApiError> {
+    if runtime
+        .secrets()
+        .get(runtime.id(), SMTP_PASSWORD_KEY)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let legacy = load_config(runtime)
+        .await?
+        .and_then(|config| config.password);
+    let legacy = legacy.ok_or_else(|| {
+        ApiError(OpenCompanyError::InvalidRequest(
+            "an SMTP password is required".to_string(),
+        ))
+    })?;
+    store_password(runtime, &legacy).await?;
+    Ok(())
 }
 
 // -- POST smtp/test ---------------------------------------------------------
@@ -310,15 +413,36 @@ async fn run_test(
     }
 }
 
-/// Loads and parses stored SMTP credentials, if any.
+/// Loads stored SMTP credentials, if any, recombining the configuration blob
+/// with the separately stored password.
+///
+/// The password comes from [`SMTP_PASSWORD_KEY`], falling back to the copy
+/// inside the blob for credentials written before the two were split. Only the
+/// send path needs this; [`get_smtp`] reads the configuration alone so that
+/// rendering the settings page never touches the secret.
 pub(crate) async fn load_credentials(
     runtime: &CompanyRuntime,
 ) -> Result<Option<SmtpCredentials>, OpenCompanyError> {
-    let Some(value) = runtime.secrets().get(runtime.id(), SMTP_KEY).await? else {
+    let Some(config) = load_config(runtime).await? else {
         return Ok(None);
     };
-    let creds: SmtpCredentials = serde_json::from_str(value.expose())?;
-    Ok(Some(creds))
+    let password = match runtime
+        .secrets()
+        .get(runtime.id(), SMTP_PASSWORD_KEY)
+        .await?
+    {
+        Some(value) => value.expose().to_string(),
+        None => config.password.clone().unwrap_or_default(),
+    };
+    Ok(Some(SmtpCredentials {
+        host: config.host,
+        port: config.port,
+        security: config.security,
+        username: config.username,
+        password,
+        from_name: config.from_name,
+        from_email: config.from_email,
+    }))
 }
 
 /// Appends a sent email to the sender's inbox so the console shows outbound mail.

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -1128,3 +1128,25 @@ async fn a_rotation_racing_the_legacy_migration_is_not_lost() {
         );
     }
 }
+
+#[test]
+fn debugging_the_stored_config_does_not_print_a_legacy_password() {
+    // `StoredConfig` is the one place a password can still ride along inside
+    // otherwise non-secret configuration, so a derived `Debug` would put a live
+    // credential into any log line or panic message that formats one.
+    let config: super::smtp::StoredConfig = serde_json::from_value(serde_json::json!({
+        "host": "smtp.acme.test",
+        "port": 587,
+        "security": "starttls",
+        "username": "mailer",
+        "password": "must-not-appear",
+        "from_name": "Acme",
+        "from_email": "ceo@acme.test",
+    }))
+    .unwrap();
+    let rendered = format!("{config:?}");
+    assert!(!rendered.contains("must-not-appear"), "{rendered}");
+    assert!(rendered.contains("<redacted>"), "{rendered}");
+    // Still useful for diagnosis.
+    assert!(rendered.contains("smtp.acme.test"), "{rendered}");
+}

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -37,6 +37,19 @@ fn manifest() -> CompanyManifest {
 
 /// Builds state holding one running company `acme`, with `connections` injected.
 async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> AppState {
+    state_with_secrets(home, connections, None).await
+}
+
+/// [`state_with`], optionally over an injected
+/// [`SecretStore`](crate::ports::SecretStore).
+///
+/// The seam exists for the tests that have to observe *when* the SMTP secrets
+/// are read and written, which the on-disk store gives no way to see.
+async fn state_with_secrets(
+    home: &std::path::Path,
+    connections: ConnectionsRuntime,
+    secrets: Option<Arc<dyn crate::ports::SecretStore>>,
+) -> AppState {
     let store = crate::store::FsCompanyStore::new(home.to_path_buf());
     let id = CompanyId::new("acme");
     store
@@ -59,11 +72,11 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
         })
         .await
         .unwrap();
-    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
-        .with_id(id.clone())
-        .build()
-        .await
-        .unwrap();
+    let mut builder = RuntimeBuilder::new(home.to_path_buf(), manifest()).with_id(id.clone());
+    if let Some(secrets) = secrets {
+        builder = builder.with_secrets(secrets);
+    }
+    let runtime = builder.build().await.unwrap();
     let state = AppState::new(AppConfig::default())
         .with_home(home.to_path_buf())
         .with_connections(connections);
@@ -665,4 +678,338 @@ async fn put_smtp_without_a_password_and_nothing_stored_is_refused() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let value = body_json(response).await;
     assert_eq!(value["code"], "invalid_request", "{value}");
+}
+
+#[tokio::test]
+async fn a_password_keeps_its_leading_and_trailing_spaces() {
+    // `str::trim` on the way in would store `" pad ded "` as `"pad ded"`, and
+    // the operator would watch authentication fail against a password they can
+    // see is correct, with nothing in any response or log naming the edit. SMTP
+    // passwords are opaque bytes; only the caller knows where they end.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let sender = Arc::new(RecordingMailSender::new());
+    let state = state_with(&home, ConnectionsRuntime::new().with_mail(sender.clone())).await;
+    let app = router(state);
+
+    // Deliberately fake, and deliberately padded at both ends.
+    let padded = "  pad ded  ";
+    let body = serde_json::json!({
+        "host": "smtp.acme.test",
+        "port": 587,
+        "security": "starttls",
+        "username": "mailer",
+        "password": padded,
+        "from_name": "Acme",
+        "from_email": "ceo@acme.test",
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // What reached the transport is the only observable answer — the password is
+    // write-only, so no read can report it back.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/smtp/test")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let presented = sender.presented();
+    assert_eq!(presented.len(), 1);
+    let crate::server::ops::mailer::MailCredentials::Smtp(creds) = &presented[0];
+    assert_eq!(
+        creds.password, padded,
+        "the stored password must be byte-for-byte what was supplied",
+    );
+}
+
+/// A secret store that lets one "concurrent rotation" land at a chosen moment.
+///
+/// The rotation commits immediately *before* this request's first write, which
+/// is the only interleaving that can lose it: the other admin's `PUT …/smtp`
+/// has landed after this request read whatever it read, so anything this
+/// request now writes is written on top of the rotation. Hanging it off the
+/// write rather than the read is deliberate — a request may read several times,
+/// and firing on the first read would let a later read observe the rotation and
+/// quietly launder the bug into a pass.
+///
+/// It is applied to both places a password can live — its own key and the
+/// pre-split configuration blob — so it is a genuine rotation under either
+/// storage layout, and the test can ask the one question that matters: does the
+/// save that follows revert it?
+#[derive(Default)]
+struct RotatingSecrets {
+    entries: std::sync::Mutex<std::collections::HashMap<String, String>>,
+    /// `(password, blob)` to commit just before the next SMTP write, once.
+    rotation: std::sync::Mutex<Option<(String, String)>>,
+}
+
+impl RotatingSecrets {
+    /// Arms the one-shot rotation.
+    fn arm(&self, password: &str, blob: &str) {
+        *self.rotation.lock().unwrap() = Some((password.to_string(), blob.to_string()));
+    }
+
+    /// The password an ordinary read would now resolve to.
+    fn stored_password(&self) -> Option<String> {
+        self.entries
+            .lock()
+            .unwrap()
+            .get(super::SMTP_PASSWORD_KEY)
+            .cloned()
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::ports::SecretStore for RotatingSecrets {
+    async fn get(
+        &self,
+        _company: &CompanyId,
+        key: &str,
+    ) -> crate::Result<Option<crate::ports::types::SecretValue>> {
+        let seen = self.entries.lock().unwrap().get(key).cloned();
+        Ok(seen.map(SecretValue))
+    }
+
+    async fn set(&self, _company: &CompanyId, key: &str, value: SecretValue) -> crate::Result<()> {
+        // The other admin gets in first; this request's write lands on top of
+        // theirs, which is what makes a lost rotation observable.
+        if matches!(key, super::SMTP_KEY | super::SMTP_PASSWORD_KEY)
+            && let Some((password, blob)) = self.rotation.lock().unwrap().take()
+        {
+            let mut entries = self.entries.lock().unwrap();
+            entries.insert(super::SMTP_PASSWORD_KEY.to_string(), password);
+            entries.insert(super::SMTP_KEY.to_string(), blob);
+        }
+        self.entries
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), value.expose().to_string());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_passwordless_save_does_not_revert_a_concurrent_rotation() {
+    // Two admins, overlapping requests. One is correcting the display name and
+    // sends no password; the other is rotating the credential. If the first
+    // request keeps the password by loading it and writing it back, it reverts
+    // the rotation it never knew about, and nothing anywhere reports that the
+    // company is now authenticating with a retired secret.
+    //
+    // The fix is structural rather than a lock: the password lives under its own
+    // key, so "keep the stored password" is the absence of a write.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let secrets = Arc::new(RotatingSecrets::default());
+    let sender = Arc::new(RecordingMailSender::new());
+    let state = state_with_secrets(
+        &home,
+        ConnectionsRuntime::new().with_mail(sender.clone()),
+        Some(secrets.clone()),
+    )
+    .await;
+    let app = router(state);
+
+    // Fake throughout; these never leave the test process.
+    let original = "original-pw";
+    let rotated = "rotated-pw";
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "host": "smtp.acme.test",
+                        "port": 587,
+                        "security": "starttls",
+                        "username": "mailer",
+                        "password": original,
+                        "from_name": "Acme",
+                        "from_email": "ceo@acme.test",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(secrets.stored_password().as_deref(), Some(original));
+
+    // The other admin's rotation, committing mid-request. The blob carries the
+    // rotated password too, so this is a real rotation even for a reader that
+    // still expects the password to live inside it.
+    secrets.arm(
+        rotated,
+        &serde_json::json!({
+            "host": "smtp.acme.test",
+            "port": 587,
+            "security": "starttls",
+            "username": "mailer",
+            "password": rotated,
+            "from_name": "Acme",
+            "from_email": "ceo@acme.test",
+        })
+        .to_string(),
+    );
+
+    // The display-name correction: same body, no password.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "host": "smtp.acme.test",
+                        "port": 587,
+                        "security": "starttls",
+                        "username": "mailer",
+                        "from_name": "Acme Inc",
+                        "from_email": "ceo@acme.test",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The rotation stands, and the display name still took effect.
+    assert_eq!(
+        secrets.stored_password().as_deref(),
+        Some(rotated),
+        "the passwordless save wrote a stale password back over the rotation",
+    );
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/smtp/test")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let presented = sender.presented();
+    assert_eq!(presented.len(), 1);
+    let crate::server::ops::mailer::MailCredentials::Smtp(creds) = &presented[0];
+    assert_eq!(creds.password, rotated);
+    assert_eq!(creds.from_name, "Acme Inc");
+}
+
+#[tokio::test]
+async fn a_pre_split_password_survives_a_passwordless_save() {
+    // Credentials written before the password moved to its own key keep it
+    // inside the configuration blob. A passwordless save rewrites that blob, so
+    // without the migration the secret would be dropped on the floor and the
+    // company would silently stop being able to send.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let secrets = Arc::new(RotatingSecrets::default());
+    let sender = Arc::new(RecordingMailSender::new());
+    let state = state_with_secrets(
+        &home,
+        ConnectionsRuntime::new().with_mail(sender.clone()),
+        Some(secrets.clone()),
+    )
+    .await;
+
+    // Seed the old layout directly: one blob, password inside, no password key.
+    let legacy = "legacy-pw";
+    crate::ports::SecretStore::set(
+        secrets.as_ref(),
+        &CompanyId::new("acme"),
+        super::SMTP_KEY,
+        SecretValue(
+            serde_json::json!({
+                "host": "smtp.acme.test",
+                "port": 587,
+                "security": "starttls",
+                "username": "mailer",
+                "password": legacy,
+                "from_name": "Acme",
+                "from_email": "ceo@acme.test",
+            })
+            .to_string(),
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(secrets.stored_password(), None);
+
+    let app = router(state);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "host": "smtp.acme.test",
+                        "port": 587,
+                        "security": "starttls",
+                        "username": "mailer",
+                        "from_name": "Acme Inc",
+                        "from_email": "ceo@acme.test",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Migrated to its own key, and still the password that reaches the wire.
+    assert_eq!(secrets.stored_password().as_deref(), Some(legacy));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/smtp/test")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let presented = sender.presented();
+    let crate::server::ops::mailer::MailCredentials::Smtp(creds) = &presented[0];
+    assert_eq!(creds.password, legacy);
+    assert_eq!(creds.from_name, "Acme Inc");
 }

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -368,3 +368,301 @@ async fn ingest_good_hmac_files_mail() {
     assert_eq!(mail[0].from_email, "a@x.test");
     assert!(!mail[0].outbound);
 }
+
+// -- GET domain -------------------------------------------------------------
+
+#[tokio::test]
+async fn get_domain_is_null_before_one_is_configured() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/domain")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    // `null`, not a synthesized empty status — the same nullability
+    // `Company.domain` reports over GraphQL, so the console has one shape to
+    // branch on rather than two.
+    assert_eq!(body_json(response).await, serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn get_domain_returns_the_records_put_stored() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+    let app = router(state);
+
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/domain")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"domain":"acme.com"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/domain")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let value = body_json(response).await;
+    assert_eq!(value["domain"], "acme.com");
+    assert_eq!(value["verified"], false);
+    // The records themselves, not just the domain: they are what the operator
+    // copies into their DNS panel, and a read that dropped them would send them
+    // back to the PUT response they no longer have.
+    assert_eq!(value["records"].as_array().unwrap().len(), 5);
+}
+
+#[tokio::test]
+async fn get_domain_carries_the_last_verify_result() {
+    // The load-bearing one. Verification is a server-side pass whose outcome
+    // lives only in the secret store; without it on the read, the console's
+    // badge resets to Pending on every page reload and an operator who has
+    // already published their records is told to publish them again.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let resolver = Arc::new(StaticDnsResolver::fully_verifying("acme.com"));
+    let state = state_with(&home, ConnectionsRuntime::new().with_dns(resolver)).await;
+    let app = router(state);
+
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/domain")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"domain":"acme.com"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/domain/verify")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/domain")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let value = body_json(response).await;
+    assert_eq!(value["verified"], true, "{value}");
+    let checks = value["checks"].as_array().expect("per-record checks");
+    assert_eq!(checks.len(), 5, "{value}");
+    assert!(checks.iter().all(|check| check["found"] == true), "{value}");
+}
+
+// -- GET smtp ---------------------------------------------------------------
+
+#[tokio::test]
+async fn get_smtp_is_unconfigured_before_any_credentials() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let value = body_json(response).await;
+    // An object saying `configured: false`, not `null`: the type carries the
+    // flag, and the GraphQL twin is the non-null `SmtpStatus!`.
+    assert_eq!(value["configured"], false, "{value}");
+    assert!(value["host"].is_null(), "{value}");
+}
+
+#[tokio::test]
+async fn get_smtp_never_returns_the_password() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+    let app = router(state);
+
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"host":"smtp.acme.test","port":587,"security":"starttls","username":"mailer","password":"read-back-secret","from_name":"Acme","from_email":"ceo@acme.test"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    // Asserted on the raw bytes rather than a parsed field, like
+    // `put_smtp_hides_password`: a field-by-field check only proves the fields
+    // someone thought to name are clean, and a password leaking under a new key
+    // would slip past it.
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(
+        !text.contains("read-back-secret"),
+        "password leaked: {text}"
+    );
+    // …while the read is still worth making: the form has something to render.
+    assert!(text.contains("smtp.acme.test"), "{text}");
+    assert!(text.contains("mailer"), "{text}");
+    assert!(text.contains("ceo@acme.test"), "{text}");
+}
+
+#[tokio::test]
+async fn saving_the_from_name_alone_keeps_the_stored_password() {
+    // A patch, not a replace. The password is write-only, so a form can never
+    // render it back; without this, correcting a display name would cost the
+    // operator a credential they would have to go and look up again.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let sender = Arc::new(RecordingMailSender::new());
+    let state = state_with(&home, ConnectionsRuntime::new().with_mail(sender.clone())).await;
+    let app = router(state);
+
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"host":"smtp.acme.test","port":587,"security":"starttls","username":"mailer","password":"the-original-pw","from_name":"Acme","from_email":"ceo@acme.test"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The same body again, minus the password, with only the display name changed.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"host":"smtp.acme.test","port":587,"security":"starttls","username":"mailer","from_name":"Acme Inc","from_email":"ceo@acme.test"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let value = body_json(response).await;
+    assert_eq!(value["from_name"], "Acme Inc", "{value}");
+    assert_eq!(value["configured"], true, "{value}");
+
+    // The proof is what reaches the transport, not what is stored: a send after
+    // the second save must still present the first save's password.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/smtp/test")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let presented = sender.presented();
+    assert_eq!(presented.len(), 1);
+    let crate::server::ops::mailer::MailCredentials::Smtp(creds) = &presented[0];
+    assert_eq!(creds.password, "the-original-pw");
+    assert_eq!(creds.from_name, "Acme Inc");
+}
+
+#[tokio::test]
+async fn put_smtp_without_a_password_and_nothing_stored_is_refused() {
+    // The other end of the patch: keeping "the stored password" only works when
+    // there is one. Accepted, it would store credentials that can never
+    // authenticate while the settings page read "configured".
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/smtp")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"host":"smtp.acme.test","port":587,"username":"mailer","from_email":"ceo@acme.test"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let value = body_json(response).await;
+    assert_eq!(value["code"], "invalid_request", "{value}");
+}

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -760,9 +760,22 @@ struct RotatingSecrets {
     entries: std::sync::Mutex<std::collections::HashMap<String, String>>,
     /// `(password, blob)` to commit just before the next SMTP write, once.
     rotation: std::sync::Mutex<Option<(String, String)>>,
+    /// Milliseconds to stall inside a read of the configuration blob.
+    ///
+    /// Holds the read-modify-write window of the legacy migration open long
+    /// enough for a rotation to try to slip into it. Without this the two
+    /// requests finish too quickly to interleave, and the test would pass just
+    /// as happily with no serialization at all.
+    stall_config_read_ms: std::sync::atomic::AtomicU64,
 }
 
 impl RotatingSecrets {
+    /// Stalls every read of the configuration blob by `ms`.
+    fn stall_config_reads(&self, ms: u64) {
+        self.stall_config_read_ms
+            .store(ms, std::sync::atomic::Ordering::SeqCst);
+    }
+
     /// Arms the one-shot rotation.
     fn arm(&self, password: &str, blob: &str) {
         *self.rotation.lock().unwrap() = Some((password.to_string(), blob.to_string()));
@@ -786,6 +799,12 @@ impl crate::ports::SecretStore for RotatingSecrets {
         key: &str,
     ) -> crate::Result<Option<crate::ports::types::SecretValue>> {
         let seen = self.entries.lock().unwrap().get(key).cloned();
+        let stall = self
+            .stall_config_read_ms
+            .load(std::sync::atomic::Ordering::SeqCst);
+        if key == super::SMTP_KEY && stall > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(stall)).await;
+        }
         Ok(seen.map(SecretValue))
     }
 
@@ -1012,4 +1031,100 @@ async fn a_pre_split_password_survives_a_passwordless_save() {
     let crate::server::ops::mailer::MailCredentials::Smtp(creds) = &presented[0];
     assert_eq!(creds.password, legacy);
     assert_eq!(creds.from_name, "Acme Inc");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_rotation_racing_the_legacy_migration_is_not_lost() {
+    // The one path that still reads and then writes: migrating a pre-split
+    // password out of the config blob. A rotation arriving while that is in
+    // flight must not be overwritten by it, so `put_smtp` serializes per
+    // company. Whichever order the two land in, the rotation is what survives —
+    // it is the later intent in both interleavings the lock permits.
+    //
+    // Run repeatedly: a lock that is missing shows up as an intermittent loss,
+    // so a single pass would be a weak witness.
+    for attempt in 0..8 {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let secrets = Arc::new(RotatingSecrets::default());
+        let state = state_with_secrets(
+            &home,
+            ConnectionsRuntime::new(),
+            Some(secrets.clone() as Arc<dyn crate::ports::SecretStore>),
+        )
+        .await;
+
+        // Seed the pre-split layout: password inside the blob, no password key.
+        let legacy = "legacy-pw";
+        let rotated = "rotated-pw";
+        crate::ports::SecretStore::set(
+            secrets.as_ref(),
+            &CompanyId::new("acme"),
+            super::SMTP_KEY,
+            SecretValue(
+                serde_json::json!({
+                    "host": "smtp.acme.test",
+                    "port": 587,
+                    "security": "starttls",
+                    "username": "mailer",
+                    "password": legacy,
+                    "from_name": "Acme",
+                    "from_email": "ceo@acme.test",
+                })
+                .to_string(),
+            ),
+        )
+        .await
+        .unwrap();
+
+        // Hold the migration's read-modify-write window open so the rotation
+        // has somewhere to land.
+        secrets.stall_config_reads(40);
+
+        let app = router(state);
+        let put = |body: serde_json::Value| {
+            let app = app.clone();
+            async move {
+                app.oneshot(
+                    Request::builder()
+                        .method("PUT")
+                        .uri("/api/v1/company/smtp")
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            }
+        };
+
+        // The passwordless save (which must migrate) against the rotation.
+        let migrating = put(serde_json::json!({
+            "host": "smtp.acme.test",
+            "port": 587,
+            "security": "starttls",
+            "username": "mailer",
+            "from_name": "Acme Inc",
+            "from_email": "ceo@acme.test",
+        }));
+        let rotating = put(serde_json::json!({
+            "host": "smtp.acme.test",
+            "port": 587,
+            "security": "starttls",
+            "username": "mailer",
+            "password": rotated,
+            "from_name": "Acme",
+            "from_email": "ceo@acme.test",
+        }));
+        let (a, b) = tokio::join!(migrating, rotating);
+        assert_eq!(a.status(), StatusCode::OK);
+        assert_eq!(b.status(), StatusCode::OK);
+
+        assert_eq!(
+            secrets.stored_password().as_deref(),
+            Some(rotated),
+            "attempt {attempt}: the legacy migration overwrote a concurrent rotation",
+        );
+    }
 }

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -1150,3 +1150,77 @@ fn debugging_the_stored_config_does_not_print_a_legacy_password() {
     // Still useful for diagnosis.
     assert!(rendered.contains("smtp.acme.test"), "{rendered}");
 }
+
+#[tokio::test]
+async fn an_all_whitespace_password_counts_as_omitted() {
+    // The other edge of "trim only decides whether one was supplied". A body
+    // carrying `"   "` is a save that names no password, so it keeps the stored
+    // one rather than replacing a working credential with blanks. Pinned because
+    // `api-write-plane.md` states it as the contract.
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let secrets = Arc::new(RotatingSecrets::default());
+    let sender = Arc::new(RecordingMailSender::new());
+    let state = state_with_secrets(
+        &home,
+        ConnectionsRuntime::new().with_mail(sender.clone()),
+        Some(secrets.clone() as Arc<dyn crate::ports::SecretStore>),
+    )
+    .await;
+    let app = router(state);
+
+    let stored = "stored-pw";
+    let save = |password: serde_json::Value, from_name: &str| {
+        let app = app.clone();
+        let body = serde_json::json!({
+            "host": "smtp.acme.test",
+            "port": 587,
+            "security": "starttls",
+            "username": "mailer",
+            "password": password,
+            "from_name": from_name,
+            "from_email": "ceo@acme.test",
+        });
+        async move {
+            app.oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/company/smtp")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        }
+    };
+
+    assert_eq!(
+        save(serde_json::json!(stored), "Acme").await.status(),
+        StatusCode::OK
+    );
+    // Whitespace only: treated as omitted, so the stored password stands.
+    assert_eq!(
+        save(serde_json::json!("   "), "Acme Inc").await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(secrets.stored_password().as_deref(), Some(stored));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/smtp/test")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let presented = sender.presented();
+    let crate::server::ops::mailer::MailCredentials::Smtp(creds) = &presented[0];
+    assert_eq!(creds.password, stored);
+    assert_eq!(creds.from_name, "Acme Inc");
+}

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -6915,7 +6915,7 @@ async fn a_member_cannot_change_what_the_company_reaches_the_world_as() {
             "/api/v1/company/smtp",
             Some(
                 json!({ "provider": "smtp", "host": "mail.example.test", "port": 587,
-                         "username": "u", "password": "p", "from": "a@example.test" }),
+                         "username": "u", "password": "p", "from_email": "a@example.test" }),
             ),
         ),
         (
@@ -6965,6 +6965,39 @@ async fn a_member_cannot_change_what_the_company_reaches_the_world_as() {
         assert_eq!(
             response["code"], "forbidden",
             "{method} {uri} refused without saying why: {response}"
+        );
+    }
+}
+
+/// The counterpart to the table above, on the same two surfaces: a member is
+/// let *through* the reads.
+///
+/// `docs/modules/server/authority.md` asserts in prose that reads on these
+/// surfaces stay open to any member — they carry non-secret routing and never a
+/// credential — and until now nothing pinned it. `GET …/domain` and
+/// `GET …/smtp` are new (issue #1460), and the easy mistake when adding a route
+/// to a module whose every other handler takes `AdminScopedCompany` is to reach
+/// for the same extractor: the console's Settings screen would then `403` for
+/// every member while the identical data stayed readable to them over GraphQL
+/// as `Company.domain` and `Company.smtp`.
+///
+/// `200` specifically, not merely "not 403": these read stored config that may
+/// be absent, and both answer that case with a body rather than a status, so
+/// anything else would mean the route did not run.
+#[tokio::test]
+async fn a_member_may_read_what_the_company_reaches_the_world_as() {
+    let home_dir = home();
+    let state = state_with_company(home_dir.path()).await;
+    let member =
+        crate::server::test_support::seed_session(&state, "acme", crate::ports::UserRole::Member)
+            .await;
+
+    for uri in ["/api/v1/company/domain", "/api/v1/company/smtp"] {
+        let (status, response) = send_cookie(&state, "GET", uri, None, &member).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "GET {uri} refused a member: {response}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The SMTP card in `Settings → General` was writing a **live sending credential to `localStorage`, on every keystroke**. This PR stops that, and cleans up what previous builds already stored.

It is deliberately the security half of #1460 only. Wiring the Domain/SMTP cards to the host routes is a larger change and follows separately, so the credential fix does not wait on it.

## What was wrong

`DomainSettings` held the whole card — domain config *and* SMTP credentials — in one `useState`, with an effect writing all of it back on every change:

```ts
const [settings, setSettings] = useState<MailSettings>(() => loadMailSettings(scope));
useEffect(() => { saveMailSettings(scope, settings); }, [scope, settings]);
```

There is no Save button on that card, so there is no commit point. The password landed in browser storage character by character as it was typed — readable by any script on the origin, surviving sign-out, with no expiry. Every other credential on this surface (Billing, Hosting, MCP, the company credential) goes write-only into the host's secret store instead.

## What changed

- **The persisted shape structurally cannot hold a password.** `saveMailSettings` now takes `StoredMailSettings`, whose `smtp.password` is typed `password?: never`. A plain `Omit<SmtpConfig, "password">` would *not* have been enough — TypeScript is structural, so a full `MailSettings` is assignable to it by width subtyping and the leaking call would still compile. `never` rejects it.
- **`loadMailSettings` returns an empty password unconditionally**, so a blob written by an older build cannot flow back into the form.
- **The card routes its write-back through `withoutSmtpPassword`.** The password lives in React state for the life of the page and nowhere else.
- **`purgeStoredSmtpPasswords()` runs at boot in `main.tsx`**, before the first render.
- **The card says what it does now** — the password field carries `"Held on this page only — never written to browser storage, and cleared when you reload."`, and the card-level notice no longer claims credentials reach a secret store.

## What happens to an operator who already typed a password

It is deleted from their browser the next time they load the console — they do not have to visit Settings, and they are not asked to do anything.

`purgeStoredSmtpPasswords()` sweeps **every** `oc-mail*` key, scoped and legacy, across every connection and company — not just the scope the current page is looking at. For each one it **rewrites rather than deletes**: host, port, security, username and the from fields are not secret and are work the operator did, so those survive; only the password is dropped. The card comes back looking the way they left it, with the password field empty.

A key whose JSON will not parse but which mentions a password is removed outright — it cannot be shown to be clean, and the function's contract is that afterwards no password remains. The sweep is idempotent.

The one thing it cannot reach is a password already exfiltrated by another script on the origin before the upgrade. Anyone who typed a real SMTP password into this card should rotate it.

## Regression coverage

`frontend/test/unit/smtp-password-never-stored.test.ts`, 11 tests. The assertions are written against **the whole of `localStorage`** rather than against a known key — a test that checks `oc-mail:…` for a missing field passes the day someone adds a second key or renames the prefix, and the credential leaks again with a green suite. So: type a password, do what the card does, then read every value in the store and assert the secret appears in none of them.

Including:
- the per-keystroke write pattern replayed character by character, asserting no intermediate write leaks even a prefix;
- a `@ts-expect-error` on `saveMailSettings(SCOPE, settingsWithPassword())`. If the signature ever becomes willing to take a password again, that directive stops being an error and `npm run typecheck:unit` **fails on the unused directive**. Someone has to delete that line on purpose to reintroduce the bug.

Mutation-checked: reverting the password blanking in `loadMailSettings` turns the suite red.

## Still open, and filed as follow-up

This PR does not fix the other two halves of #1460 — the DNS records are still generated client-side against a hardcoded `opencompany.host`, and the Pending badge / Verify DNS button still do nothing. Until that lands the card states plainly that nothing is sent to the host, so it no longer *looks* like it configured mail.

One correction to the issue while I was in here: the issue says the host implements the domain routes. It also implements **`PUT …/smtp` and `POST …/smtp/test`** (`src/server/ops/smtp.rs`), with a proper write-only `SmtpStatus` that drops the password. Neither `/domain` nor `/smtp` has a `GET`, so the wiring PR needs to add those.

## Commands run

- `npm run typecheck`
- `npm run typecheck:unit`
- `npm run typecheck:e2e`
- `npx vitest run` — 171 files, 1647 tests, all passing

No Rust touched.

Part of #1460


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added domain status, DNS records, and verification results.
  - Added SMTP status, configuration, and test-send support without exposing passwords.
  - Added frontend domain and SMTP management.

- **Security**
  - SMTP passwords are no longer stored in browser storage.
  - Existing stored passwords are removed automatically.
  - Passwords are preserved when omitted from updates.

- **Documentation**
  - Updated API, access-control, and workflow documentation, including run-history pagination.

- **Tests**
  - Expanded coverage for permissions, verification, password protection, migration, and SMTP updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->