### PR TITLE
fix(server): fail closed on a poisoned run supervisor too

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -713,10 +713,18 @@ impl CompanyRuntime {
     ///   otherwise be covered — it is kept for the case where a turn's steerable
     ///   run outlives the cycle that started it.
     ///
-    /// Cheap by construction: a non-blocking `try_lock`, a map emptiness check,
-    /// and one `std::sync::Mutex` acquisition. The platform calls this once per
-    /// idle tenant per reconcile scan against a short timeout, so anything that
-    /// could block would turn a slow company into a stalled sweep.
+    /// Every arm fails closed: the two registries report **busy** on a poisoned
+    /// mutex rather than panicking, because a panic here reaches an axum handler
+    /// with no `CatchPanicLayer` and the manager's reading of a reset connection
+    /// is to park (issues #1133, #1239).
+    ///
+    /// Cheap by construction: a non-blocking `try_lock` and at most two
+    /// `std::sync::Mutex` acquisitions — one for the run supervisor's map (the
+    /// emptiness check *is* a lock) and one for the steer registry. `||`
+    /// short-circuits, so a company already holding its cycle lock takes
+    /// neither. The platform calls this once per idle tenant per reconcile scan
+    /// against a short timeout, so anything that could block would turn a slow
+    /// company into a stalled sweep.
     pub fn is_busy(&self) -> bool {
         self.serial.try_lock().is_err()
             || !self.run_supervisor.is_empty()
@@ -3167,6 +3175,33 @@ mod tests {
             assert!(runtime.is_busy(), "a registered steer run must report busy");
         }
         assert!(!runtime.is_busy(), "the steer guard must clear it on drop");
+    }
+
+    /// A poisoned run supervisor must make `is_busy` report **busy**.
+    ///
+    /// The predicate's advertised invariant is that it fails closed, and #1133
+    /// only delivered that for two of its three sources: `steer.any_inflight`
+    /// was made poison-tolerant, but the `run_supervisor` arm still reached a
+    /// `.expect` through `len`. `GET /healthz/busy` has no `CatchPanicLayer`, so
+    /// that panic reset the connection, the manager read it as "cannot tell",
+    /// and its default is to park — losing the work the endpoint exists to
+    /// protect (issue #1239).
+    ///
+    /// Outside any feature gate on purpose, matching
+    /// `is_busy_sees_every_source_of_work`: the run supervisor is wired on the
+    /// default build, and this must not be a test that only CI's `openhuman`
+    /// lane runs.
+    #[tokio::test]
+    async fn is_busy_fails_closed_on_a_poisoned_run_supervisor() {
+        let (runtime, _record, _home) = runtime_and_record().await;
+        assert!(!runtime.is_busy(), "an idle runtime must not report busy");
+
+        runtime.run_supervisor().poison_for_test();
+
+        assert!(
+            runtime.is_busy(),
+            "a poisoned run supervisor must report busy rather than panic in the handler"
+        );
     }
 
     async fn runtime_and_record() -> (

--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -203,7 +203,12 @@ impl InflightRegistry {
         Self::default()
     }
 
-    /// Whether any company in this process has a run in flight.
+    /// Whether any run this registry tracks is in flight.
+    ///
+    /// The map is keyed by company, but the builder mints one registry per
+    /// company runtime, so in practice this answers for a single company;
+    /// `GET /healthz/busy` is what ORs the answer across every company in the
+    /// process.
     ///
     /// The manager consults this — through the workload's busy endpoint — before
     /// scaling a tenant to zero. Its own notion of "idle" is inbound proxied

--- a/src/runtime/run_supervisor.rs
+++ b/src/runtime/run_supervisor.rs
@@ -207,14 +207,58 @@ impl RunSupervisor {
             .collect()
     }
 
-    /// How many runs are currently registered. For tests and diagnostics.
+    /// How many runs are currently registered.
+    ///
+    /// For tests and diagnostics, and it stays that way: it keeps the `expect`,
+    /// so [`is_empty`](Self::is_empty) — which *is* on a production path —
+    /// deliberately does not route through it.
     pub fn len(&self) -> usize {
         self.inner.lock().expect("run supervisor poisoned").len()
     }
 
     /// Whether no run is registered.
+    ///
+    /// Poison-tolerant, and it reports **not empty** — that is, busy — rather
+    /// than panicking. [`CompanyRuntime::is_busy`] reads this for
+    /// `GET /healthz/busy`, and a panic there reaches an axum handler with no
+    /// `CatchPanicLayer`: the connection resets, the manager reads that as
+    /// "cannot tell", and its default is to park — losing the very work this
+    /// exists to protect, at the one moment the registry is in an unknown state.
+    ///
+    /// Reporting busy on poison is bounded: the manager parks anyway once a
+    /// tenant exceeds its idle timeout plus the busy extension, so a permanently
+    /// poisoned supervisor delays a park rather than preventing one.
+    ///
+    /// This mirrors [`InflightRegistry::any_inflight`], the sibling arm of the
+    /// same predicate, which was given this treatment in #1133 while this one
+    /// was missed (issue #1239).
+    ///
+    /// [`CompanyRuntime::is_busy`]: crate::company::runtime::CompanyRuntime::is_busy
+    /// [`InflightRegistry::any_inflight`]: crate::company::steer::InflightRegistry::any_inflight
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        let Ok(runs) = self.inner.lock() else {
+            return false;
+        };
+        runs.is_empty()
+    }
+
+    /// Poisons the inner mutex so a test can exercise the fail-closed read.
+    ///
+    /// Test-only: nothing in production has a reason to poison a lock. The
+    /// panic it provokes is caught by the joined thread, but the default panic
+    /// hook still prints one line to the test output — that line is expected.
+    #[cfg(test)]
+    pub(crate) fn poison_for_test(&self) {
+        let inner = Arc::clone(&self.inner);
+        let _ = std::thread::spawn(move || {
+            let _guard = inner.lock().expect("run supervisor poisoned");
+            panic!("poisoning the run supervisor for a test");
+        })
+        .join();
+        assert!(
+            self.inner.lock().is_err(),
+            "the helper must actually leave the mutex poisoned"
+        );
     }
 }
 
@@ -245,6 +289,32 @@ impl Drop for RunGuard {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// A poisoned supervisor must report **busy**, not panic.
+    ///
+    /// `is_empty` is read by `CompanyRuntime::is_busy` behind
+    /// `GET /healthz/busy`, whose router has no `CatchPanicLayer`. A panic there
+    /// resets the connection, the manager reads that as "cannot tell", and its
+    /// default is to park — destroying the in-flight work the endpoint exists to
+    /// protect, at the one moment the registry's state is unknown (issue #1239).
+    ///
+    /// `len` is the other half of the contract: it is test-and-diagnostics only,
+    /// so it keeps its `expect`, and `is_empty` therefore cannot be written as
+    /// `self.len() == 0` — which is precisely how the panic got onto the
+    /// production path in the first place.
+    #[test]
+    fn a_poisoned_supervisor_reports_busy_instead_of_panicking() {
+        let supervisor = RunSupervisor::new();
+        assert!(supervisor.is_empty(), "an untouched supervisor is empty");
+
+        supervisor.poison_for_test();
+
+        assert!(
+            !supervisor.is_empty(),
+            "a poisoned supervisor must read as not-empty, so is_busy reports busy \
+             and the manager does not park a company mid-run"
+        );
+    }
 
     /// The core loop: a begun run is registered under the id its context
     /// carries, cancelling fires the signal that context holds, and the guard

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -688,8 +688,9 @@ mod tests {
     /// iterates nothing and returns `false` without consulting any runtime, so
     /// this cannot fail for an aggregation bug. The direction that matters —
     /// that the endpoint can report `true` — is covered by
-    /// `is_busy_sees_a_cycle_holding_the_serial_lock` in `company::runtime`,
-    /// which exercises the real signal against a real runtime.
+    /// `is_busy_sees_every_source_of_work` in `company::runtime`, which
+    /// exercises the real signal against a real runtime, and by
+    /// `is_busy_fails_closed_on_a_poisoned_run_supervisor` alongside it.
     #[tokio::test]
     async fn busy_is_false_when_nothing_is_running() {
         let app = router(AppState::new(AppConfig::default()));


### PR DESCRIPTION
Fixes #1239.

#1133 gave the busy predicate a fail-closed invariant and delivered it for two of its three sources. `steer.any_inflight` was made poison-tolerant; the `run_supervisor` arm was not.

## The panic path

`CompanyRuntime::is_busy` reads `run_supervisor.is_empty()`, which was `self.len() == 0`, and `len` is `self.inner.lock().expect("run supervisor poisoned")`. So a poisoned mutex panicked inside the `GET /healthz/busy` handler.

I grepped for a panic layer to check the consequence rather than assume it: the crate has **no `CatchPanicLayer` at all** — the only match anywhere is the comment in `steer.rs` noting its absence. So the connection resets, the manager reads that as "cannot tell", and its default is to park: losing the in-flight work the endpoint exists to protect, at the one moment the registry's state is unknown.

That reasoning is not new here. It is the comment `any_inflight` already carries, applied to its sibling arm — `1eab071e` hardened `steer.rs` and `runtime.rs` and never touched `run_supervisor.rs`.

## The fix

`is_empty` now locks directly and reports **not empty** — that is, busy — on poison. Bounded rather than absolute, same as the steer arm: the manager parks anyway once a tenant passes its idle timeout plus the busy extension, so a permanently poisoned supervisor delays a park instead of preventing one.

`len` keeps its `expect` and its doc now says why. Every caller is a test or a diagnostic, so it is not on a production path — which is exactly why `is_empty` must not be written in terms of it. Writing it that way is how the panic reached the handler in the first place.

## Tests

Both sit outside any feature gate, because the run supervisor is wired on the default build and this must not be something only the `openhuman` lane runs.

- `a_poisoned_supervisor_reports_busy_instead_of_panicking` — the unit.
- `is_busy_fails_closed_on_a_poisoned_run_supervisor` — the invariant that actually matters.

**Both verified non-vacuous:** restoring `self.len() == 0` makes each fail with the real `run supervisor poisoned` panic rather than an assertion. The `#[cfg(test)] poison_for_test` helper asserts it genuinely left the mutex poisoned, so it cannot silently no-op; the one panic line it prints to test output is expected and documented.

## Three doc corrections from the same review round

- `is_busy` claimed "a map emptiness check, and one `std::sync::Mutex` acquisition". There are **two** — the map emptiness check *is* the second one. It now says two, names which is which, notes `||` short-circuits so a company already holding its cycle lock takes neither, and states the fail-closed invariant, which was advertised in review but written down nowhere.
- `any_inflight` said it reports "whether any company in this process has a run in flight". The map is keyed by company, but the builder mints one registry per company runtime (`builder.rs`, `InflightRegistry::new()` inside the per-company build), so it answers for one; `/healthz/busy` is what ORs across the process.
- `routes.rs` pointed at `is_busy_sees_a_cycle_holding_the_serial_lock`, a test renamed to `is_busy_sees_every_source_of_work` in `42d95143`. Repointed, with the new poison test named alongside it.

I left `routes.rs`'s "one `Mutex` acquisition each" alone. Read as "one each per registry" it is correct, and #1239 says it was corrected properly.

## Verification

- Full default-build lib suite: **3273 passed, 0 failed, 1 ignored**.
- `cargo fmt --check` on the four touched files, and `cargo clippy --lib --all-targets`: clean.
- Rustdoc broken-intra-doc-link count is **288 before and after**, so the two new links resolve and nothing regressed. (That pre-existing count is a repo-wide condition, untouched here.)

## Worth knowing before reading this as a production fix

The #1239 residuals sent me to check the manager, and against `opencompany-microservice` main (`9a64876`) **the busy signal is inert in production today**, for two independent reasons:

- **Nothing sets `OCM_TENANT_BUSY_PATH`.** It appears only in `.env.example` — no YAML in that repo contains it, including `deploy/k8s/manager.yaml`. `reconcile.rs` treats an unset path as `NotAsked`, so the idle timer alone decides, exactly as before the feature.
- **`KubeRuntime::is_busy` never returns `Err`.** Timeout, non-2xx, malformed JSON, missing field and wrong type each `return Ok(false)`. That makes the "Loud on purpose" `warn!("busy signal unreachable…")` in `reconcile.rs` dead code for every failure mode it was written to cover. #1239's "no log on any of them" residual is still true, for a subtler reason than when it was filed. `{"busy":"true"}` still parses as not-busy via `as_bool`.

So this change is correct and worth landing, but do not read an absence of park incidents as evidence the signal works — it is not being consulted. Those are manager-repo changes, so they are not in this PR; filing them separately there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
