### PR TITLE
fix(workspace): one first-run empty state that says what the workspace is (#1380 #1481 #1386 #1382)

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -22,9 +22,7 @@ export type NodeKind = "folder" | "file";
  * nobody. `agentId` is present exactly when `kind` is `"agent"`.
  */
 export type WorkspaceOrigin =
-  | { kind: "seed" }
-  | { kind: "operator" }
-  | { kind: "agent"; id: string };
+  { kind: "seed" } | { kind: "operator" } | { kind: "agent"; id: string };
 
 /** The origin every node falls back to — what the host defaults a legacy node to. */
 export const OPERATOR_ORIGIN: WorkspaceOrigin = { kind: "operator" };
@@ -37,7 +35,9 @@ export const OPERATOR_ORIGIN: WorkspaceOrigin = { kind: "operator" };
  * origin, whereas here the operator is the unremarkable default and badging it
  * would put a chip on nearly every note while saying nothing.
  */
-export function originLabel(origin: WorkspaceOrigin | undefined): string | null {
+export function originLabel(
+  origin: WorkspaceOrigin | undefined,
+): string | null {
   switch (origin?.kind) {
     case "agent":
       return `Teammate · ${origin.id}`;
@@ -106,7 +106,10 @@ export interface WorkspaceFile {
  * by a host that predates issue #326 gets neither field, and defaulting is
  * cheaper than a blank badge.
  */
-interface FsNodeWire extends Omit<FsNode, "parentId" | "createdBy" | "updatedBy"> {
+interface FsNodeWire extends Omit<
+  FsNode,
+  "parentId" | "createdBy" | "updatedBy"
+> {
   parentId?: string | null;
   createdBy?: WorkspaceOrigin;
   updatedBy?: WorkspaceOrigin;
@@ -135,7 +138,9 @@ export async function fetchTree(
   client: OpenCompanyClient,
   company: string | null,
 ): Promise<FsNode[]> {
-  const nodes = await client.get<FsNodeWire[]>(`${client.scopeFor(company)}/workspace`);
+  const nodes = await client.get<FsNodeWire[]>(
+    `${client.scopeFor(company)}/workspace`,
+  );
   return nodes.map(normalize);
 }
 
@@ -208,7 +213,11 @@ export async function searchWorkspace(
   if (options?.prefix) params.set("prefix", options.prefix);
   if (options?.limit !== undefined) params.set("limit", String(options.limit));
   const results = await client.get<{
-    hits: (FsNodeWire & { path: string; matched: "name" | "content"; excerpt?: string })[];
+    hits: (FsNodeWire & {
+      path: string;
+      matched: "name" | "content";
+      excerpt?: string;
+    })[];
     total: number;
   }>(`${client.scopeFor(company)}/workspace/search?${params.toString()}`);
   return {
@@ -236,7 +245,10 @@ export async function searchWorkspace(
  * An empty query yields one unmatched run, which is what keeps a cleared box
  * from marking every character.
  */
-export function highlightRuns(text: string, query: string): { text: string; hit: boolean }[] {
+export function highlightRuns(
+  text: string,
+  query: string,
+): { text: string; hit: boolean }[] {
   const needle = query.trim().toLowerCase();
   if (!needle) return [{ text, hit: false }];
   const haystack = text.toLowerCase();
@@ -246,7 +258,11 @@ export function highlightRuns(text: string, query: string): { text: string; hit:
   // Rust: JavaScript indexes strings by UTF-16 code unit and `toLowerCase` is
   // length-preserving for every character the browser will render in a note
   // title, so the two strings stay aligned.
-  for (let found = haystack.indexOf(needle); found !== -1; found = haystack.indexOf(needle, at)) {
+  for (
+    let found = haystack.indexOf(needle);
+    found !== -1;
+    found = haystack.indexOf(needle, at)
+  ) {
     if (found > at) runs.push({ text: text.slice(at, found), hit: false });
     runs.push({ text: text.slice(found, found + needle.length), hit: true });
     at = found + needle.length;
@@ -255,13 +271,65 @@ export function highlightRuns(text: string, query: string): { text: string; hit:
   return runs;
 }
 
+/**
+ * The most matches one search can return (issue #1457).
+ *
+ * Mirrors the host's `MAX_SEARCH_RESULTS` (`src/company/workspace_search.rs`).
+ * The host's *default* is 20 and its ceiling is 50, and `clamp_limit` clamps
+ * rather than refusing — so the console naming no limit at all was what capped
+ * every search at 20 while the header truthfully reported "20 of 50 matches"
+ * and offered no way to reach the other 30. There is no offset on the route, so
+ * 50 is a genuine hard ceiling; past it the honest remedy is a narrower query,
+ * which is what the foot of the list now says.
+ */
+export const SEARCH_LIMIT = 50;
+
+/**
+ * Slide an excerpt so its first match is near the front (issue #1375).
+ *
+ * The host returns a window of context around the match, and the console
+ * renders it into a `line-clamp-2` paragraph about 250px wide. When the match
+ * sits past the first dozen or so words the browser clamps *before* reaching
+ * it, so the operator gets two lines of arbitrary mid-file prose and no visible
+ * highlight — the one thing the excerpt exists to show.
+ *
+ * Pure and conservative: an early match is returned untouched (no leading `…`
+ * on text that was already fine), and a query that does not appear at all is
+ * left exactly as the host sent it. Cutting is done at a word boundary where
+ * one is near, so the result does not open mid-word.
+ */
+export function centerExcerpt(
+  excerpt: string,
+  query: string,
+  budget = 24,
+): string {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return excerpt;
+  const at = excerpt.toLowerCase().indexOf(needle);
+  if (at === -1 || at <= budget) return excerpt;
+  let cut = at - budget;
+  // Prefer the next space, so the excerpt starts on a whole word — but only if
+  // one is close, or a line with no spaces would be shifted arbitrarily far.
+  const space = excerpt.indexOf(" ", cut);
+  if (space !== -1 && space < at && space - cut < budget) cut = space + 1;
+  return `…${excerpt.slice(cut)}`;
+}
+
 /** Create a folder or file. The host mints the id and the timestamp. */
 export async function createNode(
   client: OpenCompanyClient,
   company: string | null,
-  input: { name: string; kind: NodeKind; parentId?: string | null; content?: string },
+  input: {
+    name: string;
+    kind: NodeKind;
+    parentId?: string | null;
+    content?: string;
+  },
 ): Promise<FsNode> {
-  const node = await client.post<FsNodeWire>(`${client.scopeFor(company)}/workspace`, input);
+  const node = await client.post<FsNodeWire>(
+    `${client.scopeFor(company)}/workspace`,
+    input,
+  );
   return normalize(node);
 }
 
@@ -314,7 +382,9 @@ export function deleteNode(
   company: string | null,
   id: string,
 ): Promise<void> {
-  return client.del<void>(`${client.scopeFor(company)}/workspace/${encodeURIComponent(id)}`);
+  return client.del<void>(
+    `${client.scopeFor(company)}/workspace/${encodeURIComponent(id)}`,
+  );
 }
 
 /** One folder the sweep removed, or would remove (issue #700). */
@@ -378,7 +448,8 @@ export interface MergedFolder {
 }
 
 /** Why the repair left a node exactly where it found it. */
-export type ResidualCause = "fileSharesTheName" | "fileInTheWay" | "treeMovedOn";
+export type ResidualCause =
+  "fileSharesTheName" | "fileInTheWay" | "treeMovedOn";
 
 /** One node the repair deliberately did not touch (issue #759). */
 export interface Residual {
@@ -536,6 +607,7 @@ export function formatBytes(bytes: number | undefined): string {
   if (bytes === undefined) return "unknown size";
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }

--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -25,6 +25,16 @@ export function childrenOf(nodes: FsNode[], parentId: string | null): FsNode[] {
     .filter((x) => x.parentId === parentId)
     .sort((a, b) => {
       if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+      // `derived/` sorts after the folders a person made (issue #1382). It is
+      // the one folder nobody in the company named or can write to, and sitting
+      // alphabetically among `Campaigns` and `Standards` presented it as a peer
+      // of theirs. Cosmetic and name-based, but the name is the host's and only
+      // one folder has it.
+      const aDerived =
+        a.kind === "folder" && a.name.toLowerCase() === DERIVED_DIR;
+      const bDerived =
+        b.kind === "folder" && b.name.toLowerCase() === DERIVED_DIR;
+      if (aDerived !== bDerived) return aDerived ? 1 : -1;
       return a.name.localeCompare(b.name);
     });
 }
@@ -427,6 +437,67 @@ export function sortedFolders(
   };
   walk(null);
   return out;
+}
+
+/**
+ * The root folders the host lays down on every boot, by name.
+ *
+ * Mirrors `SYSTEM_ROOTS` in `src/company/workspace_scaffold.rs`. Kept in step
+ * by name rather than by a wire field, and the risk is the same one
+ * {@link isDerivedNode} documents: if the host scaffolds a third root, this
+ * const has to follow or a fresh company will briefly look as though somebody
+ * has already been working in it.
+ */
+export const SYSTEM_ROOTS = ["agents", "secrets"] as const;
+
+/** The note the host provisions inside `secrets/` on first boot. */
+const SECRETS_README = "readme.md";
+
+/**
+ * Whether anything in this tree was put there by a person (issue #1481).
+ *
+ * `ensure_workspace_scaffold` runs on every boot, so `nodes.length === 0` is
+ * unreachable on a live company and "is this workspace empty?" cannot be asked
+ * that way. What the empty state actually needs to know is different: has
+ * anyone written anything here *yet* — because "pick a note from the explorer"
+ * is the wrong instruction to give someone whose explorer holds three rows they
+ * did not create and have no reason to open.
+ */
+export function hasOperatorContent(nodes: FsNode[]): boolean {
+  const systemRootIds = new Set(
+    nodes
+      .filter(
+        (node) =>
+          node.parentId === null &&
+          node.kind === "folder" &&
+          (SYSTEM_ROOTS as readonly string[]).includes(node.name.toLowerCase()),
+      )
+      .map((node) => node.id),
+  );
+  const agentsRootId = nodes.find((node) => isAgentsFolder(node))?.id ?? null;
+  return nodes.some((node) => {
+    if (systemRootIds.has(node.id)) return false;
+    // The scaffolded README inside `secrets/` is the host's words, not the
+    // operator's — a workspace holding only it has still never been written in.
+    if (
+      node.parentId &&
+      systemRootIds.has(node.parentId) &&
+      node.name.toLowerCase() === SECRETS_README
+    ) {
+      return false;
+    }
+    // A teammate's own `Agents/<roster-id>/` folder is minted by the host and
+    // named by id; nobody chose it. A note filed *inside* one is a person's
+    // work and counts.
+    if (
+      node.kind === "folder" &&
+      agentsRootId !== null &&
+      node.parentId === agentsRootId
+    ) {
+      return false;
+    }
+    return true;
+  });
 }
 
 export type Crumb = FsNode | null;

--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -13,7 +13,7 @@
 
 export type { FsNode } from "@/api/workspace";
 
-import { type LocalScope, scopedKeyAdoptingLegacy } from "@/connections/types";
+import { type LocalScope, scopedKey, scopedKeyAdoptingLegacy } from "@/connections/types";
 
 import type { FsNode, RepairOutcome } from "@/api/workspace";
 
@@ -523,6 +523,38 @@ export function readLegacyLocalNodes(scope: LocalScope): FsNode[] {
 export function hasLegacyLocal(scope: LocalScope): boolean {
   try {
     return localStorage.getItem(KEY(scope)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Where a declined migration offer is remembered, per connection. */
+const DECLINED_KEY = (scope: LocalScope) => scopedKey("oc-workspace-migration-declined", scope);
+
+/**
+ * Remember that the operator said "not now" to the migration offer.
+ *
+ * A decline is deliberately *not* a discard. The banner used to offer exactly
+ * two exits — import, or destroy the notes — so an operator who wanted neither
+ * met the same offer on every mount, and the quietest way to make it stop was
+ * the button that deleted the only copy. This is the third exit: the notes stay
+ * in the browser, untouched, and the offer stops asking.
+ *
+ * Scoped per connection like every other console key, so declining on one host
+ * cannot hide the offer on another that has never made it.
+ */
+export function declineLegacyImport(scope: LocalScope): void {
+  try {
+    localStorage.setItem(DECLINED_KEY(scope), "1");
+  } catch {
+    /* storage unavailable — the offer will simply be made again */
+  }
+}
+
+/** Whether this connection has already declined the migration offer. */
+export function legacyImportDeclined(scope: LocalScope): boolean {
+  try {
+    return localStorage.getItem(DECLINED_KEY(scope)) !== null;
   } catch {
     return false;
   }

--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -16,6 +16,7 @@ export type { FsNode } from "@/api/workspace";
 import { type LocalScope, scopedKey, scopedKeyAdoptingLegacy } from "@/connections/types";
 
 import type { FsNode, RepairOutcome } from "@/api/workspace";
+import { rosterDisplayName, type RosterNames } from "@/lib/roster-names";
 
 /* ---- queries ---- */
 
@@ -360,6 +361,74 @@ export function pathOf(nodes: FsNode[], id: string | null): FsNode[] {
  * ellipsis rather than dropped, so the operator can see that the path is longer
  * than what is shown instead of reading a shortened path as the whole truth.
  */
+/**
+ * Whether `folder` is the workspace's `Agents/` root — the one folder whose
+ * direct children are named by roster id rather than anything an operator
+ * chose (issue #973). Root-scoped (`parentId === null`) so a note or folder an
+ * operator names "Agents" somewhere else in the tree is never mistaken for it.
+ *
+ * Lives here rather than in the view because the tree is no longer the only
+ * surface that has to resolve those ids: the Move dialog lists the same folders
+ * (issue #1381).
+ */
+export function isAgentsFolder(folder: FsNode | undefined): boolean {
+  return (
+    folder?.kind === "folder" &&
+    folder.name === "Agents" &&
+    folder.parentId === null
+  );
+}
+
+/**
+ * A folder's full path as one line, with roster ids resolved (issue #1381).
+ *
+ * The Move dialog listed every folder by bare `name`, so two `Drafts` under
+ * different parents were identical rows and a roster folder was a raw ULID —
+ * in a list the operator is choosing a destination from, where picking the
+ * wrong one silently re-files a note.
+ */
+export function folderPathLabel(
+  nodes: FsNode[],
+  id: string,
+  names: RosterNames,
+): string {
+  return pathOf(nodes, id)
+    .map((node) =>
+      isAgentsFolder(nodeById(nodes, node.parentId))
+        ? rosterDisplayName(node.name, names)
+        : node.name,
+    )
+    .join(" / ");
+}
+
+/**
+ * Every folder in the tree, in the order the explorer draws them (issue #1381).
+ *
+ * `fetchTree` returns the host's order unmodified, and the host calls its own
+ * `tree()` order unspecified — so the destination list was arbitrary while the
+ * tree beside it was sorted. This walks the same {@link childrenOf} the tree
+ * does, depth-first, so the two agree.
+ *
+ * `blocked` drops a subtree wholesale: the moving node's own descendants (which
+ * would be a cycle), and the read-only `derived/` root, which the host refuses
+ * writes under — offering it could only ever produce an error toast.
+ */
+export function sortedFolders(
+  nodes: FsNode[],
+  blocked: ReadonlySet<string>,
+): FsNode[] {
+  const out: FsNode[] = [];
+  const walk = (parentId: string | null) => {
+    for (const node of childrenOf(nodes, parentId)) {
+      if (node.kind !== "folder" || blocked.has(node.id)) continue;
+      out.push(node);
+      walk(node.id);
+    }
+  };
+  walk(null);
+  return out;
+}
+
 export type Crumb = FsNode | null;
 
 /**

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2072,6 +2072,34 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
   // level below `Agents/`.
   const isRosterFolder = isFolder && isAgentsFolder(nodeById(nodes, node.parentId));
   const displayName = isRosterFolder ? rosterDisplayName(node.name, rosterNames) : node.name;
+  /** What this row is actually called on screen. */
+  const label = isFolder ? displayName : titleOf(node);
+  /**
+   * Whether the name is being cut off (issue #1459).
+   *
+   * A row is `truncate` inside a fixed 256px pane, indented 12px per level, so
+   * by depth 5 there are about 22 characters of room — and the seeded tree
+   * ellipsises six rows out of the box. There was no tooltip, no wrap, no row
+   * scroll and no resize handle: the only way to read a name was to open a row
+   * you could not identify.
+   *
+   * Measured rather than guessed, so the ordinary short name gets no hover
+   * chrome at all. `title` below is the unconditional fallback — it costs
+   * nothing, works on touch and for assistive tech, and means the fix does not
+   * depend on this measurement having run.
+   */
+  const nameRef = useRef<HTMLSpanElement | null>(null);
+  const [clipped, setClipped] = useState(false);
+  useEffect(() => {
+    const el = nameRef.current;
+    if (!el) return;
+    const measure = () => setClipped(el.scrollWidth > el.clientWidth);
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [label]);
   /**
    * Whether this row is the `derived/` folder or something inside it (#1377).
    *
@@ -2141,9 +2169,27 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
           ) : (
             <FileText className="ml-3.5 size-4 shrink-0 text-muted-foreground" />
           )}
-          <span className="truncate" title={isRosterFolder ? node.name : undefined}>
-            {isFolder ? displayName : titleOf(node)}
-          </span>
+          {/* The roster case keeps showing the raw id on `title`, which is
+              how #973 left the folder's real name reachable; every other row
+              now carries its own full name there instead of `undefined`. */}
+          <Tooltip open={clipped ? undefined : false}>
+            <TooltipTrigger
+              render={
+                <span
+                  ref={nameRef}
+                  className="truncate"
+                  title={isRosterFolder ? node.name : label}
+                  data-testid="workspace-tree-name"
+                />
+              }
+            >
+              {label}
+            </TooltipTrigger>
+            <TooltipContent>
+              {label}
+              {isRosterFolder && <span className="block text-3xs opacity-70">{node.name}</span>}
+            </TooltipContent>
+          </Tooltip>
           {/* The glyph is the whole of the tree-side signal: an icon, not a
               badge, because a row in a 256px pane has no width for a phrase and
               the name is the thing being scanned. The label rides along for a

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -42,6 +42,7 @@ import {
   residualReason,
   renameMoveNode,
   searchWorkspace,
+  SEARCH_LIMIT,
   sweepEmptyAgentFolders,
   uploadFile,
   writeFile,
@@ -574,7 +575,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       const mine = ++searchGen.current;
       setSearching(true);
       try {
-        const page = await searchWorkspace(client, company, query);
+        // Ask for the host's ceiling, not its default (issue #1457). The route
+        // clamps rather than refusing, so naming no limit was the console
+        // silently capping itself at 20 while the header said "20 of 50".
+        const page = await searchWorkspace(client, company, query, {
+          limit: SEARCH_LIMIT,
+        });
         if (mine !== searchGen.current) return;
         setSearchPage(page);
         setSearchError(null);

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
+  ChevronsDownUp,
   EyeOff,
   FilePlus2,
   FileText,
@@ -1441,6 +1442,18 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
           <IconBtn label="Upload" onClick={() => uploadRef.current?.click()}>
             <Upload className="size-4" />
           </IconBtn>
+          {/* Expansion persists for the session and a deep tree stays open
+              behind every reveal, so there was no way back to a readable
+              explorer short of collapsing each folder by hand (issue #1382).
+              `setExpanded(new Set())` already existed; nothing invoked it. */}
+          <IconBtn
+            label="Collapse all"
+            disabled={expanded.size === 0}
+            onClick={() => setExpanded(new Set())}
+            data-testid="workspace-collapse-all"
+          >
+            <ChevronsDownUp className="size-4" />
+          </IconBtn>
           {/* The two controls after this line repair the tree rather than adding
               to it, and both can remove folders. Kept visually apart from the
               make-something group so the row is not six identical glyphs with
@@ -1730,6 +1743,20 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                 Edited{" "}
                 {formatUpdated(openFile?.updatedAt ?? openNode.updatedAt)}
               </span>
+              {/* The backlink count, always visible (issue #1382). The rail
+                  that lists them is `xl:flex`, so below about 1280px a note
+                  with eleven backlinks and one with none looked identical —
+                  the whole signal disappeared rather than degrading. */}
+              {openFile && openFile.backlinks.length > 0 && (
+                <span
+                  className="hidden shrink-0 items-center gap-1 text-xs text-muted-foreground sm:inline-flex"
+                  data-testid="workspace-backlink-count"
+                  title="Notes that link here"
+                >
+                  <Link2 className="size-3" aria-hidden />
+                  {openFile.backlinks.length}
+                </span>
+              )}
               <SaveStatus state={saveState} />
               {/* A payload has no prose to read or edit, so the mode switch is
                   hidden rather than shown-and-broken (issue #553). The host

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2719,15 +2719,6 @@ function MoveDialog({
   );
 }
 
-/**
- * Delete confirmation for a note or folder (issue #1255).
- *
- * A folder's delete recursively takes every note nested inside it in the same
- * API call, so the dialog names exactly what that means — the file/folder
- * counts under it, from {@link subtreeCounts} — rather than a bare "are you
- * sure?" that reads the same for an empty folder and one holding a hundred
- * notes.
- */
 /** Which last-copy-destroying "Discard" the confirm is standing in front of. */
 type DiscardTarget = "legacy" | "rescued";
 
@@ -2789,6 +2780,15 @@ function DiscardConfirm({
   );
 }
 
+/**
+ * Delete confirmation for a note or folder (issue #1255).
+ *
+ * A folder's delete recursively takes every note nested inside it in the same
+ * API call, so the dialog names exactly what that means — the file/folder
+ * counts under it, from {@link subtreeCounts} — rather than a bare "are you
+ * sure?" that reads the same for an empty folder and one holding a hundred
+ * notes.
+ */
 function DeleteDialog({
   nodes,
   node,

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -90,17 +90,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { rosterDisplayName, rosterNameMap, type RosterNames } from "@/lib/roster-names";
 import { fromDto } from "@/lib/team";
 import { cn } from "@/lib/utils";
-import {
-  createSaveBuffer,
-  createUnloadGuard,
-  type SaveBuffer,
-} from "@/lib/workspace-save-buffer";
+import { createSaveBuffer, createUnloadGuard, type SaveBuffer } from "@/lib/workspace-save-buffer";
 import {
   ancestorFolderIds,
   applyRepair,
   breadcrumbOf,
   childrenOf,
   clearLegacyLocal,
+  declineLegacyImport,
   DERIVED_LABEL,
   DERIVED_REASON,
   ensureMdExt,
@@ -109,6 +106,7 @@ import {
   hasLegacyLocal,
   isDerivedNode,
   isSecretNode,
+  legacyImportDeclined,
   type MoveAudienceChange,
   type MoveAudienceWarning,
   moveAudienceWarning,
@@ -228,6 +226,19 @@ export function migrationBannerText(files: number, folders: number): string {
     `${total === 1 ? "is" : "are"} not in the company workspace yet.`
   );
 }
+
+/**
+ * What Import actually does, said before it is clicked (issue #1472).
+ *
+ * The banner used to offer "Import" and name neither half of the bargain: not
+ * where the notes land, and not that the browser's copy is **removed** on the
+ * way. It is a move, not a copy — `importLegacy` clears the scratchpad key on
+ * success — and an operator who expected a backup to remain in the browser had
+ * no way to learn otherwise until it was gone.
+ */
+export const MIGRATION_CONSEQUENCE =
+  `Import files them under “${IMPORT_FOLDER_NAME}” in the company workspace ` +
+  `and removes this browser's copy — it moves them rather than copying them.`;
 
 /** What the editor's status line is currently reporting. */
 export type SaveState = "idle" | "dirty" | "saving" | "saved" | "error";
@@ -445,7 +456,15 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   const [moving, setMoving] = useState<FsNode | null>(null);
   const [showExplorer, setShowExplorer] = useState(true);
   const [legacy, setLegacy] = useState<FsNode[]>([]);
+  // Whether this connection already said "not now" to the migration offer.
+  // Read once per company rather than per render, because the answer lives in
+  // localStorage and cannot change without this component having changed it.
+  const [importDeclined, setImportDeclined] = useState(false);
   const [importing, setImporting] = useState(false);
+  // Which of the two irreversible "Discard" buttons is waiting on a confirm
+  // (issue #1472). Both destroy the last copy of something an operator typed,
+  // so neither fires from its own click any more.
+  const [confirmDiscard, setConfirmDiscard] = useState<DiscardTarget | null>(null);
   // The empty-agent-folder tidy (issue #700), in its two stages: `preview` is
   // what the host says *would* go, `done` is what actually went. Both name every
   // folder — a count is not something an operator who disagrees can check.
@@ -678,7 +697,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         // a note the operator has just rewritten, until the next refetch.
         setOpenFile((f) =>
           f && f.id === job.id
-            ? { ...f, content: job.content, updatedAt: ack.updatedAt, updatedBy: OPERATOR_ORIGIN }
+            ? {
+                ...f,
+                content: job.content,
+                updatedAt: ack.updatedAt,
+                updatedBy: OPERATOR_ORIGIN,
+              }
             : f,
         );
         setNodes((all) =>
@@ -922,6 +946,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
 
   useEffect(() => {
     const mine = readLegacyLocalNodes(scope);
+    setImportDeclined(legacyImportDeclined(scope));
     if (mine.length > 0) {
       setLegacy(mine);
       return;
@@ -963,8 +988,17 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       }
       clearLegacyLocal(scope);
       setLegacy([]);
-      toast.success(`Imported ${importSummary(legacyFiles.length, legacyFolders.length)}.`);
+      toast.success(
+        `Imported ${importSummary(legacyFiles.length, legacyFolders.length)} into “${IMPORT_FOLDER_NAME}”.`,
+      );
       await loadTree({ silent: true });
+      // Show the operator where their notes went (issue #1472). A toast naming
+      // a folder is still a folder they then have to find in a tree they did
+      // not build; the import is the one moment the console knows exactly which
+      // row is the answer.
+      setSearchInput("");
+      setExpanded((prev) => new Set([...prev, root.id]));
+      setRevealId(root.id);
     } catch (e) {
       // The key is left intact on failure, so the banner comes back and nothing
       // the operator wrote is lost to a half-finished import.
@@ -974,9 +1008,30 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     }
   }
 
+  /**
+   * Destroy the browser's copy of the old scratchpad.
+   *
+   * Only ever reached from the confirm dialog. `clearLegacyLocal` removes both
+   * the scoped key and the pre-connection origin it was adopted from, so by
+   * construction there is nothing left to offer again — this is the delete, not
+   * a dismissal of the offer, and `declineImport` is the button for the latter.
+   */
   function discardLegacy() {
     clearLegacyLocal(scope);
     setLegacy([]);
+    setConfirmDiscard(null);
+  }
+
+  /** Stop offering the import without touching the notes (issue #1472). */
+  function declineImport() {
+    declineLegacyImport(scope);
+    setImportDeclined(true);
+  }
+
+  /** Throw away the rescued text — likewise only from the confirm. */
+  function discardRescued() {
+    setRescued(null);
+    setConfirmDiscard(null);
   }
 
   /* ---- navigation ---- */
@@ -1122,7 +1177,9 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   async function rename(node: FsNode, name: string) {
     const next = (node.kind === "file" ? ensureMdExt(name.trim()) : name.trim()) || node.name;
     try {
-      const updated = await renameMoveNode(client, company, node.id, { name: next });
+      const updated = await renameMoveNode(client, company, node.id, {
+        name: next,
+      });
       setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
       setOpenFile((f) => (f && f.id === updated.id ? { ...f, name: updated.name } : f));
     } catch (e) {
@@ -1134,7 +1191,9 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     try {
       // The move-cycle guard is the host's: it answers 400 for a folder moved
       // under its own descendant, which surfaces here as a toast.
-      const updated = await renameMoveNode(client, company, node.id, { parentId: destId });
+      const updated = await renameMoveNode(client, company, node.id, {
+        parentId: destId,
+      });
       setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
     } catch (e) {
       toast.error(message(e, "could not move this item"));
@@ -1468,12 +1527,18 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       </aside>
 
       {/* Note pane */}
-      <section className={cn("flex-1 flex-col overflow-hidden", showExplorer ? "hidden md:flex" : "flex")}>
-        {legacy.length > 0 && (
+      <section
+        className={cn("flex-1 flex-col overflow-hidden", showExplorer ? "hidden md:flex" : "flex")}
+      >
+        {legacy.length > 0 && !importDeclined && (
           <Alert className="m-3 mb-0 w-auto" data-testid="workspace-migration-banner">
             <AlertDescription className="flex flex-wrap items-center gap-3">
-              <span className="flex-1">
-                {migrationBannerText(legacyFiles.length, legacyFolders.length)}
+              <span className="flex-1 space-y-1">
+                <span className="block">
+                  {migrationBannerText(legacyFiles.length, legacyFolders.length)}
+                </span>
+                {/* What Import does, before it is clicked (issue #1472). */}
+                <span className="block text-xs text-muted-foreground">{MIGRATION_CONSEQUENCE}</span>
               </span>
               <Button
                 size="sm"
@@ -1483,7 +1548,26 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               >
                 {importing && <Loader2 className="size-3.5 animate-spin" />} Import
               </Button>
-              <Button size="sm" variant="ghost" disabled={importing} onClick={discardLegacy}>
+              {/* The non-destructive exit (issue #1472). Without it the only
+                  way to stop being asked was the button that deletes the
+                  notes, which is how the quiet control became the dangerous
+                  one. */}
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={importing}
+                onClick={declineImport}
+                data-testid="workspace-migration-decline"
+              >
+                Not now
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={importing}
+                onClick={() => setConfirmDiscard("legacy")}
+                data-testid="workspace-migration-discard"
+              >
                 Discard
               </Button>
             </AlertDescription>
@@ -1516,7 +1600,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                 <Button size="sm" variant="ghost" onClick={() => void copyRescued()}>
                   Copy
                 </Button>
-                <Button size="sm" variant="ghost" onClick={() => setRescued(null)}>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => setConfirmDiscard("rescued")}
+                  data-testid="workspace-rescued-discard"
+                >
                   Discard
                 </Button>
               </span>
@@ -1693,7 +1782,10 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
             </div>
           </>
         ) : (
-          <EmptyNote onNew={() => setPrompt({ mode: "file" })} onToggleExplorer={() => setShowExplorer((s) => !s)} />
+          <EmptyNote
+            onNew={() => setPrompt({ mode: "file" })}
+            onToggleExplorer={() => setShowExplorer((s) => !s)}
+          />
         )}
       </section>
 
@@ -1728,6 +1820,13 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         busy={repairing}
         onClose={() => setRepair(null)}
         onConfirm={() => void confirmRepair()}
+      />
+      <DiscardConfirm
+        target={confirmDiscard}
+        legacyCount={legacy.length}
+        rescuedName={rescued?.name ?? ""}
+        onClose={() => setConfirmDiscard(null)}
+        onConfirm={confirmDiscard === "rescued" ? discardRescued : discardLegacy}
       />
       <DeleteDialog
         nodes={nodes}
@@ -1817,9 +1916,7 @@ function SaveStatus({ state }: { state: SaveState }) {
         state === "dirty" && "text-foreground",
       )}
     >
-      {state === "dirty" && (
-        <span aria-hidden="true" className="size-1.5 rounded-full bg-tone-2" />
-      )}
+      {state === "dirty" && <span aria-hidden="true" className="size-1.5 rounded-full bg-tone-2" />}
       {label}
     </span>
   );
@@ -2015,8 +2112,16 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
         >
           {isFolder ? (
             <>
-              {isOpen ? <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />}
-              {isOpen ? <FolderOpen className="size-4 shrink-0 text-tone-2" /> : <Folder className="size-4 shrink-0 text-tone-2" />}
+              {isOpen ? (
+                <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              {isOpen ? (
+                <FolderOpen className="size-4 shrink-0 text-tone-2" />
+              ) : (
+                <Folder className="size-4 shrink-0 text-tone-2" />
+              )}
             </>
           ) : (
             <FileText className="ml-3.5 size-4 shrink-0 text-muted-foreground" />
@@ -2071,7 +2176,14 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
         </button>
         <DropdownMenu>
           <DropdownMenuTrigger
-            render={<Button variant="ghost" size="icon" className="size-6 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100" aria-label="Actions" />}
+            render={
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100"
+                aria-label="Actions"
+              />
+            }
           >
             <MoreHorizontal className="size-3.5" />
           </DropdownMenuTrigger>
@@ -2258,16 +2370,16 @@ function NoteMarkdown({
   onWiki: (target: string) => void;
 }) {
   if (!source.trim()) {
-    return <p className="text-sm text-muted-foreground">This note is empty. Switch to Edit to write.</p>;
+    return (
+      <p className="text-sm text-muted-foreground">This note is empty. Switch to Edit to write.</p>
+    );
   }
   // Rewrite [[target]] / [[target|alias]] into links the renderer can style —
   // but leave fenced and inline code untouched (so `[[…]]` examples survive).
   const rewritten = source.replace(
     /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)|\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g,
     (_m, code: string | undefined, target: string, alias?: string) =>
-      code
-        ? code
-        : `[${(alias ?? target).trim()}](#wiki:${encodeURIComponent(target.trim())})`,
+      code ? code : `[${(alias ?? target).trim()}](#wiki:${encodeURIComponent(target.trim())})`,
   );
   return (
     <div className="prose prose-sm max-w-none dark:prose-invert">
@@ -2307,7 +2419,13 @@ function NoteMarkdown({
   );
 }
 
-function EmptyNote({ onNew, onToggleExplorer }: { onNew: () => void; onToggleExplorer: () => void }) {
+function EmptyNote({
+  onNew,
+  onToggleExplorer,
+}: {
+  onNew: () => void;
+  onToggleExplorer: () => void;
+}) {
   return (
     <div className="flex flex-1 flex-col">
       <div className="flex items-center border-b px-3 py-2 md:hidden">
@@ -2319,7 +2437,9 @@ function EmptyNote({ onNew, onToggleExplorer }: { onNew: () => void; onToggleExp
         <FileText className="size-8 text-muted-foreground" />
         <div className="space-y-1">
           <p className="font-medium">No note open</p>
-          <p className="text-sm text-muted-foreground">Pick a note from the explorer, or create one.</p>
+          <p className="text-sm text-muted-foreground">
+            Pick a note from the explorer, or create one.
+          </p>
         </div>
         <Button variant="outline" size="sm" onClick={onNew}>
           <FilePlus2 className="size-4" /> New note
@@ -2414,7 +2534,8 @@ function NamePrompt({
     setPending({ name: next, warning });
   }
 
-  const title = state?.mode === "folder" ? "New folder" : state?.mode === "file" ? "New note" : "Rename";
+  const title =
+    state?.mode === "folder" ? "New folder" : state?.mode === "file" ? "New note" : "Rename";
 
   return (
     <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
@@ -2498,9 +2619,10 @@ function MoveDialog({
   const blocked = moving ? subtreeIds(nodes, moving.id) : new Set<string>();
   const folders = nodes.filter((x) => x.kind === "folder" && !blocked.has(x.id));
   /** The destination picked, held back until the warning is acknowledged. */
-  const [pending, setPending] = useState<{ destId: string | null; warning: MoveAudienceWarning } | null>(
-    null,
-  );
+  const [pending, setPending] = useState<{
+    destId: string | null;
+    warning: MoveAudienceWarning;
+  } | null>(null);
 
   // A second `Move to…` must not open onto the previous one's warning.
   useEffect(() => {
@@ -2572,6 +2694,67 @@ function MoveDialog({
  * sure?" that reads the same for an empty folder and one holding a hundred
  * notes.
  */
+/** Which last-copy-destroying "Discard" the confirm is standing in front of. */
+type DiscardTarget = "legacy" | "rescued";
+
+/**
+ * The confirm both workspace "Discard" buttons now sit behind (issue #1472).
+ *
+ * Neither of these deletes has an undo and neither has a second copy anywhere.
+ * The scratchpad discard removes the adopted key *and* its pre-connection
+ * origin, so the notes can never be re-offered; the rescued-text discard drops
+ * the only remaining copy of words whose note is already gone. Both were plain
+ * ghost buttons — quieter than the {@link DeleteDialog} that guards deleting a
+ * note the host still holds, which is strictly the more recoverable act.
+ *
+ * Shares {@link DeleteDialog}'s shape and its solid-destructive action rather
+ * than inventing a second confirm style, so "this cannot be undone" looks the
+ * same everywhere in the view. The copy names the quantity, because a confirm
+ * that says only "are you sure?" is one an operator learns to click through.
+ */
+function DiscardConfirm({
+  target,
+  legacyCount,
+  rescuedName,
+  onClose,
+  onConfirm,
+}: {
+  target: DiscardTarget | null;
+  legacyCount: number;
+  rescuedName: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const rescued = target === "rescued";
+  const title = rescued
+    ? "Discard your unsaved text?"
+    : `Delete ${legacyCount} note${legacyCount === 1 ? "" : "s"} kept only in this browser?`;
+  const description = rescued
+    ? `This is the last copy of what you wrote in “${rescuedName}”. That note is already gone, so nothing else holds this text. There is no undo.`
+    : "These notes were never sent to the company workspace, so this browser holds the only copy. Deleting them cannot be undone — “Not now” leaves them alone.";
+
+  return (
+    <AlertDialog open={Boolean(target)} onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep it</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-white hover:bg-destructive/90"
+            data-testid="workspace-discard-confirm"
+          >
+            {rescued ? "Discard text" : "Delete notes"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 function DeleteDialog({
   nodes,
   node,
@@ -2662,10 +2845,7 @@ function SweepDialog({
               : `${count} folder${count === 1 ? "" : "s"} under Agents/ hold nothing at all. Removing them cannot take anything with them — a folder holding any file, note or subfolder is left alone.`}
           </DialogDescription>
         </DialogHeader>
-        <ul
-          className="max-h-64 space-y-1 overflow-y-auto"
-          data-testid="workspace-sweep-folders"
-        >
+        <ul className="max-h-64 space-y-1 overflow-y-auto" data-testid="workspace-sweep-folders">
           {state?.folders.map((folder) => (
             <li
               key={folder.id}

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -86,6 +86,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { rosterDisplayName, rosterNameMap, type RosterNames } from "@/lib/roster-names";
 import { fromDto } from "@/lib/team";
@@ -1396,6 +1397,11 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
           <IconBtn label="Upload" onClick={() => uploadRef.current?.click()}>
             <Upload className="size-4" />
           </IconBtn>
+          {/* The two controls after this line repair the tree rather than adding
+              to it, and both can remove folders. Kept visually apart from the
+              make-something group so the row is not six identical glyphs with
+              two mines in it (issue #1378). */}
+          <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 self-center bg-border" />
           {/* Issue #700. A company provisioned before the tree went lazy carries
               one empty folder per teammate, and nothing else will ever remove
               them. Deliberately a button rather than something boot does: the
@@ -2449,6 +2455,18 @@ function EmptyNote({
   );
 }
 
+/**
+ * An icon-only control in the explorer header, labelled on hover (issue #1378).
+ *
+ * The header is six of these in a row — two of which delete things — and the
+ * label existed only as `aria-label`, which is to say only for a screen reader.
+ * A sighted operator had six identical grey glyphs and no way to learn what any
+ * of them did short of pressing it, in a row where two presses are destructive.
+ *
+ * The tooltip renders the same string the `aria-label` carries rather than a
+ * second, longer explanation: one label, two ways of meeting it. `TooltipProvider`
+ * is mounted globally (`main.tsx`), so this costs nothing at each site.
+ */
 function IconBtn({
   label,
   onClick,
@@ -2460,16 +2478,23 @@ function IconBtn({
   children: React.ReactNode;
 } & Omit<React.ComponentProps<typeof Button>, "onClick" | "children">) {
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="size-7 text-muted-foreground"
-      aria-label={label}
-      onClick={onClick}
-      {...rest}
-    >
-      {children}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground"
+            aria-label={label}
+            onClick={onClick}
+            {...rest}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -2864,7 +2889,16 @@ function SweepDialog({
               <Button variant="ghost" onClick={onClose}>
                 Cancel
               </Button>
-              <Button variant="destructive" disabled={busy} onClick={onConfirm}>
+              {/* The solid override, not the tinted `destructive` variant: this
+                  is the codebase's confirm-and-destroy weight, the one
+                  `DeleteDialog` wears (issue #1378). */}
+              <Button
+                variant="destructive"
+                className="bg-destructive text-white hover:bg-destructive/90"
+                disabled={busy}
+                onClick={onConfirm}
+                data-testid="workspace-sweep-confirm"
+              >
                 {busy && <Loader2 className="mr-1 size-4 animate-spin" />}
                 Remove {count}
               </Button>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1817,6 +1817,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       />
       <SweepDialog
         state={sweep}
+        rosterNames={rosterNames}
         busy={sweeping}
         onClose={() => setSweep(null)}
         onConfirm={() => void confirmSweep()}
@@ -2845,17 +2846,31 @@ interface SweepState {
 
 function SweepDialog({
   state,
+  rosterNames,
   busy,
   onClose,
   onConfirm,
 }: {
   state: SweepState | null;
+  /** The roster the swept folder names are ids in (issue #1479). */
+  rosterNames: RosterNames;
   busy: boolean;
   onClose: () => void;
   onConfirm: () => void;
 }) {
   const done = state?.stage === "done";
   const count = state?.folders.length ?? 0;
+  // Resolve, then sort by what is on screen (issue #1479). A swept folder's
+  // `name` *is* a roster id — that is what `Agents/<id>/` folders are called —
+  // so the dialog asking an operator to approve seven removals was showing
+  // seven ULIDs, in whatever order the host's tree() happened to return, in the
+  // one view that already resolves those ids in the tree behind the modal.
+  const rows = (state?.folders ?? [])
+    .map((folder) => {
+      const display = rosterDisplayName(folder.name, rosterNames);
+      return { ...folder, display, resolved: display !== folder.name };
+    })
+    .sort((a, b) => a.display.localeCompare(b.display));
 
   return (
     <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
@@ -2871,13 +2886,24 @@ function SweepDialog({
           </DialogDescription>
         </DialogHeader>
         <ul className="max-h-64 space-y-1 overflow-y-auto" data-testid="workspace-sweep-folders">
-          {state?.folders.map((folder) => (
+          {rows.map((folder) => (
             <li
               key={folder.id}
               className="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm"
             >
               <Folder className="size-4 shrink-0 text-tone-2" />
-              <span className="truncate">{folder.name}</span>
+              <span className="truncate" title={folder.name}>
+                {folder.display}
+              </span>
+              {/* An id the roster cannot resolve is the clearest case of all
+                  for sweeping: that teammate is no longer on the roster. Said
+                  plainly rather than left as a bare ULID the operator is asked
+                  to recognise. */}
+              {!folder.resolved && (
+                <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                  no longer on the roster
+                </span>
+              )}
             </li>
           ))}
         </ul>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -108,6 +108,7 @@ import {
   folderPathLabel,
   type FsNode,
   hasLegacyLocal,
+  hasOperatorContent,
   isAgentsFolder,
   isDerivedNode,
   isSecretNode,
@@ -1450,9 +1451,13 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               them. Deliberately a button rather than something boot does: the
               operator's click is the opt-in, and the dialog names every folder
               before any of them goes. */}
+          {/* Nothing to tidy or repair in a tree with nothing in it. A no-op on
+              a live company, where the scaffold guarantees rows — but the
+              controls claimed to apply to a state they cannot act on, which is
+              the same claim the dead explorer branch was making (#1380). */}
           <IconBtn
             label="Tidy empty agent folders"
-            disabled={sweeping}
+            disabled={sweeping || nodes.length === 0}
             onClick={() => void previewSweep()}
             data-testid="workspace-sweep"
           >
@@ -1467,7 +1472,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               rearranges somebody's tree unasked. */}
           <IconBtn
             label="Repair duplicate folders"
-            disabled={repairing}
+            disabled={repairing || nodes.length === 0}
             onClick={() => void previewRepair()}
             data-testid="workspace-repair"
           >
@@ -1551,11 +1556,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                 Try again
               </Button>
             </div>
-          ) : nodes.length === 0 ? (
-            <p className="px-3 py-2 text-xs text-muted-foreground">
-              This workspace is empty. Create a note to start.
-            </p>
           ) : (
+            /* The `nodes.length === 0` branch that used to sit here said "This
+               workspace is empty. Create a note to start." — dead code, since
+               `ensure_workspace_scaffold` lays down `Agents/` and `secrets/` on
+               every boot, and a second message contradicting the note pane's
+               own (issue #1380). The pane owns what an empty workspace says. */
             <Tree
               nodes={nodes}
               parentId={null}
@@ -1714,7 +1720,14 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
                   updatedBy={openFile?.updatedBy ?? openNode.updatedBy}
                 />
               )}
-              <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+              {/* Labelled (issue #1382). A bare "2 days ago" beside the title
+                  read like part of it, and did not say which event it was
+                  timing. */}
+              <span
+                className="hidden shrink-0 text-xs text-muted-foreground sm:inline"
+                data-testid="workspace-updated"
+              >
+                Edited{" "}
                 {formatUpdated(openFile?.updatedAt ?? openNode.updatedAt)}
               </span>
               <SaveStatus state={saveState} />
@@ -1852,7 +1865,9 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
           />
         ) : (
           <EmptyNote
+            variant={hasOperatorContent(nodes) ? "no-selection" : "first-run"}
             onNew={() => setPrompt({ mode: "file" })}
+            onNewFolder={() => setPrompt({ mode: "folder" })}
             onToggleExplorer={() => setShowExplorer((s) => !s)}
           />
         )}
@@ -2631,31 +2646,87 @@ function MissingNote({
   );
 }
 
+/**
+ * The pane when no note is open — in its two genuinely different situations
+ * (issues #1380, #1481).
+ *
+ * There used to be one. "No note open / Pick a note from the explorer, or
+ * create one" is right for an operator with sixty notes who has not clicked
+ * one; it is wrong on a fresh company, where the explorer holds three rows the
+ * host scaffolded and the operator has no reason to open any of them. The
+ * explorer meanwhile carried a second, contradicting message — "This workspace
+ * is empty. Create a note to start." — on a `nodes.length === 0` branch that
+ * the boot-time scaffold makes unreachable.
+ *
+ * So the note pane owns the messaging, and the first-run variant finally says
+ * what this tree *is*. That premise — the workspace is shared with the
+ * company's agents, who read what is written here and write back into it —
+ * existed only in code comments in three files, none of them rendered. An
+ * operator could not learn from this screen that anyone but themselves would
+ * ever read it.
+ */
 function EmptyNote({
+  variant,
   onNew,
+  onNewFolder,
   onToggleExplorer,
 }: {
+  variant: "first-run" | "no-selection";
   onNew: () => void;
+  onNewFolder: () => void;
   onToggleExplorer: () => void;
 }) {
+  const firstRun = variant === "first-run";
   return (
-    <div className="flex flex-1 flex-col">
+    <div
+      className="flex flex-1 flex-col"
+      data-testid={`workspace-empty-${variant}`}
+    >
       <div className="flex items-center border-b px-3 py-2 md:hidden">
         <IconBtn label="Toggle explorer" onClick={onToggleExplorer}>
           <PanelLeft className="size-4" />
         </IconBtn>
       </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
         <FileText className="size-8 text-muted-foreground" />
-        <div className="space-y-1">
-          <p className="font-medium">No note open</p>
-          <p className="text-sm text-muted-foreground">
-            Pick a note from the explorer, or create one.
-          </p>
-        </div>
-        <Button variant="outline" size="sm" onClick={onNew}>
-          <FilePlus2 className="size-4" /> New note
-        </Button>
+        {firstRun ? (
+          <>
+            <div className="max-w-md space-y-2">
+              <p className="font-medium">Your company&rsquo;s shared notes</p>
+              <p className="text-sm text-muted-foreground">
+                Everyone here reads this tree — your teammates and the
+                company&rsquo;s agents alike. What you write is what they work
+                from on their next turn, and the notes they write show up here
+                beside yours.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                A <span className="font-mono text-xs">derived/</span> folder
+                appears on its own once a ledger has rows. Nobody edits that one
+                — it is rewritten from the ledger.
+              </p>
+            </div>
+            <div className="flex flex-wrap justify-center gap-2">
+              <Button variant="outline" size="sm" onClick={onNew}>
+                <FilePlus2 className="size-4" /> New note
+              </Button>
+              <Button variant="outline" size="sm" onClick={onNewFolder}>
+                <FolderPlus className="size-4" /> New folder
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="space-y-1">
+              <p className="font-medium">No note open</p>
+              <p className="text-sm text-muted-foreground">
+                Pick a note from the explorer, or create one.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={onNew}>
+              <FilePlus2 className="size-4" /> New note
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -5,6 +5,7 @@ import {
   EyeOff,
   FilePlus2,
   FileText,
+  FileX,
   Folder,
   FolderOpen,
   FolderPlus,
@@ -1788,6 +1789,25 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               </aside>
             </div>
           </>
+        ) : openId && !openNode ? (
+          /* The pane used to answer on tree membership rather than on what was
+             asked for (issue #1473). Everything — header, error, skeleton —
+             lived inside the `openNode` branch, so a `#/workspace/<id>` link to
+             a note that had since been deleted skipped the whole thing and fell
+             through to "No note open / Pick a note from the explorer", blaming
+             the reader for a link they had just followed. The 404 that was
+             fetched, parsed and stored was never rendered at all, and the same
+             fall-through swallowed the initial load of a deep-linked id. */
+          <MissingNote
+            loading={loading}
+            error={fileError}
+            onClear={() => {
+              setOpenId(null);
+              setFileError(null);
+            }}
+            onNew={() => setPrompt({ mode: "file" })}
+            onToggleExplorer={() => setShowExplorer((s) => !s)}
+          />
         ) : (
           <EmptyNote
             onNew={() => setPrompt({ mode: "file" })}
@@ -2476,6 +2496,87 @@ function NoteMarkdown({
       >
         {rewritten}
       </ReactMarkdown>
+    </div>
+  );
+}
+
+/**
+ * The pane for an id that is not in the tree (issue #1473).
+ *
+ * Three states an idle "No note open" used to swallow whole: the tree is still
+ * arriving, the read came back with an error, or the read is done and the note
+ * genuinely is not there. All three follow from `openId` — something *was*
+ * asked for — which is the distinction the old branch could not make, because
+ * it keyed on whether the node was in the tree.
+ *
+ * The copy says nothing about *why* the note is gone. A link can go stale
+ * because the note was deleted, because it was in another company, or because
+ * the tree read failed — and this pane cannot tell those apart. Naming a cause
+ * it does not know would be worse than the fall-through it replaces.
+ */
+function MissingNote({
+  loading,
+  error,
+  onClear,
+  onNew,
+  onToggleExplorer,
+}: {
+  loading: boolean;
+  error: string | null;
+  onClear: () => void;
+  onNew: () => void;
+  onToggleExplorer: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col" data-testid="workspace-missing-note">
+      <div className="flex items-center border-b px-3 py-2 md:hidden">
+        <IconBtn label="Toggle explorer" onClick={onToggleExplorer}>
+          <PanelLeft className="size-4" />
+        </IconBtn>
+      </div>
+      {loading ? (
+        // The skeleton was trapped inside the `openNode` branch, so a
+        // deep-linked id showed the idle empty state for the whole of the tree
+        // read and then changed its mind.
+        <div
+          className="mx-auto w-full max-w-3xl space-y-3 px-6 py-6"
+          data-testid="workspace-missing-loading"
+        >
+          <Skeleton className="h-6 w-1/3" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+      ) : (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+          <FileX className="size-8 text-muted-foreground" />
+          <div className="space-y-1">
+            <p className="font-medium">
+              That note is no longer in this workspace
+            </p>
+            <p className="max-w-md text-sm text-muted-foreground">
+              The link you followed points at a note this company does not have.
+            </p>
+            {/* The stored read error, finally rendered. It is the host's own
+                sentence about this id and it was being thrown away. */}
+            {error && (
+              <p
+                className="max-w-md text-sm text-muted-foreground"
+                data-testid="workspace-missing-error"
+              >
+                {error}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Button variant="outline" size="sm" onClick={onClear}>
+              Back to the explorer
+            </Button>
+            <Button variant="outline" size="sm" onClick={onNew}>
+              <FilePlus2 className="size-4" /> New note
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -105,6 +105,7 @@ import {
   DERIVED_REASON,
   ensureMdExt,
   fileByTitle,
+  folderPathLabel,
   type FsNode,
   hasLegacyLocal,
   isAgentsFolder,
@@ -120,6 +121,7 @@ import {
   renameAudienceWarning,
   SECRETS_LABEL,
   SECRETS_REASON,
+  sortedFolders,
   subtreeCounts,
   subtreeIds,
   titleOf,
@@ -1205,6 +1207,17 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
         parentId: destId,
       });
       setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
+      // Name the destination (issue #1381). The receipt for a move that cannot
+      // be undone in one click said only that it happened, so an operator who
+      // picked the wrong row of an unsorted, unpathed list learned nothing from
+      // the confirmation either.
+      toast.success(
+        `Moved “${titleOf(node)}” to ${
+          destId
+            ? folderPathLabel(nodes, destId, rosterNames)
+            : "the workspace root"
+        }.`,
+      );
     } catch (e) {
       toast.error(message(e, "could not move this item"));
     }
@@ -1836,6 +1849,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       />
       <MoveDialog
         nodes={nodes}
+        rosterNames={rosterNames}
         moving={moving}
         onClose={() => setMoving(null)}
         onMove={(destId) => {
@@ -2768,62 +2782,95 @@ function NamePrompt({
 }
 
 /**
- * Pick a destination for a `Move to…`, and say so when the destination changes
- * who can read the note (issue #1465).
+ * Pick where a note or folder goes (issues #1381, #1477, #1465).
  *
- * Every destination but one is a filing decision. Moving into or out of
- * `secrets/` is an audience decision, and it was indistinguishable from the
- * others: one click, a "moved" toast, and a note that either stopped being
- * readable by every agent in the company or started being. So a destination
- * that crosses that line does not commit on the click — it swaps the list for
- * {@link MoveAudienceConfirm}, which names the consequence and asks again.
+ * Four filing defects, each on its own sufficient to mis-file something. The
+ * list showed bare `name`, so two `Drafts` under different parents were
+ * identical rows and a roster folder was a raw ULID. It was in the host's
+ * unspecified `tree()` order, beside a tree that was sorted. It offered
+ * `derived/`, where the host refuses every write (#1222), so picking it could
+ * only ever produce an error toast. And a single click committed the move — no
+ * Move button, no Cancel, no undo, and a success toast that did not name where
+ * the note went.
  *
- * Ordinary destinations still commit on one click, deliberately: this adds a
- * step to the moves that change something and to no others. (Issue #1477 is
- * about the destination list itself — flat, path-less — and is left alone
- * here.)
+ * So: full paths, tree order, `derived/` excluded, and select-then-confirm with
+ * the footer the sibling dialogs already have. A click still *chooses*; it no
+ * longer *commits*.
+ *
+ * On top of that, one destination is not a filing decision at all. Moving into
+ * or out of `secrets/` changes who can read the note, and #1465 made that
+ * legible twice over: the row is marked before it is picked, and pressing Move
+ * hands off to {@link MoveAudienceConfirm} rather than moving — the confirm
+ * step the ordinary destinations spend on a plain Move button is spent naming
+ * the consequence instead.
  */
 function MoveDialog({
   nodes,
+  rosterNames,
   moving,
   onClose,
   onMove,
 }: {
   nodes: FsNode[];
+  rosterNames: RosterNames;
   moving: FsNode | null;
   onClose: () => void;
   onMove: (destId: string | null) => void;
 }) {
-  const blocked = moving ? subtreeIds(nodes, moving.id) : new Set<string>();
-  const folders = nodes.filter((x) => x.kind === "folder" && !blocked.has(x.id));
-  /** The destination picked, held back until the warning is acknowledged. */
+  // `undefined` is "nothing picked yet"; `null` is the workspace root, which is
+  // a real destination and must not read as no answer.
+  const [picked, setPicked] = useState<string | null | undefined>(undefined);
+  const [filter, setFilter] = useState("");
+  /** The destination chosen, held back until its warning is acknowledged. */
   const [pending, setPending] = useState<{
     destId: string | null;
     warning: MoveAudienceWarning;
   } | null>(null);
 
-  // A second `Move to…` must not open onto the previous one's warning.
+  // A second `Move to…` must not open onto the previous one's selection or its
+  // warning.
   useEffect(() => {
-    setPending(null);
+    if (moving) {
+      setPicked(undefined);
+      setFilter("");
+      setPending(null);
+    }
   }, [moving]);
 
-  function pick(destId: string | null) {
-    if (!moving) return;
-    const warning = moveAudienceWarning(nodes, moving, destId);
+  const blocked = new Set<string>(moving ? subtreeIds(nodes, moving.id) : []);
+  for (const node of nodes) if (isDerivedNode(nodes, node.id)) blocked.add(node.id);
+
+  const needle = filter.trim().toLowerCase();
+  const destinations = sortedFolders(nodes, blocked)
+    .map((folder) => ({
+      folder,
+      label: folderPathLabel(nodes, folder.id, rosterNames),
+      audience: moving ? moveAudienceWarning(nodes, moving, folder.id)?.change : undefined,
+    }))
+    .filter(({ label }) => !needle || label.toLowerCase().includes(needle));
+
+  const here = (id: string | null) => moving?.parentId === (id ?? null);
+
+  /** Commit, or hand off to the warning when the audience changes. */
+  function confirm() {
+    if (picked === undefined || !moving) return;
+    const warning = moveAudienceWarning(nodes, moving, picked);
     if (!warning) {
-      onMove(destId);
+      onMove(picked);
       return;
     }
-    setPending({ destId, warning });
+    setPending({ destId: picked, warning });
   }
 
   return (
     <Dialog open={Boolean(moving)} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-sm">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Move “{moving ? titleOf(moving) : ""}”</DialogTitle>
           <DialogDescription>
-            {pending ? "This changes who can read it." : "Pick a destination folder."}
+            {pending
+              ? "This changes who can read it."
+              : "Pick a destination folder, then choose Move. Nothing moves until you do."}
           </DialogDescription>
         </DialogHeader>
         {pending ? (
@@ -2836,27 +2883,58 @@ function MoveDialog({
             onConfirm={() => onMove(pending.destId)}
           />
         ) : (
-          <div className="max-h-72 space-y-1 overflow-y-auto">
-            <DestRow
-              label="Workspace root"
-              disabled={moving?.parentId === null}
-              // Marked from the same predicate that raises the warning, so the
-              // consequence is legible *before* the click as well as after it.
-              // The root is never `secrets/`, so this row only ever marks the
-              // way out.
-              audience={moving ? moveAudienceWarning(nodes, moving, null)?.change : undefined}
-              onClick={() => pick(null)}
+          <>
+            <Input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter destinations…"
+              aria-label="Filter destinations"
+              data-testid="workspace-move-filter"
+              className="h-8 text-sm"
             />
-            {folders.map((f) => (
-              <DestRow
-                key={f.id}
-                label={f.name}
-                disabled={moving?.parentId === f.id}
-                audience={moving ? moveAudienceWarning(nodes, moving, f.id)?.change : undefined}
-                onClick={() => pick(f.id)}
-              />
-            ))}
-          </div>
+            <div className="max-h-72 space-y-1 overflow-y-auto" data-testid="workspace-move-list">
+              {!needle && (
+                <DestRow
+                  label="Workspace root"
+                  disabled={here(null)}
+                  selected={picked === null}
+                  // Marked from the same predicate that raises the warning, so
+                  // the consequence is legible before the pick as well as
+                  // after it. The root is never `secrets/`, so this row only
+                  // ever marks the way out.
+                  audience={moving ? moveAudienceWarning(nodes, moving, null)?.change : undefined}
+                  onClick={() => setPicked(null)}
+                />
+              )}
+              {destinations.map(({ folder, label, audience }) => (
+                <DestRow
+                  key={folder.id}
+                  label={label}
+                  disabled={here(folder.id)}
+                  selected={picked === folder.id}
+                  audience={audience}
+                  onClick={() => setPicked(folder.id)}
+                />
+              ))}
+              {destinations.length === 0 && (
+                <p className="px-2.5 py-2 text-sm text-muted-foreground">
+                  No folder matches “{filter.trim()}”.
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                disabled={picked === undefined}
+                onClick={confirm}
+                data-testid="workspace-move-confirm"
+              >
+                Move
+              </Button>
+            </DialogFooter>
+          </>
         )}
       </DialogContent>
     </Dialog>
@@ -3253,20 +3331,28 @@ function DestRow({
   label,
   disabled,
   audience,
+  selected,
   onClick,
 }: {
   label: string;
   disabled?: boolean;
   /** Set when picking this destination changes who can read the note (#1465). */
   audience?: MoveAudienceChange;
+  /** Whether this row is the destination currently chosen (issue #1381). */
+  selected?: boolean;
   onClick: () => void;
 }) {
   return (
     <button
       disabled={disabled}
       onClick={onClick}
-      className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm hover:bg-accent disabled:pointer-events-none disabled:opacity-40"
+      aria-pressed={selected}
+      data-testid="workspace-move-dest"
       data-audience-change={audience}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm hover:bg-accent disabled:pointer-events-none disabled:opacity-40",
+        selected && "bg-accent font-medium",
+      )}
     >
       <Folder className="size-4 text-tone-2" />
       <span className="truncate">{label}</span>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1140,12 +1140,16 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
   // Answers whether the note actually landed, which only the rescue banner
   // reads: it is holding the last copy of some text and must not clear itself
   // on a create that failed.
-  async function createAndOpen(name: string, content?: string): Promise<boolean> {
+  async function createAndOpen(
+    name: string,
+    content?: string,
+    parentId?: string | null,
+  ): Promise<boolean> {
     try {
       const created = await createNode(client, company, {
         name: ensureMdExt(name.trim() || "Untitled"),
         kind: "file",
-        parentId: null,
+        parentId: parentId ?? defaultParentId,
         content: content ?? "",
       });
       setNodes((all) => [...all, created]);
@@ -1173,14 +1177,15 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     }
   }
 
-  async function createFolder(name: string) {
+  async function createFolder(name: string, parentId?: string | null) {
     try {
       const created = await createNode(client, company, {
         name: name.trim() || "New folder",
         kind: "folder",
-        parentId: null,
+        parentId: parentId ?? defaultParentId,
       });
       setNodes((all) => [...all, created]);
+      if (created.parentId) revealFolder(created.parentId);
     } catch (e) {
       toast.error(message(e, "could not create the folder"));
     }
@@ -1213,9 +1218,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       // the confirmation either.
       toast.success(
         `Moved “${titleOf(node)}” to ${
-          destId
-            ? folderPathLabel(nodes, destId, rosterNames)
-            : "the workspace root"
+          destId ? folderPathLabel(nodes, destId, rosterNames) : "the workspace root"
         }.`,
       );
     } catch (e) {
@@ -1357,7 +1360,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
     if (!files?.length) return;
     for (const file of Array.from(files)) {
       try {
-        const created = await uploadFile(client, company, file, null);
+        const created = await uploadFile(client, company, file, defaultParentId);
         setNodes((all) => [...all, created]);
       } catch (e) {
         toast.error(`${file.name}: ${message(e, "upload failed")}`);
@@ -1367,6 +1370,24 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
 
   const body = draft ?? openFile?.content ?? "";
   const openNode = nodeById(nodes, openId);
+  /**
+   * Where a create with no named destination lands (issue #1477).
+   *
+   * Every create passed `parentId: null`, so an operator standing in
+   * `Standards/Engineering/` made a note and it appeared at the root,
+   * unannounced — and the only way to file it was the Move dialog, which was
+   * itself unusable (#1381). "Where I am" is the open note's folder, or the
+   * folder itself if a folder is what is open; only a genuinely empty selection
+   * falls back to the root.
+   *
+   * Never `derived/`: the host refuses writes there, so inheriting it from an
+   * open ledger file would turn every create into an error toast.
+   */
+  const defaultParentId: string | null = (() => {
+    if (!openNode) return null;
+    const parent = openNode.kind === "folder" ? openNode.id : openNode.parentId;
+    return parent && !isDerivedNode(nodes, parent) ? parent : null;
+  })();
   /**
    * Whether the host will refuse a write to the open note (issue #1222).
    *
@@ -1549,6 +1570,7 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
               onRename={(node) => setPrompt({ mode: "rename", node })}
               onMove={(node) => setMoving(node)}
               onDelete={(node) => setConfirmDelete(node)}
+              onNewHere={(folder, mode) => setPrompt({ mode, parentId: folder.id })}
             />
           )}
         </div>
@@ -1839,10 +1861,12 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       <NamePrompt
         nodes={nodes}
         state={prompt}
+        rosterNames={rosterNames}
+        defaultParentId={defaultParentId}
         onClose={() => setPrompt(null)}
         onSubmit={(name) => {
-          if (prompt?.mode === "folder") void createFolder(name);
-          else if (prompt?.mode === "file") void createAndOpen(name);
+          if (prompt?.mode === "folder") void createFolder(name, prompt.parentId);
+          else if (prompt?.mode === "file") void createAndOpen(name, undefined, prompt.parentId);
           else if (prompt?.mode === "rename" && prompt.node) void rename(prompt.node, name);
           setPrompt(null);
         }}
@@ -1997,6 +2021,8 @@ interface TreeProps {
   onRename: (node: FsNode) => void;
   onMove: (node: FsNode) => void;
   onDelete: (node: FsNode) => void;
+  /** Create inside this folder (issue #1477). */
+  onNewHere: (folder: FsNode, mode: "file" | "folder") => void;
 }
 
 /**
@@ -2313,6 +2339,21 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
               </DropdownMenuGroup>
             ) : (
               <>
+                {/* The tree is where an operator decides where a note belongs,
+                    and until now it was the one place that could not make one
+                    (issue #1477). The toolbar's New note has no idea which
+                    folder is on screen; this does. */}
+                {isFolder && (
+                  <>
+                    <DropdownMenuItem onClick={() => props.onNewHere(node, "file")}>
+                      New note here
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => props.onNewHere(node, "folder")}>
+                      New folder here
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
                 <DropdownMenuItem onClick={() => props.onRename(node)}>Rename</DropdownMenuItem>
                 <DropdownMenuItem onClick={() => props.onMove(node)}>Move to…</DropdownMenuItem>
                 <DropdownMenuSeparator />
@@ -2561,9 +2602,7 @@ function MissingNote({
         <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
           <FileX className="size-8 text-muted-foreground" />
           <div className="space-y-1">
-            <p className="font-medium">
-              That note is no longer in this workspace
-            </p>
+            <p className="font-medium">That note is no longer in this workspace</p>
             <p className="max-w-md text-sm text-muted-foreground">
               The link you followed points at a note this company does not have.
             </p>
@@ -2670,6 +2709,14 @@ function IconBtn({
 interface PromptState {
   mode: "folder" | "file" | "rename";
   node?: FsNode;
+  /**
+   * Where a create lands (issue #1477).
+   *
+   * `undefined` means "wherever the view decides"; an explicit value is a
+   * destination the operator named — including `null`, the workspace root,
+   * which is a real answer and not the absence of one.
+   */
+  parentId?: string | null;
 }
 
 /**
@@ -2687,11 +2734,16 @@ interface PromptState {
 function NamePrompt({
   nodes,
   state,
+  rosterNames,
+  defaultParentId,
   onClose,
   onSubmit,
 }: {
   nodes: FsNode[];
   state: PromptState | null;
+  rosterNames: RosterNames;
+  /** Where a create with no named destination will land (issue #1477). */
+  defaultParentId: string | null;
   onClose: () => void;
   onSubmit: (name: string) => void;
 }) {
@@ -2741,6 +2793,23 @@ function NamePrompt({
                 ? "Notes get a .md extension automatically."
                 : "Give it a name."}
           </DialogDescription>
+          {/* Where it will land, before it lands (issue #1477). Every create
+              used to go to the root regardless of what the operator had open,
+              and said so nowhere — the note simply appeared somewhere else. */}
+          {state && state.mode !== "rename" && (
+            <p className="text-xs text-muted-foreground" data-testid="workspace-prompt-dest">
+              Goes in{" "}
+              <span className="font-medium text-foreground">
+                {(() => {
+                  const parent = state.parentId === undefined ? defaultParentId : state.parentId;
+                  return parent
+                    ? folderPathLabel(nodes, parent, rosterNames)
+                    : "the workspace root";
+                })()}
+              </span>
+              .
+            </p>
+          )}
         </DialogHeader>
         {pending ? (
           <MoveAudienceConfirm

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -112,6 +112,7 @@ import {
   type MoveAudienceWarning,
   moveAudienceWarning,
   nodeById,
+  pathOf,
   readLegacyLocalNodes,
   renameAudienceWarning,
   SECRETS_LABEL,
@@ -1824,9 +1825,16 @@ export function WorkspaceView({ client, company, event, refreshTick = 0, initial
       />
       <RepairDialog
         state={repair}
+        nodes={nodes}
         busy={repairing}
         onClose={() => setRepair(null)}
         onConfirm={() => void confirmRepair()}
+        onReveal={(id) => {
+          setRepair(null);
+          const node = nodeById(nodes, id);
+          if (node?.kind === "folder") revealFolder(id);
+          else void open(id);
+        }}
       />
       <DiscardConfirm
         target={confirmDiscard}
@@ -2953,31 +2961,53 @@ interface RepairState {
 
 function RepairDialog({
   state,
+  nodes,
   busy,
   onClose,
   onConfirm,
+  onReveal,
 }: {
   state: RepairState | null;
+  /** The tree, so a residual can be given its path and its real kind (issue #1469). */
+  nodes: FsNode[];
   busy: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  /** Show a residual in the tree. Never writes — it expands and scrolls. */
+  onReveal: (id: string) => void;
 }) {
   const done = state?.stage === "done";
   const folds = state?.outcome.folders ?? [];
   const residuals = state?.outcome.residuals ?? [];
   const relocations = folds.reduce((n, folder) => n + folder.moved.length, 0);
+  // The outcome the host returns most often, and the one this dialog used to
+  // render as a no-op (issue #1469): a group holding a *file* is left entirely
+  // alone and every member comes back as a residual, so a note and a folder
+  // both called `Specs` yields zero folds and two residuals. The old copy then
+  // announced "0 folders share a name" above an empty list, under a permanently
+  // disabled "Merge 0" — a dialog whose every element denied the thing it had
+  // just been opened to report.
+  const residualOnly = folds.length === 0 && residuals.length > 0;
 
   return (
     <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{done ? "Repaired" : "Repair duplicate folders"}</DialogTitle>
+          <DialogTitle>
+            {residualOnly
+              ? "Two things share a name"
+              : done
+                ? "Repaired"
+                : "Repair duplicate folders"}
+          </DialogTitle>
           <DialogDescription>
-            {done
-              ? folds.length === 0
-                ? "Nothing was merged — the tree changed before the repair ran."
-                : `Merged ${folds.length} duplicate folder${folds.length === 1 ? "" : "s"} and moved ${relocations} item${relocations === 1 ? "" : "s"}.`
-              : `${folds.length} folder${folds.length === 1 ? "" : "s"} share a name with another folder beside them, which is why publishing there fails. Their contents move into the copy that was there first. Nothing is renamed, nothing is overwritten, and no folder is removed until it is empty.`}
+            {residualOnly
+              ? `Nothing here can be merged automatically. ${residuals.length} ${residuals.length === 1 ? "item shares its name" : "items share their names"} with something the repair must not choose between — merging would have to discard one of them. Each one below says what it needs from you.`
+              : done
+                ? folds.length === 0
+                  ? "Nothing was merged — the tree changed before the repair ran."
+                  : `Merged ${folds.length} duplicate folder${folds.length === 1 ? "" : "s"} and moved ${relocations} item${relocations === 1 ? "" : "s"}.`
+                : `${folds.length} folder${folds.length === 1 ? "" : "s"} share a name with another folder beside them, which is why publishing there fails. Their contents move into the copy that was there first. Nothing is renamed, nothing is overwritten, and no folder is removed until it is empty.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -3006,27 +3036,57 @@ function RepairDialog({
 
         {residuals.length > 0 && (
           <div className="space-y-1" data-testid="workspace-repair-residuals">
-            <p className="text-xs font-medium">
-              {done ? "Still needs you" : "These will be left for you"}
-            </p>
+            {!residualOnly && (
+              <p className="text-xs font-medium">
+                {done ? "Still needs you" : "These will be left for you"}
+              </p>
+            )}
             <ul className="max-h-40 space-y-1 overflow-y-auto">
-              {residuals.map((residual) => (
-                <li key={residual.id} className="rounded-lg px-2.5 py-1.5 text-sm">
-                  <div className="flex items-center gap-2">
-                    <FileText className="size-4 shrink-0 text-tone-2" />
-                    <span className="truncate">{residual.name}</span>
-                  </div>
-                  <p className="mt-0.5 pl-6 text-xs text-muted-foreground">
-                    {residualReason(residual.cause)}
-                  </p>
-                </li>
-              ))}
+              {residuals.map((residual) => {
+                // The kind comes from the tree rather than the wire, which
+                // carries only id/name/parentId/cause. Drawing every residual as
+                // a note was actively misleading for the commonest cause of all:
+                // `fileSharesTheName` means one of the pair is a *folder*, and
+                // "rename or remove one of them" read under two identical
+                // note-looking rows.
+                const node = nodeById(nodes, residual.id);
+                const Icon = node?.kind === "folder" ? Folder : FileText;
+                const where = pathOf(nodes, residual.parentId ?? null)
+                  .map((p) => p.name)
+                  .join(" / ");
+                return (
+                  <li key={residual.id}>
+                    <button
+                      type="button"
+                      onClick={() => onReveal(residual.id)}
+                      data-testid="workspace-repair-residual"
+                      className="w-full rounded-lg px-2.5 py-1.5 text-left text-sm hover:bg-accent"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Icon className="size-4 shrink-0 text-tone-2" />
+                        <span className="truncate">{residual.name}</span>
+                        {where && (
+                          <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
+                            in {where}
+                          </span>
+                        )}
+                      </span>
+                      <span className="mt-0.5 block pl-6 text-xs text-muted-foreground">
+                        {residualReason(residual.cause)}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}
 
         <DialogFooter>
-          {done ? (
+          {/* A residual-only outcome has nothing to confirm, so it gets the one
+              action that is true — the same `Done` a finished repair gets —
+              rather than a "Merge 0" that can never be pressed (issue #1469). */}
+          {done || residualOnly ? (
             <Button onClick={onClose}>Done</Button>
           ) : (
             <>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -107,6 +107,7 @@ import {
   fileByTitle,
   type FsNode,
   hasLegacyLocal,
+  isAgentsFolder,
   isDerivedNode,
   isSecretNode,
   legacyImportDeclined,
@@ -1982,16 +1983,6 @@ interface TreeProps {
   onRename: (node: FsNode) => void;
   onMove: (node: FsNode) => void;
   onDelete: (node: FsNode) => void;
-}
-
-/**
- * Whether `folder` is the workspace's `Agents/` root — the one folder whose
- * direct children are named by roster id rather than anything an operator
- * chose (issue #973). Root-scoped (`parentId === null`) so a note or folder an
- * operator names "Agents" somewhere else in the tree is never mistaken for it.
- */
-function isAgentsFolder(folder: FsNode | undefined): boolean {
-  return folder?.kind === "folder" && folder.name === "Agents" && folder.parentId === null;
 }
 
 /**

--- a/frontend/src/views/workspace/SearchResults.tsx
+++ b/frontend/src/views/workspace/SearchResults.tsx
@@ -286,6 +286,21 @@ export function SearchResults({
           );
         })}
       </ul>
+      {/* The head line says "20 of 50" and the list simply ends, so an operator
+          who scrolled to the bottom got no signal that 30 matches were withheld
+          — they met the last row and read it as the last match (issue #1457).
+          The route has no offset, so the remedy is a narrower query rather than
+          a next page, and this says which. */}
+      {hits.length < total && (
+        <p
+          className="border-t border-border/40 px-3 py-2 text-2xs text-muted-foreground"
+          data-testid="workspace-search-more"
+        >
+          {total - hits.length} more{" "}
+          {total - hits.length === 1 ? "match" : "matches"} not shown — narrow
+          your search to reach them.
+        </p>
+      )}
       {loading && (
         <p className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
           <Search className="size-3.5" /> Updating…

--- a/frontend/src/views/workspace/SearchResults.tsx
+++ b/frontend/src/views/workspace/SearchResults.tsx
@@ -13,7 +13,14 @@
 
 import { EyeOff, FileText, Folder, Loader2, Lock, Search } from "lucide-react";
 
-import { formatBytes, highlightRuns, isBinary, originLabel, type SearchHit } from "@/api/workspace";
+import {
+  centerExcerpt,
+  formatBytes,
+  highlightRuns,
+  isBinary,
+  originLabel,
+  type SearchHit,
+} from "@/api/workspace";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -46,10 +53,21 @@ interface Props {
  */
 function Excerpt({ text, query }: { text: string; query: string }) {
   return (
-    <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground" data-testid="workspace-search-excerpt">
-      {highlightRuns(text, query).map((run, i) =>
+    <p
+      className="mt-0.5 line-clamp-2 text-xs text-muted-foreground"
+      data-testid="workspace-search-excerpt"
+    >
+      {/* Centred first (issue #1375). The host's window is generous and this
+          paragraph is two lines of a 250px column, so a match past the first
+          dozen words was clamped away — leaving two lines of arbitrary prose
+          with nothing marked in them, in the one element whose whole job is to
+          show *why* this note came back. */}
+      {highlightRuns(centerExcerpt(text, query), query).map((run, i) =>
         run.hit ? (
-          <mark key={i} className="rounded-sm bg-highlight px-0.5 text-foreground">
+          <mark
+            key={i}
+            className="rounded-sm bg-highlight px-0.5 text-foreground"
+          >
             {run.text}
           </mark>
         ) : (
@@ -60,12 +78,32 @@ function Excerpt({ text, query }: { text: string; query: string }) {
   );
 }
 
-export function SearchResults({ query, hits, total, loading, error, onOpen }: Props) {
+/**
+ * A hit's folder path, without the filename the row above already shows.
+ *
+ * Returns the workspace root's own label for a note filed at the top, so the
+ * line is never blank — "where is this?" has an answer for a root note too.
+ */
+function parentPath(path: string): string {
+  const cut = path.lastIndexOf("/");
+  return cut === -1 ? "Workspace root" : path.slice(0, cut);
+}
+
+export function SearchResults({
+  query,
+  hits,
+  total,
+  loading,
+  error,
+  onOpen,
+}: Props) {
   if (error) {
     return (
       <div className="px-2 py-2">
         <Alert variant="destructive">
-          <AlertDescription data-testid="workspace-search-error">{error}</AlertDescription>
+          <AlertDescription data-testid="workspace-search-error">
+            {error}
+          </AlertDescription>
         </Alert>
       </div>
     );
@@ -81,9 +119,12 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
 
   if (hits.length === 0) {
     return (
-      <p className="px-3 py-2 text-xs text-muted-foreground" data-testid="workspace-search-empty">
-        No notes mention “{query}”. Search matches whole words and parts of words, but not
-        misspellings — try a shorter or different term.
+      <p
+        className="px-3 py-2 text-xs text-muted-foreground"
+        data-testid="workspace-search-empty"
+      >
+        No notes mention “{query}”. Search matches whole words and parts of
+        words, but not misspellings — try a shorter or different term.
       </p>
     );
   }
@@ -151,7 +192,10 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
                     <FileText className="size-3.5 shrink-0 text-muted-foreground" />
                   )}
                   <span className="truncate text-sm">
-                    {highlightRuns(hit.name, hit.matched === "name" ? query : "").map((run, i) =>
+                    {highlightRuns(
+                      hit.name,
+                      hit.matched === "name" ? query : "",
+                    ).map((run, i) =>
                       run.hit ? (
                         <mark
                           key={i}
@@ -184,20 +228,32 @@ export function SearchResults({ query, hits, total, loading, error, onOpen }: Pr
                     segment it explains. The scan-for-glyphs affordance lives in
                     the tree, which is the surface people browse. */}
                 <span className="mt-0.5 flex items-center gap-1.5 text-2xs text-muted-foreground">
-                  {/* `truncate` is doing two jobs, and the second one is easy
+                  {/* The *parent* path, ellipsised at the **start** (issue
+                      #1375). It used to render the full path with a tail
+                      `truncate`, which cuts the discriminating end
+                      (`Standards/Engineering/Backend/Rust/API…`) while
+                      repeating the filename already shown on the line above.
+                      Head-ellipsis via `direction: rtl` so the browser drops
+                      characters from the left at the real rendered width;
+                      `<bdi>` pins segment order so the RTL context cannot
+                      reorder the path itself.
+
+                      `truncate` stays, and is doing two jobs — the second easy
                       to mistake for missing. It carries `overflow: hidden`,
-                      which makes this flex item a scroll container — and a
-                      scroll container's automatic minimum size is 0, not its
-                      min-content width. So the path already shrinks and
-                      ellipsises rather than shouldering the badge out of a
-                      256px pane; a `min-w-0` beside it would be a no-op.
-                      Measured: with `truncate` the computed floor is `0px` and
-                      the badge overflows by 0; strip `truncate` and the floor
-                      is `auto` and it overflows. Keep them together. */}
-                  <span className="truncate">
-                    {hit.path}
-                    {isBinary(hit) && ` · ${hit.mime} · ${formatBytes(hit.size)}`}
-                  </span>
+                      which makes this flex item a scroll container, and a
+                      scroll container's automatic minimum size is 0 rather than
+                      its min-content width. So the path shrinks and ellipsises
+                      instead of shouldering the badge out of a 256px pane, and
+                      a `min-w-0` beside it would be a no-op. Measured: with
+                      `truncate` the computed floor is `0px` and the badge
+                      overflows by 0; strip it and the floor is `auto` and it
+                      overflows. */}
+                  <bdi className="truncate" dir="rtl" data-testid="workspace-search-path">
+                    {parentPath(hit.path)}
+                  </bdi>
+                  {isBinary(hit) && (
+                    <span className="shrink-0">{`${hit.mime} · ${formatBytes(hit.size)}`}</span>
+                  )}
                   {derived && (
                     <Badge
                       variant="outline"

--- a/frontend/src/views/workspace/SearchResults.tsx
+++ b/frontend/src/views/workspace/SearchResults.tsx
@@ -31,6 +31,7 @@ import {
   isSecretPath,
   SECRETS_LABEL,
   SECRETS_REASON,
+  titleOf,
 } from "@/lib/workspace";
 
 interface Props {
@@ -192,8 +193,13 @@ export function SearchResults({
                     <FileText className="size-3.5 shrink-0 text-muted-foreground" />
                   )}
                   <span className="truncate text-sm">
+                    {/* The same title the tree and the header show (issue
+                        #1382). Search rendered the raw `name`, so a hit read
+                        `Pagination.md` and clicking it renamed the thing on
+                        screen to `Pagination`. A query rarely spans the
+                        extension, so the highlight offsets are unaffected. */}
                     {highlightRuns(
-                      hit.name,
+                      hit.kind === "file" ? titleOf(hit) : hit.name,
                       hit.matched === "name" ? query : "",
                     ).map((run, i) =>
                       run.hit ? (

--- a/frontend/test/e2e/workspace.spec.ts
+++ b/frontend/test/e2e/workspace.spec.ts
@@ -245,11 +245,12 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
 
   await page.getByTestId("workspace-migration-import").click();
 
-  // The receipt names what was actually imported, per kind (#500). Two notes
-  // and one folder — not the flat list's length, and not the import folder the
-  // console creates to hold them, which is packaging rather than content.
+  // The receipt names what was actually imported, per kind (#500) — two notes
+  // and one folder, not the flat list's length — and where it went (#1472).
+  // The import folder itself is still packaging rather than content, so it is
+  // named as the destination and stays out of the tally.
   await expect(page.locator("[data-sonner-toast] [data-title]").first()).toHaveText(
-    "Imported 2 notes and 1 folder.",
+    "Imported 2 notes and 1 folder into “Imported from this browser”.",
     { timeout: 30_000 },
   );
 

--- a/frontend/test/unit/workspace-create-here.test.ts
+++ b/frontend/test/unit/workspace-create-here.test.ts
@@ -1,0 +1,285 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1477: everything an operator created landed at the root.
+ *
+ * `createAndOpen`, `createFolder` and the upload all passed `parentId: null`,
+ * the New-note and New-folder entry points were toolbar-only, and the name
+ * prompt said nothing about a destination. So an operator standing in
+ * `Standards/Engineering/` made a note and it appeared at the root, unannounced
+ * — and the only way to file it was the Move dialog, which was itself unusable
+ * (#1381).
+ */
+
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}) {
+  return { ...over, updatedAt: 1 };
+}
+
+const TREE = [
+  node({ id: "standards", name: "Standards", kind: "folder" }),
+  node({
+    id: "eng",
+    name: "Engineering",
+    kind: "folder",
+    parentId: "standards",
+  }),
+  node({ id: "note", name: "Plan.md", kind: "file", parentId: "eng" }),
+  node({ id: "derived", name: "derived", kind: "folder" }),
+  node({ id: "goals", name: "GOALS.md", kind: "file", parentId: "derived" }),
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let client: {
+  scopeFor: () => string;
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+function host() {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(async (path: string) => {
+      if (path.includes("/workspace/file/")) {
+        return {
+          id: "note",
+          name: "Plan.md",
+          content: "",
+          backlinks: [],
+          updatedAt: 1,
+        };
+      }
+      return TREE;
+    }),
+    post: vi.fn(async (_path: string, body: { name: string; kind: string }) =>
+      node({
+        id: "new",
+        name: body.name,
+        kind: body.kind as "file" | "folder",
+      }),
+    ),
+  };
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render() {
+  client = host();
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+function menuItem(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+    (el) => el.textContent?.trim() === label,
+  );
+  if (!found)
+    throw new Error(`no “${label}” menu item in:\n${document.body.innerHTML}`);
+  return found as HTMLElement;
+}
+
+function actionsButtonFor(name: string): HTMLButtonElement {
+  const row = Array.from(container.querySelectorAll("div.group")).find((d) =>
+    d.textContent?.includes(name),
+  );
+  const found = row?.querySelector('[aria-label="Actions"]');
+  if (!found) throw new Error(`no Actions button for “${name}”`);
+  return found as HTMLButtonElement;
+}
+
+/**
+ * Expand down to the seeded note. The tree opens the root's own children, so
+ * only the second level needs a click.
+ */
+async function expandToNote() {
+  for (const folder of ["Engineering"]) {
+    const row = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === folder,
+    ) as HTMLButtonElement | undefined;
+    if (!row) continue;
+    await act(async () => {
+      row.click();
+    });
+  }
+}
+
+async function submitName(name: string) {
+  const input = document.querySelector("#fs-name") as HTMLInputElement;
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, name);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await act(async () => {
+    (
+      Array.from(document.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Create",
+      ) as HTMLButtonElement
+    ).click();
+  });
+}
+
+/** The parentId the create request actually carried. */
+function createdParent(): string | null | undefined {
+  const call = client.post.mock.calls.find((c) =>
+    (c[0] as string).endsWith("/workspace"),
+  );
+  return (call?.[1] as { parentId?: string | null } | undefined)?.parentId;
+}
+
+describe("a note is created where the operator is (issue #1477)", () => {
+  it("lands beside the open note, not at the root", async () => {
+    await render();
+    await expandToNote();
+    await act(async () => {
+      (
+        Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes("Plan"),
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    await act(async () => {
+      (
+        container.querySelector('[aria-label="New file"]') as HTMLButtonElement
+      ).click();
+    });
+    // Said before it happens, not discovered afterwards.
+    expect(
+      document.querySelector('[data-testid="workspace-prompt-dest"]')
+        ?.textContent,
+    ).toContain("Standards / Engineering");
+
+    await submitName("Runbook");
+    // The reported defect: this was always null.
+    expect(createdParent()).toBe("eng");
+  });
+
+  it("falls back to the root when nothing is open", async () => {
+    await render();
+    await act(async () => {
+      (
+        container.querySelector('[aria-label="New file"]') as HTMLButtonElement
+      ).click();
+    });
+
+    expect(
+      document.querySelector('[data-testid="workspace-prompt-dest"]')
+        ?.textContent,
+    ).toContain("the workspace root");
+    await submitName("Runbook");
+    expect(createdParent()).toBe(null);
+  });
+
+  it("never inherits derived/, where the host refuses every write", async () => {
+    await render();
+    await act(async () => {
+      (
+        Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes("GOALS"),
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    await act(async () => {
+      (
+        container.querySelector('[aria-label="New file"]') as HTMLButtonElement
+      ).click();
+    });
+    await submitName("Runbook");
+
+    // Inheriting the open ledger file's folder would turn every create into an
+    // error toast.
+    expect(createdParent()).toBe(null);
+  });
+});
+
+describe("the tree can make a note where you are pointing (issue #1477)", () => {
+  it("offers New note here on a folder row and files it there", async () => {
+    await render();
+    await expandToNote();
+    await act(async () => {
+      actionsButtonFor("Engineering").click();
+    });
+    await act(async () => {
+      menuItem("New note here").click();
+    });
+
+    expect(
+      document.querySelector('[data-testid="workspace-prompt-dest"]')
+        ?.textContent,
+    ).toContain("Standards / Engineering");
+    await submitName("Runbook");
+    expect(createdParent()).toBe("eng");
+  });
+
+  it("offers New folder here too", async () => {
+    await render();
+    await act(async () => {
+      actionsButtonFor("Standards").click();
+    });
+    await act(async () => {
+      menuItem("New folder here").click();
+    });
+    await submitName("Specs");
+
+    expect(createdParent()).toBe("standards");
+    const call = client.post.mock.calls.find((c) =>
+      (c[0] as string).endsWith("/workspace"),
+    );
+    expect((call?.[1] as { kind: string }).kind).toBe("folder");
+  });
+
+  it("does not offer it on a note — a note is not a destination", async () => {
+    await render();
+    await expandToNote();
+    await act(async () => {
+      actionsButtonFor("Plan").click();
+    });
+
+    expect(
+      Array.from(document.querySelectorAll('[role="menuitem"]')).map((m) =>
+        m.textContent?.trim(),
+      ),
+    ).not.toContain("New note here");
+  });
+});

--- a/frontend/test/unit/workspace-density-nits.test.ts
+++ b/frontend/test/unit/workspace-density-nits.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1382 — the density and consistency nits from the design audit.
+ *
+ * The header showed a bare relative time beside the title, which read like part
+ * of it. The backlinks rail is `xl:flex`, so below about 1280px a note with
+ * eleven backlinks and one with none looked identical — the signal vanished
+ * rather than degrading. And `setExpanded(new Set())` already existed with
+ * nothing invoking it, so a deep tree stayed open behind every reveal with no
+ * way back short of collapsing each folder by hand.
+ */
+
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}) {
+  return { ...over, updatedAt: 1 };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function host(tree: ReturnType<typeof node>[]): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(tree),
+  } as unknown as OpenCompanyClient;
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(tree: ReturnType<typeof node>[]) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: host(tree),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+describe("the density nits (issue #1382)", () => {
+  it("labels the timestamp rather than leaving a bare relative time by the title", async () => {
+    await render([node({ id: "n1", name: "Plan.md", kind: "file" })]);
+    await act(async () => {
+      (
+        Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes("Plan"),
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(
+      container.querySelector('[data-testid="workspace-updated"]')?.textContent,
+    ).toMatch(/^Edited /);
+  });
+
+  it("keeps Collapse all disabled until something is expanded", async () => {
+    await render([]);
+
+    expect(
+      (
+        container.querySelector(
+          '[data-testid="workspace-collapse-all"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("collapses every open folder in one press", async () => {
+    await render([
+      node({ id: "a", name: "Alpha", kind: "folder" }),
+      node({ id: "b", name: "Beta", kind: "folder", parentId: "a" }),
+    ]);
+
+    // The tree opens the root's own folders on load, so Beta is on screen and
+    // the control is live before anything is clicked.
+    expect(
+      Array.from(container.querySelectorAll("button")).some(
+        (btn) => btn.textContent?.trim() === "Beta",
+      ),
+    ).toBe(true);
+    const collapse = container.querySelector(
+      '[data-testid="workspace-collapse-all"]',
+    ) as HTMLButtonElement;
+    expect(collapse.disabled).toBe(false);
+
+    await act(async () => {
+      collapse.click();
+    });
+
+    // Alpha's child is gone with it, and the control has nothing left to do.
+    expect(
+      Array.from(container.querySelectorAll("button")).some(
+        (btn) => btn.textContent?.trim() === "Beta",
+      ),
+    ).toBe(false);
+    expect(
+      (
+        container.querySelector(
+          '[data-testid="workspace-collapse-all"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+});

--- a/frontend/test/unit/workspace-discard-confirm.test.ts
+++ b/frontend/test/unit/workspace-discard-confirm.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1472: the Workspace carried two "Discard" buttons that destroyed the
+ * only copy of an operator's words on one unconfirmed click, both rendered as
+ * the quietest control in their row.
+ *
+ * The migration banner's Discard called `clearLegacyLocal`, which removes the
+ * scoped key *and* the pre-connection origin it was adopted from — so the notes
+ * can never be re-offered. Meanwhile deleting a note the host still holds is
+ * gated behind an AlertDialog saying "There is no undo". The strictly more
+ * recoverable act was the guarded one.
+ *
+ * These tests pin the fix the way `workspace-delete-confirm.test.ts` pins
+ * #1255: render the real view and assert the destructive effect does not happen
+ * until a confirm is pressed — plus that "Not now" makes the banner stop asking
+ * *without* destroying anything, which is the exit the banner never had.
+ */
+
+/** The scoped key `lib/workspace.ts` keeps this company's old scratchpad under. */
+const SCRATCHPAD_KEY = "oc-workspace:c1::acme";
+/** The pre-connection origin key that `clearLegacyLocal` also removes. */
+const LEGACY_KEY = "oc-workspace:acme";
+const DECLINED_KEY = "oc-workspace-migration-declined:c1::acme";
+
+/** Two notes the operator typed into the retired client-side scratchpad. */
+const SCRATCHPAD = JSON.stringify([
+  {
+    id: "fs-1",
+    name: "Runbook.md",
+    kind: "file",
+    parentId: null,
+    content: "steps",
+    updatedAt: 1,
+  },
+  {
+    id: "fs-2",
+    name: "Ideas.md",
+    kind: "file",
+    parentId: null,
+    content: "thoughts",
+    updatedAt: 1,
+  },
+]);
+
+function client(): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue([]),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`no “${label}” button in:\n${document.body.innerHTML}`);
+  return found as HTMLButtonElement;
+}
+
+function banner(): Element | null {
+  return document.querySelector('[data-testid="workspace-migration-banner"]');
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  // jsdom has no layout, so the tree's reveal effect (issue #1371) would throw
+  // on a method that does not exist there.
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  localStorage.setItem(SCRATCHPAD_KEY, SCRATCHPAD);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+});
+
+async function render() {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client(),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+describe("the migration banner's Discard asks before it destroys (issue #1472)", () => {
+  it("opens a confirm naming the count, and leaves the notes in the browser", async () => {
+    await render();
+    expect(banner()).not.toBeNull();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+
+    // The reported defect: this click *was* the delete.
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+    expect(document.body.textContent).toContain("Delete 2 notes kept only in this browser?");
+    expect(document.querySelector('[data-testid="workspace-discard-confirm"]')).not.toBeNull();
+  });
+
+  it("Keep it dismisses the confirm without touching the scratchpad", async () => {
+    await render();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Keep it").click();
+    });
+
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+    expect(banner()).not.toBeNull();
+  });
+
+  it("only the confirm's own action clears the key and the origin it came from", async () => {
+    localStorage.setItem(LEGACY_KEY, SCRATCHPAD);
+    await render();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Delete notes").click();
+    });
+
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBeNull();
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(banner()).toBeNull();
+  });
+});
+
+describe("declining the offer is not the same as destroying it (issue #1472)", () => {
+  it("Not now stops the banner and keeps every note", async () => {
+    await render();
+
+    await act(async () => {
+      button("Not now").click();
+    });
+
+    // The whole point of the third exit: the banner is gone and the notes are
+    // not. Before #1472 the only way to stop being asked was the delete.
+    expect(banner()).toBeNull();
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+    expect(localStorage.getItem(DECLINED_KEY)).not.toBeNull();
+  });
+
+  it("stays declined across a remount, still without destroying anything", async () => {
+    await render();
+    await act(async () => {
+      button("Not now").click();
+    });
+
+    await act(() => root.unmount());
+    root = createRoot(container);
+    await render();
+
+    expect(banner()).toBeNull();
+    expect(localStorage.getItem(SCRATCHPAD_KEY)).toBe(SCRATCHPAD);
+  });
+});
+
+/**
+ * The second Discard: the banner holding words rescued out of a note that was
+ * deleted while the operator was writing in it. Its own comment in the view
+ * says this is "the last copy of a paragraph" — and it was wired straight to
+ * `setRescued(null)` on a bare ghost button.
+ */
+describe("the rescued-text Discard asks before it destroys (issue #1472)", () => {
+  /** A host whose tree empties once `gone` flips — the deletion the frame reports. */
+  function vanishingClient(gone: { now: boolean }): OpenCompanyClient {
+    return {
+      scopeFor: () => "/api/v1/company/acme",
+      get: vi.fn(async (path: string) => {
+        if (path.includes("/workspace/file/")) {
+          return {
+            id: "note-1",
+            name: "Plan.md",
+            content: "saved body",
+            backlinks: [],
+            updatedAt: 1,
+          };
+        }
+        if (path.endsWith("/workspace")) {
+          return gone.now ? [] : [{ id: "note-1", name: "Plan.md", kind: "file", updatedAt: 1 }];
+        }
+        return [];
+      }),
+    } as unknown as OpenCompanyClient;
+  }
+
+  async function rescueBanner() {
+    const gone = { now: false };
+    const host = vanishingClient(gone);
+    // No scratchpad here — the migration banner would own the word "Discard".
+    localStorage.clear();
+
+    const paint = (event?: { tick: number; nodeId: string; change: "removed" }) =>
+      act(async () => {
+        root.render(
+          createElement(ConnectionScopeProvider, {
+            scope: { connection: "c1", company: "acme" },
+            children: createElement(WorkspaceView, {
+              client: host,
+              company: "acme",
+              event,
+            }),
+          }),
+        );
+      });
+
+    await paint();
+    await act(async () => {
+      (
+        Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes("Plan"),
+        ) as HTMLButtonElement
+      ).click();
+    });
+    await act(async () => {
+      (
+        Array.from(document.querySelectorAll('[role="tab"]')).find(
+          (t) => t.textContent?.trim() === "Edit",
+        ) as HTMLElement
+      ).click();
+    });
+
+    const editor = document.querySelector(
+      '[data-testid="workspace-editor"]',
+    ) as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      setter?.call(editor, "a paragraph nobody else has");
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    gone.now = true;
+    await paint({ tick: 1, nodeId: "note-1", change: "removed" });
+  }
+
+  it("keeps the text on screen when Discard is clicked, and asks first", async () => {
+    await rescueBanner();
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).not.toBeNull();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+
+    // The defect: this click was the discard. The words must still be here.
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).not.toBeNull();
+    expect(
+      (document.querySelector('[data-testid="workspace-rescued-text"]') as HTMLTextAreaElement)
+        .value,
+    ).toBe("a paragraph nobody else has");
+    expect(document.body.textContent).toContain("Discard your unsaved text?");
+  });
+
+  it("drops the text only once the confirm's own action is pressed", async () => {
+    await rescueBanner();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Keep it").click();
+    });
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).not.toBeNull();
+
+    await act(async () => {
+      button("Discard").click();
+    });
+    await act(async () => {
+      button("Discard text").click();
+    });
+    expect(document.querySelector('[data-testid="workspace-rescued-banner"]')).toBeNull();
+  });
+});
+
+describe("the banner says what Import will do (issue #1472)", () => {
+  it("names the destination folder and that the browser copy is removed", async () => {
+    await render();
+    const text = banner()?.textContent ?? "";
+
+    expect(text).toContain("Imported from this browser");
+    expect(text).toContain("removes this browser's copy");
+    expect(text).toContain("moves them rather than copying them");
+  });
+});

--- a/frontend/test/unit/workspace-empty-layout.test.ts
+++ b/frontend/test/unit/workspace-empty-layout.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issues #1380, #1481 and #1386.
+ *
+ * #1380: two contradictory empty states. The explorer had a `nodes.length === 0`
+ * branch saying "This workspace is empty. Create a note to start." — dead code,
+ * since `ensure_workspace_scaffold` lays down `Agents/` and `secrets/` on every
+ * boot — while the note pane said "No note open / Pick a note from the
+ * explorer". And the two maintenance buttons were enabled whatever the tree
+ * held.
+ *
+ * #1481: neither message said what the tree *is*. The premise — this workspace
+ * is shared with the company's agents, who read what is written here and write
+ * back into it — lived only in code comments in three files, none rendered.
+ *
+ * #1386: the two-pane layout is already single-pane below `md` on main. This
+ * pins that so it cannot regress silently; it is not rebuilt here.
+ */
+
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}) {
+  return { ...over, updatedAt: 1 };
+}
+
+/** Exactly what a freshly provisioned company boots with. */
+const SCAFFOLD = [
+  node({ id: "agents", name: "Agents", kind: "folder" }),
+  node({ id: "secrets", name: "secrets", kind: "folder" }),
+  node({ id: "readme", name: "README.md", kind: "file", parentId: "secrets" }),
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function host(tree: ReturnType<typeof node>[]): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(tree),
+  } as unknown as OpenCompanyClient;
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(tree: ReturnType<typeof node>[]) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: host(tree),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+describe("a workspace nobody has written in yet explains itself (issue #1481)", () => {
+  it("says the tree is shared with the company's agents", async () => {
+    await render(SCAFFOLD);
+    const pane = container.querySelector(
+      '[data-testid="workspace-empty-first-run"]',
+    );
+
+    expect(pane).not.toBeNull();
+    const text = pane?.textContent ?? "";
+    expect(text).toContain("agents");
+    // The premise lived only in code comments: that they read what you write,
+    // and write back into the same tree.
+    expect(text.toLowerCase()).toContain("what you write");
+    expect(text).toContain("derived/");
+  });
+
+  it("offers a folder as well as a note, since filing is the first decision", async () => {
+    await render(SCAFFOLD);
+    const labels = Array.from(container.querySelectorAll("button")).map((b) =>
+      b.textContent?.trim(),
+    );
+
+    expect(labels).toContain("New note");
+    expect(labels).toContain("New folder");
+  });
+
+  it("does not tell the operator to pick a note from an explorer of scaffold rows", async () => {
+    await render(SCAFFOLD);
+    expect(container.textContent).not.toContain(
+      "Pick a note from the explorer",
+    );
+  });
+});
+
+describe("a workspace with notes in it keeps the terse copy (issue #1380)", () => {
+  it("says No note open once a person has written something", async () => {
+    await render([
+      ...SCAFFOLD,
+      node({ id: "n1", name: "Plan.md", kind: "file" }),
+    ]);
+
+    expect(
+      container.querySelector('[data-testid="workspace-empty-no-selection"]'),
+    ).not.toBeNull();
+    expect(container.textContent).toContain("No note open");
+    expect(container.textContent).toContain("Pick a note from the explorer");
+  });
+});
+
+describe("the explorer no longer contradicts the pane (issue #1380)", () => {
+  it("posts no empty-workspace message of its own", async () => {
+    await render([]);
+
+    // The dead branch's exact sentence.
+    expect(container.textContent).not.toContain("This workspace is empty");
+  });
+
+  it("disables tidy and repair on a tree with nothing to act on", async () => {
+    await render([]);
+
+    expect(
+      (
+        container.querySelector(
+          '[data-testid="workspace-sweep"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      (
+        container.querySelector(
+          '[data-testid="workspace-repair"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("leaves them enabled once the tree holds anything", async () => {
+    await render(SCAFFOLD);
+
+    expect(
+      (
+        container.querySelector(
+          '[data-testid="workspace-sweep"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+  });
+});
+
+describe("the narrow-width layout shows one pane at a time (issue #1386)", () => {
+  /**
+   * Already implemented on main — this locks it. The classes are the contract:
+   * the explorer is `md:flex` plus a `showExplorer`-driven flex/hidden, and the
+   * note section is its mirror image, so below `md` exactly one is displayed
+   * while both are at `md` and up.
+   */
+  it("makes the two panes mutually exclusive below md", async () => {
+    await render(SCAFFOLD);
+
+    const explorer = container.querySelector("aside");
+    const note = container.querySelector("section");
+    expect(explorer?.className).toContain("md:flex");
+    expect(explorer?.className).toContain("flex");
+    expect(note?.className).toContain("hidden md:flex");
+  });
+
+  it("flips which pane is shown when the explorer is toggled", async () => {
+    await render(SCAFFOLD);
+
+    await act(async () => {
+      (
+        container.querySelector(
+          '[aria-label="Toggle explorer"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    const explorer = container.querySelector("aside");
+    const note = container.querySelector("section");
+    expect(explorer?.className).toContain("hidden");
+    expect(note?.className).not.toContain("hidden md:flex");
+  });
+
+  it("keeps a back affordance in the empty pane for the narrow case", async () => {
+    await render(SCAFFOLD);
+    const pane = container.querySelector(
+      '[data-testid="workspace-empty-first-run"]',
+    );
+
+    expect(
+      pane?.querySelector('[aria-label="Toggle explorer"]'),
+    ).not.toBeNull();
+    expect(pane?.querySelector(".md\\:hidden")).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/workspace-explorer-icons.test.ts
+++ b/frontend/test/unit/workspace-explorer-icons.test.ts
@@ -21,6 +21,7 @@ const HEADER_LABELS = [
   "New file",
   "New folder",
   "Upload",
+  "Collapse all",
   "Tidy empty agent folders",
   "Repair duplicate folders",
 ];
@@ -74,7 +75,7 @@ async function render() {
 }
 
 describe("every explorer icon says what it is (issue #1378)", () => {
-  it("wires each of the six header buttons to a tooltip carrying its label", async () => {
+  it("wires each header button to a tooltip carrying its label", async () => {
     await render();
 
     for (const label of HEADER_LABELS) {
@@ -93,13 +94,19 @@ describe("every explorer icon says what it is (issue #1378)", () => {
     const tidy = buttons.findIndex(
       (b) => b.getAttribute("aria-label") === "Tidy empty agent folders",
     );
-    const upload = buttons.findIndex((b) => b.getAttribute("aria-label") === "Upload");
-    expect(upload).toBeGreaterThanOrEqual(0);
-    expect(tidy).toBe(upload + 1);
+    const collapse = buttons.findIndex(
+      (b) => b.getAttribute("aria-label") === "Collapse all",
+    );
+    expect(collapse).toBeGreaterThanOrEqual(0);
+    // The repair group follows the make-and-view group, whose last member is
+    // Collapse all (added by issue #1382).
+    expect(tidy).toBe(collapse + 1);
 
     // A divider sits between the make-something group and the repair group, so
     // the row is not six identical glyphs with two mines in it.
-    const row = container.querySelector('[aria-label="Upload"]')?.parentElement;
+    const row = container.querySelector(
+      '[aria-label="Collapse all"]',
+    )?.parentElement;
     expect(row?.querySelector("span[aria-hidden].w-px")).not.toBeNull();
   });
 });

--- a/frontend/test/unit/workspace-explorer-icons.test.ts
+++ b/frontend/test/unit/workspace-explorer-icons.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1378: the explorer header is six identical icon-only ghost buttons in
+ * one undifferentiated row, two of which remove folders. Their labels existed
+ * only as `aria-label` — nothing a sighted operator ever meets — and the
+ * sweep's confirm-and-destroy button rendered as a pale tint rather than the
+ * solid red every other confirm-and-destroy in the console wears.
+ */
+
+const HEADER_LABELS = [
+  "Refresh",
+  "New file",
+  "New folder",
+  "Upload",
+  "Tidy empty agent folders",
+  "Repair duplicate folders",
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function host(): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue([
+      { id: "agents", name: "Agents", kind: "folder", updatedAt: 1 },
+      {
+        id: "empty-1",
+        name: "01JQ",
+        kind: "folder",
+        parentId: "agents",
+        updatedAt: 1,
+      },
+    ]),
+    post: vi.fn().mockResolvedValue({ wouldRemove: [{ id: "empty-1", name: "01JQ" }] }),
+  } as unknown as OpenCompanyClient;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render() {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: host(),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+describe("every explorer icon says what it is (issue #1378)", () => {
+  it("wires each of the six header buttons to a tooltip carrying its label", async () => {
+    await render();
+
+    for (const label of HEADER_LABELS) {
+      const button = container.querySelector(`[aria-label="${label}"]`);
+      expect(button, `no button labelled “${label}”`).not.toBeNull();
+      // The defect: the label was `aria-label` and nothing else, so a sighted
+      // operator met six identical glyphs.
+      expect(button?.getAttribute("data-slot"), label).toBe("tooltip-trigger");
+    }
+  });
+
+  it("separates the two folder-removing controls from the ones that make things", async () => {
+    await render();
+
+    const buttons = Array.from(container.querySelectorAll("[aria-label]"));
+    const tidy = buttons.findIndex(
+      (b) => b.getAttribute("aria-label") === "Tidy empty agent folders",
+    );
+    const upload = buttons.findIndex((b) => b.getAttribute("aria-label") === "Upload");
+    expect(upload).toBeGreaterThanOrEqual(0);
+    expect(tidy).toBe(upload + 1);
+
+    // A divider sits between the make-something group and the repair group, so
+    // the row is not six identical glyphs with two mines in it.
+    const row = container.querySelector('[aria-label="Upload"]')?.parentElement;
+    expect(row?.querySelector("span[aria-hidden].w-px")).not.toBeNull();
+  });
+});
+
+describe("the sweep's confirm wears the destroy weight (issue #1378)", () => {
+  it("renders Remove with the solid destructive class, not the pale tint", async () => {
+    await render();
+
+    await act(async () => {
+      (container.querySelector('[data-testid="workspace-sweep"]') as HTMLButtonElement).click();
+    });
+
+    const confirm = document.querySelector('[data-testid="workspace-sweep-confirm"]');
+    expect(confirm).not.toBeNull();
+    // The same override `DeleteDialog` uses — the codebase's one weight for
+    // "this button destroys something".
+    expect(confirm?.className).toContain("bg-destructive");
+    expect(confirm?.className).toContain("text-white");
+  });
+});

--- a/frontend/test/unit/workspace-folder-markers.test.ts
+++ b/frontend/test/unit/workspace-folder-markers.test.ts
@@ -180,7 +180,9 @@ describe("the two marked folders, side by side in one tree", () => {
   it("leaves an ordinary folder its whole menu", async () => {
     await render();
     const items = await menuItemsFor("Playbooks");
-    expect(items).toEqual(["Rename", "Move to…", "Delete"]);
+    // The two "New … here" entries are issue #1477's — a folder is a place to
+    // put something, and this menu is where that is decided.
+    expect(items).toEqual(["New note here", "New folder here", "Rename", "Move to…", "Delete"]);
   });
 });
 
@@ -211,10 +213,10 @@ describe("renaming the secrets root", () => {
     await act(async () => {
       // React tracks the last value it wrote, so a bare `input.value =` is
       // swallowed as "unchanged"; the native setter is how a test types.
-      Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )!.set!.call(input, next);
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!.call(
+        input,
+        next,
+      );
       input.dispatchEvent(new Event("input", { bubbles: true }));
     });
     const confirm = Array.from(document.querySelectorAll("button")).find(

--- a/frontend/test/unit/workspace-move-dialog.test.ts
+++ b/frontend/test/unit/workspace-move-dialog.test.ts
@@ -21,16 +21,12 @@ import { WorkspaceView } from "@/views/WorkspaceView";
  * Cancel and no undo.
  */
 
-function node(over: {
-  id: string;
-  name: string;
-  kind: "folder" | "file";
-  parentId?: string;
-}) {
+function node(over: { id: string; name: string; kind: "folder" | "file"; parentId?: string }) {
   return { ...over, updatedAt: 1 };
 }
 
 const TREE = [
+  node({ id: "secrets", name: "secrets", kind: "folder" }),
   node({ id: "standards", name: "Standards", kind: "folder" }),
   node({
     id: "s-drafts",
@@ -73,9 +69,7 @@ function host(team: TeamMemberDto[]) {
 }
 
 beforeEach(() => {
-  (
-    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
-  ).IS_REACT_ACT_ENVIRONMENT = true;
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   Element.prototype.scrollIntoView = vi.fn();
   localStorage.clear();
   container = document.createElement("div");
@@ -92,8 +86,7 @@ function menuItem(label: string): HTMLElement {
   const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
     (el) => el.textContent?.trim() === label,
   );
-  if (!found)
-    throw new Error(`no “${label}” menu item in:\n${document.body.innerHTML}`);
+  if (!found) throw new Error(`no “${label}” menu item in:\n${document.body.innerHTML}`);
   return found as HTMLElement;
 }
 
@@ -114,7 +107,12 @@ function destinations(): HTMLButtonElement[] {
 
 function labels(): string[] {
   return destinations().map(
-    (d) => d.textContent?.replace("Here", "").trim() ?? "",
+    (d) =>
+      d.textContent
+        ?.replace("Here", "")
+        // The audience marker (#1465) rides on the row; the label is the path.
+        .replace(/Hides it|Shares it/, "")
+        .trim() ?? "",
   );
 }
 
@@ -160,6 +158,7 @@ describe("the Move dialog says where each destination is (issue #1381)", () => {
       "Agents / Nadia",
       "Product",
       "Product / Drafts",
+      "secrets",
       "Standards",
       "Standards / Drafts",
     ]);
@@ -184,9 +183,7 @@ describe("the Move dialog says where each destination is (issue #1381)", () => {
 describe("picking a destination is not the same as moving (issue #1381)", () => {
   it("does not move on the first click", async () => {
     await openMove();
-    const target = destinations().find((d) =>
-      d.textContent?.includes("Product / Drafts"),
-    );
+    const target = destinations().find((d) => d.textContent?.includes("Product / Drafts"));
 
     await act(async () => {
       target?.click();
@@ -208,11 +205,8 @@ describe("picking a destination is not the same as moving (issue #1381)", () => 
       destinations()[1]?.click();
     });
     expect(
-      (
-        document.querySelector(
-          '[data-testid="workspace-move-confirm"]',
-        ) as HTMLButtonElement
-      ).disabled,
+      (document.querySelector('[data-testid="workspace-move-confirm"]') as HTMLButtonElement)
+        .disabled,
     ).toBe(false);
   });
 
@@ -226,17 +220,12 @@ describe("picking a destination is not the same as moving (issue #1381)", () => 
     });
     await act(async () => {
       (
-        document.querySelector(
-          '[data-testid="workspace-move-confirm"]',
-        ) as HTMLButtonElement
+        document.querySelector('[data-testid="workspace-move-confirm"]') as HTMLButtonElement
       ).click();
     });
 
     expect(client.patch).toHaveBeenCalledTimes(1);
-    const [, body] = client.patch.mock.calls[0] as [
-      string,
-      { parentId: string },
-    ];
+    const [, body] = client.patch.mock.calls[0] as [string, { parentId: string }];
     expect(body.parentId).toBe("p-drafts");
   });
 
@@ -262,19 +251,95 @@ describe("picking a destination is not the same as moving (issue #1381)", () => 
 describe("a long destination list can be narrowed (issue #1381)", () => {
   it("filters on the path label", async () => {
     await openMove();
-    const box = document.querySelector(
-      '[data-testid="workspace-move-filter"]',
-    ) as HTMLInputElement;
+    const box = document.querySelector('[data-testid="workspace-move-filter"]') as HTMLInputElement;
 
     await act(async () => {
-      const setter = Object.getOwnPropertyDescriptor(
-        HTMLInputElement.prototype,
-        "value",
-      )?.set;
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
       setter?.call(box, "product /");
       box.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
     expect(labels()).toEqual(["Product / Drafts"]);
+  });
+});
+
+/**
+ * The audience half (issue #1465) meeting select-then-confirm (issue #1381).
+ *
+ * #1465 shipped the warning on a dialog where an ordinary destination committed
+ * on one click, so the warning *was* the confirm step. Now every destination
+ * has a Move button — so the warning has to be what that button leads to for a
+ * boundary-crossing destination, rather than being skipped because a confirm
+ * already happened.
+ */
+describe("moving across the secrets boundary still asks (issues #1381, #1465)", () => {
+  it("marks the row before it is picked", async () => {
+    await openMove();
+    const secrets = destinations().find((d) => d.textContent?.startsWith("secrets"));
+
+    expect(secrets?.getAttribute("data-audience-change")).toBe("hidden");
+    expect(secrets?.textContent).toContain("Hides it");
+  });
+
+  it("does not move when Move is pressed — it names the consequence first", async () => {
+    await openMove();
+
+    await act(async () => {
+      destinations()
+        .find((d) => d.textContent?.startsWith("secrets"))
+        ?.click();
+    });
+    await act(async () => {
+      (
+        document.querySelector('[data-testid="workspace-move-confirm"]') as HTMLButtonElement
+      ).click();
+    });
+
+    expect(client.patch).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("This changes who can read it.");
+  });
+
+  it("moves once the consequence is acknowledged", async () => {
+    await openMove();
+
+    await act(async () => {
+      destinations()
+        .find((d) => d.textContent?.startsWith("secrets"))
+        ?.click();
+    });
+    await act(async () => {
+      (
+        document.querySelector('[data-testid="workspace-move-confirm"]') as HTMLButtonElement
+      ).click();
+    });
+    const confirm = Array.from(document.querySelectorAll("button")).find((b) =>
+      /hide|move/i.test(b.textContent ?? ""),
+    );
+    await act(async () => {
+      confirm?.click();
+    });
+
+    expect(client.patch).toHaveBeenCalledTimes(1);
+    expect((client.patch.mock.calls[0] as [string, { parentId: string }])[1].parentId).toBe(
+      "secrets",
+    );
+  });
+
+  it("leaves an ordinary destination one press away, as before", async () => {
+    await openMove();
+
+    await act(async () => {
+      destinations()
+        .find((d) => d.textContent?.includes("Product / Drafts"))
+        ?.click();
+    });
+    await act(async () => {
+      (
+        document.querySelector('[data-testid="workspace-move-confirm"]') as HTMLButtonElement
+      ).click();
+    });
+
+    expect(client.patch).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).not.toContain("This changes who can read it.");
   });
 });

--- a/frontend/test/unit/workspace-move-dialog.test.ts
+++ b/frontend/test/unit/workspace-move-dialog.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1381: the Move dialog listed every folder by bare name, unsorted,
+ * unpathed, offered `derived/`, and committed on the first click.
+ *
+ * Four defects each sufficient on its own to silently re-file a note: two
+ * `Drafts` under different parents were identical rows; the order was the
+ * host's unspecified `tree()` order beside a tree that was sorted; a roster
+ * folder was a raw ULID; `derived/` was offered although the host refuses every
+ * write under it (#1222); and one click moved the note with no Move button, no
+ * Cancel and no undo.
+ */
+
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}) {
+  return { ...over, updatedAt: 1 };
+}
+
+const TREE = [
+  node({ id: "standards", name: "Standards", kind: "folder" }),
+  node({
+    id: "s-drafts",
+    name: "Drafts",
+    kind: "folder",
+    parentId: "standards",
+  }),
+  node({ id: "product", name: "Product", kind: "folder" }),
+  node({ id: "p-drafts", name: "Drafts", kind: "folder", parentId: "product" }),
+  node({ id: "derived", name: "derived", kind: "folder" }),
+  node({ id: "d-goals", name: "Goals", kind: "folder", parentId: "derived" }),
+  node({ id: "agents", name: "Agents", kind: "folder" }),
+  node({
+    id: "roster",
+    name: "01JQZY8T7K",
+    kind: "folder",
+    parentId: "agents",
+  }),
+  node({ id: "note", name: "Plan.md", kind: "file" }),
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let client: {
+  scopeFor: () => string;
+  get: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  listTeam: ReturnType<typeof vi.fn>;
+};
+
+function host(team: TeamMemberDto[]) {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(TREE),
+    patch: vi.fn(async () =>
+      node({ id: "note", name: "Plan.md", kind: "file", parentId: "product" }),
+    ),
+    listTeam: vi.fn().mockResolvedValue(team),
+  };
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function menuItem(label: string): HTMLElement {
+  const found = Array.from(document.querySelectorAll('[role="menuitem"]')).find(
+    (el) => el.textContent?.trim() === label,
+  );
+  if (!found)
+    throw new Error(`no “${label}” menu item in:\n${document.body.innerHTML}`);
+  return found as HTMLElement;
+}
+
+function actionsButtonFor(name: string): HTMLButtonElement {
+  const row = Array.from(container.querySelectorAll("div.group")).find((d) =>
+    d.textContent?.includes(name),
+  );
+  const found = row?.querySelector('[aria-label="Actions"]');
+  if (!found) throw new Error(`no Actions button for “${name}”`);
+  return found as HTMLButtonElement;
+}
+
+function destinations(): HTMLButtonElement[] {
+  return Array.from(
+    document.querySelectorAll('[data-testid="workspace-move-dest"]'),
+  ) as HTMLButtonElement[];
+}
+
+function labels(): string[] {
+  return destinations().map(
+    (d) => d.textContent?.replace("Here", "").trim() ?? "",
+  );
+}
+
+async function openMove(
+  team: TeamMemberDto[] = [{ id: "01JQZY8T7K", name: "Nadia", role: "Nadia" }],
+) {
+  client = host(team);
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    actionsButtonFor("Plan").click();
+  });
+  await act(async () => {
+    menuItem("Move to…").click();
+  });
+}
+
+describe("the Move dialog says where each destination is (issue #1381)", () => {
+  it("tells two same-named folders apart by path", async () => {
+    await openMove();
+
+    expect(labels()).toContain("Standards / Drafts");
+    expect(labels()).toContain("Product / Drafts");
+    // The defect: both rows read "Drafts".
+    expect(labels().filter((l) => l === "Drafts")).toHaveLength(0);
+  });
+
+  it("lists them in the order the explorer draws them", async () => {
+    await openMove();
+    const folders = labels().filter((l) => l !== "Workspace root");
+
+    expect(folders).toEqual([
+      "Agents",
+      "Agents / Nadia",
+      "Product",
+      "Product / Drafts",
+      "Standards",
+      "Standards / Drafts",
+    ]);
+  });
+
+  it("resolves a roster folder rather than showing its id", async () => {
+    await openMove();
+    expect(labels()).toContain("Agents / Nadia");
+    expect(labels().join(" ")).not.toContain("01JQZY8T7K");
+  });
+
+  it("does not offer derived/, where the host refuses every write", async () => {
+    await openMove();
+    const joined = labels().join(" ");
+
+    expect(joined).not.toContain("derived");
+    // Nor anything beneath it.
+    expect(joined).not.toContain("Goals");
+  });
+});
+
+describe("picking a destination is not the same as moving (issue #1381)", () => {
+  it("does not move on the first click", async () => {
+    await openMove();
+    const target = destinations().find((d) =>
+      d.textContent?.includes("Product / Drafts"),
+    );
+
+    await act(async () => {
+      target?.click();
+    });
+
+    // The defect: this click was the move.
+    expect(client.patch).not.toHaveBeenCalled();
+    expect(target?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("keeps Move disabled until something is picked", async () => {
+    await openMove();
+    const confirm = document.querySelector(
+      '[data-testid="workspace-move-confirm"]',
+    ) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+
+    await act(async () => {
+      destinations()[1]?.click();
+    });
+    expect(
+      (
+        document.querySelector(
+          '[data-testid="workspace-move-confirm"]',
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+  });
+
+  it("moves to the picked folder only when Move is pressed", async () => {
+    await openMove();
+
+    await act(async () => {
+      destinations()
+        .find((d) => d.textContent?.includes("Product / Drafts"))
+        ?.click();
+    });
+    await act(async () => {
+      (
+        document.querySelector(
+          '[data-testid="workspace-move-confirm"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(client.patch).toHaveBeenCalledTimes(1);
+    const [, body] = client.patch.mock.calls[0] as [
+      string,
+      { parentId: string },
+    ];
+    expect(body.parentId).toBe("p-drafts");
+  });
+
+  it("Cancel closes without moving", async () => {
+    await openMove();
+
+    await act(async () => {
+      destinations()[1]?.click();
+    });
+    await act(async () => {
+      (
+        Array.from(document.querySelectorAll("button")).find(
+          (b) => b.textContent?.trim() === "Cancel",
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(client.patch).not.toHaveBeenCalled();
+    expect(destinations()).toHaveLength(0);
+  });
+});
+
+describe("a long destination list can be narrowed (issue #1381)", () => {
+  it("filters on the path label", async () => {
+    await openMove();
+    const box = document.querySelector(
+      '[data-testid="workspace-move-filter"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(box, "product /");
+      box.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(labels()).toEqual(["Product / Drafts"]);
+  });
+});

--- a/frontend/test/unit/workspace-move-helpers.test.ts
+++ b/frontend/test/unit/workspace-move-helpers.test.ts
@@ -87,15 +87,17 @@ describe("sortedFolders", () => {
     const order = sortedFolders(TREE, new Set()).map((f) => f.id);
 
     // Depth-first through `childrenOf`, which is the tree's own sort.
+    // `derived` sorts last among folders (issue #1382), and the destination
+    // list follows the explorer rather than second-guessing it.
     expect(order).toEqual([
       "agents",
       "roster",
-      "derived",
-      "d-child",
       "product",
       "p-drafts",
       "standards",
       "s-drafts",
+      "derived",
+      "d-child",
     ]);
     // And it agrees with the tree at the top level.
     expect(

--- a/frontend/test/unit/workspace-move-helpers.test.ts
+++ b/frontend/test/unit/workspace-move-helpers.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { FsNode } from "@/api/workspace";
+import { rosterNameMap } from "@/lib/roster-names";
+import {
+  childrenOf,
+  folderPathLabel,
+  isDerivedNode,
+  sortedFolders,
+  subtreeIds,
+} from "@/lib/workspace";
+
+/**
+ * The two derivations the Move dialog was missing (issue #1381).
+ *
+ * It listed every folder by bare `name` — so two `Drafts` under different
+ * parents were identical rows and a roster folder was a raw ULID — in the host's
+ * own unspecified `tree()` order, beside a tree that was sorted.
+ */
+
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string | null;
+}): FsNode {
+  return {
+    parentId: null,
+    updatedAt: 1,
+    createdBy: { kind: "operator" },
+    updatedBy: { kind: "operator" },
+    ...over,
+  } as FsNode;
+}
+
+const TREE: FsNode[] = [
+  node({ id: "product", name: "Product", kind: "folder" }),
+  node({ id: "p-drafts", name: "Drafts", kind: "folder", parentId: "product" }),
+  node({ id: "agents", name: "Agents", kind: "folder" }),
+  node({
+    id: "roster",
+    name: "01JQZY8T7K",
+    kind: "folder",
+    parentId: "agents",
+  }),
+  node({ id: "derived", name: "derived", kind: "folder" }),
+  node({ id: "d-child", name: "Goals", kind: "folder", parentId: "derived" }),
+  node({ id: "standards", name: "Standards", kind: "folder" }),
+  node({
+    id: "s-drafts",
+    name: "Drafts",
+    kind: "folder",
+    parentId: "standards",
+  }),
+  node({ id: "note", name: "Plan.md", kind: "file", parentId: "product" }),
+];
+
+const NAMES = rosterNameMap([{ id: "01JQZY8T7K", name: "Nadia" }]);
+
+describe("folderPathLabel", () => {
+  it("tells two same-named folders apart by their path", () => {
+    expect(folderPathLabel(TREE, "p-drafts", NAMES)).toBe("Product / Drafts");
+    expect(folderPathLabel(TREE, "s-drafts", NAMES)).toBe("Standards / Drafts");
+    // The defect: both rows read "Drafts".
+    expect(folderPathLabel(TREE, "p-drafts", NAMES)).not.toBe(
+      folderPathLabel(TREE, "s-drafts", NAMES),
+    );
+  });
+
+  it("resolves a roster id the way the tree does", () => {
+    expect(folderPathLabel(TREE, "roster", NAMES)).toBe("Agents / Nadia");
+  });
+
+  it("falls back to the id when the roster has not loaded", () => {
+    expect(folderPathLabel(TREE, "roster", new Map())).toBe(
+      "Agents / 01JQZY8T7K",
+    );
+  });
+
+  it("names a root folder as itself", () => {
+    expect(folderPathLabel(TREE, "product", NAMES)).toBe("Product");
+  });
+});
+
+describe("sortedFolders", () => {
+  it("walks the tree in the order the explorer draws it", () => {
+    const order = sortedFolders(TREE, new Set()).map((f) => f.id);
+
+    // Depth-first through `childrenOf`, which is the tree's own sort.
+    expect(order).toEqual([
+      "agents",
+      "roster",
+      "derived",
+      "d-child",
+      "product",
+      "p-drafts",
+      "standards",
+      "s-drafts",
+    ]);
+    // And it agrees with the tree at the top level.
+    expect(
+      order.filter((id) => TREE.find((n) => n.id === id)?.parentId === null),
+    ).toEqual(
+      childrenOf(TREE, null)
+        .filter((n) => n.kind === "folder")
+        .map((n) => n.id),
+    );
+  });
+
+  it("returns no files, only destinations", () => {
+    expect(sortedFolders(TREE, new Set()).some((f) => f.kind === "file")).toBe(
+      false,
+    );
+  });
+
+  it("drops a blocked subtree wholesale, not just its root", () => {
+    const derivedIds = TREE.filter((n) => isDerivedNode(TREE, n.id)).map(
+      (n) => n.id,
+    );
+    const out = sortedFolders(TREE, new Set(derivedIds)).map((f) => f.id);
+
+    expect(out).not.toContain("derived");
+    // The child would otherwise still be offered — and the host refuses writes
+    // anywhere under `derived/`.
+    expect(out).not.toContain("d-child");
+  });
+
+  it("drops the moving node's own descendants, which would be a cycle", () => {
+    const out = sortedFolders(TREE, subtreeIds(TREE, "product")).map(
+      (f) => f.id,
+    );
+    expect(out).not.toContain("product");
+    expect(out).not.toContain("p-drafts");
+    expect(out).toContain("standards");
+  });
+});

--- a/frontend/test/unit/workspace-not-found.test.ts
+++ b/frontend/test/unit/workspace-not-found.test.ts
@@ -127,11 +127,14 @@ describe("a link to a note that is gone says so (issue #1473)", () => {
       back?.click();
     });
 
-    // Now — and only now — the idle state is the honest answer.
+    // Now — and only now — the empty pane is the honest answer. This host has
+    // no operator content, so that pane is the first-run one (issue #1481).
     expect(
       container.querySelector('[data-testid="workspace-missing-note"]'),
     ).toBeNull();
-    expect(container.textContent).toContain("No note open");
+    expect(
+      container.querySelector('[data-testid="workspace-empty-first-run"]'),
+    ).not.toBeNull();
   });
 });
 
@@ -183,8 +186,10 @@ describe("the pane answers on what was asked for, not on tree membership (issue 
     expect(container.textContent).toContain("no longer in this workspace");
   });
 
-  it("shows the idle state when nothing was asked for at all", async () => {
-    await render(host([]));
+  it("shows the empty pane when nothing was asked for at all", async () => {
+    await render(
+      host([{ id: "note-1", name: "Plan.md", kind: "file", updatedAt: 1 }]),
+    );
 
     expect(
       container.querySelector('[data-testid="workspace-missing-note"]'),

--- a/frontend/test/unit/workspace-not-found.test.ts
+++ b/frontend/test/unit/workspace-not-found.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1473: a link to a note that no longer exists answered "No note open /
+ * Pick a note from the explorer, or create one."
+ *
+ * The whole file pane — header, error, skeleton, editor — lived inside
+ * `openNode && openNode.kind === "file"`, and `openNode` is a lookup in the
+ * *tree*. A `#/workspace/<id>` deep link (a shipped feature, #552's "Open in
+ * workspace") to a deleted note therefore skipped the branch entirely and fell
+ * through to the idle empty state — blaming the reader for a link they had just
+ * followed, while the 404 that had been fetched, parsed and stored was never
+ * rendered at all. The same fall-through swallowed the *initial load* of a
+ * deep-linked id.
+ *
+ * These pin the pane answering on `openId` — what was asked for — rather than
+ * on tree membership.
+ */
+
+/** A host with one note, and a read that 404s for anything else. */
+function host(tree: unknown[], readError?: string) {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn(async (path: string) => {
+      if (path.includes("/workspace/file/")) {
+        if (readError) throw new Error(readError);
+        return {
+          id: "note-1",
+          name: "Plan.md",
+          content: "body",
+          backlinks: [],
+          updatedAt: 1,
+        };
+      }
+      return tree;
+    }),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(client: OpenCompanyClient, initialNodeId?: string) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client,
+          company: "acme",
+          initialNodeId,
+        }),
+      }),
+    );
+  });
+}
+
+const IDLE = "Pick a note from the explorer";
+
+describe("a link to a note that is gone says so (issue #1473)", () => {
+  it("does not answer the idle empty state", async () => {
+    await render(host([]), "deleted-note");
+
+    // The reported defect, verbatim.
+    expect(container.textContent).not.toContain("No note open");
+    expect(container.textContent).not.toContain(IDLE);
+    expect(
+      container.querySelector('[data-testid="workspace-missing-note"]'),
+    ).not.toBeNull();
+    expect(container.textContent).toContain("no longer in this workspace");
+  });
+
+  it("renders the read error it had already fetched and stored", async () => {
+    await render(host([], "workspace node not found"), "deleted-note");
+
+    const shown = container.querySelector(
+      '[data-testid="workspace-missing-error"]',
+    );
+    expect(shown).not.toBeNull();
+    expect(shown?.textContent).toContain("not found");
+  });
+
+  it("claims nothing about why the note is gone", async () => {
+    await render(host([], "workspace node not found"), "deleted-note");
+    const text = container.textContent ?? "";
+
+    // The pane cannot tell a deletion from a wrong company from a failed tree
+    // read, so it must not name one.
+    for (const cause of ["deleted", "expired", "discarded", "removed by"]) {
+      expect(text.toLowerCase()).not.toContain(cause);
+    }
+  });
+
+  it("offers a way onward that clears the stale id", async () => {
+    await render(host([]), "deleted-note");
+
+    const back = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Back to the explorer",
+    );
+    expect(back).toBeDefined();
+
+    await act(async () => {
+      back?.click();
+    });
+
+    // Now — and only now — the idle state is the honest answer.
+    expect(
+      container.querySelector('[data-testid="workspace-missing-note"]'),
+    ).toBeNull();
+    expect(container.textContent).toContain("No note open");
+  });
+});
+
+describe("the pane answers on what was asked for, not on tree membership (issue #1473)", () => {
+  it("keeps the ordinary open-a-note path intact", async () => {
+    const tree = [
+      { id: "note-1", name: "Plan.md", kind: "file", updatedAt: 1 },
+    ];
+    await render(host(tree), "note-1");
+
+    expect(
+      container.querySelector('[data-testid="workspace-missing-note"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="workspace-note"]'),
+    ).not.toBeNull();
+  });
+
+  it("shows a skeleton while a deep-linked id is still loading, not the idle state", async () => {
+    // The skeleton lived inside the `openNode` branch too, so a deep link spent
+    // the whole tree read looking like an idle pane and then changed its mind.
+    let release: (nodes: unknown[]) => void = () => {};
+    const pending = new Promise<unknown[]>((resolve) => {
+      release = resolve;
+    });
+    const client = {
+      scopeFor: () => "/api/v1/company/acme",
+      get: vi.fn(async (path: string) => {
+        if (path.includes("/workspace/file/")) throw new Error("not found");
+        return pending;
+      }),
+    } as unknown as OpenCompanyClient;
+
+    await render(client, "deleted-note");
+
+    expect(
+      container.querySelector('[data-testid="workspace-missing-loading"]'),
+    ).not.toBeNull();
+    expect(container.textContent).not.toContain(IDLE);
+
+    await act(async () => {
+      release([]);
+      await pending;
+    });
+
+    expect(
+      container.querySelector('[data-testid="workspace-missing-loading"]'),
+    ).toBeNull();
+    expect(container.textContent).toContain("no longer in this workspace");
+  });
+
+  it("shows the idle state when nothing was asked for at all", async () => {
+    await render(host([]));
+
+    expect(
+      container.querySelector('[data-testid="workspace-missing-note"]'),
+    ).toBeNull();
+    expect(container.textContent).toContain("No note open");
+  });
+});

--- a/frontend/test/unit/workspace-operator-content.test.ts
+++ b/frontend/test/unit/workspace-operator-content.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import type { FsNode } from "@/api/workspace";
+import { childrenOf, hasOperatorContent, SYSTEM_ROOTS } from "@/lib/workspace";
+
+/**
+ * Issues #1481 and #1382 (item 4).
+ *
+ * `ensure_workspace_scaffold` runs on every boot, so `nodes.length === 0` is
+ * unreachable on a live company — which is why the explorer's "This workspace
+ * is empty" branch was dead code describing a state that cannot happen. The
+ * question the empty state actually needs answered is different: has anybody
+ * written anything here *yet*, because "pick a note from the explorer" is the
+ * wrong instruction for someone whose explorer holds three rows they did not
+ * create.
+ */
+
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string | null;
+}): FsNode {
+  return {
+    parentId: null,
+    updatedAt: 1,
+    createdBy: { kind: "seed" },
+    updatedBy: { kind: "seed" },
+    ...over,
+  } as FsNode;
+}
+
+/** Exactly what a freshly provisioned company boots with. */
+const SCAFFOLD: FsNode[] = [
+  node({ id: "agents", name: "Agents", kind: "folder" }),
+  node({ id: "secrets", name: "secrets", kind: "folder" }),
+  node({ id: "readme", name: "README.md", kind: "file", parentId: "secrets" }),
+];
+
+describe("hasOperatorContent", () => {
+  it("is false for a workspace holding nothing but the scaffold", () => {
+    expect(hasOperatorContent(SCAFFOLD)).toBe(false);
+  });
+
+  it("is false for a genuinely empty tree", () => {
+    expect(hasOperatorContent([])).toBe(false);
+  });
+
+  it("is true the moment a person writes one note", () => {
+    expect(
+      hasOperatorContent([
+        ...SCAFFOLD,
+        node({ id: "n1", name: "Plan.md", kind: "file" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not count a teammate's own Agents/<id>/ folder, which the host mints", () => {
+    expect(
+      hasOperatorContent([
+        ...SCAFFOLD,
+        node({
+          id: "roster",
+          name: "01JQZY8T7K",
+          kind: "folder",
+          parentId: "agents",
+        }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("counts a note filed inside a teammate's folder, which a person did choose", () => {
+    expect(
+      hasOperatorContent([
+        ...SCAFFOLD,
+        node({
+          id: "roster",
+          name: "01JQZY8T7K",
+          kind: "folder",
+          parentId: "agents",
+        }),
+        node({ id: "n1", name: "Brief.md", kind: "file", parentId: "roster" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("counts a folder an operator named the same as a system root elsewhere in the tree", () => {
+    // The scaffold set is root-scoped; `Product/secrets/` is somebody's folder.
+    expect(
+      hasOperatorContent([
+        ...SCAFFOLD,
+        node({ id: "product", name: "Product", kind: "folder" }),
+        node({
+          id: "nested",
+          name: "secrets",
+          kind: "folder",
+          parentId: "product",
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("mirrors the host's SYSTEM_ROOTS by name", () => {
+    expect([...SYSTEM_ROOTS]).toEqual(["agents", "secrets"]);
+  });
+});
+
+describe("childrenOf pins derived last (issue #1382)", () => {
+  it("sorts the read-only folder after the ones a person made", () => {
+    const tree = [
+      node({ id: "z", name: "Zebra", kind: "folder" }),
+      node({ id: "d", name: "derived", kind: "folder" }),
+      node({ id: "a", name: "Alpha", kind: "folder" }),
+    ];
+
+    expect(childrenOf(tree, null).map((n) => n.name)).toEqual([
+      "Alpha",
+      "Zebra",
+      "derived",
+    ]);
+  });
+
+  it("still puts every folder before every file", () => {
+    const tree = [
+      node({ id: "f", name: "Note.md", kind: "file" }),
+      node({ id: "d", name: "derived", kind: "folder" }),
+    ];
+
+    expect(childrenOf(tree, null).map((n) => n.kind)).toEqual([
+      "folder",
+      "file",
+    ]);
+  });
+
+  it("leaves an operator's own folder named derived alone relative to files", () => {
+    // Name-based and therefore blunt, but only the host's folder carries it and
+    // the effect on anything else is cosmetic ordering.
+    const tree = [
+      node({ id: "d", name: "Derived", kind: "folder", parentId: "x" }),
+      node({ id: "a", name: "Alpha", kind: "folder", parentId: "x" }),
+    ];
+
+    expect(childrenOf(tree, "x").map((n) => n.name)).toEqual([
+      "Alpha",
+      "Derived",
+    ]);
+  });
+});

--- a/frontend/test/unit/workspace-repair-residual-only.test.ts
+++ b/frontend/test/unit/workspace-repair-residual-only.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1469: the commonest repair outcome opened a dialog that denied itself.
+ *
+ * `duplicate_folder_plan` leaves any group holding a *file* entirely alone and
+ * reports every member as `fileSharesTheName` — so a note and a folder both
+ * called `Specs` yields **zero** folds and two residuals. The dialog then
+ * announced "0 folders share a name", drew an empty fold list, filed the
+ * residuals under "These will be left for you" as if they were the leftovers of
+ * work that had happened, and offered a permanently disabled "Merge 0".
+ *
+ * These pin the branch: the residual-only outcome is now the thing the dialog
+ * is about, every row carries its real kind and its path, and the footer has an
+ * action that can actually be pressed.
+ */
+
+const TREE = [
+  { id: "eng", name: "Engineering", kind: "folder", updatedAt: 1 },
+  {
+    id: "specs-folder",
+    name: "Specs",
+    kind: "folder",
+    parentId: "eng",
+    updatedAt: 1,
+  },
+  {
+    id: "specs-note",
+    name: "Specs",
+    kind: "file",
+    parentId: "eng",
+    updatedAt: 1,
+  },
+];
+
+const RESIDUAL_ONLY = {
+  residuals: [
+    {
+      id: "specs-folder",
+      name: "Specs",
+      parentId: "eng",
+      cause: "fileSharesTheName",
+    },
+    {
+      id: "specs-note",
+      name: "Specs",
+      parentId: "eng",
+      cause: "fileSharesTheName",
+    },
+  ],
+};
+
+/** The one host each test drives, so its write methods can be asserted on. */
+function host() {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(TREE),
+    post: vi.fn().mockResolvedValue(RESIDUAL_ONLY),
+    patch: vi.fn(),
+    del: vi.fn(),
+  };
+}
+
+let client: ReturnType<typeof host>;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function openRepair() {
+  client = host();
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client as unknown as OpenCompanyClient,
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    (container.querySelector('[data-testid="workspace-repair"]') as HTMLButtonElement).click();
+  });
+}
+
+function rows(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll('[data-testid="workspace-repair-residual"]'),
+  ) as HTMLElement[];
+}
+
+describe("a residual-only repair is about the residuals (issue #1469)", () => {
+  it("never claims 0 folders share a name", async () => {
+    await openRepair();
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+
+    expect(dialog?.textContent).toContain("Two things share a name");
+    // The reported defect, verbatim.
+    expect(dialog?.textContent).not.toContain("0 folders share a name");
+    expect(dialog?.textContent).not.toContain("Merge 0");
+  });
+
+  it("does not frame the residuals as the leftovers of work that happened", async () => {
+    await openRepair();
+    const dialog = document.querySelector('[role="dialog"]');
+
+    expect(dialog?.textContent).not.toContain("These will be left for you");
+    expect(dialog?.textContent).toContain("Nothing here can be merged automatically");
+  });
+
+  it("offers an action that can be pressed", async () => {
+    await openRepair();
+    const done = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Done",
+    );
+    expect(done).toBeDefined();
+    expect(done?.disabled).toBe(false);
+
+    await act(async () => {
+      done?.click();
+    });
+    expect(document.querySelector('[data-testid="workspace-repair-residual"]')).toBeNull();
+  });
+});
+
+describe("each residual says which one it is (issue #1469)", () => {
+  it("draws the folder half as a folder, not as a second note", async () => {
+    await openRepair();
+    const [first, second] = rows();
+
+    // Both were `FileText` — under an instruction reading "rename or remove one
+    // of them", which is unfollowable when both look like the same kind.
+    const icons = [first, second].map((r) => r.querySelector("svg")?.getAttribute("class") ?? "");
+    expect(icons.some((c) => c.includes("lucide-folder"))).toBe(true);
+    expect(icons.some((c) => c.includes("lucide-file-text"))).toBe(true);
+  });
+
+  it("says where each one lives", async () => {
+    await openRepair();
+    for (const row of rows()) expect(row.textContent).toContain("in Engineering");
+  });
+
+  it("reveals the node in the tree without writing anything", async () => {
+    await openRepair();
+    const postsBefore = client.post.mock.calls.length;
+    await act(async () => {
+      rows()[0].click();
+    });
+
+    // The dialog closes onto the tree; nothing was renamed, moved or deleted.
+    // Revealing must never be a write — the operator has not decided anything.
+    expect(document.querySelector('[data-testid="workspace-repair-residual"]')).toBeNull();
+    expect(client.del).not.toHaveBeenCalled();
+    expect(client.patch).not.toHaveBeenCalled();
+    expect(client.post.mock.calls.length).toBe(postsBefore);
+  });
+});

--- a/frontend/test/unit/workspace-search-excerpt.test.ts
+++ b/frontend/test/unit/workspace-search-excerpt.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { centerExcerpt, highlightRuns, SEARCH_LIMIT } from "@/api/workspace";
+
+/**
+ * Issue #1375: a search excerpt could clip its own highlight out of view.
+ *
+ * The host returns a window of context around the match; the console renders it
+ * into a two-line clamp about 250px wide. A match sitting past the first dozen
+ * words is therefore below the fold of its own excerpt, and the operator reads
+ * two lines of arbitrary prose with nothing marked in them.
+ */
+
+describe("centerExcerpt", () => {
+  it("leaves an early match exactly where the host put it", () => {
+    const text = "Pagination is decided per registry, not per call.";
+    expect(centerExcerpt(text, "Pagination")).toBe(text);
+    // No decorative ellipsis on text that was already fine.
+    expect(centerExcerpt(text, "Pagination").startsWith("…")).toBe(false);
+  });
+
+  it("pulls a late match forward so it lands in the first line", () => {
+    const text =
+      "This document opens with a long preamble about scope and ownership before it ever mentions pagination at all.";
+    const centred = centerExcerpt(text, "pagination");
+
+    expect(centred.startsWith("…")).toBe(true);
+    expect(centred).toContain("pagination");
+    // The reported defect: the match was ~100 characters in, well past a
+    // two-line clamp. It must now be near the front.
+    expect(centred.toLowerCase().indexOf("pagination")).toBeLessThan(40);
+  });
+
+  it("starts on a whole word rather than mid-word", () => {
+    const text =
+      "aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo target ppp";
+    const centred = centerExcerpt(text, "target");
+
+    // Every fragment after the leading ellipsis is one of the source's words.
+    const words = centred.replace("…", "").split(" ").filter(Boolean);
+    for (const word of words) expect(text).toContain(word);
+    expect(text.split(" ")).toContain(words[0]);
+  });
+
+  it("returns the text untouched when the query does not appear", () => {
+    const text = "Nothing in here matches.";
+    expect(centerExcerpt(text, "pagination")).toBe(text);
+  });
+
+  it("is a no-op for an empty or whitespace query", () => {
+    const text = "Some prose.";
+    expect(centerExcerpt(text, "")).toBe(text);
+    expect(centerExcerpt(text, "   ")).toBe(text);
+  });
+
+  it("keeps the highlight resolvable after centring", () => {
+    const text =
+      "A long preamble that goes on for a while before it finally says pagination out loud.";
+    const centred = centerExcerpt(text, "pagination");
+    const runs = highlightRuns(centred, "pagination");
+
+    expect(runs.some((r) => r.hit)).toBe(true);
+    expect(runs.find((r) => r.hit)?.text).toBe("pagination");
+  });
+
+  it("does not lowercase or otherwise rewrite the prose it keeps", () => {
+    const text =
+      "Mixed Case Preamble Running On And On And On Before The Word Pagination Appears.";
+    expect(centerExcerpt(text, "pagination")).toContain("Pagination");
+  });
+
+  it("survives multibyte context without splitting a character", () => {
+    const text = `${"héllo wörld ".repeat(6)}pagination`;
+    const centred = centerExcerpt(text, "pagination");
+
+    expect(centred).toContain("pagination");
+    expect(centred).not.toContain("�");
+  });
+});
+
+describe("SEARCH_LIMIT", () => {
+  it("is the host's own ceiling, not its default", () => {
+    // MAX_SEARCH_RESULTS = 50, DEFAULT_SEARCH_LIMIT = 20. Naming no limit is
+    // what capped the console at 20 (issue #1457).
+    expect(SEARCH_LIMIT).toBe(50);
+  });
+});

--- a/frontend/test/unit/workspace-search-hit-row.test.ts
+++ b/frontend/test/unit/workspace-search-hit-row.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SearchHit } from "@/api/workspace";
+import { SearchResults } from "@/views/workspace/SearchResults";
+
+/**
+ * Issue #1375, on the hit row itself.
+ *
+ * The excerpt rendered the host's full window into a two-line clamp about 250px
+ * wide, so a match past the first dozen words was clamped away — two lines of
+ * arbitrary prose with nothing marked in them. And the path rendered in full
+ * with a tail `truncate`, cutting the discriminating end off
+ * `Standards/Engineering/Backend/Rust/API design` while repeating the filename
+ * already shown on the line above.
+ */
+
+function hit(
+  over: Partial<SearchHit> & { id: string; name: string; path: string },
+): SearchHit {
+  return {
+    kind: "file",
+    parentId: null,
+    updatedAt: 1,
+    matched: "content",
+    createdBy: { kind: "operator" },
+    updatedBy: { kind: "operator" },
+    ...over,
+  } as SearchHit;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(hits: SearchHit[], total: number, query = "design") {
+  return act(async () => {
+    root.render(
+      createElement(SearchResults, {
+        query,
+        hits,
+        total,
+        loading: false,
+        error: null,
+        onOpen: vi.fn(),
+      }),
+    );
+  });
+}
+
+const ROW = hit({
+  id: "n1",
+  name: "API design.md",
+  path: "Standards/Engineering/Backend/Rust/API design.md",
+});
+
+describe("a hit's path identifies it (issue #1375)", () => {
+  it("shows the parent folders, not the filename it already printed above", async () => {
+    await render([ROW], 1);
+    const path = container.querySelector(
+      '[data-testid="workspace-search-path"]',
+    );
+
+    expect(path?.textContent).toBe("Standards/Engineering/Backend/Rust");
+    expect(path?.textContent).not.toContain("API design.md");
+  });
+
+  it("ellipsises from the start so the discriminating tail survives", async () => {
+    await render([ROW], 1);
+    const path = container.querySelector(
+      '[data-testid="workspace-search-path"]',
+    ) as HTMLElement;
+
+    // `truncate` cuts the tail; RTL makes the browser drop from the left at the
+    // real rendered width instead.
+    expect(path.getAttribute("dir")).toBe("rtl");
+    expect(path.className).toContain("truncate");
+    // `<bdi>` pins segment order so the RTL context cannot reorder the path.
+    expect(path.tagName.toLowerCase()).toBe("bdi");
+  });
+
+  it("still answers for a note at the root", async () => {
+    await render([hit({ id: "n2", name: "README.md", path: "README.md" })], 1);
+    expect(
+      container.querySelector('[data-testid="workspace-search-path"]')
+        ?.textContent,
+    ).toBe("Workspace root");
+  });
+});
+
+describe("an excerpt shows the match it came back for (issue #1375)", () => {
+  it("marks the query even when the host's window puts it late", async () => {
+    const late = hit({
+      id: "n3",
+      name: "Notes.md",
+      path: "Product/Notes.md",
+      excerpt:
+        "This section opens with a long preamble about ownership and review cadence before it ever mentions design at all.",
+    });
+    await render([late], 1);
+
+    const excerpt = container.querySelector(
+      '[data-testid="workspace-search-excerpt"]',
+    );
+    const mark = excerpt?.querySelector("mark");
+    expect(mark?.textContent).toBe("design");
+    // The reported defect: the match sat past the two-line clamp. It is now
+    // near the front of the rendered text.
+    expect((excerpt?.textContent ?? "").indexOf("design")).toBeLessThan(40);
+    expect(excerpt?.textContent?.startsWith("…")).toBe(true);
+  });
+});

--- a/frontend/test/unit/workspace-search-reach.test.ts
+++ b/frontend/test/unit/workspace-search-reach.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { SearchHit } from "@/api/workspace";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+import { SearchResults } from "@/views/workspace/SearchResults";
+
+/**
+ * Issue #1457: the console showed 20 of 50 matches and offered no way to reach
+ * the other 30.
+ *
+ * Two halves. The cap was the console's own: the host's `clamp_limit` clamps
+ * rather than refusing, its ceiling is 50 and its default is 20, and the search
+ * call named no limit at all. And the truncation was disclosed only at the
+ * *head* — the `<ul>` simply ended, so an operator who scrolled to the bottom
+ * met the last row and read it as the last match.
+ */
+
+function hit(
+  over: Partial<SearchHit> & { id: string; name: string; path: string },
+): SearchHit {
+  return {
+    kind: "file",
+    parentId: null,
+    updatedAt: 1,
+    matched: "content",
+    createdBy: { kind: "operator" },
+    updatedBy: { kind: "operator" },
+    ...over,
+  } as SearchHit;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(hits: SearchHit[], total: number, query = "design") {
+  return act(async () => {
+    root.render(
+      createElement(SearchResults, {
+        query,
+        hits,
+        total,
+        loading: false,
+        error: null,
+        onOpen: vi.fn(),
+      }),
+    );
+  });
+}
+
+const ROW = hit({
+  id: "n1",
+  name: "API design.md",
+  path: "Standards/Engineering/Backend/Rust/API design.md",
+});
+
+describe("a truncated hit list says so at the bottom (issue #1457)", () => {
+  it("names how many matches were withheld, and what to do about it", async () => {
+    await render([ROW], 50);
+
+    const foot = container.querySelector(
+      '[data-testid="workspace-search-more"]',
+    );
+    expect(foot).not.toBeNull();
+    expect(foot?.textContent).toContain("49 more matches");
+    // No offset on the route, so the remedy is a narrower query, not a page.
+    expect(foot?.textContent).toContain("narrow your search");
+  });
+
+  it("says nothing when the list is the whole answer", async () => {
+    await render([ROW], 1);
+    expect(
+      container.querySelector('[data-testid="workspace-search-more"]'),
+    ).toBeNull();
+  });
+
+  it("takes the singular for exactly one withheld match", async () => {
+    await render([ROW], 2);
+    const foot = container.querySelector(
+      '[data-testid="workspace-search-more"]',
+    );
+    expect(foot?.textContent).toContain("1 more match ");
+  });
+});
+
+describe("the console asks the host for its ceiling (issue #1457)", () => {
+  it("names limit=50 on the search request rather than taking the host default", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    localStorage.clear();
+    const seen: string[] = [];
+    const client = {
+      scopeFor: () => "/api/v1/company/acme",
+      get: vi.fn(async (path: string) => {
+        seen.push(path);
+        return path.includes("/workspace/search") ? { hits: [], total: 0 } : [];
+      }),
+    } as unknown as OpenCompanyClient;
+
+    await act(async () => {
+      root.render(
+        createElement(ConnectionScopeProvider, {
+          scope: { connection: "c1", company: "acme" },
+          children: createElement(WorkspaceView, { client, company: "acme" }),
+        }),
+      );
+    });
+
+    const box = container.querySelector(
+      '[data-testid="workspace-search"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(box, "design");
+      box.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    // The box debounces before it asks.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    const search = seen.find((url) => url.includes("/workspace/search"));
+    expect(
+      search,
+      `no search request in ${JSON.stringify(seen)}`,
+    ).toBeDefined();
+    // The reported defect: no limit at all, so the host applied its default 20
+    // while the header truthfully reported "20 of 50".
+    expect(search).toContain("limit=50");
+  });
+});

--- a/frontend/test/unit/workspace-sweep-names.test.ts
+++ b/frontend/test/unit/workspace-sweep-names.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1479: the tidy's confirm asked an operator to approve removing folders
+ * it identified by raw ULID.
+ *
+ * A swept folder's `name` *is* a roster id — that is what `Agents/<id>/`
+ * folders are called — and this view already resolves those ids in the tree
+ * sitting behind the modal (issue #973, `rosterDisplayName`). The dialog exists
+ * because "17 empty folders" is a number nobody can verify; seven opaque ids
+ * are exactly as unverifiable.
+ */
+
+function member(id: string, name: string): TeamMemberDto {
+  return { id, name, role: name };
+}
+
+const SWEEPABLE = [
+  { id: "f-1", name: "01JQZY8T7K" },
+  { id: "f-2", name: "01JQZY8T7A" },
+  { id: "f-3", name: "01JQZY8T7Z" },
+];
+
+function client(team: TeamMemberDto[]): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi
+      .fn()
+      .mockResolvedValue([{ id: "agents", name: "Agents", kind: "folder", updatedAt: 1 }]),
+    post: vi.fn().mockResolvedValue({ wouldRemove: SWEEPABLE }),
+    listTeam: vi.fn().mockResolvedValue(team),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function openSweep(team: TeamMemberDto[]) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: client(team),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+  await act(async () => {
+    (container.querySelector('[data-testid="workspace-sweep"]') as HTMLButtonElement).click();
+  });
+  const list = document.querySelector('[data-testid="workspace-sweep-folders"]');
+  if (!list) throw new Error(`no sweep list in:\n${document.body.innerHTML}`);
+  return Array.from(list.querySelectorAll("li")).map((li) => li.textContent?.trim() ?? "");
+}
+
+describe("the tidy names the teammate, not the id (issue #1479)", () => {
+  it("resolves each folder through the roster the tree behind it already uses", async () => {
+    const rows = await openSweep([
+      member("01JQZY8T7K", "Nadia"),
+      member("01JQZY8T7A", "Bruno"),
+      member("01JQZY8T7Z", "Zora"),
+    ]);
+
+    // The reported defect: these were three ULIDs.
+    expect(rows.join(" ")).toContain("Nadia");
+    expect(rows.join(" ")).toContain("Bruno");
+    expect(rows.join(" ")).not.toContain("01JQZY8T7K");
+  });
+
+  it("sorts by the name on screen, not by whatever order the host returned", async () => {
+    const rows = await openSweep([
+      member("01JQZY8T7K", "Nadia"),
+      member("01JQZY8T7A", "Bruno"),
+      member("01JQZY8T7Z", "Zora"),
+    ]);
+
+    expect(rows.map((r) => r.split(" ")[0])).toEqual(["Bruno", "Nadia", "Zora"]);
+  });
+
+  it("says an unresolved id is no longer on the roster, rather than showing a bare ULID", async () => {
+    const rows = await openSweep([member("01JQZY8T7K", "Nadia")]);
+
+    const orphan = rows.find((r) => r.startsWith("01JQZY8T7A"));
+    expect(orphan).toBeDefined();
+    expect(orphan).toContain("no longer on the roster");
+    // A resolved row makes no such claim.
+    expect(rows.find((r) => r.startsWith("Nadia"))).not.toContain("no longer on the roster");
+  });
+});

--- a/frontend/test/unit/workspace-tree-tooltip.test.ts
+++ b/frontend/test/unit/workspace-tree-tooltip.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * Issue #1459: a truncated tree name was unrecoverable.
+ *
+ * The row is `truncate` inside a fixed 256px pane, indented 12px per level, so
+ * a depth-5 note has about 22 characters of room — and the seeded tree
+ * ellipsises six rows out of the box. `title` was set for exactly one case, a
+ * roster folder showing a *substituted* name, and `undefined` for everything
+ * else. No wrap, no row scroll, no resize handle: the only way to read a name
+ * was to open a row you could not identify.
+ */
+
+function member(id: string, name: string): TeamMemberDto {
+  return { id, name, role: name };
+}
+
+const LONG =
+  "A note with a deliberately very long file name that will not fit.md";
+
+function host(team: TeamMemberDto[] = []): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue([
+      { id: "n1", name: LONG, kind: "file", updatedAt: 1 },
+      { id: "agents", name: "Agents", kind: "folder", updatedAt: 1 },
+      {
+        id: "roster",
+        name: "01JQZY8T7K",
+        kind: "folder",
+        parentId: "agents",
+        updatedAt: 1,
+      },
+    ]),
+    listTeam: vi.fn().mockResolvedValue(team),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Element.prototype.scrollIntoView = vi.fn();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(team: TeamMemberDto[] = []) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, {
+          client: host(team),
+          company: "acme",
+        }),
+      }),
+    );
+  });
+}
+
+function names(): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll('[data-testid="workspace-tree-name"]'),
+  ) as HTMLElement[];
+}
+
+describe("a clipped tree name can still be read (issue #1459)", () => {
+  it("carries its full name on every row, not just on a substituted roster one", async () => {
+    await render();
+
+    const note = names().find((n) => n.textContent?.startsWith("A note with"));
+    expect(note).toBeDefined();
+    // The defect: `title` was `undefined` for every row but one.
+    expect(note?.getAttribute("title")).toBe(
+      "A note with a deliberately very long file name that will not fit",
+    );
+  });
+
+  it("wires the name to a tooltip so a pointer meets it too", async () => {
+    await render();
+    for (const name of names()) {
+      expect(name.getAttribute("data-slot")).toBe("tooltip-trigger");
+    }
+  });
+
+  it("keeps the roster folder's raw id reachable, as #973 left it", async () => {
+    await render([member("01JQZY8T7K", "Nadia")]);
+
+    const folder = names().find((n) => n.textContent === "Nadia");
+    expect(folder).toBeDefined();
+    // The substitution shows the name; the id is still one hover away.
+    expect(folder?.getAttribute("title")).toBe("01JQZY8T7K");
+  });
+});


### PR DESCRIPTION
## Summary

The Workspace's first-run surface: one empty state instead of two contradictory ones, and it finally says what the workspace *is*.

**#1380 + #1481 — the same defect from two angles.** The explorer carried a `nodes.length === 0` branch reading "This workspace is empty. Create a note to start." That branch is dead code — `ensure_workspace_scaffold` lays down `Agents/` and `secrets/` on every boot, so it can never fire — and it contradicted the note pane, which said "No note open / Pick a note from the explorer, or create one." That second sentence is right for an operator with sixty notes who has not clicked one, and wrong on a fresh company, where the explorer holds three rows the host scaffolded and there is no reason to open any of them.

So the note pane owns the messaging and branches on `hasOperatorContent`. The first-run copy states the premise: this tree is shared with the company's agents, they read what you write and write back into it, and `derived/` appears on its own once a ledger has rows. **That sentence existed only in code comments in three files, none of them rendered** — an operator could not learn from this screen that anyone but themselves would ever read it. The two maintenance controls are also disabled on a tree with nothing in them: a no-op on a live company, but they claimed to apply to a state they cannot act on, which is the same claim the dead branch was making.

**#1386 — already on main; verified and pinned, not rebuilt.** The explorer is `md:flex` plus a `showExplorer`-driven flex/hidden and the note section is its mirror, so below `md` exactly one pane shows. This PR adds the regression test that locks it, and changes no layout code.

**#1382 — the density nits.** The header showed a bare relative time beside the title, which read like part of it; it says "Edited" now. The backlinks rail is `xl:flex`, so below about 1280px a note with eleven backlinks and one with none looked identical — a count now rides in the header at every width. `setExpanded(new Set())` already existed with nothing invoking it, so a deep tree stayed open behind every reveal — Collapse all is in the toolbar. Search rendered the raw `name`, so a hit read `Pagination.md` and clicking it renamed the thing on screen to `Pagination`; it shows the same `titleOf` the tree and header do. And `derived/` sorts after the folders a person made, rather than sitting alphabetically among them as though it were a peer.

Console-only. `hasOperatorContent`/`SYSTEM_ROOTS` mirror `workspace_scaffold.rs` by name and carry the same drift caveat `isDerivedNode` documents.

## API Or Behavior Changes

- The empty note pane has two variants; a first-run workspace gets onboarding copy and a New folder button.
- The explorer's empty-workspace line is gone.
- Tidy and Repair are disabled on an empty tree.
- New "Collapse all" control; header gains "Edited" and a backlink count.
- Search hits show the title without the extension.
- `derived/` sorts last among sibling folders.

## Tests

Console (`frontend/`) — this PR touches no Rust:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` — **1952 passed / 209 files**
- [x] `npm run build`
- N/A: `cargo fmt --all -- --check` — no Rust in this change
- N/A: `cargo clippy --all-targets -- -D warnings` — no Rust in this change
- N/A: `cargo build --all-targets` — no Rust in this change
- N/A: `cargo test` — no Rust in this change

New tests, the behavioural ones **red-proven** against the fix reverted:

- `workspace-operator-content.test.ts` — 10 pure tests. `hasOperatorContent` is false for the scaffold and for an empty tree, true on the first note, does not count a host-minted `Agents/<id>/` folder but does count a note filed inside one, and is root-scoped so `Product/secrets/` counts. `childrenOf` pins `derived` last while keeping folders before files.
- `workspace-empty-layout.test.ts` — 10 tests. The first-run pane names the agents, says what you write is what they work from, mentions `derived/`, offers New folder, and does **not** tell the operator to pick a note; one operator note flips it back to the terse copy; the explorer posts no competing message; tidy/repair are disabled on an empty tree and enabled once it holds anything; and the #1386 lock — the panes are mutually exclusive below `md`, the toggle flips which one shows, and the empty pane keeps its `md:hidden` back affordance. Forcing the variant and un-gating the buttons reds 4.
- `workspace-density-nits.test.ts` — 3 tests: the timestamp is labelled, Collapse all is disabled until something is expanded, and one press closes the tree.

Manual pass at 390px and 1100px is worth a reviewer's eye on the first-run copy — it is the operator's first impression of the surface and product voice is @senamakel's call.

## Documentation

No docs change. The first-run copy *is* the documentation this surface was missing; the reasoning sits in comments beside `EmptyNote`, `hasOperatorContent` and the `childrenOf` comparator.

## Related

Closes #1380
Closes #1481
Closes #1386
Closes #1382

**Top of the stack — merge A → B → C → D.** Stacked on `feat/workspace-search-filing` (PR #1502), itself on `feat/workspace-note-identity` (PR #1501), itself on `feat/workspace-save-safety` (PR #1498). All four clubs edit `frontend/src/views/WorkspaceView.tsx`, which is why they stack rather than run independently.

#1386 is closed here on the strength of a **verification plus regression test**, not new layout code — the collapse it asks for is already on main. Flag it if you would rather it stayed open pending the manual 390px pass.
