### PR TITLE
feat: make workflow run failures actionable

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -91,11 +91,13 @@ import { workflowSavedToast } from "@/lib/workflow-saved-toast";
 // a copilot. See `workflows/graph.ts` for why the fold is pure.
 import {
   elapsedFromRun,
+  failedNodeOf,
   failureLocation,
   foldLiveRun,
   initialRunState,
   layout,
   LEGIBLE_FIT_ZOOM,
+  nodeName,
   statesFromRun,
   windowHasRunStart,
 } from "@/views/workflows/graph";
@@ -1366,6 +1368,8 @@ export function WorkflowsView({
             atMillis: Date.now(),
             request: asked,
             dryRun,
+            runId: ownRunIdRef.current ?? undefined,
+            sawRunStart: sawOwnRunStartRef.current,
           }),
         );
         // A run that failed is journaled too (#228), and is the outcome most
@@ -2183,6 +2187,18 @@ export function WorkflowsView({
     ];
   }, [runs, pendingRun, starting, activeRunId, selectedId]);
 
+  // The failure panel can only promise a node or copilot repair once the
+  // journal has returned the matching durable run. Until then it can still
+  // open History, but never guesses at a row based on time or position.
+  const failureRun = useMemo(
+    () =>
+      runFailure?.runId
+        ? runs.find((run) => run.runId === runFailure.runId) ?? null
+        : null,
+    [runFailure, runs],
+  );
+  const failureNode = failureRun ? failedNodeOf(failureRun) : null;
+
   // `runs` already holds only the selected workflow's runs, newest first — the
   // host filters and orders them. Re-filtering here would be a second source of
   // truth that can only ever disagree with the first.
@@ -2873,6 +2889,28 @@ export function WorkflowsView({
               <RunFailurePanel
                 failure={runFailure}
                 onClose={() => setRunFailure(null)}
+                onOpenHistory={
+                  historySupported
+                    ? () => {
+                        setHistoryOpen(true);
+                        if (failureRun) setOverlayRun(failureRun);
+                      }
+                    : undefined
+                }
+                onFixWithCopilot={
+                  failureRun ? () => void handleFixWithCopilot(failureRun) : undefined
+                }
+                fixing={failureRun ? fixingRunSeq === failureRun.seq : false}
+                failedStepName={failureNode ? nodeName(graph, failureNode) : null}
+                onShowFailedStep={
+                  failureRun && failureNode
+                    ? () => {
+                        setHistoryOpen(true);
+                        setOverlayRun(failureRun);
+                        setSelectedNodeId(failureNode);
+                      }
+                    : undefined
+                }
               />
             ) : null
           }

--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -36,9 +36,24 @@ const DISPOSITION_COPY: Record<FailureDisposition, string> = {
 export function RunFailurePanel({
   failure,
   onClose,
+  onOpenHistory,
+  onFixWithCopilot,
+  fixing,
+  failedStepName,
+  onShowFailedStep,
 }: {
   failure: RunFailure;
   onClose: () => void;
+  /** Opens the durable record when the host supports history. */
+  onOpenHistory?: () => void;
+  /** Reuses the history row's copilot correction for this exact failed run. */
+  onFixWithCopilot?: () => void;
+  /** Keeps this panel's button consistent with the history row while fixing. */
+  fixing?: boolean;
+  /** The graph-authored name of the failed step, when the matching row arrived. */
+  failedStepName?: string | null;
+  /** Opens the failed run on canvas and selects the step that failed. */
+  onShowFailedStep?: () => void;
 }) {
   // How long the operator waited before this came back. The number a failure
   // most needs beside it: a run that died in 200ms was refused, and one that
@@ -118,6 +133,44 @@ export function RunFailurePanel({
         >
           {DISPOSITION_COPY[disposition]}
         </p>
+        {(onOpenHistory || onFixWithCopilot || onShowFailedStep) && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {onOpenHistory && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 px-2 text-3xs"
+                onClick={onOpenHistory}
+                data-testid="workflow-run-failure-open-history"
+              >
+                Open Run history
+              </Button>
+            )}
+            {onShowFailedStep && failedStepName && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 px-2 text-3xs"
+                onClick={onShowFailedStep}
+                data-testid="workflow-run-failure-show-step"
+              >
+                Show “{failedStepName}”
+              </Button>
+            )}
+            {onFixWithCopilot && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 px-2 text-3xs"
+                disabled={fixing}
+                onClick={onFixWithCopilot}
+                data-testid="workflow-run-failure-fix-with-copilot"
+              >
+                {fixing ? "Fixing…" : "Fix with copilot"}
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     </aside>
   );

--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 import { formatDuration } from "./run-health";
+import { stripEnginePrefixes } from "./run-error-message";
 import {
   failureDisposition,
   type FailureDisposition,
@@ -60,6 +61,7 @@ export function RunFailurePanel({
   // died after four minutes got somewhere first.
   const ranFor = Math.max(0, failure.atMillis - failure.startedAtMillis);
   const disposition = failureDisposition(failure);
+  const message = stripEnginePrefixes(failure.message);
   return (
     // Issue #1205: a right rail at `xl`, the bottom strip it used to always be
     // below that — same pattern as `RunResultPanel` next door, which is the
@@ -102,7 +104,7 @@ export function RunFailurePanel({
             className="text-xs"
             data-testid="workflow-run-failure-message"
           >
-            {failure.message}
+            {message}
           </AlertDescription>
         </Alert>
         <p className="mt-2 text-2xs text-muted-foreground">

--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -16,7 +16,22 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 import { formatDuration } from "./run-health";
-import type { RunFailure } from "./run-failure";
+import {
+  failureDisposition,
+  type FailureDisposition,
+  type RunFailure,
+} from "./run-failure";
+
+const DISPOSITION_COPY: Record<FailureDisposition, string> = {
+  transport:
+    "The request didn't complete, so the host may or may not have started this run. Run history is the answer either way.",
+  "refusal-inference":
+    "The host did not start this run because inference needs attention. Update Settings → Inference, then try again.",
+  "refusal-not-wired": "This host cannot run workflows, so it did not start this run.",
+  journaled: "This console saw the run start. Run history has the step it stopped at.",
+  cautious:
+    "The host answered, but this console did not see the run start. Run history may have more detail if it started.",
+};
 
 export function RunFailurePanel({
   failure,
@@ -29,6 +44,7 @@ export function RunFailurePanel({
   // most needs beside it: a run that died in 200ms was refused, and one that
   // died after four minutes got somewhere first.
   const ranFor = Math.max(0, failure.atMillis - failure.startedAtMillis);
+  const disposition = failureDisposition(failure);
   return (
     // Issue #1205: a right rail at `xl`, the bottom strip it used to always be
     // below that — same pattern as `RunResultPanel` next door, which is the
@@ -93,20 +109,14 @@ export function RunFailurePanel({
             {failure.request}
           </p>
         )}
-        {/* Two genuinely different next steps, and collapsing them sends the
-            operator to the wrong place. A host that answered has journaled the
-            run (#228), so its per-node trail is in Run history. Something that
-            gave up in between may have left no run at all — and telling someone
-            to look in History for a row that does not exist is how a transport
-            failure comes to read as a missing feature.
-
-            No positional wording ("below") on purpose: History has been a left
-            rail since #1107, and this panel is itself a right rail since #1205,
-            so neither is spatially "below" the other. */}
-        <p className="mt-2 text-2xs text-muted-foreground">
-          {failure.fromHost
-            ? "The host records failed runs, so this one is in Run history, with the step it stopped at."
-            : "The request didn't complete, so the host may or may not have started this run. Run history is the answer either way."}
+        {/* A host envelope proves only who answered. The structured code proves
+            known pre-execution refusals, and the console's own start frame is
+            the positive evidence needed before saying History has this run. */}
+        <p
+          className="mt-2 text-2xs text-muted-foreground"
+          data-testid="workflow-run-failure-disposition"
+        >
+          {DISPOSITION_COPY[disposition]}
         </p>
       </div>
     </aside>

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -33,6 +33,7 @@ import {
   undeliveredCount,
   undeliveredNodes,
 } from "./run-health";
+import { stripEnginePrefixes } from "./run-error-message";
 
 /** Badge styling per delivery outcome. A report that did NOT go out must not
  * look like one that did — `denied` and `failed` are the two an operator has to
@@ -121,7 +122,7 @@ export function LastRunChip({ run }: { run: WorkflowRunOutcome }) {
         run.running
           ? "This run is still going."
           : run.error
-            ? `Last run failed: ${run.error}`
+            ? `Last run failed: ${stripEnginePrefixes(run.error)}`
             : run.cancelled
               ? "An operator stopped this run before it finished."
               : `Last ${run.scheduled ? "scheduled" : "manual"} run — ${tone.label}`
@@ -377,6 +378,7 @@ function RunHistoryRow({
   // worse than a parked one — there is no card to click.
   const unparkable = blocked.reduce((n, b) => n + (b.unparkable ?? 0), 0);
   const failedNode = failedNodeOf(run);
+  const errorMessage = run.error ? stripEnginePrefixes(run.error) : null;
   const duration = runDuration(run, now);
   return (
     <div
@@ -497,7 +499,7 @@ function RunHistoryRow({
             {failedNode
               ? `This run failed at “${nodeName(graph, failedNode)}”: `
               : "This run failed: "}
-            {run.error}
+            {errorMessage}
             {/* Issue #840 (PR-3): correct the workflow with the copilot. Offered
                 only on the journaled failed run (keyed by runId) — the one
                 surface that always carries the failure, unlike the sync run

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -7,7 +7,6 @@
 
 import { useEffect, useRef, useState, type RefObject } from "react";
 
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type {
@@ -380,21 +379,43 @@ function RunHistoryRow({
   const failedNode = failedNodeOf(run);
   const errorMessage = run.error ? stripEnginePrefixes(run.error) : null;
   const duration = runDuration(run, now);
+  // Completed, quiet runs are the common case. They need enough separation to
+  // scan but not the full card chrome reserved for a state that asks something
+  // of the operator. Each condition below protects a branch further down this
+  // row, so no detail disappears into a deceptively light treatment.
+  const compact =
+    !run.error &&
+    !run.cancelled &&
+    !isRunning(run) &&
+    !isBlocked(run) &&
+    !isStranded(run) &&
+    run.pendingApprovals.length === 0 &&
+    undeliveredCount(run.deliveries) === 0 &&
+    run.deliveries.length === 0 &&
+    (run.notices?.length ?? 0) === 0;
   return (
     <div
       ref={selectedRowRef}
-      className={`rounded-lg border bg-background/40 p-2 ${
+      className={`${
+        compact
+          ? "border-x-0 border-t-0 rounded-none bg-transparent px-0 py-2"
+          : "rounded-lg border bg-background/40 p-2"
+      } ${run.error ? "border-status-failed/50 bg-status-failed-soft" : ""} ${
         selected ? "ring-2 ring-primary/40" : ""
       }`}
       data-testid="workflow-run-row"
     >
       <div className="mb-1 flex flex-wrap items-center gap-2">
         <span className={`size-1.5 rounded-full ${tone.dot}`} />
-        <Badge variant="outline" className="h-4 px-1.5 text-3xs font-normal">
-          {run.scheduled ? "scheduled" : "manual"}
-        </Badge>
-        <span className="text-2xs text-muted-foreground">
-          {new Date(run.atMillis).toLocaleString()} ·{" "}
+        {run.scheduled && (
+          <Badge variant="outline" className="h-4 px-1.5 text-3xs font-normal">
+            scheduled
+          </Badge>
+        )}
+        <span
+          className="text-2xs text-muted-foreground"
+          title={new Date(run.atMillis).toLocaleString()}
+        >
           {relativeTime(run.atMillis)}
           {/* Issue #1007: how long it took, which nothing on this surface said.
               A run that failed in 200ms was refused before it started; one that
@@ -481,8 +502,8 @@ function RunHistoryRow({
       {run.error ? (
         // The outcome that used to be quietest of all: a run that died left one
         // host-stdout warning and nothing an operator could ever find.
-        <Alert variant="destructive" className="py-2">
-          <AlertDescription className="text-2xs">
+        <>
+          <div className="rounded-md border border-status-failed/50 bg-background/40 p-2">
             {/* Name the node when the trail names one — the engine reports a
                 failing node as an errored step, so this is exact. When it does
                 not (a graph that would not compile, a capability that could not
@@ -496,39 +517,49 @@ function RunHistoryRow({
                 and a graph edited since the run can only give back the id it
                 no longer holds — both of which are the old reading, never a
                 wrong name. */}
-            {failedNode
-              ? `This run failed at “${nodeName(graph, failedNode)}”: `
-              : "This run failed: "}
-            {errorMessage}
-            {/* Issue #840 (PR-3): correct the workflow with the copilot. Offered
-                only on the journaled failed run (keyed by runId) — the one
-                surface that always carries the failure, unlike the sync run
-                result — and only when the parent wired a handler (a brain is
-                available). */}
-            {onFixWithCopilot && run.runId && (
-              <div className="mt-1.5">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-6 px-2 text-3xs"
-                  disabled={fixing || fixDisabled}
-                  onClick={() => onFixWithCopilot(run)}
-                  data-testid="workflow-run-fix-with-copilot"
+            <p className="text-2xs font-medium text-status-failed-text">
+              {failedNode
+                ? `The “${nodeName(graph, failedNode)}” step failed.`
+                : "This run failed."}
+            </p>
+            <p className="mt-1 text-2xs text-muted-foreground">
+              Review the error details, then correct the workflow and run it again.
+            </p>
+            <details className="mt-1">
+              <summary className="cursor-pointer text-2xs text-muted-foreground">
+                Details
+              </summary>
+              <pre className="mt-1 overflow-auto rounded border bg-muted/40 p-2 font-mono text-2xs leading-snug text-foreground">
+                {errorMessage}
+              </pre>
+            </details>
+          </div>
+          {/* Issue #840 (PR-3): correction is an action, not part of the
+              destructive error framing. Keeping it outside gives the neutral
+              control its ordinary token treatment. */}
+          {onFixWithCopilot && run.runId && (
+            <div className="mt-1.5">
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 px-2 text-3xs"
+                disabled={fixing || fixDisabled}
+                onClick={() => onFixWithCopilot(run)}
+                data-testid="workflow-run-fix-with-copilot"
+              >
+                {fixing ? "Fixing…" : "Fix with copilot"}
+              </Button>
+              {fixReason && (
+                <p
+                  className="mt-1 text-2xs text-muted-foreground"
+                  data-testid="workflow-run-fix-not-automatable"
                 >
-                  {fixing ? "Fixing…" : "Fix with copilot"}
-                </Button>
-                {fixReason && (
-                  <p
-                    className="mt-1 text-2xs text-muted-foreground"
-                    data-testid="workflow-run-fix-not-automatable"
-                  >
-                    The copilot couldn't fix this by re-wiring the workflow: {fixReason}
-                  </p>
-                )}
-              </div>
-            )}
-          </AlertDescription>
-        </Alert>
+                  The copilot couldn't fix this by re-wiring the workflow: {fixReason}
+                </p>
+              )}
+            </div>
+          )}
+        </>
       ) : run.cancelled ? (
         // Issue #383, the third terminal reading. Deliberately not a
         // destructive Alert: nothing went wrong, somebody decided they had seen

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -5,7 +5,7 @@
 // further out again, to `run-health.ts`, because the workflow cards need the
 // same reading — see that file's header.
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -218,6 +218,13 @@ export function RunHistoryPanel({
   // button (not just the in-flight one's) while `fixingRunSeq` is set turns
   // that race into "wait your turn".
   const anyFixInFlight = fixingRunSeq != null;
+  const selectedRowRef = useRef<HTMLDivElement>(null);
+  // The failure panel can select a row on behalf of an operator who never
+  // opened History themselves. Keep the selected failure in view without
+  // changing their scroll position when it is already visible.
+  useEffect(() => {
+    selectedRowRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [selectedRunSeq]);
   // Issue #1007: a clock, ticking only while a row is actually in flight. The
   // elapsed time on a running row is the console's acknowledgement that the
   // click did something, and it is only true if it moves.
@@ -276,6 +283,7 @@ export function RunHistoryPanel({
                 graph={graph}
                 now={now}
                 selected={run.seq === selectedRunSeq}
+                selectedRowRef={run.seq === selectedRunSeq ? selectedRowRef : undefined}
                 onSelect={() => onSelectRun(run)}
                 onFixWithCopilot={onFixWithCopilot}
                 fixing={fixingRunSeq === run.seq}
@@ -315,6 +323,7 @@ function RunHistoryRow({
   graph,
   now,
   selected,
+  selectedRowRef,
   onSelect,
   onFixWithCopilot,
   fixing,
@@ -327,6 +336,7 @@ function RunHistoryRow({
   /** The clock a still-running row counts against (issue #1007). */
   now: number;
   selected: boolean;
+  selectedRowRef?: RefObject<HTMLDivElement>;
   onSelect: () => void;
   /** Correct this run's workflow with the copilot (issue #840, PR-3). */
   onFixWithCopilot?: (run: WorkflowRunOutcome) => void;
@@ -370,6 +380,7 @@ function RunHistoryRow({
   const duration = runDuration(run, now);
   return (
     <div
+      ref={selectedRowRef}
       className={`rounded-lg border bg-background/40 p-2 ${
         selected ? "ring-2 ring-primary/40" : ""
       }`}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -398,7 +398,7 @@ function RunHistoryRow({
       ref={selectedRowRef}
       className={`${
         compact
-          ? "border-x-0 border-t-0 rounded-none bg-transparent px-0 py-2"
+          ? "border-b border-x-0 border-t-0 rounded-none bg-transparent px-0 py-2"
           : "rounded-lg border bg-background/40 p-2"
       } ${run.error ? "border-status-failed/50 bg-status-failed-soft" : ""} ${
         selected ? "ring-2 ring-primary/40" : ""

--- a/frontend/src/views/workflows/run-error-message.ts
+++ b/frontend/src/views/workflows/run-error-message.ts
@@ -1,0 +1,46 @@
+// The readable leaf of an engine error (issue #1366).
+//
+// The harness supplies useful operator prose, but its error wrapping arrives
+// as a stack of implementation labels such as
+// `harness error: capability error: agent: ...`. Those labels explain where
+// the Rust error crossed a boundary, not what the operator should act on. Peel
+// only the wrapper vocabulary the workflow contract owns; an unfamiliar prefix
+// stays byte-for-byte intact rather than being mistaken for a wrapper.
+
+import { WORKFLOW_NODE_KINDS } from "@/api/workflows";
+
+const ENGINE_PREFIXES = new Set([
+  "harness error",
+  "capability error",
+  ...WORKFLOW_NODE_KINDS,
+]);
+
+const PREFIX = /^([^:\r\n]+):[ \t]*/;
+
+/**
+ * Removes known harness, capability, and workflow-kind prefixes from an error.
+ *
+ * A raw message is the fallback whenever its first prefix is unknown or every
+ * recognised prefix leads only to whitespace. That protects error messages
+ * whose actual prose happens to contain a colon and means no information is
+ * lost when the engine introduces a new wrapper.
+ */
+export function stripEnginePrefixes(full: string): string {
+  let remaining = full;
+  let stripped = false;
+
+  while (true) {
+    const match = PREFIX.exec(remaining);
+    if (!match || !ENGINE_PREFIXES.has(match[1].trim().toLowerCase())) {
+      return stripped ? remaining : full;
+    }
+
+    const next = remaining.slice(match[0].length);
+    // A chain of labels without a human-readable leaf is less useful than the
+    // original diagnostic, and returning the original preserves it verbatim.
+    if (!next.trim()) return full;
+
+    remaining = next;
+    stripped = true;
+  }
+}

--- a/frontend/src/views/workflows/run-failure.ts
+++ b/frontend/src/views/workflows/run-failure.ts
@@ -13,6 +13,20 @@
 
 import { ApiError } from "@/api/types";
 
+import { INFERENCE_RUN_CODES } from "./run-error";
+
+/**
+ * The codes that prove the host refused a run before it could execute.
+ *
+ * Kept beside the failure record rather than derived from HTTP status or an
+ * envelope flag: a host can return an ordinary error envelope after beginning
+ * work, while these codes name the two cases in which it did not start a run.
+ */
+export const PRE_EXECUTION_REFUSAL_CODES: ReadonlySet<string> = new Set([
+  "not_wired",
+  ...INFERENCE_RUN_CODES,
+]);
+
 /** Everything the failure panel renders, captured at the moment of the catch. */
 export interface RunFailure {
   /**
@@ -37,6 +51,10 @@ export interface RunFailure {
   /** Whether the host itself refused, rather than something between it and the
    * browser giving up. Decides which of the two closing sentences is true. */
   fromHost: boolean;
+  /** The id observed in this console's own run-start frame, if it arrived. */
+  runId?: string;
+  /** Whether this console positively saw its own run start before the failure. */
+  sawRunStart: boolean;
   /** When the operator pressed Run, so the panel can say how long it ran for. */
   startedAtMillis: number;
   /** When the failure was caught. */
@@ -53,6 +71,32 @@ export interface RunFailureContext {
   atMillis: number;
   request: string;
   dryRun: boolean;
+  runId?: string;
+  sawRunStart: boolean;
+}
+
+/** What the panel can honestly say about where this failed run went next. */
+export type FailureDisposition =
+  | "transport"
+  | "refusal-inference"
+  | "refusal-not-wired"
+  | "journaled"
+  | "cautious";
+
+/**
+ * Chooses the failure panel's next-step claim.
+ *
+ * A host envelope only proves who answered; it does not prove that a run was
+ * recorded. The structured code proves the known pre-execution refusals, and a
+ * run-start frame is the positive evidence needed before saying History has
+ * this run. Everything else stays deliberately cautious.
+ */
+export function failureDisposition(failure: RunFailure): FailureDisposition {
+  if (!failure.fromHost) return "transport";
+  if (INFERENCE_RUN_CODES.has(failure.code ?? "")) return "refusal-inference";
+  if (failure.code === "not_wired") return "refusal-not-wired";
+  if (failure.sawRunStart) return "journaled";
+  return "cautious";
 }
 
 /**
@@ -69,6 +113,8 @@ export function runFailureFrom(e: unknown, ctx: RunFailureContext): RunFailure {
     atMillis: ctx.atMillis,
     request: ctx.request,
     dryRun: ctx.dryRun,
+    runId: ctx.runId,
+    sawRunStart: ctx.sawRunStart,
   };
   if (e instanceof ApiError) {
     return {

--- a/frontend/test/unit/workflow-run-error-message.test.ts
+++ b/frontend/test/unit/workflow-run-error-message.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { stripEnginePrefixes } from "@/views/workflows/run-error-message";
+
+describe("stripEnginePrefixes", () => {
+  it("shows the actionable leaf of a nested harness error", () => {
+    expect(
+      stripEnginePrefixes(
+        "harness error: capability error: agent: the writer agent has no model",
+      ),
+    ).toBe("the writer agent has no model");
+  });
+
+  it("also strips a workflow kind when it is the only engine prefix", () => {
+    expect(stripEnginePrefixes("http_request: the remote service refused the request")).toBe(
+      "the remote service refused the request",
+    );
+  });
+
+  it("keeps an unfamiliar prefix verbatim", () => {
+    const raw = "provider error: quota exhausted";
+    expect(stripEnginePrefixes(raw)).toBe(raw);
+  });
+
+  it("keeps prefix-only diagnostics verbatim", () => {
+    const raw = "harness error: capability error: ";
+    expect(stripEnginePrefixes(raw)).toBe(raw);
+  });
+});

--- a/frontend/test/unit/workflow-run-failure-disposition.test.ts
+++ b/frontend/test/unit/workflow-run-failure-disposition.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import type { RunFailure } from "@/views/workflows/run-failure";
+import {
+  failureDisposition,
+  PRE_EXECUTION_REFUSAL_CODES,
+} from "@/views/workflows/run-failure";
+
+const FAILURE: RunFailure = {
+  message: "failed",
+  fromHost: true,
+  sawRunStart: false,
+  startedAtMillis: 1_000,
+  atMillis: 1_100,
+  request: "",
+  dryRun: false,
+};
+
+describe("failureDisposition", () => {
+  it("uses the host's structured code, not merely its envelope, for pre-execution claims", () => {
+    expect(failureDisposition({ ...FAILURE, code: "not_wired" })).toBe("refusal-not-wired");
+    expect(failureDisposition({ ...FAILURE, code: "engine_failed" })).toBe("cautious");
+  });
+
+  it("keeps the known refusal codes together without treating not_wired as inference", () => {
+    expect(PRE_EXECUTION_REFUSAL_CODES.has("not_wired")).toBe(true);
+    expect(failureDisposition({ ...FAILURE, code: "inference_required" })).toBe(
+      "refusal-inference",
+    );
+  });
+
+  it("claims a history row only after this console saw the run start", () => {
+    expect(failureDisposition({ ...FAILURE, sawRunStart: true })).toBe("journaled");
+    expect(failureDisposition(FAILURE)).toBe("cautious");
+  });
+
+  it("keeps a failed transport request distinct from a host failure", () => {
+    expect(failureDisposition({ ...FAILURE, fromHost: false, sawRunStart: true })).toBe(
+      "transport",
+    );
+  });
+});

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -285,8 +285,8 @@ describe("the history row names the node the operator named", () => {
       );
     });
     const row = container.querySelector('[data-testid="workflow-run-row"]');
-    expect(row?.textContent).toContain("This run failed at “Draft the digest”");
-    expect(row?.textContent).not.toContain("failed at “n_3”");
+    expect(row?.textContent).toContain("The “Draft the digest” step failed.");
+    expect(row?.textContent).not.toContain("The “n_3” step failed.");
     // …and says how long it took, which nothing on this surface did before.
     expect(
       container.querySelector('[data-testid="workflow-run-duration"]')?.textContent,

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -72,6 +72,7 @@ Object.defineProperties(globalThis.HTMLElement.prototype, {
 
 const { WorkflowsView } = await import("@/views/WorkflowsView");
 const { RunHistoryPanel } = await import("@/views/workflows/RunHistoryPanel");
+const { RunFailurePanel } = await import("@/views/workflows/RunFailurePanel");
 const { runFailureFrom } = await import("@/views/workflows/run-failure");
 const { formatDuration, runDuration } = await import("@/views/workflows/run-health");
 
@@ -319,6 +320,45 @@ describe("what the failure panel is built from", () => {
     expect(runFailureFrom("kaboom", CTX).message).toBe("kaboom");
     expect(runFailureFrom(new Error(""), CTX).message).not.toBe("");
     expect(runFailureFrom(new ApiError(500, "x", "", true), CTX).message).toContain("500");
+  });
+});
+
+describe("failure panel follow-up controls", () => {
+  it("opens the durable row, its failed step, and the existing copilot path", async () => {
+    const openHistory = vi.fn();
+    const showStep = vi.fn();
+    const fixWithCopilot = vi.fn();
+    await act(async () => {
+      root.render(
+        createElement(RunFailurePanel, {
+          failure: {
+            message: "the writer agent has no model",
+            fromHost: true,
+            runId: "run-9",
+            sawRunStart: true,
+            startedAtMillis: 1_000,
+            atMillis: 3_400,
+            request: "",
+            dryRun: false,
+          },
+          onClose: () => {},
+          onOpenHistory: openHistory,
+          failedStepName: "Draft the digest",
+          onShowFailedStep: showStep,
+          onFixWithCopilot: fixWithCopilot,
+        }),
+      );
+    });
+
+    await act(async () => {
+      button("Open Run history").click();
+      button("Show “Draft the digest”").click();
+      button("Fix with copilot").click();
+    });
+
+    expect(openHistory).toHaveBeenCalledOnce();
+    expect(showStep).toHaveBeenCalledOnce();
+    expect(fixWithCopilot).toHaveBeenCalledOnce();
   });
 });
 

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -295,7 +295,13 @@ describe("the history row names the node the operator named", () => {
 });
 
 describe("what the failure panel is built from", () => {
-  const CTX = { startedAtMillis: 1_000, atMillis: 3_400, request: "", dryRun: false };
+  const CTX = {
+    startedAtMillis: 1_000,
+    atMillis: 3_400,
+    request: "",
+    dryRun: false,
+    sawRunStart: false,
+  };
 
   it("keeps the host's code only when the host's own envelope carried it", () => {
     const fromHost = runFailureFrom(new ApiError(409, "engine_failed", "no", true), CTX);


### PR DESCRIPTION
## Summary

- Make run-failure guidance depend on structured refusal codes and observed run-start evidence, with a cautious default.
- Let a matching failed run open and scroll Run history, reveal its failed canvas step, and use the existing copilot repair path.
- Strip known harness and engine prefixes before workflow error text reaches operators, and make clean history rows denser with semantic design tokens.

Closes #1364 #1461 #1365 #1366

## API Or Behavior Changes

The workflow failure drawer now distinguishes pre-execution refusals, confirmed journaled runs, transport failures, and uncertain host errors. Its follow-up actions appear only once the matching durable history row is available.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run`
- [x] `npm run build`

## Documentation

No standalone documentation change needed; this is an operator-console behavior and presentation update.