### PR TITLE
fix(memory): unfreeze Brain list, guard multibyte slices, serve bodies in one pass (#1488)

### DIFF
--- a/src/ports/context.rs
+++ b/src/ports/context.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use async_trait::async_trait;
 
 use crate::Result;
-use crate::ports::types::{ChunkAddr, ChunkHit, ChunkMeta, CompanyId, ContextChunk};
+use crate::ports::types::{ChunkAddr, ChunkHit, ChunkMeta, ChunkWithBody, CompanyId, ContextChunk};
 
 /// The RLM environment: addressable context chunks. Mirrors Medulla's
 /// `ContextStore` port.
@@ -15,6 +15,24 @@ pub trait ContextStore: Send + Sync {
     async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr>;
     /// Lists chunk metadata under `prefix`.
     async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>>;
+    /// Lists chunk metadata under `prefix`, each paired with its body.
+    ///
+    /// For a caller that needs every body — the console's Brain list — this is
+    /// one enumeration rather than a `list` plus one `peek` per row. The default
+    /// preserves exactly that shape (`list` then a `peek` each) so every existing
+    /// backend keeps working unchanged; the durable backends override it to read
+    /// bodies in the same pass. A read fault surfaces rather than being laundered
+    /// into a blank body — the durable overrides read each body in the row that
+    /// already carries it, so there is no separate per-row read to lose.
+    async fn list_with_bodies(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkWithBody>> {
+        let metas = self.list(id, prefix).await?;
+        let mut out = Vec::with_capacity(metas.len());
+        for meta in metas {
+            let body = self.peek(id, &meta.addr, None).await?;
+            out.push(ChunkWithBody { meta, body });
+        }
+        Ok(out)
+    }
     /// Reads a chunk (optionally a byte range) as text.
     async fn peek(
         &self,

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2020,6 +2020,21 @@ pub struct ChunkMeta {
     pub stored_at_millis: u64,
 }
 
+/// A context chunk's metadata paired with its body, returned by
+/// [`ContextStore::list_with_bodies`](crate::ports::ContextStore::list_with_bodies).
+///
+/// Lets a caller that needs every body under a prefix — the console's Brain
+/// list is the one such caller — get them in a single enumeration instead of a
+/// `list` followed by one `peek` per row, which on the provider overlay was a
+/// full account read each.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChunkWithBody {
+    /// The chunk's metadata (address, label, length, store time).
+    pub meta: ChunkMeta,
+    /// The chunk's full body.
+    pub body: String,
+}
+
 /// A single ledger movement.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LedgerEntry {

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::error::OpenCompanyError;
 use crate::ports::facts::{FactKind, FactRecord};
-use crate::ports::types::{CompanyEvent, ContextChunk};
+use crate::ports::types::{ChunkWithBody, CompanyEvent, ContextChunk};
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
@@ -332,48 +332,49 @@ async fn list_facts(
     // A fact-kind filter is inherently facts-only — context chunks carry no
     // `FactKind`, so skip them (and the reads) when one is set.
     if kind.is_none() {
-        // `""` lists every chunk; drop the operator-fact mirrors before peeking
-        // so we neither double-list them nor pay to read their bodies, then cap
-        // the reads so a huge context store can't unbound this request.
-        let mirror_prefix = format!("{OPERATOR_FACT_PREFIX}/");
-        let metas = company.runtime.context.list(company.id(), "").await?;
-        let mut chunks = Vec::new();
-        for meta in metas
-            .into_iter()
-            .filter(|m| !m.label.starts_with(&mirror_prefix))
-            .take(MAX_CONTEXT_ENTRIES)
-        {
-            // A peek failure degrades one row to an empty body rather than
-            // failing the whole list, but log it so a real storage fault
-            // surfaces instead of silently rendering blank cards.
-            let body = match company
-                .runtime
-                .context
-                .peek(company.id(), &meta.addr, None)
-                .await
-            {
-                Ok(body) => body,
-                Err(err) => {
-                    tracing::warn!(
-                        company = %company.id(),
-                        addr = %meta.addr,
-                        error = %err,
-                        "failed to peek context chunk; rendering empty body"
-                    );
-                    String::new()
-                }
-            };
-            chunks.push(RawChunk {
-                addr: meta.addr.to_string(),
-                label: meta.label,
-                body,
-                stored_at_millis: meta.stored_at_millis,
-            });
-        }
-        entries.extend(context_entries(chunks, query.as_deref()));
+        // One enumeration carries every body, so the whole page costs a single
+        // read on the durable backends (and one account read on the provider
+        // overlay) rather than a `list` followed by `MAX_CONTEXT_ENTRIES`
+        // per-row `peek`s — each a fresh account enumeration on that overlay.
+        let with_bodies = company
+            .runtime
+            .context
+            .list_with_bodies(company.id(), "")
+            .await?;
+        entries.extend(context_entries(
+            newest_context_chunks(with_bodies),
+            query.as_deref(),
+        ));
     }
 
     Ok(Json(entries))
+}
+
+/// Selects the page of context chunks the Brain list renders: drops the
+/// operator-fact mirrors, keeps the newest [`MAX_CONTEXT_ENTRIES`], and hands
+/// them to [`context_entries`] as [`RawChunk`]s carrying the body already read.
+///
+/// Backends list oldest-first, so an unsorted `take` would freeze the list on
+/// the first `MAX_CONTEXT_ENTRIES` chunks ever written and silently drop every
+/// newer memory while `/memory/stats` kept counting up (issue #1488). Sorting
+/// newest-first before the cap keeps the most recent memories, not the stalest.
+/// An unstamped chunk (`0`) sorts last, behind anything with a real stamp.
+fn newest_context_chunks(with_bodies: Vec<ChunkWithBody>) -> Vec<RawChunk> {
+    let mirror_prefix = format!("{OPERATOR_FACT_PREFIX}/");
+    let mut with_bodies = with_bodies;
+    // Drop the operator-fact mirrors: they double-list their FactStore row.
+    with_bodies.retain(|c| !c.meta.label.starts_with(&mirror_prefix));
+    with_bodies.sort_by_key(|c| std::cmp::Reverse(c.meta.stored_at_millis));
+    with_bodies
+        .into_iter()
+        .take(MAX_CONTEXT_ENTRIES)
+        .map(|c| RawChunk {
+            addr: c.meta.addr.to_string(),
+            label: c.meta.label,
+            body: c.body,
+            stored_at_millis: c.meta.stored_at_millis,
+        })
+        .collect()
 }
 
 /// `GET /memory/stats` — counts across the fact store and the agents' context
@@ -604,6 +605,85 @@ mod combined_list_tests {
             body: body.to_string(),
             stored_at_millis,
         }
+    }
+
+    fn with_body(label: &str, body: &str, stored_at_millis: u64) -> ChunkWithBody {
+        ChunkWithBody {
+            meta: crate::ports::types::ChunkMeta {
+                addr: crate::ports::types::ChunkAddr::new(format!("addr-{label}")),
+                label: label.to_string(),
+                len: body.len(),
+                stored_at_millis,
+            },
+            body: body.to_string(),
+        }
+    }
+
+    /// Major #1 (issue #1488): the Brain list froze on the oldest 500 chunks
+    /// because it capped an oldest-first enumeration with no sort — so past 500
+    /// chunks, every newer memory was silently dropped. Prove the cap now keeps
+    /// the NEWEST `MAX_CONTEXT_ENTRIES` and drops the stalest.
+    #[test]
+    fn the_cap_keeps_the_newest_chunks_not_the_oldest() {
+        // More than the cap, handed in oldest-first as the backends list them:
+        // stamp `i` for the i-th chunk, so higher stamp == newer.
+        let total = MAX_CONTEXT_ENTRIES + 50;
+        let input: Vec<ChunkWithBody> = (0..total)
+            .map(|i| with_body(&format!("agent-1/m{i}"), &format!("memory {i}"), i as u64))
+            .collect();
+
+        let kept = newest_context_chunks(input);
+        assert_eq!(kept.len(), MAX_CONTEXT_ENTRIES, "the page is capped");
+
+        let kept_stamps: std::collections::HashSet<u64> =
+            kept.iter().map(|c| c.stored_at_millis).collect();
+        // The 50 oldest (stamps 0..50) must be the ones dropped.
+        for old in 0..50u64 {
+            assert!(
+                !kept_stamps.contains(&old),
+                "the stalest chunk (stamp {old}) must be dropped, not frozen in"
+            );
+        }
+        // The newest chunk ever written must survive — the exact memory the old
+        // unsorted `take` dropped once the store passed the cap.
+        assert!(
+            kept_stamps.contains(&((total - 1) as u64)),
+            "the newest memory must be kept"
+        );
+    }
+
+    /// An unstamped legacy chunk (`0`) sorts last, so it never displaces a
+    /// real, freshly-stamped memory out of the capped page.
+    #[test]
+    fn unstamped_chunks_sort_behind_stamped_ones() {
+        let mut input = vec![with_body("agent-1/legacy", "legacy", 0)];
+        input.extend(
+            (1..=MAX_CONTEXT_ENTRIES)
+                .map(|i| with_body(&format!("agent-1/m{i}"), &format!("memory {i}"), i as u64)),
+        );
+
+        let kept = newest_context_chunks(input);
+        assert_eq!(kept.len(), MAX_CONTEXT_ENTRIES);
+        assert!(
+            !kept.iter().any(|c| c.stored_at_millis == 0),
+            "the unstamped chunk is evicted first, behind every stamped one"
+        );
+    }
+
+    /// The mirror-drop happens before the cap, and the bodies enumerated up
+    /// front reach the rendered rows without a second read.
+    #[test]
+    fn mirrors_drop_and_bodies_carry_through() {
+        let kept = newest_context_chunks(vec![
+            with_body("operator-fact/f1", "mirror body", 3),
+            with_body("agent-1/note", "real memory body", 2),
+        ]);
+        assert_eq!(kept.len(), 1, "the operator-fact mirror is dropped");
+        assert_eq!(kept[0].label, "agent-1/note");
+        assert_eq!(
+            kept[0].body, "real memory body",
+            "the body carried by the enumeration renders without a re-read"
+        );
     }
 
     fn fact(id: &str, kind: FactKind, title: &str) -> FactRecord {

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2336,6 +2336,96 @@ pub async fn assert_context_chunk_stamps(context: Arc<dyn ContextStore>) {
     assert!(context.list(&beta, "").await.unwrap().is_empty());
 }
 
+/// Asserts every [`ContextStore`] backend handles multibyte bodies without
+/// panicking, and serves bodies through `list_with_bodies` in one pass.
+///
+/// Issue #1488's two backend-side majors, pinned as one contract every backend
+/// must satisfy:
+///
+/// - **Multibyte-safe reads.** Search snippets and ranged `peek` used to slice
+///   raw byte offsets, so a match or range abutting a multibyte char panicked
+///   with "byte index is not a char boundary". `memory_recall` routes agent
+///   queries into `search`, so the panic was agent-reachable — it aborted the
+///   call. The body is built so the snippet's leading window (`pos - 24`) lands
+///   *inside* a leading 2-byte "é", and a ranged peek ends *inside* it too; both
+///   must widen to a boundary rather than aborting.
+/// - **Bodies from the enumeration.** `list_with_bodies` must carry each body
+///   from the same pass, so the console's Brain list pays one read for the page
+///   rather than a `list` plus one `peek` per row.
+pub async fn assert_context_multibyte_and_bodies(context: Arc<dyn ContextStore>) {
+    let id = CompanyId::new("acme");
+    // A leading 2-byte "é" (bytes 0..2), then 23 ASCII fillers, so "brunch"
+    // begins at byte 25 and the snippet's `pos - 24 = 1` lands mid-"é" — the
+    // exact offset the old `body[pos-24..]` panicked on. A trailing "café" and
+    // "here" give the search a whole-char window on both sides.
+    let body = "éxxxxxxxxxxxxxxxxxxxxxxxbrunch and more café here";
+    let addr = context
+        .put(
+            &id,
+            ContextChunk {
+                label: "notes/menu".to_string(),
+                body: body.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Search: the raw `body[pos-24..]` used to land mid-"é" and panic.
+    let hits = context.search(&id, "brunch", 5).await.unwrap();
+    assert_eq!(hits.len(), 1, "the one matching chunk is found");
+    assert!(
+        hits[0].snippet.contains("brunch"),
+        "the snippet keeps the match without panicking mid-codepoint: {}",
+        hits[0].snippet
+    );
+
+    // Ranged peek: the leading "é" occupies bytes 0..2, so an end of 1 lands
+    // mid-char. A raw `body[0..1]` would panic; the read widens outward to 2.
+    let ranged = context.peek(&id, &addr, Some(0..1)).await.unwrap();
+    assert_eq!(
+        ranged, "é",
+        "a mid-codepoint range widens outward rather than panicking"
+    );
+
+    // list_with_bodies carries the body from the same enumeration.
+    context
+        .put(
+            &id,
+            ContextChunk {
+                label: "notes/plain".to_string(),
+                body: "second body".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    let mut rows = context.list_with_bodies(&id, "notes/").await.unwrap();
+    rows.sort_by(|a, b| a.meta.label.cmp(&b.meta.label));
+    assert_eq!(rows.len(), 2, "both matching chunks come back with bodies");
+    assert_eq!(rows[0].meta.label, "notes/menu");
+    assert_eq!(rows[0].body, body);
+    assert_eq!(rows[1].meta.label, "notes/plain");
+    assert_eq!(rows[1].body, "second body");
+
+    // The prefix filter narrows both metadata and bodies, and isolation holds.
+    assert!(
+        context
+            .list_with_bodies(&id, "other/")
+            .await
+            .unwrap()
+            .is_empty(),
+        "a non-matching prefix returns nothing"
+    );
+    let other = CompanyId::new("beta");
+    assert!(
+        context
+            .list_with_bodies(&other, "")
+            .await
+            .unwrap()
+            .is_empty(),
+        "list_with_bodies stays scoped to its company"
+    );
+}
+
 /// Asserts the [`UsageMeter`] contract: isolation, record, and windowed query.
 pub async fn assert_usage_meter(usage: Arc<dyn UsageMeter>) {
     let alpha = CompanyId::new("alpha");

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -1318,6 +1318,34 @@ impl ContextStore for FsContextStore {
             .collect())
     }
 
+    async fn list_with_bodies(
+        &self,
+        id: &CompanyId,
+        prefix: &str,
+    ) -> Result<Vec<crate::ports::types::ChunkWithBody>> {
+        // One index read + one blob read per matching row, rather than the
+        // default's `list` followed by a fresh `peek` (its own blob read) each.
+        let bundle = self.bundle(id);
+        let index = read_jsonl::<IndexEntry>(&bundle.context_index_jsonl()).await?;
+        let mut out = Vec::new();
+        for e in index.into_iter().filter(|e| e.label.starts_with(prefix)) {
+            let blob_path = bundle.context_blob(&e.addr);
+            let body = tokio::fs::read_to_string(&blob_path)
+                .await
+                .map_err(|err| io_err(&blob_path, err))?;
+            out.push(crate::ports::types::ChunkWithBody {
+                meta: ChunkMeta {
+                    addr: ChunkAddr::new(e.addr),
+                    label: e.label,
+                    len: e.len,
+                    stored_at_millis: e.stored_at_millis,
+                },
+                body,
+            });
+        }
+        Ok(out)
+    }
+
     async fn peek(
         &self,
         id: &CompanyId,
@@ -1330,14 +1358,7 @@ impl ContextStore for FsContextStore {
             .map_err(|e| io_err(&path, e))?;
         match range {
             None => Ok(body),
-            Some(r) => {
-                let start = r.start.min(body.len());
-                let end = r.end.min(body.len());
-                if start >= end {
-                    return Ok(String::new());
-                }
-                Ok(body[start..end].to_string())
-            }
+            Some(r) => Ok(crate::store::slice_on_char_boundaries(&body, r)),
         }
     }
 
@@ -1385,11 +1406,9 @@ impl ContextStore for FsContextStore {
                 continue;
             };
             if let Some(pos) = body.find(query) {
-                let start = pos.saturating_sub(24);
-                let end = (pos + query.len() + 24).min(body.len());
                 hits.push(ChunkHit {
                     addr: ChunkAddr::new(entry.addr),
-                    snippet: body[start..end].to_string(),
+                    snippet: crate::store::search_snippet(&body, pos, query),
                     score: 1.0,
                 });
             }
@@ -2160,6 +2179,14 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_context_chunk_stamps(Arc::new(FsContextStore::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_multibyte_and_bodies() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_context_multibyte_and_bodies(Arc::new(FsContextStore::new(&root)))
+            .await;
     }
 
     /// Two event logs over one data root must not hand out the same sequence

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -415,23 +415,44 @@ impl ContextStore for ProviderContextStore {
     }
 
     async fn list(&self, company: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
+        Ok(self
+            .list_with_bodies(company, prefix)
+            .await?
+            .into_iter()
+            .map(|chunk| chunk.meta)
+            .collect())
+    }
+
+    async fn list_with_bodies(
+        &self,
+        company: &CompanyId,
+        prefix: &str,
+    ) -> Result<Vec<crate::ports::types::ChunkWithBody>> {
+        // The one account enumeration already carries every body. The default
+        // would throw those away in `list` and then re-`get` each one — a fresh
+        // full enumeration per row. Keep them, so the console route pays a single
+        // read for the whole page instead of O(n) account reads.
         let chunks: Vec<StoredChunk> = self.bound.list(company).await?;
-        let mut metas: Vec<ChunkMeta> = chunks
+        let mut with_bodies: Vec<crate::ports::types::ChunkWithBody> = chunks
             .into_iter()
             .filter(|chunk| chunk.label.starts_with(prefix))
-            .map(|chunk| ChunkMeta {
-                addr: ChunkAddr::new(content_address(&chunk.body)),
-                label: chunk.label,
-                len: chunk.body.len(),
-                stored_at_millis: chunk.stored_at_millis,
+            .map(|chunk| crate::ports::types::ChunkWithBody {
+                meta: ChunkMeta {
+                    addr: ChunkAddr::new(content_address(&chunk.body)),
+                    label: chunk.label,
+                    len: chunk.body.len(),
+                    stored_at_millis: chunk.stored_at_millis,
+                },
+                body: chunk.body,
             })
             .collect();
-        metas.sort_by(|a, b| {
-            a.stored_at_millis
-                .cmp(&b.stored_at_millis)
-                .then_with(|| a.addr.as_ref().cmp(b.addr.as_ref()))
+        with_bodies.sort_by(|a, b| {
+            a.meta
+                .stored_at_millis
+                .cmp(&b.meta.stored_at_millis)
+                .then_with(|| a.meta.addr.as_ref().cmp(b.meta.addr.as_ref()))
         });
-        Ok(metas)
+        Ok(with_bodies)
     }
 
     async fn peek(
@@ -450,7 +471,7 @@ impl ContextStore for ProviderContextStore {
         let Some(range) = range else {
             return Ok(chunk.body);
         };
-        Ok(slice_on_char_boundaries(&chunk.body, range))
+        Ok(crate::store::slice_on_char_boundaries(&chunk.body, range))
     }
 
     async fn delete(&self, company: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
@@ -487,43 +508,16 @@ impl ContextStore for ProviderContextStore {
     }
 }
 
-/// Clamps `range` to the string's length and to char boundaries.
-///
-/// A byte range that lands mid-character would panic on a naive slice. The
-/// callers here are the brain's own `peek` offsets, which are byte counts it
-/// derived from a previous read, so a mid-character bound is reachable with any
-/// non-ASCII body. Widening outward to the nearest boundary returns slightly
-/// more than asked rather than failing the read.
-fn slice_on_char_boundaries(body: &str, range: Range<usize>) -> String {
-    let start = floor_boundary(body, range.start.min(body.len()));
-    let end = ceil_boundary(body, range.end.min(body.len()));
-    if start >= end {
-        return String::new();
-    }
-    body[start..end].to_string()
-}
-
-fn floor_boundary(s: &str, mut at: usize) -> usize {
-    while at > 0 && !s.is_char_boundary(at) {
-        at -= 1;
-    }
-    at
-}
-
-fn ceil_boundary(s: &str, mut at: usize) -> usize {
-    while at < s.len() && !s.is_char_boundary(at) {
-        at += 1;
-    }
-    at
-}
-
 /// The leading window of a body, used as a search snippet.
+///
+/// Char-boundary-safe via [`crate::store::slice_on_char_boundaries`] (widening
+/// outward), so a multibyte char straddling the cut can't panic the read.
 fn snippet(body: &str) -> String {
     const MAX: usize = 200;
     if body.len() <= MAX {
         return body.to_string();
     }
-    body[..ceil_boundary(body, MAX)].to_string()
+    crate::store::slice_on_char_boundaries(body, 0..MAX)
 }
 
 // ---------------------------------------------------------------------------
@@ -779,6 +773,7 @@ mod test {
     fn peek_range_widens_to_char_boundaries_instead_of_panicking() {
         // "é" is two bytes; a range that splits it would panic on a raw slice.
         let body = "aébc";
+        use crate::store::slice_on_char_boundaries;
         assert_eq!(slice_on_char_boundaries(body, 0..2), "aé");
         assert_eq!(slice_on_char_boundaries(body, 1..2), "é");
         // Past the end clamps rather than panicking.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -116,6 +116,7 @@ pub use tinycortex::{CortexClient, CortexContextStore, CortexMemoryStore, InMemo
 pub use tinycortex_engine::EngineCortex;
 
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::ops::Range;
 
 /// Computes the content address of a context-chunk body.
 ///
@@ -127,4 +128,120 @@ pub(crate) fn content_address(body: &str) -> String {
     let mut hasher = DefaultHasher::new();
     body.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
+}
+
+/// Slices `body` on `range`, clamped to its length and widened outward to the
+/// nearest char boundaries.
+///
+/// A byte range that lands mid-character panics a naive `body[range]`. Every
+/// [`ContextStore`](crate::ports::ContextStore) backend derives such ranges from
+/// byte offsets — ranged `peek` from a caller's own byte count, and `search`
+/// from `str::find` positions widened by a fixed ±24-byte window — so a
+/// multibyte char within the window is reachable with any non-ASCII body, and is
+/// agent-reachable through `memory_recall` (see
+/// `harness::built_in::memory_tools`). Widening to the nearest boundary returns
+/// slightly more than asked rather than panicking the read.
+///
+/// A start at or past the (clamped) end yields the empty string, so a reversed
+/// or out-of-range request is an empty slice, not a panic.
+pub(crate) fn slice_on_char_boundaries(body: &str, range: Range<usize>) -> String {
+    let start = floor_char_boundary(body, range.start.min(body.len()));
+    let end = ceil_char_boundary(body, range.end.min(body.len()));
+    if start >= end {
+        return String::new();
+    }
+    body[start..end].to_string()
+}
+
+/// The largest char boundary at or below `at` (which must be `<= s.len()`).
+fn floor_char_boundary(s: &str, mut at: usize) -> usize {
+    while at > 0 && !s.is_char_boundary(at) {
+        at -= 1;
+    }
+    at
+}
+
+/// The smallest char boundary at or above `at` (which must be `<= s.len()`).
+fn ceil_char_boundary(s: &str, mut at: usize) -> usize {
+    while at < s.len() && !s.is_char_boundary(at) {
+        at += 1;
+    }
+    at
+}
+
+/// Bytes of context kept on each side of a search match in a snippet.
+const SNIPPET_CONTEXT_BYTES: usize = 24;
+
+/// Builds a search-hit snippet: `query` found at byte `pos` in `body`, plus up
+/// to [`SNIPPET_CONTEXT_BYTES`] of surrounding context on each side, sliced on
+/// char boundaries so a multibyte char inside the window can't panic the read.
+///
+/// Shared by every [`ContextStore`](crate::ports::ContextStore) backend's
+/// `search` so the fs, sqlite, and mongodb snippets are byte-for-byte identical
+/// and share the one boundary-safe path.
+pub(crate) fn search_snippet(body: &str, pos: usize, query: &str) -> String {
+    let start = pos.saturating_sub(SNIPPET_CONTEXT_BYTES);
+    let end = pos + query.len() + SNIPPET_CONTEXT_BYTES;
+    slice_on_char_boundaries(body, start..end)
+}
+
+#[cfg(test)]
+mod slice_tests {
+    use super::{search_snippet, slice_on_char_boundaries};
+
+    #[test]
+    fn ascii_range_is_returned_verbatim() {
+        assert_eq!(slice_on_char_boundaries("hello world", 0..5), "hello");
+        assert_eq!(slice_on_char_boundaries("hello world", 6..11), "world");
+    }
+
+    #[test]
+    fn a_mid_codepoint_bound_widens_instead_of_panicking() {
+        // "é" is two bytes (0xC3 0xA9). A range that starts or ends inside it
+        // would panic a naive slice; both bounds widen outward to keep the whole
+        // char rather than aborting the read.
+        let body = "aé b";
+        assert_eq!(slice_on_char_boundaries(body, 1..2), "é");
+        assert_eq!(slice_on_char_boundaries(body, 0..2), "aé");
+        // A range wholly inside the multibyte char still yields that char.
+        assert_eq!(slice_on_char_boundaries(body, 2..3), "é");
+    }
+
+    #[test]
+    fn out_of_range_and_reversed_bounds_are_empty() {
+        assert_eq!(slice_on_char_boundaries("abc", 0..999), "abc");
+        // A reversed range (start past end) is empty, not a panic. Built from
+        // variables so it isn't a literal empty-range clippy flags at compile time.
+        let (start, end) = (3usize, 1usize);
+        assert_eq!(slice_on_char_boundaries("abc", start..end), "");
+        assert_eq!(slice_on_char_boundaries("abc", 10..20), "");
+    }
+
+    #[test]
+    fn a_snippet_next_to_a_multibyte_char_does_not_panic() {
+        // The match sits one byte after a 2-byte "é", well within the 24-byte
+        // context window, so the naive `body[pos-24..]` used to land mid-"é" and
+        // panic. The snippet must come back whole, containing the match.
+        let body = "café menu today";
+        let pos = body.find("menu").expect("query present");
+        let snippet = search_snippet(body, pos, "menu");
+        assert!(
+            snippet.contains("menu"),
+            "snippet keeps the match: {snippet}"
+        );
+        assert!(snippet.contains("café"), "leading context is char-safe");
+    }
+
+    #[test]
+    fn a_snippet_bounded_by_a_trailing_multibyte_char_does_not_panic() {
+        // The 24-byte trailing window ends inside a multibyte char; widening
+        // keeps the whole char rather than aborting.
+        let body = "find the café";
+        let pos = body.find("find").expect("query present");
+        let snippet = search_snippet(body, pos, "find");
+        assert!(
+            snippet.ends_with("café"),
+            "trailing char kept whole: {snippet}"
+        );
+    }
 }

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -986,6 +986,37 @@ impl ContextStore for MongoStore {
         Ok(out)
     }
 
+    async fn list_with_bodies(
+        &self,
+        id: &CompanyId,
+        prefix: &str,
+    ) -> Result<Vec<crate::ports::types::ChunkWithBody>> {
+        // One cursor carries every field, including `body`, rather than the
+        // default's `list` followed by a per-row `peek` (a `find_one` each).
+        let mut cursor = self
+            .collection("context_chunks")
+            .find(doc! {"company_id": id.as_ref()})
+            .sort(doc! {"ord": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            let label = get_str(&doc, "label")?;
+            if label.starts_with(prefix) {
+                out.push(crate::ports::types::ChunkWithBody {
+                    meta: ChunkMeta {
+                        addr: ChunkAddr::new(get_str(&doc, "addr")?),
+                        label,
+                        len: get_i64(&doc, "len")? as usize,
+                        stored_at_millis: doc.get_i64("stored_ms").unwrap_or(0).max(0) as u64,
+                    },
+                    body: get_str(&doc, "body")?,
+                });
+            }
+        }
+        Ok(out)
+    }
+
     async fn delete(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
         let result = self
             .collection("context_chunks")
@@ -1012,14 +1043,7 @@ impl ContextStore for MongoStore {
         let body = get_str(&doc, "body")?;
         match range {
             None => Ok(body),
-            Some(r) => {
-                let start = r.start.min(body.len());
-                let end = r.end.min(body.len());
-                if start >= end {
-                    return Ok(String::new());
-                }
-                Ok(body[start..end].to_string())
-            }
+            Some(r) => Ok(crate::store::slice_on_char_boundaries(&body, r)),
         }
     }
 
@@ -1037,11 +1061,9 @@ impl ContextStore for MongoStore {
             }
             let body = get_str(&doc, "body")?;
             if let Some(pos) = body.find(query) {
-                let start = pos.saturating_sub(24);
-                let end = (pos + query.len() + 24).min(body.len());
                 hits.push(ChunkHit {
                     addr: ChunkAddr::new(get_str(&doc, "addr")?),
-                    snippet: body[start..end].to_string(),
+                    snippet: crate::store::search_snippet(&body, pos, query),
                     score: 1.0,
                 });
             }
@@ -4621,6 +4643,13 @@ mod test {
     async fn conformance_context_chunk_stamps() {
         let Some(s) = store().await else { return };
         conformance::assert_context_chunk_stamps(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_multibyte_and_bodies() {
+        let Some(s) = store().await else { return };
+        conformance::assert_context_multibyte_and_bodies(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1003,6 +1003,49 @@ impl ContextStore for SqliteStore {
         Ok(out)
     }
 
+    async fn list_with_bodies(
+        &self,
+        id: &CompanyId,
+        prefix: &str,
+    ) -> Result<Vec<crate::ports::types::ChunkWithBody>> {
+        // One query returns metadata and body together, rather than the
+        // default's `list` followed by a per-row `peek` (a `SELECT` each).
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT addr, label, len, stored_ms, body FROM context_chunks \
+                 WHERE company_id = ?1 ORDER BY rowid",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![id.as_ref()], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?,
+                    r.get::<_, i64>(3)?,
+                    r.get::<_, String>(4)?,
+                ))
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (addr, label, len, stored_ms, body) = row.map_err(sql_err)?;
+            if label.starts_with(prefix) {
+                out.push(crate::ports::types::ChunkWithBody {
+                    meta: ChunkMeta {
+                        addr: ChunkAddr::new(addr),
+                        label,
+                        len: len as usize,
+                        stored_at_millis: stored_ms.max(0) as u64,
+                    },
+                    body,
+                });
+            }
+        }
+        Ok(out)
+    }
+
     async fn peek(
         &self,
         id: &CompanyId,
@@ -1023,14 +1066,7 @@ impl ContextStore for SqliteStore {
         })?;
         match range {
             None => Ok(body),
-            Some(r) => {
-                let start = r.start.min(body.len());
-                let end = r.end.min(body.len());
-                if start >= end {
-                    return Ok(String::new());
-                }
-                Ok(body[start..end].to_string())
-            }
+            Some(r) => Ok(crate::store::slice_on_char_boundaries(&body, r)),
         }
     }
 
@@ -1062,11 +1098,9 @@ impl ContextStore for SqliteStore {
             }
             let (addr, body) = row.map_err(sql_err)?;
             if let Some(pos) = body.find(query) {
-                let start = pos.saturating_sub(24);
-                let end = (pos + query.len() + 24).min(body.len());
                 hits.push(ChunkHit {
                     addr: ChunkAddr::new(addr),
-                    snippet: body[start..end].to_string(),
+                    snippet: crate::store::search_snippet(&body, pos, query),
                     score: 1.0,
                 });
             }
@@ -3669,6 +3703,11 @@ mod test {
     #[tokio::test]
     async fn conformance_context_chunk_stamps() {
         conformance::assert_context_chunk_stamps(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_multibyte_and_bodies() {
+        conformance::assert_context_multibyte_and_bodies(store()).await;
     }
 
     /// The migration path a fresh database never exercises.

--- a/src/store/tinycortex.rs
+++ b/src/store/tinycortex.rs
@@ -464,14 +464,7 @@ impl ContextStore for CortexContextStore {
             })?;
         match range {
             None => Ok(body),
-            Some(r) => {
-                let start = r.start.min(body.len());
-                let end = r.end.min(body.len());
-                if start >= end {
-                    return Ok(String::new());
-                }
-                Ok(body[start..end].to_string())
-            }
+            Some(r) => Ok(crate::store::slice_on_char_boundaries(&body, r)),
         }
     }
 


### PR DESCRIPTION
## Summary

Three in-repo majors from the memory-stack audit (#1488). Every fix ships with a biting test.

- **Brain tab unfrozen.** `list_facts` (`src/server/ops/memory.rs`) took the first `MAX_CONTEXT_ENTRIES = 500` metas with no sort, and every backend lists oldest-first — so past 500 chunks GET `/memory` silently dropped every new memory while `/memory/stats` kept counting up. Now sorts by `stored_at_millis` **descending** before the cap (extracted as `newest_context_chunks` so it is unit-testable).
- **Multibyte slice panic closed (agent-reachable).** Search snippets and ranged `peek` in `src/store/{fs,sqlite,mongodb}.rs` sliced on raw byte offsets, panicking mid-codepoint ("byte index is not a char boundary"); `memory_recall` routes agent queries straight into `context.search`, so an agent recalling near any non-ASCII memory could panic the call. All sites now go through the shared `slice_on_char_boundaries` / `search_snippet` helpers in `src/store/mod.rs`.
- **Bodies served in one pass.** The console route re-fetched every chunk body one-by-one after a list that already carried them (up to 500 sequential `peek`s; on the provider overlay each a fresh `get`). A new `ContextStore::list_with_bodies` (default = list+peek; fs/sqlite/mongodb/provider-overlay override to read bodies in one enumeration) is wired into the console route.

A cross-backend `assert_context_multibyte_and_bodies` conformance assertion covers the last two across fs/sqlite/mongodb.

## API Or Behavior Changes

Internal store/route behavior only; the `/memory` response shape is unchanged. New `ContextStore::list_with_bodies` port method (defaulted, so existing implementors compile). No manifest/wire changes.

**Deferred (explicitly not in this PR):** the vendored tinymemory pin bump (cross-repo submodule dance) and the forget-guard shared-address / label side-table change (belongs with #1300's design).

## Tests

Biting revert-checks confirmed: reverting the sort fails the cap test with "the stalest chunk must be dropped, not frozen in"; reverting the char-boundary helper panics the conformance test `inside 'é'`.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default and `openhuman,tinycortex`)
- [x] `cargo build --all-targets`
- [x] `cargo test` (default `3206 passed`; sqlite lane `44`; openhuman store `175` / memory-ops `15` / write_test `133` — 0 failures)

## Documentation

Inline docs on the new port method and helpers; no spec/module doc restructure needed.

Closes #1488
