### PR TITLE
feat(settings): wire the domain & SMTP cards to the host (#1460)

### DIFF
--- a/frontend/src/api/domain.ts
+++ b/frontend/src/api/domain.ts
@@ -1,0 +1,143 @@
+// The company's custom mail domain and its own SMTP credentials, over the host
+// (issue #1460).
+//
+// Reads come over GraphQL (`Company.domain` / `Company.smtp`), the host's one
+// status-read plane for these; writes are REST (`PUT …/domain`,
+// `POST …/domain/verify`, `PUT …/smtp`, `POST …/smtp/test`). Credentials are
+// write-only: the SMTP password goes OUT with a save and never comes back — no
+// read here returns it, and nothing stores it in the browser. The DNS records
+// come from the host, not from the client: the console must not fabricate the
+// records an operator publishes at their own registrar.
+
+import type { OpenCompanyClient } from "@/api/client";
+
+/** One DNS record the operator must publish. Mirrors the host's `DnsRecord`. */
+export interface DnsRecord {
+  type: string;
+  name: string;
+  value: string;
+  ttl: string;
+}
+
+/** Custom-domain status. Mirrors the host's `DomainStatus`. */
+export interface DomainStatus {
+  domain: string;
+  verified: boolean;
+  records: DnsRecord[];
+}
+
+/**
+ * Non-secret SMTP status as the GraphQL read projects it — host, port,
+ * username, and whether anything is stored. Never the password, and (by the
+ * host's projection) not the security mode or from-address either; those are
+ * write-only inputs re-entered on a change, not read back.
+ */
+export interface SmtpStatus {
+  host: string;
+  port: number;
+  username: string;
+  configured: boolean;
+}
+
+export type SmtpSecurity = "none" | "starttls" | "ssl";
+
+/**
+ * The full SMTP credential a save writes. Wire keys are snake_case to match the
+ * host's `SmtpCredentials`; `password` is write-only. A save REPLACES the stored
+ * credential in full — the host has no partial-update route — so every field is
+ * sent, not just the changed one.
+ */
+export interface SmtpCredentialsInput {
+  host: string;
+  port: number;
+  security: SmtpSecurity;
+  username: string;
+  password: string;
+  from_name: string;
+  from_email: string;
+}
+
+/** The outcome of a test send. */
+export interface SmtpTestResult {
+  ok: boolean;
+  message: string;
+}
+
+const MAIL_QUERY = `query CompanyMail($id: ID) {
+  company(id: $id) {
+    domain { domain verified records { type name value ttl } }
+    smtp { host port username configured }
+  }
+}`;
+
+interface MailQueryData {
+  company: {
+    domain: DomainStatus | null;
+    smtp: SmtpStatus | null;
+  } | null;
+}
+
+/**
+ * The stored domain + SMTP status for a company, read over GraphQL.
+ *
+ * `domain` is `null` when none is set. `smtp` is always present — an
+ * unconfigured company reads `configured: false` — so the card can tell "not
+ * set" from "the host could not answer" (a thrown error) rather than conflating
+ * them.
+ */
+export async function fetchMailStatus(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<{ domain: DomainStatus | null; smtp: SmtpStatus }> {
+  const res = await client.graphqlRequest(MAIL_QUERY, { id: company });
+  if (res.errors) {
+    const message =
+      Array.isArray(res.errors) && res.errors.length > 0
+        ? String((res.errors[0] as { message?: unknown }).message ?? "GraphQL error")
+        : "GraphQL error";
+    throw new Error(message);
+  }
+  const data = res.data as MailQueryData | null | undefined;
+  return {
+    domain: data?.company?.domain ?? null,
+    smtp: data?.company?.smtp ?? { host: "", port: 0, username: "", configured: false },
+  };
+}
+
+/** Set (or clear, with an empty string) the custom domain; returns the host's records. */
+export function putDomain(
+  client: OpenCompanyClient,
+  company: string | null,
+  domain: string,
+): Promise<DomainStatus> {
+  return client.put<DomainStatus>(`${client.scopeFor(company)}/domain`, { domain });
+}
+
+/** Run a host-side DNS verification pass. 404 when the host has no DNS resolver. */
+export function verifyDomain(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<DomainStatus> {
+  return client.post<DomainStatus>(`${client.scopeFor(company)}/domain/verify`);
+}
+
+/** Store the company's SMTP credentials (write-only password); returns non-secret status. */
+export function putSmtp(
+  client: OpenCompanyClient,
+  company: string | null,
+  creds: SmtpCredentialsInput,
+): Promise<SmtpStatus> {
+  return client.put<SmtpStatus>(`${client.scopeFor(company)}/smtp`, creds);
+}
+
+/** Send a test email through the stored credentials. 404 when the host has no SMTP sender. */
+export function testSmtp(
+  client: OpenCompanyClient,
+  company: string | null,
+  to?: string,
+): Promise<SmtpTestResult> {
+  return client.post<SmtpTestResult>(
+    `${client.scopeFor(company)}/smtp/test`,
+    to ? { to } : {},
+  );
+}

--- a/frontend/src/components/domain-settings.tsx
+++ b/frontend/src/components/domain-settings.tsx
@@ -1,7 +1,21 @@
-import { useEffect, useMemo, useState } from "react";
-import { Check, Copy, Globe, Info, Mail, ShieldAlert } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Check, Copy, Globe, Info, Loader2, Mail, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  type DnsRecord,
+  type DomainStatus,
+  fetchMailStatus,
+  putDomain,
+  putSmtp,
+  type SmtpSecurity,
+  type SmtpStatus,
+  testSmtp,
+  verifyDomain,
+} from "@/api/domain";
+import { ApiError } from "@/api/types";
+import { isValidDomain, parseSmtpPort } from "@/lib/domain";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -21,19 +35,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { useLocalScope } from "@/connections/ConnectionContext";
-import {
-  type DnsRecord,
-  dnsRecords,
-  isValidDomain,
-  loadMailSettings,
-  type MailSettings,
-  saveMailSettings,
-  type SmtpSecurity,
-} from "@/lib/domain";
 
 interface Props {
+  client: OpenCompanyClient;
   company: string | null;
 }
 
@@ -43,47 +49,142 @@ const SECURITY_LABELS: Record<SmtpSecurity, string> = {
   ssl: "SSL / TLS",
 };
 
-/** Custom domain (with DNS records) and SMTP credentials for the company. */
-export function DomainSettings({ company: _company }: Props) {
-  const scope = useLocalScope();
-  const [settings, setSettings] = useState<MailSettings>(() => loadMailSettings(scope));
+type Load = "loading" | "ready" | "error";
+
+/**
+ * Custom domain (with host-issued DNS records) and the company's own SMTP
+ * credentials (issue #1460).
+ *
+ * Everything here is the host's: status is read over GraphQL, the domain and its
+ * records are set through `PUT …/domain`, verification runs on the host through
+ * `POST …/domain/verify`, and SMTP credentials are stored write-only through
+ * `PUT …/smtp`. Nothing is kept in the browser — the SMTP password is held in
+ * component state only, never persisted, and the DNS records come from the host
+ * rather than being fabricated client-side.
+ */
+export function DomainSettings({ client, company }: Props) {
+  const [load, setLoad] = useState<Load>("loading");
+  const [domain, setDomain] = useState<DomainStatus | null>(null);
+  const [smtp, setSmtp] = useState<SmtpStatus | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const status = await fetchMailStatus(client, company);
+      setDomain(status.domain);
+      setSmtp(status.smtp);
+      setLoad("ready");
+    } catch {
+      // The host could not answer the mail-status read. Say so rather than
+      // rendering an empty "nothing configured" form over unknown state.
+      setLoad("error");
+    }
+  }, [client, company]);
 
   useEffect(() => {
-    saveMailSettings(scope, settings);
-  }, [scope, settings]);
+    setLoad("loading");
+    void refresh();
+  }, [refresh]);
+
+  if (load === "loading") {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-40 rounded-xl" />
+        <Skeleton className="h-64 rounded-xl" />
+      </div>
+    );
+  }
+
+  if (load === "error") {
+    return (
+      <Card>
+        <CardContent className="py-4">
+          <p className="text-xs text-muted-foreground">
+            Couldn&apos;t read this company&apos;s mail settings — the host could not answer, so this
+            is unknown rather than unconfigured. Reload to try again.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <>
-      <DomainCard settings={settings} setSettings={setSettings} />
-      <SmtpCard settings={settings} setSettings={setSettings} />
+      <DomainCard client={client} company={company} domain={domain} onChange={setDomain} />
+      <SmtpCard client={client} company={company} smtp={smtp} onChange={setSmtp} />
     </>
   );
 }
 
 function DomainCard({
-  settings,
-  setSettings,
+  client,
+  company,
+  domain,
+  onChange,
 }: {
-  settings: MailSettings;
-  setSettings: React.Dispatch<React.SetStateAction<MailSettings>>;
+  client: OpenCompanyClient;
+  company: string | null;
+  domain: DomainStatus | null;
+  onChange: (status: DomainStatus) => void;
 }) {
-  const [draft, setDraft] = useState(settings.domain.domain);
-  const configured = Boolean(settings.domain.domain);
-  const records = useMemo(() => dnsRecords(settings.domain.domain), [settings.domain.domain]);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState<"save" | "verify" | "remove" | null>(null);
+  const configured = domain !== null && domain.domain !== "";
 
-  function connect() {
-    const domain = draft.trim().toLowerCase();
-    if (!isValidDomain(domain)) {
+  async function connect() {
+    const value = draft.trim().toLowerCase();
+    if (!isValidDomain(value)) {
       toast.error("Enter a valid domain, e.g. mail.acme.com");
       return;
     }
-    setSettings((s) => ({ ...s, domain: { domain, verified: false } }));
-    toast.success("Domain saved — add the DNS records below.");
+    setBusy("save");
+    try {
+      // The records come back from the host — the console no longer invents
+      // them, so an operator publishes what this deployment actually chose.
+      onChange(await putDomain(client, company, value));
+      setDraft("");
+      toast.success("Domain saved — add the DNS records below.");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't save the domain.");
+    } finally {
+      setBusy(null);
+    }
   }
 
-  function remove() {
-    setSettings((s) => ({ ...s, domain: { domain: "", verified: false } }));
-    setDraft("");
+  async function verify() {
+    setBusy("verify");
+    try {
+      const status = await verifyDomain(client, company);
+      onChange(status);
+      if (status.verified) {
+        toast.success("Domain verified.");
+      } else {
+        toast.message("Records not found yet — DNS changes can take up to 48h to propagate.");
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError && err.code === "not_wired"
+          ? "DNS verification isn't enabled on this host — rebuild it with the `dns` feature."
+          : err instanceof ApiError
+            ? err.message
+            : "Couldn't verify the domain.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function remove() {
+    setBusy("remove");
+    try {
+      // No delete route: clearing the domain is an empty set, which the host
+      // stores as "no domain" and answers with an empty record list.
+      onChange(await putDomain(client, company, ""));
+      setDraft("");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't remove the domain.");
+    } finally {
+      setBusy(null);
+    }
   }
 
   return (
@@ -101,9 +202,10 @@ function DomainCard({
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               placeholder="mail.acme.com"
-              onKeyDown={(e) => e.key === "Enter" && connect()}
+              onKeyDown={(e) => e.key === "Enter" && void connect()}
             />
-            <Button className="shrink-0" onClick={connect}>
+            <Button className="shrink-0" disabled={busy !== null} onClick={() => void connect()}>
+              {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : null}
               Add domain
             </Button>
           </div>
@@ -112,19 +214,20 @@ function DomainCard({
             <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3">
               <span className="inline-flex items-center gap-2 font-mono text-sm">
                 <Globe className="size-4 text-muted-foreground" />
-                {settings.domain.domain}
+                {domain.domain}
               </span>
               <div className="flex items-center gap-2">
-                {settings.domain.verified ? (
+                {domain.verified ? (
                   <Badge className="gap-1 bg-status-done-soft text-status-done-text">
                     <Check className="size-3" /> Verified
                   </Badge>
                 ) : (
                   <Badge variant="secondary" className="gap-1">
-                    <span className="size-1.5 animate-pulse rounded-full bg-status-blocked" /> Pending
+                    <span className="size-1.5 rounded-full bg-status-blocked" /> Pending
                   </Badge>
                 )}
-                <Button variant="ghost" size="sm" onClick={remove}>
+                <Button variant="ghost" size="sm" disabled={busy !== null} onClick={() => void remove()}>
+                  {busy === "remove" ? <Loader2 className="size-4 animate-spin" /> : null}
                   Remove
                 </Button>
               </div>
@@ -132,13 +235,15 @@ function DomainCard({
 
             <div className="space-y-2">
               <p className="text-sm font-medium">Add these DNS records</p>
-              <DnsTable records={records} />
+              <DnsTable records={domain.records} />
               <div className="flex items-center gap-2 pt-1">
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => toast.info("DNS verification runs on the host once connected. Records are saved.")}
+                  disabled={busy !== null}
+                  onClick={() => void verify()}
                 >
+                  {busy === "verify" ? <Loader2 className="size-4 animate-spin" /> : null}
                   Verify DNS
                 </Button>
                 <p className="text-xs text-muted-foreground">Changes can take up to 48h to propagate.</p>
@@ -152,6 +257,13 @@ function DomainCard({
 }
 
 function DnsTable({ records }: { records: DnsRecord[] }) {
+  if (records.length === 0) {
+    return (
+      <p className="rounded-lg border p-3 text-xs text-muted-foreground">
+        The host has not issued any records for this domain yet.
+      </p>
+    );
+  }
   return (
     <div className="overflow-x-auto rounded-lg border">
       <table className="w-full text-left text-xs">
@@ -206,41 +318,113 @@ function CopyCell({ value }: { value: string }) {
 }
 
 function SmtpCard({
-  settings,
-  setSettings,
+  client,
+  company,
+  smtp,
+  onChange,
 }: {
-  settings: MailSettings;
-  setSettings: React.Dispatch<React.SetStateAction<MailSettings>>;
+  client: OpenCompanyClient;
+  company: string | null;
+  smtp: SmtpStatus | null;
+  onChange: (status: SmtpStatus) => void;
 }) {
-  const s = settings.smtp;
-  const set = (patch: Partial<typeof s>) =>
-    setSettings((prev) => ({ ...prev, smtp: { ...prev.smtp, ...patch } }));
+  // The card mounts after the status read, so the non-secret fields the host
+  // returns (host / port / username) initialise the form once. The password is
+  // never returned and never stored — it lives here in memory only, and a save
+  // sends it write-only to the host's secret store.
+  const [host, setHost] = useState(smtp?.host ?? "");
+  const [port, setPort] = useState(smtp && smtp.port > 0 ? String(smtp.port) : "587");
+  const [security, setSecurity] = useState<SmtpSecurity>("starttls");
+  const [username, setUsername] = useState(smtp?.username ?? "");
+  const [password, setPassword] = useState("");
+  const [fromName, setFromName] = useState("");
+  const [fromEmail, setFromEmail] = useState("");
+  const [busy, setBusy] = useState<"save" | "test" | null>(null);
 
-  const complete = s.host && s.port && s.username && s.fromEmail;
+  const configured = smtp?.configured === true;
+  // A save REPLACES the stored credential in full — the host has no partial
+  // update — so the password is required every time, not only on first setup.
+  const canSave =
+    host.trim() !== "" &&
+    parseSmtpPort(port) !== null &&
+    username.trim() !== "" &&
+    fromEmail.trim() !== "" &&
+    password !== "";
+
+  async function save() {
+    const parsedPort = parseSmtpPort(port);
+    if (parsedPort === null) {
+      toast.error("Enter a valid port (1–65535).");
+      return;
+    }
+    setBusy("save");
+    try {
+      const status = await putSmtp(client, company, {
+        host: host.trim(),
+        port: parsedPort,
+        security,
+        username: username.trim(),
+        password,
+        from_name: fromName.trim(),
+        from_email: fromEmail.trim(),
+      });
+      onChange(status);
+      // Never keep the secret around after it has gone to the host.
+      setPassword("");
+      toast.success("SMTP credentials saved.");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't save the SMTP credentials.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function test() {
+    setBusy("test");
+    try {
+      const result = await testSmtp(client, company);
+      if (result.ok) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError && err.code === "not_wired"
+          ? "Test send isn't enabled on this host — rebuild it with the `smtp` feature."
+          : err instanceof ApiError
+            ? err.message
+            : "Couldn't send the test email.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
           <Mail className="size-4" /> Email (SMTP)
+          {configured && (
+            <Badge variant="secondary" className="gap-1">
+              <Check className="size-3" /> Configured
+            </Badge>
+          )}
         </CardTitle>
         <CardDescription>The outbound mail server your company sends through.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid gap-4 sm:grid-cols-2">
           <Field label="SMTP host" id="smtp-host">
-            <Input id="smtp-host" value={s.host} onChange={(e) => set({ host: e.target.value })} placeholder="smtp.postmarkapp.com" />
+            <Input id="smtp-host" value={host} onChange={(e) => setHost(e.target.value)} placeholder="smtp.postmarkapp.com" />
           </Field>
           <div className="grid grid-cols-2 gap-3">
             <Field label="Port" id="smtp-port">
-              <Input id="smtp-port" value={s.port} onChange={(e) => set({ port: e.target.value })} placeholder="587" inputMode="numeric" />
+              <Input id="smtp-port" value={port} onChange={(e) => setPort(e.target.value)} placeholder="587" inputMode="numeric" />
             </Field>
             <Field label="Security" id="smtp-security">
-              <Select
-                value={s.security}
-                onValueChange={(v) => v && set({ security: v as SmtpSecurity })}
-                items={SECURITY_LABELS}
-              >
+              <Select value={security} onValueChange={(v) => v && setSecurity(v as SmtpSecurity)}>
                 <SelectTrigger id="smtp-security" className="w-full">
                   <SelectValue />
                 </SelectTrigger>
@@ -255,41 +439,54 @@ function SmtpCard({
             </Field>
           </div>
           <Field label="Username" id="smtp-user">
-            <Input id="smtp-user" value={s.username} onChange={(e) => set({ username: e.target.value })} placeholder="apikey" autoComplete="off" />
+            <Input id="smtp-user" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="apikey" autoComplete="off" />
           </Field>
-          <Field label="Password" id="smtp-pass">
-            <Input id="smtp-pass" type="password" value={s.password} onChange={(e) => set({ password: e.target.value })} placeholder="••••••••" autoComplete="off" />
+          <Field label={configured ? "Password (stored — enter to replace)" : "Password"} id="smtp-pass">
+            <Input
+              id="smtp-pass"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={configured ? "•••••• write-only" : "••••••••"}
+              autoComplete="off"
+            />
           </Field>
           <Field label="From name" id="smtp-fromname">
-            <Input id="smtp-fromname" value={s.fromName} onChange={(e) => set({ fromName: e.target.value })} placeholder="Agentic Marketing Agency" />
+            <Input id="smtp-fromname" value={fromName} onChange={(e) => setFromName(e.target.value)} placeholder="Agentic Marketing Agency" />
           </Field>
           <Field label="From email" id="smtp-fromemail">
-            <Input id="smtp-fromemail" value={s.fromEmail} onChange={(e) => set({ fromEmail: e.target.value })} placeholder="hello@mail.acme.com" />
+            <Input id="smtp-fromemail" value={fromEmail} onChange={(e) => setFromEmail(e.target.value)} placeholder="hello@mail.acme.com" />
           </Field>
         </div>
 
         <Alert>
           <Info className="size-4" />
           <AlertDescription>
-            Saved to this browser as a draft. When the host is connected, credentials are stored in
-            its secret store and used per tenant — never handed to the workload directly.
+            Stored write-only in the host&apos;s secret store and used per tenant — the password is
+            never shown again, and a save replaces the whole credential. A change takes effect on the
+            next send.
           </AlertDescription>
         </Alert>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button disabled={busy !== null || !canSave} onClick={() => void save()}>
+            {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
+            Save
+          </Button>
           <Button
             variant="outline"
-            disabled={!complete}
-            onClick={() => toast.info("A test email is sent from the host once SMTP is connected.")}
+            disabled={busy !== null || !configured}
+            onClick={() => void test()}
           >
-            <ShieldAlert className="size-4" /> Test connection
+            {busy === "test" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ShieldAlert className="size-4" />
+            )}
+            Test connection
           </Button>
-          {complete ? (
-            <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
-              <Check className="size-3.5" /> Ready
-            </span>
-          ) : (
-            <span className="text-xs text-muted-foreground">Fill host, port, username, and from email.</span>
+          {!configured && (
+            <span className="text-xs text-muted-foreground">Save credentials before sending a test.</span>
           )}
         </div>
       </CardContent>

--- a/frontend/src/lib/domain.ts
+++ b/frontend/src/lib/domain.ts
@@ -1,91 +1,26 @@
-// Custom domain + SMTP setup for a company. Persisted per company in
-// localStorage; the console has no provisioning API yet, so DNS verification
-// and SMTP tests are host-side once wired. Secrets live here only as a local
-// draft until the host stores them securely.
+// Domain validation for the custom-mail settings card.
+//
+// The DNS records, the verification token and the SMTP credentials all live on
+// the host now (issue #1460): the console reads status over GraphQL and writes
+// over `…/domain` and `…/smtp`, so nothing here fabricates records or persists a
+// secret. What is left is the one purely-local question worth answering before a
+// round trip — whether a string is even shaped like a domain.
 
-import { type LocalScope, scopedKeyAdoptingLegacy } from "@/connections/types";
-
-export interface DomainConfig {
-  domain: string;
-  verified: boolean;
-}
-
-export type SmtpSecurity = "none" | "starttls" | "ssl";
-
-export interface SmtpConfig {
-  host: string;
-  port: string;
-  security: SmtpSecurity;
-  username: string;
-  password: string;
-  fromName: string;
-  fromEmail: string;
-}
-
-export interface MailSettings {
-  domain: DomainConfig;
-  smtp: SmtpConfig;
-}
-
-export function emptyMailSettings(): MailSettings {
-  return {
-    domain: { domain: "", verified: false },
-    smtp: { host: "", port: "587", security: "starttls", username: "", password: "", fromName: "", fromEmail: "" },
-  };
-}
-
-/** The platform host records point at. In production this comes from the host. */
-const PLATFORM_TARGET = "mail.opencompany.host";
-
-export interface DnsRecord {
-  type: "CNAME" | "TXT";
-  name: string;
-  value: string;
-  ttl: string;
-}
-
-/** A short, stable verification token derived from the domain. */
-function verifyToken(domain: string): string {
-  let hash = 0;
-  for (let i = 0; i < domain.length; i++) hash = (hash * 31 + domain.charCodeAt(i)) | 0;
-  return Math.abs(hash).toString(16).padStart(8, "0");
-}
-
-/** The DNS records a user must add to point a custom domain at the platform
- *  and let it send email (verification + CNAME + DKIM + SPF). */
-export function dnsRecords(domain: string): DnsRecord[] {
-  const d = domain.trim().replace(/\.$/, "");
-  if (!d) return [];
-  return [
-    { type: "TXT", name: `_opencompany.${d}`, value: `oc-verify=${verifyToken(d)}`, ttl: "3600" },
-    { type: "CNAME", name: d, value: PLATFORM_TARGET, ttl: "3600" },
-    { type: "CNAME", name: `oc1._domainkey.${d}`, value: `oc1.dkim.opencompany.host`, ttl: "3600" },
-    { type: "CNAME", name: `oc2._domainkey.${d}`, value: `oc2.dkim.opencompany.host`, ttl: "3600" },
-    { type: "TXT", name: d, value: "v=spf1 include:spf.opencompany.host ~all", ttl: "3600" },
-  ];
-}
-
+/** Whether `domain` is shaped like a hostname (at least one dot, valid labels). */
 export function isValidDomain(domain: string): boolean {
   return /^(?!-)[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(domain.trim());
 }
 
-const KEY = (scope: LocalScope) =>
-  scopedKeyAdoptingLegacy("oc-mail", scope, `oc-mail:${scope.company ?? "single"}`);
-
-export function loadMailSettings(scope: LocalScope): MailSettings {
-  try {
-    const raw = localStorage.getItem(KEY(scope));
-    if (raw) return { ...emptyMailSettings(), ...(JSON.parse(raw) as MailSettings) };
-  } catch {
-    /* fall through */
-  }
-  return emptyMailSettings();
-}
-
-export function saveMailSettings(scope: LocalScope, settings: MailSettings): void {
-  try {
-    localStorage.setItem(KEY(scope), JSON.stringify(settings));
-  } catch {
-    /* storage unavailable */
-  }
+/**
+ * Parses an SMTP port string to a valid TCP port, or `null` when it is not one.
+ *
+ * The host's `port` is a `u16`, so a non-integer, a zero, or anything above
+ * 65535 must be caught before the round trip rather than surfacing as an opaque
+ * deserialize failure.
+ */
+export function parseSmtpPort(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const port = Number(trimmed);
+  return port >= 1 && port <= 65535 ? port : null;
 }

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -119,7 +119,7 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
         )}
 
         {/* Domain & email */}
-        <DomainSettings company={company} />
+        <DomainSettings client={client} company={company} />
 
         {/* Appearance.
 

--- a/frontend/test/unit/domain.test.ts
+++ b/frontend/test/unit/domain.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { fetchMailStatus } from "@/api/domain";
+import { isValidDomain, parseSmtpPort } from "@/lib/domain";
+
+/**
+ * The custom-mail settings, now wired to the host (issue #1460).
+ *
+ * The card used to fabricate DNS records client-side and write the SMTP password
+ * to localStorage on every keystroke. The wiring moved all of that to the host;
+ * what stays on the client is validation and the shape of the status read, both
+ * pinned here.
+ */
+describe("isValidDomain", () => {
+  it("accepts a hostname with at least one dot", () => {
+    expect(isValidDomain("mail.acme.com")).toBe(true);
+    expect(isValidDomain("acme.co")).toBe(true);
+  });
+
+  it("rejects a bare label, a leading dash, and empty input", () => {
+    expect(isValidDomain("localhost")).toBe(false);
+    expect(isValidDomain("-acme.com")).toBe(false);
+    expect(isValidDomain("")).toBe(false);
+  });
+});
+
+describe("parseSmtpPort", () => {
+  it("accepts a valid TCP port", () => {
+    expect(parseSmtpPort("587")).toBe(587);
+    expect(parseSmtpPort(" 465 ")).toBe(465);
+    expect(parseSmtpPort("65535")).toBe(65535);
+    expect(parseSmtpPort("1")).toBe(1);
+  });
+
+  it("rejects zero, out-of-range, and non-numeric — before the round trip", () => {
+    // The host's port is a u16, so these must be caught here rather than
+    // surfacing as an opaque deserialize failure.
+    expect(parseSmtpPort("0")).toBeNull();
+    expect(parseSmtpPort("70000")).toBeNull();
+    expect(parseSmtpPort("587a")).toBeNull();
+    expect(parseSmtpPort("")).toBeNull();
+    expect(parseSmtpPort("-1")).toBeNull();
+  });
+});
+
+/** A client whose only method fetchMailStatus needs is `graphqlRequest`. */
+function clientReturning(result: { data?: unknown; errors?: unknown }): OpenCompanyClient {
+  return {
+    graphqlRequest: async () => result,
+  } as unknown as OpenCompanyClient;
+}
+
+describe("fetchMailStatus", () => {
+  it("returns the domain and smtp status the host reports", async () => {
+    const client = clientReturning({
+      data: {
+        company: {
+          domain: {
+            domain: "mail.acme.com",
+            verified: true,
+            records: [{ type: "TXT", name: "_oc.mail.acme.com", value: "v=1", ttl: "3600" }],
+          },
+          smtp: { host: "smtp.acme.com", port: 587, username: "apikey", configured: true },
+        },
+      },
+    });
+    const status = await fetchMailStatus(client, "acme");
+    expect(status.domain?.domain).toBe("mail.acme.com");
+    expect(status.domain?.records).toHaveLength(1);
+    expect(status.smtp.configured).toBe(true);
+    expect(status.smtp.host).toBe("smtp.acme.com");
+  });
+
+  it("reads a null domain as 'none set', and a missing smtp as unconfigured", async () => {
+    const client = clientReturning({ data: { company: { domain: null, smtp: null } } });
+    const status = await fetchMailStatus(client, null);
+    expect(status.domain).toBeNull();
+    expect(status.smtp).toEqual({ host: "", port: 0, username: "", configured: false });
+  });
+
+  it("throws on a GraphQL error rather than reporting empty state as fact", async () => {
+    // The card turns this into a "couldn't read" notice — an unanswered read is
+    // not "nothing configured".
+    const client = clientReturning({ errors: [{ message: "boom" }] });
+    await expect(fetchMailStatus(client, "acme")).rejects.toThrow(/boom/);
+  });
+});


### PR DESCRIPTION
## Summary

The Custom domain and SMTP cards were a browser-local mock (#1460): the SMTP password was written to `localStorage` on every keystroke, the DNS records handed to the operator were fabricated client-side against hardcoded `*.opencompany.host` constants, and the Verified badge / Verify button were theatre. The host already implements all of it — this connects the console to it.

- **SMTP password never touches the browser.** Credentials are held in component state only and sent write-only via `PUT …/smtp`; the read plane never returns the password. A test send goes through `POST …/smtp/test`, and a Save button (there was none) commits the credential.
- **DNS records come from the host.** `PUT …/domain` returns the records this deployment actually chose; `dnsRecords()` and `verifyToken()` are deleted, so the console no longer invents a verification token or CNAME/DKIM/SPF records.
- **The status badge is real** — reads `DomainStatus.verified`; Verify DNS calls `POST …/domain/verify` (a 404 surfaces as "verification isn't enabled on this host") instead of a permanent Pending badge and a button that only toasted.
- **Initial state is read over GraphQL** (`Company.domain` / `Company.smtp`), so a configured domain/SMTP shows on load; a failed read renders "couldn't read …" rather than a confident empty form.

New `frontend/src/api/domain.ts` (GraphQL read + REST write clients); `frontend/src/lib/domain.ts` trimmed to `isValidDomain` + `parseSmtpPort`.

## API Or Behavior Changes

Console-only, additive on the host side (all four routes and the GraphQL reads already exist). Behavior change: the cards now hit the host instead of `localStorage`; the `oc-mail:*` localStorage key is no longer written.

**Known follow-up (not in this PR):** the GraphQL `SmtpStatus` projection omits the security mode and from-address, so those two re-enter blank on a change (the host has no partial SMTP update — a save replaces the whole credential). Widening the projection is a separate backend change.

## Tests

Console gate (mirrors CI's Console job); `isValidDomain`, `parseSmtpPort`, and the `fetchMailStatus` read-shape unit-tested:

- [x] `npm run typecheck` / `typecheck:unit` / `typecheck:e2e`
- [x] `npm test` (vitest — 1671 passed)
- [x] `npm run build` + `npm run build:pages-sdk`
- [x] `scripts/ci/assert-design-tokens.sh`, `scripts/ci/assert-md-line-cap.sh`

(The cargo checks below do not apply — this PR touches only `frontend/`.)

## Documentation

None needed — the routes and GraphQL fields are pre-existing and already documented; this is the console client for them.

Closes #1460
