### PR TITLE
fix(approvals): stop attributing a late click to the operator

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -297,6 +297,15 @@ export interface ChatResponse {
    * back to re-reading history.
    */
   turnId?: string;
+  /**
+   * On a resolve: which end state it reached (#1449).
+   *
+   * The Approvals page resolves **without** `detach`, so it never sees a
+   * {@link ResolveReceipt} — this is the only shape that can tell it its click
+   * was refused. Absent on every other answer, and on a host that predates the
+   * field.
+   */
+  outcome?: ResolveOutcome;
 }
 
 /**
@@ -505,6 +514,25 @@ export interface ApprovalSummary {
 }
 
 /**
+ * **Which** end state a resolve reached (#1449).
+ *
+ * A resolve can succeed as a *request* and still not be the operator's
+ * decision, and the console has to be able to tell those apart — the whole of
+ * #1449 is that it could not, so it rendered the success line over a click the
+ * host had refused.
+ *
+ * * `settled` — the verdict is the operator's and it is recorded.
+ * * `expired` — the approval was still queued but past its deadline, so the
+ *   host default-denied it whatever the button said. **Nothing was carried
+ *   out**, and nothing was recorded against the operator's name.
+ * * `already_resolved` — there was nothing left to resolve. The click changed
+ *   nothing. Could be a double-submit, another operator, another tab, or the
+ *   sweeper retiring it a moment earlier; the host cannot tell which, and
+ *   neither may the wording.
+ */
+export type ResolveOutcome = "settled" | "expired" | "already_resolved";
+
+/**
  * The answer to a **detached** resolve (#383): the verdict is durable, and that
  * is all it claims. The agent's continuation arrives afterwards on the event
  * stream's `agent_reply` frame.
@@ -513,6 +541,12 @@ export interface ResolveReceipt {
   recorded: boolean;
   /** There was nothing left to resolve — a double-click, not a failure. */
   alreadyResolved: boolean;
+  /**
+   * Which end state this resolve reached (#1449). Absent on a host that
+   * predates the field, which the console reads as "cannot tell" and words its
+   * confirmation exactly as it did before rather than guessing.
+   */
+  outcome?: ResolveOutcome;
   /**
    * How many OTHER decisions the turn behind this approval is still blocked on
    * (issue #561). `0` means this decision released it; absent on a host that

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -71,7 +71,7 @@ import {
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { mergeReadFloors, unreadCount } from "@/lib/unread";
-import { approvedLine } from "@/lib/approval-wording";
+import { approvedLine, staleDecisionLine } from "@/lib/approval-wording";
 import { writeLastChannel } from "@/lib/last-channel";
 import { fromDto, type TeamMember } from "@/lib/team";
 import { agentDmThreads, defaultThreads, threadsFromDesks } from "@/lib/threads";
@@ -1649,6 +1649,33 @@ export function AppShell({
         detach: true,
         scope,
       });
+      // Issue #1449: the same read the Approvals page makes, for the same
+      // reason. This card detaches, so it gets a `ResolveReceipt` — which, until
+      // #1449, had no shape at all for "the host default-denied this because the
+      // deadline had passed". A card sitting in a transcript is exactly where a
+      // request goes stale unnoticed, so this is the surface it happens on most.
+      const stale = staleDecisionLine(answer.outcome);
+      if (stale) {
+        // The witnessed verdict is deliberately NOT the one that was clicked.
+        // `decidedApprovals` feeds the transcript's permanent receipt, and
+        // first write wins — so recording the request here would pin
+        // "Approved — recorded" onto the card forever, which is the same false
+        // claim as the toast, in the one place that never scrolls away.
+        //
+        // An `expired` card may be witnessed, and as a **deny**: the host has
+        // just said it default-denied it, so that is a fact, not a guess. An
+        // `already_resolved` one may not — the host cannot tell which way it
+        // went, so nothing is written and the `approval_resolved` frame (or the
+        // refresh in `finally`) settles the card with the truth.
+        if (answer.outcome === "expired") {
+          setDecidedApprovals((prev) =>
+            prev[approval.id] ? prev : { ...prev, [approval.id]: { verdict: "deny", approval } },
+          );
+        }
+        toast.info(stale);
+        noteInChannel(approval.thread, stale);
+        return;
+      }
       setDecidedApprovals((prev) => ({ ...prev, [approval.id]: { verdict, approval } }));
       toast.success(
         verdict === "approve"

--- a/frontend/src/lib/approval-wording.ts
+++ b/frontend/src/lib/approval-wording.ts
@@ -17,6 +17,8 @@
  * next is exactly the kind that drifts when it is written down three times.
  */
 
+import type { ResolveOutcome } from "@/api/types";
+
 /** How many other decisions a turn is still blocked on, as the host reports it. */
 export type StillAwaiting = number | undefined;
 
@@ -94,4 +96,49 @@ export function batchPositions(
     positions.set(a.id, { index, total: total.get(a.batch) ?? index });
   }
   return positions;
+}
+
+/**
+ * What to say when the click was not the decision (issue #1449).
+ *
+ * A resolve can succeed as a *request* and still not be the operator's verdict.
+ * Before this the console had no way to know that — the host's expired arm
+ * returned the same `Settled` shape as a real approval — so a card 30 minutes
+ * past its deadline answered a click with a green **"Approved — carrying it out
+ * now"** over work that could not have been carried out, and the journal agreed.
+ *
+ * Three end states, three sentences, and the differences between them are the
+ * point:
+ *
+ * * `settled` — `null`. This was the operator's decision; the caller's own
+ *   confirmation is the honest one and is left alone.
+ * * `expired` — the approval was still queued and the host default-denied it on
+ *   the deadline. This is the one case where the console may say flatly that
+ *   nothing was sent, because the host has just told it so.
+ * * `already_resolved` — there was nothing left to resolve. The click changed
+ *   nothing, and that is **all** that may be claimed: the host sees only that
+ *   the queue was empty, so it cannot tell a sweep from another operator from
+ *   another tab. Saying "it was declined automatically" here would be the same
+ *   defect pointing the other way — telling somebody nothing happened about a
+ *   payment a colleague approved a second earlier and which really is going out.
+ *
+ * Never `toast.success`. None of these is a success, and none is a failure
+ * either: the request was answered, correctly, and the answer is that there was
+ * no decision left to make. `toast.info` is the shape that says so.
+ */
+export function staleDecisionLine(
+  outcome: ResolveOutcome | undefined,
+  detail?: string,
+): string | null {
+  const suffix = detail ? `: ${detail}` : "";
+  switch (outcome) {
+    case "expired":
+      return `Too late — this one had passed its deadline, so it was declined automatically. Nothing was sent${suffix}`;
+    case "already_resolved":
+      return `Nothing to decide — this one was already settled before your click landed, so nothing changed${suffix}`;
+    // `settled`, and a host too old to say: the caller's own wording stands.
+    // Guessing here is exactly what #1449 is about.
+    default:
+      return null;
+  }
 }

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -22,7 +22,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
-import { approvedByRuntimeLine, approvedLine, batchPositions } from "@/lib/approval-wording";
+import {
+  approvedByRuntimeLine,
+  approvedLine,
+  batchPositions,
+  staleDecisionLine,
+} from "@/lib/approval-wording";
 import { approvalSummary, grantHeadline, timeAgo, toolAction, untilLabel } from "@/lib/language";
 import { approvalsForTask } from "@/lib/task-approvals";
 import { startVisiblePolling } from "@/lib/visible-poll";
@@ -211,6 +216,32 @@ export function ApprovalsView({
       // so approving one of several releases nothing — and saying otherwise is
       // the one part of this flow that actively misleads.
       const stillAwaiting = "stillAwaiting" in answer ? answer.stillAwaiting : undefined;
+      // Issue #1449, and it comes FIRST because everything below it is written
+      // for a decision that actually happened. The host answers `200` to a click
+      // on a card whose deadline has passed — it has to, nothing failed — and
+      // then default-denies it. Read that way, the wording below was a green
+      // success line over work the host had just refused, and the operator's
+      // only next signal was the work silently not happening.
+      //
+      // `null` means the host said `settled`, or is too old to say. Both keep
+      // the pre-#1449 wording: guessing is the defect, in either direction.
+      const stale = staleDecisionLine(
+        "outcome" in answer ? answer.outcome : undefined,
+        approvalSummary(a),
+      );
+      if (stale) {
+        onResolved(stale);
+        // Neither success nor error, exactly as the #380 timeout line is
+        // neither: the request was answered correctly and the answer is that
+        // there was no decision left to make. Still exactly one toast for this
+        // click (#1211) — the SSE echo for the id is suppressed by
+        // `onDecideStart` above, whichever verdict the host ends up appending.
+        toast.info(stale);
+        // The queue is the reconciliation: this card is gone from the host's
+        // parked set either way, so a refresh drops it.
+        void feed.refresh();
+        return;
+      }
       const line =
         verdict !== "approve"
           ? `Declined: ${approvalSummary(a)}`

--- a/frontend/test/unit/approval-wording.test.ts
+++ b/frontend/test/unit/approval-wording.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { approvedByRuntimeLine, approvedLine } from "@/lib/approval-wording";
+import { approvedByRuntimeLine, approvedLine, staleDecisionLine } from "@/lib/approval-wording";
 
 /**
  * Issue #561: the confirmation an operator reads after approving.
@@ -58,6 +58,53 @@ describe("the line an approve leaves behind", () => {
       for (const line of [approvedLine(still), approvedByRuntimeLine(still)]) {
         expect(line).not.toMatch(/completing|completed|done/i);
       }
+    }
+  });
+});
+
+/**
+ * Issue #1449: the line for a click that was never the decision.
+ *
+ * A resolve can succeed as a *request* and still not be the operator's verdict
+ * — a card past its deadline is default-denied by the host, which answers 200
+ * and mints nothing. The console had no way to tell that apart from a real
+ * approve, so it printed the green success line over work the host had just
+ * refused. These pin that each end state gets its own sentence, and that the
+ * two the console must not guess about stay silent.
+ */
+describe("the line a click that decided nothing leaves behind", () => {
+  it("says a late click was declined automatically, and that nothing was sent", () => {
+    const line = staleDecisionLine("expired");
+    expect(line).toContain("deadline");
+    expect(line).toContain("declined automatically");
+    expect(line).toContain("Nothing was sent");
+    expect(staleDecisionLine("expired", "email finance@acme.test")).toContain(
+      ": email finance@acme.test",
+    );
+  });
+
+  it("claims only that nothing changed when the queue was already empty", () => {
+    // The host sees an empty parked set and cannot tell a sweep from another
+    // operator from another tab. Saying "declined automatically" here would be
+    // #1449 pointing the other way — telling somebody nothing happened about a
+    // payment a colleague approved a second earlier and which really is going out.
+    const line = staleDecisionLine("already_resolved");
+    expect(line).toContain("already settled");
+    expect(line).not.toMatch(/deadline|declined|expired/i);
+  });
+
+  it("stays silent on a real decision, and on a host too old to say", () => {
+    // `null` is what lets the caller's own confirmation stand. Guessing in
+    // either direction is the defect.
+    expect(staleDecisionLine("settled")).toBeNull();
+    expect(staleDecisionLine(undefined)).toBeNull();
+    expect(staleDecisionLine("settled", "send an email")).toBeNull();
+  });
+
+  it("never congratulates the operator for a decision they did not make", () => {
+    for (const outcome of ["expired", "already_resolved"] as const) {
+      const line = staleDecisionLine(outcome);
+      expect(line).not.toMatch(/approved|carrying it out|picking it up/i);
     }
   });
 });

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1473,7 +1473,37 @@ impl CompanyRuntime {
         let receipt = CycleRunner::new(self)
             .settle_approval(id, verdict, by, scope)
             .await?;
+        self.retire_if_expired(id, &receipt).await?;
         Ok((receipt.clone(), self.spawn_follow_up(receipt)))
+    }
+
+    /// Finishes the retirement a [`ResolveReceipt::Expired`] owes (issue #1449).
+    ///
+    /// The gate dropped the entry inside its own critical section — that is what
+    /// `Expired` reports — and this is the rest of the transaction:
+    /// [`retire_approval`](Self::retire_approval), the single retirement
+    /// primitive, exactly as the sweeper reaches it. So a deadline that passes
+    /// unnoticed and a deadline that passes one second before the operator
+    /// clicks now leave **the same** durable trail: an `ApprovalExpired` line
+    /// and an `ApprovalResolved { verdict: Deny, by: System }` event, with no
+    /// human's name attached to an approval that did not happen.
+    ///
+    /// It runs **here**, inline, rather than inside the spawned follow-up: the
+    /// detached resolve answers `recorded: true` the moment this returns, and a
+    /// receipt that claims durability while its journal write is still queued on
+    /// another task is the same class of untrue statement as the one being fixed.
+    ///
+    /// A no-op for every other receipt.
+    async fn retire_if_expired(
+        self: &Arc<Self>,
+        id: &ApprovalId,
+        receipt: &ResolveReceipt,
+    ) -> Result<()> {
+        if !receipt.expired() {
+            return Ok(());
+        }
+        self.retire_approval(id, ExpiryReason::Ttl, now_millis())
+            .await
     }
 
     /// How many **other** decisions the turn behind `id` is still blocked on
@@ -1534,6 +1564,7 @@ impl CompanyRuntime {
         let receipt = CycleRunner::new(self)
             .settle_approval_amended(id, amended_payload, by)
             .await?;
+        self.retire_if_expired(id, &receipt).await?;
         Ok((receipt.clone(), self.spawn_follow_up(receipt)))
     }
 
@@ -1563,6 +1594,14 @@ impl CompanyRuntime {
             let event = match receipt {
                 ResolveReceipt::AlreadyResolved => {
                     return Ok(CycleRunner::new(&rt).already_resolved_report());
+                }
+                // Issue #1449: an expiry owes no continuation *from here*.
+                // `retire_approval` — already run inline by `retire_if_expired`
+                // — released the turn itself, banking the expiry as the deny it
+                // is. Running one here too would decide the same approval twice
+                // against the continuation queue.
+                ResolveReceipt::Expired => {
+                    return Ok(CycleRunner::new(&rt).expired_report());
                 }
                 ResolveReceipt::Settled(event) => *event,
             };

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -312,22 +312,52 @@ impl ManifestApprovalGate {
     /// Removes the parked entry and returns the `amended` effect to execute, or
     /// `None` when the approval is unknown or has expired past its TTL — the
     /// same default-deny-on-silence that governs [`resolve_at`](Self::resolve_at).
+    ///
+    /// Prefer [`resolve_amended_outcome`](Self::resolve_amended_outcome) when
+    /// the caller has to *report* what happened: this `None` collapses "there
+    /// was nothing parked" into "the deadline had passed", and those are
+    /// different things to write into an audit trail (issue #1449).
     pub fn resolve_amended(
+        &self,
+        id: &ApprovalId,
+        amended: Effect,
+        by: Actor,
+        now_millis: u64,
+    ) -> Option<Effect> {
+        match self.resolve_amended_outcome(id, amended, by, now_millis) {
+            ResolveOutcome::Approved(effect) => Some(effect),
+            _ => None,
+        }
+    }
+
+    /// The amend counterpart to
+    /// [`resolve_outcome`](Self::resolve_outcome): resolves a parked approval to
+    /// an operator-amended effect and says **which** outcome that was
+    /// (issue #1449).
+    ///
+    /// An amend is an approve, so the outcomes it can produce are the same
+    /// three the plain approve can: [`ResolveOutcome::NotParked`],
+    /// [`ResolveOutcome::Expired`], and [`ResolveOutcome::Approved`] carrying
+    /// the *amended* effect. It never denies — a deny cannot carry an
+    /// amendment, and the route refuses the pairing.
+    ///
+    /// The removal and the outcome decision are one critical section, for the
+    /// same reason they are on `resolve_outcome`: two concurrent resolves of
+    /// one id must not both win.
+    pub fn resolve_amended_outcome(
         &self,
         id: &ApprovalId,
         amended: Effect,
         _by: Actor,
         now_millis: u64,
-    ) -> Option<Effect> {
-        let parked = self
-            .parked
-            .lock()
-            .expect("parked map poisoned")
-            .remove(id)?;
+    ) -> ResolveOutcome {
+        let Some(parked) = self.parked.lock().expect("parked map poisoned").remove(id) else {
+            return ResolveOutcome::NotParked;
+        };
         if now_millis.saturating_sub(parked.parked_at_millis) >= self.ttl_millis {
-            return None;
+            return ResolveOutcome::Expired;
         }
-        Some(amended)
+        ResolveOutcome::Approved(amended)
     }
 
     /// Resolves a parked approval as of `now`, reporting **which** of the four

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -138,9 +138,11 @@ pub(crate) const BUILDER_ANNOTATION: &str = "\n\n[This request is already being 
 /// What settling an approval's verdict produced — the outcome of the fast half
 /// of a resolve, before any model is called (issue #383).
 ///
-/// Both arms mean the operator's decision is final. They differ only in what is
-/// still owed: `Settled` owes one follow-up cycle, `AlreadyResolved` owes
-/// nothing because a previous resolve already ran it.
+/// Every arm means the operator has no decision left to make. They differ in
+/// what is still owed and, crucially, in **what may be claimed about the
+/// operator**: `Settled` owes one follow-up cycle and is the only arm that may
+/// be journaled as this person's verdict; `AlreadyResolved` and `Expired` owe
+/// no cycle because nothing of the operator's was recorded at all.
 #[derive(Debug, Clone)]
 pub enum ResolveReceipt {
     /// Nothing was parked under this id — an unknown id, or one a concurrent
@@ -148,6 +150,24 @@ pub enum ResolveReceipt {
     /// written and no cycle is owed. Issue #243 made this a safe no-op rather
     /// than a second grant; surfacing it here lets the HTTP layer say so.
     AlreadyResolved,
+    /// The approval was still parked but past its deadline, so the gate
+    /// default-denied it whatever the operator asked for (issue #1449).
+    ///
+    /// **This is not the operator's verdict and must never be recorded as
+    /// one.** The click arrived too late to be a decision: no grant is minted,
+    /// nothing is executed, and the durable record is an
+    /// [`ApprovalExpired`](crate::runtime::journal) — the same line the sweeper
+    /// writes for the identical outcome reached by silence. Before this the arm
+    /// fell through to `Settled`, so a late click journaled a named operator
+    /// approving something the host had already refused, and told them in green
+    /// that it was being carried out.
+    ///
+    /// The retirement transaction it owes — journal, pending mark, continuation
+    /// release, event — is
+    /// [`CompanyRuntime::retire_approval`](crate::runtime::CompanyRuntime), run
+    /// by the caller that holds the `Arc`. See
+    /// [`settle_approval`](CycleRunner::settle_approval).
+    Expired,
     /// The verdict is journaled and any approved effect settled — the grant is
     /// minted, or the native effect executed. The carried `ApprovalResolved` is
     /// the event the follow-up cycle must run so the brain learns the verdict.
@@ -163,6 +183,25 @@ impl ResolveReceipt {
     /// Whether this resolve found nothing left to resolve.
     pub fn already_resolved(&self) -> bool {
         matches!(self, Self::AlreadyResolved)
+    }
+
+    /// Whether the deadline decided this rather than the operator (issue #1449).
+    pub fn expired(&self) -> bool {
+        matches!(self, Self::Expired)
+    }
+
+    /// The wire discriminator for what actually happened (issue #1449).
+    ///
+    /// A string rather than a third boolean because the arms are mutually
+    /// exclusive and there is a fourth coming: two independent `bool`s can spell
+    /// states that cannot exist, and every console reading them has to know
+    /// which combinations are real. One field with one value per arm cannot.
+    pub fn outcome(&self) -> &'static str {
+        match self {
+            Self::AlreadyResolved => "already_resolved",
+            Self::Expired => "expired",
+            Self::Settled(_) => "settled",
+        }
     }
 }
 
@@ -841,6 +880,15 @@ approval.]"
     /// [`ResolveReceipt::AlreadyResolved`] (issue #243). It writes no journal
     /// record and owes no cycle.
     ///
+    /// Resolving one that is **past its deadline** yields
+    /// [`ResolveReceipt::Expired`] and likewise writes nothing here — the
+    /// operator's click arrived too late to be a decision, so nothing about it
+    /// may be journaled (issue #1449). **The caller owes that approval its
+    /// retirement**: `Expired` means the gate has already dropped the entry, and
+    /// [`CompanyRuntime::retire_approval`](crate::runtime::CompanyRuntime) is
+    /// the one transaction that finishes the job. `resolve_approval_spawned` —
+    /// the only production caller — does exactly that.
+    ///
     /// Before this the double-submit path was indistinguishable from a deny (see
     /// [`ResolveOutcome`]), so a double-clicked approve appended a second
     /// `ApprovalResolved` to the journal and ran a second follow-up cycle over an
@@ -871,6 +919,27 @@ approval.]"
             .resolve_outcome(id, verdict, by.clone(), now_millis());
         if outcome == ResolveOutcome::NotParked {
             return Ok(ResolveReceipt::AlreadyResolved);
+        }
+        // Issue #1449: past its deadline is NOT this operator's verdict.
+        //
+        // The gate has already default-denied it — that is what `Expired`
+        // means, and the safety half has always held: no grant is minted and
+        // nothing runs. What did not exist was the *reporting* half. Falling
+        // through here appended `ApprovalResolved` — the record for "the
+        // operator decided this" — and returned `Settled { verdict: Approve }`,
+        // so the durable audit trail said a named person approved something the
+        // host had refused, and the console said so in green.
+        //
+        // Returning early leaves the retirement to the caller rather than doing
+        // it here, because the transaction an expiry owes is four steps, not
+        // one — journal, pending mark, continuation release, event — and it
+        // already exists whole as `CompanyRuntime::retire_approval`, which the
+        // sweeper reaches the identical outcome through. Re-implementing three
+        // of its four steps at this seam is exactly the failure that function's
+        // doc comment exists to prevent, and it needs an `Arc<Self>` to release
+        // the continuation, which a `CycleRunner` does not hold.
+        if outcome == ResolveOutcome::Expired {
+            return Ok(ResolveReceipt::Expired);
         }
         // Issue #796: the approval has left the parked set — drop its pending
         // mark. On approve the grant minted just below now names the task; on
@@ -1238,6 +1307,37 @@ approval.]"
         }
     }
 
+    /// The synthetic report for a decision that arrived after the deadline
+    /// (issue #1449).
+    ///
+    /// Same shape and same purpose as
+    /// [`already_resolved_report`](Self::already_resolved_report) — a receipt
+    /// that owes no cycle still answers on a handle of the same shape — and a
+    /// different sentence, because it is a different thing to have happened. The
+    /// approval was not resolved by anybody; its deadline passed and the host
+    /// declined it. Saying "already resolved" here would be the smaller version
+    /// of the same false claim this issue is about.
+    pub(crate) fn expired_report(&self) -> CycleReport {
+        CycleReport {
+            cycle_id: generate_id(),
+            responses: vec![OutboundMessage {
+                task_id: None,
+                channel: OPERATOR_CHANNEL.to_string(),
+                agent: None,
+                text: "This approval had passed its deadline, so it was declined automatically. \
+                       Nothing was carried out."
+                    .to_string(),
+                steps: Vec::new(),
+                reply_to: None,
+                message_id: None,
+            }],
+            executed_effects: Vec::new(),
+            parked: Vec::new(),
+            persisted_seq: None,
+            input_seqs: Vec::new(),
+        }
+    }
+
     /// Settles a parked approval to an operator-amended effect
     /// (approve-with-edit): overlays `amended_payload` onto the parked effect and
     /// executes the amended version (at-most-once).
@@ -1247,6 +1347,9 @@ approval.]"
     /// no `AlreadyResolved` arm: an id with nothing parked yields no executable
     /// effect and simply settles to a resolution the brain is still told about,
     /// exactly as before.
+    ///
+    /// It **does** have an [`Expired`](ResolveReceipt::Expired) arm, on the same
+    /// terms as the plain path (issue #1449), and the caller owes the retirement.
     ///
     /// Both the original and the amended effect are preserved in the immutable
     /// journal (`ApprovalParked` + `ApprovalAmended`), so the audit trail shows
@@ -1265,12 +1368,26 @@ approval.]"
             original.payload = overlay_payload(original.payload, amended_payload);
             original
         });
-        let executed = match amended {
-            Some(effect) => self
-                .rt
-                .approval_gate
-                .resolve_amended(id, effect, by.clone(), now),
-            None => None,
+        let outcome = match amended {
+            Some(effect) => {
+                self.rt
+                    .approval_gate
+                    .resolve_amended_outcome(id, effect, by.clone(), now)
+            }
+            None => ResolveOutcome::NotParked,
+        };
+        // Issue #1449, the amend half of the same defect. An edit applied to a
+        // card past its deadline is still not a decision — and it is the worse
+        // half of the bug, because the fall-through recorded an `ApprovalAmended`
+        // too: a named operator both editing and approving an effect the gate
+        // had already refused. Same answer as the plain path; the caller retires
+        // it.
+        if outcome == ResolveOutcome::Expired {
+            return Ok(ResolveReceipt::Expired);
+        }
+        let executed = match outcome {
+            ResolveOutcome::Approved(effect) => Some(effect),
+            _ => None,
         };
 
         // Audit the amendment (when one ran) and drain the queue durably.

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -4385,6 +4385,212 @@ mod test {
         );
     }
 
+    /// Parks one harness tool call behind a **zero-TTL** gate, so it is past its
+    /// deadline the instant it lands — the state an operator meets when they get
+    /// to the queue late (issue #1449).
+    async fn park_one_past_its_deadline(
+        home: std::path::PathBuf,
+    ) -> (Arc<CompanyRuntime>, ApprovalId) {
+        let gate = Arc::new(
+            ManifestApprovalGate::new(manifest("supervised").policy.clone()).with_ttl_millis(0),
+        );
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .with_approvals(gate)
+                .with_brain(Arc::new(EffectBrain {
+                    effect: harness_effect(
+                        "finance",
+                        "composio_execute",
+                        serde_json::json!({ "to": "a@b.test" }),
+                    ),
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
+                text: "do it".into(),
+                by: None,
+                chat: None,
+                deliverable: None,
+            }])
+            .await
+            .unwrap();
+        assert_eq!(report.parked.len(), 1);
+        let id = report.parked[0].clone();
+        (rt, id)
+    }
+
+    /// **The assertion this whole fix exists for** (issue #1449).
+    ///
+    /// The safety half was always right — an expired approval mints nothing, and
+    /// [`an_expired_approval_mints_nothing_even_on_approve`] pins that. What was
+    /// missing was the *reporting* half: the arm fell through to
+    /// `record_resolved`, so the immutable journal said **a named operator
+    /// approved this** about a call the host had already refused. That is a
+    /// false statement about a person, written permanently, on the surface whose
+    /// entire job is answering "who authorised this?".
+    ///
+    /// So: after a late approve, the journal must carry the expiry — the same
+    /// line the sweeper writes when the identical outcome is reached by silence
+    /// — and must carry **no** `ApprovalResolved` for that id at all.
+    #[tokio::test]
+    async fn a_late_approve_is_journaled_as_an_expiry_never_as_the_operators_verdict() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (rt, id) = park_one_past_its_deadline(home.clone()).await;
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+
+        let raw = tokio::fs::read_to_string(Bundle::new(&home, rt.id()).journal_jsonl())
+            .await
+            .unwrap();
+        let lines: Vec<serde_json::Value> = raw
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| serde_json::from_str(l).ok())
+            .collect();
+        let about_this_approval = |record: &str| {
+            lines.iter().any(|line| {
+                line["record"] == record && line["id"] == serde_json::json!(id.as_ref() as &str)
+            })
+        };
+
+        assert!(
+            about_this_approval("ApprovalExpired"),
+            "a late click leaves the SAME record as a deadline nobody noticed, got {raw}"
+        );
+        assert!(
+            !about_this_approval("ApprovalResolved"),
+            "the journal must never say this operator resolved an approval the \
+             host had already default-denied, got {raw}"
+        );
+        assert!(
+            !about_this_approval("ApprovalAmended"),
+            "and it must not record an amendment either, got {raw}"
+        );
+        // The safety half, re-checked here rather than assumed: reporting the
+        // truth is only half a fix if the grant came back.
+        assert_eq!(rt.grants.live_count(), 0);
+        assert!(rt.pending_approvals().is_empty());
+    }
+
+    /// The event log — what the brain and the operator's SSE feed read — must
+    /// agree with the journal (issue #1449).
+    ///
+    /// Before this it received `ApprovalResolved { verdict: Approve, by: <the
+    /// operator> }`, so the agent was re-dispatched to make a call it had never
+    /// been granted, and the timeline named a person who approved nothing. An
+    /// expiry is a default-**deny** by the **system**, exactly as the sweeper
+    /// appends it.
+    #[tokio::test]
+    async fn a_late_approve_appends_a_system_deny_not_the_operators_approve() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one_past_its_deadline(home_dir.path().to_path_buf()).await;
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+
+        let events = rt
+            .events()
+            .read_from(rt.id(), EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+        let resolutions: Vec<_> = events
+            .iter()
+            .filter_map(|stored| match &stored.event {
+                CompanyEvent::ApprovalResolved {
+                    approval_id,
+                    verdict,
+                    by,
+                } if approval_id == &id => Some((*verdict, by.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            resolutions.len(),
+            1,
+            "exactly one resolution event, got {resolutions:?}"
+        );
+        assert_eq!(resolutions[0].0, Verdict::Deny);
+        assert_eq!(
+            resolutions[0].1.kind,
+            ActorKind::System,
+            "the deadline decided this, not the person who clicked"
+        );
+    }
+
+    /// The receipt says which end state was reached, so the HTTP layer can too.
+    #[tokio::test]
+    async fn a_late_approve_answers_with_an_expired_receipt() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one_past_its_deadline(home_dir.path().to_path_buf()).await;
+
+        let (receipt, follow_up) = rt
+            .resolve_approval_spawned(&id, Verdict::Approve, operator(), GrantScope::Once)
+            .await
+            .unwrap();
+        assert_eq!(receipt.outcome(), "expired");
+        assert!(receipt.expired());
+        assert!(
+            !receipt.already_resolved(),
+            "the approval WAS parked — it ran out, which is a different answer \
+             from somebody else having decided it"
+        );
+        // And it owes no continuation of its own: `retire_approval` already
+        // released the turn.
+        let report = crate::company::runtime::join_follow_up(follow_up)
+            .await
+            .unwrap();
+        assert!(report.responses[0].text.contains("deadline"));
+
+        // A second click on the same card is now the ordinary already-gone case.
+        let (again, _) = rt
+            .resolve_approval_spawned(&id, Verdict::Approve, operator(), GrantScope::Once)
+            .await
+            .unwrap();
+        assert_eq!(again.outcome(), "already_resolved");
+    }
+
+    /// The amend half of the same defect: an edit applied after the deadline is
+    /// still not a decision, and recorded an `ApprovalAmended` on top of the
+    /// false approval before this (issue #1449).
+    #[tokio::test]
+    async fn a_late_amend_records_an_expiry_and_no_amendment() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (rt, id) = park_one_past_its_deadline(home.clone()).await;
+
+        let (receipt, _) = rt
+            .resolve_approval_amended_spawned(
+                &id,
+                serde_json::json!({ "to": "elsewhere@b.test" }),
+                operator(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(receipt.outcome(), "expired");
+
+        let raw = tokio::fs::read_to_string(Bundle::new(&home, rt.id()).journal_jsonl())
+            .await
+            .unwrap();
+        assert!(raw.contains("ApprovalExpired"));
+        assert!(
+            !raw.contains("ApprovalAmended"),
+            "an edit the host refused is not an amendment the operator made, got {raw}"
+        );
+        assert!(
+            !raw.contains("elsewhere@b.test"),
+            "and the edited arguments must not be recorded as approved, got {raw}"
+        );
+        assert_eq!(rt.grants.live_count(), 0);
+    }
+
     /// A live grant survives a restart; a consumed one does not come back.
     ///
     /// The window between approve and re-issue spans a model turn, so a deploy

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1323,6 +1323,19 @@ struct ChatResponse {
     /// here. A caller that finds it missing has the reply in hand anyway.
     #[serde(skip_serializing_if = "Option::is_none")]
     turn_id: Option<String>,
+    /// The same discriminator [`ResolveReceiptDto::outcome`] carries, for the
+    /// non-detached resolve the Approvals page makes (issue #1449).
+    ///
+    /// The page never sees a `ResolveReceiptDto` — that shape is the *detached*
+    /// answer, which only the inline chat card asks for — so without this the
+    /// one surface the bug was reproduced on had no way to learn its click had
+    /// been refused, whatever the receipt said.
+    ///
+    /// Only ever set by a resolve, and omitted by every host predating it, which
+    /// a console reads as "this host cannot tell me" and words its confirmation
+    /// exactly as it did before rather than guessing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<&'static str>,
 }
 
 /// The `detach: true` response (issue #983): the turn's id and the durable id of
@@ -1973,6 +1986,8 @@ async fn chat_and_emit(
         // A chat turn is nobody's sign-off, so this stays absent here.
         still_awaiting: None,
         turn_id,
+        // …and it resolves nothing, so there is no resolve outcome to report.
+        outcome: None,
     })))
 }
 
@@ -2892,6 +2907,21 @@ struct ResolveReceiptDto {
     /// the action" for all four. This is what lets it say the true thing
     /// instead. `0` means this decision released the turn.
     still_awaiting: usize,
+    /// **Which** of the end states this resolve actually reached (issue #1449):
+    /// `"settled"`, `"already_resolved"`, or `"expired"`.
+    ///
+    /// `already_resolved` above is kept and still means what it always did —
+    /// there was nothing left to resolve — so a console predating this field
+    /// behaves byte for byte as it did. What it could never express is
+    /// `expired`: the approval **was** still parked, and the host default-denied
+    /// it because its deadline had passed. Before this the receipt had no shape
+    /// for that at all, so the console rendered the one thing it could — the
+    /// success line — over a decision the host had refused.
+    ///
+    /// A string rather than a second boolean because the states are mutually
+    /// exclusive: two booleans can spell combinations that cannot happen, and
+    /// every reader would have to know which ones are real.
+    outcome: &'static str,
 }
 
 async fn run_resolve(
@@ -2932,6 +2962,10 @@ async fn run_resolve(
     // what decrements the turn's counter — has not run yet, so this still counts
     // the approval just decided and `decisions_still_awaited` subtracts it.
     let still_awaiting = runtime.decisions_still_awaited(&id);
+    // Issue #1449: which end state this actually reached, read off the receipt
+    // rather than assumed from the fact that no error was returned. A resolve
+    // can succeed as a request and still not be the operator's decision.
+    let outcome = receipt.outcome();
 
     if body.detach {
         // Nothing here waits on the turn. The webhook fan-out still owes the
@@ -2954,6 +2988,7 @@ async fn run_resolve(
             recorded: true,
             already_resolved: receipt.already_resolved(),
             still_awaiting,
+            outcome,
         })
         .into_response());
     }
@@ -2964,6 +2999,7 @@ async fn run_resolve(
         message_id: None,
         responses: report.responses,
         still_awaiting: Some(still_awaiting),
+        outcome: Some(outcome),
         // A resolve runs a follow-up cycle, not an operator turn, so it opens no
         // turn row of its own.
         turn_id: None,
@@ -3070,6 +3106,19 @@ mod test {
         config: AppConfig,
         brain: Option<Arc<dyn crate::ports::brain::Brain>>,
     ) -> AppState {
+        build_state_with_brain_and_manifest(home, lifecycle, config, brain, manifest()).await
+    }
+
+    /// [`build_state_with_brain`], with the company manifest chosen by the
+    /// caller — the approval **deadline** lives in `[policy]`, so a test about
+    /// what a past-deadline card answers has to be able to set it (issue #1449).
+    async fn build_state_with_brain_and_manifest(
+        home: &std::path::Path,
+        lifecycle: &str,
+        config: AppConfig,
+        brain: Option<Arc<dyn crate::ports::brain::Brain>>,
+        manifest: CompanyManifest,
+    ) -> AppState {
         // Pre-seed a record so the builder preserves the requested lifecycle.
         let store = FsCompanyStore::new(home.to_path_buf());
         let id = CompanyId::new("acme");
@@ -3077,7 +3126,7 @@ mod test {
         store
             .save(&CompanyRecord {
                 id: id.clone(),
-                manifest: manifest(),
+                manifest: manifest.clone(),
                 ledger: Vec::new(),
                 lifecycle: lifecycle.to_string(),
                 overlay_agents: Vec::new(),
@@ -3095,7 +3144,7 @@ mod test {
             .await
             .unwrap();
 
-        let mut builder = RuntimeBuilder::new(home.to_path_buf(), manifest()).with_id(id.clone());
+        let mut builder = RuntimeBuilder::new(home.to_path_buf(), manifest).with_id(id.clone());
         if let Some(brain) = brain {
             builder = builder.with_brain(brain);
         }
@@ -6866,7 +6915,7 @@ mode = "full"
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(
             value,
-            serde_json::json!({ "recorded": true, "alreadyResolved": false, "stillAwaiting": 0 })
+            serde_json::json!({ "recorded": true, "alreadyResolved": false, "stillAwaiting": 0, "outcome": "settled" })
         );
 
         // The answer really did precede the work: the turn is only now under
@@ -7044,13 +7093,102 @@ mode = "full"
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(
             value,
-            serde_json::json!({ "recorded": true, "alreadyResolved": true, "stillAwaiting": 0 })
+            serde_json::json!({ "recorded": true, "alreadyResolved": true, "stillAwaiting": 0, "outcome": "already_resolved" })
         );
         assert_eq!(
             c.runtime.grants.live_count(),
             1,
             "re-approving minted no second grant"
         );
+    }
+
+    /// **Issue #1449 on the wire.** A card past its deadline answers `expired`,
+    /// on both response shapes, and journals no approval against the operator.
+    ///
+    /// The two shapes matter independently. The **detached** receipt is what the
+    /// inline chat card reads; the **synchronous** `ChatResponse` is what the
+    /// Approvals page reads — the surface the defect was reported on — and it
+    /// never sees a receipt at all, so a discriminator that only rode on the
+    /// receipt would have left the reproduced bug in place.
+    #[tokio::test]
+    async fn a_resolve_past_the_deadline_answers_expired_on_both_shapes() {
+        let home_dir = home();
+        // `approval_ttl_hours = 0`: anything parked is past its deadline the
+        // instant it lands, which is the state an operator meets when they get
+        // to a queue late.
+        let expiring: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\napproval_ttl_hours = 0\n",
+        )
+        .unwrap();
+        let state = build_state_with_brain_and_manifest(
+            home_dir.path(),
+            "running",
+            AppConfig::default(),
+            Some(Arc::new(StalledContinuationBrain {
+                entered: Arc::new(tokio::sync::Notify::new()),
+                release: Arc::new(tokio::sync::Notify::new()),
+                parked: gated_tool_call(),
+            })),
+            expiring,
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let app = router(state);
+
+        let response = app.clone().oneshot(chat_request("do it")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let approval_id = runtime.pending_approvals()[0].id.clone();
+
+        // The detached shape.
+        let detached = app
+            .clone()
+            .oneshot(resolve_request(
+                &approval_id,
+                serde_json::json!({"verdict":"approve","detach":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(detached.status(), StatusCode::OK);
+        let bytes = to_bytes(detached.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            value["outcome"], "expired",
+            "the host default-denied this; the receipt has to be able to say so, got {value}"
+        );
+        assert_eq!(
+            runtime.grants.live_count(),
+            0,
+            "and it minted nothing, as it always did"
+        );
+
+        // The synchronous shape, on a second card of the same company.
+        let response = app
+            .clone()
+            .oneshot(chat_request("do it again"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let second = runtime.pending_approvals()[0].id.clone();
+        let sync = app
+            .clone()
+            .oneshot(resolve_request(
+                &second,
+                serde_json::json!({"verdict":"approve"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(sync.status(), StatusCode::OK);
+        let bytes = to_bytes(sync.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            value.get("responses").is_some_and(|r| r.is_array()),
+            "still a ChatResponse, got {value}"
+        );
+        assert_eq!(
+            value["outcome"], "expired",
+            "the Approvals page's own shape carries it too, got {value}"
+        );
+        assert_eq!(runtime.grants.live_count(), 0);
     }
 
     /// Both scope forms carry `detach` identically — the `/companies/{id}` route
@@ -7077,7 +7215,7 @@ mode = "full"
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(
             value,
-            serde_json::json!({ "recorded": true, "alreadyResolved": false, "stillAwaiting": 0 })
+            serde_json::json!({ "recorded": true, "alreadyResolved": false, "stillAwaiting": 0, "outcome": "settled" })
         );
         assert!(await_continuation(&c.runtime).await);
         assert_eq!(c.runtime.grants.live_count(), 1);


### PR DESCRIPTION
## Summary

An approval past its deadline is default-denied by the gate whatever the operator clicked. That outcome existed as `ResolveOutcome::Expired`, was constructed in exactly one place, and was consumed nowhere — so it fell through to the ordinary settle path. A late click was therefore journaled as **the operator's approval**, and the console confirmed it in green.

This makes the expired arm a real end state end to end: a third `ResolveReceipt`, a wire discriminator both response shapes carry, and console wording that says what actually happened.

## What was wrong

The safety half was always right — an expired approval mints no grant and executes nothing. The **reporting** half did not exist:

- The immutable journal got an `ApprovalResolved` naming a person who approved nothing, on the one surface whose job is answering "who authorised this?".
- The event log got `ApprovalResolved { verdict: Approve, by: <operator> }`, so the agent was re-dispatched for a call it had never been granted.
- The amend path was worse: it additionally recorded an `ApprovalAmended`, i.e. a named operator both editing *and* approving an effect the gate had already refused.
- The console printed **"Approved — carrying it out now"** over work the host had just declined; the operator's only other signal was the work silently not happening.

Reproduced by reverting the two guards locally: the journal dump shows `ApprovalResolved` written for the expired id, and the appended event carries `verdict: Approve`.

## The fix

- `ManifestApprovalGate::resolve_amended_outcome` — the amend counterpart to `resolve_outcome`, so the amend path can distinguish "nothing was parked" from "the deadline had passed". `resolve_amended` is kept and now delegates, so its callers are unchanged.
- `ResolveReceipt::Expired` — a third arm, returned instead of falling through to `record_resolved`, on both the plain and the amend path.
- The resolve path finishes the retirement through `CompanyRuntime::retire_approval`, the same single primitive the expiry sweeper reaches for the identical outcome, rather than re-implementing three of its four steps at a new seam. It runs **inline**, not in the spawned follow-up, so a detached resolve does not answer `recorded: true` while its journal write is still queued elsewhere.
- Result: a deadline that passes unnoticed and a deadline that passes one second before the click now leave the *same* durable trail — an `ApprovalExpired` line plus `ApprovalResolved { verdict: Deny, by: System }`.

## API changes

Additive, and every existing field keeps its meaning.

- `ResolveReceiptDto` (the `detach: true` answer) and the synchronous `ChatResponse` both gain **`outcome: "settled" | "expired" | "already_resolved"`**, read off the receipt rather than inferred from the absence of an error.
- Both shapes need it independently: the inline chat card detaches and reads a receipt; the Approvals page — the surface this was reported on — resolves *without* `detach` and never sees one, so a discriminator riding only on the receipt would have left the reported bug in place.
- A string rather than a second boolean, because the states are mutually exclusive and two booleans can spell combinations that cannot happen.
- `alreadyResolved` is unchanged, so a console predating the field behaves exactly as before. The console treats an absent `outcome` as "this host cannot tell me" and keeps its previous wording rather than guessing.

## Behaviour changes

- A resolve on an expired card no longer writes `ApprovalResolved`/`ApprovalAmended` against the operator, and no longer runs a follow-up continuation of its own (`retire_approval` already released the turn — running a second would decide the same approval twice against the continuation queue).
- The console answers such a click with an informational line — *"Too late — this one had passed its deadline, so it was declined automatically. Nothing was sent"* — instead of a success toast, on both the Approvals page and the inline chat card. The chat card's permanent transcript receipt records the host's **deny**, not the verdict that was clicked.
- `already_resolved` gets its own sentence claiming only that nothing changed. It deliberately does **not** say "declined automatically": the host sees an empty parked set and cannot tell a sweep from another operator from another tab, and asserting a decline there would be this same defect pointing the other way.

## Commands run locally

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test                      # 3217 passed, 0 failed
cd frontend
npm run typecheck
npm run typecheck:unit
npm run typecheck:e2e
npm test                        # 186 files, 1777 tests passed
```

The two new guards were reverted locally to confirm the added tests fail without them — all five do, and the failure output is the false `ApprovalResolved` itself rather than a renamed assertion.

Closes #1449
