### PR TITLE
fix(workspace): stop two silent data losses, and make the destructive dialogs honest (#1472 #1378 #1479 #1469)

### DIFF
--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -13,7 +13,7 @@
 
 export type { FsNode } from "@/api/workspace";
 
-import { type LocalScope, scopedKeyAdoptingLegacy } from "@/connections/types";
+import { type LocalScope, scopedKey, scopedKeyAdoptingLegacy } from "@/connections/types";
 
 import type { FsNode, RepairOutcome } from "@/api/workspace";
 
@@ -523,6 +523,38 @@ export function readLegacyLocalNodes(scope: LocalScope): FsNode[] {
 export function hasLegacyLocal(scope: LocalScope): boolean {
   try {
     return localStorage.getItem(KEY(scope)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Where a declined migration offer is remembered, per connection. */
+const DECLINED_KEY = (scope: LocalScope) => scopedKey("oc-workspace-migration-declined", scope);
+
+/**
+ * Remember that the operator said "not now" to the migration offer.
+ *
+ * A decline is deliberately *not* a discard. The banner used to offer exactly
+ * two exits — import, or destroy the notes — so an operator who wanted neither
+ * met the same offer on every mount, and the quietest way to make it stop was
+ * the button that deleted the only copy. This is the third exit: the notes stay
+ * in the browser, untouched, and the offer stops asking.
+ *
+ * Scoped per connection like every other console key, so declining on one host
+ * cannot hide the offer on another that has never made it.
+ */
+export function declineLegacyImport(scope: LocalScope): void {
+  try {
+    localStorage.setItem(DECLINED_KEY(scope), "1");
+  } catch {
+    /* storage unavailable — the offer will simply be made again */
+  }
+}
+
+/** Whether this connection has already declined the migration offer. */
+export function legacyImportDeclined(scope: LocalScope): boolean {
+  try {
+    return localStorage.getItem(DECLINED_KEY(scope)) !== null;
   } catch {
     return false;
   }

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1832,8 +1832,19 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         onReveal={(id) => {
           setRepair(null);
           const node = nodeById(nodes, id);
-          if (node?.kind === "folder") revealFolder(id);
-          else void open(id);
+          if (node?.kind === "folder") {
+            revealFolder(id);
+            return;
+          }
+          // A residual reveal is documented reveal-only (see the doc comment
+          // on RepairDialog's `onReveal` prop below). `open()` is not: it
+          // flushes the editor's staged draft before it opens anything, so
+          // falling through to it here for a file residual could fire a write
+          // the operator never asked for (#1498 review). Expand its ancestors
+          // and scroll to it, exactly like a folder — opening it is a
+          // separate, explicit click.
+          setExpanded((prev) => new Set([...prev, ...ancestorFolderIds(nodes, id)]));
+          setRevealId(id);
         }}
       />
       <DiscardConfirm

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2719,15 +2719,6 @@ function MoveDialog({
   );
 }
 
-/**
- * Delete confirmation for a note or folder (issue #1255).
- *
- * A folder's delete recursively takes every note nested inside it in the same
- * API call, so the dialog names exactly what that means — the file/folder
- * counts under it, from {@link subtreeCounts} — rather than a bare "are you
- * sure?" that reads the same for an empty folder and one holding a hundred
- * notes.
- */
 /** Which last-copy-destroying "Discard" the confirm is standing in front of. */
 type DiscardTarget = "legacy" | "rescued";
 
@@ -2789,6 +2780,15 @@ function DiscardConfirm({
   );
 }
 
+/**
+ * Delete confirmation for a note or folder (issue #1255).
+ *
+ * A folder's delete recursively takes every note nested inside it in the same
+ * API call, so the dialog names exactly what that means — the file/folder
+ * counts under it, from {@link subtreeCounts} — rather than a bare "are you
+ * sure?" that reads the same for an empty folder and one holding a hundred
+ * notes.
+ */
 function DeleteDialog({
   nodes,
   node,

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -90,17 +90,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { rosterDisplayName, rosterNameMap, type RosterNames } from "@/lib/roster-names";
 import { fromDto } from "@/lib/team";
 import { cn } from "@/lib/utils";
-import {
-  createSaveBuffer,
-  createUnloadGuard,
-  type SaveBuffer,
-} from "@/lib/workspace-save-buffer";
+import { createSaveBuffer, createUnloadGuard, type SaveBuffer } from "@/lib/workspace-save-buffer";
 import {
   ancestorFolderIds,
   applyRepair,
   breadcrumbOf,
   childrenOf,
   clearLegacyLocal,
+  declineLegacyImport,
   DERIVED_LABEL,
   DERIVED_REASON,
   ensureMdExt,
@@ -109,6 +106,7 @@ import {
   hasLegacyLocal,
   isDerivedNode,
   isSecretNode,
+  legacyImportDeclined,
   type MoveAudienceChange,
   type MoveAudienceWarning,
   moveAudienceWarning,
@@ -228,6 +226,19 @@ export function migrationBannerText(files: number, folders: number): string {
     `${total === 1 ? "is" : "are"} not in the company workspace yet.`
   );
 }
+
+/**
+ * What Import actually does, said before it is clicked (issue #1472).
+ *
+ * The banner used to offer "Import" and name neither half of the bargain: not
+ * where the notes land, and not that the browser's copy is **removed** on the
+ * way. It is a move, not a copy — `importLegacy` clears the scratchpad key on
+ * success — and an operator who expected a backup to remain in the browser had
+ * no way to learn otherwise until it was gone.
+ */
+export const MIGRATION_CONSEQUENCE =
+  `Import files them under “${IMPORT_FOLDER_NAME}” in the company workspace ` +
+  `and removes this browser's copy — it moves them rather than copying them.`;
 
 /** What the editor's status line is currently reporting. */
 export type SaveState = "idle" | "dirty" | "saving" | "saved" | "error";
@@ -445,7 +456,15 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   const [moving, setMoving] = useState<FsNode | null>(null);
   const [showExplorer, setShowExplorer] = useState(true);
   const [legacy, setLegacy] = useState<FsNode[]>([]);
+  // Whether this connection already said "not now" to the migration offer.
+  // Read once per company rather than per render, because the answer lives in
+  // localStorage and cannot change without this component having changed it.
+  const [importDeclined, setImportDeclined] = useState(false);
   const [importing, setImporting] = useState(false);
+  // Which of the two irreversible "Discard" buttons is waiting on a confirm
+  // (issue #1472). Both destroy the last copy of something an operator typed,
+  // so neither fires from its own click any more.
+  const [confirmDiscard, setConfirmDiscard] = useState<DiscardTarget | null>(null);
   // The empty-agent-folder tidy (issue #700), in its two stages: `preview` is
   // what the host says *would* go, `done` is what actually went. Both name every
   // folder — a count is not something an operator who disagrees can check.
@@ -678,7 +697,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         // a note the operator has just rewritten, until the next refetch.
         setOpenFile((f) =>
           f && f.id === job.id
-            ? { ...f, content: job.content, updatedAt: ack.updatedAt, updatedBy: OPERATOR_ORIGIN }
+            ? {
+                ...f,
+                content: job.content,
+                updatedAt: ack.updatedAt,
+                updatedBy: OPERATOR_ORIGIN,
+              }
             : f,
         );
         setNodes((all) =>
@@ -922,6 +946,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
 
   useEffect(() => {
     const mine = readLegacyLocalNodes(scope);
+    setImportDeclined(legacyImportDeclined(scope));
     if (mine.length > 0) {
       setLegacy(mine);
       return;
@@ -963,8 +988,17 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       }
       clearLegacyLocal(scope);
       setLegacy([]);
-      toast.success(`Imported ${importSummary(legacyFiles.length, legacyFolders.length)}.`);
+      toast.success(
+        `Imported ${importSummary(legacyFiles.length, legacyFolders.length)} into “${IMPORT_FOLDER_NAME}”.`,
+      );
       await loadTree({ silent: true });
+      // Show the operator where their notes went (issue #1472). A toast naming
+      // a folder is still a folder they then have to find in a tree they did
+      // not build; the import is the one moment the console knows exactly which
+      // row is the answer.
+      setSearchInput("");
+      setExpanded((prev) => new Set([...prev, root.id]));
+      setRevealId(root.id);
     } catch (e) {
       // The key is left intact on failure, so the banner comes back and nothing
       // the operator wrote is lost to a half-finished import.
@@ -974,9 +1008,30 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     }
   }
 
+  /**
+   * Destroy the browser's copy of the old scratchpad.
+   *
+   * Only ever reached from the confirm dialog. `clearLegacyLocal` removes both
+   * the scoped key and the pre-connection origin it was adopted from, so by
+   * construction there is nothing left to offer again — this is the delete, not
+   * a dismissal of the offer, and `declineImport` is the button for the latter.
+   */
   function discardLegacy() {
     clearLegacyLocal(scope);
     setLegacy([]);
+    setConfirmDiscard(null);
+  }
+
+  /** Stop offering the import without touching the notes (issue #1472). */
+  function declineImport() {
+    declineLegacyImport(scope);
+    setImportDeclined(true);
+  }
+
+  /** Throw away the rescued text — likewise only from the confirm. */
+  function discardRescued() {
+    setRescued(null);
+    setConfirmDiscard(null);
   }
 
   /* ---- navigation ---- */
@@ -1122,7 +1177,9 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   async function rename(node: FsNode, name: string) {
     const next = (node.kind === "file" ? ensureMdExt(name.trim()) : name.trim()) || node.name;
     try {
-      const updated = await renameMoveNode(client, company, node.id, { name: next });
+      const updated = await renameMoveNode(client, company, node.id, {
+        name: next,
+      });
       setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
       setOpenFile((f) => (f && f.id === updated.id ? { ...f, name: updated.name } : f));
     } catch (e) {
@@ -1134,7 +1191,9 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     try {
       // The move-cycle guard is the host's: it answers 400 for a folder moved
       // under its own descendant, which surfaces here as a toast.
-      const updated = await renameMoveNode(client, company, node.id, { parentId: destId });
+      const updated = await renameMoveNode(client, company, node.id, {
+        parentId: destId,
+      });
       setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
     } catch (e) {
       toast.error(message(e, "could not move this item"));
@@ -1468,12 +1527,18 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       </aside>
 
       {/* Note pane */}
-      <section className={cn("flex-1 flex-col overflow-hidden", showExplorer ? "hidden md:flex" : "flex")}>
-        {legacy.length > 0 && (
+      <section
+        className={cn("flex-1 flex-col overflow-hidden", showExplorer ? "hidden md:flex" : "flex")}
+      >
+        {legacy.length > 0 && !importDeclined && (
           <Alert className="m-3 mb-0 w-auto" data-testid="workspace-migration-banner">
             <AlertDescription className="flex flex-wrap items-center gap-3">
-              <span className="flex-1">
-                {migrationBannerText(legacyFiles.length, legacyFolders.length)}
+              <span className="flex-1 space-y-1">
+                <span className="block">
+                  {migrationBannerText(legacyFiles.length, legacyFolders.length)}
+                </span>
+                {/* What Import does, before it is clicked (issue #1472). */}
+                <span className="block text-xs text-muted-foreground">{MIGRATION_CONSEQUENCE}</span>
               </span>
               <Button
                 size="sm"
@@ -1483,7 +1548,26 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               >
                 {importing && <Loader2 className="size-3.5 animate-spin" />} Import
               </Button>
-              <Button size="sm" variant="ghost" disabled={importing} onClick={discardLegacy}>
+              {/* The non-destructive exit (issue #1472). Without it the only
+                  way to stop being asked was the button that deletes the
+                  notes, which is how the quiet control became the dangerous
+                  one. */}
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={importing}
+                onClick={declineImport}
+                data-testid="workspace-migration-decline"
+              >
+                Not now
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={importing}
+                onClick={() => setConfirmDiscard("legacy")}
+                data-testid="workspace-migration-discard"
+              >
                 Discard
               </Button>
             </AlertDescription>
@@ -1516,7 +1600,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                 <Button size="sm" variant="ghost" onClick={() => void copyRescued()}>
                   Copy
                 </Button>
-                <Button size="sm" variant="ghost" onClick={() => setRescued(null)}>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => setConfirmDiscard("rescued")}
+                  data-testid="workspace-rescued-discard"
+                >
                   Discard
                 </Button>
               </span>
@@ -1693,7 +1782,10 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
             </div>
           </>
         ) : (
-          <EmptyNote onNew={() => setPrompt({ mode: "file" })} onToggleExplorer={() => setShowExplorer((s) => !s)} />
+          <EmptyNote
+            onNew={() => setPrompt({ mode: "file" })}
+            onToggleExplorer={() => setShowExplorer((s) => !s)}
+          />
         )}
       </section>
 
@@ -1728,6 +1820,13 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         busy={repairing}
         onClose={() => setRepair(null)}
         onConfirm={() => void confirmRepair()}
+      />
+      <DiscardConfirm
+        target={confirmDiscard}
+        legacyCount={legacy.length}
+        rescuedName={rescued?.name ?? ""}
+        onClose={() => setConfirmDiscard(null)}
+        onConfirm={confirmDiscard === "rescued" ? discardRescued : discardLegacy}
       />
       <DeleteDialog
         nodes={nodes}
@@ -1817,9 +1916,7 @@ function SaveStatus({ state }: { state: SaveState }) {
         state === "dirty" && "text-foreground",
       )}
     >
-      {state === "dirty" && (
-        <span aria-hidden="true" className="size-1.5 rounded-full bg-tone-2" />
-      )}
+      {state === "dirty" && <span aria-hidden="true" className="size-1.5 rounded-full bg-tone-2" />}
       {label}
     </span>
   );
@@ -2015,8 +2112,16 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
         >
           {isFolder ? (
             <>
-              {isOpen ? <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />}
-              {isOpen ? <FolderOpen className="size-4 shrink-0 text-tone-2" /> : <Folder className="size-4 shrink-0 text-tone-2" />}
+              {isOpen ? (
+                <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              {isOpen ? (
+                <FolderOpen className="size-4 shrink-0 text-tone-2" />
+              ) : (
+                <Folder className="size-4 shrink-0 text-tone-2" />
+              )}
             </>
           ) : (
             <FileText className="ml-3.5 size-4 shrink-0 text-muted-foreground" />
@@ -2071,7 +2176,14 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
         </button>
         <DropdownMenu>
           <DropdownMenuTrigger
-            render={<Button variant="ghost" size="icon" className="size-6 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100" aria-label="Actions" />}
+            render={
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100"
+                aria-label="Actions"
+              />
+            }
           >
             <MoreHorizontal className="size-3.5" />
           </DropdownMenuTrigger>
@@ -2258,16 +2370,16 @@ function NoteMarkdown({
   onWiki: (target: string) => void;
 }) {
   if (!source.trim()) {
-    return <p className="text-sm text-muted-foreground">This note is empty. Switch to Edit to write.</p>;
+    return (
+      <p className="text-sm text-muted-foreground">This note is empty. Switch to Edit to write.</p>
+    );
   }
   // Rewrite [[target]] / [[target|alias]] into links the renderer can style —
   // but leave fenced and inline code untouched (so `[[…]]` examples survive).
   const rewritten = source.replace(
     /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)|\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g,
     (_m, code: string | undefined, target: string, alias?: string) =>
-      code
-        ? code
-        : `[${(alias ?? target).trim()}](#wiki:${encodeURIComponent(target.trim())})`,
+      code ? code : `[${(alias ?? target).trim()}](#wiki:${encodeURIComponent(target.trim())})`,
   );
   return (
     <div className="prose prose-sm max-w-none dark:prose-invert">
@@ -2307,7 +2419,13 @@ function NoteMarkdown({
   );
 }
 
-function EmptyNote({ onNew, onToggleExplorer }: { onNew: () => void; onToggleExplorer: () => void }) {
+function EmptyNote({
+  onNew,
+  onToggleExplorer,
+}: {
+  onNew: () => void;
+  onToggleExplorer: () => void;
+}) {
   return (
     <div className="flex flex-1 flex-col">
       <div className="flex items-center border-b px-3 py-2 md:hidden">
@@ -2319,7 +2437,9 @@ function EmptyNote({ onNew, onToggleExplorer }: { onNew: () => void; onToggleExp
         <FileText className="size-8 text-muted-foreground" />
         <div className="space-y-1">
           <p className="font-medium">No note open</p>
-          <p className="text-sm text-muted-foreground">Pick a note from the explorer, or create one.</p>
+          <p className="text-sm text-muted-foreground">
+            Pick a note from the explorer, or create one.
+          </p>
         </div>
         <Button variant="outline" size="sm" onClick={onNew}>
           <FilePlus2 className="size-4" /> New note
@@ -2414,7 +2534,8 @@ function NamePrompt({
     setPending({ name: next, warning });
   }
 
-  const title = state?.mode === "folder" ? "New folder" : state?.mode === "file" ? "New note" : "Rename";
+  const title =
+    state?.mode === "folder" ? "New folder" : state?.mode === "file" ? "New note" : "Rename";
 
   return (
     <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
@@ -2498,9 +2619,10 @@ function MoveDialog({
   const blocked = moving ? subtreeIds(nodes, moving.id) : new Set<string>();
   const folders = nodes.filter((x) => x.kind === "folder" && !blocked.has(x.id));
   /** The destination picked, held back until the warning is acknowledged. */
-  const [pending, setPending] = useState<{ destId: string | null; warning: MoveAudienceWarning } | null>(
-    null,
-  );
+  const [pending, setPending] = useState<{
+    destId: string | null;
+    warning: MoveAudienceWarning;
+  } | null>(null);
 
   // A second `Move to…` must not open onto the previous one's warning.
   useEffect(() => {
@@ -2572,6 +2694,67 @@ function MoveDialog({
  * sure?" that reads the same for an empty folder and one holding a hundred
  * notes.
  */
+/** Which last-copy-destroying "Discard" the confirm is standing in front of. */
+type DiscardTarget = "legacy" | "rescued";
+
+/**
+ * The confirm both workspace "Discard" buttons now sit behind (issue #1472).
+ *
+ * Neither of these deletes has an undo and neither has a second copy anywhere.
+ * The scratchpad discard removes the adopted key *and* its pre-connection
+ * origin, so the notes can never be re-offered; the rescued-text discard drops
+ * the only remaining copy of words whose note is already gone. Both were plain
+ * ghost buttons — quieter than the {@link DeleteDialog} that guards deleting a
+ * note the host still holds, which is strictly the more recoverable act.
+ *
+ * Shares {@link DeleteDialog}'s shape and its solid-destructive action rather
+ * than inventing a second confirm style, so "this cannot be undone" looks the
+ * same everywhere in the view. The copy names the quantity, because a confirm
+ * that says only "are you sure?" is one an operator learns to click through.
+ */
+function DiscardConfirm({
+  target,
+  legacyCount,
+  rescuedName,
+  onClose,
+  onConfirm,
+}: {
+  target: DiscardTarget | null;
+  legacyCount: number;
+  rescuedName: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const rescued = target === "rescued";
+  const title = rescued
+    ? "Discard your unsaved text?"
+    : `Delete ${legacyCount} note${legacyCount === 1 ? "" : "s"} kept only in this browser?`;
+  const description = rescued
+    ? `This is the last copy of what you wrote in “${rescuedName}”. That note is already gone, so nothing else holds this text. There is no undo.`
+    : "These notes were never sent to the company workspace, so this browser holds the only copy. Deleting them cannot be undone — “Not now” leaves them alone.";
+
+  return (
+    <AlertDialog open={Boolean(target)} onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep it</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-white hover:bg-destructive/90"
+            data-testid="workspace-discard-confirm"
+          >
+            {rescued ? "Discard text" : "Delete notes"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 function DeleteDialog({
   nodes,
   node,
@@ -2662,10 +2845,7 @@ function SweepDialog({
               : `${count} folder${count === 1 ? "" : "s"} under Agents/ hold nothing at all. Removing them cannot take anything with them — a folder holding any file, note or subfolder is left alone.`}
           </DialogDescription>
         </DialogHeader>
-        <ul
-          className="max-h-64 space-y-1 overflow-y-auto"
-          data-testid="workspace-sweep-folders"
-        >
+        <ul className="max-h-64 space-y-1 overflow-y-auto" data-testid="workspace-sweep-folders">
           {state?.folders.map((folder) => (
             <li
               key={folder.id}

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -86,6 +86,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { rosterDisplayName, rosterNameMap, type RosterNames } from "@/lib/roster-names";
 import { fromDto } from "@/lib/team";
@@ -1396,6 +1397,11 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
           <IconBtn label="Upload" onClick={() => uploadRef.current?.click()}>
             <Upload className="size-4" />
           </IconBtn>
+          {/* The two controls after this line repair the tree rather than adding
+              to it, and both can remove folders. Kept visually apart from the
+              make-something group so the row is not six identical glyphs with
+              two mines in it (issue #1378). */}
+          <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 self-center bg-border" />
           {/* Issue #700. A company provisioned before the tree went lazy carries
               one empty folder per teammate, and nothing else will ever remove
               them. Deliberately a button rather than something boot does: the
@@ -2449,6 +2455,18 @@ function EmptyNote({
   );
 }
 
+/**
+ * An icon-only control in the explorer header, labelled on hover (issue #1378).
+ *
+ * The header is six of these in a row — two of which delete things — and the
+ * label existed only as `aria-label`, which is to say only for a screen reader.
+ * A sighted operator had six identical grey glyphs and no way to learn what any
+ * of them did short of pressing it, in a row where two presses are destructive.
+ *
+ * The tooltip renders the same string the `aria-label` carries rather than a
+ * second, longer explanation: one label, two ways of meeting it. `TooltipProvider`
+ * is mounted globally (`main.tsx`), so this costs nothing at each site.
+ */
 function IconBtn({
   label,
   onClick,
@@ -2460,16 +2478,23 @@ function IconBtn({
   children: React.ReactNode;
 } & Omit<React.ComponentProps<typeof Button>, "onClick" | "children">) {
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="size-7 text-muted-foreground"
-      aria-label={label}
-      onClick={onClick}
-      {...rest}
-    >
-      {children}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground"
+            aria-label={label}
+            onClick={onClick}
+            {...rest}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -2864,7 +2889,16 @@ function SweepDialog({
               <Button variant="ghost" onClick={onClose}>
                 Cancel
               </Button>
-              <Button variant="destructive" disabled={busy} onClick={onConfirm}>
+              {/* The solid override, not the tinted `destructive` variant: this
+                  is the codebase's confirm-and-destroy weight, the one
+                  `DeleteDialog` wears (issue #1378). */}
+              <Button
+                variant="destructive"
+                className="bg-destructive text-white hover:bg-destructive/90"
+                disabled={busy}
+                onClick={onConfirm}
+                data-testid="workspace-sweep-confirm"
+              >
                 {busy && <Loader2 className="mr-1 size-4 animate-spin" />}
                 Remove {count}
               </Button>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1817,6 +1817,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       />
       <SweepDialog
         state={sweep}
+        rosterNames={rosterNames}
         busy={sweeping}
         onClose={() => setSweep(null)}
         onConfirm={() => void confirmSweep()}
@@ -2845,17 +2846,31 @@ interface SweepState {
 
 function SweepDialog({
   state,
+  rosterNames,
   busy,
   onClose,
   onConfirm,
 }: {
   state: SweepState | null;
+  /** The roster the swept folder names are ids in (issue #1479). */
+  rosterNames: RosterNames;
   busy: boolean;
   onClose: () => void;
   onConfirm: () => void;
 }) {
   const done = state?.stage === "done";
   const count = state?.folders.length ?? 0;
+  // Resolve, then sort by what is on screen (issue #1479). A swept folder's
+  // `name` *is* a roster id — that is what `Agents/<id>/` folders are called —
+  // so the dialog asking an operator to approve seven removals was showing
+  // seven ULIDs, in whatever order the host's tree() happened to return, in the
+  // one view that already resolves those ids in the tree behind the modal.
+  const rows = (state?.folders ?? [])
+    .map((folder) => {
+      const display = rosterDisplayName(folder.name, rosterNames);
+      return { ...folder, display, resolved: display !== folder.name };
+    })
+    .sort((a, b) => a.display.localeCompare(b.display));
 
   return (
     <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
@@ -2871,13 +2886,24 @@ function SweepDialog({
           </DialogDescription>
         </DialogHeader>
         <ul className="max-h-64 space-y-1 overflow-y-auto" data-testid="workspace-sweep-folders">
-          {state?.folders.map((folder) => (
+          {rows.map((folder) => (
             <li
               key={folder.id}
               className="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm"
             >
               <Folder className="size-4 shrink-0 text-tone-2" />
-              <span className="truncate">{folder.name}</span>
+              <span className="truncate" title={folder.name}>
+                {folder.display}
+              </span>
+              {/* An id the roster cannot resolve is the clearest case of all
+                  for sweeping: that teammate is no longer on the roster. Said
+                  plainly rather than left as a bare ULID the operator is asked
+                  to recognise. */}
+              {!folder.resolved && (
+                <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                  no longer on the roster
+                </span>
+              )}
             </li>
           ))}
         </ul>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -3067,9 +3067,17 @@ function RepairDialog({
                 // note-looking rows.
                 const node = nodeById(nodes, residual.id);
                 const Icon = node?.kind === "folder" ? Folder : FileText;
-                const where = pathOf(nodes, residual.parentId ?? null)
-                  .map((p) => p.name)
-                  .join(" / ");
+                // A root-level residual (`parentId === null`) walks zero
+                // folders, so the join is empty — and `where && (...)` used to
+                // read that as "nothing to say" and drop the location
+                // entirely, for exactly the residuals with the shortest
+                // answer to give (#1498 review). "Workspace root" is the
+                // same fallback label the move dialog already uses for this
+                // spot (see `DestRow` above), reused rather than reworded.
+                const where =
+                  pathOf(nodes, residual.parentId ?? null)
+                    .map((p) => p.name)
+                    .join(" / ") || "Workspace root";
                 return (
                   <li key={residual.id}>
                     <button
@@ -3081,11 +3089,9 @@ function RepairDialog({
                       <span className="flex items-center gap-2">
                         <Icon className="size-4 shrink-0 text-tone-2" />
                         <span className="truncate">{residual.name}</span>
-                        {where && (
-                          <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
-                            in {where}
-                          </span>
-                        )}
+                        <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
+                          in {where}
+                        </span>
                       </span>
                       <span className="mt-0.5 block pl-6 text-xs text-muted-foreground">
                         {residualReason(residual.cause)}

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2887,7 +2887,12 @@ function SweepDialog({
   const rows = (state?.folders ?? [])
     .map((folder) => {
       const display = rosterDisplayName(folder.name, rosterNames);
-      return { ...folder, display, resolved: display !== folder.name };
+      // Membership, not a string compare (#1498 review): `agent_slug` derives
+      // a roster id from the display name, so a name that is already legal
+      // snake_case — "ops", "scout" — slugs to itself, and `display !==
+      // folder.name` would then read a present, valid entry as absent just
+      // because its name and id happen to be spelled the same.
+      return { ...folder, display, resolved: rosterNames.has(folder.name) };
     })
     .sort((a, b) => a.display.localeCompare(b.display));
 

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -112,6 +112,7 @@ import {
   type MoveAudienceWarning,
   moveAudienceWarning,
   nodeById,
+  pathOf,
   readLegacyLocalNodes,
   renameAudienceWarning,
   SECRETS_LABEL,
@@ -1824,9 +1825,16 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       />
       <RepairDialog
         state={repair}
+        nodes={nodes}
         busy={repairing}
         onClose={() => setRepair(null)}
         onConfirm={() => void confirmRepair()}
+        onReveal={(id) => {
+          setRepair(null);
+          const node = nodeById(nodes, id);
+          if (node?.kind === "folder") revealFolder(id);
+          else void open(id);
+        }}
       />
       <DiscardConfirm
         target={confirmDiscard}
@@ -2953,31 +2961,53 @@ interface RepairState {
 
 function RepairDialog({
   state,
+  nodes,
   busy,
   onClose,
   onConfirm,
+  onReveal,
 }: {
   state: RepairState | null;
+  /** The tree, so a residual can be given its path and its real kind (issue #1469). */
+  nodes: FsNode[];
   busy: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  /** Show a residual in the tree. Never writes — it expands and scrolls. */
+  onReveal: (id: string) => void;
 }) {
   const done = state?.stage === "done";
   const folds = state?.outcome.folders ?? [];
   const residuals = state?.outcome.residuals ?? [];
   const relocations = folds.reduce((n, folder) => n + folder.moved.length, 0);
+  // The outcome the host returns most often, and the one this dialog used to
+  // render as a no-op (issue #1469): a group holding a *file* is left entirely
+  // alone and every member comes back as a residual, so a note and a folder
+  // both called `Specs` yields zero folds and two residuals. The old copy then
+  // announced "0 folders share a name" above an empty list, under a permanently
+  // disabled "Merge 0" — a dialog whose every element denied the thing it had
+  // just been opened to report.
+  const residualOnly = folds.length === 0 && residuals.length > 0;
 
   return (
     <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{done ? "Repaired" : "Repair duplicate folders"}</DialogTitle>
+          <DialogTitle>
+            {residualOnly
+              ? "Two things share a name"
+              : done
+                ? "Repaired"
+                : "Repair duplicate folders"}
+          </DialogTitle>
           <DialogDescription>
-            {done
-              ? folds.length === 0
-                ? "Nothing was merged — the tree changed before the repair ran."
-                : `Merged ${folds.length} duplicate folder${folds.length === 1 ? "" : "s"} and moved ${relocations} item${relocations === 1 ? "" : "s"}.`
-              : `${folds.length} folder${folds.length === 1 ? "" : "s"} share a name with another folder beside them, which is why publishing there fails. Their contents move into the copy that was there first. Nothing is renamed, nothing is overwritten, and no folder is removed until it is empty.`}
+            {residualOnly
+              ? `Nothing here can be merged automatically. ${residuals.length} ${residuals.length === 1 ? "item shares its name" : "items share their names"} with something the repair must not choose between — merging would have to discard one of them. Each one below says what it needs from you.`
+              : done
+                ? folds.length === 0
+                  ? "Nothing was merged — the tree changed before the repair ran."
+                  : `Merged ${folds.length} duplicate folder${folds.length === 1 ? "" : "s"} and moved ${relocations} item${relocations === 1 ? "" : "s"}.`
+                : `${folds.length} folder${folds.length === 1 ? "" : "s"} share a name with another folder beside them, which is why publishing there fails. Their contents move into the copy that was there first. Nothing is renamed, nothing is overwritten, and no folder is removed until it is empty.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -3006,27 +3036,57 @@ function RepairDialog({
 
         {residuals.length > 0 && (
           <div className="space-y-1" data-testid="workspace-repair-residuals">
-            <p className="text-xs font-medium">
-              {done ? "Still needs you" : "These will be left for you"}
-            </p>
+            {!residualOnly && (
+              <p className="text-xs font-medium">
+                {done ? "Still needs you" : "These will be left for you"}
+              </p>
+            )}
             <ul className="max-h-40 space-y-1 overflow-y-auto">
-              {residuals.map((residual) => (
-                <li key={residual.id} className="rounded-lg px-2.5 py-1.5 text-sm">
-                  <div className="flex items-center gap-2">
-                    <FileText className="size-4 shrink-0 text-tone-2" />
-                    <span className="truncate">{residual.name}</span>
-                  </div>
-                  <p className="mt-0.5 pl-6 text-xs text-muted-foreground">
-                    {residualReason(residual.cause)}
-                  </p>
-                </li>
-              ))}
+              {residuals.map((residual) => {
+                // The kind comes from the tree rather than the wire, which
+                // carries only id/name/parentId/cause. Drawing every residual as
+                // a note was actively misleading for the commonest cause of all:
+                // `fileSharesTheName` means one of the pair is a *folder*, and
+                // "rename or remove one of them" read under two identical
+                // note-looking rows.
+                const node = nodeById(nodes, residual.id);
+                const Icon = node?.kind === "folder" ? Folder : FileText;
+                const where = pathOf(nodes, residual.parentId ?? null)
+                  .map((p) => p.name)
+                  .join(" / ");
+                return (
+                  <li key={residual.id}>
+                    <button
+                      type="button"
+                      onClick={() => onReveal(residual.id)}
+                      data-testid="workspace-repair-residual"
+                      className="w-full rounded-lg px-2.5 py-1.5 text-left text-sm hover:bg-accent"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Icon className="size-4 shrink-0 text-tone-2" />
+                        <span className="truncate">{residual.name}</span>
+                        {where && (
+                          <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
+                            in {where}
+                          </span>
+                        )}
+                      </span>
+                      <span className="mt-0.5 block pl-6 text-xs text-muted-foreground">
+                        {residualReason(residual.cause)}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}
 
         <DialogFooter>
-          {done ? (
+          {/* A residual-only outcome has nothing to confirm, so it gets the one
+              action that is true — the same `Done` a finished repair gets —
+              rather than a "Merge 0" that can never be pressed (issue #1469). */}
+          {done || residualOnly ? (
             <Button onClick={onClose}>Done</Button>
           ) : (
             <>

--- a/frontend/test/e2e/workspace.spec.ts
+++ b/frontend/test/e2e/workspace.spec.ts
@@ -245,11 +245,12 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
 
   await page.getByTestId("workspace-migration-import").click();
 
-  // The receipt names what was actually imported, per kind (#500). Two notes
-  // and one folder — not the flat list's length, and not the import folder the
-  // console creates to hold them, which is packaging rather than content.
+  // The receipt names what was actually imported, per kind (#500) — two notes
+  // and one folder, not the flat list's length — and where it went (#1472).
+  // The import folder itself is still packaging rather than content, so it is
+  // named as the destination and stays out of the tally.
   await expect(page.locator("[data-sonner-toast] [data-title]").first()).toHaveText(
-    "Imported 2 notes and 1 folder.",
+    "Imported 2 notes and 1 folder into “Imported from this browser”.",
     { timeout: 30_000 },
   );
 

--- a/frontend/test/unit/workspace-discard-confirm.test.ts
+++ b/frontend/test/unit/workspace-discard-confirm.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1472: the Workspace carried two "Discard" buttons that destroyed the
+ * only copy of an operator's words on one unconfirmed click, both rendered as
+ * the quietest control in their row.
+ *
+ * The migration banner's Discard called `clearLegacyLocal`, which removes the
+ * scoped key *and* the pre-connection origin it was adopted from — so the notes
+ * can never be re-offered. Meanwhile deleting a note the host still holds is
+ * gated behind an AlertDialog saying "There is no undo". The strictly more
+ * recoverable act was the guarded one.
+ *
+ * These tests pin the fix the way `workspace-delete-confirm.test.ts` pins
+ * #1255: render the real view and assert the destructive effect does not happen
+ * until a confirm is pressed — plus that "Not now" makes the banner stop asking
+ * *without* destroying anything, which is the exit the banner never had.
+ */
+
+/** The scoped key `lib/workspace.ts` keeps this company's old scratchpad under. */
+const SCRATCHPAD_KEY = "oc-workspace:c1::acme";
+/** The pre-connection origin key that `clearLegacyLocal` also removes. */
+const LEGACY_KEY = "oc-workspace:acme";
+const DECLINED_KEY = "oc-workspace-migration-declined:c1::acme";
+
+/** Two notes the operator typed into the retired client-side scratchpad. */
+const SCRATCHPAD = JSON.stringify([
+  {
+    id: "fs-1",
+    name: "Runbook.md",
+    kind: "file",
+    parentId: null,
+    content: "steps",
+    updatedAt: 1,
+  },
+  {
+    id: "fs-2",
+    name: "Ideas.md",
+    kind: "file",
+    parentId: null,
+    content: "thoughts",
+    updatedAt: 1,
+  },
+]);
+
+function client(): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue([]),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” button in:\n${document.body.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+function banner(): Element | null {
+  return document.querySelector('[data-testid="workspace-migration-banner"]');
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  // jsdom has no layout, so the tree's reveal effect (issue #1371) would throw
+  // on a method that does not exist there.
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  localStorage.setItem(SCRATCHPAD_KEY, SCRATCHPAD);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+});
+
+async function render() {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client(),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+describe("the migration banner's Discard asks before it destroys (issue #1472)", () => {
+  it("opens a confirm naming the count, and leaves the notes in the browser", async () => {
+    await render();
+    expect(banner()).not.toBeNull();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+
+    // The reported defect: this click *was* the delete.
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+    expect(document.body.textContent).toContain("Delete 2 notes kept only in this browser?");
+    expect(document.querySelector('[data-testid="workspace-discard-confirm"]')).not.toBeNull();
+  });
+
+  it("Keep it dismisses the confirm without touching the scratchpad", async () => {
+    await render();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Keep it").click();
+    });
+
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+    expect(banner()).not.toBeNull();
+  });
+
+  it("only the confirm's own action clears the key and the origin it came from", async () => {
+    localStorage.setItem(LEGACY_KEY, SCRATCHPAD);
+    await render();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Delete notes").click();
+    });
+
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBeNull();
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(banner()).toBeNull();
+  });
+});
+
+describe("declining the offer is not the same as destroying it (issue #1472)", () => {
+  it("Not now stops the banner and keeps every note", async () => {
+    await render();
+
+    await act(async () => {
+      button("Not now").click();
+    });
+
+    // The whole point of the third exit: the banner is gone and the notes are
+    // not. Before #1472 the only way to stop being asked was the delete.
+    expect(banner()).toBeNull();
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+    expect(localStorage.getItem(DECLINED_KEY)).not.toBeNull();
+  });
+
+  it("stays declined across a remount, still without destroying anything", async () => {
+    await render();
+    await act(async () => {
+      button("Not now").click();
+    });
+
+    await act(() => root.unmount());
+    root = createRoot(container);
+    await render();
+
+    expect(banner()).toBeNull();
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+  });
+});
+
+/**
+ * The second Discard: the banner holding words rescued out of a note that was
+ * deleted while the operator was writing in it. Its own comment in the view
+ * says this is "the last copy of a paragraph" — and it was wired straight to
+ * `setRescued(null)` on a bare ghost button.
+ */
+describe("the rescued-text Discard asks before it destroys (issue #1472)", () => {
+  /** A host whose tree empties once `gone` flips — the deletion the frame reports. */
+  function vanishingClient(gone: { now: boolean }): OpenCompanyClient {
+    return {
+      scopeFor: () => "/api/v1/company/acme",
+      get: vi.fn(async (path: string) => {
+        if (path.includes("/workspace/file/")) {
+          return {
+            id: "note-1",
+            name: "Plan.md",
+            content: "saved body",
+            backlinks: [],
+            updatedAt: 1,
+          };
+        }
+        if (path.endsWith("/workspace")) {
+          return gone.now ? [] : [{ id: "note-1", name: "Plan.md", kind: "file", updatedAt: 1 }];
+        }
+        return [];
+      }),
+    } as unknown as OpenCompanyClient;
+  }
+
+  async function rescueBanner() {
+    const gone = { now: false };
+    const host = vanishingClient(gone);
+    // No scratchpad here — the migration banner would own the word "Discard".
+    localStorage.clear();
+
+    const paint = (event?: { tick: number; nodeId: string; change: "removed" }) =>
+      act(async () => {
+        root.render(
+          createElement(ConnectionScopeProvider, {
+            scope: { connection: "c1", company: "acme" },
+            children: createElement(WorkspaceView, {
+              client: host,
+              company: "acme",
+              event,
+            }),
+          }),
+        );
+      });
+
+    await paint();
+    await act(async () => {
+      (
+        Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes("Plan"),
+        ) as HTMLButtonElement
+      ).click();
+    });
+    await act(async () => {
+      (
+        Array.from(document.querySelectorAll('[role="tab"]')).find(
+          (t) => t.textContent?.trim() === "Edit",
+        ) as HTMLElement
+      ).click();
+    });
+
+    const editor = document.querySelector(
+      '[data-testid="workspace-editor"]',
+    ) as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(editor, "a paragraph nobody else has");
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    gone.now = true;
+    await paint({ tick: 1, nodeId: "note-1", change: "removed" });
+  }
+
+  it("keeps the text on screen when Discard is clicked, and asks first", async () => {
+    await rescueBanner();
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).not.toBeNull();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+
+    // The defect: this click was the discard. The words must still be here.
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).not.toBeNull();
+    expect(
+      (document.querySelector('[data-testid="workspace-rescued-text"]') as HTMLTextAreaElement)
+        .value,
+    ).toBe("a paragraph nobody else has");
+    expect(document.body.textContent).toContain("Discard your unsaved text?");
+  });
+
+  it("drops the text only once the confirm's own action is pressed", async () => {
+    await rescueBanner();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Keep it").click();
+    });
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).not.toBeNull();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Discard text").click();
+    });
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).toBeNull();
+  });
+});
+
+describe("the banner says what Import will do (issue #1472)", () => {
+  it("names the destination folder and that the browser copy is removed", async () => {
+    await render();
+    const text = banner()?.textContent ?? "";
+
+    expect(text).toContain("Imported from this browser");
+    expect(text).toContain("removes this browser's copy");
+    expect(text).toContain("moves them rather than copying them");
+  });
+});

--- a/frontend/test/unit/workspace-explorer-icons.test.ts
+++ b/frontend/test/unit/workspace-explorer-icons.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1378: the explorer header is six identical icon-only ghost buttons in
+ * one undifferentiated row, two of which remove folders. Their labels existed
+ * only as `aria-label` — nothing a sighted operator ever meets — and the
+ * sweep's confirm-and-destroy button rendered as a pale tint rather than the
+ * solid red every other confirm-and-destroy in the console wears.
+ */
+
+const HEADER_LABELS = [
+  "Refresh",
+  "New file",
+  "New folder",
+  "Upload",
+  "Tidy empty agent folders",
+  "Repair duplicate folders",
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function host(): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue([
+      { id: "agents", name: "Agents", kind: "folder", updatedAt: 1 },
+      {
+        id: "empty-1",
+        name: "01JQ",
+        kind: "folder",
+        parentId: "agents",
+        updatedAt: 1,
+      },
+    ]),
+    post: vi.fn().mockResolvedValue({ wouldRemove: [{ id: "empty-1", name: "01JQ" }] }),
+  } as unknown as OpenCompanyClient;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render() {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: host(),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+describe("every explorer icon says what it is (issue #1378)", () => {
+  it("wires each of the six header buttons to a tooltip carrying its label", async () => {
+    await render();
+
+    for (const label of HEADER_LABELS) {
+      const button = container.querySelector(`[aria-label="${label}"]`);
+      expect(button, `no button labelled “${label}”`).not.toBeNull();
+      // The defect: the label was `aria-label` and nothing else, so a sighted
+      // operator met six identical glyphs.
+      expect(button?.getAttribute("data-slot"), label).toBe("tooltip-trigger");
+    }
+  });
+
+  it("separates the two folder-removing controls from the ones that make things", async () => {
+    await render();
+
+    const buttons = Array.from(container.querySelectorAll("[aria-label]"));
+    const tidy = buttons.findIndex(
+      (b) => b.getAttribute("aria-label") === "Tidy empty agent folders",
+    );
+    const upload = buttons.findIndex((b) => b.getAttribute("aria-label") === "Upload");
+    expect(upload).toBeGreaterThanOrEqual(0);
+    expect(tidy).toBe(upload + 1);
+
+    // A divider sits between the make-something group and the repair group, so
+    // the row is not six identical glyphs with two mines in it.
+    const row = container.querySelector('[aria-label="Upload"]')?.parentElement;
+    expect(row?.querySelector("span[aria-hidden].w-px")).not.toBeNull();
+  });
+});
+
+describe("the sweep's confirm wears the destroy weight (issue #1378)", () => {
+  it("renders Remove with the solid destructive class, not the pale tint", async () => {
+    await render();
+
+    await act(async () => {
+      (container.querySelector('[data-testid="workspace-sweep"]') as HTMLButtonElement).click();
+    });
+
+    const confirm = document.querySelector('[data-testid="workspace-sweep-confirm"]');
+    expect(confirm).not.toBeNull();
+    // The same override `DeleteDialog` uses — the codebase's one weight for
+    // "this button destroys something".
+    expect(confirm?.className).toContain("bg-destructive");
+    expect(confirm?.className).toContain("text-white");
+  });
+});

--- a/frontend/test/unit/workspace-repair-residual-only.test.ts
+++ b/frontend/test/unit/workspace-repair-residual-only.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1469: the commonest repair outcome opened a dialog that denied itself.
+ *
+ * `duplicate_folder_plan` leaves any group holding a *file* entirely alone and
+ * reports every member as `fileSharesTheName` — so a note and a folder both
+ * called `Specs` yields **zero** folds and two residuals. The dialog then
+ * announced "0 folders share a name", drew an empty fold list, filed the
+ * residuals under "These will be left for you" as if they were the leftovers of
+ * work that had happened, and offered a permanently disabled "Merge 0".
+ *
+ * These pin the branch: the residual-only outcome is now the thing the dialog
+ * is about, every row carries its real kind and its path, and the footer has an
+ * action that can actually be pressed.
+ */
+
+const TREE = [
+  { id: "eng", name: "Engineering", kind: "folder", updatedAt: 1 },
+  {
+    id: "specs-folder",
+    name: "Specs",
+    kind: "folder",
+    parentId: "eng",
+    updatedAt: 1,
+  },
+  {
+    id: "specs-note",
+    name: "Specs",
+    kind: "file",
+    parentId: "eng",
+    updatedAt: 1,
+  },
+];
+
+const RESIDUAL_ONLY = {
+  residuals: [
+    {
+      id: "specs-folder",
+      name: "Specs",
+      parentId: "eng",
+      cause: "fileSharesTheName",
+    },
+    {
+      id: "specs-note",
+      name: "Specs",
+      parentId: "eng",
+      cause: "fileSharesTheName",
+    },
+  ],
+};
+
+/** The one host each test drives, so its write methods can be asserted on. */
+function host() {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(TREE),
+    post: vi.fn().mockResolvedValue(RESIDUAL_ONLY),
+    patch: vi.fn(),
+    del: vi.fn(),
+  };
+}
+
+let client: ReturnType<typeof host>;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function openRepair() {
+  client = host();
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    (container.querySelector('[data-testid="workspace-repair"]') as HTMLButtonElement).click();
+  });
+}
+
+function rows(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll('[data-testid="workspace-repair-residual"]'),
+  ) as HTMLElement[];
+}
+
+describe("a residual-only repair is about the residuals (issue #1469)", () => {
+  it("never claims 0 folders share a name", async () => {
+    await openRepair();
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+
+    expect(dialog?.textContent).toContain("Two things share a name");
+    // The reported defect, verbatim.
+    expect(dialog?.textContent).not.toContain("0 folders share a name");
+    expect(dialog?.textContent).not.toContain("Merge 0");
+  });
+
+  it("does not frame the residuals as the leftovers of work that happened", async () => {
+    await openRepair();
+    const dialog = document.querySelector('[role="dialog"]');
+
+    expect(dialog?.textContent).not.toContain("These will be left for you");
+    expect(dialog?.textContent).toContain("Nothing here can be merged automatically");
+  });
+
+  it("offers an action that can be pressed", async () => {
+    await openRepair();
+    const done = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Done",
+    );
+    expect(done).toBeDefined();
+    expect(done?.disabled).toBe(false);
+
+    await act(async () => {
+      done?.click();
+    });
+    expect(document.querySelector('[data-testid="workspace-repair-residual"]')).toBeNull();
+  });
+});
+
+describe("each residual says which one it is (issue #1469)", () => {
+  it("draws the folder half as a folder, not as a second note", async () => {
+    await openRepair();
+    const [first, second] = rows();
+
+    // Both were `FileText` — under an instruction reading "rename or remove one
+    // of them", which is unfollowable when both look like the same kind.
+    const icons = [first, second].map((r) => r.querySelector("svg")?.getAttribute("class") ?? "");
+    expect(icons.some((c) => c.includes("lucide-folder"))).toBe(true);
+    expect(icons.some((c) => c.includes("lucide-file-text"))).toBe(true);
+  });
+
+  it("says where each one lives", async () => {
+    await openRepair();
+    for (const row of rows()) expect(row.textContent).toContain("in Engineering");
+  });
+
+  it("reveals the node in the tree without writing anything", async () => {
+    await openRepair();
+    const postsBefore = client.post.mock.calls.length;
+    await act(async () => {
+      rows()[0].click();
+    });
+
+    // The dialog closes onto the tree; nothing was renamed, moved or deleted.
+    // Revealing must never be a write — the operator has not decided anything.
+    expect(document.querySelector('[data-testid="workspace-repair-residual"]')).toBeNull();
+    expect(client.del).not.toHaveBeenCalled();
+    expect(client.patch).not.toHaveBeenCalled();
+    expect(client.post.mock.calls.length).toBe(postsBefore);
+  });
+});

--- a/frontend/test/unit/workspace-repair-residual-root-path.test.ts
+++ b/frontend/test/unit/workspace-repair-residual-root-path.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * PR #1498 review (CodeRabbit, thread 3829432151): the repair dialog's
+ * residual rows are supposed to say where each one lives (issue #1469's own
+ * requirement — "each one below says what it needs from you"). `pathOf` walks
+ * zero folders for a root-level residual (`parentId === null`), so the joined
+ * `where` string came out empty, and `{where && (...)}` read that as "say
+ * nothing" — the one row with the shortest possible answer ("Workspace root")
+ * was the one that went silent.
+ */
+
+const ROOT_DUPE_A = "root-dupe-a";
+const ROOT_DUPE_B = "root-dupe-b";
+const NESTED_DUPE = "nested-dupe";
+const FOLDER = "notes";
+
+const TREE = [
+  { id: ROOT_DUPE_A, name: "Notes.md", kind: "file", parentId: null, updatedAt: 1 },
+  { id: ROOT_DUPE_B, name: "Notes", kind: "folder", parentId: null, updatedAt: 1 },
+  { id: FOLDER, name: "Notes", kind: "folder", parentId: null, updatedAt: 1 },
+  { id: NESTED_DUPE, name: "Draft.md", kind: "file", parentId: FOLDER, updatedAt: 1 },
+];
+
+/** One root-level residual pair, plus a nested one as a same-row control. */
+const RESIDUAL_ONLY = {
+  residuals: [
+    { id: ROOT_DUPE_A, name: "Notes.md", parentId: null, cause: "fileSharesTheName" },
+    { id: NESTED_DUPE, name: "Draft.md", parentId: FOLDER, cause: "fileSharesTheName" },
+  ],
+};
+
+function host() {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(TREE),
+    post: vi.fn().mockResolvedValue(RESIDUAL_ONLY),
+    patch: vi.fn(),
+    del: vi.fn(),
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function openRepair() {
+  const client = host();
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    (container.querySelector('[data-testid="workspace-repair"]') as HTMLButtonElement).click();
+  });
+}
+
+function rows(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll('[data-testid="workspace-repair-residual"]'),
+  ) as HTMLElement[];
+}
+
+describe("every residual row says where it lives, root-level included (#1498 review)", () => {
+  it("labels a root-level residual 'Workspace root' instead of omitting the location", async () => {
+    await openRepair();
+    const [rootRow] = rows();
+
+    expect(rootRow.textContent).toContain("Notes.md");
+    expect(rootRow.textContent).toContain("in Workspace root");
+  });
+
+  it("still says the real folder name for a nested residual", async () => {
+    await openRepair();
+    const [, nestedRow] = rows();
+
+    expect(nestedRow.textContent).toContain("in Notes");
+    expect(nestedRow.textContent).not.toContain("Workspace root");
+  });
+});

--- a/frontend/test/unit/workspace-repair-reveal-no-write.test.ts
+++ b/frontend/test/unit/workspace-repair-reveal-no-write.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * PR #1498 review (CodeRabbit, thread 3829432141): `RepairDialog.onReveal` is
+ * documented "Show a residual in the tree. Never writes — it expands and
+ * scrolls." — but a *file* residual fell through to the ordinary `open()`
+ * route, and `open()` starts with `await flush()`. If the editor held a
+ * staged draft when the operator clicked "show me" on a file residual, that
+ * draft got written to the host as a side effect of a control promised as
+ * reveal-only.
+ *
+ * This pins the fix at the one place that could actually observe it: with a
+ * *different* note open and dirty, revealing a file residual must not touch
+ * the network, and the dirty note's draft must still read as unsaved
+ * afterward — not "saving" or "saved" out from under the operator.
+ */
+
+const ENG = "eng";
+const SPECS_FOLDER = "specs-folder";
+const SPECS_NOTE = "specs-note";
+const OPEN_NOTE = "note-1";
+
+const TREE = [
+  { id: ENG, name: "Engineering", kind: "folder", updatedAt: 1 },
+  { id: SPECS_FOLDER, name: "Specs", kind: "folder", parentId: ENG, updatedAt: 1 },
+  { id: SPECS_NOTE, name: "Specs", kind: "file", parentId: ENG, updatedAt: 1 },
+  { id: OPEN_NOTE, name: "Notes.md", kind: "file", updatedAt: 1 },
+];
+
+/** The repair preview: a residual-only outcome naming both the folder and the file above. */
+const RESIDUAL_ONLY = {
+  residuals: [
+    { id: SPECS_FOLDER, name: "Specs", parentId: ENG, cause: "fileSharesTheName" },
+    { id: SPECS_NOTE, name: "Specs", parentId: ENG, cause: "fileSharesTheName" },
+  ],
+};
+
+/** The one host each test drives, so its write methods can be asserted on. */
+function host() {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(async (path: string) => {
+      if (path.includes("/workspace/file/")) {
+        return {
+          id: OPEN_NOTE,
+          name: "Notes.md",
+          content: "saved body",
+          backlinks: [],
+          updatedAt: 1,
+        };
+      }
+      return TREE;
+    }),
+    post: vi.fn().mockResolvedValue(RESIDUAL_ONLY),
+    patch: vi.fn(),
+    del: vi.fn(),
+    // The write route a residual reveal must never reach (`writeFile` calls
+    // `client.put`) — asserted on directly rather than inferred from state.
+    put: vi.fn().mockResolvedValue({ updatedAt: 2 }),
+  };
+}
+
+let client: ReturnType<typeof host>;
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function button(label: string): HTMLButtonElement {
+  const match = Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  expect(match, `no button labeled "${label}"`).toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
+function saveStateAttr(): string | null {
+  return document.querySelector('[data-testid="workspace-save-state"]')?.getAttribute("data-state") ?? null;
+}
+
+function residualRows(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll('[data-testid="workspace-repair-residual"]'),
+  ) as HTMLElement[];
+}
+
+/**
+ * Open `Notes.md`, switch it to Edit, and type a paragraph the host has never
+ * seen — the exact "staged draft" precondition the finding names — then open
+ * the repair dialog on top of it without letting the autosave debounce (800ms,
+ * real timers here) ever fire.
+ */
+async function openRepairWithADirtyNoteBehindIt() {
+  client = host();
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+
+  await act(async () => {
+    button("Notes").click();
+  });
+
+  await act(async () => {
+    (
+      Array.from(document.querySelectorAll('[role="tab"]')).find(
+        (t) => t.textContent?.trim() === "Edit",
+      ) as HTMLElement
+    ).click();
+  });
+
+  const editor = document.querySelector('[data-testid="workspace-editor"]') as HTMLTextAreaElement;
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+    setter?.call(editor, "a paragraph the host has never seen");
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  expect(saveStateAttr()).toBe("dirty");
+
+  await act(async () => {
+    (container.querySelector('[data-testid="workspace-repair"]') as HTMLButtonElement).click();
+  });
+}
+
+describe("a residual reveal never flushes a dirty draft (PR #1498 review)", () => {
+  it("does not call the write route when the residual is a file", async () => {
+    await openRepairWithADirtyNoteBehindIt();
+    const rows = residualRows();
+    expect(rows).toHaveLength(2);
+
+    // rows()[1] is SPECS_NOTE — the file residual, and the one `open()` used
+    // to swallow. rows()[0] (the folder) already went through `revealFolder`,
+    // which never wrote.
+    await act(async () => {
+      rows[1].click();
+    });
+
+    expect(client.put).not.toHaveBeenCalled();
+    expect(client.patch).not.toHaveBeenCalled();
+    expect(client.del).not.toHaveBeenCalled();
+  });
+
+  it("leaves the open note's draft reading as unsaved, not saving or saved", async () => {
+    await openRepairWithADirtyNoteBehindIt();
+    const rows = residualRows();
+
+    await act(async () => {
+      rows[1].click();
+    });
+
+    // If the reveal had gone through `open()` -> `flush()`, this would read
+    // "saving" (or "saved", once the mocked `put` resolved) instead — the
+    // operator's still-open, still-unsaved note would look like it had been
+    // written out from under them by a click that named a different file.
+    expect(saveStateAttr()).toBe("dirty");
+  });
+
+  it("still does the reveal: closes the dialog and does not disturb the open note", async () => {
+    await openRepairWithADirtyNoteBehindIt();
+    const rows = residualRows();
+
+    await act(async () => {
+      rows[1].click();
+    });
+
+    expect(document.querySelector('[data-testid="workspace-repair-residual"]')).toBeNull();
+    // The open note is still Notes.md, still in Edit, with the same unwritten
+    // text — the reveal changed the tree's selection, not the open pane.
+    const editor = document.querySelector('[data-testid="workspace-editor"]') as HTMLTextAreaElement;
+    expect(editor).not.toBeNull();
+    expect(editor.value).toBe("a paragraph the host has never seen");
+  });
+});

--- a/frontend/test/unit/workspace-sweep-names.test.ts
+++ b/frontend/test/unit/workspace-sweep-names.test.ts
@@ -111,4 +111,43 @@ describe("the tidy names the teammate, not the id (issue #1479)", () => {
     // A resolved row makes no such claim.
     expect(rows.find((r) => r.startsWith("Nadia"))).not.toContain("no longer on the roster");
   });
+
+  it("does not call a roster hit orphaned just because its slug id equals its name (#1498 review)", async () => {
+    // `agent_slug` (src/ports/ids.rs) derives a roster id from the display
+    // name by lowercasing and joining with underscores — so a name that is
+    // already legal snake_case, like "ops", slugs to itself. A `folder.name`
+    // vs `display` string compare cannot tell that apart from an id the
+    // roster has never heard of; only membership can.
+    const selfSlugged = [{ id: "f-1", name: "ops" }];
+    const selfSluggedClient = {
+      scopeFor: () => "/api/v1/company/acme",
+      get: vi
+        .fn()
+        .mockResolvedValue([{ id: "agents", name: "Agents", kind: "folder", updatedAt: 1 }]),
+      post: vi.fn().mockResolvedValue({ wouldRemove: selfSlugged }),
+      listTeam: vi.fn().mockResolvedValue([member("ops", "ops")]),
+    } as unknown as OpenCompanyClient;
+
+    await act(async () => {
+      root.render(
+        createElement(ConnectionScopeProvider, {
+          scope: { connection: "c1", company: "acme" },
+          children: createElement(WorkspaceView, {
+            client: selfSluggedClient,
+            company: "acme",
+          }),
+        }),
+      );
+    });
+    await act(async () => {
+      (container.querySelector('[data-testid="workspace-sweep"]') as HTMLButtonElement).click();
+    });
+    const list = document.querySelector('[data-testid="workspace-sweep-folders"]');
+    if (!list) throw new Error(`no sweep list in:\n${document.body.innerHTML}`);
+    const rows = Array.from(list.querySelectorAll("li")).map((li) => li.textContent?.trim() ?? "");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("ops");
+    expect(rows[0]).not.toContain("no longer on the roster");
+  });
 });

--- a/frontend/test/unit/workspace-sweep-names.test.ts
+++ b/frontend/test/unit/workspace-sweep-names.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1479: the tidy's confirm asked an operator to approve removing folders
+ * it identified by raw ULID.
+ *
+ * A swept folder's `name` *is* a roster id — that is what `Agents/<id>/`
+ * folders are called — and this view already resolves those ids in the tree
+ * sitting behind the modal (issue #973, `rosterDisplayName`). The dialog exists
+ * because "17 empty folders" is a number nobody can verify; seven opaque ids
+ * are exactly as unverifiable.
+ */
+
+function member(id: string, name: string): TeamMemberDto {
+  return { id, name, role: name };
+}
+
+const SWEEPABLE = [
+  { id: "f-1", name: "01JQZY8T7K" },
+  { id: "f-2", name: "01JQZY8T7A" },
+  { id: "f-3", name: "01JQZY8T7Z" },
+];
+
+function client(team: TeamMemberDto[]): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi
+      .fn()
+      .mockResolvedValue([{ id: "agents", name: "Agents", kind: "folder", updatedAt: 1 }]),
+    post: vi.fn().mockResolvedValue({ wouldRemove: SWEEPABLE }),
+    listTeam: vi.fn().mockResolvedValue(team),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function openSweep(team: TeamMemberDto[]) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client(team),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    (container.querySelector('[data-testid="workspace-sweep"]') as HTMLButtonElement).click();
+  });
+  const list = document.querySelector('[data-testid="workspace-sweep-folders"]');
+  if (!list) throw new Error(`no sweep list in:\n${document.body.innerHTML}`);
+  return Array.from(list.querySelectorAll("li")).map((li) => li.textContent?.trim() ?? "");
+}
+
+describe("the tidy names the teammate, not the id (issue #1479)", () => {
+  it("resolves each folder through the roster the tree behind it already uses", async () => {
+    const rows = await openSweep([
+      member("01JQZY8T7K", "Nadia"),
+      member("01JQZY8T7A", "Bruno"),
+      member("01JQZY8T7Z", "Zora"),
+    ]);
+
+    // The reported defect: these were three ULIDs.
+    expect(rows.join(" ")).toContain("Nadia");
+    expect(rows.join(" ")).toContain("Bruno");
+    expect(rows.join(" ")).not.toContain("01JQZY8T7K");
+  });
+
+  it("sorts by the name on screen, not by whatever order the host returned", async () => {
+    const rows = await openSweep([
+      member("01JQZY8T7K", "Nadia"),
+      member("01JQZY8T7A", "Bruno"),
+      member("01JQZY8T7Z", "Zora"),
+    ]);
+
+    expect(rows.map((r) => r.split(" ")[0])).toEqual(["Bruno", "Nadia", "Zora"]);
+  });
+
+  it("says an unresolved id is no longer on the roster, rather than showing a bare ULID", async () => {
+    const rows = await openSweep([member("01JQZY8T7K", "Nadia")]);
+
+    const orphan = rows.find((r) => r.startsWith("01JQZY8T7A"));
+    expect(orphan).toBeDefined();
+    expect(orphan).toContain("no longer on the roster");
+    // A resolved row makes no such claim.
+    expect(rows.find((r) => r.startsWith("Nadia"))).not.toContain("no longer on the roster");
+  });
+});


### PR DESCRIPTION
## Summary

Four Workspace defects that share one surface, ordered data-loss first.

**#1472 (data loss).** Two ghost `Discard` buttons destroyed the only copy of an operator's words on one unconfirmed click. The migration banner's called `clearLegacyLocal`, which removes the scoped key *and* the pre-connection origin it was adopted from, so the notes could never be re-offered; the rescued-text banner's dropped words whose note was already gone. Deleting a note the host still holds — strictly the more recoverable act — was the one gated behind "There is no undo". Both now sit behind a confirm sharing `DeleteDialog`'s shape and its solid destructive action. The banner also gains the exit it never had: **Not now** stops the offer without touching the notes, so the quietest way to stop being asked is no longer the delete. It now says what Import does *before* it is clicked — the destination folder, and that the browser's copy is removed, because it is a move — and reveals the folder afterwards instead of naming it in a toast the operator then has to go find.

**#1378.** Six icon-only ghost buttons in one row, two of them destructive, labelled only by `aria-label`. `IconBtn` now wires the tooltip once for the whole header, a divider separates the folder-removing controls from the ones that add to the tree, and the sweep's confirm wears the solid destructive weight every other confirm-and-destroy in the console wears.

**#1479.** A swept folder's `name` *is* a roster id, so the confirm asked an operator to approve removing seven opaque ULIDs — in the one view that already resolves those ids in the tree behind the modal. Rows resolve through `rosterDisplayName`, sort by what is on screen, and an unresolvable id says the teammate is no longer on the roster, which is the clearest case for sweeping there is.

**#1469.** `duplicate_folder_plan` leaves any group holding a file entirely alone and reports every member as `fileSharesTheName`, so the commonest outcome is zero folds and two residuals — which the dialog rendered as "0 folders share a name" over an empty list, under a permanently disabled "Merge 0". That case is now what the dialog is about. Residuals take their kind from the tree rather than the wire (`fileSharesTheName` means one of the pair is a *folder*, and "rename or remove one of them" is unfollowable under two identical note-looking rows), carry their path, and reveal the node — never a write.

Console-only. No host change; `Residual`'s wire shape is unchanged and the kind is derived client-side from the tree.

## API Or Behavior Changes

- Both workspace `Discard` buttons now require a confirm. The destructive effect no longer fires on the first click.
- New non-destructive **Not now** on the migration banner, persisted per connection under `oc-workspace-migration-declined:<connection>::<company>`.
- Import's toast names the destination folder and the tree reveals it.
- Sweep confirm lists teammate names, sorted, instead of raw ids.
- A residual-only repair shows a different title, sentence and footer action.

## Tests

Console (`frontend/`) — this PR touches no Rust:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` — **1875 passed / 198 files**
- [x] `npm run build`
- N/A: `cargo fmt --all -- --check` — no Rust in this change
- N/A: `cargo clippy --all-targets -- -D warnings` — no Rust in this change
- N/A: `cargo build --all-targets` — no Rust in this change
- N/A: `cargo test` — no Rust in this change

New regression tests, each **red-proven** against the fix reverted:

- `workspace-discard-confirm.test.ts` — 8 tests. Both data-loss paths: the migration `Discard` leaves the scratchpad key intact until the confirm's own action, "Keep it" changes nothing, and the confirm clears both the scoped key and the origin. The rescued-text `Discard` keeps the paragraph on screen and asks first. "Not now" hides the banner across a remount **without** destroying anything. Reverting either gate reds 3 and 2 tests respectively.
- `workspace-explorer-icons.test.ts` — 3 tests. Each of the six header buttons is a tooltip trigger carrying its label; the divider sits between the make group and the repair group; the sweep confirm carries the solid destructive class.
- `workspace-sweep-names.test.ts` — 3 tests. Rows resolve through the roster, sort by display name, and an unresolved id is labelled rather than shown raw.
- `workspace-repair-residual-only.test.ts` — 6 tests. No "0 folders share a name", no "Merge 0", no "left for you" framing; the folder half draws as a folder; each row says where it lives; revealing issues no write. Forcing `residualOnly` false reds 3.

## Documentation

No docs change. Every behaviour here is console copy the operator meets directly, and the reasoning is in the code comments beside each change (`DiscardConfirm`, `IconBtn`, `SweepDialog`, `RepairDialog`).

## Related

Closes #1472
Closes #1378
Closes #1479
Closes #1469

**Base of a four-PR stack — merge A → B → C → D.** This is A; B (`feat/workspace-note-identity`), C (`feat/workspace-search-filing`) and D (`feat/workspace-empty-layout`) each branch off the previous one, because all four edit `frontend/src/views/WorkspaceView.tsx`.

Dropped from the original club and **not** in this PR: #1372 (already merged) and #1377 (already merged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer migration messaging explaining that importing moves notes and removes the browser copy.
  - Added “Not now” to hide migration prompts and remember the choice per connection.
  - Added confirmation steps before discarding legacy or rescued content.
  - Improved import completion feedback and automatically reveals the imported folder.
  - Enhanced workspace cleanup and repair dialogs with readable names, sorting, item details, and links to affected items.
  - Added hover tooltips and clearer grouping for workspace action buttons.

- **Bug Fixes**
  - Improved handling of duplicate-name repairs when items cannot be merged automatically, including residual items at the workspace root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->