### PR TITLE
chore(deps): follow the openhuman pin past tinymemory #76/#77 and onto the crates/ layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1903,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashify"
@@ -1909,11 +1921,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3193,7 +3205,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
  "toml_edit",
  "tower",
  "tower-http 0.7.0",
@@ -3206,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.13"
+version = "0.63.15"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3221,7 +3233,7 @@ dependencies = [
  "chrono-tz",
  "cron",
  "directories",
- "dirs",
+ "dirs 5.0.1",
  "dotenvy",
  "ed25519-dalek",
  "flate2",
@@ -3272,7 +3284,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4004,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -5214,7 +5226,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "futures",
  "log",
  "parking_lot",
@@ -5230,7 +5242,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
  "walkdir",
@@ -5293,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5309,9 +5321,19 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "log",
  "schemars",
+ "serde",
+ "serde_json",
+ "tinymemory-bus",
+]
+
+[[package]]
+name = "tinymemory-bus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5336,17 +5358,17 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "futures",
  "log",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tinyagents",
  "tinycortex",
@@ -5371,8 +5393,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tinymemory-api",
+ "tokio",
 ]
 
 [[package]]
@@ -5390,7 +5413,7 @@ dependencies = [
  "serde_json",
  "tinymemory-api",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
  "walkdir",
@@ -5582,21 +5605,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -5604,19 +5612,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -5635,10 +5634,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -5647,7 +5646,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -6531,12 +6530,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,9 +268,9 @@ tinycortex = { version = "0.1", optional = true }
 # NOT part of `tinymemory`: depending on it unconditionally would drag
 # `tinycortex`, and with it a bundled SQLite build, into a tenant that
 # selected a hosted engine over HTTP and needs neither (tinymemory#18 §D).
-tinymemory = { path = "vendor/openhuman/vendor/tinymemory", optional = true }
-tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/api", optional = true }
-tinymemory-remote = { path = "vendor/openhuman/vendor/tinymemory/adapters/remote", optional = true }
+tinymemory = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory", optional = true }
+tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-api", optional = true }
+tinymemory-remote = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-remote", optional = true }
 # `tinymemory-core` carries `UnifiedMemory` — the contract's own durable SQLite
 # store (`impl Memory for UnifiedMemory`, driver id `namespace`) — which is what
 # lets the *embedded* mode bind through the provider seam instead of around it
@@ -283,8 +283,8 @@ tinymemory-remote = { path = "vendor/openhuman/vendor/tinymemory/adapters/remote
 # (tinymemory#18 §D). `remote` and `null` continue to need only the three
 # contract crates above. Same single-checkout rule as those three: the path is
 # byte-identical to the one `vendor/openhuman/Cargo.toml` declares.
-tinymemory-core = { path = "vendor/openhuman/vendor/tinymemory/core", optional = true }
-tinymemory-tinycortex = { path = "vendor/openhuman/vendor/tinymemory/adapters/tinycortex", optional = true }
+tinymemory-core = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-core", optional = true }
+tinymemory-tinycortex = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-tinycortex", optional = true }
 
 # Single-file `.tar` packing/unpacking for `opencompany export`/`import`. Pure
 # Rust, no system libs, no network. Only links under the `export` feature; the
@@ -547,7 +547,7 @@ paypal = ["dep:reqwest"]
 # in its Cargo.toml); replicated here with the path rebased onto the vendored
 # checkout, same as the WS4 entries below.
 [patch."https://github.com/tinyhumansai/tinymemory"]
-tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/api" }
+tinymemory-api = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-api" }
 
 [patch.crates-io]
 # Reuse OpenHuman's own TinyAgents pin (2.1.0). This satisfies OpenHuman's
@@ -586,7 +586,7 @@ tempfile = "3"
 # (tinymemory-api + async-trait + serde_json + anyhow), deliberately barred
 # from reaching any engine, so it adds no engine weight to any lane's graph.
 # Same byte-identical-path rule as the `tinymemory*` entries above.
-tinymemory-conformance = { path = "vendor/openhuman/vendor/tinymemory/conformance" }
+tinymemory-conformance = { path = "vendor/openhuman/vendor/tinymemory/crates/tinymemory-conformance" }
 # `test-util` only — for `#[tokio::test(start_paused = true)]`, which the git
 # deadline test needs to fire a timeout deterministically instead of racing a
 # real child process. Dev-only: under resolver v2 this feature is not unified

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2232,14 +2232,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3644,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.13"
+version = "0.63.15"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -4603,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.13.1",
  "fallible-iterator",
@@ -6362,7 +6365,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6378,9 +6381,19 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "log",
  "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "tinymemory-bus",
+]
+
+[[package]]
+name = "tinymemory-bus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -6395,17 +6408,17 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "futures",
  "log",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tinyagents",
  "tinycortex",
@@ -6435,7 +6448,7 @@ dependencies = [
  "serde_json",
  "tinymemory-api",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "walkdir",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -100,7 +100,7 @@ tempfile = "3"
 # Keep this byte-identical to the host's table modulo the `../` prefix. The
 # comments explaining each entry live there; this is the replica.
 [patch."https://github.com/tinyhumansai/tinymemory"]
-tinymemory-api = { path = "../vendor/openhuman/vendor/tinymemory/api" }
+tinymemory-api = { path = "../vendor/openhuman/vendor/tinymemory/crates/tinymemory-api" }
 
 [patch.crates-io]
 tinyagents = { path = "../vendor/openhuman/vendor/tinyagents" }


### PR DESCRIPTION
## Summary

Bumps `vendor/openhuman` `6c0df6074 → f7ef1525e` (openhuman #5657), whose nested `vendor/tinymemory` pin is `1d6b997` — tinymemory main with both #75 fix batches (Supermemory re-store blocker, keyed delete, pager ceiling, cognee recall/timestamp fixes, capped error bodies, typed multipart, off-executor embedded SQL, KV read/write symmetry + conformance). **This is the hop that delivers the keyed-CRUD line to the product** — at the old pin, every keyed remote read/delete still enumerated the whole account.

tinymemory #73 made that repo's root a virtual workspace (everything under `crates/`), so the seven path strings reaching into the nested vendor are rewritten in the same atomic commit — five optional deps (`Cargo.toml:271-287`), the conformance dev-dep, and the `[patch]` entry — byte-identical to openhuman's own paths, preserving cargo's unification of the two dependency sets into one package each (the two-`MemoryProvider`-traits hazard recorded at `Cargo.toml:249-252`). `rusqlite` unifies at `=0.40.2` through openhuman's aligned manifests.

This is PR 1 of #1524's Wave 1 (whose tree-state section references this branch); with it merged, #1524's PR 1 reduces to the CI-lane addition.

## API Or Behavior Changes

None in opencompany's own surface. Behavior delivered transitively by the new pin: remote memory drivers gain the #75 fixes above; `cargo tree -e normal --features openhuman,tinycortex,tinymemory-embedded -d` reports no duplicated `tinymemory-*` package.

## Tests

- [x] `cargo fmt --all -- --check` — clean on the merged tree
- [x] `cargo clippy --all-targets --features openhuman,tinycortex -- -D warnings` — zero (compiles all test targets against the new pin)
- [x] `cargo test --features openhuman,tinycortex` — 4941 passed / 0 failed on the pre-#1489-merge tree; the post-merge rerun of the full lane matrix (feature, bare, `acp,runner,tinymemory`, `tinymemory-embedded`) is running locally — CI is authoritative for the final tree
- [x] `cargo metadata` resolves clean (the seven-path atomicity property)

## Documentation

No doc changes needed — the path comments in `Cargo.toml` still describe the layout accurately; #1524 carries the follow-up comment corrections (`migrate.rs`, `driver.rs`) scoped to its PR 1 remainder.