### PR TITLE
fix(company): add avatars to desk seats and pickers (#1430)

### DIFF
--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -13,6 +13,8 @@ import { Crown } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { DeskDto, TeamMemberDto } from "@/api/types";
+import { TeammateAvatar } from "@/components/teammate-avatar";
+import { avatarFor, toneFor } from "@/lib/team";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -206,6 +208,12 @@ export function DeskCreateDialog({
                     )}
                   >
                     <span className="flex min-w-0 items-center gap-1.5">
+                      <TeammateAvatar
+                        name={member.name ?? member.role}
+                        avatar={avatarFor(member.id ?? member.name ?? "")}
+                        tone={toneFor(member.id ?? member.name ?? "")}
+                        className="size-5 shrink-0"
+                      />
                       {order === 0 && (
                         <Crown role="img" aria-label="Desk lead" className="size-3.5 shrink-0 text-muted-foreground" />
                       )}

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -39,6 +39,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import { ApiError, type DeskDto, type TeamMemberDto } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { TeammateAvatar } from "@/components/teammate-avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,7 +50,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
-import { roleSubtitle } from "@/lib/team";
+import { avatarFor, roleSubtitle, toneFor, type TeamMember } from "@/lib/team";
 import {
   addMemberFailure,
   addOutcome,
@@ -740,7 +741,7 @@ function DeskNode({
   onDelete,
 }: {
   desk: OrgDesk;
-  addable: { id: string; name: string }[];
+  addable: TeamMember[];
   busy: string | null;
   /** This desk is the one a `#/company/<deskId>` link asked for. */
   focused: boolean;
@@ -976,6 +977,12 @@ function DeskNode({
                         key={member.id}
                         onClick={() => onAdd(member.id)}
                       >
+                        <TeammateAvatar
+                          name={member.name}
+                          avatar={member.avatar}
+                          tone={member.tone}
+                          className="size-5 shrink-0"
+                        />
                         <span className="truncate">{member.name}</span>
                       </DropdownMenuItem>
                     ))}
@@ -1105,6 +1112,12 @@ function Seat({
 
   const label = (
     <>
+      <TeammateAvatar
+        name={seat.name}
+        avatar={avatarFor(seat.id)}
+        tone={toneFor(seat.id)}
+        className="size-5 shrink-0"
+      />
       {seat.lead && (
         <Crown
           role="img"
@@ -1245,8 +1258,14 @@ function Unplaced({ tree }: { tree: OrgTree }) {
                     <a
                       href={href}
                       title={`Open ${member.name}`}
-                      className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs outline-none hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50"
+                      className="flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs outline-none hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50"
                     >
+                      <TeammateAvatar
+                        name={member.name}
+                        avatar={member.avatar}
+                        tone={member.tone}
+                        className="size-5 shrink-0"
+                      />
                       {member.name}
                       <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
                     </a>
@@ -1255,6 +1274,12 @@ function Unplaced({ tree }: { tree: OrgTree }) {
                     // rather than as a pill: the border is what made the inert
                     // version of this chip a lie.
                     <InertChip title="This teammate has no id, so their page can't be opened.">
+                      <TeammateAvatar
+                        name={member.name}
+                        avatar={member.avatar}
+                        tone={member.tone}
+                        className="size-5 shrink-0"
+                      />
                       {member.name}
                     </InertChip>
                   )}


### PR DESCRIPTION
## Summary

On `#/company/desks`, every person was rendered as bare text while the roster went to the trouble of giving them faces. Added `<TeammateAvatar>` (~20px, colored initial tiles) to all four person-rendering locations:

- Each seat in every desk
- Each "Not on a desk" unplaced chip
- The per-desk "Add teammate" dropdown items
- The New desk dialog's roster picker

Uses the existing `TeammateAvatar` component from `@/components/teammate-avatar` which handles the small-size fallback.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`

Closes #1430