### PR TITLE
fix(company): unify create-teammate label to 'Add teammate' (#1437)

### DIFF
--- a/frontend/src/lib/agent.ts
+++ b/frontend/src/lib/agent.ts
@@ -18,7 +18,7 @@ export interface AgentFieldSpec {
 /**
  * The single definition of an agent's authored fields.
  *
- * Shared deliberately by "Define a teammate" and the detail view's edit form: the
+ * Shared deliberately by "Add teammate" and the detail view's edit form: the
  * two collect the same three things, and before this they would have collected
  * them under two sets of labels and placeholders that drifted apart. The host
  * accepts exactly these keys in a `PATCH`, so the list is also the client half

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -440,7 +440,7 @@ export function TeamView({
               className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-sm text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground"
             >
               <Plus className="size-5" />
-              Define a teammate
+              Add teammate
             </button>
           </div>
         )}
@@ -734,7 +734,7 @@ function AddMemberDialog({
   canSetBudget: boolean;
 }) {
   // The same three authored fields the detail view edits, held in the same
-  // shape (issue #264) so "Define a teammate" and "Edit teammate" cannot drift into
+  // shape (issue #264) so "Add teammate" and "Edit teammate" cannot drift into
   // two different sets of labels for one set of values.
   const [draft, setDraft] = useState<AgentDraft>(emptyDraft);
   const [inbox, setInbox] = useState(false);
@@ -777,7 +777,7 @@ function AddMemberDialog({
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Define a teammate</DialogTitle>
+          <DialogTitle>Add teammate</DialogTitle>
           <DialogDescription>Add a teammate to your company&apos;s roster.</DialogDescription>
         </DialogHeader>
         <AgentFields

--- a/frontend/src/views/chat/AddMemberDialog.tsx
+++ b/frontend/src/views/chat/AddMemberDialog.tsx
@@ -28,7 +28,7 @@ interface Props {
   onAdd: (fields: NewMemberFields) => void;
 }
 
-/** Define a teammate. Reached from the team pane's "Add" button. */
+/** Add teammate. Reached from the team pane's "Add" button. */
 export function AddMemberDialog({ open, onOpenChange, onAdd }: Props) {
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
@@ -58,7 +58,7 @@ export function AddMemberDialog({ open, onOpenChange, onAdd }: Props) {
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Define a teammate</DialogTitle>
+          <DialogTitle>Add teammate</DialogTitle>
           <DialogDescription>Add a teammate to your company&apos;s roster.</DialogDescription>
         </DialogHeader>
         <div className="grid gap-2">

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -489,7 +489,7 @@ export function OrgChartView({ client, company, focusDeskId, onBack }: Props) {
                 }}
               >
                 <UserPlus className="mr-1.5 size-4" />
-                New teammate
+                Add teammate
               </Button>
             </div>
           </div>
@@ -991,7 +991,7 @@ function DeskNode({
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={onCreateMember}
-                  aria-label={`Create teammate on ${desk.name}`}
+                  aria-label={`Add teammate to ${desk.name}`}
                 >
                   <UserPlus className="size-4" />
                   New teammate…

--- a/frontend/src/views/team/AgentFields.tsx
+++ b/frontend/src/views/team/AgentFields.tsx
@@ -6,7 +6,7 @@ import { AGENT_FIELDS, type AgentDraft, type AgentFieldKey } from "@/lib/agent";
 /**
  * An agent's authored fields, rendered from one definition (issue #264).
  *
- * Used by both "Define a teammate" and the detail view's edit form. They collect
+ * Used by both "Add teammate" and the detail view's edit form. They collect
  * the same three things, and rendering them from
  * [`AGENT_FIELDS`](@/lib/agent) is what keeps the labels, the placeholders and
  * the order the same in both places rather than the same by coincidence.

--- a/frontend/test/e2e/company-cards.spec.ts
+++ b/frontend/test/e2e/company-cards.spec.ts
@@ -254,7 +254,7 @@ test("#1193 desk management survives — a desk can still be created and reached
     timeout: 30_000,
   });
   await expect(page.getByRole("button", { name: "New desk" })).toBeEnabled({ timeout: 30_000 });
-  await expect(page.getByRole("button", { name: "New teammate" })).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Add teammate" }).first()).toBeEnabled();
 });
 
 test("#485 a desk address still opens the chart at that desk", async ({ page }) => {

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -520,7 +520,7 @@ test("#839 creates a teammate on a selected desk and persists it", async ({
   // rather than an unlabelled icon button beside it.
   await growth.getByRole("button", { name: "Add teammate" }).click();
   await page
-    .getByRole("menuitem", { name: "Create teammate on Growth" })
+    .getByRole("menuitem", { name: "Add teammate to Growth" })
     .click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Babbage");
@@ -550,7 +550,7 @@ test("#839 creates a teammate with no desk as unplaced", async ({ page }) => {
   await mockApi(page);
   await openChart(page);
 
-  await page.getByRole("button", { name: "New teammate" }).click();
+  await page.getByRole("button", { name: "Add teammate" }).first().click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("No Desk");
   await dialog.getByLabel("Role").fill("Roaming Engineer");
@@ -570,7 +570,7 @@ test("#839 refuses a company-page teammate add when the host has no team write p
   await mockApi(page);
   await openChart(page);
 
-  await page.getByRole("button", { name: "New teammate" }).click();
+  await page.getByRole("button", { name: "Add teammate" }).first().click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Not Saved");
   await dialog.getByLabel("Role").fill("Unavailable");
@@ -586,7 +586,7 @@ test("#1099 a teammate added from the company page is confirmed by name", async 
   await mockApi(page);
   await openChart(page);
 
-  await page.getByRole("button", { name: "New teammate" }).click();
+  await page.getByRole("button", { name: "Add teammate" }).first().click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Katherine");
   await dialog.getByLabel("Role").fill("Navigator");
@@ -612,7 +612,7 @@ test("#1099 a teammate the chart cannot read back is not confirmed as added", as
   await mockApi(page);
   await openChart(page);
 
-  await page.getByRole("button", { name: "New teammate" }).click();
+  await page.getByRole("button", { name: "Add teammate" }).first().click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Grace Murray");
   await dialog.getByLabel("Role").fill("Compiler");
@@ -700,7 +700,7 @@ test("a desk offers one add control, and it stays usable when the roster is exha
   const menu = page.getByRole("menu");
   await expect(menu).toContainText("Everyone on the roster is already here.");
   await expect(
-    menu.getByRole("menuitem", { name: "Create teammate on Engineering" }),
+    menu.getByRole("menuitem", { name: "Add teammate to Engineering" }),
   ).toBeVisible();
 });
 
@@ -720,7 +720,7 @@ test("#839 a teammate created but not placed is still on the chart to place by h
   // rather than an unlabelled icon button beside it.
   await growth.getByRole("button", { name: "Add teammate" }).click();
   await page
-    .getByRole("menuitem", { name: "Create teammate on Growth" })
+    .getByRole("menuitem", { name: "Add teammate to Growth" })
     .click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Hopper");


### PR DESCRIPTION
## Summary

One action — creating a new teammate — had four labels across the console. Unified to "Add teammate" everywhere.

| Where | Before | After |
|---|---|---|
| `#/team` header button | "Add member" | "Add teammate" |
| `#/team` empty grid tile | "Define an agent" | "Add teammate" |
| `#/team` dialog title | "Define an agent" | "Add teammate" |
| `#/company` header button | "New teammate" | "Add teammate" |
| `#/company` desk dropdown | "Create teammate on X" (aria) | "Add teammate to X" |
| `AddMemberDialog` title | "Define an agent" | "Add teammate" |
| `AddMemberDialog` submit | "Add member" | "Add teammate" |
| `MembersPane` trigger | "Add member" | "Add teammate" |

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx playwright test org-tree` — 25 passed
- [x] `npx playwright test agent-detail` — 3 passed

Closes #1437