### PR TITLE
fix(console): keep `company` when stripping a magic link

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -89,12 +89,22 @@ function readHubError(): boolean {
  *
  * The code is a single-use credential, so it must not linger in the URL, the
  * history, or a `Referer` header once we hold it.
+ *
+ * `company` is deliberately kept, for the same reason `clearHubResultFromUrl`
+ * keeps it: it is not a credential, and it is what scopes the console. This
+ * once deleted it too — harmless back when the console was one implicit host,
+ * and a silent state reset once connections arrived. `restoreConnections` is
+ * told which same-origin console this load is (`isThisConsole`, added for
+ * #1167), and on a stripped URL that is `defaultCompany === null` — so the
+ * profile the link had just written is skipped, and `addConnection` mints a
+ * *second* id for the one host. Every key named after that id starts over: the
+ * tour, unread counts, the last-visited channel, the mail draft. The reported
+ * symptom was a welcome tour that came back after being skipped; see #1306.
  */
-function clearMagicLinkFromUrl(): void {
+export function clearMagicLinkFromUrl(): void {
   const params = new URLSearchParams(window.location.search);
   if (!params.has("code")) return;
   params.delete("code");
-  params.delete("company");
   const query = params.toString();
   window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,13 +100,20 @@ function readHubError(): boolean {
  * *second* id for the one host. Every key named after that id starts over: the
  * tour, unread counts, the last-visited channel, the mail draft. The reported
  * symptom was a welcome tour that came back after being skipped; see #1306.
+ *
+ * The hash is preserved: it is the router's, not ours, and a magic link may
+ * carry a deep link to land on.
  */
 export function clearMagicLinkFromUrl(): void {
   const params = new URLSearchParams(window.location.search);
   if (!params.has("code")) return;
   params.delete("code");
   const query = params.toString();
-  window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
+  window.history.replaceState(
+    {},
+    "",
+    window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
+  );
 }
 
 /**
@@ -119,15 +126,23 @@ export function clearMagicLinkFromUrl(): void {
  *
  * `company` is deliberately kept. It is not a credential, and dropping it would
  * un-scope the console on a reload of a multi-company host.
+ *
+ * The hash is preserved for the same reason it is in `clearMagicLinkFromUrl`:
+ * it belongs to the router, and rewriting the URL without it would bounce a
+ * deep link back to the default view.
  */
-function clearHubResultFromUrl(): void {
+export function clearHubResultFromUrl(): void {
   const params = new URLSearchParams(window.location.search);
   if (params.get("key") !== "auth") return;
   params.delete("token");
   params.delete("error");
   params.delete("key");
   const query = params.toString();
-  window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
+  window.history.replaceState(
+    {},
+    "",
+    window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
+  );
 }
 
 /**

--- a/frontend/test/unit/magic-link-scope.test.ts
+++ b/frontend/test/unit/magic-link-scope.test.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { clearMagicLinkFromUrl } from "@/App";
+import { clearHubResultFromUrl, clearMagicLinkFromUrl } from "@/App";
 import { resolveConfig } from "@/config";
 import { addConnection, resetConnections, restoreConnections } from "@/connections/registry";
 import { readProfiles } from "@/connections/profileStore";
@@ -95,12 +95,31 @@ describe("clearing a magic link", () => {
     ).toBe(JSON.stringify({ skipped: true }));
   });
 
+  it("leaves the router's hash alone, so a deep link survives the strip", () => {
+    land("?company=agentic-software-company&code=s3cret", "#/tasks/abc");
+
+    clearMagicLinkFromUrl();
+
+    expect(window.location.hash).toBe("#/tasks/abc");
+  });
+
   it("does nothing at all when there is no code to strip", () => {
-    land("?company=agentic-software-company");
+    land("?company=agentic-software-company", "#/overview");
 
     clearMagicLinkFromUrl();
 
     expect(window.location.search).toBe("?company=agentic-software-company");
+    expect(window.location.hash).toBe("#/overview");
   });
 });
 
+describe("clearing a hub sign-in result", () => {
+  it("takes the token out but keeps the scope and the hash", () => {
+    land("?company=agentic-software-company&token=jwt&key=auth", "#/overview");
+
+    clearHubResultFromUrl();
+
+    expect(window.location.search).toBe("?company=agentic-software-company");
+    expect(window.location.hash).toBe("#/overview");
+  });
+});

--- a/frontend/test/unit/magic-link-scope.test.ts
+++ b/frontend/test/unit/magic-link-scope.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { clearMagicLinkFromUrl } from "@/App";
+import { resolveConfig } from "@/config";
+import { addConnection, resetConnections, restoreConnections } from "@/connections/registry";
+import { readProfiles } from "@/connections/profileStore";
+import { scopedKey } from "@/connections/types";
+
+/**
+ * What a landing credential is allowed to take with it when it leaves the URL.
+ *
+ * The address bar is not cosmetic here. `resolveConfig` reads `?company=` back
+ * on every load, and that value is what `restoreConnections` is told this page
+ * load *is* — so deleting the param is the same act as changing which
+ * browser-local namespace the next load lands in. Issue #1306: the magic-link
+ * cleaner dropped `company`, and the welcome tour came back after being
+ * skipped.
+ *
+ * These drive the real cleaners against a real `localStorage`, then do what a
+ * reload does — throw away the in-memory registry, re-read the URL, re-run the
+ * bootstrap — and assert the connection id survived it.
+ */
+
+/** The landing URL a magic link produces, per the issue's repro table. */
+function land(search: string, hash = ""): void {
+  window.history.replaceState({}, "", `/login${search}${hash}`);
+}
+
+/**
+ * A reload, as `App`'s bootstrap `useMemo` performs it.
+ *
+ * Mirrors the two calls at the top of that memo, including the same-origin
+ * argument added for #1167 — which is the half that turns a missing `?company=`
+ * into a skipped profile and a freshly minted id.
+ */
+function bootstrap(): string {
+  resetConnections();
+  const config = resolveConfig();
+  restoreConnections(
+    undefined,
+    config.baseUrl === "" ? { defaultCompany: config.company } : undefined,
+  );
+  return addConnection({ baseUrl: config.baseUrl, defaultCompany: config.company });
+}
+
+beforeEach(() => {
+  resetConnections();
+  window.localStorage.clear();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("clearing a magic link", () => {
+  it("takes the code out of the address bar", () => {
+    land("?company=agentic-software-company&code=s3cret");
+
+    clearMagicLinkFromUrl();
+
+    expect(window.location.search).not.toContain("code");
+    expect(window.location.search).not.toContain("s3cret");
+  });
+
+  it("keeps company, so a reload lands in the same connection scope", () => {
+    // THE regression. `company` is not a credential — it is the scope. Stripping
+    // it made the reload present `defaultCompany === null`, so `isThisConsole`
+    // skipped the profile the link had just written and `addConnection` minted a
+    // second id for the one host.
+    land("?company=agentic-software-company&code=s3cret");
+    const first = bootstrap();
+    clearMagicLinkFromUrl();
+
+    const second = bootstrap();
+
+    expect(second).toBe(first);
+    expect(readProfiles()).toHaveLength(1);
+  });
+
+  it("does not orphan the tour state it recorded before the reload", () => {
+    // The symptom as an operator meets it: skip the welcome tour, reload, and
+    // the welcome tour is back — because the key moved underneath it.
+    land("?company=agentic-software-company&code=s3cret");
+    const first = bootstrap();
+    clearMagicLinkFromUrl();
+    const company = "agentic-software-company";
+    window.localStorage.setItem(
+      scopedKey("oc-tour", { connection: first, company }),
+      JSON.stringify({ skipped: true }),
+    );
+
+    const second = bootstrap();
+
+    expect(
+      window.localStorage.getItem(scopedKey("oc-tour", { connection: second, company })),
+    ).toBe(JSON.stringify({ skipped: true }));
+  });
+
+  it("does nothing at all when there is no code to strip", () => {
+    land("?company=agentic-software-company");
+
+    clearMagicLinkFromUrl();
+
+    expect(window.location.search).toBe("?company=agentic-software-company");
+  });
+});
+


### PR DESCRIPTION
## Summary

Signing in through a magic link and then reloading minted a **second connection profile for the same host**, orphaning every piece of browser-local state keyed by connection id. The visible symptom: dismiss the welcome tour, reload, and the welcome tour is back.

Fixes #1306.

## Root cause

`clearMagicLinkFromUrl` in `frontend/src/App.tsx` deleted `?company=` alongside `?code=`. Only the code is a credential — `company` is what scopes the console:

1. `resolveConfig` (`frontend/src/config.ts`) re-reads `?company=` on **every** load.
2. `restoreConnections` is told which same-origin console this load is, and `isThisConsole` (added for #1167) keeps only the same-origin profile whose `defaultCompany` matches it.
3. On a stripped URL that is `defaultCompany === null`, so the profile the magic link had just written is skipped and `addConnection` mints a fresh id.
4. `scopedKey` is `${prefix}:${connection}::${company ?? "single"}` — both halves moved, so `oc-tour:<id-a>::acme` became `oc-tour:<id-b>::single`. The skip was recorded against the first; the shell now reads the second.

`git log -L` puts the deletion in the original login-view commit, back when `readMagicLink` read `company` into a local in the same function and nothing was keyed on it. `clearHubResultFromUrl` was written later and already carries the carve-out, with a comment saying exactly why. This is the same carve-out.

## Changes

**`fix(console): keep \`company\` when stripping a magic link`** — drop the `params.delete("company")`, with the reasoning in the doc comment.

**`fix(console): keep the router's hash when stripping a landing credential`** — a second, smaller defect on the same two lines: both cleaners rebuilt the URL as `pathname + query`, dropping the hash, so a link carrying a deep link (`?code=…#/tasks/abc`) landed on the default view. `app-shell.tsx` already preserves the hash in its own `replaceState`; these two were the outliers. Separate commit — drop it if you'd rather it went on its own.

## Tests

New `frontend/test/unit/magic-link-scope.test.ts` (6 tests) drives the real cleaners against a real `localStorage`, then does what a reload does — throw away the in-memory registry, re-read the URL, re-run the bootstrap as `App`'s `useMemo` does — and asserts the connection id and the tour state survive it.

Verified it catches the bug: reverting the fix fails 3 of 6 (scope, tour state, hash).

## Not included

The issue's optional second half — collapsing an already-orphaned `(baseUrl:"", defaultCompany:null)` row on restore. Two reasons:

- It can't be distinguished from a legitimate alias-mode profile. `findProfile` documents that `?company=a` and the no-company form are deliberately two different consoles with separate view state, so a blanket collapse would merge real state for anyone who has opened a host both ways.
- `isThisConsole` already skips rather than forgets, so the stale row does **not** appear in the host switcher. What remains is an inert `localStorage` entry, not a visible duplicate.

If you want it cleaned up anyway, I'd suggest a one-shot versioned migration (`oc.connections.v1` → `v2`) rather than a heuristic on every restore — happy to add it here or as a follow-up.

## Commands run

```
npm run typecheck        # clean
npm run typecheck:unit   # clean
npx vitest run           # 203 files, 1925 tests passed
```

No `eslint.config.*` exists in `frontend/`, so there is no lint step to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)