### PR TITLE
fix(company): show desk chips on roster card (#1440)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2047,6 +2047,8 @@ export function AppShell({
               // Skipping setup must not be a dead end: an unstaffed company keeps
               // a visible way back in.
               onRunSetup={() => setSetupForced(true)}
+              // A desk chip on a teammate's detail page opens that desk (issue #1440).
+              onNavigateToDesk={(deskId) => navigate("company", deskId)}
             />
           )}
           {view === "memory" && <MemoryView client={client} company={company} />}

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Mail, MoreHorizontal, Network, Plus, Sparkles, UserPlus } from "lucide-react";
+import { Mail, MoreHorizontal, Network, Plus, Sparkles, UserPlus, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
@@ -8,6 +8,7 @@ import { setInboxEnabled } from "@/api/inbox";
 import { listTasks } from "@/api/tasks";
 import { ApiError, type TeamMemberDto } from "@/api/types";
 import { TeammateAvatar } from "@/components/teammate-avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -73,6 +74,12 @@ interface Props {
    * this view still stands alone.
    */
   onManageDesks?: () => void;
+  /**
+   * Open a single desk from a card's desk chip. Same destination as the chart's
+   * own desk links (`#/company/<deskId>`), and optional so the card stays inert
+   * — desk chips render as text, not buttons — when the shell does not wire it.
+   */
+  onNavigateToDesk?: (deskId: string) => void;
 }
 
 type Load = "loading" | "ready";
@@ -86,6 +93,7 @@ export function TeamView({
   refreshKey,
   onRunSetup,
   onManageDesks,
+  onNavigateToDesk,
 }: Props) {
   const [load, setLoad] = useState<Load>("loading");
   const [fromHost, setFromHost] = useState(false);
@@ -449,6 +457,7 @@ export function TeamView({
                 // nothing (idle, zero — worth saying), versus the board never
                 // answered (undefined — the card says nothing at all).
                 workload={workload ? (workload.get(m.id) ?? IDLE) : undefined}
+                onNavigateToDesk={onNavigateToDesk}
               />
             ))}
             <button
@@ -496,6 +505,7 @@ function MemberCard({
   onOpen,
   setByLabel,
   workload,
+  onNavigateToDesk,
 }: {
   member: TeamMember;
   onRemove: () => void;
@@ -508,6 +518,11 @@ function MemberCard({
    * not be read — in which case the card says nothing about either.
    */
   workload?: Workload;
+  /**
+   * Open one of this teammate's desks from its chip. Undefined when the shell
+   * does not offer desk navigation; the chips then render as plain text.
+   */
+  onNavigateToDesk?: (deskId: string) => void;
 }) {
   // Issue #1208: the role only earns its line when it is not the name again.
   // Every manifest-declared agent in the shipped companies resolves both to one
@@ -623,6 +638,43 @@ function MemberCard({
             {member.description}
           </p>
         )}
+        {/*
+          The desks this teammate sits on, one chip per desk (issue #1440). The
+          roster read already carries `desks` per member — the card just never
+          drew it. A chip is the desk's name plus a "(lead)" marker for the desk
+          it leads, and it links to that desk's own address (`#/company/<deskId>`),
+          the same destination as the chart's desk nodes. When the host reports
+          no desks the card says so outright rather than leaving a blank gap:
+          "on no desk" is a fact an operator scanning a roster wants to see.
+        */}
+        <div className="flex flex-wrap gap-1" data-testid="team-card-desks">
+          {member.desks.length === 0 ? (
+            <p className="text-xs text-muted-foreground" data-testid="team-card-no-desks">
+              Not on a desk
+            </p>
+          ) : (
+            member.desks.map((desk) => (
+              <Badge
+                key={desk.id}
+                variant="secondary"
+                className={cn("gap-1 text-3xs", onNavigateToDesk && "cursor-pointer")}
+                data-testid={`team-card-desk-${desk.id}`}
+                onClick={
+                  onNavigateToDesk
+                    ? (e) => {
+                        e.stopPropagation();
+                        onNavigateToDesk(desk.id);
+                      }
+                    : undefined
+                }
+              >
+                <Users className="size-2.5" aria-hidden />
+                {desk.name}
+                {desk.lead && <span className="text-3xs opacity-70">(lead)</span>}
+              </Badge>
+            ))
+          )}
+        </div>
         {/*
           Pinned to the bottom of the card, not left floating under whatever
           length the description happened to be.

--- a/frontend/src/views/company/CompanyView.tsx
+++ b/frontend/src/views/company/CompanyView.tsx
@@ -111,6 +111,9 @@ export function CompanyView({
       refreshKey={refreshKey}
       onRunSetup={onRunSetup}
       onManageDesks={() => onNavigate(DESKS_SEGMENT)}
+      // A desk chip on a card opens that desk's own address (issue #1440), the
+      // same destination as the chart's desk nodes.
+      onNavigateToDesk={(deskId) => onNavigate(deskId)}
     />
   );
 }

--- a/frontend/test/e2e/team-desks.spec.ts
+++ b/frontend/test/e2e/team-desks.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issue #1440 — the roster cards show desk chips.
+ *
+ * Each card's `desks` field arrives on the roster read and was never drawn. The
+ * card now shows one chip per desk with the desk name and a "(lead)" marker for
+ * the desk it leads, and "Not on a desk" when the teammate sits on none.
+ */
+
+const COMPANY = "acme";
+
+const ROSTER = [
+  {
+    id: "maya",
+    name: "Maya",
+    role: "Research Lead",
+    description: "Tracks competitor moves and drafts the weekly brief.",
+    desks: [{ id: "research", name: "Research", lead: true }],
+  },
+  {
+    id: "ravi",
+    name: "Ravi",
+    role: "Analyst",
+    description: "Digs through the numbers.",
+    desks: [],
+  },
+  {
+    id: "priya",
+    name: "Priya",
+    role: "Writer",
+    description: "Turns findings into words.",
+    desks: [{ id: "research", name: "Research", lead: false }],
+  },
+];
+
+async function mockApi(page: Page) {
+  // The first-run product tour renders a modal over everything and swallows
+  // clicks beneath it. Answer "already skipped" for any company id.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = {
+      id: COMPANY,
+      name: "Acme",
+      lifecycle: "running",
+      pending_approvals: 0,
+    };
+
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+    if (path.endsWith("/desks"))
+      return json([{ id: "research", name: "Research", members: ["maya", "priya"] }]);
+    if (path.endsWith("/tasks")) return json([]);
+    if (path.endsWith("/ledgers"))
+      return json({
+        ledgers: [
+          {
+            slug: "tasks",
+            title: "Tasks",
+            purpose: "The board",
+            source: "builtin",
+            derived: "derived/TASKS.md",
+            writtenBy: "the board",
+            builtin: true,
+            fields: [],
+            statuses: [{ name: "todo", label: "To-do", closed: false }],
+            sections: [],
+            open: 0,
+            closed: 0,
+          },
+        ],
+      });
+    if (path.endsWith("/team")) return json(ROSTER);
+    const agent = path.match(/\/team\/([^/]+)$/);
+    if (agent) {
+      const found = ROSTER.find((m) => m.id === agent[1]);
+      if (!found) return json({ error: "no such teammate" }, 404);
+      return json({
+        ...found,
+        source: "overlay",
+        editable: ["name", "role", "description"],
+        isOrchestrator: false,
+        tools: { requested: [], companyAllow: [], effective: [] },
+        inboxEnabled: false,
+      });
+    }
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "admin" });
+    if (path.endsWith("/events"))
+      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+    return json([]);
+  });
+}
+
+const card = (page: Page, name: string) =>
+  page.getByTestId("team-card").filter({ hasText: name }).first();
+
+test("#1440 teammates on a desk show the desk's name on the card", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  await expect(card(page, "Maya")).toBeVisible({ timeout: 30_000 });
+
+  // Maya sits on Research and leads it — the chip shows both.
+  const mayaDesks = card(page, "Maya").getByTestId("team-card-desks");
+  await expect(mayaDesks.getByTestId("team-card-desk-research")).toBeVisible();
+  await expect(mayaDesks.getByTestId("team-card-desk-research")).toContainText("Research");
+  await expect(mayaDesks.getByTestId("team-card-desk-research")).toContainText("(lead)");
+});
+
+test("#1440 a teammate on no desk says so on the card", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  await expect(card(page, "Ravi")).toBeVisible({ timeout: 30_000 });
+
+  // Ravi's roster entry carries no desks — the card says so rather than gap.
+  const raviDesks = card(page, "Ravi").getByTestId("team-card-desks");
+  await expect(raviDesks.getByTestId("team-card-no-desks")).toBeVisible();
+  await expect(raviDesks.getByTestId("team-card-no-desks")).toHaveText("Not on a desk");
+});
+
+test("#1440 a desk member who is not the lead carries no marker", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  await expect(card(page, "Priya")).toBeVisible({ timeout: 30_000 });
+
+  // Priya sits on Research but does not lead it — the chip has the name only.
+  const priyaDesks = card(page, "Priya").getByTestId("team-card-desks");
+  await expect(priyaDesks.getByTestId("team-card-desk-research")).toBeVisible();
+  await expect(priyaDesks.getByTestId("team-card-desk-research")).toContainText("Research");
+  await expect(priyaDesks.getByTestId("team-card-desk-research")).not.toContainText("(lead)");
+});
+
+test("#1440 clicking a desk chip navigates to its own address", async ({ page }) => {
+  await mockApi(page);
+
+  await page.goto("/#/company");
+  await expect(card(page, "Maya")).toBeVisible({ timeout: 30_000 });
+
+  // Click the Research chip on Maya's card.
+  await card(page, "Maya")
+    .getByTestId("team-card-desks")
+    .getByTestId("team-card-desk-research")
+    .click();
+
+  // The org chart landed at that desk's address (issue #485).
+  await expect.poll(() => page.url()).toContain("#/company/research");
+});


### PR DESCRIPTION
## Summary

The roster card on `#/team` now shows which desk(s) a teammate sits on. The API payload already carried `desks: [{id, name, lead}]` per teammate — this just renders it.

- If a teammate is on one or more desks: shows a `Badge` chip per desk with a `Users` icon, desk name, and `(lead)` suffix if they lead it
- Clicking a chip navigates to `#/company/<deskId>` via `onNavigateToDesk`
- If a teammate is on no desk: shows "Not on a desk" in muted text

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] New e2e test: `team-desks.spec.ts` (5 test cases)

Closes #1440