### PR TITLE
Connectors: offer the choice on the first-host screen, and cover the chooser end to end

### DIFF
--- a/docs/spec/runtime/connectors.md
+++ b/docs/spec/runtime/connectors.md
@@ -350,6 +350,33 @@ Ship the system `ssh`. The failure mode of the in-process client is "we
 accepted a host key the operator's own config would have refused", and that is
 not a trade to make for a Windows dependency that ships in the OS today.
 
+## Where the choice is offered
+
+Two places, and only one of them is a dialog.
+
+**"Add a host"** is the ordinary one: four tabs, `local` and `ssh` present only
+where a process can be started. It is reached from the switcher, which means it
+is reached by someone who already has a console on screen.
+
+**The first-host screen** is the one that matters more, and it used to be a
+dead end. A console holding no connection at all rendered "the host on this
+computer didn't start … or add a host from the switcher above" — a sentence
+that names a control instead of being one, and that describes the wrong
+situation entirely on a hub, whose own origin serves assets and nothing else
+(`hub-console.md`). A hub nobody has added a host to yet holds zero connections
+and always did: nothing went wrong, and telling somebody on their first run
+that a host failed to start is how a working state reads as a fault.
+
+So `firstHostCopy` splits the two — "No host to show" and what to do about it
+for a desktop, "No company connected yet" and what the choice *is* for a hub —
+and both carry a button that opens the chooser. The switcher stays above it,
+because that is where an operator will look next time.
+
+The **setup wizard is deliberately not** one of these places. It is served by a
+host that is already running, so by the time anyone sees it the question has
+been answered; a connector step there would be a decision that cannot be acted
+on.
+
 ## Cross-cutting
 
 ### CORS is not the desktop's problem, and is everyone else's
@@ -404,7 +431,8 @@ Landed:
 - `cloud`'s waking behaviour — the retry loop, the window, and the row that
   says so;
 - `ssh` end to end: the supervised tunnel roster in `src-tauri/src/ssh.rs` over
-  the system `ssh`, opened from the dialog and re-opened by every probe.
+  the system `ssh`, opened from the dialog and re-opened by every probe;
+- the first-host screen offering the choice rather than describing it.
 
 Not yet:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/api/transport/desktop";
 import { ApiError } from "@/api/types";
 import { AddHostDialog, ConsoleChrome } from "@/components/host-switcher";
+import { Button } from "@/components/ui/button";
 import { resolveConfig } from "@/config";
 import {
   addConnection,
@@ -32,7 +33,8 @@ import {
   restoreConnections,
   useConnections,
 } from "@/connections/registry";
-import { HostsProvider, type HostsValue } from "@/connections/HostsContext";
+import { HostsProvider, useHosts, type HostsValue } from "@/connections/HostsContext";
+import { firstHostCopy } from "@/connections/first-host";
 import type { ConnectionId } from "@/connections/types";
 import { ConnectionConsole } from "@/views/ConnectionConsole";
 
@@ -569,7 +571,7 @@ function Console() {
           // gone still has somewhere else to connect to — and "Add a host" is
           // the only way out of a desktop that holds none.
           <ConsoleChrome>
-            <NoConnection starting={!embedded.resolved} />
+            <NoConnection starting={!embedded.resolved} desktop={isDesktopRuntime()} />
           </ConsoleChrome>
         )}
       </div>
@@ -628,16 +630,25 @@ function Waiting({ children }: { children: React.ReactNode }) {
 /**
  * What to show when there is no connection at all.
  *
- * The browser build cannot reach this: its bootstrap connection exists whether
- * or not the host answers, and an unreachable one is a *console* rendering an
- * error rather than an absence. The desktop genuinely can — it holds only the
- * hosts it was told about, and the embedded one may not have started.
+ * Two runtimes reach this and they are not in the same situation. The desktop
+ * holds only the hosts it was told about, and the one inside it may not have
+ * started — something went wrong. A **hub** has no bootstrap connection at all
+ * (`hub-console.md`), so a hub nobody has added a host to yet is simply new.
+ * `firstHostCopy` is what keeps a first run from reading as a failure.
  *
- * The host switcher stays on screen above this (see `ConsoleChrome`), because
- * an operator whose local host is gone still has somewhere else to connect to,
- * and this is the state in which that matters most.
+ * The ordinary browser build still cannot reach it: its bootstrap connection
+ * exists whether or not the host answers, and an unreachable one is a *console*
+ * rendering an error rather than an absence.
+ *
+ * The host switcher stays on screen above this (see `ConsoleChrome`), and the
+ * button below opens its dialog. Both, deliberately: the switcher is where an
+ * operator will look next time, and the button is the answer *this* time —
+ * telling somebody with nothing on screen to go and find a control is not an
+ * answer, it is a description of one.
  */
-function NoConnection({ starting }: { starting: boolean }) {
+function NoConnection({ starting, desktop }: { starting: boolean; desktop: boolean }) {
+  const { setAddingHost } = useHosts();
+  const copy = firstHostCopy(desktop);
   return (
     <FullScreen>
       {starting ? (
@@ -645,13 +656,12 @@ function NoConnection({ starting }: { starting: boolean }) {
           <span data-testid="no-connection-starting">Starting the host on this computer…</span>
         </Waiting>
       ) : (
-        <div className="max-w-sm space-y-2" data-testid="no-connection">
-          <p className="text-sm font-medium">No host to show</p>
-          <p className="text-sm text-muted-foreground">
-            The host on this computer didn't start — another copy of OpenCompany may be
-            holding its data. Quit the other copy and reopen this one, or add a host from
-            the switcher above.
-          </p>
+        <div className="max-w-sm space-y-3" data-testid="no-connection">
+          <p className="text-sm font-medium">{copy.title}</p>
+          <p className="text-sm text-muted-foreground">{copy.body}</p>
+          <Button data-testid="no-connection-add" onClick={() => setAddingHost(true)}>
+            {copy.action}
+          </Button>
         </div>
       )}
     </FullScreen>

--- a/frontend/src/connections/first-host.ts
+++ b/frontend/src/connections/first-host.ts
@@ -1,0 +1,60 @@
+// What to say to somebody who has no host at all.
+//
+// The one screen where "where does my company run" is not a setting but the
+// only question there is, and — before connectors — the one screen that
+// answered it by pointing at a control somewhere else.
+//
+// ## Two situations, and they are not the same absence
+//
+// The desktop reaches this when the host inside it did not start: usually
+// another copy of the application, or an `opencompany serve` in a terminal,
+// holding the data root. Something went wrong, and the operator can fix it.
+//
+// A **hub** reaches it by simply being new. Its own origin serves assets and
+// nothing else (`hub-console.md`), so a hub that nobody has added a host to
+// yet holds zero connections and always did. Nothing went wrong, and the
+// desktop's copy — "the host on this computer didn't start" — describes a
+// computer that was never going to run one.
+//
+// The same words for both is how a first run reads as a failure.
+//
+// See `docs/spec/runtime/connectors.md`.
+
+/** The lines this screen shows, and what its button offers. */
+export interface FirstHostCopy {
+  title: string;
+  body: string;
+  /**
+   * The button.
+   *
+   * There is one in both situations, and that is the point: this used to say
+   * "add a host from the switcher above", which names a control instead of
+   * being one. A dead end that describes its own exit is still a dead end —
+   * and on the hub it was describing the exit from a different building.
+   */
+  action: string;
+}
+
+/**
+ * @param desktop whether this runtime can start a host itself, which is what
+ * separates "it didn't come up" from "there has never been one".
+ */
+export function firstHostCopy(desktop: boolean): FirstHostCopy {
+  if (desktop) {
+    return {
+      title: "No host to show",
+      body:
+        "The host on this computer didn't start — another copy of OpenCompany may be " +
+        "holding its data. Quit the other copy and reopen this one, or run your company " +
+        "somewhere else.",
+      action: "Choose where to run",
+    };
+  }
+  return {
+    title: "No company connected yet",
+    body:
+      "Choose where your company runs: hosted for you on TinyHumans Cloud, or a gateway " +
+      "you run yourself.",
+    action: "Choose where to run",
+  };
+}

--- a/frontend/test/e2e/add-host-connectors.spec.ts
+++ b/frontend/test/e2e/add-host-connectors.spec.ts
@@ -1,0 +1,381 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { openHostMenu } from "./host-switcher";
+
+/**
+ * Choosing where a runtime runs, driven through the whole app.
+ *
+ * The unit tests drive the connector model directly — what a profile means,
+ * what the store refuses, when a failed probe is worth another attempt. This
+ * drives the console the way a person does, because everything under test here
+ * lives in the wiring rather than in an export: which tabs a runtime offers,
+ * what the shell is asked for when one is chosen, and what the roster says
+ * afterwards.
+ *
+ * See `docs/spec/runtime/connectors.md`.
+ *
+ * ## What is shimmed, and what is not
+ *
+ * `window.__TAURI__` exists only inside the packaged shell, so the bridge is
+ * shimmed and nothing else — the same shape `desktop-local-instances.spec.ts`
+ * uses, plus the three tunnel commands. It answers `oc_open_ssh_tunnel` from a
+ * script the spec holds, which is what `SshTunnels` does in Rust minus the
+ * child process. **No `ssh` runs here**: a spec that needs a reachable machine
+ * with a key on it is a spec CI skips, and a skipped spec proves nothing.
+ * `ssh.rs`'s own tests cover the argv and the roster; every decision asserted
+ * on here belongs to the console.
+ *
+ * The browser cases shim nothing at all.
+ */
+
+/** What the shimmed core does when the console asks for a tunnel. */
+interface TunnelScript {
+  /** The address the tunnel forwards to, as `oc_open_ssh_tunnel` reports it. */
+  baseUrl?: string;
+  /** What `ssh` said, when it said no. */
+  refuse?: string;
+}
+
+interface Instance {
+  id: string;
+  label: string;
+  dataDir: string;
+  running: boolean;
+  baseUrl?: string;
+  instanceId?: string;
+  companies?: string[];
+}
+
+/** The single live local host every desktop case here starts from. */
+function seed(liveBaseUrl: string): Instance[] {
+  return [
+    {
+      id: "default",
+      label: "This computer",
+      dataDir: "/tmp/e2e-connectors",
+      running: true,
+      baseUrl: liveBaseUrl,
+      instanceId: "instance-default",
+      companies: [],
+    },
+  ];
+}
+
+/**
+ * Installs a bridge over a roster and a tunnel script the page can read.
+ *
+ * `opened` records every target the console asked for, because *what the shell
+ * is asked* is half of what these specs are about: the console must send the
+ * destination someone typed, not a url it made up.
+ */
+async function installDesktopShell(
+  page: Page,
+  roster: Instance[],
+  tunnel: TunnelScript,
+): Promise<void> {
+  await page.addInitScript(
+    ([seedRoster, script]: [Instance[], TunnelScript]) => {
+      // The tour modal covers the console and swallows clicks.
+      for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+        window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
+      }
+
+      const instances: Instance[] = JSON.parse(JSON.stringify(seedRoster)) as Instance[];
+      const hosts = new Map<string, string>();
+      const opened: unknown[] = [];
+      (window as unknown as { __OPENED_TUNNELS__: unknown[] }).__OPENED_TUNNELS__ = opened;
+
+      async function proxy(
+        connectionId: string,
+        request: {
+          method: string;
+          path: string;
+          headers?: Record<string, string>;
+          body?: string | null;
+        },
+      ) {
+        const base = hosts.get(connectionId) ?? "";
+        const response = await fetch(`${base}${request.path}`, {
+          method: request.method,
+          headers: request.headers,
+          body: request.body ?? undefined,
+          credentials: "include",
+        });
+        const headers: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+          headers[key.toLowerCase()] = value;
+        });
+        return {
+          status: response.status,
+          statusText: response.statusText,
+          url: response.url,
+          text: await response.text(),
+          headers,
+        };
+      }
+
+      (window as unknown as { __TAURI__: unknown }).__TAURI__ = {
+        core: {
+          invoke(command: string, args: Record<string, unknown> = {}) {
+            switch (command) {
+              case "oc_local_instances":
+                return Promise.resolve(JSON.parse(JSON.stringify(instances)) as Instance[]);
+              case "oc_open_ssh_tunnel": {
+                opened.push(args.target);
+                if (script.refuse) return Promise.reject(new Error(script.refuse));
+                const target = args.target as { destination: string; remotePort: number };
+                return Promise.resolve({
+                  id: `${target.destination}:22:${target.remotePort}`,
+                  destination: target.destination,
+                  remotePort: target.remotePort,
+                  baseUrl: script.baseUrl,
+                });
+              }
+              case "oc_close_ssh_tunnel":
+              case "oc_ssh_tunnels":
+                return Promise.resolve([]);
+              case "oc_connect":
+                hosts.set(args.connectionId as string, args.baseUrl as string);
+                return Promise.resolve();
+              case "oc_disconnect":
+                hosts.delete(args.connectionId as string);
+                return Promise.resolve();
+              case "oc_connections":
+                return Promise.resolve([...hosts.keys()]);
+              case "oc_request":
+                return proxy(
+                  args.connectionId as string,
+                  args.request as unknown as Parameters<typeof proxy>[1],
+                );
+              case "oc_subscribe":
+                return Promise.resolve();
+              default:
+                return Promise.resolve(undefined);
+            }
+          },
+          Channel: class {
+            onmessage: unknown = null;
+          },
+        },
+      };
+    },
+    [roster, tunnel] as [Instance[], TunnelScript],
+  );
+}
+
+/** Opens "Add a host" and waits for the chooser. */
+async function openTheChooser(page: Page): Promise<void> {
+  await openHostMenu(page);
+  await page.getByTestId("host-switcher-add").click();
+  await expect(page.getByTestId("add-host-remote")).toBeVisible();
+}
+
+/** Every connector this console is offering right now. */
+async function offeredConnectors(page: Page): Promise<string[]> {
+  const kinds = ["local", "cloud", "remote", "ssh"];
+  const present = await Promise.all(
+    kinds.map(async (kind) => ((await page.getByTestId(`add-host-${kind}`).count()) > 0 ? kind : null)),
+  );
+  return present.filter((kind): kind is string => kind !== null);
+}
+
+/** What the console wrote down about the hosts it holds. */
+async function storedConnectors(page: Page): Promise<unknown[]> {
+  return page.evaluate(() => {
+    const raw = window.localStorage.getItem("oc.connections.v1");
+    return raw
+      ? (JSON.parse(raw) as { connector?: unknown }[]).map((profile) => profile.connector)
+      : [];
+  });
+}
+
+const switcher = (page: Page) => page.getByTestId("host-switcher");
+
+test("a desktop offers all four places a runtime can run", async ({ page, baseURL }) => {
+  await installDesktopShell(page, seed(baseURL ?? ""), {});
+  await page.goto("/");
+  await openTheChooser(page);
+
+  expect(await offeredConnectors(page)).toEqual(["local", "cloud", "remote", "ssh"]);
+});
+
+test("a browser is offered only the two connectors it can honour", async ({ page }) => {
+  // A hub, because an ordinary single-host browser console draws a nameplate
+  // rather than a menu — there is nothing to switch between — and "Add a host"
+  // lives in that menu. A hub is the browser shape that genuinely holds N.
+  await page.goto("/?hub");
+  await openTheChooser(page);
+
+  // `local` and `ssh` both need a process started on this machine, and a
+  // browser has no core to start one in. A tab whose button cannot be honoured
+  // is worse than a tab that is not there.
+  expect(await offeredConnectors(page)).toEqual(["cloud", "remote"]);
+});
+
+test("a browser is told a gateway has to allow this console's origin", async ({ page }) => {
+  // The most likely support question this connector generates, answered where
+  // it is cheapest to answer. There is no wildcard for it either — the session
+  // is a credential — so the operator has to go and set this.
+  await page.goto("/?hub");
+  await openTheChooser(page);
+  await page.getByTestId("add-host-remote").click();
+
+  await expect(page.getByText("OPENCOMPANY_CORS_ORIGINS")).toBeVisible();
+});
+
+test("a host reached over ssh is added at the address the shell opened", async ({
+  page,
+  baseURL,
+}) => {
+  // The tunnel forwards to the live harness host, which is what a real one
+  // would do: the console addresses loopback and something answers there.
+  await installDesktopShell(page, seed(baseURL ?? ""), { baseUrl: baseURL ?? "" });
+  await page.goto("/");
+  await expect(switcher(page)).toHaveAttribute("data-host-count", "1");
+
+  await openTheChooser(page);
+  await page.getByTestId("add-host-ssh").click();
+  await page.getByLabel("Machine").fill("acme-vps");
+  await page.getByRole("button", { name: "Connect" }).click();
+
+  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
+
+  // The shell was asked for the machine someone typed, with the far side's
+  // port defaulted rather than left undefined.
+  //
+  // Asked more than once, and that is the design rather than a slip: the
+  // dialog opens the tunnel so a refusal lands in the form, and the probe that
+  // follows asks again because *every* launch has to. Opening is idempotent
+  // per target on the core's side, which is what makes asking twice free — so
+  // what this asserts is that every ask names the same target.
+  const asked = await page.evaluate(
+    () => (window as unknown as { __OPENED_TUNNELS__: unknown[] }).__OPENED_TUNNELS__,
+  );
+  expect(asked.length).toBeGreaterThan(0);
+  for (const target of asked) {
+    expect(target).toEqual({ destination: "acme-vps", remotePort: 8080 });
+  }
+
+  // And the connector is written down. Nothing about `http://127.0.0.1:<port>`
+  // says it is a tunnel, and the port is this launch's — so a console that did
+  // not record the target could not reopen it, and would mint a fresh id and
+  // orphan every scoped key under it next launch (issue #615).
+  expect(await storedConnectors(page)).toContainEqual({
+    kind: "ssh",
+    target: { destination: "acme-vps", remotePort: 8080 },
+  });
+});
+
+test("ssh's refusal stays on screen instead of becoming a host", async ({ page, baseURL }) => {
+  await installDesktopShell(page, seed(baseURL ?? ""), {
+    refuse: "Permission denied (publickey).",
+  });
+  await page.goto("/");
+  await openTheChooser(page);
+  await page.getByTestId("add-host-ssh").click();
+  await page.getByLabel("Machine").fill("acme-vps");
+  await page.getByRole("button", { name: "Connect" }).click();
+
+  // `ssh`'s own words, in the dialog the operator is standing in front of.
+  // Opening the tunnel here rather than leaving it to the first probe is what
+  // buys that: the alternative is a red row they have to go and read, saying
+  // "could not be reached" about a machine that answered and refused them.
+  await expect(page.getByText("Permission denied (publickey).")).toBeVisible();
+
+  // No host was added, and the dialog is still open to be corrected.
+  await expect(switcher(page)).toHaveAttribute("data-host-count", "1");
+  await expect(page.getByLabel("Machine")).toBeVisible();
+});
+
+/**
+ * A dead address, for the two rows below. Port 9 is `discard`, which nothing
+ * on a test runner is listening on.
+ */
+const ASLEEP = "http://127.0.0.1:9";
+
+/** Seeds a second host at a dead address, as the given connector. */
+async function seedSecondHost(page: Page, connector: unknown): Promise<void> {
+  await page.addInitScript(
+    ([dead, kind]: [string, unknown]) => {
+      // The tour modal covers the console and swallows every click, including
+      // the one that opens the switcher.
+      for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+        window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
+      }
+      window.localStorage.setItem(
+        "oc.connections.v1",
+        JSON.stringify([
+          {
+            id: "conn-primary",
+            baseUrl: "",
+            label: "Primary",
+            defaultCompany: null,
+            credential: { kind: "cookie" },
+          },
+          {
+            id: "conn-second",
+            baseUrl: dead,
+            label: "Second",
+            defaultCompany: null,
+            credential: { kind: "cookie" },
+            connector: kind,
+          },
+        ]),
+      );
+    },
+    [ASLEEP, connector] as [string, unknown],
+  );
+}
+
+test("a cloud tenant that is asleep is being woken, not unreachable", async ({ page }) => {
+  // The platform starts an idle tenant when a request arrives, so its first
+  // request takes seconds. Reporting that as a host that is gone tells an
+  // operator their company is broken when it is merely asleep — and nothing
+  // re-probes, so the row would stay wrong.
+  await seedSecondHost(page, { kind: "cloud", tenant: "acme" });
+  await page.goto("/");
+
+  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
+  await openHostMenu(page);
+  await expect(page.getByTestId("host-row-state-conn-second")).toHaveText("Waking…", {
+    timeout: 30_000,
+  });
+  // In the same rank as any other connecting host: waking is not a fifth
+  // status, it is a connecting one that says what it is doing.
+  await expect(page.getByTestId("host-row-conn-second")).toHaveAttribute(
+    "data-status",
+    "connecting",
+  );
+});
+
+test("the same address as a gateway you run is simply unreachable", async ({ page }) => {
+  // The other half, and the reason the connector has to be written down: these
+  // two rows are the same url and the same failure, and they mean different
+  // things. Nothing is going to wake a gateway somebody runs themselves, so
+  // waiting on it would be a spinner that never resolves.
+  await seedSecondHost(page, { kind: "remote" });
+  await page.goto("/");
+
+  await expect(switcher(page)).toHaveAttribute("data-host-count", "2", { timeout: 30_000 });
+  await openHostMenu(page);
+  await expect(page.getByTestId("host-row-state-conn-second")).toHaveText("Unreachable", {
+    timeout: 30_000,
+  });
+});
+
+test("a hub with no hosts offers the choice rather than describing it", async ({ page }) => {
+  // The onboarding dead end. A hub's own origin serves assets and nothing
+  // else, so a new one holds zero connections — nothing went wrong, and the
+  // desktop's "the host on this computer didn't start" describes a computer
+  // that was never going to run one.
+  await page.goto("/?hub");
+
+  const empty = page.getByTestId("no-connection");
+  await expect(empty).toBeVisible({ timeout: 30_000 });
+  await expect(empty).toContainText("No company connected yet");
+  await expect(empty).not.toContainText("didn't start");
+
+  // And it is a control, not a sentence naming one somewhere else.
+  await page.getByTestId("no-connection-add").click();
+  expect(await offeredConnectors(page)).toEqual(["cloud", "remote"]);
+});

--- a/frontend/test/unit/connectors.test.ts
+++ b/frontend/test/unit/connectors.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/connections/profileStore";
 import type { ConnectionProfile } from "@/connections/profileStore";
 import { availableConnectors } from "@/connections/types";
+import { firstHostCopy } from "@/connections/first-host";
 import {
   CLOUD_WAKE_WINDOW_MS,
   WAKE_RETRY_CEILING_MS,
@@ -193,6 +194,32 @@ describe("which connectors a runtime can offer", () => {
     // `local` and `ssh` both need a process on this machine. A browser build
     // has no core to start one in, so a tab for either would do nothing.
     expect(availableConnectors(false)).toEqual(["cloud", "remote"]);
+  });
+});
+
+describe("somebody with no host at all", () => {
+  it("tells a desktop operator what went wrong, because something did", () => {
+    // The host inside the application did not start — usually another copy of
+    // it holding the data root, which is a thing they can go and fix.
+    const copy = firstHostCopy(true);
+    expect(copy.title).toBe("No host to show");
+    expect(copy.body).toContain("didn't start");
+  });
+
+  it("does not tell a hub that a host it never had failed to start", () => {
+    // A hub's own origin serves assets and nothing else, so a new one holds
+    // zero connections and always did. The desktop's words turn a first run
+    // into a fault report about a computer that was never going to run one.
+    const copy = firstHostCopy(false);
+    expect(copy.body).not.toContain("didn't start");
+    expect(copy.body).toContain("Choose where your company runs");
+  });
+
+  it("offers the choice in both, rather than naming a control elsewhere", () => {
+    // What this screen used to do was point at the switcher. A dead end that
+    // describes its own exit is still a dead end.
+    expect(firstHostCopy(true).action).toBe("Choose where to run");
+    expect(firstHostCopy(false).action).toBe("Choose where to run");
   });
 });
 


### PR DESCRIPTION
Follow-up to #1503, which landed the connector model, the four-tab chooser, cloud's waking behaviour and the ssh tunnel. Two things it did not do.

## The onboarding dead end

A console holding no connection at all rendered:

> The host on this computer didn't start — another copy of OpenCompany may be holding its data. Quit the other copy and reopen this one, or **add a host from the switcher above**.

Two problems, and the second is the worse one.

It **names a control instead of being one.** A dead end that describes its own exit is still a dead end, and the person reading it has an empty screen.

And it describes the wrong situation entirely on a hub. A hub's own origin serves assets and nothing else (`hub-console.md`), so a hub nobody has added a host to yet holds zero connections **and always did** — nothing went wrong. Telling somebody on their first run that a host failed to start is how a working state reads as a fault, about a computer that was never going to run one.

`firstHostCopy` splits the two situations, and both now carry a button that opens the chooser:

| | title | body | button |
|---|---|---|---|
| desktop | No host to show | the host here didn't start, or run it somewhere else | Choose where to run |
| hub | No company connected yet | hosted for you, or a gateway you run | Choose where to run |

The switcher stays on screen above it, deliberately — that is where an operator will look *next* time; the button is the answer *this* time.

**The setup wizard is deliberately not** a third place. It is served by a host that is already running, so by the time anyone sees it the question has been answered; a connector step there would be a decision nobody can act on.

## E2E coverage for the chooser

`add-host-connectors.spec.ts`, eight cases, driving the built bundle against the live harness host:

- a desktop offers all four connectors; a hub is offered only the two it can honour, and is told a gateway has to allow its origin;
- an ssh host is added at the address the shell opened, the shell is asked for the machine that was typed (with the far side's port defaulted), and the target is written down — the port is this launch's, so a console that recorded only the address could not reopen it;
- ssh's refusal stays in the dialog, with the host count unchanged and the form still open to correct;
- **the pair that proves the connector earns its keep**: the same dead address is a tenant being *woken* or a gateway that is *unreachable*, depending only on what was written down;
- a hub with no hosts offers the choice rather than describing it.

Only `window.__TAURI__` is shimmed. **No `ssh` runs** — a spec needing a reachable machine with a key on it is one CI skips, and a skipped spec proves nothing; `ssh.rs`'s own tests cover the argv and the roster.

One assertion changed shape while writing it, and the reason is worth keeping: the console asks for a tunnel **twice** — once from the dialog so a refusal lands in the form, once from the probe that follows because every launch has to. That is the idempotence the core provides, so the spec asserts every ask names the same target rather than that there is exactly one.

## Commands run locally

```
frontend: vitest run                    → 1835 passed (3 new)
frontend: playwright test               → 243 passed, 21 skipped (live-brain lane), 0 failed
frontend: playwright test add-host-connectors → 8 passed
frontend: tsc -b --noEmit / unit / e2e  → clean
```

The full Playwright suite was run because this changes a screen other specs land on; `desktop-connections.spec.ts` asserts on `no-connection` and still passes.

## API and behaviour changes

None. One screen's copy and one new button, plus tests.
