### PR TITLE
fix(company): replace redundant blueprint badges with lock icon (#1431)

### DIFF
--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -26,6 +26,7 @@ import {
   ChevronRight,
   ChevronUp,
   Crown,
+  Lock,
   Plus,
   Trash2,
   UserPlus,
@@ -755,6 +756,13 @@ function DeskNode({
   onDelete: () => void;
 }) {
   const locked = busy !== null;
+  // Whether any seat on this desk was added at runtime rather than declared by
+  // the manifest. Only on such a "mixed provenance" desk does the Blueprint
+  // badge still earn its place — everywhere else the whole desk is blueprint,
+  // so a muted lock says it with far less noise than a badge on every seat.
+  const hasOverlaySeats = desk.seats.some(
+    (s) => s.provenance === "overlay",
+  );
   // Whether the seat currently being dragged (from anywhere on the chart)
   // could land on *this* desk: it must come from a different desk, and it
   // must be an overlay seat — the host refuses to remove a blueprint member
@@ -835,11 +843,18 @@ function DeskNode({
           <div className="min-w-0">
             <p className="flex items-center gap-2 truncate font-medium">
               {desk.name}
-              {desk.provenance === "blueprint" && (
-                <Badge variant="secondary" className="shrink-0 text-3xs">
-                  Blueprint
-                </Badge>
-              )}
+              {desk.provenance === "blueprint" &&
+                (hasOverlaySeats ? (
+                  <Badge variant="secondary" className="shrink-0 text-3xs">
+                    Blueprint
+                  </Badge>
+                ) : (
+                  <Lock
+                    role="img"
+                    aria-label="Part of the company blueprint"
+                    className="size-3.5 shrink-0 text-muted-foreground"
+                  />
+                ))}
             </p>
             {desk.description && (
               <p className="line-clamp-2 text-xs text-muted-foreground">
@@ -891,6 +906,7 @@ function DeskNode({
               index={index}
               deskId={desk.id}
               deskName={desk.name}
+              deskHasOverlaySeats={hasOverlaySeats}
               first={index === 0}
               last={index === desk.seats.length - 1}
               busy={busy === `${desk.id}:${seat.id}`}
@@ -964,6 +980,7 @@ function Seat({
   index,
   deskId,
   deskName,
+  deskHasOverlaySeats,
   first,
   last,
   busy,
@@ -981,6 +998,8 @@ function Seat({
   index: number;
   deskId: string;
   deskName: string;
+  /** Whether this seat's desk mixes blueprint and overlay members. */
+  deskHasOverlaySeats: boolean;
   first: boolean;
   last: boolean;
   busy: boolean;
@@ -1157,10 +1176,16 @@ function Seat({
           >
             <X className="size-3.5" />
           </Button>
-        ) : (
+        ) : deskHasOverlaySeats ? (
           <Badge variant="secondary" className="shrink-0 text-3xs">
             Blueprint
           </Badge>
+        ) : (
+          <Lock
+            role="img"
+            aria-label="Part of the company blueprint"
+            className="size-3.5 shrink-0 text-muted-foreground"
+          />
         )}
       </span>
     </div>

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -838,7 +838,14 @@ test("#311 blueprint structure offers no control the host would refuse", async (
   await openChart(page);
 
   // A manifest desk cannot be deleted at runtime, so no delete is offered.
-  await expect(deskNode(page, "Engineering")).toContainText("Blueprint");
+  // Its blueprint provenance is a muted lock, not a word badge — the badge only
+  // survives on a mixed-provenance desk, where it distinguishes one member from
+  // the runtime-added one beside it.
+  await expect(
+    deskNode(page, "Engineering")
+      .getByRole("img", { name: "Part of the company blueprint" })
+      .first(),
+  ).toBeVisible();
   await expect(
     deskNode(page, "Engineering").getByRole("button", {
       name: "Delete Engineering",


### PR DESCRIPTION
## Summary

On `#/company/desks`, every desk header and every seat carried an identical `Blueprint` badge — 12 on screen, distinguishing nothing.

- **All-blueprint desk** (common case): replaced with a muted `Lock` icon with `aria-label="Part of the company blueprint"`
- **Mixed-provenance desk** (blueprint + overlay seats): keeps the `Blueprint` badge, now it actually distinguishes something
- Overlay seats keep their `X` remove button (unchanged)

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] Updated e2e assertion in `org-tree.spec.ts`

Closes #1431