### PR TITLE
feat(workflows): improve authoring and index clarity

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -1340,7 +1340,13 @@ export function previewCron(
   );
 }
 
-export const CREATABLE_NODE_KINDS: { value: string; label: string }[] = [
+/**
+ * Every workflow node kind the host accepts, paired with its operator-facing
+ * label. This is the console's single vocabulary for authoring and display:
+ * consumers that need only the wire values derive them below rather than
+ * maintaining another list that can drift.
+ */
+export const NODE_KINDS: readonly { value: string; label: string }[] = [
   { value: "trigger", label: "Trigger — starts the workflow" },
   { value: "agent", label: "Agent — a teammate performs a step" },
   { value: "condition", label: "Condition — branches on something" },
@@ -1350,32 +1356,32 @@ export const CREATABLE_NODE_KINDS: { value: string; label: string }[] = [
   { value: "tool_call", label: "Tool call — runs a tool by slug" },
   { value: "http_request", label: "HTTP request — calls a URL" },
   { value: "switch", label: "Switch — routes to a labeled branch" },
+  { value: "split_out", label: "Split out — sends each item down the next step" },
   { value: "output_parser", label: "Output parser — coerces to a schema" },
   { value: "sub_workflow", label: "Sub-workflow — runs another workflow" },
 ];
 
 /**
+ * A readable node-kind label, including for a kind introduced by a newer host.
+ * The fallback deliberately humanises separators instead of exposing a raw
+ * snake_case machine token as the primary label.
+ */
+export function nodeKindLabel(kind: string): string {
+  const known = NODE_KINDS.find((candidate) => candidate.value === kind)?.label;
+  if (known) return known.split(" — ", 1)[0];
+
+  const words = kind.trim().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
+  if (!words) return "Unknown node kind";
+  return words.replace(/^\p{L}/u, (letter) => letter.toLocaleUpperCase());
+}
+
+/**
  * Every node kind the host accepts in a saved graph — the OpenCompany authoring
  * contract, mirroring `WORKFLOW_NODE_KINDS` in `src/company/workflow_file.rs`.
  *
- * Broader than {@link CREATABLE_NODE_KINDS} on purpose: the palette omits
- * `split_out` (it has no create control yet), but a graph may legitimately
- * contain one, so a copilot proposal that adds one must not be refused. This is
- * the set the proposal validator checks a proposed `kind` against — a kind the
- * host would reject on write is caught here, before the operator is shown a diff
- * for a step that cannot be applied.
+ * Derived from {@link NODE_KINDS}, so the authoring palette, inspector labels,
+ * and proposal validation cannot disagree about which kinds are allowed.
  */
-export const WORKFLOW_NODE_KINDS: readonly string[] = [
-  "trigger",
-  "agent",
-  "tool_call",
-  "http_request",
-  "condition",
-  "output",
-  "switch",
-  "merge",
-  "split_out",
-  "transform",
-  "output_parser",
-  "sub_workflow",
-];
+export const WORKFLOW_NODE_KINDS: readonly string[] = NODE_KINDS.map(
+  (kind) => kind.value,
+);

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -11,6 +11,17 @@ export interface WorkflowSummary {
   name: string;
   description?: string;
   /**
+   * The trigger node's 5-field UTC cron. `null` means the current host inspected
+   * the graph and found no schedule; `undefined` means an older host did not
+   * send this summary field, so the console must make no claim either way.
+   */
+  schedule?: string | null;
+  /**
+   * How many steps are in the graph. Absent on hosts predating the widened
+   * summary response; `0` is a real count and must still render.
+   */
+  nodeCount?: number;
+  /**
    * Whether this workflow can be edited or deleted through the API (issue
    * #259). `false` for a graph defined by a file in the company source tree,
    * and for a name-only entry with no saved graph at all — the host refuses

--- a/frontend/src/lib/workflow-node-config.ts
+++ b/frontend/src/lib/workflow-node-config.ts
@@ -5,9 +5,9 @@
 //
 // The engine (`vendor/openhuman/vendor/tinyflows`) parses and runs all five
 // kinds already; only the console lacked controls to author their config, so
-// `tool_call`/`http_request`/`switch`/`output_parser`/`sub_workflow` were kept
-// off the palette (`CREATABLE_NODE_KINDS`) rather than shipping a node that
-// errors at run time. These forms emit EXACTLY the keys the tinyflows executors
+// `tool_call`/`http_request`/`switch`/`output_parser`/`sub_workflow` needed
+// matching controls before they joined the shared `NODE_KINDS` palette. These
+// forms emit EXACTLY the keys the tinyflows executors
 // read — verified against `catalog.rs`, `nodes/integration/*`, and
 // OpenCompany's `translate.rs` (which lays a node's `config` over the derived
 // defaults verbatim):

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -303,11 +303,35 @@ function nodeLabel(node: DraftNode): string {
   return node.name.trim() || node.id.trim() || "this node";
 }
 
-interface DraftEdge {
+export interface DraftEdge {
   key: string;
   from: string;
   to: string;
   label: string;
+}
+
+/**
+ * Add only the missing adjacent edges for the node order shown in the form.
+ * Invalid/duplicate ids leave the explicit graph untouched so this convenience
+ * never manufactures a self-edge or guesses which duplicate row was intended.
+ */
+export function edgesConnectingNodesInOrder(
+  nodes: readonly Pick<DraftNode, "id">[],
+  edges: readonly DraftEdge[],
+): DraftEdge[] {
+  const ids = nodes.map((node) => node.id.trim());
+  if (ids.length < 2 || ids.some((nodeId) => !nodeId) || new Set(ids).size !== ids.length) {
+    return [...edges];
+  }
+  const next = [...edges];
+  for (let index = 0; index < ids.length - 1; index += 1) {
+    const from = ids[index];
+    const to = ids[index + 1];
+    if (!next.some((edge) => edge.from === from && edge.to === to)) {
+      next.push({ key: nextKey(), from, to, label: "" });
+    }
+  }
+  return next;
 }
 
 /** The node fields that validate on blur (issue #261) — the ones with a real
@@ -1083,6 +1107,16 @@ export function WorkflowCreateDialog({
     clearSubmitError();
   }
 
+  /**
+   * Connect each visible node to the next one, preserving explicit branches and
+   * labels already authored. Existing pairs count as connected regardless of
+   * label, so pressing the affordance twice never adds duplicate edges.
+   */
+  function connectNodesInOrder() {
+    setEdges((rows) => edgesConnectingNodesInOrder(nodes, rows));
+    clearSubmitError();
+  }
+
   function updateEdge(key: string, fields: Partial<DraftEdge>) {
     setEdges((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
     clearSubmitError();
@@ -1727,7 +1761,16 @@ export function WorkflowCreateDialog({
         <fieldset disabled={submitting} className="contents">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="grid gap-2">
-              <Label htmlFor={`${formId}-id`}>Id</Label>
+              <Label htmlFor={`${formId}-name`}>Name</Label>
+              <Input
+                id={`${formId}-name`}
+                value={name}
+                onChange={(e) => changeName(e.target.value)}
+                placeholder="e.g. Campaign pipeline"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor={`${formId}-id`}>Workflow ID</Label>
               {/* Read-only in edit mode, not merely rejected on save: the id keys
                   the saved graph, the scheduler and every past run, so the host
                   answers 400 to a rename. Letting an author type a new one and
@@ -1741,21 +1784,11 @@ export function WorkflowCreateDialog({
                 className={editing ? "text-muted-foreground" : undefined}
                 placeholder="e.g. campaign_pipeline"
               />
-              {editing && (
-                <p className="text-2xs leading-snug text-muted-foreground">
-                  A workflow&apos;s id can&apos;t change. It keys the saved graph, its
-                  schedule and its run history.
-                </p>
-              )}
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor={`${formId}-name`}>Name</Label>
-              <Input
-                id={`${formId}-name`}
-                value={name}
-                onChange={(e) => changeName(e.target.value)}
-                placeholder="e.g. Campaign pipeline"
-              />
+              <p className="text-2xs leading-snug text-muted-foreground">
+                {editing
+                  ? "This permanent machine ID can’t change. It keys the saved graph, its schedule and its run history."
+                  : "Generated from the name. You can change it now; after creation it becomes the permanent machine ID for schedules and run history."}
+              </p>
             </div>
           </div>
           <div className="grid gap-2">
@@ -1821,17 +1854,38 @@ export function WorkflowCreateDialog({
           </div>
 
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <Label>Edges</Label>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={addEdge}
-                disabled={nodes.length < 2 || submitting}
-              >
-                <Plus className="size-3.5" /> Add edge
-              </Button>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <Label>Connections</Label>
+                <p className="text-2xs text-muted-foreground">
+                  Connect a simple sequence automatically, or edit branches explicitly.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={connectNodesInOrder}
+                  disabled={
+                    submitting ||
+                    nodes.length < 2 ||
+                    nodes.some((node) => !node.id.trim()) ||
+                    new Set(nodes.map((node) => node.id.trim())).size !== nodes.length
+                  }
+                >
+                  Connect in order
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addEdge}
+                  disabled={nodes.length < 2 || submitting}
+                >
+                  <Plus className="size-3.5" /> Add edge
+                </Button>
+              </div>
             </div>
             <div className="space-y-2">
               {edges.map((e) => (
@@ -1845,7 +1899,7 @@ export function WorkflowCreateDialog({
               ))}
               {edges.length === 0 && (
                 <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
-                  No edges yet — nodes won&apos;t be connected.
+                  No connections yet — connect the steps in order or add an explicit edge.
                 </p>
               )}
             </div>
@@ -2028,7 +2082,11 @@ function NodeRow({
   return (
     <div className="grid gap-2 rounded-lg border p-2 sm:grid-cols-[1fr_1fr_1.4fr_auto] sm:items-start">
       <div className="grid gap-1">
+        <Label htmlFor={`${rowId}-id`} className="text-2xs text-muted-foreground">
+          Node ID
+        </Label>
         <Input
+          id={`${rowId}-id`}
           value={node.id}
           onChange={(e) => onChange({ id: e.target.value })}
           placeholder="node id"
@@ -2038,6 +2096,7 @@ function NodeRow({
             never holds a value whose control is no longer on screen. Without
             this, picking a destination and then changing the kind left the row
             un-submittable with nothing visible to clear. */}
+        <Label className="mt-1 text-2xs text-muted-foreground">Kind</Label>
         <Select value={node.kind} onValueChange={(v) => onChange(changeKind(v ?? ""))}>
           <SelectTrigger className="h-8" aria-label="Node kind">
             <SelectValue />
@@ -2052,7 +2111,11 @@ function NodeRow({
         </Select>
       </div>
       <div className="grid gap-1">
+        <Label htmlFor={`${rowId}-name`} className="text-2xs text-muted-foreground">
+          Step name
+        </Label>
         <Input
+          id={`${rowId}-name`}
           value={node.name}
           onChange={(e) => onChange({ name: e.target.value })}
           placeholder="display name"
@@ -2060,29 +2123,42 @@ function NodeRow({
         />
         {node.kind === "agent" &&
           (roster.length > 0 ? (
-            <Select value={node.agent} onValueChange={(v) => onChange({ agent: v ?? "" })}>
-              <SelectTrigger className="h-8" aria-label="Teammate">
-                <SelectValue placeholder="Pick a teammate" />
-              </SelectTrigger>
-              <SelectContent>
-                {roster.map((m) => (
-                  <SelectItem key={m.id} value={m.id}>
-                    {m.name ?? m.role}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <>
+              <Label className="mt-1 text-2xs text-muted-foreground">Teammate</Label>
+              <Select value={node.agent} onValueChange={(v) => onChange({ agent: v ?? "" })}>
+                <SelectTrigger className="h-8" aria-label="Teammate">
+                  <SelectValue placeholder="Pick a teammate" />
+                </SelectTrigger>
+                <SelectContent>
+                  {roster.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.name ?? m.role}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </>
           ) : (
-            <Input
-              value={node.agent}
-              onChange={(e) => onChange({ agent: e.target.value })}
-              placeholder="teammate id"
-              aria-label="Teammate id"
-            />
+            <>
+              <Label htmlFor={`${rowId}-teammate`} className="mt-1 text-2xs text-muted-foreground">
+                Teammate ID
+              </Label>
+              <Input
+                id={`${rowId}-teammate`}
+                value={node.agent}
+                onChange={(e) => onChange({ agent: e.target.value })}
+                placeholder="teammate id"
+                aria-label="Teammate id"
+              />
+            </>
           ))}
       </div>
       <div className="grid gap-1">
+        <Label htmlFor={`${rowId}-summary`} className="text-2xs text-muted-foreground">
+          Summary
+        </Label>
         <Input
+          id={`${rowId}-summary`}
           value={node.summary}
           onChange={(e) => onChange({ summary: e.target.value })}
           placeholder="summary (optional)"

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -1,7 +1,7 @@
 // The workflow creator (issue #69): a plain form editor — not a drag canvas —
 // that builds a `WorkflowGraph` and posts it via `createWorkflow`. Node kinds
 // are the ones the engine executes and the console can author from a form
-// (`CREATABLE_NODE_KINDS`). The five that need kind-specific config —
+// (`NODE_KINDS`). The five that need kind-specific config —
 // `tool_call`, `http_request`, `switch`, `output_parser`, `sub_workflow` —
 // grew their controls in issue #541; each renders `NodeConfigFields`, whose
 // spec table (`@/lib/workflow-node-config`) is the single source of the engine
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { History, Loader2, Plus, RotateCcw, Sparkles, Trash2 } from "lucide-react";
 
 import {
-  CREATABLE_NODE_KINDS,
+  NODE_KINDS,
   DESTINATION_KINDS,
   destinationLabel,
   createWorkflow,
@@ -2043,7 +2043,7 @@ function NodeRow({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {CREATABLE_NODE_KINDS.map((k) => (
+            {NODE_KINDS.map((k) => (
               <SelectItem key={k.value} value={k.value}>
                 {k.label}
               </SelectItem>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -51,7 +51,7 @@ import {
 import type { CompanyStreamEvent } from "@/hooks/use-events";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
-import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import type { ApprovalSummary, GrantScope, TeamMemberDto, Verdict } from "@/api/types";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -411,6 +411,8 @@ export function WorkflowsView({
   // A run the copilot judged un-fixable, shown inline under that run's row.
   const [fixReason, setFixReason] = useState<{ seq: number; reason: string } | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  /** Roster used only while an assigned agent node is being inspected. */
+  const [nodeRoster, setNodeRoster] = useState<TeamMemberDto[]>([]);
   // Issue #228: what past runs did, read back from the host's journal. This is
   // the half that survives a reload — before it, a manual run's delivery rows
   // vanished when the drawer was dismissed and a scheduled run's never reached
@@ -2064,6 +2066,27 @@ export function WorkflowsView({
     [graph, selectedNodeId],
   );
 
+  // Resolve an agent id to the teammate's display name in the inspector. Keep
+  // this lazy: workflows with no selected agent node do not need a roster read.
+  useEffect(() => {
+    if (!selectedNode?.agent) {
+      setNodeRoster([]);
+      return;
+    }
+    let live = true;
+    void client
+      .listTeam(company)
+      .then((team) => {
+        if (live) setNodeRoster(team);
+      })
+      .catch(() => {
+        if (live) setNodeRoster([]);
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company, selectedNode?.agent]);
+
   // Issue #596: lazily fetch a past run's per-node output ONCE when it is
   // overlaid, so clicking any of its nodes can show what that node produced. A
   // 404 (predates capture / dry / hard-aborted / older host) settles to `record:
@@ -2970,6 +2993,7 @@ export function WorkflowsView({
                 selectedNode && (
                   <NodeDetailPanel
                     node={selectedNode}
+                    roster={nodeRoster}
                     output={selectedNodeOutput}
                     onClose={() => setSelectedNodeId(null)}
                   />

--- a/frontend/src/views/workflows/NodeDetailPanel.tsx
+++ b/frontend/src/views/workflows/NodeDetailPanel.tsx
@@ -6,7 +6,8 @@ import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { WorkflowNode as WorkflowNodeModel } from "@/api/workflows";
+import { nodeKindLabel, type WorkflowNode as WorkflowNodeModel } from "@/api/workflows";
+import type { TeamMemberDto } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { nodeKindMeta } from "@/lib/workflow-sample";
@@ -20,10 +21,13 @@ import { type NodeOutputView, parseNodeMessages } from "./run-output";
  * kind-specific config / error-handling policy. */
 export function NodeDetailPanel({
   node,
+  roster = [],
   output,
   onClose,
 }: {
   node: WorkflowNodeModel;
+  /** Roster names for resolving an agent node's machine id. */
+  roster?: TeamMemberDto[];
   /**
    * This node's output on the run being inspected (issue #596). `undefined`
    * means "not inspecting a run" — the panel then shows only the node's static
@@ -34,6 +38,9 @@ export function NodeDetailPanel({
   onClose: () => void;
 }) {
   const meta = nodeKindMeta(node.kind);
+  const kindLabel = nodeKindLabel(node.kind);
+  const teammate = node.agent ? roster.find((member) => member.id === node.agent) : undefined;
+  const teammateName = teammate ? teammate.name?.trim() || teammate.role : undefined;
   const hasConfig =
     node.config !== undefined && node.config !== null &&
     !(typeof node.config === "object" && Object.keys(node.config as object).length === 0);
@@ -53,7 +60,7 @@ export function NodeDetailPanel({
           </span>
           <div className="min-w-0">
             <div className="truncate text-sm font-semibold">{node.name}</div>
-            <div className="truncate text-2xs text-muted-foreground">{node.id}</div>
+            <div className="truncate text-2xs text-muted-foreground">{kindLabel}</div>
           </div>
         </div>
         <Button variant="ghost" size="sm" className="-mr-1 h-7 px-2" onClick={onClose}>
@@ -64,7 +71,7 @@ export function NodeDetailPanel({
       <div className="min-h-0 flex-1 space-y-3 overflow-auto px-3 py-3 text-sm">
         <div className="flex flex-wrap items-center gap-1.5">
           <Badge variant="outline" className="font-normal">
-            {node.kind}
+            {kindLabel}
           </Badge>
           {node.requiresApproval && (
             <Badge variant="outline" className="border-status-blocked/40 bg-status-blocked-soft font-normal">
@@ -91,6 +98,10 @@ export function NodeDetailPanel({
           )}
         </div>
 
+        <DetailField label="Node ID">
+          <p className="font-mono text-xs text-muted-foreground">{node.id}</p>
+        </DetailField>
+
         {/* A saved schedule must be visible, not write-only — otherwise an
             operator cannot tell a self-running workflow from a manual one. */}
         {node.schedule && (
@@ -108,7 +119,10 @@ export function NodeDetailPanel({
 
         {node.agent && (
           <DetailField label="Assigned teammate">
-            <p className="font-mono text-xs">{node.agent}</p>
+            <p className="text-sm">{teammateName ?? node.agent}</p>
+            {teammateName && teammateName !== node.agent && (
+              <p className="font-mono text-3xs text-muted-foreground">Roster ID: {node.agent}</p>
+            )}
           </DetailField>
         )}
 

--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -11,13 +11,11 @@
 // answer short of selecting each in turn and reading its chip.
 //
 // WHAT A CARD IS ALLOWED TO SAY is the whole design constraint here. Two
-// requests back this surface — `GET …/workflows` (id, name, description,
-// editable, enabled) and `GET …/workflows/runs` (the company-wide run journal)
-// — and a card renders strictly what those two carry. In particular it does NOT
-// show *when* a workflow is scheduled, or a node count: both live only in the
-// full graph, which is a per-workflow `GET …/workflows/{wid}`, and fetching one
-// per card would be an N+1 on every render of this panel. Showing "no schedule"
-// without having looked would be a lie, so the card never names a cron.
+// requests back this surface — `GET …/workflows` (including schedule and node
+// count on current hosts) and `GET …/workflows/runs` (the company-wide run
+// journal) — and a card renders strictly what those two carry. The widened
+// summary avoids an N+1 full-graph request per card. An older host omits both
+// fields; omission renders nothing rather than inventing "manual" or zero steps.
 //
 // It does say whether a schedule is OFF (issue #1209), because `enabled` is on
 // the list wire and needs no second request. The two are different claims: "it
@@ -69,6 +67,97 @@ function PausedBadge({ enabled }: { enabled: boolean | undefined }) {
     >
       Paused
     </Badge>
+  );
+}
+
+const WEEKDAY_NAMES: Record<string, string> = {
+  "0": "Sunday",
+  "7": "Sunday",
+  SUN: "Sunday",
+  "1": "Monday",
+  MON: "Monday",
+  "2": "Tuesday",
+  TUE: "Tuesday",
+  "3": "Wednesday",
+  WED: "Wednesday",
+  "4": "Thursday",
+  THU: "Thursday",
+  "5": "Friday",
+  FRI: "Friday",
+  "6": "Saturday",
+  SAT: "Saturday",
+};
+
+/**
+ * The index's prose reading of a summary schedule.
+ *
+ * `null` is current-host knowledge that the workflow is manual. `undefined` is
+ * no knowledge at all from an older host, and therefore renders nothing.
+ */
+export function workflowTriggerLine(schedule: string | null | undefined): string | null {
+  if (schedule === undefined) return null;
+  if (schedule === null || !schedule.trim()) return "Runs on request";
+
+  const cron = schedule.trim().replace(/\s+/g, " ");
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = cron.split(" ");
+  const number = (value: string | undefined, ceiling: number) => {
+    if (!value || !/^\d+$/.test(value)) return null;
+    const parsed = Number(value);
+    return parsed >= 0 && parsed <= ceiling ? parsed : null;
+  };
+  const minuteNumber = number(minute, 59);
+  const hourNumber = number(hour, 23);
+  const clock =
+    minuteNumber !== null && hourNumber !== null
+      ? `${String(hourNumber).padStart(2, "0")}:${String(minuteNumber).padStart(2, "0")}`
+      : null;
+
+  if (minute === "*" && hour === "*" && dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+    return "Runs every minute";
+  }
+  if (
+    minuteNumber !== null &&
+    hour === "*" &&
+    dayOfMonth === "*" &&
+    month === "*" &&
+    dayOfWeek === "*"
+  ) {
+    return minuteNumber === 0
+      ? "Runs hourly on the hour"
+      : `Runs hourly at ${String(minuteNumber).padStart(2, "0")} minutes past`;
+  }
+  if (clock && dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+    return `Runs daily at ${clock} UTC`;
+  }
+  const weekday = dayOfWeek ? WEEKDAY_NAMES[dayOfWeek.toUpperCase()] : undefined;
+  if (clock && dayOfMonth === "*" && month === "*" && weekday) {
+    return `Runs every ${weekday} at ${clock} UTC`;
+  }
+  const monthDay = number(dayOfMonth, 31);
+  if (clock && monthDay !== null && monthDay > 0 && month === "*" && dayOfWeek === "*") {
+    return `Runs monthly on day ${monthDay} at ${clock} UTC`;
+  }
+  return "Runs automatically on a custom schedule";
+}
+
+/** Facts shared verbatim by card and list layouts. */
+function WorkflowFacts({ workflow }: { workflow: WorkflowSummary }) {
+  const trigger = workflowTriggerLine(workflow.schedule);
+  const steps =
+    workflow.nodeCount === undefined
+      ? null
+      : `${workflow.nodeCount} ${workflow.nodeCount === 1 ? "step" : "steps"}`;
+  if (!trigger && !steps) return null;
+  return (
+    <p
+      className="truncate text-2xs text-muted-foreground"
+      data-testid="workflow-index-facts"
+      title={[trigger, steps].filter(Boolean).join(" · ")}
+    >
+      {trigger}
+      {trigger && steps && " · "}
+      {steps}
+    </p>
   );
 }
 
@@ -212,6 +301,8 @@ function WorkflowCard({
         <p className="text-xs italic text-muted-foreground/70">No description.</p>
       )}
 
+      <WorkflowFacts workflow={workflow} />
+
       <div className="mt-auto space-y-1.5 pt-1">
         <HealthLine runs={runs} runsLoaded={runsLoaded} />
         <RunStrip runs={runs} />
@@ -260,25 +351,28 @@ function WorkflowRow({
       data-testid="workflow-list-row"
       className="grid w-full grid-cols-[minmax(0,1fr)_13rem_4.5rem] items-center gap-x-3 px-3 py-2 text-left transition hover:bg-accent/40 @3xl:grid-cols-[17.5rem_minmax(0,1fr)_13rem_4.5rem]"
     >
-      <span className="flex min-w-0 items-center gap-2">
-        {/* `title` because the column is fixed: a truncated name is unreadable
-            without one, and this is the only place the row says which workflow
-            it is. */}
-        <span className="truncate text-sm font-medium" title={workflow.name}>
-          {workflow.name}
+      <span className="min-w-0">
+        <span className="flex min-w-0 items-center gap-2">
+          {/* `title` because the column is fixed: a truncated name is unreadable
+              without one, and this is the only place the row says which workflow
+              it is. */}
+          <span className="truncate text-sm font-medium" title={workflow.name}>
+            {workflow.name}
+          </span>
+          {/* Issue #1136: inside the name cell, not floating between columns —
+              the badges qualify the name, so they travel with it. */}
+          <PausedBadge enabled={workflow.enabled} />
+          {workflow.editable === false && (
+            <Badge
+              variant="outline"
+              className="h-4 shrink-0 px-1.5 text-3xs font-normal"
+              title="Defined by a file in the company source tree, so it can't be changed or removed from the console."
+            >
+              in source
+            </Badge>
+          )}
         </span>
-        {/* Issue #1136: inside the name cell, not floating between columns —
-            the badges qualify the name, so they travel with it. */}
-        <PausedBadge enabled={workflow.enabled} />
-        {workflow.editable === false && (
-          <Badge
-            variant="outline"
-            className="h-4 shrink-0 px-1.5 text-3xs font-normal"
-            title="Defined by a file in the company source tree, so it can't be changed or removed from the console."
-          >
-            in source
-          </Badge>
-        )}
+        <WorkflowFacts workflow={workflow} />
       </span>
       <span
         className="hidden min-w-0 truncate text-xs text-muted-foreground @3xl:block"

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -237,8 +237,8 @@ test("a valid workflow still saves", async ({ page }) => {
   await openCreateDialog(page);
   const dialog = page.getByRole("dialog");
 
-  // `exact` matters: "Id" is also a substring of the row-level "Node id".
-  await dialog.getByLabel("Id", { exact: true }).fill(`e2e_feedback_${stamp}`);
+  // `exact` matters: the dialog also carries a row-level "Node ID" field.
+  await dialog.getByLabel("Workflow ID", { exact: true }).fill(`e2e_feedback_${stamp}`);
   await dialog.getByLabel("Name", { exact: true }).fill(`Feedback probe ${stamp}`);
 
   // Trigger row: a preset schedule, which previews too.
@@ -345,7 +345,7 @@ test("submitting with an empty id surfaces the validation message on-screen (#81
   // #813 defect 6: the banner sat below the fold, so Create looked dead. On a
   // failed submit it must be brought into view (and focused).
   const dialog = await openCreateDialog(page);
-  await dialog.getByLabel("Id", { exact: true }).fill("");
+  await dialog.getByLabel("Workflow ID", { exact: true }).fill("");
   await dialog.getByRole("button", { name: "Create workflow" }).click();
 
   const banner = dialog.getByText("Give the workflow an id.");

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -397,14 +397,14 @@ test("an author can change a saved workflow's schedule, and the id is read-only"
     const dialog = await openEditDialog(page, name);
 
     // Hydrated from the saved graph, not blank — the whole point of edit mode.
-    await expect(dialog.getByLabel("Id", { exact: true })).toHaveValue(id);
+    await expect(dialog.getByLabel("Workflow ID", { exact: true })).toHaveValue(id);
     await expect(dialog.getByLabel("Name", { exact: true })).toHaveValue(name);
     await expect(dialog.getByRole("textbox", { name: "Node id" }).first()).toHaveValue("start");
 
     // The id may not change through a PUT — the host answers 400 — so the field
     // states that by being unwritable rather than by refusing after the click.
     await expect(
-      dialog.getByLabel("Id", { exact: true }),
+      dialog.getByLabel("Workflow ID", { exact: true }),
       "an id field that accepts a rename can only ever 400",
     ).toHaveJSProperty("readOnly", true);
 

--- a/frontend/test/e2e/workflow-node-config.spec.ts
+++ b/frontend/test/e2e/workflow-node-config.spec.ts
@@ -69,7 +69,7 @@ test("authoring a tool_call node's config through the form round-trips to the ho
     await expect(dialog.getByText("New workflow", { exact: true })).toBeVisible();
 
     // Name the workflow.
-    await dialog.getByLabel("Id", { exact: true }).fill(id);
+    await dialog.getByLabel("Workflow ID", { exact: true }).fill(id);
     await dialog.getByLabel("Name", { exact: true }).fill(name);
 
     // The starter trigger row is already `start`. Add a second node and make it

--- a/frontend/test/unit/node-detail-panel-repeatable.test.ts
+++ b/frontend/test/unit/node-detail-panel-repeatable.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { WorkflowNode } from "@/api/workflows";
+import type { TeamMemberDto } from "@/api/types";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 
 /**
@@ -18,9 +19,9 @@ import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 let container: HTMLDivElement;
 let root: Root;
 
-function render(node: WorkflowNode) {
+function render(node: WorkflowNode, roster: TeamMemberDto[] = []) {
   act(() => {
-    root.render(createElement(NodeDetailPanel, { node, onClose: () => {} }));
+    root.render(createElement(NodeDetailPanel, { node, roster, onClose: () => {} }));
   });
 }
 
@@ -62,5 +63,32 @@ describe("NodeDetailPanel — repeatable and the empty-details state", () => {
   it("does not show the empty-details message when another field also carries a detail", () => {
     render(baseNode({ repeatable: false, onError: "continue" }));
     expect(container.textContent).not.toContain("This node has no extra details");
+  });
+});
+
+describe("NodeDetailPanel — operator-facing identity", () => {
+  it("uses the shared readable kind label and humanises a newer unknown kind", () => {
+    render(baseNode({ kind: "output_parser" }));
+    expect(container.textContent).toContain("Output parser");
+    expect(container.textContent).not.toContain("coerces to a schema");
+    expect(container.textContent).not.toContain("output_parser");
+
+    render(baseNode({ kind: "future_magic" }));
+    expect(container.textContent).toContain("Future magic");
+    expect(container.textContent).not.toContain("future_magic");
+  });
+
+  it("shows an assigned teammate's display name and demotes roster ids", () => {
+    render(baseNode({ kind: "agent", agent: "research-lead" }), [
+      { id: "research-lead", name: "Maya Chen", role: "Research lead" },
+    ]);
+
+    expect(container.textContent).toContain("Maya Chen");
+    expect(container.textContent).toContain("Roster ID: research-lead");
+    expect(container.textContent).toContain("Node ID");
+    expect(
+      container.querySelector('[data-testid="workflow-node-detail"] > div:first-child')
+        ?.textContent,
+    ).not.toContain("research-lead");
   });
 });

--- a/frontend/test/unit/workflow-authoring-vocabulary.test.ts
+++ b/frontend/test/unit/workflow-authoring-vocabulary.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NODE_KINDS,
+  nodeKindLabel,
+  WORKFLOW_NODE_KINDS,
+} from "@/api/workflows";
+import {
+  edgesConnectingNodesInOrder,
+  type DraftEdge,
+} from "@/views/WorkflowCreateDialog";
+
+describe("the shared workflow node-kind vocabulary", () => {
+  it("backs every accepted host kind, including split_out", () => {
+    expect(NODE_KINDS.map((kind) => kind.value)).toEqual(WORKFLOW_NODE_KINDS);
+    expect(WORKFLOW_NODE_KINDS).toContain("split_out");
+  });
+
+  it("labels known kinds and keeps newer unknown kinds readable", () => {
+    expect(nodeKindLabel("tool_call")).toBe("Tool call");
+    expect(nodeKindLabel("output_parser")).toBe("Output parser");
+    expect(nodeKindLabel("future_kind")).toBe("Future kind");
+    expect(nodeKindLabel("")).toBe("Unknown node kind");
+  });
+});
+
+describe("connect in order", () => {
+  const edge = (key: string, from: string, to: string, label = ""): DraftEdge => ({
+    key,
+    from,
+    to,
+    label,
+  });
+
+  it("adds a deterministic linear chain while preserving explicit branches", () => {
+    const nodes = [{ id: "start" }, { id: "draft" }, { id: "publish" }];
+    const branch = edge("branch", "start", "publish", "fast path");
+
+    const connected = edgesConnectingNodesInOrder(nodes, [branch]);
+
+    expect(connected.map(({ from, to, label }) => ({ from, to, label }))).toEqual([
+      { from: "start", to: "publish", label: "fast path" },
+      { from: "start", to: "draft", label: "" },
+      { from: "draft", to: "publish", label: "" },
+    ]);
+  });
+
+  it("does not duplicate an existing pair or add more on a second press", () => {
+    const nodes = [{ id: "start" }, { id: "draft" }, { id: "publish" }];
+    const existing = [edge("one", "start", "draft", "already connected")];
+    const once = edgesConnectingNodesInOrder(nodes, existing);
+    const twice = edgesConnectingNodesInOrder(nodes, once);
+
+    expect(twice).toEqual(once);
+    expect(twice).toHaveLength(2);
+  });
+
+  it("leaves the graph alone when ids are blank or duplicated", () => {
+    const existing = [edge("branch", "start", "publish")];
+    expect(edgesConnectingNodesInOrder([{ id: "start" }, { id: "" }], existing)).toEqual(
+      existing,
+    );
+    expect(
+      edgesConnectingNodesInOrder([{ id: "same" }, { id: "same" }], existing),
+    ).toEqual(existing);
+  });
+});

--- a/frontend/test/unit/workflow-id-derivation.test.ts
+++ b/frontend/test/unit/workflow-id-derivation.test.ts
@@ -132,6 +132,25 @@ afterAll(() => {
 });
 
 describe("the create form derives the id from the name (#1053)", () => {
+  it("starts with the human name, then explains the editable permanent machine id", async () => {
+    await open();
+
+    const name = field("name");
+    const id = field("id");
+    expect(name.compareDocumentPosition(id) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(document.body.textContent).toContain("Generated from the name");
+    expect(document.body.textContent).toContain("permanent machine ID");
+
+    for (const label of ["Node ID", "Kind", "Step name", "Summary"]) {
+      expect(document.body.textContent).toContain(label);
+    }
+    expect(
+      Array.from(document.body.querySelectorAll("button")).some(
+        (button) => button.textContent?.trim() === "Connect in order",
+      ),
+    ).toBe(true);
+  });
+
   it("fills the id in as the name is typed, so a bare name is not rejected", async () => {
     await open();
 

--- a/frontend/test/unit/workflow-index-summary.test.ts
+++ b/frontend/test/unit/workflow-index-summary.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { WorkflowSummary } from "@/api/workflows";
+import {
+  WorkflowIndex,
+  workflowTriggerLine,
+} from "@/views/workflows/WorkflowIndex";
+
+const WORKFLOWS: WorkflowSummary[] = [
+  {
+    id: "scheduled",
+    name: "Scheduled digest",
+    schedule: "0 9 * * MON",
+    nodeCount: 3,
+    enabled: false,
+  },
+  { id: "manual", name: "Manual review", schedule: null, nodeCount: 1 },
+  { id: "older", name: "Older host row" },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(mode: "cards" | "list") {
+  act(() => {
+    root.render(
+      createElement(WorkflowIndex, {
+        workflows: WORKFLOWS,
+        runsByWorkflow: new Map(),
+        onSelect: () => {},
+        mode,
+        loading: false,
+        runsLoaded: true,
+      }),
+    );
+  });
+}
+
+function item(selector: string, name: string): HTMLElement {
+  const result = Array.from(container.querySelectorAll<HTMLElement>(selector)).find((row) =>
+    row.textContent?.includes(name),
+  );
+  expect(result, `no ${selector} for ${name}`).toBeTruthy();
+  return result as HTMLElement;
+}
+
+describe("workflow index summary facts", () => {
+  for (const [mode, selector] of [
+    ["cards", '[data-testid="workflow-card"]'],
+    ["list", '[data-testid="workflow-list-row"]'],
+  ] as const) {
+    it(`shows the same trigger prose and step count in ${mode} mode`, () => {
+      render(mode);
+
+      expect(item(selector, "Scheduled digest").textContent).toContain(
+        "Runs every Monday at 09:00 UTC · 3 steps",
+      );
+      expect(item(selector, "Scheduled digest").textContent).toContain("Paused");
+      expect(item(selector, "Manual review").textContent).toContain("Runs on request · 1 step");
+
+      const older = item(selector, "Older host row");
+      expect(older.querySelector('[data-testid="workflow-index-facts"]')).toBeNull();
+      expect(older.textContent).not.toContain("Runs on request");
+      expect(older.textContent).not.toContain("0 steps");
+    });
+  }
+});
+
+describe("workflowTriggerLine", () => {
+  it("distinguishes unknown, manual, and common scheduled cadences", () => {
+    expect(workflowTriggerLine(undefined)).toBeNull();
+    expect(workflowTriggerLine(null)).toBe("Runs on request");
+    expect(workflowTriggerLine("0 * * * *")).toBe("Runs hourly on the hour");
+    expect(workflowTriggerLine("15 2 1 * *")).toBe("Runs monthly on day 1 at 02:15 UTC");
+    expect(workflowTriggerLine("*/10 8-17 * * MON-FRI")).toBe(
+      "Runs automatically on a custom schedule",
+    );
+    expect(workflowTriggerLine("*/10 8-17 * * MON-FRI")).not.toContain("*/10");
+  });
+});

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -798,7 +798,10 @@ pub fn parse_workflow(toml_src: &str) -> Result<WorkflowFile> {
 /// Loads the enabled workflow graphs from a company directory.
 ///
 /// `dir` is the company root; each enabled id resolves to
-/// `dir/workflows/<id>.toml`. A missing or malformed file is an error.
+/// `dir/workflows/<id>.toml`. A missing or malformed file is an error. A file
+/// whose parsed `id` does not match its filename stem is skipped with a warning:
+/// serving it under the embedded id would list a workflow that the id-based read
+/// path can never open.
 pub fn load_company_workflows(dir: &Path, enabled: &[String]) -> Result<Vec<WorkflowFile>> {
     let mut out = Vec::with_capacity(enabled.len());
     for id in enabled {
@@ -818,6 +821,19 @@ pub fn load_company_workflows(dir: &Path, enabled: &[String]) -> Result<Vec<Work
             }
             Err(other) => return Err(other),
         };
+        let stem = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default();
+        if workflow.id != stem {
+            tracing::warn!(
+                path = %path.display(),
+                stem,
+                workflow_id = %workflow.id,
+                "skipping workflow whose filename stem does not match its id"
+            );
+            continue;
+        }
         out.push(workflow);
     }
     Ok(out)
@@ -1889,6 +1905,61 @@ fn contains_non_finite_float(value: &toml::Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const LOADABLE_WORKFLOW: &str = r#"
+        id = "valid"
+        name = "Valid"
+        [[node]]
+        id = "start"
+        kind = "trigger"
+        name = "Start"
+        [[node]]
+        id = "done"
+        kind = "output"
+        name = "Done"
+        [[edge]]
+        from = "start"
+        to = "done"
+    "#;
+
+    /// The filename is the id-based lookup key. A different id inside the body
+    /// must never leak into a list as a row that `GET /workflows/{id}` cannot
+    /// open, while a valid sibling continues to load.
+    #[test]
+    fn load_company_workflows_skips_filename_id_mismatches() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("valid.toml"), LOADABLE_WORKFLOW).unwrap();
+        std::fs::write(
+            workflows.join("wrong-stem.toml"),
+            LOADABLE_WORKFLOW.replace("id = \"valid\"", "id = \"different\""),
+        )
+        .unwrap();
+
+        let loaded =
+            load_company_workflows(dir.path(), &["wrong-stem".to_string(), "valid".to_string()])
+                .expect("a mismatched body is skipped rather than failing the load");
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "valid");
+    }
+
+    /// The directory scan shares the loader's stem/id choke point, so a bad
+    /// file is absent from the picker rather than listed under its embedded id.
+    #[test]
+    fn list_source_workflows_never_lists_a_mismatched_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(
+            workflows.join("wrong-stem.toml"),
+            LOADABLE_WORKFLOW.replace("id = \"valid\"", "id = \"different\""),
+        )
+        .unwrap();
+
+        assert!(list_source_workflows(Some(dir.path())).is_empty());
+    }
 
     #[test]
     fn render_workflow_round_trips_through_parse_workflow() {

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -218,6 +218,12 @@ struct WorkflowSummary {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    /// The trigger node's 5-field UTC cron, or explicit `null` for a manual
+    /// workflow. Kept present when `None` so a current host can distinguish
+    /// "manual" from an older host that predates this field.
+    schedule: Option<String>,
+    /// Number of nodes in the graph. A body-less manifest entry reports zero.
+    node_count: usize,
     /// Whether `PUT`/`DELETE` on this id will be accepted (issue #259) — see
     /// [`is_editable`]. The console disables its Edit/Delete affordances on a
     /// `false`, so an operator is told *before* clicking rather than by a 409
@@ -236,10 +242,14 @@ struct WorkflowSummary {
 
 impl WorkflowSummary {
     fn new(f: WorkflowFile, editable: bool, enabled: bool) -> Self {
+        let schedule = f.trigger_schedule().map(str::to_owned);
+        let node_count = f.nodes.len();
         Self {
             id: f.id,
             name: f.name,
             description: f.description,
+            schedule,
+            node_count,
             editable,
             enabled,
         }
@@ -508,6 +518,8 @@ async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSumma
             id: id.clone(),
             name: id,
             description: None,
+            schedule: None,
+            node_count: 0,
             // A manifest-`enabled` id with no body in either source: there is
             // nothing to replace or remove, and the write core says so with a
             // 409. Never editable.
@@ -3521,6 +3533,25 @@ mod tests {
             summaries[0].description.as_deref(),
             Some("A tiny trigger → agent → output graph.")
         );
+        assert_eq!(summaries[0].schedule, None);
+        assert_eq!(summaries[0].node_count, 3);
+
+        let json = serde_json::to_value(&summaries[0]).unwrap();
+        assert_eq!(json["schedule"], serde_json::Value::Null);
+        assert_eq!(json["nodeCount"], 3);
+    }
+
+    #[test]
+    fn scheduled_summary_carries_the_trigger_cron_and_node_count() {
+        let scheduled = DEMO.replace(
+            "name = \"Start\"\n        summary",
+            "name = \"Start\"\n        schedule = \"0 9 * * MON\"\n        summary",
+        );
+        let file = crate::company::parse_workflow(&scheduled).expect("scheduled fixture parses");
+        let json = serde_json::to_value(WorkflowSummary::new(file, false, true)).unwrap();
+
+        assert_eq!(json["schedule"], "0 9 * * MON");
+        assert_eq!(json["nodeCount"], 3);
     }
 
     #[test]
@@ -5535,6 +5566,8 @@ mod tests {
                 .find(|w| w["id"] == "greeter")
                 .expect("listed");
             assert_eq!(row["enabled"], serde_json::json!(false));
+            assert_eq!(row["schedule"], serde_json::Value::Null);
+            assert_eq!(row["nodeCount"], 2);
             assert_eq!(
                 row["editable"],
                 serde_json::json!(true),
@@ -5580,6 +5613,20 @@ mod tests {
 
             // And the graph read agrees, so it is the store's answer rather than
             // something the write path made up on the way out.
+            let listed = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            let body = json_body(listed).await;
+            let row = body
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|workflow| workflow["id"] == "digest")
+                .expect("scheduled workflow is listed");
+            assert_eq!(row["schedule"], "0 9 * * *");
+            assert_eq!(row["nodeCount"], 2);
+
             let read = router(state)
                 .oneshot(request("GET", "/api/v1/company/workflows/digest", None))
                 .await

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -542,7 +542,7 @@ async fn get_workflow(
     let (overlays, disabled, globals_disable) = workflow_state(&company).await?;
     let file = load_workflow_with_globals(source_dir, &overlays, &globals_disable, &wid)
         .map_err(ApiError)?
-        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
+        .ok_or_else(|| ApiError(OpenCompanyError::NotFound(format!("workflow {wid}"))))?;
     // Issue #259: the version token rides out with the graph, so the console
     // gets it for free on the same read it renders from — there is no second
     // round trip for a caller to skip and thereby lose the concurrency guard.
@@ -985,7 +985,7 @@ async fn set_workflow_enabled(
     let source_dir = company.runtime.source_dir();
     let file = load_workflow_with_globals(source_dir, &overlays, &globals_disable, &wid)
         .map_err(ApiError)?
-        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
+        .ok_or_else(|| ApiError(OpenCompanyError::NotFound(format!("workflow {wid}"))))?;
     let editable = is_editable(source_dir, &overlays, &wid);
     let version = editable
         .then(|| overlay_toml(&overlays, &wid).map(workflow_version))
@@ -1407,7 +1407,7 @@ async fn run_workflow(
     // `wid` becomes a filename — reject anything that could escape `workflows/`.
     if !safe_wid(&wid) {
         return Err(
-            ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))).into_response(),
+            ApiError(OpenCompanyError::NotFound(format!("workflow {wid}"))).into_response(),
         );
     }
 
@@ -1424,7 +1424,7 @@ async fn run_workflow(
     )
     .map_err(|e| ApiError(e).into_response())?
     .ok_or_else(|| {
-        ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))).into_response()
+        ApiError(OpenCompanyError::NotFound(format!("workflow {wid}"))).into_response()
     })?;
 
     let body = body.map(|Json(b)| b).unwrap_or_default();
@@ -2024,7 +2024,7 @@ async fn fix_from_run(
     // escape `workflows/`.
     if !safe_wid(&wid) {
         return Err(
-            ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))).into_response(),
+            ApiError(OpenCompanyError::NotFound(format!("workflow {wid}"))).into_response(),
         );
     }
 
@@ -2067,7 +2067,7 @@ async fn fix_from_run(
     )
     .map_err(|e| ApiError(e).into_response())?
     .ok_or_else(|| {
-        ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))).into_response()
+        ApiError(OpenCompanyError::NotFound(format!("workflow {wid}"))).into_response()
     })?;
     // `workflow_spec_from_graph` below has no `on_error`/`retry`/`repeatable`
     // field on `WorkflowNodeSpec` (the builder never authors them — see its
@@ -5605,6 +5605,25 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        /// A missing workflow is a missing nested resource, not a missing
+        /// company. Both variants are 404, so the envelope code pins the
+        /// distinction that operators and clients actually consume.
+        #[tokio::test]
+        async fn reading_an_unknown_workflow_reports_resource_not_found() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/ghost", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            let body = json_body(response).await;
+            assert_eq!(body["code"], "not_found", "{body}");
+            assert_eq!(body["error"], "not found: workflow ghost", "{body}");
         }
 
         /// A **global-only** workflow — no seed file, no overlay body, just the


### PR DESCRIPTION
## Summary

- make workflow creation name-first, label node fields, and connect linear nodes in order
- centralize node-kind vocabulary and show operator-friendly teammate and node metadata in the inspector
- add schedule and node count to workflow summaries and render prose trigger facts on cards and rows
- skip stem/id-mismatched workflow files with a warning and report missing workflows as resources

## API Or Behavior Changes

`WorkflowSummary` now optionally includes `schedule` and `nodeCount`. Older hosts that omit both fields continue to render no trigger metadata. Workflow files whose declared id differs from the filename stem are skipped with a warning, and missing workflow operations now return the generic resource `NotFound` response.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (1,803 passed)
- [x] `npm run build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo test --lib server::ops::workflows` (123 passed)

## Documentation

No standalone documentation change is needed; labels and authoring guidance are presented inline, and the wire/loader behavior is covered by focused tests.

Closes #1367
Closes #1369
Closes #1466
Closes #1463