### PR TITLE
feat(policy): gate MCP bridge calls on a per-server read-only declaration (#1124)

### DIFF
--- a/frontend/src/api/mcp.ts
+++ b/frontend/src/api/mcp.ts
@@ -54,6 +54,8 @@ export interface AddMcpServer {
   description?: string;
   allowedTools?: string[];
   disallowedTools?: string[];
+  /** Remote tool names to declare read-only on this server (issue #1124). */
+  readOnlyTools?: string[];
   timeoutSecs?: number;
   token?: string;
   authKind?: McpAuthKind;
@@ -77,6 +79,11 @@ export interface UpdateMcpServer {
   description?: string;
   allowedTools?: string[];
   disallowedTools?: string[];
+  /**
+   * Replace the read-only declaration (issue #1124). Omit to leave it
+   * unchanged; send `[]` to clear it.
+   */
+  readOnlyTools?: string[];
   timeoutSecs?: number;
   /** Rotate the outbound credential (write-only). Omit to leave it unchanged. */
   token?: string;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1070,6 +1070,16 @@ export interface McpServer {
   enabled: boolean;
   allowedTools: string[];
   disallowedTools: string[];
+  /**
+   * Remote tool names the operator has declared **read-only** on this server
+   * (issue #1124). A bridge call to one is priced as an outward read rather than
+   * parked for approval, so it can run unattended under `auto`; every other call
+   * through the server still parks. Independent of {@link McpServer.allowedTools}
+   * / {@link McpServer.disallowedTools} — it says nothing about whether a tool is
+   * exposed, only how a call to it is gated. Carries this row's provenance badge
+   * exactly as the two lists above do.
+   */
+  readOnlyTools: string[];
   timeoutSecs: number;
   /** Whether an outbound credential is stored — never the credential itself. */
   authConfigured: boolean;

--- a/frontend/test/unit/connection-detail.test.ts
+++ b/frontend/test/unit/connection-detail.test.ts
@@ -108,6 +108,7 @@ describe("mcpStanding", () => {
       enabled: true,
       allowedTools: [],
       disallowedTools: [],
+      readOnlyTools: [],
       timeoutSecs: 30,
       authConfigured: true,
       ...over,

--- a/frontend/test/unit/mcp-registry-row.test.ts
+++ b/frontend/test/unit/mcp-registry-row.test.ts
@@ -44,6 +44,7 @@ function row(over: Partial<McpServer> & { source: McpSource }): McpServer {
     enabled: true,
     allowedTools: [],
     disallowedTools: [],
+    readOnlyTools: [],
     timeoutSecs: 30,
     authConfigured: false,
     ...over,

--- a/frontend/test/unit/provider-detail-render.test.ts
+++ b/frontend/test/unit/provider-detail-render.test.ts
@@ -276,6 +276,7 @@ function mcpServer(over: Partial<McpServer> = {}): McpServer {
     enabled: true,
     allowedTools: [],
     disallowedTools: [],
+    readOnlyTools: [],
     timeoutSecs: 30,
     authConfigured: true,
     ...over,

--- a/src/company/mcp.rs
+++ b/src/company/mcp.rs
@@ -264,6 +264,12 @@ pub struct McpServerDecl {
     pub allowed_tools: Vec<String>,
     /// Deny-list of remote tool names (takes precedence).
     pub disallowed_tools: Vec<String>,
+    /// Remote tool names the operator declares **read-only** on this server
+    /// (issue #1124). Merged through [`effective_mcp_servers`] and editable
+    /// through the runtime-override layer exactly as the two lists above are, so
+    /// an operator expresses it without hand-editing the manifest. A call to a
+    /// tool named here does not park under `auto`; every other bridge call does.
+    pub read_only_tools: Vec<String>,
     /// Per-request timeout in seconds.
     pub timeout_secs: u64,
     /// Whether this server is exposed to agents.
@@ -282,6 +288,7 @@ impl McpServerDecl {
             description: server.description.clone(),
             allowed_tools: normalize_tools(&server.allowed_tools),
             disallowed_tools: normalize_tools(&server.disallowed_tools),
+            read_only_tools: normalize_tools(&server.read_only_tools),
             timeout_secs: server.timeout_secs,
             enabled: server.enabled,
             source,
@@ -356,6 +363,23 @@ pub fn effective_mcp_servers(
     }
 
     out
+}
+
+/// Flattens a company's effective MCP servers into the `(server, tool)`
+/// read-only set the approval gate consults (issue #1124).
+///
+/// Keyed by the server's `name` — the slug the `mcp_call_tool` bridge names its
+/// server under — paired with each `read_only_tools` entry. The gate looks a
+/// live call's `(server, tool)` pair up here; an undeclared pair is simply
+/// absent, which is the gated answer. A disabled server contributes nothing: it
+/// hands out no tool, so a call through it could not have been made.
+pub fn mcp_read_set(servers: &[McpServerDecl]) -> crate::policy::McpReadSet {
+    crate::policy::McpReadSet::from_pairs(servers.iter().filter(|s| s.enabled).flat_map(|server| {
+        server
+            .read_only_tools
+            .iter()
+            .map(move |tool| (server.name.clone(), tool.clone()))
+    }))
 }
 
 /// Loads the runtime server index from the secret store. A missing/empty key
@@ -939,6 +963,7 @@ mod tests {
             command: None,
             allowed_tools: Vec::new(),
             disallowed_tools: Vec::new(),
+            read_only_tools: Vec::new(),
             timeout_secs: 30,
             enabled: true,
             auth_secret: None,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -983,6 +983,16 @@ pub struct McpServer {
     /// Exact remote tool names to always hide/block (takes precedence).
     #[serde(default)]
     pub disallowed_tools: Vec<String>,
+    /// Exact remote tool names on this server the operator declares **read-only**
+    /// (issue #1124): they read and change nothing, so a bridge call to one need
+    /// not park under `auto` the way calling *through* a server otherwise does.
+    ///
+    /// This is an operator declaration, not a claim read off the remote — there
+    /// is no client-side annotation to trust — so an undeclared tool always
+    /// gates. Independent of `allowed_tools`/`disallowed_tools`: it says nothing
+    /// about whether a tool is *exposed*, only how a call to it is priced.
+    #[serde(default)]
+    pub read_only_tools: Vec<String>,
     /// Per-request timeout in seconds.
     #[serde(default = "default_mcp_timeout_secs")]
     pub timeout_secs: u64,

--- a/src/harness/built_in/mcp.rs
+++ b/src/harness/built_in/mcp.rs
@@ -783,6 +783,7 @@ mod tests {
             description: None,
             allowed_tools: Vec::new(),
             disallowed_tools: Vec::new(),
+            read_only_tools: Vec::new(),
             timeout_secs: 30,
             enabled: true,
             source: crate::company::mcp::McpSource::Runtime,

--- a/src/harness/built_in/mcp_probe.rs
+++ b/src/harness/built_in/mcp_probe.rs
@@ -535,6 +535,7 @@ mod tests {
             description: None,
             allowed_tools: Vec::new(),
             disallowed_tools: Vec::new(),
+            read_only_tools: Vec::new(),
             timeout_secs: 30,
             enabled: true,
             source: McpSource::Runtime,

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -3028,6 +3028,13 @@ pub(crate) fn build_roster(
     // the delegating-orchestrator persona + tools (issue #53).
     let orchestrator = orchestrator::orchestrator_id(&company.manifest.agents);
 
+    // Issue #1124: the company's per-server read-only MCP declaration, resolved
+    // once and installed on every agent's policy so a server-declared read-only
+    // bridge call does not park under `auto`. Built from the same effective MCP
+    // servers the harness wires tools from, so the gate and the toolbelt cannot
+    // disagree about which server declared what.
+    let mcp_reads = crate::company::mcp::mcp_read_set(&deps.mcp_servers);
+
     let mut roster =
         Vec::with_capacity(company.manifest.agents.len() + company.overlay_agents.len());
 
@@ -3049,7 +3056,10 @@ pub(crate) fn build_roster(
             .with_requests(deps.approval_requests.clone())
             // Issue #243: stamp who the parked effect belongs to, so approving it
             // can hand the grant back to this agent rather than to nobody.
-            .with_agent(manifest_agent.id.clone());
+            .with_agent(manifest_agent.id.clone())
+            // Issue #1124: the per-server read-only MCP declaration, so a
+            // server-declared read-only bridge call does not park under `auto`.
+            .with_mcp_reads(mcp_reads.clone());
         // Issue #304: give the policy something to measure `budget_usd_daily`
         // against. Only wired when the host has a meter — without one the cap
         // arm stays inert and warns once, rather than parking every priced call
@@ -3113,7 +3123,10 @@ pub(crate) fn build_roster(
             .with_requests(deps.approval_requests.clone())
             // An overlay teammate is a real roster agent and re-dispatches the
             // same way a manifest one does (issue #243).
-            .with_agent(manifest_agent.id.clone());
+            .with_agent(manifest_agent.id.clone())
+            // Issue #1124: the same per-server read-only MCP declaration the
+            // manifest agents get — an overlay teammate calls the same servers.
+            .with_mcp_reads(mcp_reads.clone());
         if let Some(meter) = deps.meter.as_ref() {
             agent_policy = agent_policy.with_spend(meter.clone(), company.id.clone());
         }
@@ -4934,6 +4947,7 @@ description = "Builds the product."
                 command: None,
                 allowed_tools: Vec::new(),
                 disallowed_tools: Vec::new(),
+                read_only_tools: Vec::new(),
                 timeout_secs: 30,
                 enabled: true,
                 auth_secret: None,
@@ -6693,6 +6707,7 @@ budget_usd_daily = 0.0
                 description: None,
                 allowed_tools: Vec::new(),
                 disallowed_tools: Vec::new(),
+                read_only_tools: Vec::new(),
                 timeout_secs: 30,
                 enabled: true,
                 source: crate::company::mcp::McpSource::Runtime,

--- a/src/harness/built_in/policy.rs
+++ b/src/harness/built_in/policy.rs
@@ -132,7 +132,7 @@ use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
 use crate::metering::{usd_spent_by_agent, utc_day_start_millis};
-use crate::policy::CallPath;
+use crate::policy::{CallPath, McpReadSet};
 use crate::ports::UsageMeter;
 use crate::ports::types::{CompanyId, Effect, EffectGroup};
 use crate::runtime::grants::{GrantSet, GrantSubject, GrantedCall};
@@ -783,6 +783,20 @@ pub struct ApprovalPolicy {
     /// gate pass builds its own policy for its own pass, and nothing else shares
     /// it.
     call_path: CallPath,
+    /// The operator's per-server declaration of which remote MCP tools only read
+    /// (issue #1124), consulted by the tier dispatch to downgrade a
+    /// server-declared read-only bridge call so it does not park under `auto`.
+    ///
+    /// **Empty at every non-harness construction site** — the default — which
+    /// keeps every one of them (and the workflow gate, and every test that sets
+    /// no declaration) gating every `mcp_call_tool` / `mcp_registry_tool_call`
+    /// exactly as before. Only `build_roster` chains
+    /// [`with_mcp_reads`](Self::with_mcp_reads), from the company's effective MCP
+    /// servers. `consequence_of` cannot read this because it is a pure,
+    /// company-blind free function; the declaration is company context, so it
+    /// arrives here and the gate applies it through
+    /// [`mcp_call_reach`](crate::policy::consequence::mcp_call_reach).
+    mcp_reads: McpReadSet,
 }
 
 /// Where the per-agent daily spend cap reads today's spend from (issue #304):
@@ -823,6 +837,9 @@ impl ApprovalPolicy {
             no_meter_warned: AtomicBool::new(false),
             // The strict path by default — see `for_authored_workflow_nodes`.
             call_path: CallPath::Agent,
+            // No read declaration by default, so every MCP bridge call gates
+            // exactly as before — see `with_mcp_reads`.
+            mcp_reads: McpReadSet::default(),
         }
     }
 
@@ -847,6 +864,21 @@ impl ApprovalPolicy {
     /// effect knows whose tool call it came from (issue #243).
     pub fn with_agent(mut self, agent: impl Into<String>) -> Self {
         self.agent = Some(agent.into());
+        self
+    }
+
+    /// Installs the operator's per-server declaration of which remote MCP tools
+    /// only read (issue #1124), so a server-declared read-only bridge call does
+    /// not park under `auto`.
+    ///
+    /// Without this the declaration is empty and every `mcp_call_tool` /
+    /// `mcp_registry_tool_call` gates — which is exactly what every non-harness
+    /// construction site wants. Chained by `build_roster` alongside
+    /// [`with_requests`](Self::with_requests) / [`with_agent`](Self::with_agent),
+    /// the same way those are, because the declaration is company context the
+    /// pure `consequence_of` cannot see.
+    pub fn with_mcp_reads(mut self, reads: McpReadSet) -> Self {
+        self.mcp_reads = reads;
         self
     }
 
@@ -1259,6 +1291,25 @@ impl ApprovalPolicy {
         );
         ToolPolicyDecision::require_approval(reason)
     }
+
+    /// What this call reaches, with the one company-context downgrade the pure
+    /// [`consequence_of`](crate::policy::consequence_of) cannot make: an MCP
+    /// bridge call whose remote tool the operator has declared read-only on this
+    /// server (issue #1124).
+    ///
+    /// Every non-bridge tool takes the plain classifier, so nothing else changes.
+    /// A bridge call is graded by [`mcp_call_reach`](crate::policy::consequence::mcp_call_reach),
+    /// which downgrades to [`Reach::ExternalRead`](crate::policy::Reach::ExternalRead)
+    /// only on affirmative membership of this policy's declaration and returns the
+    /// gated base otherwise — so an undeclared server, an unreadable argument, or
+    /// a policy with no declaration all keep the parking verdict this arm read
+    /// before.
+    fn consequence_for(&self, tool: &str, args: &serde_json::Value) -> crate::policy::Consequence {
+        if crate::policy::consequence::is_mcp_bridge_tool(tool) {
+            return crate::policy::consequence::mcp_call_reach(tool, args, &self.mcp_reads);
+        }
+        crate::policy::consequence_of(tool, args)
+    }
 }
 
 #[async_trait]
@@ -1405,7 +1456,7 @@ impl ToolPolicy for ApprovalPolicy {
         // operator who does want a per-call gate has
         // `[policy].always_approve = ["web_search"]`, which wins over every
         // tier including `full`.
-        let consequence = crate::policy::consequence_of(tool, &request.arguments);
+        let consequence = self.consequence_for(tool, &request.arguments);
         let reach = consequence.reach;
         let by_mode = match self.mode {
             PolicyMode::Full => ToolPolicyDecision::Allow,
@@ -1936,6 +1987,96 @@ mod tests {
                 "{tool} leaves the company or spends money and must still park under auto"
             );
         }
+    }
+
+    /// **Issue #1124, end to end at the policy layer.** A bridge call to a
+    /// remote tool the operator has declared read-only on this server runs
+    /// unattended under `auto`; the same call with no declaration, a write on
+    /// the same server, and a read on an undeclared server all still park.
+    ///
+    /// The `consequence.rs` tests prove [`mcp_call_reach`](crate::policy::consequence::mcp_call_reach)
+    /// in isolation. This one proves the wiring that makes it fire in
+    /// production — `with_mcp_reads` installs the declaration, `consequence_for`
+    /// routes the bridge tool through it, and the `auto` arm of `check` reads
+    /// the downgraded reach. Reverting any link (dropping `with_mcp_reads`,
+    /// routing the bridge tool through the plain `consequence_of`, or reverting
+    /// the classifier) puts the first two `Allow`s back to `RequireApproval`.
+    #[tokio::test]
+    async fn auto_runs_a_server_declared_read_only_mcp_call_but_parks_the_rest() {
+        let reads = crate::policy::McpReadSet::from_pairs([
+            ("jira".to_string(), "get_issue".to_string()),
+            ("registry-42".to_string(), "list_rows".to_string()),
+        ]);
+        let p = policy("auto", &[], None).with_mcp_reads(reads);
+
+        // The declared read on each bridge tool runs unattended.
+        for (tool, args) in [
+            (
+                "mcp_call_tool",
+                serde_json::json!({ "server": "jira", "tool": "get_issue", "arguments": {} }),
+            ),
+            (
+                "mcp_registry_tool_call",
+                serde_json::json!({
+                    "server_id": "registry-42",
+                    "tool_name": "list_rows",
+                    "arguments": {},
+                }),
+            ),
+        ] {
+            assert_eq!(
+                p.check(&request(tool, args)).await,
+                ToolPolicyDecision::Allow,
+                "{tool} names a server-declared read and must run unattended under auto"
+            );
+        }
+
+        // Everything else through the same policy still parks: a write on the
+        // declared server, a read on an undeclared server, and a bridge call the
+        // gate cannot read the (server, tool) pair from.
+        for (tool, args) in [
+            (
+                "mcp_call_tool",
+                serde_json::json!({ "server": "jira", "tool": "create_issue", "arguments": {} }),
+            ),
+            (
+                "mcp_call_tool",
+                serde_json::json!({ "server": "confluence", "tool": "get_issue", "arguments": {} }),
+            ),
+            (
+                "mcp_registry_tool_call",
+                serde_json::json!({
+                    "server_id": "registry-42",
+                    "tool_name": "write_row",
+                    "arguments": {},
+                }),
+            ),
+            ("mcp_call_tool", serde_json::json!({})),
+        ] {
+            assert!(
+                matches!(
+                    p.check(&request(tool, args)).await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "{tool} is not an affirmatively-declared read and must still park under auto"
+            );
+        }
+
+        // And with NO declaration — the default at every non-harness site — even
+        // the declared pair parks, exactly as it did before this issue.
+        let no_reads = policy("auto", &[], None);
+        assert!(
+            matches!(
+                no_reads
+                    .check(&request(
+                        "mcp_call_tool",
+                        serde_json::json!({ "server": "jira", "tool": "get_issue", "arguments": {} }),
+                    ))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a policy with no read declaration must gate every bridge call, as before #1124"
+        );
     }
 
     /// `always_approve` wins over `auto` exactly as it wins over `full`, and the

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -340,6 +340,38 @@ pub const WEB_FETCH: &str = "web_fetch";
 /// could not have run anyway; a call this cannot read simply stays `PerCall`.
 pub(crate) const WEB_FETCH_URL_KEY: &str = "url";
 
+/// The bridge tool that calls through a company-declared MCP server (#1124).
+///
+/// Argument-classified because one name carries every remote tool on every
+/// server: filing a Jira ticket and reading one arrive here identically, so
+/// classifying the *name* charged the operator the same approval card for both.
+/// The (server, tool) pair the call already carries is what separates them —
+/// see [`mcp_call_tool_consequence`].
+pub const MCP_CALL_TOOL: &str = "mcp_call_tool";
+
+/// The bridge tool that calls through a **registry**-installed MCP server
+/// (#1124) — a different store from [`MCP_CALL_TOOL`]'s, keyed by `server_id`
+/// rather than by name, but graded on the same declaration for the same reason.
+pub const MCP_REGISTRY_TOOL_CALL: &str = "mcp_registry_tool_call";
+
+/// The argument key [`MCP_CALL_TOOL`] names its server under. A required
+/// parameter of the tool's schema (`OcMcpCallTool::parameters_schema`), so a
+/// call this cannot read could not have run — and stays gated.
+pub(crate) const MCP_CALL_SERVER_KEY: &str = "server";
+
+/// The argument key [`MCP_CALL_TOOL`] names the remote tool under.
+pub(crate) const MCP_CALL_TOOL_KEY: &str = "tool";
+
+/// The argument key [`MCP_REGISTRY_TOOL_CALL`] names its server under —
+/// `server_id`, not `server`: the registry addresses installs by a stable id,
+/// not by the display name the [`MCP_CALL_TOOL`] path uses.
+pub(crate) const MCP_REGISTRY_SERVER_KEY: &str = "server_id";
+
+/// The argument key [`MCP_REGISTRY_TOOL_CALL`] names the remote tool under —
+/// `tool_name`, not `tool`, matching the vendored `McpRegistryToolCallTool`
+/// schema.
+pub(crate) const MCP_REGISTRY_TOOL_KEY: &str = "tool_name";
+
 /// Every tool this crate can wire onto an agent, and what it can reach.
 ///
 /// Ordered by family for reading, not by any semantic. The **coverage test**
@@ -641,7 +673,13 @@ const DECLARED: &[Declared] = &[
         EffectGroup::Other,
         Reach::Nothing,
     ),
-    d("mcp_call_tool", EffectGroup::Other, Reach::Consequence),
+    // `mcp_call_tool` keeps its row so `declared_tools` still walks it, but its
+    // reach is decided from the (server, tool) pair the call carries against the
+    // operator's per-server read declaration — see `mcp_call_tool_consequence`
+    // (#1124). This row's `Consequence` is the answer for a call whose server or
+    // tool argument cannot be read, and for a build without the classifier, both
+    // of which that function falls back to.
+    d(MCP_CALL_TOOL, EffectGroup::Other, Reach::Consequence),
     // Billing (issues #788, #789). Both integrations read the company's OWN
     // Chargebee site and PayPal account, so the reads are `Nothing` rather than
     // `ExternalRead`: that tier exists for reaching into a *counterparty's*
@@ -678,8 +716,10 @@ const DECLARED: &[Declared] = &[
         EffectGroup::Other,
         Reach::Consequence,
     ),
+    // The registry twin of `mcp_call_tool`, graded the same way against the same
+    // declaration (#1124). Its row is the fallback for an unreadable call.
     d(
-        "mcp_registry_tool_call",
+        MCP_REGISTRY_TOOL_CALL,
         EffectGroup::Other,
         Reach::Consequence,
     ),
@@ -872,6 +912,12 @@ type Grader = fn(&serde_json::Value) -> Consequence;
 /// * `web_fetch` — #673, keyed on the URL's host.
 /// * `shell` — #875, keyed on the command line.
 /// * `git_operations` — #877, keyed on the `operation`.
+/// * `mcp_call_tool` / `mcp_registry_tool_call` — #1124, keyed on the
+///   (server, tool) pair, but *only downgraded* against a per-server read
+///   declaration the operator supplies — which is company context this pure
+///   function cannot see. So the roster entry answers the fail-closed base
+///   (`Reach::Consequence`), and the downgrade is applied by
+///   [`mcp_call_reach`], which the policy calls with the declaration in hand.
 ///
 /// Every name here must be **lower-case**: [`consequence_of`] matches against a
 /// lower-cased tool name, so a mixed-case entry would be an entry that never
@@ -881,6 +927,8 @@ const ARGUMENT_GRADED: &[(&str, Grader)] = &[
     (WEB_FETCH, web_fetch_consequence),
     (SHELL, shell_consequence),
     (GIT_OPERATIONS, git_operations_consequence),
+    (MCP_CALL_TOOL, mcp_call_tool_consequence),
+    (MCP_REGISTRY_TOOL_CALL, mcp_call_tool_consequence),
 ];
 
 /// The classifier that answers for `name`, or `None` when the table does.
@@ -1517,6 +1565,152 @@ fn git_operations_consequence(args: &serde_json::Value) -> Consequence {
 /// itself does not classify (`push`, `pull`, `fetch`, `merge`, `rebase`,
 /// `clone`).
 const GIT_READ_ONLY_OPERATIONS: &[&str] = &["status", "diff", "log", "show", "branch", "rev-parse"];
+
+/// The consequence of one MCP bridge call — the fail-closed base for both
+/// [`MCP_CALL_TOOL`] and [`MCP_REGISTRY_TOOL_CALL`] (#1124).
+///
+/// One name carries every remote tool on every server, so this cannot be
+/// classified from the name: a call that reads a Jira ticket and one that files
+/// one arrive here identically. The distinguishing information is the (server,
+/// tool) pair in the arguments — but *whether that pair only reads* is an
+/// **operator declaration** per server, which is company context. A pure
+/// classifier cannot reach it, so this answers the cautious base every call
+/// keeps until proven otherwise: a call through a third-party server can perform
+/// any effect that server advertises, so it parks under `supervised` and `auto`
+/// and holds no standing grant.
+///
+/// The downgrade — the whole point of the issue — is applied by
+/// [`mcp_call_reach`], which the policy calls **with** the declaration. That the
+/// base is `Reach::Consequence` is what makes the split fail closed by
+/// construction: an undeclared server, a server whose declaration does not name
+/// this tool, a missing or non-string `server`/`tool` argument, and a build
+/// whose policy carries no declaration all resolve here, never to a downgrade.
+fn mcp_call_tool_consequence(_args: &serde_json::Value) -> Consequence {
+    Consequence {
+        group: EffectGroup::Other,
+        reach: Reach::Consequence,
+        standing: Standing::PerCall,
+    }
+}
+
+/// The operator's declaration of which remote MCP tools **only read**, keyed by
+/// the `(server, tool)` pair the bridge call carries (#1124).
+///
+/// This is the third per-server list beside `allowed_tools` / `disallowed_tools`
+/// (`McpServerDecl::read_only_tools`), flattened to a set the gate can consult
+/// in one lookup. It arrives on the policy — [`ApprovalPolicy::with_mcp_reads`]
+/// — because [`consequence_of`] is pure and company-blind; the policy is the one
+/// layer that has both the live call and this declaration.
+///
+/// The key is the server **as the call names it**: the `server` display name for
+/// [`MCP_CALL_TOOL`], the `server_id` for [`MCP_REGISTRY_TOOL_CALL`]. Two
+/// registries, one set — a caller populates it from whichever declaration source
+/// keys each server the way its bridge call will. Nothing here interprets the
+/// server key; membership is exact, so a server the operator has not declared a
+/// read for is simply absent, which is the gated answer.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct McpReadSet {
+    pairs: std::collections::HashSet<(String, String)>,
+}
+
+impl McpReadSet {
+    /// Builds the set from `(server, tool)` pairs. Empty — the default — means
+    /// no remote tool is declared read-only, so every bridge call gates, which
+    /// is exactly what every construction site that sets no declaration wants.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -> Self {
+        Self {
+            pairs: pairs.into_iter().collect(),
+        }
+    }
+
+    /// Has the operator declared this exact remote tool on this server a read?
+    pub fn contains(&self, server: &str, tool: &str) -> bool {
+        self.pairs.contains(&(server.to_string(), tool.to_string()))
+    }
+
+    /// Whether any read is declared at all, so a caller can skip the lookup for
+    /// a policy that carries no declaration.
+    pub fn is_empty(&self) -> bool {
+        self.pairs.is_empty()
+    }
+}
+
+/// The `(server, tool)` pair an MCP bridge call names, read from the arguments
+/// with the keys the tool's own schema requires (#1124).
+///
+/// `None` when the tool is neither bridge tool, or when either key is absent or
+/// not a string — the tools' schemas mark both required, so such a call could
+/// not have run, and guessing a pair for it would be inventing a verdict for a
+/// call that never happened. The keys differ by tool: `mcp_call_tool` names its
+/// server `server` and its remote tool `tool`; `mcp_registry_tool_call` names
+/// them `server_id` and `tool_name`.
+fn mcp_call_pair<'a>(tool: &str, args: &'a serde_json::Value) -> Option<(&'a str, &'a str)> {
+    let (server_key, tool_key) = if tool.eq_ignore_ascii_case(MCP_CALL_TOOL) {
+        (MCP_CALL_SERVER_KEY, MCP_CALL_TOOL_KEY)
+    } else if tool.eq_ignore_ascii_case(MCP_REGISTRY_TOOL_CALL) {
+        (MCP_REGISTRY_SERVER_KEY, MCP_REGISTRY_TOOL_KEY)
+    } else {
+        return None;
+    };
+    let object = args.as_object()?;
+    let server = object.get(server_key)?.as_str()?;
+    let remote_tool = object.get(tool_key)?.as_str()?;
+    Some((server, remote_tool))
+}
+
+/// The reach of one MCP bridge call, downgraded to [`Reach::ExternalRead`]
+/// **only** when the operator has declared this call's remote tool a read on
+/// this server (#1124).
+///
+/// The one place the (server, tool) pair meets the declaration. Every other
+/// answer is [`Reach::Consequence`], the [`mcp_call_tool_consequence`] base:
+///
+///  1. a tool that is neither bridge tool — `None` from [`mcp_call_pair`];
+///  2. a call whose `server` / `tool` argument cannot be read — same;
+///  3. a server the operator has not declared this tool a read on — the set
+///     lookup misses.
+///
+/// So the downgrade is affirmative-membership-only, and the gate stays fail
+/// closed by construction rather than by a rule someone has to remember — the
+/// same shape [`git_operations_consequence`] takes against its read set. Returns
+/// the whole [`Consequence`] rather than a bare [`Reach`] so the policy replaces
+/// the base verdict wholesale, exactly as the argument graders do.
+///
+/// The downgrade is [`Reach::ExternalRead`], not [`Reach::Nothing`], and this is
+/// the Composio-read precedent (#559) rather than a fresh choice: a remote MCP
+/// read reaches a *third party's* server with the company's own connected
+/// credential. It changes nothing there or here and is billed for nothing, so
+/// `supervised` and `auto` let it run — the whole point of the issue — but a
+/// `readonly` desk still denies it, because that tier's contract is that nothing
+/// outside the company is reached at all. Folding it into [`Reach::Nothing`]
+/// would break that contract; folding it into [`Reach::Money`] would bill the
+/// operator for every page read.
+///
+/// [`Standing::PerCall`] stays: the declaration says "this reads", which is not
+/// "hand every remote tool on this server over for a week". A read-only remote
+/// tool nevertheless never parks under `auto` on its own, so nothing is grantable
+/// here for the tier to consult.
+pub fn mcp_call_reach(tool: &str, args: &serde_json::Value, reads: &McpReadSet) -> Consequence {
+    let base = mcp_call_tool_consequence(args);
+    if reads.is_empty() {
+        return base;
+    }
+    match mcp_call_pair(tool, args) {
+        Some((server, remote_tool)) if reads.contains(server, remote_tool) => Consequence {
+            group: EffectGroup::Other,
+            reach: Reach::ExternalRead,
+            standing: Standing::PerCall,
+        },
+        _ => base,
+    }
+}
+
+/// Whether `tool` is one of the MCP bridge tools whose reach a read declaration
+/// can downgrade (#1124). The policy asks this before consulting its
+/// declaration, so a non-bridge tool takes the plain [`consequence_of`] path.
+pub fn is_mcp_bridge_tool(tool: &str) -> bool {
+    tool.eq_ignore_ascii_case(MCP_CALL_TOOL) || tool.eq_ignore_ascii_case(MCP_REGISTRY_TOOL_CALL)
+}
 
 /// Lexical backstop for [`shell_consequence`]: does any whitespace-separated
 /// token in `command` name a location outside the agent's working directory?
@@ -3919,5 +4113,208 @@ mod tests {
         let c = consequence_of(SHELL, &json!({ SHELL_COMMAND_KEY: "ls -la" }));
         assert_eq!(c.reach, Reach::Consequence);
         assert!(c.parks_under_auto());
+    }
+
+    // ── MCP bridge calls, graded against a per-server read declaration (#1124) ──
+
+    /// A `mcp_call_tool` call as the policy layer sees it.
+    fn mcp_call(server: &str, tool: &str) -> serde_json::Value {
+        json!({
+            MCP_CALL_SERVER_KEY: server,
+            MCP_CALL_TOOL_KEY: tool,
+            "arguments": {},
+        })
+    }
+
+    /// A `mcp_registry_tool_call` call — different argument keys, same shape.
+    fn registry_call(server_id: &str, tool_name: &str) -> serde_json::Value {
+        json!({
+            MCP_REGISTRY_SERVER_KEY: server_id,
+            MCP_REGISTRY_TOOL_KEY: tool_name,
+            "arguments": {},
+        })
+    }
+
+    /// **Acceptance criterion 1, for both tools.** A call to a server-declared
+    /// read-only remote tool does not park under `auto`; every other combination
+    /// still parks.
+    ///
+    /// This is the classifier's OWN test (criterion 4): reverting
+    /// [`mcp_call_reach`] to return its base for the declared pair — the whole of
+    /// the downgrade — makes the first two assertions fail, because the declared
+    /// read would park again.
+    #[test]
+    fn a_declared_read_only_remote_tool_does_not_park_but_everything_else_does() {
+        let reads = McpReadSet::from_pairs([
+            ("jira".to_string(), "get_issue".to_string()),
+            ("registry-42".to_string(), "list_rows".to_string()),
+        ]);
+
+        // The declared read on each tool downgrades and stops parking.
+        let call_read = mcp_call_reach(MCP_CALL_TOOL, &mcp_call("jira", "get_issue"), &reads);
+        assert_eq!(call_read.reach, Reach::ExternalRead);
+        assert!(
+            !call_read.parks_under_auto(),
+            "a server-declared read must not park under auto"
+        );
+        let registry_read = mcp_call_reach(
+            MCP_REGISTRY_TOOL_CALL,
+            &registry_call("registry-42", "list_rows"),
+            &reads,
+        );
+        assert_eq!(registry_read.reach, Reach::ExternalRead);
+        assert!(!registry_read.parks_under_auto());
+
+        // Every other combination still parks: a write on the same declared
+        // server, a read on an undeclared server, and the same declared tool name
+        // on the WRONG tool of the pair (server declared, tool not).
+        for (tool, args) in [
+            (MCP_CALL_TOOL, mcp_call("jira", "create_issue")),
+            (MCP_CALL_TOOL, mcp_call("confluence", "get_issue")),
+            (MCP_CALL_TOOL, mcp_call("jira", "list_rows")),
+            (
+                MCP_REGISTRY_TOOL_CALL,
+                registry_call("registry-42", "write_row"),
+            ),
+            (
+                MCP_REGISTRY_TOOL_CALL,
+                registry_call("registry-99", "list_rows"),
+            ),
+            // The keys are not interchangeable across the two tools: a
+            // registry-shaped payload under `mcp_call_tool` reads no `server`.
+            (MCP_CALL_TOOL, registry_call("jira", "get_issue")),
+        ] {
+            let verdict = mcp_call_reach(tool, &args, &reads);
+            assert_eq!(
+                verdict.reach,
+                Reach::Consequence,
+                "`{tool}` {args} is not an affirmatively-declared read and must park"
+            );
+            assert!(
+                verdict.parks_under_auto(),
+                "`{tool}` {args} must park under auto"
+            );
+        }
+    }
+
+    /// The fail-closed base: with no declaration, every bridge call parks — the
+    /// verdict both tools carried before this issue, and the answer for every
+    /// non-harness construction site whose policy sets no read declaration.
+    #[test]
+    fn with_no_declaration_every_bridge_call_gates() {
+        let empty = McpReadSet::default();
+        assert!(empty.is_empty());
+        for (tool, args) in [
+            (MCP_CALL_TOOL, mcp_call("jira", "get_issue")),
+            (MCP_REGISTRY_TOOL_CALL, registry_call("r", "get_issue")),
+        ] {
+            let verdict = mcp_call_reach(tool, &args, &empty);
+            assert_eq!(verdict.reach, Reach::Consequence);
+            assert_eq!(verdict.standing, Standing::PerCall);
+            assert!(verdict.parks_under_auto());
+        }
+    }
+
+    /// A downgraded read is `ExternalRead`, not `Nothing`: it reaches a third
+    /// party's server with the company's credential, so a `readonly` desk still
+    /// denies it and it is never billed — the Composio-read precedent (#559).
+    #[test]
+    fn a_downgraded_read_is_denied_under_readonly_and_is_not_a_spend() {
+        let reads = McpReadSet::from_pairs([("jira".to_string(), "get_issue".to_string())]);
+        let verdict = mcp_call_reach(MCP_CALL_TOOL, &mcp_call("jira", "get_issue"), &reads);
+        assert_eq!(verdict.reach, Reach::ExternalRead);
+        assert!(
+            verdict.reach.denied_under_readonly(),
+            "a read of a counterparty's account is exactly what readonly refuses"
+        );
+        assert!(!verdict.reach.costs_money(), "a read is not billed");
+        assert!(
+            !verdict.reach.parks_under_supervision(),
+            "supervised runs it — nothing changes and nothing is spent"
+        );
+        assert_eq!(verdict.standing, Standing::PerCall);
+    }
+
+    /// A call this cannot read gates, whichever key is missing or mistyped. The
+    /// tools' schemas mark both required, so each of these is a call that could
+    /// not have run — the same fail-closed rule the other argument graders keep.
+    #[test]
+    fn an_unreadable_bridge_call_gates_even_with_a_matching_declaration() {
+        let reads = McpReadSet::from_pairs([
+            ("jira".to_string(), "get_issue".to_string()),
+            ("r".to_string(), "get_issue".to_string()),
+        ]);
+        let unreadable_call = [
+            json!({ MCP_CALL_TOOL_KEY: "get_issue", "arguments": {} }), // no server
+            json!({ MCP_CALL_SERVER_KEY: "jira", "arguments": {} }),    // no tool
+            json!({ MCP_CALL_SERVER_KEY: 7, MCP_CALL_TOOL_KEY: "get_issue" }), // non-string
+            json!({ MCP_CALL_SERVER_KEY: "jira", MCP_CALL_TOOL_KEY: null }),
+            json!(null),
+            json!("jira"),
+        ];
+        for args in unreadable_call {
+            let verdict = mcp_call_reach(MCP_CALL_TOOL, &args, &reads);
+            assert_eq!(verdict.reach, Reach::Consequence, "unreadable: {args}");
+            assert!(verdict.parks_under_auto(), "unreadable: {args}");
+        }
+        // …and the registry twin, under its own keys.
+        for args in [
+            json!({ MCP_REGISTRY_TOOL_KEY: "get_issue", "arguments": {} }),
+            json!({ MCP_REGISTRY_SERVER_KEY: "r", "arguments": {} }),
+            json!({ MCP_REGISTRY_SERVER_KEY: "r", MCP_REGISTRY_TOOL_KEY: 7 }),
+        ] {
+            let verdict = mcp_call_reach(MCP_REGISTRY_TOOL_CALL, &args, &reads);
+            assert_eq!(
+                verdict.reach,
+                Reach::Consequence,
+                "unreadable registry: {args}"
+            );
+        }
+    }
+
+    /// The tool name is matched case-insensitively, the way every other arm of
+    /// the gate reads it — the argument keys, and the bridge-tool predicate.
+    #[test]
+    fn the_bridge_tool_name_is_matched_case_insensitively() {
+        let reads = McpReadSet::from_pairs([("jira".to_string(), "get_issue".to_string())]);
+        assert!(is_mcp_bridge_tool("MCP_CALL_TOOL"));
+        assert!(is_mcp_bridge_tool("Mcp_Registry_Tool_Call"));
+        assert!(!is_mcp_bridge_tool("mcp_list_tools"));
+        let verdict = mcp_call_reach("MCP_CALL_TOOL", &mcp_call("jira", "get_issue"), &reads);
+        assert_eq!(verdict.reach, Reach::ExternalRead);
+    }
+
+    /// The plain `consequence_of` — which the roster, the coverage test and every
+    /// company-blind caller read — still sees the gated verdict for both bridge
+    /// tools. The downgrade lives only where the declaration does, on the policy.
+    #[test]
+    fn consequence_of_reads_both_bridge_tools_as_gated() {
+        for tool in [MCP_CALL_TOOL, MCP_REGISTRY_TOOL_CALL] {
+            let verdict = consequence_of(tool, &mcp_call("jira", "get_issue"));
+            assert_eq!(verdict.reach, Reach::Consequence, "`{tool}`");
+            assert_eq!(verdict.standing, Standing::PerCall, "`{tool}`");
+            assert!(verdict.parks_under_auto(), "`{tool}`");
+        }
+    }
+
+    /// **Acceptance criterion 3.** Both bridge tools sit on the argument-graded
+    /// side of the partition, so the roster and the table stay disjoint and
+    /// `declared_tools` enumerates each exactly once. This is a direct probe of
+    /// the same facts `the_roster_and_the_table_partition_the_known_tool_names`
+    /// enforces over the whole set, named here so a reader of this issue's change
+    /// sees the criterion asserted.
+    #[test]
+    fn both_bridge_tools_are_argument_graded_and_enumerated_once() {
+        for tool in [MCP_CALL_TOOL, MCP_REGISTRY_TOOL_CALL] {
+            assert!(
+                argument_grader(tool).is_some(),
+                "`{tool}` must be dispatched from its arguments"
+            );
+            assert_eq!(
+                declared_tools().filter(|name| *name == tool).count(),
+                1,
+                "`{tool}` holds both a roster entry and a DECLARED row and must be enumerated once"
+            );
+        }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -34,6 +34,6 @@ pub mod judgement;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-pub use consequence::{Consequence, Reach, Standing, consequence_of};
+pub use consequence::{Consequence, McpReadSet, Reach, Standing, consequence_of};
 pub use gate::{DEFAULT_TTL_MILLIS, ManifestApprovalGate};
 pub use judgement::{CallPath, Judgement, StopReason, judge};

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -83,6 +83,10 @@ pub(super) struct McpServerDto {
     pub(super) enabled: bool,
     pub(super) allowed_tools: Vec<String>,
     pub(super) disallowed_tools: Vec<String>,
+    /// Remote tool names the operator declared read-only on this server (issue
+    /// #1124). The console renders this beside the two lists above, with the same
+    /// source badge, so an operator sees which layer declared it.
+    pub(super) read_only_tools: Vec<String>,
     pub(super) timeout_secs: u64,
     /// Whether an outbound credential is stored — never the credential itself.
     ///
@@ -198,6 +202,9 @@ struct AddServer {
     allowed_tools: Vec<String>,
     #[serde(default)]
     disallowed_tools: Vec<String>,
+    /// Remote tool names to declare read-only on this server (issue #1124).
+    #[serde(default)]
+    read_only_tools: Vec<String>,
     #[serde(default)]
     timeout_secs: Option<u64>,
     /// The outbound credential value, stored write-only. Omit to leave auth
@@ -230,6 +237,10 @@ struct UpdateServer {
     allowed_tools: Option<Vec<String>>,
     #[serde(default)]
     disallowed_tools: Option<Vec<String>>,
+    /// Replace the read-only declaration (issue #1124). Omit to leave it
+    /// unchanged; send `[]` to clear it.
+    #[serde(default)]
+    read_only_tools: Option<Vec<String>>,
     #[serde(default)]
     timeout_secs: Option<u64>,
     /// Rotate the outbound credential (write-only). Omit to leave it unchanged.
@@ -315,6 +326,7 @@ fn dto_from_decl(
         enabled: decl.enabled,
         allowed_tools: decl.allowed_tools.clone(),
         disallowed_tools: decl.disallowed_tools.clone(),
+        read_only_tools: decl.read_only_tools.clone(),
         timeout_secs: decl.timeout_secs,
         auth_configured: decl.auth.is_configured(),
         // A List A decl knows nothing about a directory install; the merge pass
@@ -493,6 +505,7 @@ async fn add_server(
         command: None,
         allowed_tools: body.allowed_tools.clone(),
         disallowed_tools: body.disallowed_tools.clone(),
+        read_only_tools: body.read_only_tools.clone(),
         timeout_secs: body.timeout_secs.unwrap_or(30),
         enabled: true,
         auth_secret: None,
@@ -590,6 +603,9 @@ async fn update_server(
     }
     if let Some(disallowed) = patch.disallowed_tools.clone() {
         server.disallowed_tools = disallowed;
+    }
+    if let Some(read_only) = patch.read_only_tools.clone() {
+        server.read_only_tools = read_only;
     }
     if let Some(timeout) = patch.timeout_secs {
         server.timeout_secs = timeout;

--- a/src/server/ops/mcp_registry.rs
+++ b/src/server/ops/mcp_registry.rs
@@ -316,11 +316,12 @@ fn row_from_install(
         description: install.description,
         source: McpSource::Registry,
         enabled: install.enabled,
-        // The directory does not express per-tool allow/deny, and OpenHuman's
-        // bridge tools do not consult one. Empty is the truthful projection, not
-        // a placeholder.
+        // The directory does not express per-tool allow/deny or a read-only
+        // declaration (issue #1124), and OpenHuman's bridge tools do not consult
+        // one here. Empty is the truthful projection, not a placeholder.
         allowed_tools: Vec::new(),
         disallowed_tools: Vec::new(),
+        read_only_tools: Vec::new(),
         timeout_secs: REGISTRY_TIMEOUT_SECS,
         auth_configured: install.auth_configured,
         server_id: Some(install.server_id),

--- a/src/server/ops/mcp_registry/tests.rs
+++ b/src/server/ops/mcp_registry/tests.rs
@@ -20,6 +20,7 @@ fn declared(name: &str, endpoint: &str, source: McpSource) -> McpServerDto {
         enabled: true,
         allowed_tools: Vec::new(),
         disallowed_tools: Vec::new(),
+        read_only_tools: Vec::new(),
         timeout_secs: 30,
         auth_configured: false,
         server_id: None,


### PR DESCRIPTION
## Summary

`mcp_call_tool` and `mcp_registry_tool_call` were declared flatly by tool name in `src/policy/consequence.rs`, so every remote MCP call cost the operator the same approval card whether it read a Jira ticket or filed one (#1124, split from #877). This keys the gate on the (server, tool) pair the call already carries, downgrading **only** a server-declared read-only remote tool.

- A third per-server list, `read_only_tools`, on `McpServerDecl` / `McpServer` (`#[serde(default)]`, normalized like `allowed_tools`/`disallowed_tools`), merged through `effective_mcp_servers` into an `McpReadSet` and editable through the runtime-override layer.
- The lookup reaches the pure `consequence_of` via a `with_mcp_reads(...)` builder on `ApprovalPolicy` (mirroring `with_requests`/`with_spend`/`with_agent`), wired only in `build_roster` for both manifest and overlay agents.
- Both `mcp_call_tool` and `mcp_registry_tool_call` are `ARGUMENT_GRADED` rows (keyed on `server`/`tool` and `server_id`/`tool_name` respectively, both required per their schemas).
- **Fail-closed by construction:** `mcp_call_reach` returns the parking `Reach::Consequence` base for an empty read set, an unreadable argument, an undeclared server, or a tool not on the read list; only affirmative `McpReadSet` membership yields `Reach::ExternalRead`. It does **not** call the tier-coupled vendored `Tool::external_effect_with_args` (which fails open); the vendored hook is used only as a test oracle at `AutonomyLevel::Supervised`.
- Console DTO + Add/Update bodies + API-client types carry `read_only_tools`/`readOnlyTools`.

## API Or Behavior Changes

Additive. `read_only_tools` is a new optional per-server manifest/runtime field (absent → today's behavior exactly: every remote call parks). A remote tool an operator declares read-only on its server no longer parks under `auto`; every other combination still parks.

**Scoped follow-up (not in this PR):** an interactive `readOnlyTools` editor in the console. The existing `allowed_tools`/`disallowed_tools` lists are not rendered/edited anywhere in the views today, so a three-list tool editor is net-new UI rather than a small extension. Backend + wire + provenance-badge inheritance are complete.

## Tests

Consequence-layer tests (fail-closed base, `ExternalRead`-not-`Nothing`, unreadable-argument for both tools, case-insensitivity, the partition probe) plus a new end-to-end policy-layer test driving `ApprovalPolicy::check()` under `auto`. Revert-checks bite (neutralizing the downgrade fails 3 consequence tests; neutralizing the bridge routing fails the policy test).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default and `openhuman,tinycortex,mcp`)
- [x] `cargo build --all-targets`
- [x] `cargo test` (default `3204 passed`; `--features openhuman,tinycortex,mcp` `4858 passed`; integration targets pass) — plus `frontend` `tsc`/`build`/`1664` tests for the wire fields

## Documentation

Inline docs on the new declaration, `McpReadSet`, and the fail-closed reasoning. No spec/module doc restructure needed.

Closes #1124
