### PR TITLE
fix(workspace): say which folder the agents cannot read, and warn when a move changes that

### DIFF
--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -247,14 +247,20 @@ export function moveAudienceWarning(
   if (wasSecret === willBeSecret) return null;
 
   // A folder move takes every note under it in the same call, so the sentence
-  // has to say so — "this note" would understate a move of thirty.
-  const what = node.kind === "folder" ? "this folder and everything in it" : "this note";
+  // has to say so — "this note" would understate a move of thirty. The title
+  // is the line that gets read, so it says it too: a heading that promises one
+  // note above a paragraph describing a subtree is the wrong half to be vague
+  // in.
+  const folder = node.kind === "folder";
+  const what = folder ? "this folder and everything in it" : "this note";
+  // The title needs the short form — it is a heading, not a sentence.
+  const subject = folder ? "this folder" : "this note";
   const name = titleOf(node);
 
   return willBeSecret
     ? {
         change: "hidden",
-        title: "Agents will no longer be able to read this note.",
+        title: `Agents will no longer be able to read ${subject}.`,
         body:
           `“${name}” moves into ${SECRETS_DIR}/, where ${what} stops being ` +
           "visible to the company's agents — they cannot list, read, search or write it.",
@@ -262,11 +268,77 @@ export function moveAudienceWarning(
       }
     : {
         change: "exposed",
-        title: "Agents will be able to read this note.",
+        title: `Agents will be able to read ${subject}.`,
         body:
           `“${name}” moves out of ${SECRETS_DIR}/, and ${what} becomes part of the ` +
           "shared tree every agent can read and search. Check it holds no credentials first.",
         confirmLabel: "Move out of secrets",
+      };
+}
+
+/**
+ * A **rename** that changes who can read a note, and what to say about it
+ * (issue #1465).
+ *
+ * The hole `moveAudienceWarning` left. The host's rule is `is_agent_hidden_path`
+ * in `src/company/workspace_scaffold.rs` — the *first path segment*, compared to
+ * `secrets` — and a rename of a root folder rewrites that segment for its whole
+ * subtree. Renaming `secrets/` to `vault/` therefore hands every note under it
+ * to every agent in the company, and the host allows it: a `PATCH
+ * …/workspace/<id>` with `{"name":"vault"}` answers `200`, because nothing on
+ * that path is guarded the way `derived/` is by `DerivedGuardWorkspace`.
+ *
+ * Allowing it is defensible — the operator owns `secrets/`, and an operator who
+ * means to retire the folder is entitled to. Doing it in silence is not, and
+ * silence is exactly what the move warning exists to end. So a rename that
+ * crosses the boundary is put through the same panel, in the same words.
+ *
+ * Only a **root** node can cross it. A rename deeper in the tree cannot touch
+ * the first segment — that belongs to an ancestor — so this returns `null` for
+ * every one of them, which is nearly all renames.
+ *
+ * Not reachable by an agent, for the record: agent workspace tools address the
+ * tree through `PathIndex::build_for_agent`, which drops hidden nodes from both
+ * the path and the id map, and the move tool confines destinations to the
+ * agent's own `Agents/<id>/` home. This is an operator-surface rule, and this is
+ * the operator surface.
+ */
+export function renameAudienceWarning(
+  nodes: FsNode[],
+  node: FsNode,
+  nextName: string,
+): MoveAudienceWarning | null {
+  const wasSecret = isSecretNode(nodes, node.id);
+  // A nested node's first segment is its root ancestor's name, which a rename
+  // here does not touch.
+  const willBeSecret =
+    node.parentId === null ? nextName.trim().toLowerCase() === SECRETS_DIR : wasSecret;
+  if (wasSecret === willBeSecret) return null;
+
+  const folder = node.kind === "folder";
+  const what = folder ? "this folder and everything in it" : "this note";
+  const subject = folder ? "this folder" : "this note";
+  const name = titleOf(node);
+  const next = nextName.trim();
+
+  return willBeSecret
+    ? {
+        change: "hidden",
+        title: `Agents will no longer be able to read ${subject}.`,
+        body:
+          `Renaming “${name}” to “${next}” puts it at the top of ${SECRETS_DIR}/, where ` +
+          `${what} stops being visible to the company's agents — they cannot list, read, ` +
+          "search or write it.",
+        confirmLabel: "Rename into secrets",
+      }
+    : {
+        change: "exposed",
+        title: `Agents will be able to read ${subject}.`,
+        body:
+          `${SECRETS_DIR}/ is hidden from agents by its name. Renaming it to “${next}” ends ` +
+          `that: ${what} becomes part of the shared tree every agent can read and search. ` +
+          "Check it holds no credentials first.",
+        confirmLabel: "Rename out of secrets",
       };
 }
 

--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -125,6 +125,151 @@ export const DERIVED_REASON =
   "This file is written by a ledger and re-derived on every write to it — " +
   "an edit here would be erased. Change it on the Ledgers page instead.";
 
+/**
+ * The one folder in this shared tree the company's agents cannot reach.
+ *
+ * Kept in step with `SECRETS_ROOT` in `src/company/workspace_scaffold.rs`. The
+ * host scaffolds it on every boot and excludes it from the agent path index,
+ * from agent writes and from agent search — listing, reading, searching and
+ * writing, all four. If the host ever renames it, a folder the console called
+ * private would be one the agents could read.
+ *
+ * The sibling of {@link DERIVED_DIR}, and the exact inverse of it (issue
+ * #1465). `derived/` is "agents write this, you do not"; `secrets/` is "you
+ * write this, agents do not". To an operator scanning one tree they are the
+ * same kind of fact, so they are marked the same way and their strings live
+ * side by side here.
+ */
+export const SECRETS_DIR = "secrets";
+
+/**
+ * Whether the node at `id` is the `secrets/` root or something beneath it
+ * (issue #1465).
+ *
+ * A **folder** rule, mirroring `is_agent_hidden_path` in
+ * `src/company/workspace_scaffold.rs` — first path segment, compared
+ * case-insensitively so a `Secrets` node cannot become an accidental
+ * agent-visible twin, and by segment rather than string prefix so a
+ * `secrets-old/` remains ordinary shared content.
+ *
+ * The console evaluates the same rule rather than reading a flag because the
+ * wire carries none — `GET …/workspace` returns no `hiddenFromAgents` — and
+ * because a rule read off the same fact on both sides cannot drift the way two
+ * lists would. Written exactly like {@link isDerivedNode}, on purpose.
+ */
+export function isSecretNode(nodes: FsNode[], id: string | null): boolean {
+  const ancestry = pathOf(nodes, id);
+  const head = ancestry[0];
+  if (!head) return false;
+  return head.kind === "folder" && head.name.trim().toLowerCase() === SECRETS_DIR;
+}
+
+/**
+ * The same rule as {@link isSecretNode}, applied to a **path string** rather
+ * than a tree (issue #1465).
+ *
+ * The search hit list replaces the tree in the explorer pane, so it has no
+ * ancestry to walk — but every hit carries its own `path`. Written from the
+ * same {@link SECRETS_DIR} constant so the two cannot disagree about which
+ * notes an agent can read.
+ *
+ * Leading slashes are tolerated and the string is trimmed first, because the
+ * host's `is_agent_hidden_path` does both: a guard a stray space defeats is not
+ * a guard.
+ */
+export function isSecretPath(path: string): boolean {
+  const head = path.trim().replace(/^\/+/, "").split("/")[0];
+  return head !== undefined && head.trim().toLowerCase() === SECRETS_DIR;
+}
+
+/**
+ * What the tree, the search list and the note header all call a note under
+ * `secrets/` (issue #1465).
+ *
+ * One phrase in three places, for the same reason {@link DERIVED_LABEL}
+ * is: three surfaces describing one rule in three wordings is how an operator
+ * comes to believe there are three rules. It states the audience rather than a
+ * permission — "Private" would say who may not open it in the console, which is
+ * nobody; the fact is who cannot read it *elsewhere*.
+ */
+export const SECRETS_LABEL = "Hidden from agents";
+
+/**
+ * The long form of {@link SECRETS_LABEL} — the whole of the rule, including the
+ * half that is about the rest of the tree.
+ *
+ * The second sentence is the one that matters. Until this shipped, the only
+ * statement of the rule was a `README.md` seeded *inside* `secrets/`, which you
+ * read only if you already went looking — and the operator who most needs it is
+ * the one deciding where to put a credential, looking at a tree in which
+ * nothing said one folder was different.
+ */
+export const SECRETS_REASON =
+  "The company's agents cannot list, read, search or write anything under " +
+  "`secrets/`. Everything outside it, they can read.";
+
+/**
+ * A move that changes who can read a note, and what to say about it
+ * (issue #1465).
+ *
+ * `Move to…` is the only control in the console that changes a note's audience,
+ * and it changed it in **both** directions with no more than a "moved" toast.
+ * Moving into `secrets/` revokes agent access; moving out grants it. Returns
+ * `null` for every other move, which is nearly all of them — a warning shown on
+ * moves that change nothing is a warning nobody reads on the move that does.
+ *
+ * The copy lives here rather than in the dialog so it can be pinned by a test
+ * without mounting `WorkspaceView`, and so it sits beside the predicate whose
+ * answer it describes.
+ */
+export type MoveAudienceChange = "hidden" | "exposed";
+
+export interface MoveAudienceWarning {
+  /** Which direction the audience moves — the two are not equally dangerous. */
+  change: MoveAudienceChange;
+  /** The consequence, in one sentence, in the console's own voice. */
+  title: string;
+  /** What is moving, where, and what to check before confirming. */
+  body: string;
+  /** The confirm button's own words, so it never reads a bare "Move". */
+  confirmLabel: string;
+}
+
+export function moveAudienceWarning(
+  nodes: FsNode[],
+  node: FsNode,
+  destId: string | null,
+): MoveAudienceWarning | null {
+  const wasSecret = isSecretNode(nodes, node.id);
+  // The workspace root is never `secrets/`, so a `null` destination is always
+  // agent-visible.
+  const willBeSecret = destId !== null && isSecretNode(nodes, destId);
+  if (wasSecret === willBeSecret) return null;
+
+  // A folder move takes every note under it in the same call, so the sentence
+  // has to say so — "this note" would understate a move of thirty.
+  const what = node.kind === "folder" ? "this folder and everything in it" : "this note";
+  const name = titleOf(node);
+
+  return willBeSecret
+    ? {
+        change: "hidden",
+        title: "Agents will no longer be able to read this note.",
+        body:
+          `“${name}” moves into ${SECRETS_DIR}/, where ${what} stops being ` +
+          "visible to the company's agents — they cannot list, read, search or write it.",
+        confirmLabel: "Move into secrets",
+      }
+    : {
+        change: "exposed",
+        title: "Agents will be able to read this note.",
+        body:
+          `“${name}” moves out of ${SECRETS_DIR}/, and ${what} becomes part of the ` +
+          "shared tree every agent can read and search. Check it holds no credentials first.",
+        confirmLabel: "Move out of secrets",
+      };
+}
+
 /** Ancestor folders (root → current), for breadcrumbs. */
 export function pathOf(nodes: FsNode[], id: string | null): FsNode[] {
   const path: FsNode[] = [];

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -114,6 +114,7 @@ import {
   moveAudienceWarning,
   nodeById,
   readLegacyLocalNodes,
+  renameAudienceWarning,
   SECRETS_LABEL,
   SECRETS_REASON,
   subtreeCounts,
@@ -1697,6 +1698,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       </section>
 
       <NamePrompt
+        nodes={nodes}
         state={prompt}
         onClose={() => setPrompt(null)}
         onSubmit={(name) => {
@@ -2358,20 +2360,59 @@ interface PromptState {
   node?: FsNode;
 }
 
+/**
+ * Name a new node, or rename one — and stop first when the new name is what
+ * decides who can read it (issue #1465).
+ *
+ * `Move to…` was not the only control that crosses the `secrets/` boundary.
+ * The host's rule is the *first path segment*, so renaming the root `secrets/`
+ * folder rewrites that segment for everything under it; the host accepts the
+ * rename (`PATCH …/workspace/<id>` with a new `name` answers 200 — only
+ * `derived/` is guarded there), and until this it did so on one click and a
+ * toast. Same boundary, same consequence, so the same panel and the same words
+ * as {@link MoveDialog}.
+ */
 function NamePrompt({
+  nodes,
   state,
   onClose,
   onSubmit,
 }: {
+  nodes: FsNode[];
   state: PromptState | null;
   onClose: () => void;
   onSubmit: (name: string) => void;
 }) {
   const [name, setName] = useState("");
+  /** The typed name, held back until the audience warning is acknowledged. */
+  const [pending, setPending] = useState<{ name: string; warning: MoveAudienceWarning } | null>(
+    null,
+  );
 
   useEffect(() => {
     setName(state?.mode === "rename" ? (state.node?.name ?? "") : "");
+    // A second Rename must not open onto the previous one's warning.
+    setPending(null);
   }, [state]);
+
+  /**
+   * Submit, unless the name changes the audience — in which case ask first.
+   *
+   * Only a rename can: a *new* node is created empty, so naming one `secrets`
+   * hides nothing that was not already nothing.
+   */
+  function submit(next: string) {
+    if (state?.mode !== "rename" || !state.node) {
+      onSubmit(next);
+      return;
+    }
+    const warning = renameAudienceWarning(nodes, state.node, next);
+    if (!warning) {
+      onSubmit(next);
+      return;
+    }
+    setPending({ name: next, warning });
+  }
 
   const title = state?.mode === "folder" ? "New folder" : state?.mode === "file" ? "New note" : "Rename";
 
@@ -2381,30 +2422,47 @@ function NamePrompt({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
-            {state?.mode === "file" ? "Notes get a .md extension automatically." : "Give it a name."}
+            {pending
+              ? "This changes who can read it."
+              : state?.mode === "file"
+                ? "Notes get a .md extension automatically."
+                : "Give it a name."}
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-2">
-          <Label htmlFor="fs-name">Name</Label>
-          <Input
-            id="fs-name"
-            autoFocus
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && name.trim()) onSubmit(name);
-            }}
-            placeholder={state?.mode === "folder" ? "e.g. Campaigns" : "e.g. Notes"}
+        {pending ? (
+          <MoveAudienceConfirm
+            warning={pending.warning}
+            // Back to the field rather than out of the dialog: the operator who
+            // reads the warning and changes their mind wanted a different name,
+            // not to abandon the rename.
+            onCancel={() => setPending(null)}
+            onConfirm={() => onSubmit(pending.name)}
           />
-        </div>
-        <DialogFooter>
-          <Button variant="ghost" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button disabled={!name.trim()} onClick={() => onSubmit(name)}>
-            {state?.mode === "rename" ? "Rename" : "Create"}
-          </Button>
-        </DialogFooter>
+        ) : (
+          <>
+            <div className="grid gap-2">
+              <Label htmlFor="fs-name">Name</Label>
+              <Input
+                id="fs-name"
+                autoFocus
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && name.trim()) submit(name);
+                }}
+                placeholder={state?.mode === "folder" ? "e.g. Campaigns" : "e.g. Notes"}
+              />
+            </div>
+            <DialogFooter>
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button disabled={!name.trim()} onClick={() => submit(name)}>
+                {state?.mode === "rename" ? "Rename" : "Create"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
+  EyeOff,
   FilePlus2,
   FileText,
   Folder,
@@ -102,13 +103,20 @@ import {
   type FsNode,
   hasLegacyLocal,
   isDerivedNode,
+  isSecretNode,
+  type MoveAudienceChange,
+  type MoveAudienceWarning,
+  moveAudienceWarning,
   nodeById,
   readLegacyLocalNodes,
+  SECRETS_LABEL,
+  SECRETS_REASON,
   subtreeCounts,
   subtreeIds,
   titleOf,
 } from "@/lib/workspace";
 import { useLocalScope } from "@/connections/ConnectionContext";
+import { MoveAudienceConfirm } from "@/views/workspace/MoveAudienceConfirm";
 import { SearchResults } from "@/views/workspace/SearchResults";
 
 /**
@@ -1229,6 +1237,15 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
    * something else asks it to.
    */
   const readOnlyNote = isDerivedNode(nodes, openId);
+  /**
+   * Whether the open note is one the company's agents cannot read (#1465).
+   *
+   * The same folder rule the tree row asks, asked again for the header, because
+   * this is the pane an operator is looking at while typing the credential —
+   * and a note opened from a search hit or a `[[wiki link]]` arrives here with
+   * the tree never scrolled to it.
+   */
+  const secretNote = isSecretNode(nodes, openId);
 
   return (
     <div className="flex flex-1 overflow-hidden">
@@ -1465,6 +1482,22 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                 <Breadcrumb nodes={nodes} nodeId={openNode.id} onOpenFolder={revealFolder} />
                 <span className="truncate text-sm font-medium">{titleOf(openNode)}</span>
               </span>
+              {/* Said in the header and not only in the tree, because this is
+                  the pane the typing happens in — and unlike the tree, it is
+                  reached from a search hit and a wiki link too (issue #1465).
+                  It sits after the crumb rail rather than inside it: the rail
+                  says where the note is filed, this says who can read it. */}
+              {secretNote && (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 gap-1 font-normal"
+                  title={SECRETS_REASON}
+                  data-testid="workspace-secret"
+                >
+                  <EyeOff className="size-3" />
+                  {SECRETS_LABEL}
+                </Badge>
+              )}
               {/* No authorship on a derived file (#1377). `derived::publish`
                   stamps `WorkspaceOrigin::Seed` — that is how the write guard
                   tells its own derivation from a person — so `originLabel`
@@ -1475,7 +1508,10 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                   console-authored badges disagreeing about the same file is
                   worse than one, so the chip that IS true says it alone. The
                   breadcrumb above stays either way: where a derived file lives
-                  is the fact that explains which ledger wrote it. */}
+                  is the fact that explains which ledger wrote it.
+
+                  A `secrets/` note keeps its authorship — the README the host
+                  seeds there really was seeded, so both chips are true. */}
               {!readOnlyNote && (
                 <Authorship
                   createdBy={openFile?.createdBy ?? openNode.createdBy}
@@ -1871,6 +1907,25 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
    * nodes at most and is already re-sorted per level on every render.
    */
   const derived = isDerivedNode(nodes, node.id);
+  /**
+   * Whether this row is the `secrets/` folder or something inside it (#1465).
+   *
+   * The tree is where an operator decides where to put a credential, and until
+   * this shipped it was the one place that decision got no help: `secrets`
+   * rendered with the same folder icon, the same weight and the same `…` menu
+   * as `Playbooks`, and sorted in among them. The only statement of the rule
+   * was a README seeded inside the folder — reachable only by someone who had
+   * already found it.
+   *
+   * Recomputed per row rather than threaded down through {@link Tree}, for the
+   * same reason `derived` above is: the rule stays one function, asked by every
+   * surface, against a tree of a few hundred nodes that is already re-sorted
+   * per level on every render.
+   *
+   * Never true at the same time as `derived`: both read the first ancestor, and
+   * a node has one.
+   */
+  const secret = isSecretNode(nodes, node.id);
 
   return (
     <>
@@ -1879,9 +1934,10 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
         className={cn(
           "group flex items-center gap-1 rounded-md px-1.5 py-1 text-sm",
           active ? "bg-accent font-medium" : "hover:bg-accent/50",
-          // Muted whether or not it is the open note: what writes the file does
-          // not change when you select it.
-          derived && "text-muted-foreground",
+          // Muted whether or not it is the open note: neither what writes the
+          // file (#1377) nor who can read it (#1465) changes when you select
+          // it. The glyph after the name is what says which of the two it is.
+          (derived || secret) && "text-muted-foreground",
         )}
         style={{ paddingLeft: 6 + depth * 12 }}
       >
@@ -1900,11 +1956,16 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
           <span className="truncate" title={isRosterFolder ? node.name : undefined}>
             {isFolder ? displayName : titleOf(node)}
           </span>
-          {/* The lock is the whole of the tree-side signal: an icon, not a
+          {/* The glyph is the whole of the tree-side signal: an icon, not a
               badge, because a row in a 256px pane has no width for a phrase and
               the name is the thing being scanned. The label rides along for a
               screen reader, which gets no glyph, and the full reason is on the
-              `title` for a pointer. */}
+              `title` for a pointer.
+
+              A lock means `derived/` — "you may not write this" (#1377). An
+              eye-off means `secrets/` — the other rule: you may write it, and
+              no agent reads it (#1465). Two rules, two glyphs, and no row ever
+              wears both. */}
           {derived && (
             <span
               className="flex shrink-0 items-center"
@@ -1913,6 +1974,16 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
             >
               <Lock className="size-3" aria-hidden />
               <span className="sr-only">{DERIVED_LABEL}</span>
+            </span>
+          )}
+          {secret && (
+            <span
+              className="flex shrink-0 items-center"
+              title={SECRETS_REASON}
+              data-testid="workspace-tree-secret"
+            >
+              <EyeOff className="size-3" aria-hidden />
+              <span className="sr-only">{SECRETS_LABEL}</span>
             </span>
           )}
           {/* Agent-created nodes get a marker in the tree itself, so "what has
@@ -2273,6 +2344,22 @@ function NamePrompt({
   );
 }
 
+/**
+ * Pick a destination for a `Move to…`, and say so when the destination changes
+ * who can read the note (issue #1465).
+ *
+ * Every destination but one is a filing decision. Moving into or out of
+ * `secrets/` is an audience decision, and it was indistinguishable from the
+ * others: one click, a "moved" toast, and a note that either stopped being
+ * readable by every agent in the company or started being. So a destination
+ * that crosses that line does not commit on the click — it swaps the list for
+ * {@link MoveAudienceConfirm}, which names the consequence and asks again.
+ *
+ * Ordinary destinations still commit on one click, deliberately: this adds a
+ * step to the moves that change something and to no others. (Issue #1477 is
+ * about the destination list itself — flat, path-less — and is left alone
+ * here.)
+ */
 function MoveDialog({
   nodes,
   moving,
@@ -2286,20 +2373,67 @@ function MoveDialog({
 }) {
   const blocked = moving ? subtreeIds(nodes, moving.id) : new Set<string>();
   const folders = nodes.filter((x) => x.kind === "folder" && !blocked.has(x.id));
+  /** The destination picked, held back until the warning is acknowledged. */
+  const [pending, setPending] = useState<{ destId: string | null; warning: MoveAudienceWarning } | null>(
+    null,
+  );
+
+  // A second `Move to…` must not open onto the previous one's warning.
+  useEffect(() => {
+    setPending(null);
+  }, [moving]);
+
+  function pick(destId: string | null) {
+    if (!moving) return;
+    const warning = moveAudienceWarning(nodes, moving, destId);
+    if (!warning) {
+      onMove(destId);
+      return;
+    }
+    setPending({ destId, warning });
+  }
 
   return (
     <Dialog open={Boolean(moving)} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <DialogTitle>Move “{moving ? titleOf(moving) : ""}”</DialogTitle>
-          <DialogDescription>Pick a destination folder.</DialogDescription>
+          <DialogDescription>
+            {pending ? "This changes who can read it." : "Pick a destination folder."}
+          </DialogDescription>
         </DialogHeader>
-        <div className="max-h-72 space-y-1 overflow-y-auto">
-          <DestRow label="Workspace root" disabled={moving?.parentId === null} onClick={() => onMove(null)} />
-          {folders.map((f) => (
-            <DestRow key={f.id} label={f.name} disabled={moving?.parentId === f.id} onClick={() => onMove(f.id)} />
-          ))}
-        </div>
+        {pending ? (
+          <MoveAudienceConfirm
+            warning={pending.warning}
+            // Back to the list rather than out of the dialog: the operator who
+            // reads the warning and changes their mind wanted a different
+            // folder, not to abandon the move.
+            onCancel={() => setPending(null)}
+            onConfirm={() => onMove(pending.destId)}
+          />
+        ) : (
+          <div className="max-h-72 space-y-1 overflow-y-auto">
+            <DestRow
+              label="Workspace root"
+              disabled={moving?.parentId === null}
+              // Marked from the same predicate that raises the warning, so the
+              // consequence is legible *before* the click as well as after it.
+              // The root is never `secrets/`, so this row only ever marks the
+              // way out.
+              audience={moving ? moveAudienceWarning(nodes, moving, null)?.change : undefined}
+              onClick={() => pick(null)}
+            />
+            {folders.map((f) => (
+              <DestRow
+                key={f.id}
+                label={f.name}
+                disabled={moving?.parentId === f.id}
+                audience={moving ? moveAudienceWarning(nodes, moving, f.id)?.change : undefined}
+                onClick={() => pick(f.id)}
+              />
+            ))}
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );
@@ -2547,16 +2681,44 @@ function RepairDialog({
   );
 }
 
-function DestRow({ label, disabled, onClick }: { label: string; disabled?: boolean; onClick: () => void }) {
+function DestRow({
+  label,
+  disabled,
+  audience,
+  onClick,
+}: {
+  label: string;
+  disabled?: boolean;
+  /** Set when picking this destination changes who can read the note (#1465). */
+  audience?: MoveAudienceChange;
+  onClick: () => void;
+}) {
   return (
     <button
       disabled={disabled}
       onClick={onClick}
       className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm hover:bg-accent disabled:pointer-events-none disabled:opacity-40"
+      data-audience-change={audience}
     >
       <Folder className="size-4 text-tone-2" />
       <span className="truncate">{label}</span>
       {disabled && <span className="ml-auto text-xs text-muted-foreground">Here</span>}
+      {/* Two words, not the sentence: the row is a choice, and the sentence is
+          on the panel that follows the click. `Shares it` wears the destructive
+          colour because that is the direction there is no undoing — a note the
+          agents have read is read. */}
+      {!disabled && audience && (
+        <span
+          className={cn(
+            "ml-auto flex shrink-0 items-center gap-1 text-xs",
+            audience === "exposed" ? "text-destructive" : "text-muted-foreground",
+          )}
+          data-testid="workspace-move-dest-audience"
+        >
+          <EyeOff className="size-3" aria-hidden />
+          {audience === "hidden" ? "Hides it" : "Shares it"}
+        </span>
+      )}
     </button>
   );
 }

--- a/frontend/src/views/workspace/MoveAudienceConfirm.tsx
+++ b/frontend/src/views/workspace/MoveAudienceConfirm.tsx
@@ -1,0 +1,65 @@
+// The one step in `Move to…` that stops and says something (issue #1465).
+//
+// `secrets/` is the only part of the workspace tree the company's agents cannot
+// reach, and `Move to…` was the only control that changed a note's membership
+// of it — in both directions, on a single click, with a plain "moved" toast
+// either way. The tree marker added by the same issue is passive; this is the
+// moment the audience actually changes, so this is where the sentence belongs.
+//
+// Split out of `WorkspaceView.tsx` for the reason `SearchResults` was: that file
+// is past 2,300 lines and a confirmation panel has nothing to do with the tree
+// or the editor it would otherwise sit among. Presentational only — it renders
+// the `MoveAudienceWarning` it is handed and reports the two buttons.
+
+import { EyeOff, TriangleAlert } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+import type { MoveAudienceWarning } from "@/lib/workspace";
+
+export function MoveAudienceConfirm({
+  warning,
+  onCancel,
+  onConfirm,
+}: {
+  warning: MoveAudienceWarning;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  // The two directions are not the same event. Moving a note *into* `secrets/`
+  // is almost always what the operator meant, and the panel is there to confirm
+  // it worked rather than to talk them out of it. Moving one *out* publishes
+  // whatever is in it to every agent in the company, and cannot be un-published
+  // — so that one wears the destructive treatment, on the alert and on the
+  // button alike.
+  const exposing = warning.change === "exposed";
+
+  return (
+    <div className="space-y-4" data-testid="workspace-move-audience">
+      <Alert
+        variant={exposing ? "destructive" : "default"}
+        data-audience-change={warning.change}
+      >
+        {exposing ? <TriangleAlert /> : <EyeOff />}
+        <AlertTitle>{warning.title}</AlertTitle>
+        <AlertDescription>{warning.body}</AlertDescription>
+      </Alert>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        {/* The confirm never reads a bare "Move": the button is the last thing
+            read before the click, so it repeats the direction rather than
+            relying on the operator having read the paragraph above it. */}
+        <Button
+          variant={exposing ? "destructive" : "default"}
+          onClick={onConfirm}
+          data-testid="workspace-move-audience-confirm"
+        >
+          {warning.confirmLabel}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/frontend/src/views/workspace/SearchResults.tsx
+++ b/frontend/src/views/workspace/SearchResults.tsx
@@ -11,13 +11,20 @@
 // want?") and showing both at once would leave the operator reading a tree that
 // is not what they just asked for.
 
-import { FileText, Folder, Loader2, Lock, Search } from "lucide-react";
+import { EyeOff, FileText, Folder, Loader2, Lock, Search } from "lucide-react";
 
 import { formatBytes, highlightRuns, isBinary, originLabel, type SearchHit } from "@/api/workspace";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { DERIVED_LABEL, DERIVED_REASON, isDerivedPath } from "@/lib/workspace";
+import {
+  DERIVED_LABEL,
+  DERIVED_REASON,
+  isDerivedPath,
+  isSecretPath,
+  SECRETS_LABEL,
+  SECRETS_REASON,
+} from "@/lib/workspace";
 
 interface Props {
   /** The query the results below answer — not the input's live value. */
@@ -101,9 +108,29 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
            * explorer has never expanded, so there is no ancestry here to walk.
            */
           const derived = isDerivedPath(hit.path);
+          /**
+           * Whether this hit names a note the company's agents cannot read
+           * (issue #1465).
+           *
+           * Operator search is deliberately unfiltered — `search_workspace`
+           * keeps the whole tree while `search_workspace_for_agent` drops
+           * `secrets/` — which is right, and is also why a private note used to
+           * come back in this list looking exactly like a shared one. A console
+           * on a shared screen leaked it.
+           *
+           * The sibling of `derived` above and never true at the same time: a
+           * path has one first segment, and the two rules read that same
+           * segment against different names.
+           */
+          const secret = isSecretPath(hit.path);
           // `Seeded` on a derived hit is not merely uninformative, it is
           // wrong — see the note above `Authorship` in `WorkspaceView`. The
           // badge slot says the true thing instead of the false one.
+          //
+          // A `secrets/` hit is the other way round and keeps its origin badge:
+          // a `Seeded` note under `secrets/` really was seeded (the host lays
+          // down one README there on first boot), so both badges are true and
+          // say different things (issue #1465).
           const origin = derived ? null : originLabel(hit.updatedBy);
           return (
             <li key={hit.id}>
@@ -147,14 +174,15 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
                     notes can share a name, and the tree that would have told
                     them apart is not on screen while a search is showing.
 
-                    It is also where the ledger badge goes, rather than up beside
-                    the name where `Seeded` used to sit. "Written by a ledger" is
-                    wide, the pane is 256px, and on the name line it truncated
-                    the very thing the operator is scanning for — `DECISIONS.md`
-                    became `DECISIONS…`. Down here it costs nothing and lands
-                    next to its own evidence, the `derived/` segment it explains.
-                    The scan-for-locks affordance lives in the tree, which is
-                    the surface people browse. */}
+                    It is also where the folder badge goes, rather than up
+                    beside the name where `Seeded` used to sit. "Written by a
+                    ledger" and "Hidden from agents" are both wide, the pane is
+                    256px, and on the name line either truncated the very thing
+                    the operator is scanning for — `DECISIONS.md` became
+                    `DECISIONS…`. Down here it costs no name width and lands
+                    next to its own evidence, the `derived/` or `secrets/`
+                    segment it explains. The scan-for-glyphs affordance lives in
+                    the tree, which is the surface people browse. */}
                 <span className="mt-0.5 flex items-center gap-1.5 text-2xs text-muted-foreground">
                   <span className="truncate">
                     {hit.path}
@@ -169,6 +197,20 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
                     >
                       <Lock className="size-2.5" aria-hidden />
                       {DERIVED_LABEL}
+                    </Badge>
+                  )}
+                  {secret && (
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 gap-1 pl-1 text-3xs font-normal"
+                      title={SECRETS_REASON}
+                      data-testid="workspace-search-secret"
+                    >
+                      {/* An eye-off rather than a lock: a lock in this console
+                          means `derived/`, "you may not write this", and this
+                          rule is the other one. */}
+                      <EyeOff className="size-2.5" aria-hidden />
+                      {SECRETS_LABEL}
                     </Badge>
                   )}
                 </span>

--- a/frontend/src/views/workspace/SearchResults.tsx
+++ b/frontend/src/views/workspace/SearchResults.tsx
@@ -184,6 +184,16 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
                     segment it explains. The scan-for-glyphs affordance lives in
                     the tree, which is the surface people browse. */}
                 <span className="mt-0.5 flex items-center gap-1.5 text-2xs text-muted-foreground">
+                  {/* `truncate` is doing two jobs, and the second one is easy
+                      to mistake for missing. It carries `overflow: hidden`,
+                      which makes this flex item a scroll container — and a
+                      scroll container's automatic minimum size is 0, not its
+                      min-content width. So the path already shrinks and
+                      ellipsises rather than shouldering the badge out of a
+                      256px pane; a `min-w-0` beside it would be a no-op.
+                      Measured: with `truncate` the computed floor is `0px` and
+                      the badge overflows by 0; strip `truncate` and the floor
+                      is `auto` and it overflows. Keep them together. */}
                   <span className="truncate">
                     {hit.path}
                     {isBinary(hit) && ` · ${hit.mime} · ${formatBytes(hit.size)}`}

--- a/frontend/test/unit/workspace-folder-markers.test.ts
+++ b/frontend/test/unit/workspace-folder-markers.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * The two marked folders in one tree, and the fact that they are marked
+ * differently (issues #1377 and #1465).
+ *
+ * Both rules land on the same three lines of `TreeRow`: the row's muting, the
+ * glyph after the name, and the `…` menu. Read on its own each rule is obvious;
+ * read together they are the exact inverse of each other, and the inversion is
+ * what a careless merge flattens:
+ *
+ * * `derived/` is "an agent writes this, you do not", so #1377 takes **Rename**
+ *   and **Move to…** off its menu — the host refuses both, and a control whose
+ *   only outcome is an error toast is worse than no control.
+ * * `secrets/` is "you write this, an agent does not", so #1465 **keeps** the
+ *   whole menu. `Move to…` is the only control in the console that changes a
+ *   note's audience, and the warning #1465 exists to show is reached through
+ *   that item and nowhere else.
+ *
+ * So a resolution that muted or short-menued both folders from one predicate
+ * would leave every other test in this repo passing while #1465's warning
+ * became unreachable. That is the thing this file pins, and it is why the two
+ * rules are asserted against one tree rather than one apiece.
+ */
+
+/** A minimal `FsNode` off the wire — only the fields the tree reads. */
+function node(over: { id: string; name: string; kind: "folder" | "file"; parentId?: string }) {
+  return { ...over, updatedAt: 1 };
+}
+
+/** A fake host: `get` answers the workspace tree read. */
+function client(tree: ReturnType<typeof node>[]): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(tree),
+  } as unknown as OpenCompanyClient;
+}
+
+/**
+ * One `derived/` file, one `secrets/` file, one ordinary note — plus the two
+ * lookalike roots that are ordinary shared content host-side. Marking either of
+ * those would promise a rule the host does not enforce.
+ */
+const TREE = [
+  node({ id: "d", name: "derived", kind: "folder" }),
+  node({ id: "goals", name: "GOALS.md", kind: "file", parentId: "d" }),
+  node({ id: "s", name: "secrets", kind: "folder" }),
+  node({ id: "keys", name: "Stripe keys.md", kind: "file", parentId: "s" }),
+  node({ id: "p", name: "Playbooks", kind: "folder" }),
+  node({ id: "run", name: "Runbook.md", kind: "file", parentId: "p" }),
+  node({ id: "dish", name: "derived-notes", kind: "folder" }),
+  node({ id: "sold", name: "secrets-old", kind: "folder" }),
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render() {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, { client: client(TREE), company: "acme" }),
+      }),
+    );
+  });
+  await act(async () => {});
+}
+
+// Each tree row is exactly one `div.group` (see `TreeRow`), so matching on that
+// class picks the row rather than an ancestor that merely contains the text.
+function row(name: string): HTMLElement {
+  const found = Array.from(container.querySelectorAll("div.group")).find(
+    (d) => d.querySelector("span.truncate")?.textContent?.trim() === name,
+  );
+  if (!found) throw new Error(`no tree row for “${name}” in:\n${container.innerHTML}`);
+  return found as HTMLElement;
+}
+
+/** Open a row's `…` Actions menu and read back its items. */
+async function menuItemsFor(name: string): Promise<string[]> {
+  const trigger = row(name).querySelector('[aria-label="Actions"]');
+  if (!trigger) throw new Error(`no Actions button for “${name}”`);
+  await act(async () => {
+    (trigger as HTMLElement).click();
+  });
+  // The menu portals onto `document.body`, not into `container`.
+  return Array.from(document.querySelectorAll('[role="menuitem"]')).map((el) =>
+    (el.textContent ?? "").trim(),
+  );
+}
+
+describe("the two marked folders, side by side in one tree", () => {
+  it("gives each folder its own glyph, and no folder both", async () => {
+    await render();
+    // A lock is "you may not write this"; an eye-off is "nobody else reads
+    // this". Same slot, opposite rules — one glyph each is the whole point.
+    expect(row("derived").querySelector('[data-testid="workspace-tree-derived"]')).not.toBeNull();
+    expect(row("derived").querySelector('[data-testid="workspace-tree-secret"]')).toBeNull();
+    expect(row("secrets").querySelector('[data-testid="workspace-tree-secret"]')).not.toBeNull();
+    expect(row("secrets").querySelector('[data-testid="workspace-tree-derived"]')).toBeNull();
+  });
+
+  it("mutes both marked folders and neither lookalike", async () => {
+    await render();
+    for (const name of ["derived", "secrets"]) {
+      expect(row(name).className).toContain("text-muted-foreground");
+    }
+    // `derived-notes/` and `secrets-old/` are ordinary shared content: the rule
+    // is a segment rule, not a prefix rule, on both sides.
+    for (const name of ["Playbooks", "derived-notes", "secrets-old"]) {
+      expect(row(name).className).not.toContain("text-muted-foreground");
+      expect(row(name).querySelector('[data-testid="workspace-tree-derived"]')).toBeNull();
+      expect(row(name).querySelector('[data-testid="workspace-tree-secret"]')).toBeNull();
+    }
+  });
+
+  it("takes Rename and Move to… off a derived row, because the host refuses both", async () => {
+    await render();
+    const items = await menuItemsFor("derived");
+    expect(items).toContain("Delete");
+    expect(items).not.toContain("Rename");
+    expect(items).not.toContain("Move to…");
+  });
+
+  it("keeps the whole menu on a secrets row, because Move to… is where the warning lives", async () => {
+    await render();
+    // The regression this file exists for: #1465's audience warning is raised
+    // by `MoveDialog`, and `Move to…` is the only way into it. Short-menuing
+    // `secrets/` the way `derived/` is short-menued would delete the warning
+    // without touching a line of `MoveDialog` or failing one of its tests.
+    const items = await menuItemsFor("secrets");
+    expect(items).toContain("Move to…");
+    expect(items).toContain("Rename");
+    expect(items).toContain("Delete");
+  });
+
+  it("leaves an ordinary folder its whole menu", async () => {
+    await render();
+    const items = await menuItemsFor("Playbooks");
+    expect(items).toEqual(["Rename", "Move to…", "Delete"]);
+  });
+});

--- a/frontend/test/unit/workspace-folder-markers.test.ts
+++ b/frontend/test/unit/workspace-folder-markers.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { type FsNode, OPERATOR_ORIGIN } from "@/api/workspace";
 import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
 import { WorkspaceView } from "@/views/WorkspaceView";
 
@@ -31,16 +32,37 @@ import { WorkspaceView } from "@/views/WorkspaceView";
  * rules are asserted against one tree rather than one apiece.
  */
 
-/** A minimal `FsNode` off the wire — only the fields the tree reads. */
-function node(over: { id: string; name: string; kind: "folder" | "file"; parentId?: string }) {
-  return { ...over, updatedAt: 1 };
+/**
+ * A whole `FsNode`, not a partial one.
+ *
+ * The omissions this replaces were survivable rather than correct: `fetchTree`
+ * normalizes a wire node (`parentId ?? null`, `createdBy ?? OPERATOR_ORIGIN`),
+ * and the fixture reaches the view through it, so a missing `parentId` became
+ * `null` and a missing `createdBy` became the operator before `TreeRow` read
+ * either. Spelling them out anyway costs nothing and stops the fixture relying
+ * on a defaulting step that belongs to a different test's subject.
+ */
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}): FsNode {
+  return {
+    parentId: null,
+    updatedAt: 1,
+    createdBy: OPERATOR_ORIGIN,
+    updatedBy: OPERATOR_ORIGIN,
+    ...over,
+  };
 }
 
-/** A fake host: `get` answers the workspace tree read. */
-function client(tree: ReturnType<typeof node>[]): OpenCompanyClient {
+/** A fake host: `get` answers the tree read, `patch` the rename/move call. */
+function client(tree: FsNode[], patch = vi.fn()): OpenCompanyClient {
   return {
     scopeFor: () => "/api/v1/company/acme",
     get: vi.fn().mockResolvedValue(tree),
+    patch,
   } as unknown as OpenCompanyClient;
 }
 
@@ -75,12 +97,12 @@ afterEach(() => {
   container.remove();
 });
 
-async function render() {
+async function render(patch = vi.fn()) {
   await act(async () => {
     root.render(
       createElement(ConnectionScopeProvider, {
         scope: { connection: "c1", company: "acme" },
-        children: createElement(WorkspaceView, { client: client(TREE), company: "acme" }),
+        children: createElement(WorkspaceView, { client: client(TREE, patch), company: "acme" }),
       }),
     );
   });
@@ -159,5 +181,76 @@ describe("the two marked folders, side by side in one tree", () => {
     await render();
     const items = await menuItemsFor("Playbooks");
     expect(items).toEqual(["Rename", "Move to…", "Delete"]);
+  });
+});
+
+/**
+ * The rename half of the boundary (issue #1465, review).
+ *
+ * The host reads agent visibility off the *first path segment*, and a rename of
+ * a root folder rewrites it for the whole subtree. `PATCH …/workspace/<id>` with
+ * `{"name":"vault"}` answers 200 against a running host — only `derived/` is
+ * guarded on that route — so `secrets/` was one unannounced click from being
+ * agent-readable. The move already stops and asks; this pins that the rename
+ * does too, at the surface rather than only in the pure function.
+ */
+describe("renaming the secrets root", () => {
+  /** Open the row's `…` menu, click Rename, and type `next` into the field. */
+  async function typeRename(rowName: string, next: string) {
+    const trigger = row(rowName).querySelector('[aria-label="Actions"]');
+    await act(async () => {
+      (trigger as HTMLElement).click();
+    });
+    const item = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+      (el) => el.textContent?.trim() === "Rename",
+    );
+    await act(async () => {
+      (item as HTMLElement).click();
+    });
+    const input = document.querySelector<HTMLInputElement>("#fs-name")!;
+    await act(async () => {
+      // React tracks the last value it wrote, so a bare `input.value =` is
+      // swallowed as "unchanged"; the native setter is how a test types.
+      Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!.call(input, next);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const confirm = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Rename",
+    );
+    await act(async () => {
+      (confirm as HTMLButtonElement).click();
+    });
+  }
+
+  it("asks before it renames the boundary away, and does not call the host", async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    await render(patch);
+    await typeRename("secrets", "vault");
+
+    const panel = document.querySelector('[data-testid="workspace-move-audience"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.textContent).toContain("Agents will be able to read this folder.");
+    // The whole point: the rename has not happened yet.
+    expect(patch).not.toHaveBeenCalled();
+
+    const confirm = document.querySelector<HTMLButtonElement>(
+      '[data-testid="workspace-move-audience-confirm"]',
+    );
+    expect(confirm?.textContent).toBe("Rename out of secrets");
+    await act(async () => confirm?.click());
+    expect(patch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renames an ordinary folder on one click, as before", async () => {
+    // The step is added to the renames that change something and to no others.
+    const patch = vi.fn().mockResolvedValue({});
+    await render(patch);
+    await typeRename("Playbooks", "Runbooks");
+
+    expect(document.querySelector('[data-testid="workspace-move-audience"]')).toBeNull();
+    expect(patch).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/test/unit/workspace-search-secrets.test.ts
+++ b/frontend/test/unit/workspace-search-secrets.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SearchHit } from "@/api/workspace";
+import { SECRETS_LABEL } from "@/lib/workspace";
+import { SearchResults } from "@/views/workspace/SearchResults";
+
+/**
+ * Issue #1465, the search half.
+ *
+ * Operator search is deliberately unfiltered — `search_workspace` keeps the
+ * whole tree while `search_workspace_for_agent` drops `secrets/` — which is
+ * right, and is exactly why a private note used to come back in this list
+ * looking like any other. A search replaces the tree in the explorer pane, so a
+ * hit row is the only thing on screen: the row that says nothing is the row a
+ * screen-shared console leaks.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function hit(partial: Partial<SearchHit> & { id: string; name: string; path: string }): SearchHit {
+  return {
+    kind: "file",
+    parentId: null,
+    updatedAt: 0,
+    createdBy: { kind: "seed" },
+    updatedBy: { kind: "seed" },
+    matched: "content",
+    ...partial,
+  } as SearchHit;
+}
+
+const HITS: SearchHit[] = [
+  hit({ id: "keys", name: "Stripe keys.md", path: "secrets/Stripe keys.md" }),
+  hit({ id: "deep", name: "Twilio.md", path: "secrets/vendors/Twilio.md" }),
+  // An ordinary note, and a lookalike folder that is ordinary shared content
+  // host-side — marking it would promise a privacy it does not have.
+  hit({ id: "runbook", name: "Runbook.md", path: "Playbooks/Runbook.md" }),
+  hit({ id: "old", name: "Archived key.md", path: "secrets-old/Archived key.md" }),
+];
+
+function renderHits(hits: SearchHit[]) {
+  act(() =>
+    root.render(
+      createElement(SearchResults, {
+        query: "key",
+        hits,
+        total: hits.length,
+        loading: false,
+        error: null,
+        onOpen: () => {},
+      }),
+    ),
+  );
+}
+
+function rowFor(id: string): HTMLElement {
+  const row = container.querySelector<HTMLElement>(`[data-node-id="${id}"]`);
+  if (!row) throw new Error(`no hit row for ${id}`);
+  return row;
+}
+
+function markerIn(id: string) {
+  return rowFor(id).querySelector('[data-testid="workspace-search-secret"]');
+}
+
+describe("a note the agents cannot read, in the search hit list", () => {
+  it("says so on the row", () => {
+    renderHits(HITS);
+    expect(markerIn("keys")?.textContent).toContain(SECRETS_LABEL);
+    // The rule travels with the marker for a pointer, so the label is not a
+    // bare two words — the tree row and the note header carry the same one.
+    expect(markerIn("keys")?.getAttribute("title")).toContain("cannot list, read, search or write");
+  });
+
+  it("marks a note nested deeper than the folder itself", () => {
+    renderHits(HITS);
+    expect(markerIn("deep")).not.toBeNull();
+  });
+
+  it("leaves ordinary hits unmarked", () => {
+    renderHits(HITS);
+    expect(markerIn("runbook")).toBeNull();
+    expect(markerIn("old")).toBeNull();
+  });
+
+  it("keeps the origin badge, unlike the derived marking", () => {
+    // A `Seeded` note under `secrets/` really was seeded — the host lays down
+    // one README there on first boot — so both badges are true and say
+    // different things. (`derived/` suppresses `Seeded` because it is false
+    // there; see #1377.)
+    renderHits(HITS);
+    expect(rowFor("keys").textContent).toContain("Seeded");
+  });
+});

--- a/frontend/test/unit/workspace-secrets-hidden.test.ts
+++ b/frontend/test/unit/workspace-secrets-hidden.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import type { FsNode } from "@/api/workspace";
+import { isSecretNode, isSecretPath, SECRETS_DIR, SECRETS_LABEL, SECRETS_REASON } from "@/lib/workspace";
+
+/**
+ * Issue #1465: which notes the company's agents cannot read.
+ *
+ * `secrets/` is the one part of the shared workspace tree the host keeps away
+ * from agent tools — `is_agent_hidden_path` in
+ * `src/company/workspace_scaffold.rs` drops it from the agent path index, from
+ * agent writes and from agent search alike. The console knew nothing about it,
+ * so the folder rendered like any other and the only statement of the rule was
+ * a README seeded *inside* it.
+ *
+ * The rule is a **folder** rule and the host's is written on the first path
+ * segment, so the cases that matter are the ones a casual check gets wrong: a
+ * deep descendant, a differently-cased root, and a folder whose name merely
+ * starts with the word.
+ */
+
+function node(partial: Partial<FsNode> & { id: string; name: string }): FsNode {
+  return {
+    kind: "file",
+    parentId: null,
+    updatedAt: 0,
+    ...partial,
+  } as FsNode;
+}
+
+const TREE: FsNode[] = [
+  node({ id: "s", name: "secrets", kind: "folder" }),
+  node({ id: "readme", name: "README.md", parentId: "s" }),
+  node({ id: "keys", name: "Stripe keys.md", parentId: "s" }),
+  node({ id: "sub", name: "vendors", kind: "folder", parentId: "s" }),
+  node({ id: "deep", name: "Twilio.md", parentId: "sub" }),
+  // An ordinary note, and a folder whose name merely contains the word.
+  node({ id: "plays", name: "Playbooks", kind: "folder" }),
+  node({ id: "runbook", name: "Runbook.md", parentId: "plays" }),
+  node({ id: "lookalike", name: "secrets-old", kind: "folder" }),
+  node({ id: "inside", name: "Archived key.md", parentId: "lookalike" }),
+  // The host compares case-insensitively so a `Secrets` node cannot become an
+  // agent-visible twin of the real one.
+  node({ id: "shouty", name: "Secrets", kind: "folder" }),
+  node({ id: "shoutychild", name: "Root password.md", parentId: "shouty" }),
+];
+
+describe("which notes the workspace marks as hidden from agents", () => {
+  it("marks the folder and everything under it", () => {
+    expect(isSecretNode(TREE, "s")).toBe(true);
+    expect(isSecretNode(TREE, "readme")).toBe(true);
+    expect(isSecretNode(TREE, "keys")).toBe(true);
+    expect(isSecretNode(TREE, "sub")).toBe(true);
+    // Deeper than the host scaffolds, and marked anyway: the rule is the
+    // folder, so it holds for a path nothing seeded.
+    expect(isSecretNode(TREE, "deep")).toBe(true);
+  });
+
+  it("cannot be stepped around by capitalising a letter", () => {
+    // A false *negative* here is the whole failure mode of this issue: an
+    // unmarked note that agents genuinely cannot read is one an operator files
+    // a credential beside, believing the folder is ordinary.
+    expect(isSecretNode(TREE, "shouty")).toBe(true);
+    expect(isSecretNode(TREE, "shoutychild")).toBe(true);
+  });
+
+  it("leaves ordinary notes alone", () => {
+    expect(isSecretNode(TREE, "runbook")).toBe(false);
+    expect(isSecretNode(TREE, "plays")).toBe(false);
+    // Only the root segment counts. `secrets-old/` is ordinary shared content
+    // host-side, and a false positive here would promise privacy it does not
+    // have — the more dangerous of the two mistakes.
+    expect(isSecretNode(TREE, "lookalike")).toBe(false);
+    expect(isSecretNode(TREE, "inside")).toBe(false);
+    expect(isSecretNode(TREE, null)).toBe(false);
+    expect(isSecretNode(TREE, "no-such-node")).toBe(false);
+  });
+
+  it("reads the same rule off a path, for the search hit list", () => {
+    expect(isSecretPath("secrets/Stripe keys.md")).toBe(true);
+    expect(isSecretPath("/secrets/Stripe keys.md")).toBe(true);
+    expect(isSecretPath("secrets")).toBe(true);
+    expect(isSecretPath("secrets/vendors/Twilio.md")).toBe(true);
+    expect(isSecretPath("Secrets/Root password.md")).toBe(true);
+    // The host trims before it strips slashes; so does this. A guard a stray
+    // space defeats is not a guard.
+    expect(isSecretPath("  /secrets/Stripe keys.md")).toBe(true);
+
+    expect(isSecretPath("Playbooks/secrets/Notes.md")).toBe(false);
+    expect(isSecretPath("secrets-old/Archived key.md")).toBe(false);
+    expect(isSecretPath("Runbook.md")).toBe(false);
+    expect(isSecretPath("")).toBe(false);
+    expect(isSecretPath("/")).toBe(false);
+  });
+
+  it("agrees with the tree rule on the same node", () => {
+    // The two predicates are the point of failure: one is asked by the tree and
+    // the header, the other by the search list, and a disagreement would mean
+    // the same note is marked private in one pane and shared in another.
+    expect(isSecretNode(TREE, "keys")).toBe(isSecretPath("secrets/Stripe keys.md"));
+    expect(isSecretNode(TREE, "deep")).toBe(isSecretPath("secrets/vendors/Twilio.md"));
+    expect(isSecretNode(TREE, "inside")).toBe(isSecretPath("secrets-old/Archived key.md"));
+    expect(isSecretNode(TREE, "runbook")).toBe(isSecretPath("Playbooks/Runbook.md"));
+    expect(isSecretNode(TREE, "shoutychild")).toBe(isSecretPath("Secrets/Root password.md"));
+  });
+
+  it("names the folder the host names", () => {
+    // If `SECRETS_ROOT` is ever renamed host-side, a folder the console calls
+    // private is one the agents can read. This is the tripwire.
+    expect(SECRETS_DIR).toBe("secrets");
+  });
+
+  it("states the audience, and states the other half of the rule", () => {
+    // "Private" would describe who may open it in the console, which is
+    // everyone. The fact is who cannot read it elsewhere.
+    expect(SECRETS_LABEL).toBe("Hidden from agents");
+    // And the reason has to say what the rest of the tree means, because the
+    // operator being warned is the one choosing between two folders.
+    expect(SECRETS_REASON).toContain("Everything outside it, they can read.");
+  });
+});

--- a/frontend/test/unit/workspace-secrets-move-warning.test.ts
+++ b/frontend/test/unit/workspace-secrets-move-warning.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FsNode } from "@/api/workspace";
+import { moveAudienceWarning } from "@/lib/workspace";
+import { MoveAudienceConfirm } from "@/views/workspace/MoveAudienceConfirm";
+
+/**
+ * Issue #1465, the half that matters most.
+ *
+ * A marker on a folder is passive. `Move to…` is the one control in the console
+ * that changes a note's *audience*, and it changed it in both directions on a
+ * single click with a plain "moved" toast either way: moving into `secrets/`
+ * revoked every agent's access, moving out granted it. Neither was announced.
+ *
+ * The two directions are not the same event, so the copy is asserted per
+ * direction and not merely "a warning appeared".
+ */
+
+function node(partial: Partial<FsNode> & { id: string; name: string }): FsNode {
+  return {
+    kind: "file",
+    parentId: null,
+    updatedAt: 0,
+    ...partial,
+  } as FsNode;
+}
+
+const TREE: FsNode[] = [
+  node({ id: "s", name: "secrets", kind: "folder" }),
+  node({ id: "keys", name: "Stripe keys.md", parentId: "s" }),
+  node({ id: "sub", name: "vendors", kind: "folder", parentId: "s" }),
+  node({ id: "deep", name: "Twilio.md", parentId: "sub" }),
+  node({ id: "plays", name: "Playbooks", kind: "folder" }),
+  node({ id: "runbook", name: "Runbook.md", parentId: "plays" }),
+  node({ id: "prod", name: "Product", kind: "folder" }),
+];
+
+const NOTE = (id: string) => TREE.find((n) => n.id === id)!;
+
+describe("a move that changes who can read the note", () => {
+  it("warns on the way in", () => {
+    const warning = moveAudienceWarning(TREE, NOTE("runbook"), "s");
+    expect(warning?.change).toBe("hidden");
+    expect(warning?.title).toBe("Agents will no longer be able to read this note.");
+    // The name is in the sentence, because a move dialog opened from a row menu
+    // is the only place the operator sees which note this is about.
+    expect(warning?.body).toContain("Runbook");
+    expect(warning?.confirmLabel).toBe("Move into secrets");
+  });
+
+  it("warns on the way out, and says to check it first", () => {
+    const warning = moveAudienceWarning(TREE, NOTE("keys"), "plays");
+    expect(warning?.change).toBe("exposed");
+    expect(warning?.title).toBe("Agents will be able to read this note.");
+    // The dangerous direction: a note the agents have read cannot be un-read,
+    // so the sentence has to ask for the check before the click, not after.
+    expect(warning?.body).toContain("Check it holds no credentials first.");
+    expect(warning?.confirmLabel).toBe("Move out of secrets");
+  });
+
+  it("warns on a move out to the workspace root", () => {
+    // The root is agent-visible, and `destId === null` is the code path a
+    // direction check written on the destination *node* would miss entirely.
+    expect(moveAudienceWarning(TREE, NOTE("keys"), null)?.change).toBe("exposed");
+  });
+
+  it("counts a nested destination as inside", () => {
+    // `secrets/vendors/` is as hidden as `secrets/` — the host's rule is the
+    // root segment, so a check written on the destination's own name would say
+    // "vendors" is ordinary and warn about nothing.
+    expect(moveAudienceWarning(TREE, NOTE("runbook"), "sub")?.change).toBe("hidden");
+    // And a move *within* `secrets/` changes nothing, so it must not warn.
+    expect(moveAudienceWarning(TREE, NOTE("keys"), "sub")).toBeNull();
+  });
+
+  it("says nothing about a move that changes nothing", () => {
+    // Nearly every move. A warning shown on those is one nobody reads on the
+    // move that matters.
+    expect(moveAudienceWarning(TREE, NOTE("runbook"), "prod")).toBeNull();
+    expect(moveAudienceWarning(TREE, NOTE("runbook"), null)).toBeNull();
+  });
+
+  it("says a folder move takes everything in it", () => {
+    // A folder's move carries every note under it in the same call, so "this
+    // note" would understate a move of thirty.
+    const warning = moveAudienceWarning(TREE, NOTE("plays"), "s");
+    expect(warning?.body).toContain("this folder and everything in it");
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(warning: NonNullable<ReturnType<typeof moveAudienceWarning>>, onConfirm = () => {}) {
+  act(() =>
+    root.render(
+      createElement(MoveAudienceConfirm, { warning, onCancel: () => {}, onConfirm }),
+    ),
+  );
+}
+
+describe("the confirmation the move dialog shows instead of committing", () => {
+  it("shows the whole sentence, not a tooltip", () => {
+    const warning = moveAudienceWarning(TREE, NOTE("keys"), "plays")!;
+    render(warning);
+    const panel = container.querySelector('[data-testid="workspace-move-audience"]');
+    expect(panel?.textContent).toContain(warning.title);
+    expect(panel?.textContent).toContain(warning.body);
+  });
+
+  it("marks the outward move as the destructive one", () => {
+    render(moveAudienceWarning(TREE, NOTE("keys"), "plays")!);
+    expect(container.querySelector('[data-audience-change="exposed"]')).not.toBeNull();
+    // The button repeats the direction: it is the last thing read before the
+    // click, and a bare "Move" there would undo the paragraph above it.
+    const confirm = container.querySelector('[data-testid="workspace-move-audience-confirm"]');
+    expect(confirm?.textContent).toBe("Move out of secrets");
+  });
+
+  it("does not commit until the confirm is clicked", () => {
+    const onConfirm = vi.fn();
+    render(moveAudienceWarning(TREE, NOTE("runbook"), "s")!, onConfirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+    const confirm = container.querySelector<HTMLButtonElement>(
+      '[data-testid="workspace-move-audience-confirm"]',
+    );
+    expect(confirm?.textContent).toBe("Move into secrets");
+    act(() => confirm?.click());
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/test/unit/workspace-secrets-move-warning.test.ts
+++ b/frontend/test/unit/workspace-secrets-move-warning.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FsNode } from "@/api/workspace";
-import { moveAudienceWarning } from "@/lib/workspace";
+import { moveAudienceWarning, renameAudienceWarning } from "@/lib/workspace";
 import { MoveAudienceConfirm } from "@/views/workspace/MoveAudienceConfirm";
 
 /**
@@ -89,6 +89,84 @@ describe("a move that changes who can read the note", () => {
     // note" would understate a move of thirty.
     const warning = moveAudienceWarning(TREE, NOTE("plays"), "s");
     expect(warning?.body).toContain("this folder and everything in it");
+  });
+
+  it("says folder in the title too, not only in the body", () => {
+    // The title is the line that gets read. A heading promising one note above
+    // a paragraph describing a subtree is the wrong half to be vague in.
+    expect(moveAudienceWarning(TREE, NOTE("plays"), "s")?.title).toBe(
+      "Agents will no longer be able to read this folder.",
+    );
+    expect(moveAudienceWarning(TREE, NOTE("sub"), null)?.title).toBe(
+      "Agents will be able to read this folder.",
+    );
+    // And a note still says note.
+    expect(moveAudienceWarning(TREE, NOTE("runbook"), "s")?.title).toBe(
+      "Agents will no longer be able to read this note.",
+    );
+    expect(moveAudienceWarning(TREE, NOTE("keys"), "plays")?.title).toBe(
+      "Agents will be able to read this note.",
+    );
+  });
+});
+
+/**
+ * The other control that crosses the same boundary (issue #1465, review).
+ *
+ * The host decides agent visibility from the *first path segment*
+ * (`is_agent_hidden_path`), so renaming the root `secrets/` folder rewrites
+ * that segment for its whole subtree — and the host allows it: a `PATCH
+ * …/workspace/<id>` with `{"name":"vault"}` answers 200, verified against a
+ * running host. Only `derived/` is guarded on that route. So the rename needed
+ * the same panel the move got, or the console's promise was one click from
+ * quietly ending.
+ */
+describe("a rename that changes who can read the note", () => {
+  it("warns when the secrets root is renamed away", () => {
+    const warning = renameAudienceWarning(TREE, NOTE("s"), "vault");
+    expect(warning?.change).toBe("exposed");
+    expect(warning?.title).toBe("Agents will be able to read this folder.");
+    expect(warning?.body).toContain("vault");
+    expect(warning?.body).toContain("Check it holds no credentials first.");
+    expect(warning?.confirmLabel).toBe("Rename out of secrets");
+  });
+
+  it("warns when the secrets root is *moved* under another folder", () => {
+    // The same segment rewrite by the other route: `secrets/` nested under
+    // `Playbooks/` becomes `Playbooks/secrets/...`, whose first segment is no
+    // longer `secrets`, so the host stops hiding it. `moveAudienceWarning`
+    // already caught this — it compares the node's own ancestry to the
+    // destination's — but nothing pinned it, and it is half the boundary.
+    const warning = moveAudienceWarning(TREE, NOTE("s"), "plays");
+    expect(warning?.change).toBe("exposed");
+    expect(warning?.title).toBe("Agents will be able to read this folder.");
+  });
+
+  it("warns when an ordinary root folder is renamed into the boundary", () => {
+    const warning = renameAudienceWarning(TREE, NOTE("plays"), "secrets");
+    expect(warning?.change).toBe("hidden");
+    expect(warning?.confirmLabel).toBe("Rename into secrets");
+  });
+
+  it("cannot be stepped around by capitalising it", () => {
+    // The host compares the segment case-insensitively, so `Secrets` hides just
+    // as `secrets` does — and renaming `secrets` to `SECRETS` changes nothing,
+    // so it must not warn.
+    expect(renameAudienceWarning(TREE, NOTE("plays"), "Secrets")?.change).toBe("hidden");
+    expect(renameAudienceWarning(TREE, NOTE("s"), "SECRETS")).toBeNull();
+    expect(renameAudienceWarning(TREE, NOTE("s"), "  secrets  ")).toBeNull();
+  });
+
+  it("says nothing about a rename that cannot move the boundary", () => {
+    // A nested node's first segment belongs to an ancestor, so no rename of it
+    // can cross the line — including one that names it `secrets`.
+    expect(renameAudienceWarning(TREE, NOTE("keys"), "Stripe keys (old).md")).toBeNull();
+    expect(renameAudienceWarning(TREE, NOTE("sub"), "secrets")).toBeNull();
+    expect(renameAudienceWarning(TREE, NOTE("runbook"), "secrets")).toBeNull();
+    // And an ordinary root renamed to another ordinary name.
+    expect(renameAudienceWarning(TREE, NOTE("plays"), "Runbooks")).toBeNull();
+    // `secrets-old` is ordinary content on both sides of the rename.
+    expect(renameAudienceWarning(TREE, NOTE("plays"), "secrets-old")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #1465.

## The problem

Every company gets a `secrets/` root, scaffolded on every boot. It is the **only** part of the shared workspace tree the company's agents cannot reach — `is_agent_hidden_path` (`src/company/workspace_scaffold.rs:158`) drops it from the agent path index, from agent writes, and from agent search. Listing, reading, searching, writing, all four.

The Workspace view's own premise is that this is one tree that operator and agents share. `secrets/` is the exception to that premise, and `grep -rni secret frontend/src/views/WorkspaceView.tsx frontend/src/lib/workspace.ts` returned nothing: the console had no concept of the folder at all. `secrets` rendered with the same folder icon, the same weight, the same `…` menu as `Playbooks`, and sorted in among them.

The one statement of the rule was a `README.md` seeded **inside** the folder — which you read only if you already went looking. The operator who most needs it is the one deciding *where to put a credential*, and that decision is made from the tree, looking at a row that said nothing.

Three ways that went wrong, and all three are fixed here:

1. A key pasted into `Playbooks/Runbook.md` because nothing said one folder in this tree was private.
2. **`Move to…` changed a note's audience in both directions, silently.** Into `secrets/` revoked every agent's access; out of it granted access. One click, a plain "moved" toast either way.
3. **Operator search handed `secrets/` content back unmarked**, so a private note appeared beside ordinary ones with nothing on the row saying so. A screen-shared console leaked it.

## Diagnosis, confirmed against the code

The host's rule is the **first path segment**, `trim()` then leading slashes stripped, compared case-insensitively — the same shape as `is_derived_path`, and keyed on a literal folder name rather than a flag. There is nothing on the wire for the console to read: `GET …/workspace` carries no `hiddenFromAgents`. So the console evaluates the same rule off the same fact, exactly as `isDerivedNode` does for `derived/`.

## What changed

**One phrase, four places.** `SECRETS_DIR`, `SECRETS_LABEL` ("Hidden from agents") and `SECRETS_REASON` live in `lib/workspace` beside `DERIVED_DIR`, with `isSecretNode` (tree) and `isSecretPath` (a hit's path) mirroring `is_agent_hidden_path` character for character.

**Tree.** The `secrets` folder and everything under it is muted and carries an **eye-off**, with the reason on hover and the label for a screen reader. Deliberately *not* a lock: a lock in this tree is about to mean `derived/` ("you may not write this"), and this is the other rule — you may write it, nobody else reads it. Muted whether or not the row is the open note.

**Note header.** A `Hidden from agents` chip beside the title, because the pane where a credential actually gets typed is the editor, and a note opened from a search hit or a `[[wiki link]]` arrives there with the tree never scrolled to it.

**Search hits.** The same marker on the path line, next to the `secrets/` segment it explains. Unlike the `derived/` marking in #1377, the `Seeded` origin badge **stays**: a seeded note under `secrets/` really was seeded (the host lays down one README there on first boot), so both badges are true and say different things.

**`Move to…` — the part that matters.** A marker on a folder is passive; the move is the moment the audience changes.

- Destination rows that change the audience say so *before* the click: `Hides it` on `secrets`, `Shares it` (in the destructive colour) on the way out.
- A destination that crosses the line no longer commits on the click. The dialog swaps the list for a confirmation naming the consequence — and the two directions are **not** the same event. Moving *in* is almost always what the operator meant, so it is a plain panel confirming it worked. Moving *out* publishes the contents to every agent in the company and cannot be un-published, so that one wears the destructive alert and a destructive button.
- The confirm button repeats the direction (`Move into secrets` / `Move out of secrets`) rather than reading a bare "Move" — it is the last thing read before the click.
- Cancel returns to the destination list, not out of the dialog: an operator who reads the warning and changes their mind wanted a *different folder*, not to abandon the move.
- Every other destination still commits on one click. This adds a step to the moves that change something and to none of the others.

## Consistency with #1377 / PR #1452

Same shape on purpose — to an operator these two rules are siblings ("agents write this, you don't" / "you write this, agents don't"), so reading as siblings is most of the value:

| | `derived/` (#1377) | `secrets/` (#1465) |
|---|---|---|
| shared strings | `DERIVED_DIR` / `_LABEL` / `_REASON` in `lib/workspace` | `SECRETS_DIR` / `_LABEL` / `_REASON`, beside them |
| predicates | `isDerivedNode` (tree) + `isDerivedPath` (hit) | `isSecretNode` + `isSecretPath`, written the same way |
| tree | muted row, glyph, reason on hover, label for SR | identical, with an eye-off instead of the lock |
| search | marker on the path line | identical |
| header | chip | chip |

Deliberate divergences, both because the polarity is flipped: the glyph (a lock would collide), and the origin badge (suppressed there because `Seeded` is *false* on a derived file; kept here because it is true). `derived/` replaces the note's editing affordances because the host refuses the write; `secrets/` does not — the host is happy for an operator to write there, so nothing is taken away.

`MoveAudienceConfirm` is a sibling module of `SearchResults` rather than more of `WorkspaceView.tsx`, which is past 2,300 lines. That also keeps it out of the way of #1477, which is about the destination list itself (flat, path-less, raw ULIDs) and is untouched here.

## Not changed

- **Sort order.** `secrets` still sorts alphabetically among `Agents`, `Playbooks`, `Product`. #1452 made the same call for `derived`, and the issue's own suggestion is to decide it for both at once; the marking makes the folder legible at a glance either way.
- **The permission model, and the host.** No new routes, no guard on `rename_move`. Moving in and out of `secrets/` stays something an operator is allowed to do — it is now something they are told they are doing.

## Commands run

```
npm run typecheck        # clean
npm run typecheck:unit   # clean
npm run typecheck:e2e    # clean
npx vitest run           # 173 files, 1656 tests passed
scripts/ci/assert-design-tokens.sh   # clean
```

Browser-verified at 1440px, **light and dark**, against a freshly provisioned `agentic_software_company` on its own host and data dir: the tree collapsed and expanded, the note header, the search hit list, the destination list with its `Hides it` marker, both warning panels, and Cancel returning to the list.

## Tests

- `frontend/test/unit/workspace-secrets-hidden.test.ts` — `isSecretNode` / `isSecretPath` against the cases a casual check gets wrong (deep descendant, `Secrets` capitalised, `secrets-old/` left alone, padded and slash-prefixed paths), a case asserting the two predicates agree on the same node, and the tripwire on `SECRETS_DIR` matching the host's `SECRETS_ROOT`.
- `frontend/test/unit/workspace-secrets-move-warning.test.ts` — both directions of `moveAudienceWarning` with their copy pinned, the `destId === null` path (a check written on the destination *node* would miss it), a nested `secrets/vendors/` destination, moves within `secrets/` warning about nothing, folder wording, and a render of `MoveAudienceConfirm` asserting the sentence is visible rather than a tooltip, that the outward move is the destructive one, and that nothing commits until the confirm is clicked.
- `frontend/test/unit/workspace-search-secrets.test.ts` — renders `SearchResults` and asserts the marker on a `secrets/` hit and on one nested deeper, its absence on an ordinary hit and on `secrets-old/`, and that the origin badge survives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear indicators and explanations for derived files, which cannot be renamed or moved.
  - Marked `secrets/` content as inaccessible to agents in workspace views and search results.
  - Added warnings and confirmation steps when moving files into or out of `secrets/`.
  - Updated search results with derived and secret status badges.
  - Preserved relevant file-origin information while hiding authorship details for derived files.
- **Tests**
  - Added coverage for workspace markers, search indicators, secret detection, and move confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->