### PR TITLE
fix(company): align people view padding, buttons, and error display (#1439)

### DIFF
--- a/frontend/src/views/PeopleView.tsx
+++ b/frontend/src/views/PeopleView.tsx
@@ -172,7 +172,7 @@ export function PeopleView({ client, company }: Props) {
 
   if (loading) {
     return (
-      <div className="space-y-3 p-6">
+      <div className="space-y-3 px-4 py-6">
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-24 w-full" />
         <Skeleton className="h-24 w-full" />
@@ -182,7 +182,7 @@ export function PeopleView({ client, company }: Props) {
 
   if (!isAdmin) {
     return (
-      <div className="mx-auto w-full max-w-3xl p-6">
+      <div className="mx-auto w-full max-w-3xl px-4 py-6">
         <div className="mb-6 space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">People</h1>
           <p className="text-sm text-muted-foreground">
@@ -201,7 +201,7 @@ export function PeopleView({ client, company }: Props) {
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-8 p-6">
+    <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-6">
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">People</h1>
@@ -209,8 +209,8 @@ export function PeopleView({ client, company }: Props) {
             The humans who can sign in. Access is invite-only.
           </p>
         </div>
-        <Button onClick={() => setInviteOpen(true)}>
-          <UserPlus className="mr-2 size-4" />
+        <Button size="sm" variant="outline" onClick={() => setInviteOpen(true)}>
+          <UserPlus className="mr-1.5 size-4" />
           Invite
         </Button>
       </div>

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -37,6 +37,7 @@ import { toast } from "sonner";
 import { listPeople } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError, type DeskDto, type TeamMemberDto } from "@/api/types";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -501,12 +502,9 @@ export function OrgChartView({ client, company, focusDeskId, onBack }: Props) {
         </div>
 
         {error && (
-          <div
-            role="alert"
-            className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-          >
-            {error}
-          </div>
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
         )}
 
         {load === "loading" ? (
@@ -1142,7 +1140,7 @@ function Seat({
       onDragOver={dragOver}
       onDrop={drop}
       className={cn(
-        "flex cursor-grab items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm active:cursor-grabbing",
+        "flex cursor-grab items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm active:cursor-grabbing",
         busy && "opacity-50",
       )}
     >
@@ -1228,7 +1226,7 @@ function Unplaced({ tree }: { tree: OrgTree }) {
     <div className="space-y-4">
       {tree.unassigned.length > 0 && (
         <section className="space-y-2">
-          <h3 className="text-sm font-medium">Not on a desk</h3>
+          <h3 className="text-sm font-medium text-muted-foreground">Not on a desk</h3>
           <p className="text-xs text-muted-foreground">
             Roster teammates the company has not staffed anywhere. Add them to a
             desk above.
@@ -1266,7 +1264,7 @@ function Unplaced({ tree }: { tree: OrgTree }) {
       )}
       {tree.people.length > 0 && (
         <section className="space-y-2">
-          <h3 className="text-sm font-medium">People</h3>
+          <h3 className="text-sm font-medium text-muted-foreground">People</h3>
           <p className="text-xs text-muted-foreground">
             The humans who can sign in. Desks staff teammates, so the company
             declares no desk for a person, and this chart does not guess one.


### PR DESCRIPTION
## Summary

Aligned `#/settings/people` (`PeopleView`) with the canonical view layout used by `#/company` and other console pages:

- **Wrapper padding**: `p-6` → `px-4 py-6` (matches every other view)
- **Section spacing**: `space-y-8` → `space-y-6`
- **Button style**: Added `size="sm"` `variant="outline"` to Invite button, fixed icon margin `mr-2`→`mr-1.5`
- **Error display**: Migrated `OrgChartView`'s custom error `<div>` to use the shadcn `<Alert variant="destructive">` component

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`

Closes #1439