### PR TITLE
fix(settings): stop the MCP settings surface contradicting itself (#1405 #1464 #1467 #1475)

### DIFF
--- a/frontend/src/lib/channels.ts
+++ b/frontend/src/lib/channels.ts
@@ -1,0 +1,41 @@
+// What a saved Telegram channel is actually doing, kept as one decision so the
+// badge and the "can't collect or reply" notice cannot contradict each other
+// (issue #1467).
+
+/**
+ * Whether a configured Telegram channel is collecting and replying.
+ *
+ * - `delivering` — a token is stored AND the host reports it is polling. The
+ *   green "configured" badge is honest only here.
+ * - `stored-not-delivering` — a token is stored but the host explicitly reports
+ *   `polling: false`: it has no outbound transport, so it can neither collect
+ *   nor reply. This is the state the rebuild notice is for.
+ * - `unknown` — a token is stored but the host did not say whether it polls.
+ *   `getTelegramChannel` is an unvalidated cast, so a host predating the
+ *   `polling` field sends nothing; treating that silence as `false` told the
+ *   operator to rebuild their host on the strength of a field that was never
+ *   sent. Claim neither delivery nor its absence.
+ * - `unconfigured` — no token stored.
+ *
+ * `configured` alone must never drive the badge: a stored token is not delivery,
+ * and `configured && !polling` (which the notice fired on) is satisfiable at the
+ * same time as a `configured`-only badge — the two rendered together by
+ * construction.
+ */
+export type TelegramDelivery =
+  | "delivering"
+  | "stored-not-delivering"
+  | "unknown"
+  | "unconfigured";
+
+export function telegramDelivery(
+  status: { configured: boolean; polling?: boolean } | null | undefined,
+): TelegramDelivery {
+  if (!status || !status.configured) return "unconfigured";
+  // `polling` is typed `boolean`, but the unvalidated wire read makes `undefined`
+  // reachable at runtime — hence the explicit true/false checks with an
+  // `unknown` fall-through rather than a truthiness test.
+  if (status.polling === true) return "delivering";
+  if (status.polling === false) return "stored-not-delivering";
+  return "unknown";
+}

--- a/frontend/src/lib/mcp-bridge.ts
+++ b/frontend/src/lib/mcp-bridge.ts
@@ -14,7 +14,7 @@
 // as "no teammate can use these" would be a fresh lie in the other direction. Only
 // an explicit `false` is absence.
 
-import type { CapabilityStatusDto } from "@/api/types";
+import type { CapabilityStatusDto, McpHealth } from "@/api/types";
 
 /**
  * What this build can do with MCP servers.
@@ -58,4 +58,65 @@ export function mcpAddedMessage(name: string, bridge: McpBridgeState): string {
   return bridge === "absent"
     ? `Added ${name}. It is stored, but no teammate can call it until this deployment is rebuilt with the MCP bridge.`
     : `Added ${name}. Teammates pick it up on their next turn.`;
+}
+
+/**
+ * The visual register a server-health badge is entitled to.
+ *
+ * - `delivering` — the success colour. The probe answered AND the bridge carries
+ *   its tools to teammates.
+ * - `configured` — the neutral register: stored/reachable, but NOT delivering.
+ *   The success colour is withheld here on purpose.
+ * - `warn` / `error` — a genuine probe problem, bridge or no bridge.
+ */
+export type McpBadgeTone = "delivering" | "configured" | "warn" | "error";
+
+export interface McpBadgeDescriptor {
+  tone: McpBadgeTone;
+  label: string;
+}
+
+/**
+ * What the per-row MCP health badge should read, folding the bridge state in
+ * (issue #1405).
+ *
+ * The badge used to derive entirely from `health.status`, so a reachable server
+ * read a green `ok · N tools` even under the banner saying no teammate can call
+ * any of them — reachability rendered as delivery. `HostingView` solved the same
+ * shape by folding `inBuild` into its `connected` expression; this does the
+ * equivalent for MCP. On `bridge === "absent"` every affirmative reading drops
+ * out of the success colour into the neutral `configured` register — the badge
+ * then says the same thing as the banner. `needs_config` / `error` are real
+ * problems either way and keep their own registers. `unknown` (an older host, or
+ * a failed capability read) is treated as delivering: claiming non-delivery
+ * there would be the #567 lie in the other direction.
+ *
+ * Returns `null` when there is nothing to show — never probed and no stored
+ * credential, or a probe status the badge does not render.
+ */
+export function mcpHealthBadge(
+  health: McpHealth | undefined,
+  authConfigured: boolean,
+  bridge: McpBridgeState,
+): McpBadgeDescriptor | null {
+  const delivers = bridge !== "absent";
+  if (!health) {
+    if (!authConfigured) return null;
+    return delivers
+      ? { tone: "delivering", label: "auth set" }
+      : { tone: "configured", label: "auth set · not delivered" };
+  }
+  const tools = `${health.toolCount} tool${health.toolCount === 1 ? "" : "s"}`;
+  switch (health.status) {
+    case "ok":
+      return delivers
+        ? { tone: "delivering", label: `ok · ${tools}` }
+        : { tone: "configured", label: `reachable · ${tools}, not delivered` };
+    case "needs_config":
+      return { tone: "warn", label: "needs config" };
+    case "error":
+      return { tone: "error", label: "error" };
+    default:
+      return null;
+  }
 }

--- a/frontend/src/lib/skills.ts
+++ b/frontend/src/lib/skills.ts
@@ -56,3 +56,21 @@ export const SKILLS_READ_ONLY_NOTE =
 export function skillReachLabel(enabled: boolean): string {
   return enabled ? "Teammates can read this" : "Hidden from teammates";
 }
+
+/**
+ * The empty-state line the registry tab shows when it has no rows to render
+ * (issue #1467).
+ *
+ * A failed registry read leaves the list empty too, so the naive "this host
+ * serves no shared skill registry" asserted a fact about the host derived from
+ * the very failure the error alert above already reported — two contradicting
+ * claims stacked. When the read failed, `hasError` wins and the line says only
+ * that. The "serves no registry" claim is reserved for a read that *succeeded*
+ * and came back empty; a non-empty registry filtered to nothing by a search is
+ * the third case.
+ */
+export function registryEmptyLabel(hasError: boolean, registryIsEmpty: boolean): string {
+  if (hasError) return "Couldn't reach the registry.";
+  if (registryIsEmpty) return "This host serves no shared skill registry.";
+  return "No skills match that search.";
+}

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -41,6 +41,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import {
   CATEGORY_STYLES,
+  registryEmptyLabel,
   SKILLS_READ_ONLY_NOTE,
   type SkillCategory,
   skillReachLabel,
@@ -253,13 +254,11 @@ export function SkillsView({ client, company }: Props) {
                 <Skeleton className="h-32 rounded-xl" />
               </div>
             ) : visibleRegistry.length === 0 ? (
-              <Empty
-                label={
-                  registry.length === 0
-                    ? "This host serves no shared skill registry."
-                    : "No skills match that search."
-                }
-              />
+              // A failed read leaves `registry` empty too, so the label must not
+              // derive "serves no registry" from the same failure the alert above
+              // already reports (issue #1467). The decider keeps the three cases
+              // apart.
+              <Empty label={registryEmptyLabel(registryError !== null, registry.length === 0)} />
             ) : (
               <div className="grid gap-3 sm:grid-cols-2">
                 {visibleRegistry.map((s) => (

--- a/frontend/src/views/connections/ChannelsSection.tsx
+++ b/frontend/src/views/connections/ChannelsSection.tsx
@@ -11,6 +11,7 @@ import {
   type TelegramChannelStatus,
 } from "@/api/channels";
 import { ApiError } from "@/api/types";
+import { telegramDelivery } from "@/lib/channels";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -139,13 +140,21 @@ export function ChannelsSection({ client, company, canManage }: Props) {
   // hosts without the channels routes).
   if (load === "unavailable") return null;
 
+  // One reading of what the saved channel is doing, shared by the badge and the
+  // rebuild notice so they cannot disagree (issue #1467).
+  const delivery = telegramDelivery(status);
+
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           Channels
         </h3>
-        {load === "ready" && status?.configured && (
+        {/* The badge asserts a working channel, so it must agree with the
+            "can neither collect nor reply" notice below (issue #1467): a stored
+            token alone is not delivery. `telegramDelivery` is the one decision
+            both read, so they cannot contradict. */}
+        {load === "ready" && delivery === "delivering" && (
           <Badge variant="secondary" className="gap-1">
             <Check className="size-3" /> Telegram configured
           </Badge>
@@ -212,7 +221,9 @@ export function ChannelsSection({ client, company, canManage }: Props) {
               Listening for messages by polling Telegram — no public URL needed.
             </p>
           )}
-          {status?.configured && !status.polling && (
+          {/* Fires only when the host explicitly reports `polling: false`, never
+              on a missing field (issue #1467) — see `telegramDelivery`. */}
+          {delivery === "stored-not-delivering" && (
             <p className="text-xs text-muted-foreground">
               This host has no outbound Telegram transport, so it can neither collect messages nor
               reply. Rebuild it with the <code className="font-mono">telegram</code> feature.

--- a/frontend/src/views/connections/McpRegistryBrowser.tsx
+++ b/frontend/src/views/connections/McpRegistryBrowser.tsx
@@ -310,12 +310,22 @@ export function McpRegistryBrowser({ client, company, onInstalled }: Props) {
           notice points down here in as many words when it is the thing standing
           in their way. A save re-runs the current search, so setting the key
           fills the list they are already looking at instead of leaving them to
-          guess it worked. */}
-      <McpDirectoryCredentialCard
-        client={client}
-        company={company}
-        onChanged={() => void runSearch(1)}
-      />
+          guess it worked.
+
+          Withheld while the directory is known-unwired (issue #1467): on a build
+          without the `mcp` feature the search returns the `unwired` outage and
+          the notice above says the directory isn't enabled in this build.
+          Rendering a green "Set for this company" credential card with working
+          Rotate/Clear controls under that notice asserts a feature it just
+          denied. Any other state — idle, a transient directory error, or a live
+          catalogue — still shows the card. */}
+      {!(results.kind === "outage" && results.outage.kind === "unwired") && (
+        <McpDirectoryCredentialCard
+          client={client}
+          company={company}
+          onChanged={() => void runSearch(1)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -42,7 +42,12 @@ import {
   type McpStatus,
   type McpToolInfo,
 } from "@/api/types";
-import { type McpBridgeState, mcpAddedMessage, mcpBridgeState } from "@/lib/mcp-bridge";
+import {
+  type McpBridgeState,
+  mcpAddedMessage,
+  mcpBridgeState,
+  mcpHealthBadge,
+} from "@/lib/mcp-bridge";
 import {
   missingEnvKeys,
   mcpRowControls,
@@ -176,6 +181,12 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
   // Starts `unknown` so nothing is claimed before the capability read lands.
   const [bridge, setBridge] = useState<McpBridgeState>("unknown");
   const [servers, setServers] = useState<McpServer[]>([]);
+  // The name of the row (or `"add"`) currently mutating. Every mutating handler
+  // serialises on it with an `if (busy) return`, so while one is in flight the
+  // controls on ALL rows disable, not just the busy one (issue #1475): the guard
+  // used to be invisible on the other rows, which accepted clicks and silently
+  // did nothing. The active control still shows its own spinner via
+  // `busy === server.name`, so the operator can see which row holds the lock.
   const [busy, setBusy] = useState<string | null>(null);
   const [tools, setTools] = useState<Record<string, ToolsState>>({});
   // Live health from an on-demand Test, overriding the persisted badge per row.
@@ -392,7 +403,15 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     if (!token) return;
     setBusy(server.name);
     try {
-      await updateMcpServer(client, company, server.name, { token, authKind: "bearer" });
+      // Rotate the credential VALUE only — never the auth scheme (issue #1464).
+      // The read model carries no `authKind`, so the console cannot know whether
+      // this server was added as a bearer token, an `X-Api-Key:` header or a
+      // `?api_key=` query parameter. Sending `authKind: "bearer"` here silently
+      // rewrote a header/query server to bearer, after which it rejected every
+      // request — and the immediate re-test below surfaced that as a bad-token
+      // error, sending the operator to re-paste a key that was never the
+      // problem. Omitting the field leaves the host's stored scheme untouched.
+      await updateMcpServer(client, company, server.name, { token });
       setCredentialFor(null);
       setCredentialDraft("");
       await refresh();
@@ -766,12 +785,16 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                         <Badge variant={badge.variant} data-testid="mcp-source-badge">
                           {badge.label}
                         </Badge>
-                        <McpHealthBadge health={health} authConfigured={server.authConfigured} />
+                        <McpHealthBadge
+                          health={health}
+                          authConfigured={server.authConfigured}
+                          bridge={bridge}
+                        />
                         <span className="ml-auto flex items-center gap-2">
                           {controls.toggle && (
                             <Switch
                               checked={server.enabled}
-                              disabled={busy === server.name || !canManage}
+                              disabled={busy !== null || !canManage}
                               onCheckedChange={(v) => void toggle(server, v)}
                               aria-label={`Enable ${server.name}`}
                             />
@@ -792,7 +815,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                                 variant="default"
                                 size="sm"
                                 data-testid="mcp-add-token"
-                                disabled={busy === server.name}
+                                disabled={busy !== null}
                                 onClick={() => {
                                   setCredentialDraft("");
                                   setCredentialFor(server.name);
@@ -805,7 +828,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                             <Button
                               variant="default"
                               size="sm"
-                              disabled={busy === server.name}
+                              disabled={busy !== null}
                               onClick={() => void signIn(server)}
                             >
                               {busy === server.name ? (
@@ -827,7 +850,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                                 variant="default"
                                 size="sm"
                                 data-testid="mcp-rotate-env"
-                                disabled={busy === server.name}
+                                disabled={busy !== null}
                                 onClick={() => void openEnvRotation(server)}
                               >
                                 <KeyRound className="size-4" /> Credentials
@@ -838,7 +861,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               variant="ghost"
                               size="sm"
                               data-testid="mcp-lifecycle"
-                              disabled={busy === server.name}
+                              disabled={busy !== null}
                               onClick={() => void lifecycle(server, dial)}
                             >
                               {busy === server.name ? (
@@ -862,7 +885,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                disabled={busy === server.name}
+                                disabled={busy !== null}
                                 onClick={() => void test(server)}
                               >
                                 {busy === server.name ? (
@@ -875,7 +898,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                disabled={busy === server.name}
+                                disabled={busy !== null}
                                 onClick={() => void discover(server)}
                               >
                                 <ChevronDown className="size-4" /> Tools
@@ -886,7 +909,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                             <Button
                               variant="ghost"
                               size="sm"
-                              disabled={busy === server.name}
+                              disabled={busy !== null}
                               onClick={() => void remove(server)}
                               aria-label={`Remove ${server.name}`}
                             >
@@ -901,8 +924,17 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           so that empty case is flagged loudly rather than shown as a blank list.
                           A disabled server is empty by construction — the harness hands out no
                           tool for it whatever the grants say — so the loud state is scoped to
-                          enabled servers; flagging an off server would cry wolf on intent. */}
-                      {server.reachableBy !== undefined &&
+                          enabled servers; flagging an off server would cry wolf on intent.
+
+                          Suppressed entirely when the bridge is absent (issue #1467): the
+                          reachability walk knows nothing about whether the `mcp` feature is
+                          compiled in, so with no bridge the red "no tool grant covers …, widen a
+                          grant" advice misdiagnoses the cause — grants cannot fix a missing
+                          bridge — and the positive "Reachable by: …" line contradicts the banner
+                          that says no teammate receives these tools. The banner already carries
+                          the real message here. */}
+                      {bridge !== "absent" &&
+                        server.reachableBy !== undefined &&
                         server.enabled &&
                         (server.reachableBy.length === 0 ? (
                           <p
@@ -935,6 +967,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           <div className="flex-1 space-y-1">
                             <Label htmlFor={`mcp-token-${server.name}`} className="text-xs">
                               API token for {server.name}
+                              {/* The value is write-only and unrecoverable, so
+                                  say when saving it overwrites an existing one
+                                  (issue #1464). */}
+                              {server.authConfigured ? " — replaces the stored credential" : ""}
                             </Label>
                             <Input
                               id={`mcp-token-${server.name}`}
@@ -952,7 +988,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           <Button
                             size="sm"
                             data-testid="mcp-token-save"
-                            disabled={busy === server.name || !credentialDraft.trim()}
+                            disabled={busy !== null || !credentialDraft.trim()}
                             onClick={() => void saveCredential(server)}
                           >
                             {busy === server.name ? (
@@ -964,7 +1000,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           <Button
                             size="sm"
                             variant="ghost"
-                            disabled={busy === server.name}
+                            disabled={busy !== null}
                             onClick={() => setCredentialFor(null)}
                           >
                             Cancel
@@ -1014,7 +1050,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                               <Button
                                 size="sm"
                                 data-testid="mcp-env-save"
-                                disabled={busy === server.name}
+                                disabled={busy !== null}
                                 onClick={() => void saveEnvRotation(server, envFields.keys)}
                               >
                                 {busy === server.name ? (
@@ -1027,7 +1063,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                             <Button
                               size="sm"
                               variant="ghost"
-                              disabled={busy === server.name}
+                              disabled={busy !== null}
                               onClick={() => setEnvFor(null)}
                             >
                               {envFields.kind === "ready" && envFields.keys.length > 0
@@ -1132,7 +1168,7 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                   </div>
                   <Button
                     data-testid="mcp-add-submit"
-                    disabled={busy === "add"}
+                    disabled={busy !== null}
                     onClick={() => void add()}
                   >
                     {busy === "add" ? (
@@ -1205,44 +1241,44 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
  * The per-server health badge: green `ok · N tools`, amber `needs config`, red
  * `error`. Falls back to a plain "auth set" hint when the server has never been
  * probed (no `health`).
+ *
+ * Bridge state is folded in the way `HostingView` folds `inBuild` (issue #1405).
+ * On a build with no MCP bridge the probe still answers for real — the server is
+ * reachable — but nothing it reports is delivered to a teammate, and the banner
+ * above the list says exactly that. A green `ok` under that banner tells the
+ * operator twelve tools are working when no teammate can call one, so on
+ * `bridge === "absent"` every affirmative reading drops out of the success
+ * colour into the neutral register: reachable and configured, but not
+ * delivering. `needs config` / `error` are genuine problems either way and keep
+ * their amber/red.
  */
 function McpHealthBadge({
   health,
   authConfigured,
+  bridge,
 }: {
   health?: McpHealth;
   authConfigured: boolean;
+  bridge: McpBridgeState;
 }) {
-  if (!health) {
-    // Never probed — show only the non-secret auth hint (unchanged behavior).
-    return authConfigured ? (
-      <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-        <Check className="size-3" /> auth set
-      </span>
-    ) : null;
-  }
-  if (health.status === "ok") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-        <Check className="size-3" /> ok · {health.toolCount} tool{health.toolCount === 1 ? "" : "s"}
-      </span>
-    );
-  }
-  if (health.status === "needs_config") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs text-status-blocked-text">
-        <AlertTriangle className="size-3" /> needs config
-      </span>
-    );
-  }
-  if (health.status === "error") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs text-destructive">
-        <AlertTriangle className="size-3" /> error
-      </span>
-    );
-  }
-  return null;
+  // The decision — which register, and the text — is the pure `mcpHealthBadge`
+  // decider (issue #1405), so the bridge fold is unit-tested and this component
+  // only maps a tone to its token colour and icon.
+  const badge = mcpHealthBadge(health, authConfigured, bridge);
+  if (!badge) return null;
+  const tone =
+    badge.tone === "delivering"
+      ? { className: "text-status-done-text", Icon: Check }
+      : badge.tone === "configured"
+        ? { className: "text-muted-foreground", Icon: Info }
+        : badge.tone === "warn"
+          ? { className: "text-status-blocked-text", Icon: AlertTriangle }
+          : { className: "text-destructive", Icon: AlertTriangle };
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs ${tone.className}`}>
+      <tone.Icon className="size-3" /> {badge.label}
+    </span>
+  );
 }
 
 /** Renders the live-discovered tool list for one server. */

--- a/frontend/test/unit/mcp-bridge.test.ts
+++ b/frontend/test/unit/mcp-bridge.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { mcpAddedMessage, mcpBridgeState } from "@/lib/mcp-bridge";
-import type { CapabilityStatusDto } from "@/api/types";
+import { mcpAddedMessage, mcpBridgeState, mcpHealthBadge } from "@/lib/mcp-bridge";
+import type { CapabilityStatusDto, McpHealth } from "@/api/types";
 
 /**
  * The MCP tab's build-state signal (issue #567).
@@ -74,5 +74,63 @@ describe("mcpAddedMessage", () => {
     // Unknown is not absence: claiming no agent can use the server, on a host
     // that never said so, is the same class of lie in the other direction.
     expect(mcpAddedMessage("notion", "unknown")).toBe(mcpAddedMessage("notion", "present"));
+  });
+});
+
+/**
+ * The per-row health badge's register (issue #1405).
+ *
+ * The bug this pins: a reachable server read a green `ok · N tools` even under
+ * the banner saying no teammate can call one — reachability rendered as
+ * delivery. Folding the bridge state in demotes every affirmative reading to the
+ * neutral register when — and only when — the bridge is explicitly absent.
+ */
+function health(over: Partial<McpHealth> = {}): McpHealth {
+  return { status: "ok", message: "", toolCount: 3, checkedAtMillis: 1, ...over };
+}
+
+describe("mcpHealthBadge", () => {
+  it("reads a healthy server as delivering when the bridge is present", () => {
+    const badge = mcpHealthBadge(health({ toolCount: 12 }), true, "present");
+    expect(badge).toEqual({ tone: "delivering", label: "ok · 12 tools" });
+  });
+
+  it("drops a healthy server out of the success colour when the bridge is absent", () => {
+    // The exact #1405 contradiction: green `ok` under the "no teammate receives
+    // their tools" banner. Reachable, but not delivering.
+    const badge = mcpHealthBadge(health({ toolCount: 12 }), true, "absent");
+    expect(badge?.tone).toBe("configured");
+    expect(badge?.tone).not.toBe("delivering");
+    expect(badge?.label).toMatch(/not delivered/);
+    expect(badge?.label).toContain("12 tools");
+  });
+
+  it("keeps the success colour on an unknown host — non-delivery must not be invented", () => {
+    // Symmetry with the banner: `unknown` has not said the bridge is missing, so
+    // demoting the badge there would be the #567 lie in the other direction.
+    expect(mcpHealthBadge(health(), true, "unknown")?.tone).toBe("delivering");
+  });
+
+  it("singularises a one-tool count in both registers", () => {
+    expect(mcpHealthBadge(health({ toolCount: 1 }), true, "present")?.label).toBe("ok · 1 tool");
+    expect(mcpHealthBadge(health({ toolCount: 1 }), true, "absent")?.label).toMatch(/1 tool,/);
+  });
+
+  it("shows the auth hint when never probed, and demotes it under an absent bridge", () => {
+    expect(mcpHealthBadge(undefined, true, "present")).toEqual({
+      tone: "delivering",
+      label: "auth set",
+    });
+    expect(mcpHealthBadge(undefined, true, "absent")?.tone).toBe("configured");
+    // Nothing at all when there is neither a probe nor a stored credential.
+    expect(mcpHealthBadge(undefined, false, "present")).toBeNull();
+  });
+
+  it("leaves genuine probe problems in their own register, bridge or no bridge", () => {
+    // A missing credential or an unreachable endpoint is a real problem the
+    // bridge state does not change — these keep amber / red.
+    expect(mcpHealthBadge(health({ status: "needs_config" }), true, "present")?.tone).toBe("warn");
+    expect(mcpHealthBadge(health({ status: "needs_config" }), true, "absent")?.tone).toBe("warn");
+    expect(mcpHealthBadge(health({ status: "error" }), true, "absent")?.tone).toBe("error");
   });
 });

--- a/frontend/test/unit/skills-registry-empty.test.ts
+++ b/frontend/test/unit/skills-registry-empty.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { registryEmptyLabel } from "@/lib/skills";
+
+/**
+ * The registry tab's empty-state line (issue #1467).
+ *
+ * The bug this pins: a failed registry read left the list empty, so the tab
+ * rendered a destructive "couldn't reach the registry" alert AND, directly
+ * below it, "this host serves no shared skill registry" — a fact about the host
+ * asserted from the very failure the alert reports. The two claims contradict.
+ * A read error must win the label.
+ */
+describe("registryEmptyLabel", () => {
+  it("says only that the read failed when there was an error", () => {
+    const label = registryEmptyLabel(true, true);
+    expect(label).toMatch(/couldn't reach the registry/i);
+    // Must NOT assert a fact about the host derived from the same failure.
+    expect(label).not.toMatch(/serves no/i);
+  });
+
+  it("an error wins even if some rows had loaded before it", () => {
+    expect(registryEmptyLabel(true, false)).toMatch(/couldn't reach the registry/i);
+  });
+
+  it("claims 'no registry' only for a read that succeeded and came back empty", () => {
+    expect(registryEmptyLabel(false, true)).toMatch(/serves no shared skill registry/i);
+  });
+
+  it("reads a non-empty registry filtered to nothing as a search miss", () => {
+    expect(registryEmptyLabel(false, false)).toMatch(/no skills match/i);
+  });
+});

--- a/frontend/test/unit/telegram-delivery.test.ts
+++ b/frontend/test/unit/telegram-delivery.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { telegramDelivery } from "@/lib/channels";
+
+/**
+ * The one reading the Telegram badge and the "can't collect or reply" notice
+ * both consult (issue #1467).
+ *
+ * The bug this pins: the green "configured" badge fired on a stored token alone,
+ * while the rebuild notice fired on `configured && !polling` — both satisfiable
+ * at once, so a working-looking badge sat above a notice telling the operator to
+ * rebuild their host. And because the status is an unvalidated cast, an older
+ * host that never sent `polling` made `!polling` truthy and produced that notice
+ * on the strength of a field that was never sent.
+ */
+describe("telegramDelivery", () => {
+  it("delivers only when a token is stored AND the host reports polling", () => {
+    expect(telegramDelivery({ configured: true, polling: true })).toBe("delivering");
+  });
+
+  it("reports stored-not-delivering only on an explicit polling:false", () => {
+    // This is the state the rebuild notice is for — and the only one it may fire
+    // on, so it can never co-occur with the badge.
+    expect(telegramDelivery({ configured: true, polling: false })).toBe("stored-not-delivering");
+  });
+
+  it("treats a missing polling field as unknown, not as not-delivering", () => {
+    // An older host predating the field, arriving through the unvalidated cast.
+    // Neither a green badge nor a "rebuild your host" instruction is warranted.
+    expect(telegramDelivery({ configured: true })).toBe("unknown");
+    const drift = { configured: true, polling: undefined } as {
+      configured: boolean;
+      polling?: boolean;
+    };
+    expect(telegramDelivery(drift)).toBe("unknown");
+  });
+
+  it("is unconfigured with no token, and on a missing status", () => {
+    expect(telegramDelivery({ configured: false, polling: true })).toBe("unconfigured");
+    expect(telegramDelivery(null)).toBe("unconfigured");
+    expect(telegramDelivery(undefined)).toBe("unconfigured");
+  });
+
+  it("gives the badge and the notice mutually exclusive triggers", () => {
+    // The structural guarantee the badge/notice split relies on: no single
+    // status is ever both "delivering" (badge) and "stored-not-delivering"
+    // (notice), so the two can never render together.
+    const verdicts = [true, false, undefined].map((polling) =>
+      telegramDelivery({ configured: true, polling }),
+    );
+    expect(verdicts.filter((v) => v === "delivering")).toHaveLength(1);
+    expect(verdicts.filter((v) => v === "stored-not-delivering")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Four defects on **Settings → MCP Servers** and its badge-vs-banner siblings, all one rule (the #1262 family): a UI marker must not assert what the page's own banner denies.

- **#1405** — the per-row health badge derived only from `health.status`, so a reachable server read a green `ok · N tools` under the banner saying no teammate can call one. Folded the bridge state in the way `HostingView` folds `inBuild`, extracted as the pure `mcpHealthBadge` decider: on `bridge === "absent"` every affirmative reading drops to the neutral register; `unknown` still delivers so non-delivery is never invented.
- **#1464** — rotating a server's credential hardcoded `authKind: "bearer"`, silently rewriting a server added with a custom header or query parameter to bearer (after which it rejected every request and the re-test misattributed it to a bad token). The read model carries no `authKind`, so the field is dropped from the patch, leaving the host's stored scheme untouched. The token field is relabelled to say it replaces the stored credential.
- **#1467** — four badge-vs-banner contradictions: MCP reachability line suppressed when the bridge is absent (its "widen a grant" advice misdiagnosed the cause); directory credential card withheld while the directory is known-unwired; Telegram badge driven from `telegramDelivery` (deliver only on an explicit `polling: true`; a missing field is unknown, not not-delivering); skills-registry empty label no longer asserts "serves no registry" off a failed read (`registryEmptyLabel`).
- **#1475** — while one server row was busy, every other row's controls stayed enabled and silently no-op'd. All mutating controls disable while any row works; the active row keeps its spinner.

## API Or Behavior Changes

No wire/API changes. Console-only: several badges/notices change register or wording so they agree with the page's banners; the rotate-token patch no longer sends `authKind`.

## Tests

Console gate (mirrors CI's Console job); pure deciders unit-tested (`mcpHealthBadge`, `telegramDelivery`, `registryEmptyLabel`):

- [x] `npm run typecheck` / `typecheck:unit` / `typecheck:e2e`
- [x] `npm test` (vitest — 1679 passed)
- [x] `npm run build` + `npm run build:pages-sdk`
- [x] `scripts/ci/assert-design-tokens.sh`, `scripts/ci/assert-md-line-cap.sh`

(The cargo checks below do not apply — this PR touches only `frontend/`.)

## Documentation

None needed — no public API, architecture, or route changes.

Closes #1405
Closes #1464
Closes #1467
Closes #1475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram connection status messaging to distinguish active delivery, unavailable delivery, and unknown status without contradictory notices.
  * Improved MCP health indicators based on bridge availability, authentication, and server reachability.
  * Prevented misleading reachability messages and hid directory credentials when the registry is unavailable.
  * Clarified skill registry messages for loading errors, empty registries, and searches with no matches.
  * Disabled MCP controls during updates and preserved existing authentication settings during credential rotation.

* **Tests**
  * Added coverage for Telegram delivery states, MCP health badges, and skill registry empty-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->