### PR TITLE
test(e2e): bar the durable read from the window the cut test measures

### DIFF
--- a/frontend/test/e2e/chat-detached-post-failure.spec.ts
+++ b/frontend/test/e2e/chat-detached-post-failure.spec.ts
@@ -37,10 +37,27 @@ import { LIVE_BRAIN } from "./capabilities";
  * no pause and the suppression is lifted before the frame lands, which renders
  * it by the ordinary path and proves nothing about the outcome split.
  *
- * Nothing else can draw this reply. The `202` body never reached the page, so
- * no turn id was learned and the run poll is never armed; the channel was
- * hydrated before the send and is never reopened or reloaded. If the bubble
- * appears, the released frame is what put it there.
+ * Nothing else can draw this reply, and the spec makes that true rather than
+ * assuming it. The `202` body never reached the page, so no turn id was learned
+ * from the POST — but the shell also arms its turn poll from `listRuns` at
+ * mount, and the harness company this suite shares carries open desk work. A
+ * run settling inside the eight-second pause takes the poll's terminal
+ * `chat/history` re-read with it, and that read folds in whatever the durable
+ * transcript holds by then: this turn's own reply, drawn seconds before the
+ * connection is cut.
+ *
+ * That is what the CI failure artifact shows. Beside the early reply, the
+ * operator's own message is rendered *twice* — which nothing but a durable fold
+ * can produce, because the optimistic bubble's id is only reconciled by the
+ * POST response this test destroys — and the working row is still up, so a turn
+ * was armed. A flake in the environment, not a defect in the product, and it
+ * reported itself as a 60-second wait for `Couldn't send`, the loudest symptom
+ * being the one thing that was not wrong.
+ *
+ * So from the moment the send starts, `chat/history` answers `[]`. The channel
+ * is hydrated before that and is never reopened or reloaded; the durable read
+ * is barred from the window under test. If the bubble appears, the released
+ * frame is the only thing that can have put it there.
  */
 
 const ENGINEERING = { id: "engineering", channel: "engineering-desk" };
@@ -68,9 +85,33 @@ test("a chat POST killed in flight still shows the reply the host went on to wri
   test.setTimeout(150_000);
 
   let cuts = 0;
-  // Named before the route is registered so the premise assertion inside it
+  // Named before the route is registered so the premise reading taken inside it
   // can target this turn's own reply.
   const marker = `cut-${Date.now()}`;
+
+  // The durable transcript, barred from the window under test — see the header.
+  // Held only from the send onwards, so the channel still hydrates normally
+  // first: what is excluded is a re-read landing *during* the cut, not the
+  // hydration the premise depends on.
+  let holdHistory = false;
+  await page.route("**/chat/history*", async (route) => {
+    if (!holdHistory) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "[]",
+    });
+  });
+
+  // What was on screen at the moment of the cut, read inside the handler and
+  // asserted after it. An `expect` that throws inside a route handler aborts
+  // the handler, so `route.abort` never runs, the POST never fails, and the
+  // run dies waiting for an error line that was never going to appear —
+  // reporting a premise violation as a timeout somewhere else entirely.
+  let repliesAtCut: number | null = null;
   await page.route("**/chat", async (route) => {
     if (route.request().method() !== "POST") {
       await route.continue();
@@ -81,19 +122,20 @@ test("a chat POST killed in flight still shows the reply the host went on to wri
     await route.fetch();
     await new Promise((resolve) => setTimeout(resolve, CUT_AFTER_MS));
     cuts += 1;
-    // The premise, asserted rather than assumed: at the moment the connection
+    // The premise, recorded rather than assumed: at the moment the connection
     // is cut, nothing has drawn this reply yet — it can only appear later from
     // the released frame, which is exactly what the assertions below pin.
     // `reply` targets this turn's own echo, not the total bubble count, so a
     // line that would render the answer early fails the test instead of this
-    // assertion hardening nothing.
-    expect(await reply(page, marker).count()).toBe(0);
+    // reading hardening nothing.
+    repliesAtCut = await reply(page, marker).count();
     await route.abort("connectionaborted");
   });
 
   await openChannel(page, ENGINEERING.id);
 
   await page.getByPlaceholder(/^Message /).fill(marker);
+  holdHistory = true;
   await page.keyboard.press("Enter");
 
   // The operator is told the request failed, and that stays true — a reply
@@ -102,6 +144,7 @@ test("a chat POST killed in flight still shows the reply the host went on to wri
   // from a dropped one.
   await expect(page.getByText(/Couldn't send/).first()).toBeVisible({ timeout: 60_000 });
   expect(cuts, "the chat POST must actually have been cut").toBe(1);
+  expect(repliesAtCut, "nothing had drawn this reply when the connection was cut").toBe(0);
 
   // …and the answer is on screen anyway, drawn from the frame that was held
   // while the POST's fate was unknown and released when it turned out to have


### PR DESCRIPTION
## The failure

`Console E2E` has been red intermittently on unrelated pull requests, always on
one spec:

```
1) test/e2e/chat-detached-post-failure.spec.ts:62:1 › a chat POST killed in flight still shows the reply the host went on to write
   Error: expect(received).toBe(expected)  // Expected: 0  Received: 1
   Error: expect(locator).toBeVisible() failed — getByText(/Couldn't send/)
   1 failed, 230 passed
```

It is not a regression in the chat path. It failed on `main` at `82f3d595` and
passes on other heads with the same code; nothing between the last green run and
the first red one touches chat, the shell, or the host.

## What is actually happening

The spec asserts, from inside its route handler, that nothing has drawn the
reply at the moment it cuts the connection. Its header explains why that should
hold: the `202` body never reached the page, so "no turn id was learned and the
run poll is never armed".

The poll has a second way in. The shell also arms it from `listRuns` at mount,
and the harness company this suite shares carries open desk work — the echo
reply in the artifact literally recites an open desk card. A run settling inside
the eight-second pause takes the poll's terminal `chat/history` re-read with it,
and that read folds in the durable transcript as it stands, which by then
includes the very turn this test is killing the response for.

The failure artifact shows precisely that shape:

- the reply, on screen before the cut;
- the operator's own message rendered **twice** — which only a durable fold can
  produce, because the optimistic bubble's id is reconciled by the POST response
  this test destroys;
- the working row still up, so a turn was armed.

And because the premise was asserted *inside* the route handler, the throw
aborted the handler: `route.abort` never ran, the POST never failed, and the run
died 60 seconds later waiting for a `Couldn't send` line that was never coming.
The reported failure was the one thing that was not wrong.

## The fix

Two changes, neither weakening what the spec asserts:

- **The durable read is barred from the window under test.** From the send
  onwards, `chat/history` answers `[]`. The channel still hydrates normally
  before that, so what is excluded is a re-read landing *during* the cut — not
  the hydration the premise depends on. The frame `PendingSyncPosts` releases on
  the failed POST is then the only thing that can put the reply on screen, which
  is exactly the claim the spec exists to make. If the assertion ever fails now,
  it is the product, not the fixture.
- **The premise is recorded in the handler and asserted after it**, so a
  violation reports itself instead of cascading into an unrelated timeout, and
  the connection is always cut.

## Validation

- `npx playwright test test/e2e/chat-detached-post-failure.spec.ts --repeat-each=3` — 3/3 green against a real host
- `npm run typecheck:e2e` — clean

Spec origin: #1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
