### PR TITLE
Connectors: choose where an OpenCompany runtime runs

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -112,6 +112,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [runtime/data-root.md](runtime/data-root.md) | Data-root resolution, the single-writer lock, instance identity |
 | [runtime/desktop.md](runtime/desktop.md) | The desktop client: connections, transport seam, embedded host |
 | [runtime/desktop-instances.md](runtime/desktop-instances.md) | Several local hosts on one machine: the roster, onboarding, dev runs |
+| [runtime/connectors.md](runtime/connectors.md) | Connectors: choosing where the runtime runs — this computer, TinyHumans Cloud, a remote gateway, or over SSH |
 | [runtime/offline.md](runtime/offline.md) | Running with no network: the configuration, what is not local, and the CI lane that proves it |
 | [runtime/hub-console.md](runtime/hub-console.md) | One console deployment operating many hosts on other origins |
 | [security/agent-isolation.md](security/agent-isolation.md) | What confines an agent and what does not — enforced controls, the gaps, and the capability that survives every planned control |

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -124,6 +124,9 @@ Supporting docs:
   `wallet`, or `none` (no sign-in, for the desktop app), and what each changes
 - [hub-console.md](hub-console.md) — one console deployment operating many hosts
   on other origins: the carried session, CORS, and what it costs
+- [connectors.md](connectors.md) — where the runtime runs: the four connectors
+  (this computer, TinyHumans Cloud, a remote gateway, over SSH), why the choice
+  is per host rather than per application, and what each one costs
 - [company-setup.md](company-setup.md) — first-run **company** setup: three
   questions asked once, turned into a real roster of agents. Distinct from
   [setup.md](setup.md), which configures the *instance*

--- a/docs/spec/runtime/connectors.md
+++ b/docs/spec/runtime/connectors.md
@@ -1,0 +1,425 @@
+# Connectors — where the runtime runs
+
+A **connector** is the answer to one question an operator has to answer before
+anything else works: *where does my company actually run?* Today the console
+answers it twice, in two unrelated places — the desktop's "Add a host" dialog
+offers a local instance or a typed URL, and the hosted platform is reached by
+being handed a link. Neither is a choice presented as a choice.
+
+This document defines the connector as a first-class thing: a named way of
+reaching a runtime, with its own setup flow, its own credential, and its own
+failure modes, selected per host rather than per application.
+
+Prior art is [`nousresearch/hermes-agent`](https://github.com/nousresearch/hermes-agent),
+which separates the *gateway* an operator talks to from the *terminal backend*
+the agent executes on, and asks at setup which of local, its own cloud, a remote
+gateway, or an SSH target it should be. OpenCompany has the same split already —
+the console is one codebase, the host is one binary, and
+[`desktop.md`](desktop.md) is the seam between them — so what is missing is not
+architecture but the chooser and two of the four destinations.
+
+Read [`desktop.md`](desktop.md) and [`desktop-instances.md`](desktop-instances.md)
+first: connections, the proxy and the local roster are the machinery this builds
+on. [`hub-console.md`](hub-console.md) carries the cross-origin session rules
+that the cloud and remote connectors inherit.
+
+## The four
+
+| | who starts the process | where the data root is | credential | available in |
+|---|---|---|---|---|
+| **`local`** — on this computer | this application | `<data-dir>/instances/<id>` | none (`auth_mode = none`) | desktop only |
+| **`cloud`** — TinyHumans Cloud | the `opencompany-manager` control plane | the tenant volume at `/data` | carried session | desktop, browser, hub |
+| **`remote`** — a gateway you run | you, on a box you own | that box's `OPENCOMPANY_DATA_DIR` | paired device or carried session | desktop, browser, hub |
+| **`ssh`** — over SSH | you, on a box you own; this application opens the tunnel | that box's `OPENCOMPANY_DATA_DIR` | paired device over loopback | desktop only |
+
+Two of these exist. `local` is `src-tauri/src/local.rs` and the "On this
+computer" tab; `remote` is the "Somewhere else" tab, which is a URL field and
+nothing else. `cloud` and `ssh` are new, and `remote` grows a setup flow rather
+than a text input.
+
+## A connector is a property of a connection, not a mode of the app
+
+The rule that governs everything below is already written down in
+`frontend/src/connections/registry.ts`: **N connections, and no active one.**
+Selecting a host is a rendering choice, not a state change.
+
+A connector chooser that sets "the app is in cloud mode" would undo that. There
+is no application-wide answer to "where does it run", because the honest answer
+for a real operator is *several places at once* — a scratch company on the
+laptop, the real one in the cloud, a customer's on a VPS reached over SSH. All
+four connectors must be holdable simultaneously, each with its own status row,
+each failing on its own.
+
+So the connector is a field on `Connection`, chosen once when the host is added,
+and the chooser is the "Add a host" dialog growing from two tabs to four.
+
+### It extends `ConnectionOrigin`, and turns it into a tagged union
+
+`frontend/src/connections/types.ts` has the seed of this already:
+
+```ts
+export type ConnectionOrigin = "embedded";
+```
+
+with a comment explaining why the marker has to be *durable* — the embedded
+host's address is regenerated on every launch, so recognising last launch's row
+as *this* host is what stops a dead one accumulating per run.
+
+That argument generalises exactly, and it is the reason the connector cannot be
+inferred from the URL at read time. An SSH tunnel's local port is chosen at
+open time and differs every launch, so `http://127.0.0.1:49221` is *this*
+connector's address today and nobody's tomorrow. A cloud tenant and a
+self-hosted gateway are both `https://…` and are told apart by nothing in the
+address. The connector is therefore persisted, and carries the kind-specific
+configuration needed to re-establish the connection:
+
+```ts
+export type Connector =
+  /** The host inside this application, over a data root it owns. */
+  | { kind: "local" }
+  /** A tenant of the hosted control plane. */
+  | { kind: "cloud"; tenant: string }
+  /** A host someone else's process is serving, addressed directly. */
+  | { kind: "remote" }
+  /** A host bound to loopback on another machine, reached through a tunnel. */
+  | { kind: "ssh"; target: SshTarget };
+```
+
+`local` carries no instance id: the host's own identity already reaches the
+connection through `/spec` and through `oc_embedded`, and a second copy of it
+inside the connector would be a field that can disagree with itself.
+
+Three vintages of `localStorage` have to be read forward, and `connectorOf` in
+`profileStore.ts` is the one place that does it: a `connector`, or
+`origin: "embedded"` from the version before it, or — for the oldest — the
+signature the bug left behind, this client's own label at a loopback address.
+The guess happens once, because the first save after a restore writes a real
+connector. `origin` is still written *beside* it for one release, so a build
+someone rolls back to still recognises a local host and still prunes last
+launch's address.
+
+`Connection.baseUrl` stays what it is — the address this client uses *right
+now* — and for `local` and `ssh` it is derived at launch rather than restored.
+The connector is what survives; the address is what is rebuilt from it.
+
+## `local` — on this computer
+
+Unchanged, and described in [`desktop-instances.md`](desktop-instances.md): a
+roster in `<data-dir>/instances.json`, one host per data root, `oc_embedded` and
+the `oc_*_local_instance` commands. What the connector chooser adds is framing —
+this is one of four answers rather than the tab that happens to be first.
+
+Keep the ordering. The desktop leads with the local half because starting a host
+is the thing it can do that a browser cannot, and because a person who has just
+installed the application has no URL to type and no account yet.
+
+## `cloud` — TinyHumans Cloud
+
+The destination that exists in production and has no client-side front door.
+The control plane is `opencompany-manager` (the superproject at
+`tinyhumansai/opencompany-microservices`, where this repo is the `opencompany/`
+submodule). It builds this crate into a per-tenant container and injects
+`OPENCOMPANY_COMPANY`, `OPENCOMPANY_BIND=0.0.0.0:8080`,
+`OPENCOMPANY_DATA_DIR=/data`, `OPENCOMPANY_PUBLIC_URL` and
+`OPENCOMPANY_ADMIN_EMAIL`; storage is per-tenant MongoDB or the shared-single-DB
+mode described in [`storage.md`](storage.md).
+
+What the connector has to do:
+
+1. **Sign in to the control plane**, not to a host. This is the one connector
+   where the operator's account is with TinyHumans rather than with the runtime,
+   and the first credential obtained is a control-plane one.
+2. **List the tenants that account owns**, and let the operator pick one — or
+   provision a new one, which is the manager's job and the point at which the
+   company template is chosen.
+3. **Register a connection** at the tenant's `OPENCOMPANY_PUBLIC_URL`, and sign
+   in to *that host* as a person. The admin invite is already standing:
+   `OPENCOMPANY_ADMIN_EMAIL` is the address that provisioned the instance, which
+   is why a provisioned company whose manifest names nobody still has somebody
+   eligible ([`users.md`](users.md)).
+
+Two consequences fall out of the platform's own shape and both are load-bearing
+for the client.
+
+**The credential is a carried session, not a cookie.** A cloud tenant is on a
+different origin from the console — its own subdomain — so the host's
+`SameSite=Lax` cookie is withheld from every request the console makes, and
+`SameSite=None` merely turns it into a third-party cookie Safari discards. This
+is the hub console's situation exactly, and it takes the hub's answer:
+`{ kind: "session", value }` in `x-opencompany-session`, with the cost stated in
+[`hub-console.md`](hub-console.md). On the desktop the proxy sidesteps the whole
+question — see *CORS* below — but the browser and hub builds do not, so each
+tenant must allow-list the console origin in `OPENCOMPANY_CORS_ORIGINS`.
+Provisioning should write that, because an operator cannot: they have no shell
+in the container.
+
+**A hibernating tenant is not a down tenant.** The manager runs a
+wake-on-request proxy that blocks on `/healthz` and gives up after its startup
+timeout. A tenant that has been idle therefore answers its first request in
+seconds, not milliseconds — the same hibernation Hermes gets from Modal and
+Daytona, and the reason serverless hosting costs nearly nothing when idle.
+
+The console's probe budget today assumes a host that is either listening or
+gone. Applied to a cold tenant it reports `down`, which is wrong in the way
+that matters: it tells the operator their company is broken when it is asleep.
+The connector therefore carries the patience, not the prober:
+
+- a `cloud` connection that fails its probe keeps trying, and stays
+  `connecting` while it does. `waking.ts` holds the two decisions: `keepWaking`
+  (only `cloud`, only `down`, only inside the window) and `wakeRetryDelay`, an
+  exponential backoff capped at eight seconds. Retrying is not optional — the
+  console has no periodic re-probe, so a row parked on `connecting` with
+  nothing behind it would simply hang.
+- the row says *Waking…* for that window. Not a fifth `ConnectionStatus`:
+  waking is a connecting host and ranks exactly like one on the trigger, so a
+  new status would need a place in the severity ordering and a branch in every
+  `switch` for a state that behaves identically. `statusCopy` in
+  `host-switcher.tsx` takes the *connection* and supplies the word.
+
+`unauthenticated` is excluded deliberately. It is an answer — the tenant is
+awake and refusing this credential — and retrying it would hide the sign-in the
+operator has to do behind a spinner.
+
+The window is a ceiling this client imposes (90s), not one the manager reports:
+nothing surfaces its startup timeout. Being too patient costs a row that says
+"Waking…" for longer than it had to; being too impatient costs telling somebody
+their company is gone.
+
+**What has not landed** is the front door. The tab asks for the address the
+platform gave you, because an account-scoped tenant listing is the manager's
+surface to expose and it does not exist yet. Control-plane sign-in, the tenant
+list, and provisioning from the dialog all wait on it — the connector, and the
+patience it carries, do not.
+
+## `remote` — a gateway you run
+
+The `$5 VPS` case, and the one that half-exists: `RemoteHost` in the switcher is
+a URL field, an Add button, and no notion of how the console is going to
+authenticate once it gets there.
+
+What it needs beyond the field:
+
+- **A probe before commit.** `/spec` answers with the host's identity and
+  capabilities and is unauthenticated; asking it before the row is written turns
+  a typo into an error message in the dialog rather than a permanently red row
+  in the switcher. Note that `capabilities` being absent means *assume REST
+  only* — an older host omits the field — so `undefined` and `[]` must not be
+  conflated.
+- **A sign-in step**, choosing by address. `needsCarriedSession` already
+  decides between the cookie and the carried header from the address, and the
+  desktop has a third option the browser does not: `oc_pair_device` mints a
+  paired device session whose token lives in the OS keychain and is referenced,
+  never held, by the connection record (`{ kind: "device"; ref }`).
+- **The address rule.** `isAddressableBaseUrl()` — `http:` or `https:` with an
+  authority. On the desktop a base url is absolute or it is nothing: the proxy
+  concatenates it with a path, and `localhost:8080` or `/api` yields a relative
+  url that `reqwest` refuses at `send`, so the request never reaches a socket
+  and the console reports a failure about a host it never addressed
+  ([#613](https://github.com/tinyhumansai/opencompany/issues/613)).
+
+The honest limitation to print in the dialog: **from a browser, a remote gateway
+must allow-list this console's origin.** There is no wildcard, because the
+session is a credential and `Access-Control-Allow-Origin: *` is forbidden with
+credentials. An operator adding a host from the web build and getting nothing
+but CORS failures is the most likely support question this connector generates,
+and the dialog is where it is cheapest to answer.
+
+## `ssh` — over SSH
+
+The genuinely new capability, and the reason the desktop earns its existence a
+second time.
+
+The case it serves is the one where `remote` is wrong: a host on a box that has
+no public address, no TLS, and no business having either — a homelab machine, a
+work VM behind a bastion, a cloud instance whose only open port is 22. Today
+that operator's options are to expose the host to the internet or to run
+`ssh -L` in a terminal and add `http://127.0.0.1:<port>` by hand. Both work.
+Neither is a product.
+
+The connector makes the tunnel the application's job:
+
+```
+console ──▶ ProxyTransport ──▶ 127.0.0.1:<local> ═══ssh═══▶ remote 127.0.0.1:8080
+```
+
+The host stays bound to loopback on the far side and is never reachable from
+anywhere else. That is the security argument for this connector over `remote`,
+and it is a strong one: an OpenCompany host holds a company's credentials, its
+repositories and its journal, and the smallest number of ways to reach it is the
+right number.
+
+### What the operator supplies
+
+```ts
+interface SshTarget {
+  /** `user@host`, or a `Host` alias out of `~/.ssh/config`. */
+  destination: string;
+  port?: number;
+  /** Where the host is listening on the far side. Defaults to 8080. */
+  remotePort: number;
+}
+```
+
+An alias out of `~/.ssh/config` is the field to lead with. Anyone with a
+bastion, a jump host or a non-default key has already written that file, and a
+form that re-asks for its contents is a form they will fill in wrong.
+
+No secret, and no keychain handle for one. The child has no terminal, so a
+passphrase or password prompt would block forever with nothing on screen;
+`BatchMode=yes` refuses prompts outright and the connection fails immediately
+with what `ssh` printed instead. **The key has to be one `ssh` can use without
+asking** — an agent key, or one with no passphrase. That is a real limit, and
+it is the honest one: a legible refusal an operator can act on beats a spinner
+that never stops.
+
+The destination is validated before it becomes an argument. A value starting
+with `-` reads as an ssh *option* rather than a host — `-oProxyCommand=…` being
+the memorable one — and there is no legitimate destination of that shape, so it
+is refused rather than escaped. No shell is involved either way; the child is
+spawned with an argv.
+
+### What the shell has to do
+
+The tunnel is a resource with a lifetime, which makes it the local host's
+sibling rather than the remote host's: something `src-tauri` starts, supervises,
+and tears down, alongside `local.rs`. The command surface mirrors the roster's:
+
+- `oc_open_ssh_tunnel(target) -> SshTunnelInfo` — bind an ephemeral loopback
+  port, open the forward, **wait for the local end to actually accept a
+  connection**, and answer with the address the connection should use. Waiting
+  is the part that matters: an address handed back before the tunnel forwards
+  goes straight to the proxy, whose first request fails and parks the row on
+  "unreachable" — blaming the host for a tunnel that was still being built.
+  Idempotent per target, because the console asks on every probe.
+- `oc_close_ssh_tunnel(target)` — by target, not by the id the info carries, so
+  the roster key stays derived in exactly one place. The console persists the
+  target and has never seen the id; a second copy of that derivation in
+  TypeScript would be a rule two languages have to keep in step.
+- `oc_ssh_tunnels()` — the roster, so a tunnel that dropped is a row carrying
+  its reason rather than a connection that silently went `down`.
+
+**A failed open leaves nothing behind.** The child is killed and no row is
+kept: a roster entry for a tunnel that is not forwarding is a host the console
+would probe forever and never reach.
+
+### Who opens it, and when
+
+Not a startup pass. `probe` opens the tunnel for an `ssh` connection before it
+contacts anything, and re-seats the connection if the address moved — which it
+does on every launch. That is what makes the ephemeral port harmless, and it
+needs no separate idea of which tunnels are up, because opening is idempotent
+on the core's side.
+
+The dialog is the exception, and deliberately: adding a host opens the tunnel
+there so that a destination `ssh` refuses is reported in the form the operator
+is standing in front of, rather than becoming a red row they have to go and
+read.
+
+An `ssh` connection is also recognised by its **target** rather than by its
+address (`findSshProfile`). Matching on `http://127.0.0.1:49221` would mint a
+fresh id every launch and orphan the tour state, the last-read channel and the
+mail draft with it — [#615](https://github.com/tinyhumansai/opencompany/issues/615)
+reached through a different connector.
+
+Three rules carry over from the local roster, for the same reasons stated there:
+
+- **One failed tunnel is a row, not a launch failure.** A bastion that is down
+  must not stop the other connectors from coming up.
+- **Bind the local port ephemerally and record it nowhere.** It is regenerated
+  per launch, exactly like the embedded host's address, which is why the
+  connector rather than the URL is what persists.
+- **Autostart is a record of the last explicit action.** A tunnel the operator
+  closed is not silently reopened by the next launch.
+
+### Which SSH
+
+Two implementations, and the choice is not obvious.
+
+**Shelling out to the system `ssh`** inherits `~/.ssh/config`, `ProxyJump`, the
+agent, hardware keys, and the operator's `known_hosts` — including its
+`StrictHostKeyChecking` prompt, which is a security control this application
+must not reimplement worse. It costs a child process to supervise and is absent
+on a stock Windows install predating OpenSSH's inclusion.
+
+**An in-process client** (`russh`) has no dependency and no process to babysit,
+but owns host-key verification, agent negotiation and config parsing itself —
+each of which is a way to be subtly less safe than the tool the operator already
+trusts.
+
+Ship the system `ssh`. The failure mode of the in-process client is "we
+accepted a host key the operator's own config would have refused", and that is
+not a trade to make for a Windows dependency that ships in the OS today.
+
+## Cross-cutting
+
+### CORS is not the desktop's problem, and is everyone else's
+
+The desktop's `ProxyTransport` issues requests from Rust, so no browser origin
+is involved and no preflight happens. This is why the desktop can add any host
+that answers, and the web build cannot.
+
+The consequence for the chooser: `cloud` and `remote` are offered everywhere,
+`local` and `ssh` are desktop-only, and the browser build must not render a tab
+it cannot honour. `isDesktopRuntime()` is the existing predicate, already used
+to decide whether the "On this computer" tab appears at all.
+
+### Secrets go in the keychain, references go in the record
+
+Uniformly, across all four: `src-tauri/src/keychain.rs` holds the secret and the
+connection record holds a handle. The rule and its reason are already stated for
+device tokens in `types.ts` — connection records are persisted and passed around
+the UI, so a token in one ends up in `localStorage` and in every React devtools
+inspection.
+
+The single exception stays the carried session, which is a secret that lives in
+the page because the alternative is signing in on every reload. It is bounded
+by being a *session* — revocable from the host's device list, expiring on its
+own — and by being chosen only where a cookie could not have worked.
+
+### Browser-local state is still keyed by `(connection, company)`
+
+`scopedKey` does not change, and no connector may be tempted to key on its
+address instead. Two SSH tunnels to two machines that both serve `acme`, or a
+cloud tenant and a laptop copy of the same company, are precisely the collisions
+that key exists to prevent.
+
+### Moving between connectors is export/import, not a toggle
+
+The chooser picks where a *new* host lives. It does not migrate an existing
+one, and the UI must not imply it does. The data root is on the machine the
+runtime runs on; moving a company between connectors is the tar export/import of
+the company bundle, and it belongs to the company, not to the connection.
+
+Stating this in the dialog is worth a sentence, because "choose where to run"
+reads to a new operator as a switch that moves their work.
+
+## What has landed, and what has not
+
+Landed:
+
+- the `Connector` union, persisted per connection, with every older vintage of
+  the profile store read forward;
+- the four-tab chooser, offering `local` and `ssh` only where a process can be
+  started;
+- `cloud`'s waking behaviour — the retry loop, the window, and the row that
+  says so;
+- `ssh` end to end: the supervised tunnel roster in `src-tauri/src/ssh.rs` over
+  the system `ssh`, opened from the dialog and re-opened by every probe.
+
+Not yet:
+
+- **the cloud front door.** Control-plane sign-in, the tenant list, and
+  provisioning from the dialog, all gated on the manager exposing an
+  account-scoped tenant listing. Until then the tab takes the address the
+  platform gave you.
+- **`remote`'s probe-before-commit and sign-in step.** Adding a gateway still
+  writes the row first and discovers the typo as a red row rather than as an
+  error in the dialog.
+- **a tunnel roster in the UI.** `oc_ssh_tunnels` reports a tunnel that
+  dropped; nothing renders it yet, so a dropped tunnel currently reads as an
+  unreachable host until the next probe re-opens it.
+
+Each of the four is a connection the console already knows how to hold. Nothing
+here changes the runtime, the API, or what a host is — which is the point: the
+connector is a client-side answer to a client-side question, and the day it
+starts reaching into the kernel is the day it has been designed wrong.

--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -95,6 +95,9 @@ legible: Tauri reports `Unable to find your web assets … frontendDist is set t
 "../frontend/dist"` with the absolute path it resolved, rather than an `npm
 ENOENT` for a directory nobody named.
 
+Which kinds of host it can hold, and how an operator picks one, is
+[`connectors.md`](connectors.md).
+
 ## N connections, and no active one
 
 `frontend/src/connections/registry.ts` holds a map of connections and

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import {
   createLocalInstance,
   embeddedHost,
   localInstances,
+  openSshTunnel,
   startLocalInstance,
   stopLocalInstance,
   type LocalInstance,
@@ -486,8 +487,8 @@ function Console() {
     connections,
     selected: active?.id ?? null,
     onSelect: setSelected,
-    onAdd: (baseUrl) => {
-      const id = addConnection({ baseUrl });
+    onAdd: (baseUrl, connector) => {
+      const id = addConnection({ baseUrl, connector });
       setSelected(id);
       void probe(id);
     },
@@ -507,6 +508,26 @@ function Console() {
             );
             if (opened) setSelected(opened.id);
           }
+        }
+      : undefined,
+    // Only where a process can be started, like the local half above. The
+    // tunnel is opened here rather than left to the first probe so that a
+    // destination `ssh` refuses is reported in the dialog the operator is
+    // standing in front of, instead of becoming a red row they have to go and
+    // read. Every *later* launch does it from `probe`, where the address of a
+    // remembered tunnel is rebuilt.
+    onAddSsh: isDesktopRuntime()
+      ? async (target) => {
+          const tunnel = await openSshTunnel(target);
+          const id = addConnection({
+            baseUrl: tunnel.baseUrl,
+            // The machine's name, not the loopback port: the port is this
+            // launch's and means nothing to the person who typed the other.
+            label: target.destination,
+            connector: { kind: "ssh", target },
+          });
+          setSelected(id);
+          void probe(id);
         }
       : undefined,
     onStartLocal: isDesktopRuntime()

--- a/frontend/src/api/transport/desktop.ts
+++ b/frontend/src/api/transport/desktop.ts
@@ -23,6 +23,8 @@
 // from holding more than one host, and a convenience default here would
 // reintroduce it above the seam instead of below it.
 
+import type { SshTarget } from "@/connections/types";
+
 import { tauriCore } from "./bridge";
 
 /** What `oc_embedded` answers with. Mirrors `EmbeddedInfo` in Rust. */
@@ -276,6 +278,73 @@ export async function forgetLocalInstance(id: string): Promise<void> {
   const desktop = tauriCore();
   if (!desktop) throw new Error("running a host locally needs the desktop application");
   await desktop.invoke<void>("oc_forget_local_instance", { id });
+}
+
+/**
+ * One tunnel this application is holding open. Mirrors `SshTunnelInfo` in Rust.
+ */
+export interface SshTunnel {
+  /** Stable for a target across launches, and what closing one names. */
+  id: string;
+  destination: string;
+  remotePort: number;
+  /** The loopback address to address this host at, this launch. */
+  baseUrl: string;
+  /** Why it stopped forwarding, in `ssh`'s own words. */
+  error?: string;
+}
+
+/**
+ * Opens a tunnel to a host on another machine, and answers with the address to
+ * use for it.
+ *
+ * Idempotent per target: a host already tunnelled answers with the tunnel that
+ * is up. That is what lets the probe call this unconditionally rather than the
+ * console keeping its own idea of which tunnels exist.
+ *
+ * Rejects with what `ssh` printed — "Host key verification failed" and
+ * "Permission denied (publickey)" being the two likely ones, both of which the
+ * operator has to go and fix in a specific way that only `ssh` knows.
+ */
+export async function openSshTunnel(target: SshTarget): Promise<SshTunnel> {
+  const desktop = tauriCore();
+  if (!desktop) throw new Error("reaching a host over ssh needs the desktop application");
+  return desktop.invoke<SshTunnel>("oc_open_ssh_tunnel", { target });
+}
+
+/**
+ * Closes the tunnel to a target.
+ *
+ * Named by the target rather than by the id {@link SshTunnel} carries, so the
+ * roster key stays derived on the core's side alone. A connection restored
+ * from `localStorage` has the target and has never seen the id, and a second
+ * copy of that derivation here would be a rule two languages have to keep in
+ * step.
+ *
+ * Not an error when there is no such tunnel — removal can arrive twice.
+ */
+export async function closeSshTunnel(target: SshTarget): Promise<void> {
+  await tauriCore()?.invoke<void>("oc_close_ssh_tunnel", { target });
+}
+
+/**
+ * Every tunnel, and which of them stopped forwarding.
+ *
+ * `[]` in a browser, which holds none. `null` on a shell built before tunnels
+ * existed — the same distinction {@link localInstances} draws, and for the same
+ * reason: "this shell cannot do it" and "there are none" have different
+ * answers.
+ */
+export async function sshTunnels(): Promise<SshTunnel[] | null> {
+  const desktop = tauriCore();
+  if (!desktop) return [];
+  try {
+    const answer = await desktop.invoke<SshTunnel[]>("oc_ssh_tunnels");
+    return Array.isArray(answer) ? answer : null;
+  } catch (error) {
+    console.warn("[desktop] this shell has no ssh tunnels", error);
+    return null;
+  }
 }
 
 /**

--- a/frontend/src/components/host-switcher.tsx
+++ b/frontend/src/components/host-switcher.tsx
@@ -54,7 +54,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { isDesktopRuntime } from "@/api/transport";
 import type { LocalInstance } from "@/api/transport/desktop";
 import { hostShortcutLabel, useHosts } from "@/connections/HostsContext";
-import type { Connection, ConnectionStatus } from "@/connections/types";
+import type {
+  Connection,
+  ConnectionStatus,
+  ConnectorKind,
+  SshTarget,
+} from "@/connections/types";
+import { DEFAULT_REMOTE_PORT, availableConnectors } from "@/connections/types";
 import { cn } from "@/lib/utils";
 
 /**
@@ -65,13 +71,33 @@ import { cn } from "@/lib/utils";
  * #1167), because hue alone tells an operator that *something* differs without
  * saying what, and tells someone who cannot separate amber from green nothing.
  */
-const STATUS_COPY: Record<ConnectionStatus, { label: string; dot: string }> = {
+export const STATUS_COPY: Record<ConnectionStatus, { label: string; dot: string }> = {
   connecting: { label: "Connecting…", dot: "bg-muted-foreground/50" },
   live: { label: "Connected", dot: "bg-status-done" },
   degraded: { label: "Partly available", dot: "bg-status-blocked" },
   down: { label: "Unreachable", dot: "bg-destructive" },
   unauthenticated: { label: "Sign-in needed", dot: "bg-status-blocked" },
 };
+
+/**
+ * How a host's state reads on its own row.
+ *
+ * {@link STATUS_COPY} keyed by status, except for the one case where the
+ * status alone is not the whole answer: a cloud tenant that has been idle is
+ * being *started*, not contacted, and that takes seconds rather than
+ * milliseconds. "Connecting…" for that long reads as a hang, so the connector
+ * supplies the word — which is why this takes a connection rather than a
+ * status.
+ *
+ * Deliberately not a fifth `ConnectionStatus`. Waking is a connecting host and
+ * ranks exactly like one on the trigger; a new status would need a place in the
+ * severity ordering, and every `switch` over the union would have to grow a
+ * branch for a state that behaves identically.
+ */
+export function statusCopy(connection: Connection): { label: string; dot: string } {
+  const copy = STATUS_COPY[connection.status];
+  return connection.waking ? { ...copy, label: "Waking…" } : copy;
+}
 
 /**
  * How loudly each state asks to be noticed.
@@ -248,7 +274,7 @@ export function HostSwitcher({ variant = "sidebar", companyName }: Props) {
       <DropdownMenuGroup>
         <DropdownMenuLabel>Hosts</DropdownMenuLabel>
         {connections.map((connection, index) => {
-          const status = STATUS_COPY[connection.status];
+          const status = statusCopy(connection);
           const shortcut = hostShortcutLabel(index);
           return (
             <DropdownMenuItem
@@ -421,11 +447,19 @@ export function AddHostDialog() {
     setAddingHost: onOpenChange,
     localInstances,
     onAddLocal,
+    onAddSsh,
     onStartLocal,
     onStopLocal,
   } = hosts;
-  const onAdd = (baseUrl: string) => {
-    hosts.onAdd(baseUrl);
+  // The two connectors that need a process on this machine are offered only
+  // where one can be started. `onAddLocal` rather than `isDesktopRuntime()`:
+  // `App` withholds these handlers on a shell too old to honour them, and a tab
+  // whose button does nothing is worse than a tab that is not there.
+  const tabs = availableConnectors(Boolean(onAddLocal)).filter(
+    (kind) => kind !== "ssh" || onAddSsh,
+  );
+  const onAdd = (baseUrl: string, kind: ConnectorKind) => {
+    hosts.onAdd(baseUrl, kind === "cloud" ? { kind, tenant: tenantOf(baseUrl) } : { kind: "remote" });
     onOpenChange(false);
   };
 
@@ -435,23 +469,28 @@ export function AddHostDialog() {
         <DialogHeader>
           <DialogTitle>Add a host</DialogTitle>
           <DialogDescription>
-            A host is one OpenCompany server. Run another on this computer, or point at one
-            somewhere else. Either way it stays connected alongside the others.
+            A host is one OpenCompany server. Run one on this computer, use one hosted
+            for you, or point at one somewhere else — over ssh if it is not on the open
+            internet. Whichever you choose stays connected alongside the others, and it
+            decides where a <em>new</em> company lives rather than moving one you have.
           </DialogDescription>
         </DialogHeader>
-        {onAddLocal ? (
-          // The desktop leads with the local half, because starting a host is
-          // the thing it can do that a browser cannot — and because a person
-          // who has just installed the application has no URL to type.
-          <Tabs defaultValue="local">
-            <TabsList className="w-full">
-              <TabsTrigger value="local" data-testid="add-host-local">
-                On this computer
+        {/*
+          The desktop leads with the local half, because starting a host is the
+          thing it can do that a browser cannot — and because a person who has
+          just installed the application has no URL to type. A browser leads
+          with the cloud, which is the only one of the four it can offer that
+          nobody has to run themselves.
+        */}
+        <Tabs defaultValue={tabs[0]}>
+          <TabsList className="w-full">
+            {tabs.map((kind) => (
+              <TabsTrigger key={kind} value={kind} data-testid={`add-host-${kind}`}>
+                {CONNECTOR_LABELS[kind]}
               </TabsTrigger>
-              <TabsTrigger value="remote" data-testid="add-host-remote">
-                Somewhere else
-              </TabsTrigger>
-            </TabsList>
+            ))}
+          </TabsList>
+          {onAddLocal ? (
             <TabsContent value="local">
               <LocalInstances
                 instances={localInstances}
@@ -460,15 +499,95 @@ export function AddHostDialog() {
                 onStop={onStopLocal}
               />
             </TabsContent>
-            <TabsContent value="remote">
-              <RemoteHost onAdd={onAdd} onCancel={() => onOpenChange(false)} />
+          ) : null}
+          <TabsContent value="cloud">
+            <CloudHost
+              onAdd={(baseUrl) => onAdd(baseUrl, "cloud")}
+              onCancel={() => onOpenChange(false)}
+            />
+          </TabsContent>
+          <TabsContent value="remote">
+            <RemoteHost
+              onAdd={(baseUrl) => onAdd(baseUrl, "remote")}
+              onCancel={() => onOpenChange(false)}
+              desktop={Boolean(onAddLocal)}
+            />
+          </TabsContent>
+          {onAddSsh ? (
+            <TabsContent value="ssh">
+              <SshHost onAdd={onAddSsh} onDone={() => onOpenChange(false)} />
             </TabsContent>
-          </Tabs>
-        ) : (
-          <RemoteHost onAdd={onAdd} onCancel={() => onOpenChange(false)} />
-        )}
+          ) : null}
+        </Tabs>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** What each connector is called where an operator has to choose between them. */
+const CONNECTOR_LABELS: Record<ConnectorKind, string> = {
+  local: "On this computer",
+  cloud: "TinyHumans Cloud",
+  remote: "Another gateway",
+  ssh: "Over SSH",
+};
+
+/**
+ * Which tenant a cloud address names.
+ *
+ * The first label of the host name, which is the subdomain the control plane
+ * gives a tenant. Only ever a *name* — it decides nothing about where requests
+ * go, which is `baseUrl`'s job — so a url shaped some other way degrading to
+ * the whole authority costs nothing but a longer word in a row.
+ */
+function tenantOf(baseUrl: string): string {
+  try {
+    const { hostname } = new URL(baseUrl);
+    return hostname.split(".")[0] || hostname;
+  } catch {
+    return baseUrl;
+  }
+}
+
+/** A tenant of the hosted platform, at the address it was given. */
+function CloudHost({
+  onAdd,
+  onCancel,
+}: {
+  onAdd: (baseUrl: string) => void;
+  onCancel: () => void;
+}) {
+  const [url, setUrl] = useState("");
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="cloud-url">Company address</Label>
+        <Input
+          id="cloud-url"
+          placeholder="https://acme.opencompany.cloud"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        {/*
+          Worth saying before the first probe rather than after it: a tenant
+          that has been idle is not running, and the platform starts it when a
+          request arrives. The row says "Waking…" for as long as that takes,
+          and an operator who has not been told that reads it as a hang.
+        */}
+        <p className="text-muted-foreground text-xs">
+          A company hosted for you. If it has been idle it is started on the next
+          request, so the first connection can take a few seconds.
+        </p>
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button disabled={!url.trim()} onClick={() => onAdd(url.trim())}>
+          Add
+        </Button>
+      </DialogFooter>
+    </>
   );
 }
 
@@ -476,9 +595,11 @@ export function AddHostDialog() {
 function RemoteHost({
   onAdd,
   onCancel,
+  desktop,
 }: {
   onAdd: (baseUrl: string) => void;
   onCancel: () => void;
+  desktop: boolean;
 }) {
   const [url, setUrl] = useState("");
   return (
@@ -491,6 +612,20 @@ function RemoteHost({
           value={url}
           onChange={(e) => setUrl(e.target.value)}
         />
+        {/*
+          The most likely support question this tab generates, answered where
+          it is cheapest to answer. A browser reaches a gateway from *this*
+          origin, so the gateway has to allow it — and there is no wildcard,
+          because the session is a credential. The desktop proxies from Rust,
+          where no origin is involved and none of this applies.
+        */}
+        {desktop ? null : (
+          <p className="text-muted-foreground text-xs">
+            A gateway you run yourself. It has to allow this console's address in{" "}
+            <code>OPENCOMPANY_CORS_ORIGINS</code>, or your browser will block every
+            reply.
+          </p>
+        )}
       </div>
       <DialogFooter>
         <Button variant="ghost" onClick={onCancel}>
@@ -498,6 +633,85 @@ function RemoteHost({
         </Button>
         <Button disabled={!url.trim()} onClick={() => onAdd(url.trim())}>
           Add
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+/**
+ * A host on another machine that is bound to loopback there, reached through a
+ * tunnel this application opens.
+ *
+ * The destination leads and everything else has a default, because the shape
+ * this is for is `acme-vps` — a `Host` alias out of `~/.ssh/config`. Anyone
+ * with a bastion, a jump host or a non-default key has already written that
+ * file, and a form that re-asks for its contents is one they will fill in
+ * wrong.
+ */
+function SshHost({
+  onAdd,
+  onDone,
+}: {
+  onAdd: (target: SshTarget) => Promise<void>;
+  onDone: () => void;
+}) {
+  const [destination, setDestination] = useState("");
+  const [remotePort, setRemotePort] = useState(String(DEFAULT_REMOTE_PORT));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function add(): Promise<void> {
+    setBusy(true);
+    setError(null);
+    try {
+      await onAdd({
+        destination: destination.trim(),
+        remotePort: Number(remotePort) || DEFAULT_REMOTE_PORT,
+      });
+      onDone();
+    } catch (err) {
+      // `ssh`'s own words, kept: "Host key verification failed" and
+      // "Permission denied (publickey)" each name a specific thing to go and
+      // fix, and a summary of either would name none of them.
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="ssh-destination">Machine</Label>
+        <Input
+          id="ssh-destination"
+          placeholder="acme-vps, or deploy@10.0.0.4"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+        />
+        <Label htmlFor="ssh-remote-port">Port it serves on there</Label>
+        <Input
+          id="ssh-remote-port"
+          inputMode="numeric"
+          placeholder={String(DEFAULT_REMOTE_PORT)}
+          value={remotePort}
+          onChange={(e) => setRemotePort(e.target.value)}
+        />
+        <p className="text-muted-foreground text-xs">
+          The host stays reachable only from that machine; this application
+          forwards it over your own ssh. Your key has to be one ssh can use
+          without asking — an agent key, or one with no passphrase.
+        </p>
+        {error ? <p className="text-destructive text-xs">{error}</p> : null}
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onDone}>
+          Cancel
+        </Button>
+        <Button disabled={busy || !destination.trim()} onClick={() => void add()}>
+          {busy ? <Loader2 className="size-4 animate-spin" /> : null}
+          Connect
         </Button>
       </DialogFooter>
     </>

--- a/frontend/src/connections/HostsContext.tsx
+++ b/frontend/src/connections/HostsContext.tsx
@@ -23,7 +23,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 
 import type { LocalInstance } from "@/api/transport/desktop";
-import type { Connection, ConnectionId } from "@/connections/types";
+import type { Connection, ConnectionId, Connector, SshTarget } from "@/connections/types";
 
 export interface HostsValue {
   connections: Connection[];
@@ -31,8 +31,15 @@ export interface HostsValue {
   selected: ConnectionId | null;
   /** Puts another host's console on screen. A filter — see the note above. */
   onSelect: (id: ConnectionId) => void;
-  /** Registers a host reachable at `baseUrl`, and opens it. */
-  onAdd: (baseUrl: string) => void;
+  /**
+   * Registers a host reachable at `baseUrl`, and opens it.
+   *
+   * The connector says which of the four this is, and is not derivable from
+   * the address: a cloud tenant and a gateway someone runs are both
+   * `https://…`, and only the first is worth waiting for when it does not
+   * answer. See `docs/spec/runtime/connectors.md`.
+   */
+  onAdd: (baseUrl: string, connector?: Connector) => void;
   /**
    * The hosts this machine runs, running or not.
    *
@@ -44,6 +51,17 @@ export interface HostsValue {
   onAddLocal?: (label: string) => Promise<void>;
   onStartLocal?: (id: string) => Promise<void>;
   onStopLocal?: (id: string) => Promise<void>;
+  /**
+   * Opens a tunnel to a host on another machine and registers it.
+   *
+   * Absent in a browser, which cannot start a process — and absent on a shell
+   * built before tunnels existed, so the tab is offered only where the button
+   * behind it can be honoured.
+   *
+   * Rejects with what `ssh` said, which the dialog shows: a refused key names
+   * a specific thing to go and fix.
+   */
+  onAddSsh?: (target: SshTarget) => Promise<void>;
   /** Whether this is a hub deployment, which offers the switcher at any count. */
   hub: boolean;
 }

--- a/frontend/src/connections/profileStore.ts
+++ b/frontend/src/connections/profileStore.ts
@@ -22,7 +22,14 @@
 // in desktop localStorage is a shortcut it means to undo. This one does not
 // inherit the shortcut.
 
-import type { ConnectionId, ConnectionOrigin, Credential } from "./types";
+import type {
+  ConnectionId,
+  ConnectionOrigin,
+  Connector,
+  Credential,
+  SshTarget,
+} from "./types";
+import { DEFAULT_CONNECTOR } from "./types";
 
 const INDEX_KEY = "oc.connections.v1";
 
@@ -49,6 +56,25 @@ export interface ConnectionProfile {
    * `/spec` — after the point where it would have been useful for matching.
    */
   instanceId?: string;
+  /**
+   * Where this host runs. See `Connector`.
+   *
+   * Absent on every profile written before connectors existed; `connectorOf`
+   * reads those forward off {@link ConnectionProfile.origin}.
+   */
+  connector?: Connector;
+  /**
+   * What `connector` used to be, written alongside it for one release.
+   *
+   * A downgrade is a real path here — the desktop shell and the console ship
+   * independently, so an older bundle can end up reading storage a newer one
+   * wrote — and an older bundle that cannot recognise a local host treats every
+   * one of them as a host someone typed in. It then never prunes last launch's
+   * address, which is issue #615 coming back through the version someone rolled
+   * back to. Drop this field once no shipped build reads it.
+   *
+   * @deprecated Written for compatibility; read through `connectorOf`.
+   */
   origin?: ConnectionOrigin;
 }
 
@@ -93,7 +119,35 @@ function isProfile(value: unknown): value is ConnectionProfile {
     // common case on an upgrade — so missing is valid and only a *wrong* type
     // disqualifies the entry.
     (p.instanceId === undefined || typeof p.instanceId === "string") &&
-    (p.origin === undefined || p.origin === "embedded")
+    (p.origin === undefined || p.origin === "embedded") &&
+    (p.connector === undefined || isConnector(p.connector))
+  );
+}
+
+/**
+ * Whether a stored value is a connector this build understands.
+ *
+ * Validated rather than cast, like everything else read out of this store: a
+ * hand-edited `{"kind":"ssh"}` with no target would otherwise reach the shell
+ * as a tunnel request for `undefined`. An unrecognised kind disqualifies the
+ * whole profile, which sends it back through `connectorOf` — where it comes
+ * out as `remote`, the only reading that is safe for a url nobody can explain.
+ */
+function isConnector(value: unknown): value is Connector {
+  if (typeof value !== "object" || value === null) return false;
+  const c = value as Record<string, unknown>;
+  if (c.kind === "local" || c.kind === "remote") return true;
+  if (c.kind === "cloud") return typeof c.tenant === "string";
+  if (c.kind !== "ssh") return false;
+  const target = c.target as Record<string, unknown> | undefined;
+  return (
+    typeof target === "object" &&
+    target !== null &&
+    typeof target.destination === "string" &&
+    target.destination.length > 0 &&
+    typeof target.remotePort === "number" &&
+    (target.port === undefined || typeof target.port === "number") &&
+    (target.secretRef === undefined || typeof target.secretRef === "string")
   );
 }
 
@@ -129,22 +183,79 @@ export function findProfile(
 }
 
 /**
- * Every profile that is — or once was — the host running inside this client.
+ * The stored profile for a host reached over a tunnel, matched by where the
+ * tunnel *goes*.
  *
- * `origin` says so outright for anything this version wrote. Older versions
- * recorded nothing that distinguished the embedded host from a host someone
- * typed in, so the second clause recognises them by the signature the bug left
- * behind: the label this client gives its own host, at a loopback address.
+ * The address cannot do it. A tunnel binds an ephemeral loopback port, so
+ * `http://127.0.0.1:49221` is this launch's address for this host and nobody's
+ * address next launch — matching on it would mint a fresh id every run and
+ * orphan the tour state, the last-read channel and the mail draft with it,
+ * which is issue #615 reached through a different connector.
+ *
+ * The target is the durable identity, and the three fields compared here are
+ * the same three the shell keys its tunnel roster on (`SshTarget::key` in
+ * `ssh.rs`): two connections to one machine on one port are one host.
+ */
+export function findSshProfile(target: SshTarget): ConnectionProfile | undefined {
+  return readProfiles().find((p) => {
+    const connector = connectorOf(p);
+    return (
+      connector.kind === "ssh" &&
+      connector.target.destination === target.destination &&
+      (connector.target.port ?? 22) === (target.port ?? 22) &&
+      connector.target.remotePort === target.remotePort
+    );
+  });
+}
+
+/**
+ * Every profile that is — or once was — a host running inside this client.
+ *
+ * {@link connectorOf} decides, which is where every vintage of this store is
+ * read forward — including the oldest, which recorded nothing distinguishing
+ * the embedded host from a host someone typed in and is recognised only by the
+ * signature the bug left behind: the label this client gives its own host, at a
+ * loopback address.
  *
  * Narrow on purpose, because the consequence of a false positive is deleting a
  * connection an operator added. A host added by hand is labelled by `hostLabel`
  * — `127.0.0.1:8080`, never this string — and only a profile carrying *neither*
  * new field is old enough to need guessing about at all.
+ *
+ * An `ssh` profile is deliberately **not** here despite also being addressed at
+ * loopback. Its host is somebody else's machine: the local roster knows nothing
+ * about it, so pruning it against that roster would delete it on every launch.
  */
-export function embeddedProfiles(): ConnectionProfile[] {
-  return readProfiles().filter(
-    (p) => p.origin === "embedded" || isLegacyEmbedded(p),
-  );
+export function localProfiles(): ConnectionProfile[] {
+  return readProfiles().filter((p) => connectorOf(p).kind === "local");
+}
+
+/**
+ * Which connector a stored profile describes, including the ones written
+ * before connectors existed.
+ *
+ * Three vintages, read in order of how much they said about themselves:
+ *
+ * 1. a `connector`, which is what this version writes;
+ * 2. `origin: "embedded"`, the one marker the version before it wrote, naming
+ *    what is now `local`;
+ * 3. nothing at all, where {@link isLegacyEmbedded} is the only evidence there
+ *    is.
+ *
+ * Anything else is a url someone typed, which is `remote`.
+ *
+ * The reading is durable, not repeated: the first save after a restore writes
+ * a real `connector`, so the guesswork in the third case happens once per
+ * profile and never again. That is also why it lives here rather than beside
+ * the type — the heuristic is about what a past version *stored*, and it needs
+ * this module's `EMBEDDED_LABEL` to do it.
+ */
+export function connectorOf(profile: ConnectionProfile): Connector {
+  if (profile.connector) return profile.connector;
+  if (profile.origin === "embedded" || isLegacyEmbedded(profile)) {
+    return { kind: "local" };
+  }
+  return DEFAULT_CONNECTOR;
 }
 
 /** `http://127.0.0.1:<port>`, the only address the embedded host ever had. */
@@ -152,6 +263,7 @@ const LOOPBACK_URL = /^http:\/\/127\.0\.0\.1:\d+$/;
 
 function isLegacyEmbedded(profile: ConnectionProfile): boolean {
   return (
+    profile.connector === undefined &&
     profile.origin === undefined &&
     profile.instanceId === undefined &&
     profile.label === EMBEDDED_LABEL &&

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -24,12 +24,19 @@ import {
   mayCarryACredential,
 } from "@/api/transport";
 import type { Transport } from "@/api/transport";
-import { forgetConnection, registerConnection } from "@/api/transport/desktop";
+import {
+  closeSshTunnel,
+  forgetConnection,
+  openSshTunnel,
+  registerConnection,
+} from "@/api/transport/desktop";
 import {
   EMBEDDED_LABEL,
   type ConnectionProfile,
-  embeddedProfiles,
+  localProfiles,
+  connectorOf,
   findProfile,
+  findSshProfile,
   forgetProfile,
   readProfiles,
   saveProfile,
@@ -37,11 +44,13 @@ import {
 import {
   type Connection,
   type ConnectionId,
-  type ConnectionOrigin,
+  type Connector,
   type Credential,
   type InstanceIdentity,
+  DEFAULT_CONNECTOR,
   connectionConfig,
 } from "./types";
+import { keepWaking, wakeRetryDelay } from "./waking";
 
 /** The alphabet a generated connection id uses. Excludes `:` — see `scopedKey`. */
 const ID_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -165,7 +174,8 @@ export interface AddConnection {
    * the host's own fuller answer.
    */
   identity?: InstanceIdentity;
-  origin?: ConnectionOrigin;
+  /** Where this host runs. Defaults to `remote` — a url someone supplied. */
+  connector?: Connector;
 }
 
 /**
@@ -182,7 +192,13 @@ export interface AddConnection {
 export function addConnection(input: AddConnection): ConnectionId {
   const baseUrl = input.baseUrl.replace(/\/$/, "");
   const defaultCompany = input.defaultCompany ?? null;
-  const remembered = findProfile(baseUrl, defaultCompany);
+  // An `ssh` host is recognised by where its tunnel goes, not by the loopback
+  // port this launch happened to bind — see `findSshProfile`. Every other
+  // connector's address is what it is remembered by.
+  const remembered =
+    input.connector?.kind === "ssh"
+      ? findSshProfile(input.connector.target)
+      : findProfile(baseUrl, defaultCompany);
 
   // Already registered this session (StrictMode double-invokes, and the web
   // build adds its bootstrap connection from a `useMemo`). Hand back the
@@ -211,7 +227,7 @@ export function addConnection(input: AddConnection): ConnectionId {
     status: "connecting",
     identity: input.identity ?? null,
     companies: [],
-    origin: input.origin,
+    connector: input.connector ?? DEFAULT_CONNECTOR,
   };
   // The desktop routes this connection through its own core; the browser
   // build keeps `fetch`. `defaultTransport` decides, so neither the registry
@@ -244,7 +260,10 @@ function profileOf(connection: Connection): ConnectionProfile {
     defaultCompany: connection.defaultCompany,
     credential: connection.credential,
     instanceId: connection.identity?.instanceId,
-    origin: connection.origin,
+    connector: connection.connector,
+    // Written beside it for one release so a rolled-back build still
+    // recognises a local host; see `ConnectionProfile.origin`.
+    origin: connection.connector.kind === "local" ? "embedded" : undefined,
   };
 }
 
@@ -340,7 +359,7 @@ export function restoreConnections(
         defaultCompany: profile.defaultCompany,
         credential: profile.credential,
         identity: profile.instanceId ? { instanceId: profile.instanceId } : undefined,
-        origin: profile.origin,
+        connector: connectorOf(profile),
         transport,
       }),
     );
@@ -479,7 +498,7 @@ export function adoptLocalHosts(
     .map((host) => host.instanceId)
     .filter((id): id is string => id !== undefined),
 ): ConnectionId[] {
-  const known = embeddedProfiles();
+  const known = localProfiles();
   const rostered = new Set(knownInstanceIds);
   // Matched first, all of them, before anything is removed. `thisHost` falls
   // back to an id-less profile — the one an older version wrote — and two
@@ -544,7 +563,7 @@ function adoptOne(
     // it forever.
     label: host.label ?? mine?.label ?? EMBEDDED_LABEL,
     identity,
-    origin: "embedded",
+    connector: { kind: "local" },
     transport: host.transport,
   });
 }
@@ -580,7 +599,7 @@ function reseatEmbedded(
 ): ConnectionId {
   if (
     connection.baseUrl === baseUrl &&
-    connection.origin === "embedded" &&
+    connection.connector.kind === "local" &&
     (label === undefined || connection.label === label)
   ) {
     // The same host at the same address: a second call in one session, which
@@ -591,7 +610,7 @@ function reseatEmbedded(
     ...connection,
     baseUrl,
     label: label ?? connection.label,
-    origin: "embedded",
+    connector: { kind: "local" },
     identity: identity ?? connection.identity,
     // Whatever the last probe concluded, it concluded about the old address.
     status: "connecting",
@@ -659,9 +678,15 @@ export function adoptSession(id: ConnectionId, session: string): void {
 }
 
 export function removeConnection(id: ConnectionId): void {
+  const going = getConnection(id);
   entries = entries.filter((e) => e.connection.id !== id);
   forgetProfile(id);
-  if (isDesktopRuntime()) forgetConnection(id);
+  if (isDesktopRuntime()) {
+    forgetConnection(id);
+    // A tunnel outliving the connection it was opened for is an `ssh` process
+    // nothing lists and nobody can stop from the application.
+    if (going?.connector.kind === "ssh") void closeSshTunnel(going.connector.target);
+  }
   emit();
 }
 
@@ -698,46 +723,135 @@ export function resetConnections(): void {
  * the other connections carry on regardless.
  */
 export async function probe(id: ConnectionId): Promise<void> {
-  const client = clientFor(id);
-  if (!client || probing.has(id)) return;
-  const insecure = insecurelyCredentialed(getConnection(id));
-  if (insecure) {
-    // Refused here rather than left to fail at the core, because this is the
-    // one function that owns a row's status — and the core's refusal arrives
-    // as an IPC rejection that `client.ts` has already flattened into "cannot
-    // reach the company host". Saying it here is what makes the row name the
-    // reason instead of blaming a network that is working (issue #731).
-    patch(id, { status: "down", error: insecure });
-    return;
-  }
+  if (!clientFor(id) || probing.has(id)) return;
   probing.add(id);
-  patch(id, { status: "connecting", error: undefined });
+  patch(id, { status: "connecting", error: undefined, waking: false });
   try {
-    await runProbe(id, client);
+    if (!(await ensureTunnel(id))) return;
+    const insecure = insecurelyCredentialed(getConnection(id));
+    if (insecure) {
+      // Refused here rather than left to fail at the core, because this is the
+      // one function that owns a row's status — and the core's refusal arrives
+      // as an IPC rejection that `client.ts` has already flattened into "cannot
+      // reach the company host". Saying it here is what makes the row name the
+      // reason instead of blaming a network that is working (issue #731).
+      patch(id, { status: "down", error: insecure });
+      return;
+    }
+    // Re-read: `ensureTunnel` may have moved this connection to a new address,
+    // which replaces its client.
+    const client = clientFor(id);
+    if (!client) return;
+    await probeUntilAwake(id, client);
   } finally {
     probing.delete(id);
   }
 }
 
-async function runProbe(id: ConnectionId, client: OpenCompanyClient): Promise<void> {
+/**
+ * Makes sure an `ssh` connection has a tunnel under it, and that its address is
+ * this launch's rather than last launch's.
+ *
+ * Every other connector is already reachable or is not, so this answers `true`
+ * immediately for them.
+ *
+ * Done here rather than at startup because the address is the problem. A
+ * tunnel binds an ephemeral loopback port, so the url a restored `ssh`
+ * connection comes back holding belonged to a tunnel that closed when the
+ * application last quit — and probing it would report an unreachable host for
+ * a machine that is fine. Opening is idempotent per target on the core's side,
+ * so asking on every probe costs one IPC round trip and needs no separate idea
+ * of which tunnels are up.
+ *
+ * A tunnel that cannot be opened is the connection's own failure, carrying
+ * `ssh`'s words: "Permission denied (publickey)" is a row an operator can act
+ * on, where "could not be reached" is one they cannot.
+ */
+async function ensureTunnel(id: ConnectionId): Promise<boolean> {
+  const connection = getConnection(id);
+  if (!connection || connection.connector.kind !== "ssh") return true;
+  if (!isDesktopRuntime()) {
+    patch(id, { status: "down", error: "reaching a host over ssh needs the desktop application" });
+    return false;
+  }
+  try {
+    const tunnel = await openSshTunnel(connection.connector.target);
+    if (tunnel.baseUrl !== connection.baseUrl) {
+      reseat(id, { ...connection, baseUrl: tunnel.baseUrl, error: undefined });
+    }
+    return true;
+  } catch (err) {
+    patch(id, { status: "down", error: err instanceof Error ? err.message : String(err) });
+    return false;
+  }
+}
 
+/**
+ * Probes, and keeps probing for as long as the connector says a failure might
+ * still be a host on its way up.
+ *
+ * One attempt for every connector but `cloud`, where the loop is what turns a
+ * hibernating tenant into "Waking…" rather than into a red row nothing would
+ * ever re-probe — see `waking.ts`. The in-flight guard in {@link probe} is what
+ * keeps the loop singular: a second call while this one is waiting returns
+ * immediately rather than starting a competing chain.
+ */
+async function probeUntilAwake(
+  id: ConnectionId,
+  client: OpenCompanyClient,
+): Promise<void> {
+  const startedAt = Date.now();
+  for (let attempt = 0; ; attempt += 1) {
+    const failure = await runProbe(id, client);
+    if (!failure) return;
+    // Removed or retired while the request was in flight — including by
+    // `resetConnections`, which is how a test escapes this loop.
+    const connection = getConnection(id);
+    if (!connection) return;
+    const status = failure.status ?? "down";
+    if (!keepWaking(connection.connector, status, Date.now() - startedAt)) {
+      patch(id, { ...failure, waking: false });
+      return;
+    }
+    patch(id, { status: "connecting", error: undefined, waking: true });
+    await sleep(wakeRetryDelay(attempt));
+    if (!getConnection(id)) return;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * One attempt: patches what it found, and answers with the failure it did not
+ * record as final.
+ *
+ * Returning the failure rather than patching it is what lets the caller decide
+ * whether `down` is the end of the story. Success is patched here, because
+ * there is nothing to decide about it.
+ */
+async function runProbe(
+  id: ConnectionId,
+  client: OpenCompanyClient,
+): Promise<Partial<Connection> | null> {
   const identity = await readIdentity(client);
   if (identity) patch(id, { identity, label: identity.displayName ?? labelOf(id) });
 
   try {
     const companies = await client.listCompanies();
-    patch(id, { status: "live", companies: companies.map((c) => c.id) });
-    return;
+    patch(id, { status: "live", companies: companies.map((c) => c.id), waking: false });
+    return null;
   } catch (listErr) {
     // A single-company (prosumer) host has no `/api/v1/companies`; its sole
     // company answers on the alias instead. Falling back rather than failing is
     // what lets one client hold a platform host and a prosumer host at once.
     try {
       await client.status(null);
-      patch(id, { status: "live", companies: [] });
-      return;
+      patch(id, { status: "live", companies: [], waking: false });
+      return null;
     } catch (statusErr) {
-      patch(id, statusFromError(statusErr ?? listErr));
+      return statusFromError(statusErr ?? listErr);
     }
   }
 }

--- a/frontend/src/connections/types.ts
+++ b/frontend/src/connections/types.ts
@@ -107,14 +107,109 @@ export interface InstanceIdentity {
 /**
  * Where a connection came from, when that is not "someone typed an address".
  *
- * Only `embedded` so far: the host running inside this application. It is
- * singular in a way no other connection is — there is exactly one per client,
- * this client both starts it and knows its identity without asking, and its
- * address is regenerated on every launch. That last property is why the
- * marker has to be durable: recognising last launch's row as *this* host is
- * what stops a dead one accumulating per run.
+ * Superseded by {@link Connector}, and kept only as the shape older profiles
+ * were written in — `origin: "embedded"` is what a build predating connectors
+ * left in `localStorage`, and `connectorOf` is what reads it forward.
+ *
+ * @deprecated Read `Connection.connector`.
  */
 export type ConnectionOrigin = "embedded";
+
+/**
+ * Where a runtime runs, and how this client gets to it.
+ *
+ * The four answers an operator can give to "where does my company live", and
+ * the reason this is a durable property of a connection rather than something
+ * derived from its address when it is needed:
+ *
+ * - a `local` host binds an **ephemeral port on purpose** — a fixed one
+ *   collides with a dev server — so its address is different on every launch;
+ * - an `ssh` connection's address is a loopback port this client chose when it
+ *   opened the tunnel, so it is different on every launch too, and is nobody's
+ *   address once the tunnel closes;
+ * - `cloud` and `remote` are both `https://…` and are told apart by nothing
+ *   whatsoever in the url.
+ *
+ * Recognising last launch's row as *this* host is what stops a dead one
+ * accumulating per run (issue #615), and only a persisted marker can do it.
+ *
+ * See `docs/spec/runtime/connectors.md`.
+ */
+export type Connector =
+  /**
+   * A host running inside this application, over a data root it owns.
+   *
+   * Desktop only, and the one connector where nothing has to be typed: the
+   * core starts the host and reports its address over IPC.
+   */
+  | { kind: "local" }
+  /**
+   * A tenant of the hosted control plane.
+   *
+   * Distinguished from {@link Connector} `remote` by behaviour rather than by
+   * address. A tenant container is woken on request by the manager's proxy, so
+   * its first request after an idle period takes seconds — see
+   * `wakingWindow` in `registry.ts`, which is why a cold tenant reads as
+   * "Waking…" instead of as a host that is gone.
+   */
+  | { kind: "cloud"; tenant: string }
+  /** A host someone else's process is serving, addressed directly. */
+  | { kind: "remote" }
+  /**
+   * A host bound to loopback on another machine, reached through a tunnel this
+   * application opens and supervises.
+   *
+   * Desktop only: a browser cannot start a process.
+   */
+  | { kind: "ssh"; target: SshTarget };
+
+export type ConnectorKind = Connector["kind"];
+
+/** Where the far end of an SSH tunnel is, and how to reach it. */
+export interface SshTarget {
+  /**
+   * `user@host`, or a `Host` alias out of `~/.ssh/config`.
+   *
+   * An alias is the form to prefer. Anyone with a bastion, a jump host or a
+   * non-default key has already written that file, and re-asking for its
+   * contents in a dialog is asking to be told them wrong.
+   */
+  destination: string;
+  /** The SSH port, when it is not 22. */
+  port?: number;
+  /** Where the host is listening on the far side. */
+  remotePort: number;
+  /**
+   * A keychain handle for a key passphrase or password — **never the secret**.
+   *
+   * The same rule as `{ kind: "device"; ref }` above, for the same reason:
+   * connection records are persisted and passed around the UI.
+   */
+  secretRef?: string;
+}
+
+/**
+ * Where a host listens on the far side of a tunnel, when nobody says otherwise.
+ *
+ * The port `opencompany serve` binds. Kept in step with `DEFAULT_REMOTE_PORT`
+ * in the shell's `ssh.rs`, which is what applies it when the console omits it.
+ */
+export const DEFAULT_REMOTE_PORT = 8080;
+
+/** The connector a host typed into "Add a host" gets. */
+export const DEFAULT_CONNECTOR: Connector = { kind: "remote" };
+
+/**
+ * Which connectors this runtime can offer.
+ *
+ * `local` and `ssh` both need a process started on this machine, which only
+ * the desktop shell can do. Offering them in a browser would put a tab on
+ * screen that cannot be honoured — and the browser build has no core to
+ * report the failure through, so it would simply do nothing.
+ */
+export function availableConnectors(desktop: boolean): ConnectorKind[] {
+  return desktop ? ["local", "cloud", "remote", "ssh"] : ["cloud", "remote"];
+}
 
 export interface Connection {
   id: ConnectionId;
@@ -138,7 +233,16 @@ export interface Connection {
   companies: string[];
   /** Why it is `down` or `unauthenticated`, for the connection's own row. */
   error?: string;
-  origin?: ConnectionOrigin;
+  /** Where this host runs. See {@link Connector}. */
+  connector: Connector;
+  /**
+   * Whether `connecting` means "waking a hibernating tenant" rather than
+   * "contacting a host".
+   *
+   * Session state, never persisted: it says what this probe is doing right
+   * now. Only a `cloud` connection is ever `true`.
+   */
+  waking?: boolean;
 }
 
 /** The fields needed to construct a connection's client. */

--- a/frontend/src/connections/waking.ts
+++ b/frontend/src/connections/waking.ts
@@ -1,0 +1,71 @@
+// A hibernating cloud tenant is not a host that is gone.
+//
+// The hosted control plane runs a wake-on-request proxy: a tenant container
+// that has been idle is not running, and the proxy starts it when a request
+// arrives, blocking on `/healthz` until it answers. The first request after an
+// idle period therefore takes seconds, which is the whole point — a tenant
+// costs nearly nothing while nobody is using it.
+//
+// The console's probe assumes a host that is either listening or gone, and
+// applied to a cold tenant it concludes `down`. That is wrong in the way that
+// matters most: it tells an operator their company is broken when it is asleep,
+// and the row stays red because nothing re-probes on its own.
+//
+// So the patience belongs to the connector, not to the prober. A `cloud`
+// connection that cannot be reached keeps trying, and stays `connecting` while
+// it does — labelled "Waking…", because "Connecting…" for ninety seconds reads
+// as a hang.
+//
+// See `docs/spec/runtime/connectors.md`.
+
+import type { ConnectionStatus, Connector } from "./types";
+
+/**
+ * How long a tenant is given to wake before it is called unreachable.
+ *
+ * A ceiling this client imposes, not one the manager reports: there is no
+ * surface that says what its startup timeout is. Generous on purpose — the
+ * cost of being too patient is a row that says "Waking…" for a while longer
+ * than it needed to, and the cost of being too impatient is telling somebody
+ * their company is gone.
+ */
+export const CLOUD_WAKE_WINDOW_MS = 90_000;
+
+/** The longest gap between attempts, once the backoff has climbed to it. */
+export const WAKE_RETRY_CEILING_MS = 8_000;
+
+/**
+ * Whether a failed probe is worth another attempt.
+ *
+ * Three conditions, and each excludes a case that would otherwise retry
+ * forever over something retrying cannot fix:
+ *
+ * - **only `cloud`.** No other connector has anything waking it up. A local
+ *   host that is not listening is not listening; an `ssh` tunnel that is down
+ *   is a tunnel to report, not a host to wait for.
+ * - **only `down`.** `unauthenticated` is an *answer* — the tenant is awake
+ *   and refusing this credential — and retrying it would hide the sign-in the
+ *   operator has to do behind a spinner.
+ * - **only inside the window**, after which the honest reading is that
+ *   something is actually wrong.
+ */
+export function keepWaking(
+  connector: Connector,
+  status: ConnectionStatus,
+  elapsedMs: number,
+): boolean {
+  if (connector.kind !== "cloud") return false;
+  if (status !== "down") return false;
+  return elapsedMs < CLOUD_WAKE_WINDOW_MS;
+}
+
+/**
+ * How long to wait before attempt `attempt` (zero-based).
+ *
+ * Exponential and capped. A tenant takes seconds rather than milliseconds to
+ * boot, so hammering it adds load to the thing being waited for; and the cap
+ * keeps the last attempt near the end of the window rather than well past it.
+ */
+export function wakeRetryDelay(attempt: number): number {
+  return Math.min(1_000 * 2 ** attempt, WAKE_RETRY_CEILING_MS);
+}

--- a/frontend/test/unit/connectors.test.ts
+++ b/frontend/test/unit/connectors.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { addConnection, resetConnections, restoreConnections } from "@/connections/registry";
+import {
+  EMBEDDED_LABEL,
+  connectorOf,
+  localProfiles,
+  readProfiles,
+  saveProfile,
+} from "@/connections/profileStore";
+import type { ConnectionProfile } from "@/connections/profileStore";
+import { availableConnectors } from "@/connections/types";
+import {
+  CLOUD_WAKE_WINDOW_MS,
+  WAKE_RETRY_CEILING_MS,
+  keepWaking,
+  wakeRetryDelay,
+} from "@/connections/waking";
+
+/**
+ * Where a runtime runs, and the three things that have to stay true about it.
+ *
+ * A connector is a *durable* claim: a local host and an SSH tunnel both change
+ * address on every launch, and a cloud tenant and a self-hosted gateway are
+ * both `https://…`. So nothing may be re-derived from the url, an upgrade must
+ * not lose what an older version recorded, and a hibernating tenant must not
+ * be reported as a host that is gone.
+ */
+
+const INDEX_KEY = "oc.connections.v1";
+
+function stored(profiles: unknown[]): void {
+  window.localStorage.setItem(INDEX_KEY, JSON.stringify(profiles));
+}
+
+const BASE = {
+  id: "aaaaaaaaaaaa",
+  baseUrl: "http://127.0.0.1:65275",
+  label: EMBEDDED_LABEL,
+  defaultCompany: null,
+  credential: { kind: "cookie" as const },
+};
+
+beforeEach(() => {
+  resetConnections();
+  window.localStorage.clear();
+});
+
+describe("reading an older store forward", () => {
+  it("recognises the marker the version before connectors wrote", () => {
+    expect(connectorOf({ ...BASE, origin: "embedded" })).toEqual({ kind: "local" });
+  });
+
+  it("recognises the embedded host a version that wrote no marker at all left", () => {
+    // The only evidence is the signature the bug left behind: this client's own
+    // label, at a loopback address, with neither newer field present.
+    expect(connectorOf(BASE)).toEqual({ kind: "local" });
+  });
+
+  it("does not mistake a host someone typed for one this client started", () => {
+    // The false positive that matters: guessing wrong here deletes a
+    // connection an operator added, because a local profile is pruned against
+    // the core's roster and this host is not on it.
+    expect(connectorOf({ ...BASE, label: "127.0.0.1:8080" })).toEqual({ kind: "remote" });
+    expect(connectorOf({ ...BASE, instanceId: "acme" })).toEqual({ kind: "remote" });
+    expect(connectorOf({ ...BASE, baseUrl: "https://acme.example.com" })).toEqual({
+      kind: "remote",
+    });
+  });
+
+  it("prefers what is written down over anything guessed from it", () => {
+    const ssh: ConnectionProfile = {
+      ...BASE,
+      connector: { kind: "ssh", target: { destination: "vps", remotePort: 8080 } },
+    };
+    // Loopback and this client's own label, and still not a local host: an SSH
+    // tunnel is addressed at loopback too, and pruning it against the local
+    // roster would drop it on every launch.
+    expect(connectorOf(ssh).kind).toBe("ssh");
+    saveProfile(ssh);
+    expect(localProfiles()).toHaveLength(0);
+  });
+
+  it("settles the guess permanently on the first save", () => {
+    stored([BASE]);
+    restoreConnections();
+
+    const [written] = readProfiles();
+    expect(written.connector).toEqual({ kind: "local" });
+    // And keeps the retired field beside it, so a build rolled back to the
+    // previous version still prunes last launch's address (issue #615).
+    expect(written.origin).toBe("embedded");
+  });
+});
+
+describe("what the store refuses to read", () => {
+  it("drops a profile whose connector is not one this build knows", () => {
+    // User-writable storage. An unrecognised kind must not reach the shell as
+    // a tunnel request for `undefined`.
+    stored([{ ...BASE, connector: { kind: "kubernetes" } }]);
+    expect(readProfiles()).toHaveLength(0);
+  });
+
+  it("drops an ssh connector with nothing to connect to", () => {
+    stored([{ ...BASE, connector: { kind: "ssh", target: { remotePort: 8080 } } }]);
+    expect(readProfiles()).toHaveLength(0);
+  });
+
+  it("keeps a well-formed one", () => {
+    stored([
+      { ...BASE, connector: { kind: "cloud", tenant: "acme" } },
+      {
+        ...BASE,
+        id: "bbbbbbbbbbbb",
+        connector: { kind: "ssh", target: { destination: "bastion", remotePort: 8080 } },
+      },
+    ]);
+    expect(readProfiles()).toHaveLength(2);
+  });
+});
+
+describe("what a connection is registered as", () => {
+  it("treats a url someone supplied as a gateway they run", () => {
+    const id = addConnection({ baseUrl: "https://acme.example.com" });
+    expect(readProfiles().find((p) => p.id === id)?.connector).toEqual({ kind: "remote" });
+  });
+
+  it("carries the connector across a reload", () => {
+    addConnection({
+      baseUrl: "https://acme.opencompany.cloud",
+      connector: { kind: "cloud", tenant: "acme" },
+    });
+
+    resetConnections();
+    const [id] = restoreConnections();
+    // The whole point of persisting it: the address says nothing about which
+    // of the two `https://` connectors this is, so a reload that re-derived it
+    // would silently lose the waking behaviour.
+    expect(connectorOf(readProfiles().find((p) => p.id === id)!)).toEqual({
+      kind: "cloud",
+      tenant: "acme",
+    });
+  });
+});
+
+describe("a host reached over a tunnel", () => {
+  const target = { destination: "acme-vps", remotePort: 8080 } as const;
+
+  it("keeps its id when the tunnel comes back on a different port", () => {
+    // The loopback port is bound fresh every launch, so matching on the
+    // address would mint a new id per run and orphan every scoped key under
+    // it — issue #615, reached through a different connector.
+    const first = addConnection({
+      baseUrl: "http://127.0.0.1:49221",
+      connector: { kind: "ssh", target },
+    });
+
+    resetConnections();
+    const second = addConnection({
+      baseUrl: "http://127.0.0.1:51873",
+      connector: { kind: "ssh", target },
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it("is a different host when the tunnel goes somewhere else", () => {
+    const acme = addConnection({
+      baseUrl: "http://127.0.0.1:49221",
+      connector: { kind: "ssh", target },
+    });
+    const beam = addConnection({
+      baseUrl: "http://127.0.0.1:49222",
+      connector: { kind: "ssh", target: { destination: "beam-vps", remotePort: 8080 } },
+    });
+    const otherPort = addConnection({
+      baseUrl: "http://127.0.0.1:49223",
+      connector: { kind: "ssh", target: { destination: "acme-vps", remotePort: 9090 } },
+    });
+
+    expect(new Set([acme, beam, otherPort]).size).toBe(3);
+  });
+});
+
+describe("which connectors a runtime can offer", () => {
+  it("offers all four where a process can be started", () => {
+    expect(availableConnectors(true)).toEqual(["local", "cloud", "remote", "ssh"]);
+  });
+
+  it("offers a browser only the two it can honour", () => {
+    // `local` and `ssh` both need a process on this machine. A browser build
+    // has no core to start one in, so a tab for either would do nothing.
+    expect(availableConnectors(false)).toEqual(["cloud", "remote"]);
+  });
+});
+
+describe("waiting for a hibernating tenant", () => {
+  const cloud = { kind: "cloud", tenant: "acme" } as const;
+
+  it("keeps waiting on a cloud tenant that has not answered yet", () => {
+    expect(keepWaking(cloud, "down", 0)).toBe(true);
+    expect(keepWaking(cloud, "down", CLOUD_WAKE_WINDOW_MS - 1)).toBe(true);
+  });
+
+  it("gives up once the window has passed", () => {
+    expect(keepWaking(cloud, "down", CLOUD_WAKE_WINDOW_MS)).toBe(false);
+  });
+
+  it("does not wait on a host that answered and refused", () => {
+    // `unauthenticated` is an answer: the tenant is awake. Retrying it would
+    // hide the sign-in the operator has to do behind a spinner.
+    expect(keepWaking(cloud, "unauthenticated", 0)).toBe(false);
+  });
+
+  it("does not wait on any other connector", () => {
+    // Nothing is waking these up. A local host that is not listening is not
+    // listening, and a dropped tunnel is a tunnel to report.
+    expect(keepWaking({ kind: "local" }, "down", 0)).toBe(false);
+    expect(keepWaking({ kind: "remote" }, "down", 0)).toBe(false);
+    expect(
+      keepWaking({ kind: "ssh", target: { destination: "vps", remotePort: 8080 } }, "down", 0),
+    ).toBe(false);
+  });
+
+  it("backs off, and stops backing off", () => {
+    expect(wakeRetryDelay(0)).toBe(1_000);
+    expect(wakeRetryDelay(1)).toBe(2_000);
+    expect(wakeRetryDelay(99)).toBe(WAKE_RETRY_CEILING_MS);
+  });
+});

--- a/frontend/test/unit/host-switcher.test.ts
+++ b/frontend/test/unit/host-switcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { hostSwitcherInteractive, worstStatus } from "@/components/host-switcher";
+import { hostSwitcherInteractive, statusCopy, worstStatus } from "@/components/host-switcher";
 import { hostShortcutLabel, HOST_SHORTCUT_LIMIT } from "@/connections/HostsContext";
 import type { Connection, ConnectionStatus } from "@/connections/types";
 
@@ -24,6 +24,7 @@ function host(status: ConnectionStatus, id: string = status): Connection {
     status,
     identity: null,
     companies: [],
+    connector: { kind: "remote" },
   };
 }
 
@@ -49,6 +50,23 @@ describe("worstStatus", () => {
 
   it("does not claim everything is fine while a roster is still settling", () => {
     expect(worstStatus([host("live"), host("connecting")])).toBe("connecting");
+  });
+});
+
+describe("statusCopy", () => {
+  it("says what an ordinary host is doing", () => {
+    expect(statusCopy(host("connecting")).label).toBe("Connecting…");
+    expect(statusCopy(host("down")).label).toBe("Unreachable");
+  });
+
+  it("says a hibernating tenant is being started, not merely contacted", () => {
+    // "Connecting…" for the seconds a cold tenant takes to boot reads as a
+    // hang, and the operator's next move is to go looking for a fault that is
+    // not there.
+    const waking = { ...host("connecting"), waking: true };
+    expect(statusCopy(waking).label).toBe("Waking…");
+    // Same dot: it is a connecting host, and ranks as one on the trigger.
+    expect(statusCopy(waking).dot).toBe(statusCopy(host("connecting")).dot);
   });
 });
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -383,6 +383,43 @@ pub async fn oc_rename_local_instance(
     state.local.lock().await.rename(&id, &label)
 }
 
+/// Opens a tunnel to a host on another machine, and answers with the loopback
+/// address the console should use for it.
+///
+/// Idempotent per target: asking for a host that is already tunnelled hands
+/// back the tunnel that is up. The console reopens every remembered `ssh`
+/// connection at launch, and a second call must not mean a second child.
+#[tauri::command]
+pub async fn oc_open_ssh_tunnel(
+    state: State<'_, crate::AppHandleState>,
+    target: crate::ssh::SshTarget,
+) -> Result<crate::ssh::SshTunnelInfo, String> {
+    state.ssh.lock().await.open(target).await
+}
+
+/// Closes the tunnel to a target. Not an error when there is none — the
+/// console closes on removal, and removal can arrive twice.
+#[tauri::command]
+pub async fn oc_close_ssh_tunnel(
+    state: State<'_, crate::AppHandleState>,
+    target: crate::ssh::SshTarget,
+) -> Result<(), String> {
+    state.ssh.lock().await.close(&target).await;
+    Ok(())
+}
+
+/// Every tunnel, and which of them stopped forwarding.
+///
+/// The roster the console re-reads rather than keeping its own copy of, for
+/// the same reason [`oc_local_instances`] is: one source of truth, on the side
+/// that actually holds the processes.
+#[tauri::command]
+pub async fn oc_ssh_tunnels(
+    state: State<'_, crate::AppHandleState>,
+) -> Result<Vec<crate::ssh::SshTunnelInfo>, String> {
+    Ok(state.ssh.lock().await.list())
+}
+
 /// Drops a host from the roster. **Leaves its data on disk** — see
 /// [`crate::local::LocalHosts::forget`].
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@
 //!   server to point at.
 //! - **[`local`]** — the roster of those hosts, so one machine can run several
 //!   companies side by side rather than exactly one.
+//! - **[`ssh`]** — tunnels to hosts on *other* machines that are bound to
+//!   loopback there, which is the one connector a browser cannot have.
 //! - **[`keychain`]** — where a paired device's token lives, so the webview
 //!   holds a handle and never the secret.
 //! - **[`commands`]** — the thin Tauri surface over all three.
@@ -22,10 +24,12 @@ pub mod embedded;
 pub mod keychain;
 pub mod local;
 pub mod proxy;
+pub mod ssh;
 
 use std::path::PathBuf;
 
 use crate::local::LocalHosts;
+use crate::ssh::SshTunnels;
 
 /// Process-wide state the commands read.
 pub struct AppHandleState {
@@ -43,6 +47,14 @@ pub struct AppHandleState {
     /// launch. The desktop also talks to *remote* hosts, and a busy root must
     /// not stop it doing that.
     pub local: tokio::sync::Mutex<LocalHosts>,
+    /// Every SSH tunnel this application is holding open.
+    ///
+    /// Beside the local roster rather than inside it: both are processes this
+    /// shell starts and must be able to stop, and neither is a host it can
+    /// merely address. What they are not is the same thing — a tunnel's host
+    /// belongs to somebody else's machine — so pruning one against the other
+    /// would delete it.
+    pub ssh: tokio::sync::Mutex<SshTunnels>,
 }
 
 /// The platform directory this instance keeps its data in.
@@ -124,6 +136,7 @@ pub fn run() {
         .manage(AppHandleState {
             data_dir,
             local: tokio::sync::Mutex::new(local),
+            ssh: tokio::sync::Mutex::new(SshTunnels::default()),
         })
         .invoke_handler(tauri::generate_handler![
             commands::oc_connect,
@@ -140,6 +153,9 @@ pub fn run() {
             commands::oc_stop_local_instance,
             commands::oc_rename_local_instance,
             commands::oc_forget_local_instance,
+            commands::oc_open_ssh_tunnel,
+            commands::oc_close_ssh_tunnel,
+            commands::oc_ssh_tunnels,
         ])
         .run(tauri::generate_context!())
         .expect("run the desktop shell");

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -1,0 +1,475 @@
+//! Hosts reached over an SSH tunnel this application opens and supervises.
+//!
+//! ## The case this exists for
+//!
+//! A host on a machine with no public address, no TLS, and no business having
+//! either: a homelab box, a work VM behind a bastion, a cloud instance whose
+//! only open port is 22. The `remote` connector cannot reach it, and the two
+//! ways an operator has today are to expose the host to the internet or to run
+//! `ssh -L` in a terminal and paste `http://127.0.0.1:<port>` into "Add a
+//! host". Both work; neither is a product.
+//!
+//! So the tunnel becomes this shell's job:
+//!
+//! ```text
+//! console ──▶ ProxyTransport ──▶ 127.0.0.1:<local> ═══ssh═══▶ remote 127.0.0.1:8080
+//! ```
+//!
+//! The host stays bound to loopback on the far side and is reachable from
+//! nowhere else. That is the argument for this connector over `remote`: an
+//! OpenCompany host holds a company's credentials, its repositories and its
+//! journal, and the smallest number of ways to reach it is the right number.
+//!
+//! ## Why the system `ssh` and not a library
+//!
+//! An in-process client (`russh`) would have no dependency and no child to
+//! supervise, and would own host-key verification, agent negotiation and
+//! config parsing itself — each of them a way to be subtly less safe than the
+//! tool the operator already trusts. Shelling out inherits `~/.ssh/config`,
+//! `ProxyJump`, the agent, hardware keys and the operator's own `known_hosts`,
+//! including its refusal to connect to a host whose key changed.
+//!
+//! The failure mode of the library is "we accepted a key their own config
+//! would have refused", which is not a trade worth making for a Windows
+//! dependency that has shipped in the OS since 2018.
+//!
+//! ## `BatchMode=yes`, and what it costs
+//!
+//! This child has no terminal. A passphrase or password prompt would therefore
+//! block forever with nothing on screen, so prompts are refused outright and
+//! the connection fails immediately with what `ssh` printed. The cost is real
+//! and worth stating: **the key must be in the agent, or be passphrase-less.**
+//! A legible refusal an operator can act on beats a spinner that never stops.
+//!
+//! See `docs/spec/runtime/connectors.md`.
+
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncReadExt;
+use tokio::process::{Child, Command};
+
+/// Where the host listens on the far side when nobody says otherwise.
+pub const DEFAULT_REMOTE_PORT: u16 = 8080;
+
+/// How long a tunnel is given to start forwarding before it is called failed.
+///
+/// Generous, because the first hop of a `ProxyJump` chain and an agent
+/// confirmation prompt both land inside it.
+const READY_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How often the local end is tried while waiting for that.
+const READY_POLL: Duration = Duration::from_millis(150);
+
+/// Where the far end of a tunnel is, as the console describes it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SshTarget {
+    /// `user@host`, or a `Host` alias out of `~/.ssh/config`.
+    pub destination: String,
+    /// The SSH port, when it is not 22.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    /// Where the host is listening on the far side.
+    #[serde(default = "default_remote_port")]
+    pub remote_port: u16,
+}
+
+fn default_remote_port() -> u16 {
+    DEFAULT_REMOTE_PORT
+}
+
+impl SshTarget {
+    /// The roster key for this target.
+    ///
+    /// Derived rather than minted, which is what makes [`SshTunnels::open`]
+    /// idempotent: asking twice for the same host answers with the tunnel that
+    /// is already up instead of opening a second one beside it. The console
+    /// needs that — it reopens every remembered `ssh` connection at launch,
+    /// and React's StrictMode does everything twice in development.
+    fn key(&self) -> String {
+        format!(
+            "{}:{}:{}",
+            self.destination,
+            self.port.unwrap_or(22),
+            self.remote_port
+        )
+    }
+
+    /// Why this target cannot be handed to `ssh`, or `None` when it can.
+    ///
+    /// The destination becomes an argument to a program whose arguments are
+    /// mostly flags, so a value starting with `-` is the one shape that turns
+    /// a host name into an option — `-oProxyCommand=…` being the memorable
+    /// example. Rejected outright rather than escaped: there is no legitimate
+    /// destination of that shape, and this is a text field in a dialog.
+    ///
+    /// No shell is involved (the child is spawned with an argv, never through
+    /// `sh -c`), so nothing else here needs quoting.
+    fn problem(&self) -> Option<String> {
+        let destination = self.destination.trim();
+        if destination.is_empty() {
+            return Some(
+                "name the machine to connect to, as user@host or an ssh config alias".into(),
+            );
+        }
+        if destination.starts_with('-') {
+            return Some(format!(
+                "`{destination}` is not a destination — it reads as an ssh option"
+            ));
+        }
+        if destination
+            .chars()
+            .any(|c| c.is_whitespace() || c.is_control())
+        {
+            return Some(format!(
+                "`{destination}` is not a destination — it contains a space"
+            ));
+        }
+        if self.remote_port == 0 {
+            return Some("the host's port on the far side cannot be 0".into());
+        }
+        None
+    }
+}
+
+/// One tunnel as the console sees it.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SshTunnelInfo {
+    /// Stable for a target across launches, and what closing one names.
+    pub id: String,
+    pub destination: String,
+    pub remote_port: u16,
+    /// The loopback address the console addresses this host at.
+    ///
+    /// A different port on every launch, which is why the console persists the
+    /// *target* and not this.
+    pub base_url: String,
+    /// Why it is not forwarding, in `ssh`'s own words.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+struct Tunnel {
+    target: SshTarget,
+    base_url: String,
+    child: Child,
+}
+
+/// Every tunnel this application is holding open.
+///
+/// The sibling of [`crate::local::LocalHosts`] rather than of a remote
+/// connection: a tunnel is a resource with a lifetime that this process owns,
+/// so it is something to start, supervise and tear down.
+#[derive(Default)]
+pub struct SshTunnels {
+    tunnels: HashMap<String, Tunnel>,
+}
+
+impl SshTunnels {
+    /// Opens a tunnel to `target`, or hands back the one already open to it.
+    ///
+    /// Resolves only once the local end actually accepts a connection. An
+    /// address returned before then would be handed straight to the proxy,
+    /// which would fail its first request and park the row on "unreachable" —
+    /// blaming the host for a tunnel that was merely still being built.
+    pub async fn open(&mut self, target: SshTarget) -> Result<SshTunnelInfo, String> {
+        if let Some(problem) = target.problem() {
+            return Err(problem);
+        }
+        let key = target.key();
+
+        if let Some(existing) = self.tunnels.get_mut(&key) {
+            match existing.child.try_wait() {
+                // Still forwarding. Answering with it is what makes a relaunch
+                // — or StrictMode — cost nothing.
+                Ok(None) => {
+                    return Ok(info(&key, existing, None));
+                }
+                // Died since it was opened. Dropped here so the open below is
+                // a fresh start rather than a second entry for one host.
+                _ => {
+                    self.tunnels.remove(&key);
+                }
+            }
+        }
+
+        let local_port = free_loopback_port()?;
+        let mut child = spawn_ssh(&target, local_port)?;
+        let base_url = format!("http://127.0.0.1:{local_port}");
+
+        match wait_until_forwarding(&mut child, local_port).await {
+            Ok(()) => {
+                let tunnel = Tunnel {
+                    target,
+                    base_url,
+                    child,
+                };
+                let entry = self.tunnels.entry(key.clone()).or_insert(tunnel);
+                Ok(info(&key, entry, None))
+            }
+            Err(why) => {
+                // Nothing is listening, so there is no tunnel to remember —
+                // only a message. A dead row in the roster would be a host the
+                // console keeps probing and can never reach.
+                let _ = child.kill().await;
+                Err(why)
+            }
+        }
+    }
+
+    /// Closes the tunnel to `target` and forgets it.
+    ///
+    /// Named by the target rather than by the id [`SshTunnelInfo`] carries, so
+    /// that the key stays derived in exactly one place. The console persists
+    /// the target and not the id — an `ssh` connection restored from
+    /// `localStorage` never saw this side's answer — and a second copy of this
+    /// derivation over there is a rule two languages have to keep in step.
+    ///
+    /// A target with no tunnel is not an error: the console closes on removal,
+    /// and removal can arrive twice.
+    pub async fn close(&mut self, target: &SshTarget) {
+        if let Some(mut tunnel) = self.tunnels.remove(&target.key()) {
+            let _ = tunnel.child.kill().await;
+        }
+    }
+
+    /// Every tunnel, saying which of them are still forwarding.
+    ///
+    /// A tunnel that died — the network moved, the bastion rebooted, someone
+    /// killed the session — is a row carrying its reason rather than a missing
+    /// entry, for the same reason a local instance that will not start is.
+    /// Silence would leave the console reporting a host that is unreachable
+    /// with no clue that the path to it is what broke.
+    pub fn list(&mut self) -> Vec<SshTunnelInfo> {
+        self.tunnels
+            .iter_mut()
+            .map(|(key, tunnel)| {
+                let error = match tunnel.child.try_wait() {
+                    Ok(Some(status)) => Some(format!("the ssh tunnel stopped ({status})")),
+                    Ok(None) => None,
+                    Err(err) => Some(format!("the ssh tunnel could not be checked: {err}")),
+                };
+                info(key, tunnel, error)
+            })
+            .collect()
+    }
+}
+
+fn info(id: &str, tunnel: &Tunnel, error: Option<String>) -> SshTunnelInfo {
+    SshTunnelInfo {
+        id: id.to_string(),
+        destination: tunnel.target.destination.clone(),
+        remote_port: tunnel.target.remote_port,
+        base_url: tunnel.base_url.clone(),
+        error,
+    }
+}
+
+/// A loopback port nothing is using.
+///
+/// Asked of the OS rather than picked, by binding port 0 and reading back what
+/// it chose. There is a race between the listener closing and `ssh` binding the
+/// same port, and it is accepted: the alternative is handing `ssh` a port this
+/// process still holds, which fails every time instead of almost never.
+/// `ExitOnForwardFailure` turns the rare loss into an immediate, legible error.
+fn free_loopback_port() -> Result<u16, String> {
+    let listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .map_err(|err| format!("no local port was available for the tunnel: {err}"))?;
+    listener
+        .local_addr()
+        .map(|addr| addr.port())
+        .map_err(|err| format!("no local port was available for the tunnel: {err}"))
+}
+
+fn spawn_ssh(target: &SshTarget, local_port: u16) -> Result<Child, String> {
+    let mut command = Command::new("ssh");
+    command
+        // No command on the far side, and no shell: this connection exists to
+        // forward a port. `-T` because without a command `ssh` would otherwise
+        // still ask for a pty on some servers.
+        .arg("-N")
+        .arg("-T")
+        // The whole point. Without it a forward that cannot be established
+        // leaves `ssh` connected and happily forwarding nothing, and the
+        // failure surfaces as an unreachable host rather than as a broken
+        // tunnel.
+        .arg("-o")
+        .arg("ExitOnForwardFailure=yes")
+        // No terminal here — see the module note.
+        .arg("-o")
+        .arg("BatchMode=yes")
+        // Notices a bastion that went away, rather than holding a dead socket
+        // open until the OS gives up on it.
+        // A bastion that is simply not there must fail in seconds, not after
+        // however long this OS takes to give up on a TCP connect.
+        .arg("-o")
+        .arg("ConnectTimeout=10")
+        .arg("-o")
+        .arg("ServerAliveInterval=15")
+        .arg("-o")
+        .arg("ServerAliveCountMax=3")
+        .arg("-L")
+        .arg(format!(
+            "127.0.0.1:{local_port}:127.0.0.1:{}",
+            target.remote_port
+        ));
+    if let Some(port) = target.port {
+        command.arg("-p").arg(port.to_string());
+    }
+    command
+        .arg(&target.destination)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        // A tunnel outliving the shell that opened it would be a process
+        // nothing lists and nobody can stop from the application.
+        .kill_on_drop(true);
+
+    command.spawn().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            "this computer has no `ssh` command to open a tunnel with".to_string()
+        } else {
+            format!("the ssh tunnel could not be started: {err}")
+        }
+    })
+}
+
+/// Waits for the local end to accept a connection, or for `ssh` to explain why
+/// it never will.
+///
+/// Both halves are needed. Polling alone would wait the full timeout on a host
+/// key mismatch that `ssh` reported in the first hundred milliseconds; watching
+/// the child alone would never notice a tunnel that came up fine.
+async fn wait_until_forwarding(child: &mut Child, local_port: u16) -> Result<(), String> {
+    let deadline = Instant::now() + READY_TIMEOUT;
+    loop {
+        if let Ok(Some(_)) = child.try_wait() {
+            return Err(ssh_said(child).await);
+        }
+        if tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, local_port))
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "the ssh tunnel did not start forwarding within {}s",
+                READY_TIMEOUT.as_secs()
+            ));
+        }
+        tokio::time::sleep(READY_POLL).await;
+    }
+}
+
+/// What `ssh` printed, turned into something a dialog can show.
+///
+/// Its own words rather than a summary of them: "Host key verification failed"
+/// and "Permission denied (publickey)" are the two most likely outcomes here,
+/// and both are things the operator has to go and fix in a specific way that
+/// only `ssh` knows the shape of.
+async fn ssh_said(child: &mut Child) -> String {
+    let mut said = String::new();
+    if let Some(mut stderr) = child.stderr.take() {
+        let _ = stderr.read_to_string(&mut said).await;
+    }
+    let trimmed = said.trim();
+    if trimmed.is_empty() {
+        "the ssh tunnel closed without saying why".to_string()
+    } else {
+        // The last line is the verdict; the ones above it are usually
+        // `debug`-ish noise from the operator's own config.
+        trimmed.lines().last().unwrap_or(trimmed).trim().to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn target(destination: &str) -> SshTarget {
+        SshTarget {
+            destination: destination.into(),
+            port: None,
+            remote_port: 8080,
+        }
+    }
+
+    #[test]
+    fn one_target_is_one_tunnel() {
+        // The roster key is what makes `open` idempotent, and the console
+        // depends on that: it reopens every remembered ssh host at launch, and
+        // StrictMode calls everything twice.
+        assert_eq!(target("vps").key(), target("vps").key());
+    }
+
+    #[test]
+    fn a_different_port_on_the_far_side_is_a_different_tunnel() {
+        let mut other = target("vps");
+        other.remote_port = 9090;
+        assert_ne!(target("vps").key(), other.key());
+    }
+
+    #[test]
+    fn refuses_a_destination_that_reads_as_an_option() {
+        // The one shape that turns a host name into an ssh flag. There is no
+        // legitimate destination like it, and this is a text field in a dialog.
+        assert!(
+            target("-oProxyCommand=curl evil.example")
+                .problem()
+                .is_some()
+        );
+        assert!(target("").problem().is_some());
+        assert!(target("user@host with space").problem().is_some());
+    }
+
+    #[test]
+    fn accepts_what_an_operator_actually_types() {
+        assert!(target("vps").problem().is_none());
+        assert!(target("deploy@10.0.0.4").problem().is_none());
+        assert!(target("bastion.example.com").problem().is_none());
+    }
+
+    #[test]
+    fn refuses_a_port_nothing_can_listen_on() {
+        let mut zero = target("vps");
+        zero.remote_port = 0;
+        assert!(zero.problem().is_some());
+    }
+
+    #[test]
+    fn the_far_side_defaults_to_the_port_a_host_serves() {
+        let parsed: SshTarget = serde_json::from_str(r#"{"destination":"vps"}"#).unwrap();
+        assert_eq!(parsed.remote_port, DEFAULT_REMOTE_PORT);
+    }
+
+    #[test]
+    fn reads_what_the_console_sends() {
+        let parsed: SshTarget =
+            serde_json::from_str(r#"{"destination":"vps","port":2222,"remotePort":9090}"#).unwrap();
+        assert_eq!(parsed.port, Some(2222));
+        assert_eq!(parsed.remote_port, 9090);
+    }
+
+    #[tokio::test]
+    async fn keeps_no_row_for_a_tunnel_that_never_opened() {
+        // A destination in the reserved `.invalid` TLD, so this fails at
+        // resolution rather than after a connect timeout — and finishes at all,
+        // which is what `BatchMode=yes` buys: no password prompt is waiting for
+        // a window that does not exist.
+        //
+        // The assertion that matters is the second. A failed open must leave
+        // *nothing* behind: a roster row for a tunnel that is not forwarding is
+        // a host the console would probe forever and never reach.
+        let mut tunnels = SshTunnels::default();
+        let unreachable = target("opencompany-desktop-test.invalid");
+
+        assert!(tunnels.open(unreachable).await.is_err());
+        assert!(tunnels.list().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Defines the **connector** — the answer to "where does my company actually run" — and implements it. Four answers, modelled on the gateway/backend split in [`nousresearch/hermes-agent`](https://github.com/nousresearch/hermes-agent): this computer, TinyHumans Cloud, a gateway you run, or a host reached over an ssh tunnel.

Two of those existed. `local` was the "On this computer" tab; `remote` was a bare URL field. `cloud` and `ssh` are new, and the choice itself is now a durable property of a connection rather than something re-derived from its address.

Spec: `docs/spec/runtime/connectors.md`.

## What changed

**The model.** `Connector` is a tagged union on `Connection`, persisted per host:

```ts
type Connector =
  | { kind: "local" }
  | { kind: "cloud"; tenant: string }
  | { kind: "remote" }
  | { kind: "ssh"; target: SshTarget };
```

It cannot be inferred from the url, which is the whole reason it is written down: a local host and an ssh tunnel both bind an ephemeral port and change address every launch, and a cloud tenant and a self-hosted gateway are both `https://…`. `connectorOf` reads three vintages of `localStorage` forward — a real `connector`, `origin: "embedded"` from the version before it, or the loopback + "This computer" signature the oldest builds left behind. The guess settles on the first save. `origin` is still written *beside* the connector for one release, so a build someone rolls back to still recognises a local host and still prunes last launch's address (#615).

**Cloud carries the patience its host needs.** The manager's wake-on-request proxy starts an idle tenant when a request arrives, so its first request takes seconds. Today's probe concludes `down` — telling an operator their company is broken when it is asleep — and nothing re-probes, so the row stays red. `waking.ts` holds the two decisions: `keepWaking` (only `cloud`, only `down`, only inside a 90s window) and `wakeRetryDelay` (exponential, capped at 8s). `unauthenticated` is excluded deliberately: it is an *answer*, and retrying it would hide the sign-in behind a spinner.

The row reads **Waking…**, not a fifth `ConnectionStatus` — waking is a connecting host and ranks exactly like one, so a new status would need a place in the severity ordering and a branch in every `switch` for a state that behaves identically. `statusCopy` takes the connection and supplies the word.

**SSH, end to end.** `src-tauri/src/ssh.rs` is a supervised tunnel roster over the **system `ssh`**, which inherits `~/.ssh/config`, `ProxyJump`, the agent, hardware keys and the operator's own `known_hosts`. An in-process client (`russh`) would own host-key verification itself, and its failure mode is "we accepted a key their own config would have refused" — not a trade worth making for a Windows dependency that has shipped in the OS since 2018.

- `open` waits until the local end actually **accepts a connection** before answering. An address returned earlier goes straight to the proxy, whose first request fails and parks the row on "unreachable" — blaming the host for a tunnel still being built. A failed open leaves no row behind.
- `close` takes the **target**, not the id, so the roster key stays derived in one place; the console persists the target and has never seen the id.
- `probe` opens the tunnel before contacting anything (idempotent per target), so the changing loopback port is invisible. The dialog opens it too, so a refused key lands in the form the operator is standing in front of.
- Connections are matched by target (`findSshProfile`), not by address — otherwise every launch mints a fresh id and orphans the tour state, last-read channel and mail draft, which is #615 through a different connector.

**The chooser.** "Add a host" grows from two tabs to four. `local` and `ssh` appear only where `App` passes a handler that can be honoured, and the CORS caveat prints on the remote tab in browser builds only (the desktop proxies from Rust, where no origin is involved).

## Costs, stated plainly

- **`BatchMode=yes`.** The ssh child has no terminal, so a passphrase prompt would block forever with nothing on screen. Prompts are refused outright and the failure carries what `ssh` printed. **The key has to be one `ssh` can use without asking** — an agent key, or one with no passphrase. The dialog says so.
- **Destinations starting with `-` are refused**, not escaped: `-oProxyCommand=…` is a host name that reads as an option. No shell is involved either way.
- **The wake window is a ceiling this client imposes**, not one the manager reports — nothing surfaces its startup timeout.

## Deliberately not in this PR

Written into the spec's "what has not landed":

- **The cloud front door.** Control-plane sign-in, the tenant list and provisioning are gated on the manager exposing an account-scoped tenant listing. Until then the tab takes the address the platform gave you — the connector and its waking behaviour do not wait on it.
- **`remote`'s probe-before-commit and sign-in step.** Adding a gateway still writes the row first, so a typo is a red row rather than an error in the dialog.
- **A UI for `oc_ssh_tunnels`.** The command reports a tunnel that dropped; nothing renders it, so a dropped tunnel reads as an unreachable host until the next probe re-opens it.

## Commands run locally

```
frontend: vitest run              → 1832 passed (190 files)
frontend: tsc -b --noEmit         → clean
frontend: tsc -p tsconfig.unit.json / tsconfig.e2e.json → clean
frontend: npm run build           → ok
src-tauri: cargo fmt --all -- --check   → clean
src-tauri: cargo clippy --all-targets -- -D warnings → clean
src-tauri: cargo test --lib       → 104 passed (8 new)
```

New coverage: `frontend/test/unit/connectors.test.ts` (19) covers reading each older store vintage forward, refusing a hand-edited connector, connector survival across a reload, ssh id stability across a re-bound port, per-runtime availability, and the waking window and backoff. `host-switcher.test.ts` gains the `statusCopy` cases. `ssh.rs` tests the roster key, destination validation, the camelCase wire shape and the default remote port, and asserts a failed open keeps no row.

## API and behaviour changes

No host-side change: the runtime, its API and what a host *is* are untouched. The connector is a client-side answer to a client-side question. Three new desktop commands — `oc_open_ssh_tunnel`, `oc_close_ssh_tunnel`, `oc_ssh_tunnels`.
