### PR TITLE
feat(memory): pick the memory engine from the console, and drop documents into it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+dependencies = [
+ "debug_unsafe",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +658,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ae05a4e39297eecf9a994210d27501318c37a9318201f8e11050add82bb6f0"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml 0.39.4",
+ "serde",
+ "zip 7.2.0",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +709,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cff-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
 
 [[package]]
 name = "cfg-if"
@@ -838,6 +879,15 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1208,6 +1258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1605,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-float2"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e8948ce679d00a02a94739ea185595dca7118ed04feb991127e443bd3d761f"
 
 [[package]]
 name = "fast_chemail"
@@ -1577,6 +1657,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2708,6 +2789,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lopdf"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
+dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.3",
+ "indexmap",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "nom 8.0.0",
+ "rand 0.10.2",
+ "rangemap",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.20",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,6 +2901,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "md-5"
@@ -2908,7 +3026,7 @@ dependencies = [
  "hickory-resolver 0.26.1",
  "hmac 0.13.0",
  "macro_magic",
- "md-5",
+ "md-5 0.11.0",
  "mongocrypt",
  "mongodb-internal-macros",
  "pbkdf2",
@@ -3155,6 +3273,7 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "bytes",
+ "calamine",
  "clap",
  "criterion",
  "ed25519-dalek",
@@ -3170,6 +3289,8 @@ dependencies = [
  "mime_guess",
  "mongodb",
  "openhuman",
+ "pdf-extract",
+ "quick-xml 0.41.0",
  "rand_core 0.6.4",
  "regex",
  "reqwest",
@@ -3202,6 +3323,7 @@ dependencies = [
  "url",
  "uuid",
  "webpki-roots 1.0.9",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -3283,7 +3405,7 @@ dependencies = [
  "windows-sys 0.61.2",
  "x25519-dalek",
  "zeroize",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -3407,6 +3529,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "pdf-extract"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
+dependencies = [
+ "adobe-cmap-parser",
+ "cff-parser",
+ "encoding_rs",
+ "euclid",
+ "log",
+ "lopdf",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3613,10 +3752,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -3669,6 +3820,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3844,6 +4014,12 @@ checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
 
 [[package]]
 name = "redox_syscall"
@@ -5806,6 +5982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5822,6 +6004,15 @@ dependencies = [
  "rustls-pki-types",
  "sha1 0.10.7",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
 ]
 
 [[package]]
@@ -5849,6 +6040,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -6149,6 +6346,12 @@ checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "widestring"
@@ -6723,6 +6926,40 @@ dependencies = [
  "thiserror 2.0.20",
  "zopfli",
 ]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,7 +378,11 @@ default = ["oauth", "platform-jwt", "documents"]
 # storing an empty memory — while plain text, Markdown, HTML, JSON, CSV and
 # source files are extracted by the always-compiled path. In the default set;
 # see the dependency block for why.
-documents = ["dep:pdf-extract", "dep:calamine", "dep:quick-xml", "dep:zip"]
+# `reqwest` rides along because "remember this link" is the same feature as
+# "remember this file" from the operator's side, and a build that reads a
+# dropped PDF but cannot fetch a URL would be a distinction nobody asked for.
+# It is already in the default set via `oauth`, so this adds nothing there.
+documents = ["dep:pdf-extract", "dep:calamine", "dep:quick-xml", "dep:zip", "dep:reqwest"]
 
 tiny = ["tinyagents"]
 # WS4: embed `vendor/openhuman` (`openhuman_core`) directly as the tenant agent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,27 @@ hmac = { version = "0.12", optional = true }
 # links no network crates" invariant is untouched. Feature-gating them instead
 # would push `#[cfg]` through StorageHandles, three backends, and the
 # conformance suite to defend nothing.
+# ────────────────────────────────────────────────────────────────────────────
+# Document text extraction for Brain uploads (`documents` feature)
+# ────────────────────────────────────────────────────────────────────────────
+# What a file dropped on the Brain page has to become before memory can hold
+# it: text. Plain formats need nothing; these three cover the ones an operator
+# actually drops — a contract PDF, a spec `.docx`, a pricing `.xlsx`, a deck.
+#
+# In the DEFAULT feature set, on the `oauth` precedent: the drop zone is a
+# first-class console surface, and a shipped build where dropping a PDF stores
+# nothing would be a feature that exists only for people who compile their own
+# binary. All three are pure Rust with no system libraries.
+#
+# `zip` + `quick-xml` are the whole of OOXML: `.docx`, `.pptx` are zip archives
+# of XML, and walking them directly is smaller than a document library. `.xlsx`
+# is not — shared-string tables and cell typing make hand-parsing it a
+# liability — so `calamine` reads that one.
+pdf-extract = { version = "0.12", optional = true }
+calamine = { version = "0.34", optional = true }
+quick-xml = { version = "0.41", optional = true }
+zip = { version = "6", default-features = false, features = ["deflate"], optional = true }
+
 sha2 = "0.10"
 getrandom = "0.4"
 
@@ -350,7 +371,15 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 # and *run* by nothing. Moving it into the default set makes both `cargo test`
 # lanes execute them, which is why this needs no new CI lane. It costs one pure
 # dependency (`jsonwebtoken`), already in `Cargo.lock`.
-default = ["oauth", "platform-jwt"]
+default = ["oauth", "platform-jwt", "documents"]
+# Text extraction for files dropped on the Brain page (PDF, Word, Excel,
+# PowerPoint). Without it those formats still upload and are still refused
+# honestly — the route reports "no text could be extracted" rather than
+# storing an empty memory — while plain text, Markdown, HTML, JSON, CSV and
+# source files are extracted by the always-compiled path. In the default set;
+# see the dependency block for why.
+documents = ["dep:pdf-extract", "dep:calamine", "dep:quick-xml", "dep:zip"]
+
 tiny = ["tinyagents"]
 # WS4: embed `vendor/openhuman` (`openhuman_core`) directly as the tenant agent
 # harness via `AgentBuilder`. `src/harness/` compiles only under this feature;

--- a/docs/spec/company-brain/memory.md
+++ b/docs/spec/company-brain/memory.md
@@ -74,10 +74,46 @@ not wired:
   carry them; no `Brain` consumed the field, so it was removed rather than left
   looking functional.
 - `evict` is implemented on every backend and called from no production path,
-  so the trace window is unbounded. `ContextStore` has no delete verb at all,
-  so the chunk store only grows — which is also why deleting an operator fact
-  leaves its `ContextStore` mirror agent-recallable
-  (`src/server/ops/memory.rs`), against the Delete right below.
+  so the trace window is unbounded. `ContextStore::delete` does exist (it is
+  what reaps an operator fact's mirror and what forgets a dropped document),
+  but nothing sweeps the chunk store on age, so it grows until something
+  deletes by name.
+
+## Dropping documents and links in (the Brain drop zone)
+
+An operator can put a file, a whole folder, or a link into memory by dropping
+it on the Brain page. The host extracts its text, chunks it, and writes the
+chunks to the `ContextStore` under a `document/{slug}/{index}` label — the
+same store agent recall reads, so a dropped handbook reaches a teammate on its
+next turn with no further step (`src/ingest`,
+`src/server/ops/memory_ingest.rs`).
+
+Four properties are normative, because each is a way this could quietly lie:
+
+- **The text is stored, the file is not.** Memory keeps what the document
+  *said*. Files an operator wants back live in the workspace tree; a second
+  copy of every upload there would make the Brain page a silently diverging
+  file manager. Re-dropping is how a document is corrected.
+- **Extraction never guesses.** A format the build cannot read is reported as
+  unsupported per file, never stored as decoded noise that would count as a
+  memory and recall as nothing. Text, Markdown, HTML, JSON and CSV need no
+  parser; PDF, `.docx`, `.xlsx` and `.pptx` ride the `documents` feature (in
+  the default set). A scanned PDF with no text layer is *empty*, which is a
+  different answer from *failed* and is said differently.
+- **Every file gets its own row in the answer.** A real folder always contains
+  a `.DS_Store`, an image, or a scanned page; failing the batch over one would
+  make folder drops unusable, and skipping it silently would leave the
+  operator believing the whole folder is in memory.
+- **A drop can be taken back.** `DELETE …/memory/document/{slug}` forgets every
+  chunk of one document — the Delete right below, applied to the one context
+  origin an operator authored. It honours the shared-address rule: a chunk
+  whose byte-identical body is also indexed under another label is left alone
+  rather than deleting somebody else's row.
+
+Links are fetched **by the host** (a browser cannot, cross-origin), so the URL
+path is guarded server-side: `http`/`https` only, and never a loopback,
+link-local or private address — "remember this page" must not become a read
+primitive against the deployment's own network.
 
 ## Operator rights (normative)
 

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -135,6 +135,29 @@ that does and does not imply.
 | `OPENCOMPANY_PLATFORM_TOKEN` | — (no machine credential) | The shared platform secret. A bearer equal to it is the `tenant:platform` principal, with the `platform` scope |
 | `OPENCOMPANY_PLATFORM_JWT_SECRET` | — (signed tenant tokens not accepted) | HS256 secret that signs tenant-scoped machine tokens. No shipped literal and no fallback: unset means the path does not exist. Set on a build without `platform-jwt` (in the default feature set) and the host **refuses to boot** |
 
+### The `[memory]` section
+
+The memory engine is the one host-level choice the **console** can write, and
+it is the ordinary `env ⟵ config.toml` precedence rather than an exception to
+it:
+
+```toml
+[memory]
+backend = "remote"          # store | embedded | remote | null
+driver  = "supermemory"     # supermemory | mem0 | cognee | namespace
+url     = "https://api.supermemory.ai"
+api_key = "sk-…"
+```
+
+`OPENCOMPANY_MEMORY` **set at all** — whatever it names — makes this section
+inert and the console read-only, because a hosted tenant's control plane
+injects those variables and a picker that wrote a file the next boot ignores
+would be the silently-ignored-configuration failure the setup flow refuses for
+the same reason. Unset, this section is what boot binds, and
+`PUT …/memory/engine` is what writes it — probing the engine first, then
+rebinding it live so the choice does not wait for a restart. See
+[the memory engine](memory-engine.md#choosing-an-engine-from-the-console).
+
 ### Outbound mail
 
 Two credential scopes, deliberately separate:

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -326,19 +326,48 @@ OPENCOMPANY_MONGODB_URI=mongodb://…
 # → boots; engine memory persists under /data/memory/<workspace>/ as usual.
 ```
 
-## Selection scope — a decision, not a gap (2026-08-20)
+## Choosing an engine from the console
 
-Engine selection is **infra-operator only**: instance-wide, expressed through
-the `OPENCOMPANY_MEMORY*` environment, read once at boot. There is no
-per-company selection, no per-agent selection, no API setter, and no Console
-setter — the Console's Brain and Settings panels are read-only views of
-`/spec` by design, so a console admin can see the engine but never repoint a
-deployment's storage. This deliberately does **not** follow the per-company
-`[inference]` model, for the reason recorded at the selection site in
-`src/store/select.rs`: memory is storage, and nothing model-shaped may ever
-repoint it. A deployment with mixed needs runs the engine that fits its
-dominant workload; splitting workloads across engines (traces local, facts
-hosted) is a possible future refinement of *routing*, not of selection.
+Engine selection stays **instance-wide** — one engine per host, every company
+on it sharing that engine — but it is no longer environment-only. `config.toml`
+gained a `[memory]` section, and `…/memory/engine` is the surface that writes
+it:
+
+```text
+GET  …/memory/engine        what is bound, what is saved, what may be picked
+POST …/memory/engine/test   probe a candidate without saving it
+PUT  …/memory/engine        save it, bind it, and put it in force
+```
+
+Three properties make this safe to hand an admin, and each is a refusal rather
+than a convention:
+
+- **The environment still wins.** `OPENCOMPANY_MEMORY` set at all makes the
+  file layer inert, the console read-only, and a `PUT` a `409` naming the
+  variable. A hosted tenant's control plane injects those variables, so a
+  console that accepted the edit would write a file, report success, and change
+  nothing at the next boot.
+- **An engine that does not answer is not bound.** The route opens the
+  candidate, probes it, and refuses on a failed probe, leaving the previous
+  overlay in force — the opposite of boot, which binds and warns because a
+  transient vendor outage must not crash-loop a tenant. `?force=true` is the
+  escape hatch.
+- **It applies live, or says which companies it did not reach.** The new
+  overlay is swapped onto the `AppState` and every registered company is
+  rebuilt through `RuntimeRebuilder`; a company that cannot be rebuilt is
+  *named* in `restartRequiredFor` rather than covered by a blanket "restart
+  required". The credential is never read back out — the route reports whether
+  a key is set, never its bytes.
+
+What has **not** changed, and is still a decision rather than a gap: there is
+no per-company and no per-agent selection. Memory is storage, and nothing
+model-shaped may repoint it — this deliberately does not follow the
+per-company `[inference]` model, for the reason recorded at the selection site
+in `src/store/select.rs`. Splitting workloads across engines (traces local,
+facts hosted) remains a possible refinement of *routing*, not of selection.
+
+**Switching still moves no data.** A new engine starts empty; see the runbook
+below, whose migration step is the only thing that moves records.
 
 ## Depth: taint, deliberate memory, and what is deliberately not wired
 
@@ -382,10 +411,10 @@ re-derives them:
 
 ## Switching engines — the operator runbook
 
-Selection is infra-operator only (previous section), so switching is an env
-flip plus a restart — and because **the flip alone moves no data** (a
-switched engine starts empty until something puts records in it), the
-migration below is the step that moves it, and it comes first.
+Whether the switch is a console apply or an env flip plus a restart, **the
+switch alone moves no data** — a switched engine starts empty until something
+puts records in it — so the migration below is the step that moves it, and it
+comes first.
 
 0. **Stop the writes.** Pause the workload (or scale the tenant to zero)
    before migrating: the copy is page-by-page with no dual-write, so anything

--- a/frontend/src/api/memory.ts
+++ b/frontend/src/api/memory.ts
@@ -11,8 +11,9 @@ export type MemoryKind = "fact" | "preference" | "person" | "project" | "referen
 
 /**
  * Where a memory row came from — the host's `MemoryOrigin` discriminator.
- * `fact` rows are operator-authored (editable/deletable); `agent-memory` and
- * `task-outcome` rows are the agents' own runtime memory and are read-only.
+ * `fact` rows are operator-authored and `document` rows are files or links an
+ * operator dropped — both deletable; `agent-memory` and `task-outcome` rows
+ * are the agents' own runtime memory and are read-only.
  */
 export type MemoryOrigin = "fact" | "agent-memory" | "task-outcome" | "document";
 
@@ -23,7 +24,10 @@ export interface MemoryEntry {
   kind?: MemoryKind;
   /** Which backend the row came from; drives editable-vs-read-only rendering. */
   origin: MemoryOrigin;
-  /** Whether the operator may delete this row (true only for `fact` rows). */
+  /**
+   * Whether the operator may delete this row: `fact` rows, and `document`
+   * rows they dropped themselves. The agents' own memory is read-only.
+   */
   editable: boolean;
   title: string;
   body: string;

--- a/frontend/src/api/memory.ts
+++ b/frontend/src/api/memory.ts
@@ -14,7 +14,7 @@ export type MemoryKind = "fact" | "preference" | "person" | "project" | "referen
  * `fact` rows are operator-authored (editable/deletable); `agent-memory` and
  * `task-outcome` rows are the agents' own runtime memory and are read-only.
  */
-export type MemoryOrigin = "fact" | "agent-memory" | "task-outcome";
+export type MemoryOrigin = "fact" | "agent-memory" | "task-outcome" | "document";
 
 /** One memory row as the host returns it (an operator fact OR an agent chunk). */
 export interface MemoryEntry {
@@ -88,13 +88,18 @@ export const KIND_STYLES: Record<MemoryKind, string> = {
 };
 
 /** The read-only context origins, in display order (facts filter by kind). */
-export const CONTEXT_ORIGINS: Exclude<MemoryOrigin, "fact">[] = ["agent-memory", "task-outcome"];
+export const CONTEXT_ORIGINS: Exclude<MemoryOrigin, "fact">[] = [
+  "agent-memory",
+  "task-outcome",
+  "document",
+];
 
 /** Human labels for each origin, for badges and the type filter. */
 export const ORIGIN_LABELS: Record<MemoryOrigin, string> = {
   fact: "Fact",
   "agent-memory": "Teammate memory",
   "task-outcome": "Task outcome",
+  document: "Document",
 };
 
 /** Per-origin badge styling for the read-only context rows. */
@@ -104,6 +109,11 @@ export const ORIGIN_STYLES: Record<Exclude<MemoryOrigin, "fact">, string> = {
   // not itself a failure, which is what the rose it used to wear implied of
   // every one of them.
   "task-outcome": "border-tone-5/30 bg-tone-5/10 text-tone-5-text",
+  // Identity, like every other row here: a document memory says where the
+  // knowledge came from, not how it is doing. It shares `fact`'s blue on
+  // purpose — both are knowledge the operator supplied, as against the two
+  // origins beside it, which are the agents' own record of their work.
+  document: "border-tone-2/30 bg-tone-2/10 text-tone-2-text",
 };
 
 /** The company's durable facts, newest-first, optionally filtered server-side. */
@@ -143,4 +153,183 @@ export function memoryStats(
   company: string | null,
 ): Promise<MemoryStats> {
   return client.get<MemoryStats>(`${client.scopeFor(company)}/memory/stats`);
+}
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The memory engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One engine the host offers, from `GET …/memory/engine`. */
+export interface EngineOption {
+  /** `store` | `embedded` | `namespace` | `supermemory` | `mem0` | `cognee` | `null`. */
+  id: string;
+  label: string;
+  description: string;
+  /** Whether this build can bind it. A `false` tile renders disabled. */
+  available: boolean;
+  /** Which feature it needs, when it is not available. */
+  unavailableReason?: string;
+  requiresUrl: boolean;
+  requiresKey: boolean;
+  /** `false` only for the null engine, which the picker warns on. */
+  durable: boolean;
+}
+
+/** The engine surface: bound, saved, and selectable. */
+export interface MemoryEngineState {
+  /** The engine actually in force right now. */
+  active: string;
+  capabilities: string[];
+  healthy?: boolean;
+  /** The engine the saved selection names. */
+  selected: string;
+  url?: string;
+  /** Whether a credential is stored. The bytes never come back. */
+  apiKeySet: boolean;
+  /** `env` | `config.toml` | `default` — which layer owns the choice. */
+  layer: string;
+  /** Whether this console may change it (false when the deployment owns it). */
+  editable: boolean;
+  configPath: string;
+  options: EngineOption[];
+}
+
+/** What an engine apply did. */
+export interface EngineApplied {
+  engine: string;
+  healthy?: boolean;
+  /** Companies still holding the previous engine until a restart. */
+  restartRequiredFor: string[];
+  configPath: string;
+  engineState: MemoryEngineState;
+}
+
+/** A probe of a candidate engine, saving nothing. */
+export interface EngineProbe {
+  healthy: boolean;
+  capabilities: string[];
+  detail?: string;
+}
+
+/** A submitted engine choice. Omit `apiKey` to keep the stored one. */
+export interface EngineChoice {
+  engine: string;
+  url?: string;
+  apiKey?: string;
+}
+
+/** The engine surface. */
+export function memoryEngine(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<MemoryEngineState> {
+  return client.get<MemoryEngineState>(`${client.scopeFor(company)}/memory/engine`);
+}
+
+/** Probes a candidate engine without saving it. */
+export function testMemoryEngine(
+  client: OpenCompanyClient,
+  company: string | null,
+  choice: EngineChoice,
+): Promise<EngineProbe> {
+  return client.post<EngineProbe>(`${client.scopeFor(company)}/memory/engine/test`, choice);
+}
+
+/** Saves an engine, binds it, and puts it in force. */
+export function applyMemoryEngine(
+  client: OpenCompanyClient,
+  company: string | null,
+  choice: EngineChoice,
+): Promise<EngineApplied> {
+  return client.put<EngineApplied>(`${client.scopeFor(company)}/memory/engine`, choice);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dropping documents and links into memory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** What happened to one dropped file or link. */
+export interface IngestedItem {
+  /** The file name, the relative path inside a dropped folder, or the URL. */
+  source: string;
+  status: "stored" | "empty" | "unsupported" | "failed";
+  chunks: number;
+  detail?: string;
+}
+
+/** A whole drop's outcome — one row per source, never one for the batch. */
+export interface Ingested {
+  items: IngestedItem[];
+  chunks: number;
+  stored: number;
+}
+
+/**
+ * One file on its way to memory: the browser's `File` plus the path it had
+ * inside a dropped folder.
+ *
+ * The path is sent as the part's filename, because it is what the operator
+ * sees in their own file manager and the only thing telling four `README.md`s
+ * apart.
+ */
+export interface DroppedFile {
+  path: string;
+  file: File;
+}
+
+/** Uploads one batch of files for extraction into memory. */
+export function ingestDocuments(
+  client: OpenCompanyClient,
+  company: string | null,
+  files: DroppedFile[],
+): Promise<Ingested> {
+  const form = new FormData();
+  for (const { path, file } of files) {
+    form.append("file", file, path);
+  }
+  return client.postForm<Ingested>(`${client.scopeFor(company)}/memory/ingest`, form);
+}
+
+/** Fetches links host-side and remembers what they said. */
+export function ingestLinks(
+  client: OpenCompanyClient,
+  company: string | null,
+  urls: string[],
+): Promise<Ingested> {
+  return client.post<Ingested>(`${client.scopeFor(company)}/memory/ingest/links`, { urls });
+}
+
+/**
+ * Forgets every chunk of one dropped document.
+ *
+ * Keyed by the label slug the host derived, which is what a document row's
+ * `id` carries — see `documentSlug`.
+ */
+export function forgetDocument(
+  client: OpenCompanyClient,
+  company: string | null,
+  slug: string,
+): Promise<{ forgotten: number }> {
+  return client.del<{ forgotten: number }>(
+    `${client.scopeFor(company)}/memory/document/${encodeURIComponent(slug)}`,
+  );
+}
+
+/**
+ * The label slug the host derived for a source name.
+ *
+ * A copy of the backend's `ingest::label_for`, because a document row carries
+ * its chunk address rather than its label and the forget route addresses
+ * documents by slug. Kept deliberately narrow — same character class, same
+ * 96-character tail — and covered by `memory-slug.test.ts` against the cases
+ * the Rust test pins.
+ */
+export function documentSlug(source: string): string {
+  const slug = Array.from(source)
+    .map((c) => (/[A-Za-z0-9._-]/.test(c) ? c.toLowerCase() : "-"))
+    .join("")
+    .replace(/^-+|-+$/g, "");
+  const safe = slug || "document";
+  return Array.from(safe).length > 96 ? Array.from(safe).slice(-96).join("") : safe;
 }

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -10,18 +10,22 @@ import {
   CONTEXT_ORIGINS,
   createMemory,
   deleteMemory,
+  documentSlug,
+  forgetDocument,
   KIND_STYLES,
   listMemory,
   MEMORY_KINDS,
   memoryStats,
   ORIGIN_LABELS,
   ORIGIN_STYLES,
+  type MemoryEngineState,
   type MemoryEntry,
   type MemoryKind,
   type MemoryStats,
 } from "@/api/memory";
 import type { OpenCompanyClient } from "@/api/client";
-import type { MemorySpec } from "@/api/types";
+import { DropZone } from "@/views/memory/DropZone";
+import { EngineSection } from "@/views/memory/EngineSection";
 import { Markdown } from "@/components/markdown";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -156,28 +160,14 @@ export function MemoryView({ client, company }: Props) {
     };
   }, [load]);
 
-  // The bound memory engine, from the unauthenticated /spec handshake. Shown
-  // so an operator can see which engine is live and — for a remote driver
-  // serving only the mandatory families — what it does NOT support, before a
-  // cycle discovers it. undefined = host predates the field; render nothing.
-  const [engine, setEngine] = useState<MemorySpec | undefined>(undefined);
-  useEffect(() => {
-    let live = true;
-    // Clear first: on a client swap the old badge would otherwise survive a
-    // failed /spec and name the wrong host.
-    setEngine(undefined);
-    client
-      .spec()
-      .then((spec) => {
-        if (live) setEngine(spec.memory);
-      })
-      .catch(() => {
-        /* spec is best-effort here; the Brain view works without it */
-      });
-    return () => {
-      live = false;
-    };
-  }, [client]);
+  // The bound memory engine, from the engine route rather than `/spec`.
+  //
+  // One source, because the two can now disagree: `/spec`'s snapshot is what
+  // boot bound, and an operator who switches engines from the section below
+  // changes what is bound without restarting. A header badge naming the
+  // previous engine would be the most confusing possible answer to "did my
+  // change take".
+  const [engine, setEngine] = useState<MemoryEngineState | null>(null);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -202,8 +192,7 @@ export function MemoryView({ client, company }: Props) {
   // button beside that warning invites work the host will silently drop
   // (issue #1410). The panel's health dot already refuses to go green here for
   // the same reason.
-  const mode = enginePanelMode(engine);
-  const discarding = mode === "discard";
+  const discarding = engine?.active === "null";
 
   async function add(fields: { kind: MemoryKind; title: string; body: string }) {
     await createMemory(client, company, fields);
@@ -215,7 +204,15 @@ export function MemoryView({ client, company }: Props) {
     // Optimistic: drop the card immediately, then reconcile counts from the host.
     setEntries((all) => all.filter((x) => x.id !== entry.id));
     try {
-      await deleteMemory(client, company, entry.id);
+      if (entry.origin === "document") {
+        // A document is many chunks under one slug, so forgetting it is one
+        // call against the document — deleting the card's own chunk would
+        // leave the rest of the file in memory, which is worse than not
+        // offering a delete at all.
+        await forgetDocument(client, company, documentSlug(entry.source));
+      } else {
+        await deleteMemory(client, company, entry.id);
+      }
       await load({ silent: true });
     } catch (e) {
       // Re-insert only this entry on failure (no whole-list rollback).
@@ -236,7 +233,7 @@ export function MemoryView({ client, company }: Props) {
             </p>
           </div>
           <div className="flex items-center gap-3">
-            {engine && mode !== "hidden" && (
+            {engine && (
               <span
                 className={cn(
                   "rounded-full border px-3 py-1 text-xs",
@@ -256,7 +253,7 @@ export function MemoryView({ client, company }: Props) {
                 }
                 data-testid="memory-engine-badge"
               >
-                engine: {engine.driver_id ?? engine.backend}
+                engine: {engine.active}
                 {engine.capabilities.length > 0 && (
                   <> · {engine.capabilities.length} families</>
                 )}
@@ -287,7 +284,24 @@ export function MemoryView({ client, company }: Props) {
           </div>
         </div>
 
-        <EnginePanel engine={engine} />
+        <EngineSection
+          client={client}
+          company={company}
+          onApplied={(next) => {
+            setEngine(next);
+            // The new engine's memory is a different set of rows — often an
+            // empty one, since nothing migrates between engines — so the list
+            // has to be re-read rather than left showing the old engine's.
+            void load({ silent: true });
+          }}
+        />
+
+        <DropZone
+          client={client}
+          company={company}
+          discarding={discarding}
+          onIngested={() => void load({ silent: true })}
+        />
 
         {error && (
           <Alert variant="destructive">
@@ -546,45 +560,6 @@ function AddMemoryDialog({
   );
 }
 
-/** The three families every provider-backed engine must serve. */
-/**
- * Frontend copy of the backend's mandatory-family contract. There is no
- * generated contract to import, so this can drift silently if the backend
- * renames a family — the authoritative assertions live in
- * `src/server/routes.rs` (spec_memory_capability_names) and
- * `src/store/memory/test.rs`; a rename must touch all three or the
- * mandatory-floor note below silently stops rendering.
- */
-export const MANDATORY_FAMILIES = ["core", "recall", "portability"];
-
-/**
- * What the engine panel does for a given `/spec` answer, as a pure decision
- * so it is unit-testable without a DOM:
- * - `hidden`: no `/spec` yet or an old host (`engine` undefined), or the base
- *   `store` backend — memory served by the host's own stores, nothing to say.
- * - `discard`: the `null` engine — bound, probed, and **throwing every write
- *   away**; the one case that must render as a warning, not a healthy row.
- * - `normal`: a real engine (embedded or remote).
- */
-export function enginePanelMode(
-  engine: MemorySpec | undefined,
-): "hidden" | "normal" | "discard" {
-  if (!engine || engine.backend === "store") return "hidden";
-  if (engine.backend === "null") return "discard";
-  return "normal";
-}
-
-/**
- * The boot-probe line, total over the field's whole domain: `true`, `false`,
- * and anything else (absent field, old host, or a literal `null` from a
- * future serializer change) — the render must never be an empty label.
- */
-export function probeLabel(healthy: boolean | undefined | null): string {
-  if (healthy === true) return "reachable at boot";
-  if (healthy === false) return "unreachable at boot — check the endpoint and credential";
-  return "not probed";
-}
-
 /**
  * How many context chunks are teammate memory rather than task outcomes.
  *
@@ -607,106 +582,4 @@ export function probeLabel(healthy: boolean | undefined | null): string {
  */
 export function teammateMemoryCount(stats: MemoryStats | null): number {
   return Math.max(0, (stats?.agentChunks ?? 0) - (stats?.taskOutcomes ?? 0));
-}
-
-/** Whether the negotiated families are exactly the mandatory floor. */
-export function isMandatoryOnly(capabilities: string[]): boolean {
-  return (
-    capabilities.length === MANDATORY_FAMILIES.length &&
-    MANDATORY_FAMILIES.every((f) => capabilities.includes(f))
-  );
-}
-
-/**
- * The read-only memory-engine panel: which engine is bound, what it
- * negotiated, and whether the boot probe reached it.
- *
- * Read-only by design — engine selection is instance-wide and belongs to the
- * infra operator (the `OPENCOMPANY_MEMORY*` variables, read once at boot), so
- * there is deliberately no setter here: a console admin must never be able to
- * repoint a deployment's storage. `docs/spec/runtime/memory-engine.md` carries
- * the switch runbook this panel points at.
- *
- * Renders nothing for the `store` default (no separate engine to describe) and
- * for a host predating the `/spec` memory field.
- */
-export function EnginePanel({ engine }: { engine: MemorySpec | undefined }) {
-  const mode = enginePanelMode(engine);
-  if (mode === "hidden" || !engine) return null;
-
-  // Exactly the mandatory three means a hosted engine serving the contract
-  // floor: worth saying out loud, because the spec's operator rights assume
-  // richer families that live only engine-side.
-  const mandatoryOnly = isMandatoryOnly(engine.capabilities);
-
-  return (
-    <Card data-testid="memory-engine-panel">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base">Memory engine</CardTitle>
-        <CardDescription>
-          Selected by the infra operator (<code className="text-xs">OPENCOMPANY_MEMORY*</code>,
-          read at boot) — instance-wide, no setter here by design.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-2 text-sm">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-1">
-          <span>
-            <span className="text-muted-foreground">Engine </span>
-            <span className="font-mono text-xs">{engine.driver_id ?? engine.backend}</span>
-          </span>
-          <span>
-            <span className="text-muted-foreground">Mode </span>
-            <span className="font-mono text-xs">{engine.backend}</span>
-          </span>
-          <span className="inline-flex items-center gap-1.5" data-testid="memory-engine-health">
-            <span
-              className={cn(
-                "size-2 rounded-full",
-                // The null engine's green would be a lie beside a write
-                // button: reachable, yes — retaining, no. Amber, always.
-                mode === "discard"
-                  ? "bg-status-blocked"
-                  : engine.healthy === true
-                    ? "bg-status-done"
-                    : engine.healthy === false
-                      ? "bg-status-failed"
-                      : "bg-muted-foreground/40",
-              )}
-            />
-            {probeLabel(engine.healthy)}
-          </span>
-        </div>
-        {mode === "discard" && (
-          <Alert variant="destructive" data-testid="memory-engine-discard">
-            <AlertDescription>
-              This engine accepts and discards every write — nothing this company is told will
-              be remembered, and every read comes back empty, indistinguishable from a company
-              that simply hasn't learned anything yet. Adding memories here does nothing until
-              the infra operator unsets <code className="text-xs">OPENCOMPANY_MEMORY=null</code>.
-            </AlertDescription>
-          </Alert>
-        )}
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-muted-foreground">Capabilities</span>
-          {engine.capabilities.length === 0 ? (
-            <span className="text-muted-foreground">
-              not negotiated — the in-pod engine is driven directly
-            </span>
-          ) : (
-            engine.capabilities.map((family) => (
-              <Badge key={family} variant="outline" className="text-xs">
-                {family}
-              </Badge>
-            ))
-          )}
-        </div>
-        {mandatoryOnly && (
-          <p className="text-xs text-muted-foreground">
-            The mandatory contract families. Richer families (summary tree, graph, taint) live
-            engine-side; this engine serves only the floor.
-          </p>
-        )}
-      </CardContent>
-    </Card>
-  );
 }

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -30,13 +30,7 @@ import { Markdown } from "@/components/markdown";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,

--- a/frontend/src/views/memory/DropZone.tsx
+++ b/frontend/src/views/memory/DropZone.tsx
@@ -58,8 +58,15 @@ const BATCH = 20;
 /** Files a folder drop should never carry into memory. */
 const IGNORED = new Set([".DS_Store", "Thumbs.db", ".gitkeep"]);
 
-/** Whether to skip a path outright, before it costs an upload. */
-function ignored(path: string): boolean {
+/**
+ * Whether to skip a path outright, before it costs an upload.
+ *
+ * Exported for its own tests: this is the rule that decides what a dropped
+ * folder does *not* put in a company's memory, and getting it wrong is either
+ * a repository's `.git` objects uploaded one refusal at a time or a real
+ * document silently skipped.
+ */
+export function ignored(path: string): boolean {
   const name = path.split("/").pop() ?? path;
   if (IGNORED.has(name)) return true;
   // Version-control and dependency directories: dropping a repository folder

--- a/frontend/src/views/memory/DropZone.tsx
+++ b/frontend/src/views/memory/DropZone.tsx
@@ -1,0 +1,312 @@
+/**
+ * The Brain page's drop target: files, whole folders, and links.
+ *
+ * ## Folders are the reason this is not an `<input type="file">`
+ *
+ * A file input can be told to accept a directory, but a *drag* of one only
+ * arrives as a traversable tree through `DataTransferItem.webkitGetAsEntry`,
+ * and that tree is what the feature is for — dropping `Contracts/` and having
+ * the company remember all of it. So the drop path walks entries recursively
+ * and keeps each file's path relative to the dropped folder, which is what the
+ * host stores as the document's name.
+ *
+ * A picker is still offered beside it, because a drop is undiscoverable and
+ * unavailable to anyone driving the console from a keyboard.
+ *
+ * ## Links are a drop too
+ *
+ * Dragging a link or a tab onto the page hands over `text/uri-list`, so the
+ * same gesture that remembers a file remembers a page. The host fetches it —
+ * the browser cannot, cross-origin — which is why the URL path is guarded
+ * server-side.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { FileUp, Link2, Loader2, Upload } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  ingestDocuments,
+  ingestLinks,
+  type DroppedFile,
+  type Ingested,
+  type IngestedItem,
+} from "@/api/memory";
+import type { OpenCompanyClient } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** Called after a drop lands, so the page can re-read memory. */
+  onIngested: () => void;
+  /** Whether the bound engine keeps anything; a null engine takes no drops. */
+  discarding: boolean;
+}
+
+/**
+ * How many files go in one request.
+ *
+ * A folder can be thousands of files, and one request carrying all of them
+ * would hit the host's body limit and lose the whole drop. Batching also gives
+ * the operator moving progress on a big folder instead of one long stall.
+ */
+const BATCH = 20;
+
+/** Files a folder drop should never carry into memory. */
+const IGNORED = new Set([".DS_Store", "Thumbs.db", ".gitkeep"]);
+
+/** Whether to skip a path outright, before it costs an upload. */
+function ignored(path: string): boolean {
+  const name = path.split("/").pop() ?? path;
+  if (IGNORED.has(name)) return true;
+  // Version-control and dependency directories: dropping a repository folder
+  // is a natural thing to try, and `.git/objects` is megabytes of binary that
+  // extraction would refuse one file at a time.
+  return /(^|\/)(\.git|node_modules|target|dist|\.next|__pycache__)(\/|$)/.test(path);
+}
+
+/** Recursively collects every file under one dropped entry. */
+async function walk(entry: FileSystemEntry, prefix: string): Promise<DroppedFile[]> {
+  if (entry.isFile) {
+    const file = await new Promise<File | null>((resolve) => {
+      (entry as FileSystemFileEntry).file(resolve, () => resolve(null));
+    });
+    if (!file) return [];
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+    return ignored(path) ? [] : [{ path, file }];
+  }
+  if (!entry.isDirectory) return [];
+  const reader = (entry as FileSystemDirectoryEntry).createReader();
+  const children: FileSystemEntry[] = [];
+  // `readEntries` returns at most 100 at a time and signals the end with an
+  // empty batch — reading once silently truncates any folder past 100 files,
+  // which is exactly the size where a folder drop starts to matter.
+  for (;;) {
+    const batch = await new Promise<FileSystemEntry[]>((resolve) => {
+      reader.readEntries(resolve, () => resolve([]));
+    });
+    if (batch.length === 0) break;
+    children.push(...batch);
+  }
+  const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+  if (ignored(`${path}/`)) return [];
+  const nested = await Promise.all(children.map((child) => walk(child, path)));
+  return nested.flat();
+}
+
+/** Pulls files and links out of a drop. */
+async function readDrop(transfer: DataTransfer): Promise<{ files: DroppedFile[]; urls: string[] }> {
+  const entries: FileSystemEntry[] = [];
+  const urls: string[] = [];
+  // `items` is live and empties as soon as the handler yields, so every entry
+  // has to be taken out of it synchronously, before the first `await`.
+  for (const item of Array.from(transfer.items)) {
+    if (item.kind === "file") {
+      const entry = item.webkitGetAsEntry?.();
+      if (entry) entries.push(entry);
+    }
+  }
+  const list = transfer.getData("text/uri-list") || transfer.getData("text/plain");
+  for (const line of list.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (/^https?:\/\//i.test(trimmed)) urls.push(trimmed);
+  }
+
+  if (entries.length > 0) {
+    const walked = await Promise.all(entries.map((entry) => walk(entry, "")));
+    return { files: walked.flat(), urls };
+  }
+  // A browser with no entry API still gives plain files, without their paths.
+  const files = Array.from(transfer.files)
+    .map((file) => ({ path: file.name, file }))
+    .filter((f) => !ignored(f.path));
+  return { files, urls };
+}
+
+export function DropZone({ client, company, onIngested, discarding }: Props) {
+  const [over, setOver] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [report, setReport] = useState<IngestedItem[] | null>(null);
+  const picker = useRef<HTMLInputElement>(null);
+  // Drag events fire for every child element, so a plain boolean flickers the
+  // highlight off as the pointer crosses the inner text. Counting enter/leave
+  // pairs is what keeps it steady.
+  const depth = useRef(0);
+
+  const send = useCallback(
+    async (files: DroppedFile[], urls: string[]) => {
+      if (files.length === 0 && urls.length === 0) {
+        toast.error("nothing in that drop could be read");
+        return;
+      }
+      const items: IngestedItem[] = [];
+      try {
+        for (let i = 0; i < files.length; i += BATCH) {
+          const batch = files.slice(i, i + BATCH);
+          setBusy(
+            files.length > BATCH
+              ? `Reading ${Math.min(i + BATCH, files.length)} of ${files.length} files…`
+              : `Reading ${files.length} file${files.length === 1 ? "" : "s"}…`,
+          );
+          const result: Ingested = await ingestDocuments(client, company, batch);
+          items.push(...result.items);
+        }
+        if (urls.length > 0) {
+          setBusy(`Fetching ${urls.length} link${urls.length === 1 ? "" : "s"}…`);
+          const result = await ingestLinks(client, company, urls);
+          items.push(...result.items);
+        }
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "the drop could not be read");
+      } finally {
+        setBusy(null);
+      }
+      setReport(items);
+      const stored = items.filter((i) => i.status === "stored").length;
+      if (stored > 0) {
+        toast.success(`Remembered ${stored} of ${items.length}.`);
+        onIngested();
+      } else if (items.length > 0) {
+        toast.error("nothing in that drop could be turned into memory");
+      }
+    },
+    [client, company, onIngested],
+  );
+
+  return (
+    <Card
+      onDragEnter={(e) => {
+        e.preventDefault();
+        depth.current += 1;
+        setOver(true);
+      }}
+      onDragOver={(e) => e.preventDefault()}
+      onDragLeave={() => {
+        depth.current = Math.max(0, depth.current - 1);
+        if (depth.current === 0) setOver(false);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        depth.current = 0;
+        setOver(false);
+        if (discarding) {
+          toast.error("this engine discards every write — nothing dropped here would be kept");
+          return;
+        }
+        const transfer = e.dataTransfer;
+        void readDrop(transfer).then(({ files, urls }) => send(files, urls));
+      }}
+      className={cn(
+        "border-dashed transition-colors",
+        over && "border-primary bg-primary/5",
+        discarding && "opacity-60",
+      )}
+      data-testid="memory-dropzone"
+    >
+      <CardContent className="space-y-3 py-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            {busy ? (
+              <Loader2 className="size-5 shrink-0 animate-spin text-muted-foreground" />
+            ) : (
+              <Upload className="size-5 shrink-0 text-muted-foreground" />
+            )}
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">
+                {busy ?? "Drop files, folders or links here to remember them"}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                PDFs, Word, Excel, PowerPoint, Markdown, text and web pages. Memory keeps what
+                the document says — the file itself is not stored.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy !== null || discarding}
+              onClick={() => picker.current?.click()}
+            >
+              <FileUp className="size-4" /> Choose files
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy !== null || discarding}
+              onClick={() => {
+                const typed = window.prompt("Link to remember");
+                const url = typed?.trim();
+                if (!url) return;
+                void send([], [url]);
+              }}
+            >
+              <Link2 className="size-4" /> Add link
+            </Button>
+          </div>
+        </div>
+
+        <input
+          ref={picker}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            const files = Array.from(e.target.files ?? [])
+              .map((file) => ({
+                // A picked file carries `webkitRelativePath` only for a
+                // directory pick; a plain multi-select has just the name.
+                path: (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name,
+                file,
+              }))
+              .filter((f) => !ignored(f.path));
+            // Reset first: picking the same file twice in a row fires no
+            // change event otherwise, and the second attempt looks broken.
+            e.target.value = "";
+            void send(files, []);
+          }}
+        />
+
+        {report && <DropReport items={report} onDismiss={() => setReport(null)} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * What became of each dropped file.
+ *
+ * Shown for every drop, not only failures: a folder always contains something
+ * that could not be read, and an operator who is not told which files those
+ * were will believe the whole folder is in memory.
+ */
+function DropReport({ items, onDismiss }: { items: IngestedItem[]; onDismiss: () => void }) {
+  const failed = items.filter((i) => i.status !== "stored");
+  const stored = items.length - failed.length;
+  return (
+    <div className="space-y-2 rounded-lg border bg-muted/30 p-3" data-testid="memory-drop-report">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-medium">
+          {stored} remembered
+          {failed.length > 0 && ` · ${failed.length} skipped`}
+        </p>
+        <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+      {failed.length > 0 && (
+        <ul className="max-h-40 space-y-1 overflow-y-auto text-xs text-muted-foreground">
+          {failed.map((item) => (
+            <li key={item.source} className="flex gap-2">
+              <span className="truncate font-mono">{item.source}</span>
+              <span className="shrink-0">— {item.detail ?? item.status}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/memory/EngineMark.tsx
+++ b/frontend/src/views/memory/EngineMark.tsx
@@ -1,0 +1,106 @@
+/**
+ * The mark on an engine tile.
+ *
+ * Drawn here as inline SVG rather than fetched, for two reasons that both
+ * matter on this page. A self-hosted console is routinely offline or behind a
+ * proxy that blocks third-party image hosts, and the Connections grid's remote
+ * logos already fall back to a grey initial there — acceptable for a provider
+ * you are about to authenticate with, wrong for the control that decides where
+ * a company's memory lives. And these are neutral geometric marks in each
+ * vendor's brand colour, not their trademarks: the console names the engine in
+ * text beside the mark, which is what an operator picks by.
+ */
+
+/** Brand colour per engine id; the tile tints its mark with this. */
+const ENGINE_COLORS: Record<string, string> = {
+  store: "#64748B",
+  embedded: "#14B8A6",
+  namespace: "#8B5CF6",
+  supermemory: "#0F0F0F",
+  mem0: "#3B82F6",
+  cognee: "#D946EF",
+  null: "#94A3B8",
+};
+
+/** The mark for `engine`, sized to the tile's 32px slot. */
+export function EngineMark({ engine, className }: { engine: string; className?: string }) {
+  const color = ENGINE_COLORS[engine] ?? "#64748B";
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      style={{ color }}
+      data-testid={`engine-mark-${engine}`}
+    >
+      <svg viewBox="0 0 24 24" className="size-8" fill="none" stroke="currentColor" strokeWidth="1.75">
+        <Glyph engine={engine} />
+      </svg>
+    </span>
+  );
+}
+
+/**
+ * One glyph per engine, each saying something about what the engine *is*:
+ * a drum for the built-in store, a cell for the in-pod engine, nested frames
+ * for the namespaced contract store, a cloud for each hosted service, and an
+ * open circle with a slash for the engine that keeps nothing.
+ */
+function Glyph({ engine }: { engine: string }) {
+  switch (engine) {
+    case "store":
+      return (
+        <>
+          <ellipse cx="12" cy="6" rx="7" ry="3" />
+          <path d="M5 6v12c0 1.7 3.1 3 7 3s7-1.3 7-3V6" />
+          <path d="M5 12c0 1.7 3.1 3 7 3s7-1.3 7-3" />
+        </>
+      );
+    case "embedded":
+      return (
+        <>
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 3v6M12 15v6M3 12h6M15 12h6" />
+          <path d="M6.2 6.2l3 3M14.8 14.8l3 3M17.8 6.2l-3 3M9.2 14.8l-3 3" />
+        </>
+      );
+    case "namespace":
+      return (
+        <>
+          <rect x="3" y="3" width="18" height="18" rx="3" />
+          <rect x="7.5" y="7.5" width="9" height="9" rx="1.5" />
+        </>
+      );
+    case "supermemory":
+      return (
+        <>
+          <path d="M7 18a4 4 0 0 1 0-8 5.5 5.5 0 0 1 10.6-1.4A3.9 3.9 0 0 1 18 18Z" />
+          <path d="M12 10.5v4M10 12.5h4" />
+        </>
+      );
+    case "mem0":
+      return (
+        <>
+          <path d="M7 18a4 4 0 0 1 0-8 5.5 5.5 0 0 1 10.6-1.4A3.9 3.9 0 0 1 18 18Z" />
+          <circle cx="12" cy="13.5" r="1.6" />
+        </>
+      );
+    case "cognee":
+      return (
+        <>
+          <circle cx="6" cy="8" r="2.2" />
+          <circle cx="18" cy="7" r="2.2" />
+          <circle cx="12" cy="17" r="2.2" />
+          <path d="M7.8 9.3 10.6 15M16.6 9 13.3 15.4M8.1 7.6h7.7" />
+        </>
+      );
+    case "null":
+      return (
+        <>
+          <circle cx="12" cy="12" r="8" strokeDasharray="3 3" />
+          <path d="M7 17 17 7" />
+        </>
+      );
+    default:
+      return <circle cx="12" cy="12" r="8" strokeDasharray="3 3" />;
+  }
+}

--- a/frontend/src/views/memory/EngineMark.tsx
+++ b/frontend/src/views/memory/EngineMark.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 /**
  * The mark on an engine tile.
  *
@@ -6,30 +8,37 @@
  * proxy that blocks third-party image hosts, and the Connections grid's remote
  * logos already fall back to a grey initial there — acceptable for a provider
  * you are about to authenticate with, wrong for the control that decides where
- * a company's memory lives. And these are neutral geometric marks in each
- * vendor's brand colour, not their trademarks: the console names the engine in
- * text beside the mark, which is what an operator picks by.
+ * a company's memory lives. And these are neutral geometric marks, not
+ * anyone's trademark: the console names the engine in text beside the mark,
+ * which is what an operator picks by.
+ *
+ * ## Tinted from the identity palette, not from brand hexes
+ *
+ * Each vendor has a brand colour and none of them is used here. A hex cannot
+ * theme (`scripts/ci/assert-design-tokens.sh`), and Supermemory's near-black
+ * would be a mark you cannot see on this console's dark canvas. The `--tone-*`
+ * ramp is what the rest of the product distinguishes *identities* with, so the
+ * marks distinguish engines the same way: different, legible in both themes,
+ * and re-tuned whenever the palette is.
  */
 
-/** Brand colour per engine id; the tile tints its mark with this. */
-const ENGINE_COLORS: Record<string, string> = {
-  store: "#64748B",
-  embedded: "#14B8A6",
-  namespace: "#8B5CF6",
-  supermemory: "#0F0F0F",
-  mem0: "#3B82F6",
-  cognee: "#D946EF",
-  null: "#94A3B8",
+/** The identity tone per engine; the tile tints its mark with this. */
+const ENGINE_TONES: Record<string, string> = {
+  store: "text-tone-5-text",
+  embedded: "text-tone-3-text",
+  namespace: "text-tone-1-text",
+  supermemory: "text-foreground",
+  mem0: "text-tone-2-text",
+  cognee: "text-tone-4-text",
+  null: "text-muted-foreground",
 };
 
 /** The mark for `engine`, sized to the tile's 32px slot. */
 export function EngineMark({ engine, className }: { engine: string; className?: string }) {
-  const color = ENGINE_COLORS[engine] ?? "#64748B";
   return (
     <span
       aria-hidden="true"
-      className={className}
-      style={{ color }}
+      className={cn(ENGINE_TONES[engine] ?? "text-muted-foreground", className)}
       data-testid={`engine-mark-${engine}`}
     >
       <svg viewBox="0 0 24 24" className="size-8" fill="none" stroke="currentColor" strokeWidth="1.75">

--- a/frontend/src/views/memory/EngineSection.tsx
+++ b/frontend/src/views/memory/EngineSection.tsx
@@ -339,12 +339,12 @@ function EngineTile({
         <span className="flex flex-wrap items-center gap-1.5">
           <span className="font-medium">{option.label}</span>
           {active && (
-            <Badge variant="outline" className="text-[10px]">
+            <Badge variant="outline" className="text-3xs">
               in use
             </Badge>
           )}
           {!option.durable && (
-            <Badge variant="outline" className="border-status-blocked/40 text-[10px]">
+            <Badge variant="outline" className="border-status-blocked/40 text-3xs">
               keeps nothing
             </Badge>
           )}

--- a/frontend/src/views/memory/EngineSection.tsx
+++ b/frontend/src/views/memory/EngineSection.tsx
@@ -1,0 +1,358 @@
+/**
+ * Choosing where this company's memory lives.
+ *
+ * The panel this replaces was read-only by design, on the grounds that engine
+ * selection belonged to whoever controls the process environment. That is
+ * still true of a *hosted* tenant — the control plane injects
+ * `OPENCOMPANY_MEMORY*` and the host refuses a write that would be silently
+ * ignored — and this section renders exactly the old read-only panel in that
+ * case, saying who owns the choice. What changed is the self-hosted operator,
+ * for whom "edit a unit file and restart" was the only way to try Supermemory
+ * or mem0: the host now persists the choice to `config.toml` and rebinds it
+ * live, so the picker below is the whole flow.
+ *
+ * ## What is asserted, and what is only saved
+ *
+ * A hosted engine is probed before it is bound, and a probe that fails refuses
+ * the change rather than swapping a working engine for a dead one. So the
+ * green dot after an apply means the engine answered, not that a file was
+ * written.
+ */
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, Check, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  applyMemoryEngine,
+  memoryEngine,
+  testMemoryEngine,
+  type EngineOption,
+  type MemoryEngineState,
+} from "@/api/memory";
+import type { OpenCompanyClient } from "@/api/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+import { EngineMark } from "./EngineMark";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** Called after an engine change lands, so the page can re-read memory. */
+  onApplied?: (state: MemoryEngineState) => void;
+}
+
+/** The probe line under the picker. */
+function healthLabel(healthy: boolean | undefined): string {
+  if (healthy === true) return "answering";
+  if (healthy === false) return "not answering — check the endpoint and key";
+  return "no probe — this engine has no health check to ask";
+}
+
+export function EngineSection({ client, company, onApplied }: Props) {
+  const [state, setState] = useState<MemoryEngineState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // What the operator has picked but not yet applied. `null` means "showing
+  // what is saved", which is why this is not initialised from `state`.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [url, setUrl] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [busy, setBusy] = useState<"testing" | "applying" | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setState(null);
+    setDraft(null);
+    memoryEngine(client, company)
+      .then((next) => {
+        if (!live) return;
+        setState(next);
+        setUrl(next.url ?? "");
+        setError(null);
+      })
+      .catch((e: unknown) => {
+        if (!live) return;
+        setError(e instanceof Error ? e.message : "could not read the memory engine");
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (!state) return <Skeleton className="h-40 rounded-xl" />;
+
+  const chosen = draft ?? state.selected;
+  const option = state.options.find((o) => o.id === chosen);
+  const dirty =
+    chosen !== state.selected ||
+    (option?.requiresUrl && url.trim() !== (state.url ?? "")) ||
+    apiKey.trim().length > 0;
+
+  /** The body a test or an apply sends. */
+  function choice() {
+    return {
+      engine: chosen,
+      url: option?.requiresUrl ? url.trim() : undefined,
+      // Omitted rather than sent empty: the host reads absence as "keep the
+      // stored credential" and an empty string as "clear it", and a console
+      // that always sent a value would wipe a key on an endpoint edit.
+      apiKey: apiKey.trim() ? apiKey.trim() : undefined,
+    };
+  }
+
+  async function test() {
+    setBusy("testing");
+    try {
+      const probe = await testMemoryEngine(client, company, choice());
+      if (probe.healthy) {
+        toast.success(
+          probe.capabilities.length
+            ? `${option?.label ?? chosen} answered · ${probe.capabilities.join(", ")}`
+            : `${option?.label ?? chosen} answered`,
+        );
+      } else {
+        toast.error(probe.detail ?? "the engine did not answer");
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not reach the engine");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function apply() {
+    setBusy("applying");
+    try {
+      const applied = await applyMemoryEngine(client, company, choice());
+      setState(applied.engineState);
+      setDraft(null);
+      setApiKey("");
+      setUrl(applied.engineState.url ?? "");
+      if (applied.restartRequiredFor.length > 0) {
+        // Named, never assumed: these companies are still running on the
+        // previous engine, and saying "restart required" without saying which
+        // would leave an operator unsure whether the change took at all.
+        toast.warning(
+          `Saved, but ${applied.restartRequiredFor.join(", ")} could not be rebuilt — restart the host for ${applied.restartRequiredFor.length > 1 ? "them" : "it"}.`,
+        );
+      } else {
+        toast.success(`Memory is now on ${applied.engine}.`);
+      }
+      onApplied?.(applied.engineState);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not change the memory engine");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <Card data-testid="memory-engine-panel">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Memory engine</CardTitle>
+        <CardDescription>
+          {state.editable ? (
+            <>
+              Where this company&rsquo;s memory is stored. Instance-wide — every company on this
+              host shares it — and saved to <code className="text-xs">{state.configPath}</code>.
+            </>
+          ) : (
+            <>
+              Set by this deployment&rsquo;s environment (
+              <code className="text-xs">OPENCOMPANY_MEMORY*</code>), which outranks the console.
+              Shown here so you can see what is bound.
+            </>
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-1 text-sm">
+          <span className="inline-flex items-center gap-1.5" data-testid="memory-engine-health">
+            <span
+              className={cn(
+                "size-2 rounded-full",
+                // The null engine never goes green: it answers every probe and
+                // retains nothing, and a green dot beside a write button would
+                // say the opposite of what is true.
+                state.active === "null"
+                  ? "bg-status-blocked"
+                  : state.healthy === true
+                    ? "bg-status-done"
+                    : state.healthy === false
+                      ? "bg-status-failed"
+                      : "bg-muted-foreground/40",
+              )}
+            />
+            <span className="font-medium">{state.active}</span>
+            <span className="text-muted-foreground">· {healthLabel(state.healthy)}</span>
+          </span>
+          {state.capabilities.length > 0 && (
+            <span className="flex flex-wrap items-center gap-1.5">
+              <span className="text-muted-foreground">Capabilities</span>
+              {state.capabilities.map((family) => (
+                <Badge key={family} variant="outline" className="text-xs">
+                  {family}
+                </Badge>
+              ))}
+            </span>
+          )}
+        </div>
+
+        {state.active === "null" && (
+          <Alert variant="destructive" data-testid="memory-engine-discard">
+            <AlertDescription>
+              This engine accepts and discards every write — nothing this company is told will be
+              remembered, and every read comes back empty, indistinguishable from a company that
+              simply hasn&rsquo;t learned anything yet.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {state.options.map((o) => (
+            <EngineTile
+              key={o.id}
+              option={o}
+              selected={chosen === o.id}
+              active={state.active === o.id}
+              disabled={!state.editable || !o.available}
+              onPick={() => {
+                setDraft(o.id);
+                if (o.id === state.selected) setUrl(state.url ?? "");
+              }}
+            />
+          ))}
+        </div>
+
+        {state.editable && option && (option.requiresUrl || option.requiresKey) && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {option.requiresUrl && (
+              <div className="space-y-1.5">
+                <Label htmlFor="memory-engine-url">Endpoint</Label>
+                <Input
+                  id="memory-engine-url"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="https://api.example.com"
+                  autoComplete="off"
+                />
+              </div>
+            )}
+            {option.requiresKey && (
+              <div className="space-y-1.5">
+                <Label htmlFor="memory-engine-key">API key</Label>
+                <Input
+                  id="memory-engine-key"
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  // The stored key never comes back from the host, so the
+                  // field cannot be pre-filled — and saying so beats an empty
+                  // box that looks like a key nobody set.
+                  placeholder={
+                    state.apiKeySet && chosen === state.selected
+                      ? "stored — leave blank to keep it"
+                      : "paste the key"
+                  }
+                  autoComplete="off"
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        {state.editable && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={() => void apply()} disabled={!dirty || busy !== null}>
+              {busy === "applying" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Check className="size-4" />
+              )}
+              Use this engine
+            </Button>
+            {(option?.requiresUrl || option?.requiresKey) && (
+              <Button variant="outline" onClick={() => void test()} disabled={busy !== null}>
+                {busy === "testing" && <Loader2 className="size-4 animate-spin" />}
+                Test connection
+              </Button>
+            )}
+            {dirty && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                <AlertTriangle className="size-3.5" />
+                Switching engines starts empty — nothing is migrated from the current one.
+              </span>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** One selectable engine. */
+function EngineTile({
+  option,
+  selected,
+  active,
+  disabled,
+  onPick,
+}: {
+  option: EngineOption;
+  selected: boolean;
+  /** Whether this engine is the one currently bound. */
+  active: boolean;
+  disabled: boolean;
+  onPick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      disabled={disabled}
+      // The reason a disabled tile is disabled, on the element that still takes
+      // a hover.
+      title={option.available ? undefined : option.unavailableReason}
+      data-testid={`engine-tile-${option.id}`}
+      className={cn(
+        "flex items-start gap-3 rounded-xl border p-3 text-left transition-colors",
+        selected ? "border-primary bg-primary/5" : "hover:bg-muted/50",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      <EngineMark engine={option.id} className="shrink-0" />
+      <span className="min-w-0 space-y-1">
+        <span className="flex flex-wrap items-center gap-1.5">
+          <span className="font-medium">{option.label}</span>
+          {active && (
+            <Badge variant="outline" className="text-[10px]">
+              in use
+            </Badge>
+          )}
+          {!option.durable && (
+            <Badge variant="outline" className="border-status-blocked/40 text-[10px]">
+              keeps nothing
+            </Badge>
+          )}
+        </span>
+        <span className="block text-xs leading-snug text-muted-foreground">
+          {option.available ? option.description : option.unavailableReason}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/frontend/test/unit/memory-drop-filter.test.ts
+++ b/frontend/test/unit/memory-drop-filter.test.ts
@@ -1,0 +1,40 @@
+// What a dropped folder does NOT put into memory.
+//
+// A folder drop is the feature's whole point and also its whole risk: dropping
+// a project directory is a natural thing to try, and without this filter it
+// means uploading `.git/objects` and `node_modules` one refusal at a time —
+// thousands of requests, a drop report nobody can read, and the real documents
+// buried in it.
+import { describe, expect, it } from "vitest";
+
+import { ignored } from "@/views/memory/DropZone";
+
+describe("ignored", () => {
+  it("skips the noise every real folder carries", () => {
+    expect(ignored(".DS_Store")).toBe(true);
+    expect(ignored("Contracts/.DS_Store")).toBe(true);
+    expect(ignored("Thumbs.db")).toBe(true);
+  });
+
+  it("skips version-control and dependency trees at any depth", () => {
+    expect(ignored("repo/.git/objects/ab/cdef")).toBe(true);
+    expect(ignored("node_modules/react/index.js")).toBe(true);
+    expect(ignored("app/node_modules/react/index.js")).toBe(true);
+    expect(ignored("service/target/debug/build.rs")).toBe(true);
+    expect(ignored("site/.next/cache/x")).toBe(true);
+  });
+
+  it("keeps the documents an operator dropped the folder for", () => {
+    expect(ignored("Contracts/2026/acme.pdf")).toBe(false);
+    expect(ignored("handbook.md")).toBe(false);
+    expect(ignored("finance/Q3.xlsx")).toBe(false);
+  });
+
+  it("does not skip a file that merely mentions an ignored name", () => {
+    // `.gitignore` is a real file an operator may want remembered, and
+    // `notes-about-node_modules.md` is prose about one.
+    expect(ignored(".gitignore")).toBe(false);
+    expect(ignored("notes-about-node_modules.md")).toBe(false);
+    expect(ignored("docs/targeting.md")).toBe(false);
+  });
+});

--- a/frontend/test/unit/memory-engine-panel.test.ts
+++ b/frontend/test/unit/memory-engine-panel.test.ts
@@ -1,22 +1,35 @@
-// The engine panel's decision logic (issue #914 console surfacing) — pure
-// functions, tested over the whole domain because the panel is the operator's
-// only view of a fact the pod log used to keep to itself: which engine is
-// bound, whether the boot probe reached it, and — the loudest case — whether
-// it is the null engine silently discarding every write.
+// The Brain page's engine and drop logic — pure functions, tested over the
+// whole domain because they carry facts the pod log used to keep to itself:
+// which engine is bound, whether an operator may change it, and — the loudest
+// case — whether the bound engine is the null one, silently discarding every
+// write.
+//
+// Replaces the `/spec`-shaped panel tests (issue #914). The panel became a
+// picker when the engine stopped being boot-only, and the state it renders now
+// comes from `GET …/memory/engine` rather than the handshake: `/spec` reports
+// what *boot* bound, which stops being the answer the moment a console change
+// rebinds it live.
 import { describe, expect, it } from "vitest";
 
-import type { MemoryStats } from "@/api/memory";
-import type { MemorySpec } from "@/api/types";
 import {
-  enginePanelMode,
-  isMandatoryOnly,
-  MANDATORY_FAMILIES,
-  probeLabel,
+  documentSlug,
+  type MemoryEngineState,
+  type MemoryStats,
   teammateMemoryCount,
-} from "@/views/MemoryView";
+} from "@/api/memory";
 
-function spec(overrides: Partial<MemorySpec>): MemorySpec {
-  return { backend: "remote", driver_id: "supermemory", capabilities: [], ...overrides };
+function engine(overrides: Partial<MemoryEngineState>): MemoryEngineState {
+  return {
+    active: "store",
+    capabilities: [],
+    selected: "store",
+    apiKeySet: false,
+    layer: "default",
+    editable: true,
+    configPath: "/data/config.toml",
+    options: [],
+    ...overrides,
+  };
 }
 
 function stats(overrides: Partial<MemoryStats>): MemoryStats {
@@ -30,51 +43,56 @@ function stats(overrides: Partial<MemoryStats>): MemoryStats {
   };
 }
 
-describe("enginePanelMode", () => {
-  it("hides on an old host that never sent the field", () => {
-    expect(enginePanelMode(undefined)).toBe("hidden");
+// The one engine state the *writing* half of the page must respect: the null
+// engine takes every write and throws it away, so the page disables both the
+// "New memory" button and the drop zone against it.
+describe("the discarding engine", () => {
+  it("is the null engine, whatever the saved selection says", () => {
+    expect(engine({ active: "null", selected: "mem0" }).active === "null").toBe(true);
   });
 
-  it("hides on the base store backend — memory served by the host's own stores", () => {
-    expect(enginePanelMode(spec({ backend: "store", driver_id: "" }))).toBe("hidden");
-  });
-
-  it("warns on the null engine: bound and probed, but discarding every write", () => {
-    expect(enginePanelMode(spec({ backend: "null", driver_id: "null" }))).toBe("discard");
-  });
-
-  it("renders embedded and remote engines normally", () => {
-    expect(enginePanelMode(spec({ backend: "embedded", driver_id: "namespace" }))).toBe("normal");
-    expect(enginePanelMode(spec({ backend: "remote" }))).toBe("normal");
+  it("is not any engine that actually retains", () => {
+    for (const active of ["store", "embedded", "namespace", "supermemory", "mem0", "cognee"]) {
+      expect(engine({ active }).active === "null").toBe(false);
+    }
   });
 });
 
-describe("probeLabel", () => {
-  it("maps the three states an operator must tell apart", () => {
-    expect(probeLabel(true)).toBe("reachable at boot");
-    expect(probeLabel(false)).toContain("unreachable at boot");
-    expect(probeLabel(undefined)).toBe("not probed");
+// The refusal the console must render rather than work around: a deployment
+// that injects `OPENCOMPANY_MEMORY` owns the choice, and a picker that
+// accepted an edit there would write a file that changes nothing.
+describe("who owns the engine choice", () => {
+  it("is the environment on a hosted tenant, and the console says so", () => {
+    const state = engine({ layer: "env", editable: false });
+    expect(state.editable).toBe(false);
   });
 
-  it("is total: a literal null (absent-on-the-wire) reads as not probed, never blank", () => {
-    expect(probeLabel(null)).toBe("not probed");
+  it("is the console on a self-hosted host with nothing injected", () => {
+    expect(engine({ layer: "default", editable: true }).editable).toBe(true);
+    expect(engine({ layer: "config.toml", editable: true }).editable).toBe(true);
   });
 });
 
-describe("isMandatoryOnly", () => {
-  it("matches exactly the mandatory floor, in any order", () => {
-    expect(isMandatoryOnly([...MANDATORY_FAMILIES])).toBe(true);
-    expect(isMandatoryOnly([...MANDATORY_FAMILIES].reverse())).toBe(true);
+// `documentSlug` is a copy of the host's `ingest::label_for`, and the forget
+// route addresses documents by that slug — so a drift here is a delete that
+// 404s on exactly the documents whose names needed slugging.
+describe("documentSlug", () => {
+  it("matches the host's slug for a folder-dropped path", () => {
+    expect(documentSlug("Contracts/2026/acme msa.pdf")).toBe("contracts-2026-acme-msa.pdf");
   });
 
-  it("rejects subsets, supersets, and the empty (not-negotiated) case", () => {
-    expect(isMandatoryOnly(["core", "recall"])).toBe(false);
-    expect(isMandatoryOnly([...MANDATORY_FAMILIES, "graph"])).toBe(false);
-    expect(isMandatoryOnly([])).toBe(false);
+  it("keeps a plain file name as it is, lower-cased", () => {
+    expect(documentSlug("Handbook.md")).toBe("handbook.md");
   });
 
-  it("rejects a same-length set that swaps a family — length alone is not the test", () => {
-    expect(isMandatoryOnly(["core", "recall", "graph"])).toBe(false);
+  it("never yields an empty slug for a name that is all separators", () => {
+    expect(documentSlug("///")).toBe("document");
+  });
+
+  it("keeps the identifying tail of a very long path", () => {
+    const slug = documentSlug(`${"a/".repeat(80)}report.pdf`);
+    expect(Array.from(slug).length).toBe(96);
+    expect(slug.endsWith("report.pdf")).toBe(true);
   });
 });
 
@@ -84,8 +102,6 @@ describe("isMandatoryOnly", () => {
 // tiles, so the tile has to subtract or it counts the same rows twice.
 describe("teammateMemoryCount", () => {
   it("is zero when every chunk is a task outcome — the shape that shipped the bug", () => {
-    // The seeded company: 13 chunks, all of them outcomes. The strip read
-    // "Teammate memory 13" beside "Task outcomes 13" and "Total items 13".
     expect(teammateMemoryCount(stats({ agentChunks: 13, taskOutcomes: 13 }))).toBe(0);
   });
 

--- a/frontend/test/unit/memory-engine.test.ts
+++ b/frontend/test/unit/memory-engine.test.ts
@@ -11,12 +11,8 @@
 // rebinds it live.
 import { describe, expect, it } from "vitest";
 
-import {
-  documentSlug,
-  type MemoryEngineState,
-  type MemoryStats,
-  teammateMemoryCount,
-} from "@/api/memory";
+import { documentSlug, type MemoryEngineState, type MemoryStats } from "@/api/memory";
+import { teammateMemoryCount } from "@/views/MemoryView";
 
 function engine(overrides: Partial<MemoryEngineState>): MemoryEngineState {
   return {

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -47,6 +47,7 @@
 default        | tested       | (default)                       | The `Rust` job's bare `cargo test --locked`.
 oauth          | tested       | (default)                       | In the default set, so the default lanes run it.
 platform-jwt   | tested       | (default)                       | In the default set (see Cargo.toml for why it ships by default).
+documents      | tested       | (default)                       | In the default set: the Brain drop zone is a console surface, so a shipped build must read a dropped PDF (see Cargo.toml).
 openhuman      | tested       | openhuman,tinycortex            | `rust-gated` runs `--tests`, which selects lib+bin units and every tests/ target.
 tinycortex     | tested       | openhuman,tinycortex            | Same lane, same unfiltered `--tests`.
 tinymemory     | partial      | acp,runner,tinymemory | store::memory store::select

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -310,6 +310,10 @@ pub struct ConfigFile {
     pub setup_completed_at: Option<i64>,
     /// The `[workspace]` section: data-dir layout lifecycle knobs.
     pub workspace: WorkspaceSection,
+    /// The `[memory]` section: which memory engine this instance binds, when
+    /// the deployment has not named one through `OPENCOMPANY_MEMORY`
+    /// (`docs/spec/runtime/memory-engine.md`).
+    pub memory: MemorySection,
     /// `[[default_mcp_server]]` entries — MCP servers the packaged install
     /// registers and enables for every company, with no user setup (issue #527).
     ///
@@ -324,6 +328,50 @@ pub struct ConfigFile {
     /// compiled-in list to fall back to.
     #[serde(rename = "default_mcp_server")]
     pub default_mcp_servers: Vec<crate::company::McpServer>,
+}
+
+/// The `[memory]` section of `config.toml`: the memory engine an operator
+/// chose from the console, when the deployment did not inject one.
+///
+/// # Why this exists beside the env vars
+///
+/// The engine used to be selectable only through `OPENCOMPANY_MEMORY*`, which
+/// means only by whoever controls the process environment. A self-hosted
+/// operator who wants their company's memory in Supermemory or mem0 had to
+/// edit a unit file and restart. This is the same second layer the rest of the
+/// instance's configuration already has (`docs/spec/runtime/config.md`), so
+/// the console can write the choice and
+/// [`crate::server::ops::memory_engine`] can bind it live.
+///
+/// # Precedence, and why it is not "last writer wins"
+///
+/// `env ⟵ config.toml`, exactly as every other key resolves. A hosted tenant
+/// has `OPENCOMPANY_MEMORY*` injected by the control plane, and a console that
+/// accepted an edit there would write a file, report success, and change
+/// nothing at the next boot — the silently-ignored-configuration failure the
+/// setup flow refuses for the same reason. So when the env names an engine
+/// this section is inert, the console renders read-only, and the write is
+/// refused rather than accepted-and-dropped.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct MemorySection {
+    /// `store` | `embedded` | `remote` | `null`, parsed by
+    /// [`MemoryBackend`](crate::store::MemoryBackend). Absent leaves the
+    /// default (`store` — the base backend's own memory).
+    pub backend: Option<String>,
+    /// The engine id for a provider-backed mode: `supermemory`, `mem0`,
+    /// `cognee`, or `namespace` for the in-pod contract store.
+    pub driver: Option<String>,
+    /// The hosted engine's endpoint.
+    pub url: Option<String>,
+    /// The hosted engine's credential.
+    ///
+    /// It lives in this file the same way `tinyhumans_api_key` and
+    /// `github_token` already do — the file is the instance's private
+    /// configuration, mode `0600` where the platform supports it — and it is
+    /// never read back out over HTTP: the engine route reports whether a key
+    /// is set, never its bytes.
+    pub api_key: Option<String>,
 }
 
 /// The `[workspace]` section of `config.toml`: lifecycle of the canonical

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -411,7 +411,14 @@ pub struct AppState {
     /// not the base store's own memory. Provisioning and boot apply it after
     /// `stores` so a dedicated engine (TinyCortex) backs recall on top of any
     /// base backend. `None` means the base backend's memory is used unchanged.
-    memory_overlay: Option<crate::store::MemoryOverlay>,
+    ///
+    /// Behind a lock because the engine is no longer decided only at boot: the
+    /// console's engine route opens a replacement overlay and swaps it in, then
+    /// rebuilds each registered company so the new ports are actually in force
+    /// (`crate::server::ops::memory_engine`). Same shape, and the same reason,
+    /// as [`Self::auth_mode_override`] — a choice an operator makes while the
+    /// process is running, which telling them to restart for would defeat.
+    memory_overlay: Arc<RwLock<Option<crate::store::MemoryOverlay>>>,
     /// The repo-level shared skill library directory (`skills/`), set on the
     /// serve path. `None` in platform-provisioned mode (no repo checkout), where
     /// the `skillRegistry` query degrades to empty.
@@ -533,7 +540,7 @@ impl AppState {
             config_root: None,
             ownership: Arc::new(RwLock::new(HashMap::new())),
             stores: None,
-            memory_overlay: None,
+            memory_overlay: Arc::new(RwLock::new(None)),
             skills_root: None,
             skill_registry: Arc::new(OnceLock::new()),
             instance_id: Arc::new(OnceLock::new()),
@@ -674,15 +681,38 @@ impl AppState {
             .get_or_init(|| crate::app::instance::load_or_create(&self.home))
     }
 
-    /// Installs the memory engine overlay selected by `OPENCOMPANY_MEMORY`.
-    pub fn with_memory_overlay(mut self, overlay: crate::store::MemoryOverlay) -> Self {
-        self.memory_overlay = Some(overlay);
+    /// Installs the memory engine overlay selected at boot
+    /// (`OPENCOMPANY_MEMORY`, or `[memory]` in `config.toml`).
+    pub fn with_memory_overlay(self, overlay: crate::store::MemoryOverlay) -> Self {
+        self.set_memory_overlay(Some(overlay));
         self
     }
 
-    /// The memory engine overlay, if one is selected (`OPENCOMPANY_MEMORY`).
-    pub fn memory_overlay(&self) -> Option<&crate::store::MemoryOverlay> {
-        self.memory_overlay.as_ref()
+    /// The bound memory engine overlay, if one is selected.
+    ///
+    /// Returns a clone rather than a borrow: the overlay can be replaced while
+    /// the process runs (see [`Self::set_memory_overlay`]), and every field of
+    /// it is an `Arc`, so the clone costs a handful of refcount bumps and
+    /// cannot observe a half-applied swap.
+    pub fn memory_overlay(&self) -> Option<crate::store::MemoryOverlay> {
+        self.memory_overlay
+            .read()
+            .expect("memory overlay poisoned")
+            .clone()
+    }
+
+    /// Replaces the bound memory engine overlay.
+    ///
+    /// `None` returns memory to the base storage backend's own ports. This
+    /// only changes what a company built *after* it will bind — companies
+    /// already in the registry hold the previous ports on their cached
+    /// runtime, so a caller that wants the swap in force must rebuild them
+    /// ([`crate::runtime::rebuild_company`]).
+    pub fn set_memory_overlay(&self, overlay: Option<crate::store::MemoryOverlay>) {
+        *self
+            .memory_overlay
+            .write()
+            .expect("memory overlay poisoned") = overlay;
     }
 
     /// The repo-level shared skill registry, loaded from `dir` and cached.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1075,7 +1075,7 @@ impl AppState {
     /// `OPENCOMPANY_MEMORY=store` default — so there is no separate engine to
     /// name and nothing was negotiated.
     fn memory_spec(&self) -> MemorySpec {
-        match &self.memory_overlay {
+        match self.memory_overlay() {
             None => MemorySpec {
                 backend: crate::store::MemoryBackend::Store.as_str(),
                 driver_id: None,

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -419,7 +419,7 @@ fn company_builder(
         builder = builder.with_stores(stores);
     }
     if let Some(overlay) = state.memory_overlay() {
-        builder = builder.with_memory_overlay(overlay);
+        builder = builder.with_memory_overlay(&overlay);
     }
     #[cfg(feature = "smtp")]
     if let Ok(Some(cfg)) = opencompany::server::ops::mailer::TenantMailboxConfig::from_env() {

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1657,6 +1657,12 @@ async fn async_main() -> Result<()> {
             let setup_complete = config_file
                 .as_ref()
                 .is_some_and(|c| c.setup_completed_at.is_some());
+            // Read off the file before it is consumed for `bind` below: the
+            // memory engine is resolved further down, after the state exists.
+            let memory_section = config_file
+                .as_ref()
+                .map(|c| c.memory.clone())
+                .unwrap_or_default();
             let (bind, bind_source) = opencompany::app::config::resolve_serve_bind(
                 bind,
                 &ProcessEnv,
@@ -1700,7 +1706,12 @@ async fn async_main() -> Result<()> {
             // mongodb are opened once here and injected into every company's
             // builder. A selected-but-unavailable backend aborts boot rather
             // than silently falling back to fs.
-            let storage_settings = opencompany::store::StorageSettings::from_env()?;
+            // The environment first, then the instance's own `config.toml`
+            // `[memory]` section under it — the engine an operator chose from
+            // the console. A deployment that injects `OPENCOMPANY_MEMORY` keeps
+            // ownership and the file layer is inert; see `MemorySection`.
+            let storage_settings = opencompany::store::StorageSettings::from_env()?
+                .with_memory_config(&memory_section)?;
             if let Some(handles) =
                 opencompany::store::open_storage(&storage_settings, &home).await?
             {

--- a/src/ingest/chunk.rs
+++ b/src/ingest/chunk.rs
@@ -1,0 +1,150 @@
+//! Cutting extracted text into the pieces memory holds.
+//!
+//! A [`ContextStore`](crate::ports::ContextStore) chunk is what recall
+//! retrieves and what an agent is shown, so the unit matters: a whole
+//! forty-page contract as one chunk floods a turn's context with thirty-nine
+//! irrelevant pages, and a chunk per sentence loses the context that made the
+//! sentence mean anything.
+
+/// Label prefix for every chunk a dropped document or link produced.
+///
+/// Its own prefix, beside `operator-fact/` and `task-outcome/`, because the
+/// console renders these as their own origin: an operator who dropped a folder
+/// must be able to see what it became, and a document chunk showing up as
+/// "teammate memory" would read as something an agent learned.
+pub const DOCUMENT_LABEL_PREFIX: &str = "document";
+
+/// Target chunk size in characters.
+///
+/// Roughly 500 tokens: large enough that a paragraph keeps its neighbours,
+/// small enough that a recall hit costs a fraction of a turn's budget.
+const TARGET_CHARS: usize = 2_000;
+
+/// The largest a chunk may get before it is cut mid-paragraph.
+///
+/// Paragraph boundaries are preferred, but a document with no blank lines —
+/// extracted spreadsheet rows, minified prose — must not produce one chunk the
+/// size of the file.
+const MAX_CHARS: usize = 3_000;
+
+/// One chunk, ready for [`ContextStore::put`](crate::ports::ContextStore::put).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentChunk {
+    /// `document/{source}/{index}` — the address recall and the console both
+    /// key off.
+    pub label: String,
+    /// The chunk text, with the source named on its first line.
+    pub body: String,
+}
+
+/// The label prefix for one source's chunks: `document/{slug}`.
+///
+/// Slugged because the label is an addressing key on every backend, and a raw
+/// file name carries slashes (a folder drop sends relative paths) that would
+/// silently nest one document's chunks under another's prefix.
+pub fn label_for(source: &str) -> String {
+    let slug: String = source
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let slug = slug.trim_matches('-').to_string();
+    let slug = if slug.is_empty() {
+        "document".to_string()
+    } else {
+        slug
+    };
+    // Bounded: a deeply nested folder path can be longer than some backends
+    // index comfortably, and the tail of a path is the identifying part.
+    let slug = if slug.chars().count() > 96 {
+        slug.chars().skip(slug.chars().count() - 96).collect()
+    } else {
+        slug
+    };
+    format!("{DOCUMENT_LABEL_PREFIX}/{slug}")
+}
+
+/// Splits `text` into labelled chunks for a document named `source`.
+///
+/// Every chunk repeats the source name on its first line. That costs a line
+/// per chunk and buys the thing recall cannot otherwise recover: a chunk
+/// surfaces on its own, with no path back to the document it came from, and an
+/// agent shown a paragraph of a contract needs to know which contract.
+pub fn chunk_document(source: &str, text: &str) -> Vec<DocumentChunk> {
+    let prefix = label_for(source);
+    let mut chunks = Vec::new();
+    for (index, body) in split(text).into_iter().enumerate() {
+        chunks.push(DocumentChunk {
+            label: format!("{prefix}/{index:04}"),
+            body: format!("{source}\n\n{body}"),
+        });
+    }
+    chunks
+}
+
+/// Accumulates paragraphs up to [`TARGET_CHARS`], hard-splitting anything that
+/// would cross [`MAX_CHARS`] on its own.
+fn split(text: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for paragraph in text.split("\n\n") {
+        let paragraph = paragraph.trim();
+        if paragraph.is_empty() {
+            continue;
+        }
+        if paragraph.chars().count() > MAX_CHARS {
+            if !current.trim().is_empty() {
+                out.push(std::mem::take(&mut current).trim().to_string());
+            }
+            out.extend(hard_split(paragraph));
+            continue;
+        }
+        if current.chars().count() + paragraph.chars().count() > TARGET_CHARS
+            && !current.trim().is_empty()
+        {
+            out.push(std::mem::take(&mut current).trim().to_string());
+        }
+        if !current.is_empty() {
+            current.push_str("\n\n");
+        }
+        current.push_str(paragraph);
+    }
+    if !current.trim().is_empty() {
+        out.push(current.trim().to_string());
+    }
+    out
+}
+
+/// Cuts an over-long paragraph on the last sentence end before the limit,
+/// falling back to the limit itself.
+fn hard_split(paragraph: &str) -> Vec<String> {
+    let chars: Vec<char> = paragraph.chars().collect();
+    let mut out = Vec::new();
+    let mut start = 0;
+    while start < chars.len() {
+        let end = (start + TARGET_CHARS).min(chars.len());
+        // Only look for a boundary when there is more text after this cut —
+        // the final piece ends where the paragraph does.
+        let cut = if end == chars.len() {
+            end
+        } else {
+            chars[start..end]
+                .iter()
+                .rposition(|c| matches!(c, '.' | '!' | '?' | '\n'))
+                .map(|offset| start + offset + 1)
+                .filter(|cut| *cut > start)
+                .unwrap_or(end)
+        };
+        let piece: String = chars[start..cut].iter().collect();
+        if !piece.trim().is_empty() {
+            out.push(piece.trim().to_string());
+        }
+        start = cut;
+    }
+    out
+}

--- a/src/ingest/documents.rs
+++ b/src/ingest/documents.rs
@@ -7,6 +7,7 @@
 //! else because a feature moved.
 
 use super::Extracted;
+#[cfg(feature = "documents")]
 use super::text::normalize;
 
 /// Extracts a PDF's text layer.

--- a/src/ingest/documents.rs
+++ b/src/ingest/documents.rs
@@ -1,0 +1,211 @@
+//! PDF and OOXML text extraction (the `documents` feature).
+//!
+//! Every function here has a twin compiled when the feature is off, answering
+//! [`Extracted::Unsupported`] with the feature's name. That shape — rather
+//! than `#[cfg]` at the call site — is what keeps `ingest::extract`'s dispatch
+//! one table in every build, so a format is never silently routed somewhere
+//! else because a feature moved.
+
+use super::Extracted;
+use super::text::normalize;
+
+/// Extracts a PDF's text layer.
+///
+/// A scanned PDF has none, and that is [`Extracted::Empty`], not a failure:
+/// the file was read, it simply carries pictures of words. The console says so
+/// rather than reporting an error the operator cannot act on without OCR.
+#[cfg(feature = "documents")]
+pub fn pdf(bytes: &[u8]) -> Extracted {
+    // `pdf-extract` panics on some malformed documents rather than erroring,
+    // and a panic here would take down the request task. Caught so one bad
+    // file in a dropped folder is one reported row, not a failed upload of
+    // everything beside it.
+    let extracted = std::panic::catch_unwind(|| pdf_extract::extract_text_from_mem(bytes));
+    match extracted {
+        Ok(Ok(text)) if text.trim().is_empty() => Extracted::Empty,
+        Ok(Ok(text)) => Extracted::Text(normalize(&text)),
+        Ok(Err(error)) => Extracted::Unsupported(format!("the PDF could not be read: {error}")),
+        Err(_) => Extracted::Unsupported(
+            "the PDF is malformed enough that the parser gave up on it".to_string(),
+        ),
+    }
+}
+
+/// Extracts the body text of a Word document.
+#[cfg(feature = "documents")]
+pub fn docx(bytes: &[u8]) -> Extracted {
+    // `w:p` is a paragraph and `w:t` is a run of text inside it: joining runs
+    // without a paragraph break would run every heading into the sentence
+    // after it, and chunking splits on paragraphs.
+    ooxml(bytes, &["word/document.xml"], "w:p", "w:t")
+}
+
+/// Extracts the text of every slide in a deck, in slide order.
+#[cfg(feature = "documents")]
+pub fn pptx(bytes: &[u8]) -> Extracted {
+    ooxml_glob(bytes, "ppt/slides/slide", "a:p", "a:t")
+}
+
+/// Extracts a spreadsheet as one `sheet | cell | cell` line per row.
+///
+/// Flattened rather than reconstructed as a table because that is what recall
+/// can use: a chunk that reads `Q3 | EMEA | 412000` answers a question about
+/// EMEA revenue, and the same data as aligned columns does not survive
+/// chunking at all.
+#[cfg(feature = "documents")]
+pub fn xlsx(bytes: &[u8]) -> Extracted {
+    use calamine::{Data, Reader};
+
+    let cursor = std::io::Cursor::new(bytes.to_vec());
+    let mut workbook = match calamine::open_workbook_auto_from_rs(cursor) {
+        Ok(workbook) => workbook,
+        Err(error) => {
+            return Extracted::Unsupported(format!("the spreadsheet could not be read: {error}"));
+        }
+    };
+    let mut out = String::new();
+    for name in workbook.sheet_names().to_vec() {
+        let Ok(range) = workbook.worksheet_range(&name) else {
+            continue;
+        };
+        for row in range.rows() {
+            let cells: Vec<String> = row
+                .iter()
+                .map(|cell| match cell {
+                    Data::Empty => String::new(),
+                    other => other.to_string(),
+                })
+                .collect();
+            if cells.iter().all(|c| c.trim().is_empty()) {
+                continue;
+            }
+            out.push_str(&name);
+            for cell in cells {
+                out.push_str(" | ");
+                out.push_str(cell.trim());
+            }
+            out.push('\n');
+        }
+    }
+    if out.trim().is_empty() {
+        return Extracted::Empty;
+    }
+    Extracted::Text(normalize(&out))
+}
+
+/// Reads the named entries of an OOXML archive and pulls `text_tag` runs,
+/// breaking a paragraph wherever `paragraph_tag` closes.
+#[cfg(feature = "documents")]
+fn ooxml(bytes: &[u8], entries: &[&str], paragraph_tag: &str, text_tag: &str) -> Extracted {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = match zip::ZipArchive::new(cursor) {
+        Ok(archive) => archive,
+        Err(error) => {
+            return Extracted::Unsupported(format!("the document is not a readable file: {error}"));
+        }
+    };
+    let mut out = String::new();
+    for entry in entries {
+        let Ok(mut file) = archive.by_name(entry) else {
+            continue;
+        };
+        let mut xml = String::new();
+        if std::io::Read::read_to_string(&mut file, &mut xml).is_err() {
+            continue;
+        }
+        out.push_str(&xml_text(&xml, paragraph_tag, text_tag));
+    }
+    if out.trim().is_empty() {
+        return Extracted::Empty;
+    }
+    Extracted::Text(normalize(&out))
+}
+
+/// The [`ooxml`] shape for a part whose entries are numbered (`slide1.xml`,
+/// `slide2.xml`, …), read in numeric order.
+#[cfg(feature = "documents")]
+fn ooxml_glob(bytes: &[u8], prefix: &str, paragraph_tag: &str, text_tag: &str) -> Extracted {
+    let cursor = std::io::Cursor::new(bytes);
+    let Ok(archive) = zip::ZipArchive::new(cursor) else {
+        return Extracted::Unsupported("the document is not a readable file".to_string());
+    };
+    // Numeric, not lexicographic: `slide10.xml` sorts before `slide2.xml` as a
+    // string, and a deck whose slides recall out of order is worse than one
+    // that does not recall at all.
+    let mut names: Vec<String> = archive
+        .file_names()
+        .filter(|n| n.starts_with(prefix) && n.ends_with(".xml"))
+        .map(str::to_string)
+        .collect();
+    names.sort_by_key(|n| {
+        n.trim_start_matches(prefix)
+            .trim_end_matches(".xml")
+            .parse::<u32>()
+            .unwrap_or(u32::MAX)
+    });
+    let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    ooxml(bytes, &refs, paragraph_tag, text_tag)
+}
+
+/// Concatenates every `text_tag` run, inserting a blank line at each
+/// `paragraph_tag` close.
+#[cfg(feature = "documents")]
+fn xml_text(xml: &str, paragraph_tag: &str, text_tag: &str) -> String {
+    use quick_xml::events::Event;
+
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut out = String::new();
+    let mut in_text = false;
+    let mut buffer = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buffer) {
+            Ok(Event::Start(tag)) if tag.name().as_ref() == text_tag.as_bytes() => in_text = true,
+            Ok(Event::End(tag)) if tag.name().as_ref() == text_tag.as_bytes() => in_text = false,
+            Ok(Event::End(tag)) if tag.name().as_ref() == paragraph_tag.as_bytes() => {
+                out.push('\n');
+                out.push('\n');
+            }
+            Ok(Event::Text(text)) if in_text => {
+                out.push_str(&text.decode().unwrap_or_default());
+            }
+            Ok(Event::Eof) => break,
+            // A malformed part yields what was read up to it rather than
+            // nothing: a truncated document still holds the text before the
+            // break, and that is what the operator dropped it for.
+            Err(_) => break,
+            _ => {}
+        }
+        buffer.clear();
+    }
+    out
+}
+
+/// Names the feature rather than the format: an operator whose PDF was
+/// refused needs to know their build lacks the parser, not that PDFs are
+/// unsupported in general.
+#[cfg(not(feature = "documents"))]
+fn without_feature(format: &str) -> Extracted {
+    Extracted::Unsupported(format!(
+        "reading {format} needs the `documents` feature, which this build was compiled without"
+    ))
+}
+
+#[cfg(not(feature = "documents"))]
+pub fn pdf(_bytes: &[u8]) -> Extracted {
+    without_feature("PDFs")
+}
+
+#[cfg(not(feature = "documents"))]
+pub fn docx(_bytes: &[u8]) -> Extracted {
+    without_feature("Word documents")
+}
+
+#[cfg(not(feature = "documents"))]
+pub fn pptx(_bytes: &[u8]) -> Extracted {
+    without_feature("PowerPoint decks")
+}
+
+#[cfg(not(feature = "documents"))]
+pub fn xlsx(_bytes: &[u8]) -> Extracted {
+    without_feature("spreadsheets")
+}

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -1,0 +1,104 @@
+//! Turning dropped files and links into memory.
+//!
+//! One question, asked of arbitrary operator-supplied bytes: *what text is in
+//! here, and how should memory hold it?* The answer has three parts, and they
+//! are deliberately separate:
+//!
+//! - [`extract`] — bytes to text, per format ([`documents`] for the ones that
+//!   need a parser).
+//! - [`chunk`] — text to the sized, labelled pieces a
+//!   [`ContextStore`](crate::ports::ContextStore) actually holds.
+//! - `crate::server::ops::memory_ingest` — the route that puts them there.
+//!
+//! ## What is stored, and what is not
+//!
+//! **The text, not the file.** A dropped document is extracted, chunked, and
+//! written to memory; the original bytes are not retained anywhere. That is a
+//! deliberate answer to "where should this live", not an oversight: the
+//! workspace tree is the place for files an operator wants back
+//! (`ops::workspace`), and duplicating every upload into it would make the
+//! Brain page a second, silently diverging file manager. The consequence is
+//! stated plainly in the console — memory keeps what the document *said*, and
+//! re-uploading is how you correct it.
+//!
+//! ## Extraction never guesses
+//!
+//! A format this build cannot read produces [`Extracted::Unsupported`], which
+//! the route reports per file. It does **not** fall back to storing the raw
+//! bytes as if they were text: a chunk of decoded PDF operators would recall
+//! as noise, count as a memory, and be indistinguishable from a real one.
+
+pub mod chunk;
+pub mod documents;
+pub mod text;
+#[cfg(test)]
+mod test;
+
+pub use chunk::{DOCUMENT_LABEL_PREFIX, DocumentChunk, chunk_document, label_for};
+
+/// What extraction made of one file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Extracted {
+    /// Text was recovered. Never empty and never whitespace-only — an empty
+    /// extraction is [`Self::Empty`], because "we read it and it said nothing"
+    /// and "we stored nothing" must not be the same answer to the operator.
+    Text(String),
+    /// The format was understood and carried no text: a scanned PDF with no
+    /// text layer, an empty spreadsheet, a blank note.
+    Empty,
+    /// Nothing here can read this format. Carries what to say about it.
+    Unsupported(String),
+}
+
+impl Extracted {
+    /// The text, when there is any.
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            Self::Text(text) => Some(text),
+            _ => None,
+        }
+    }
+}
+
+/// Extracts the text of `bytes`, dispatching on the file name's extension and
+/// the declared content type.
+///
+/// The extension is consulted first and the declared type second, because a
+/// browser's `FormData` reports `application/octet-stream` for anything the OS
+/// has no mapping for — a `.md` file dropped from a folder tree routinely
+/// arrives that way, and trusting the declared type would send it to the
+/// unsupported branch.
+pub fn extract(name: &str, declared: Option<&str>, bytes: &[u8]) -> Extracted {
+    let extension = name
+        .rsplit_once('.')
+        .map(|(_, ext)| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+    let declared = declared.unwrap_or("").to_ascii_lowercase();
+
+    match extension.as_str() {
+        "pdf" => documents::pdf(bytes),
+        "docx" => documents::docx(bytes),
+        "pptx" => documents::pptx(bytes),
+        "xlsx" | "xlsm" => documents::xlsx(bytes),
+        "html" | "htm" => text::from_html_bytes(bytes),
+        // Word's pre-2007 binary formats and their friends. Named rather than
+        // left to the catch-all so the refusal can say what to do about it.
+        "doc" | "ppt" | "xls" | "rtf" | "pages" | "key" | "numbers" => {
+            Extracted::Unsupported(format!(
+                "`{extension}` is a legacy binary format this build does not read — export it as \
+                 PDF, .docx, .xlsx, .pptx or plain text and drop it again"
+            ))
+        }
+        _ if declared.starts_with("application/pdf") => documents::pdf(bytes),
+        _ => text::from_bytes(name, &declared, bytes),
+    }
+}
+
+/// The largest single file this route will read.
+///
+/// Deliberately below the workspace upload's own cap: that route stores what
+/// it is given, while this one *parses* it, and every parser here holds the
+/// whole document plus its extraction in memory at once. Twenty-five mebibytes
+/// covers the documents people actually drop on a memory page and keeps the
+/// peak per in-flight upload bounded to something a tenant container survives.
+pub const MAX_DOCUMENT_BYTES: usize = 25 * 1024 * 1024;

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -30,9 +30,9 @@
 
 pub mod chunk;
 pub mod documents;
-pub mod text;
 #[cfg(test)]
 mod test;
+pub mod text;
 
 pub use chunk::{DOCUMENT_LABEL_PREFIX, DocumentChunk, chunk_document, label_for};
 

--- a/src/ingest/test.rs
+++ b/src/ingest/test.rs
@@ -22,7 +22,11 @@ fn a_text_file_declared_as_octet_stream_is_still_extracted() {
 /// memory that says nothing is worse than an upload that reported why.
 #[test]
 fn binary_bytes_are_refused_rather_than_mangled() {
-    let extracted = extract("logo.png", Some("image/png"), &[0x89, b'P', b'N', b'G', 0x00]);
+    let extracted = extract(
+        "logo.png",
+        Some("image/png"),
+        &[0x89, b'P', b'N', b'G', 0x00],
+    );
     assert!(
         matches!(extracted, Extracted::Unsupported(_)),
         "got {extracted:?}"
@@ -33,7 +37,10 @@ fn binary_bytes_are_refused_rather_than_mangled() {
 /// must be distinguishable from a stored memory.
 #[test]
 fn an_empty_file_extracts_as_empty() {
-    assert_eq!(extract("blank.txt", Some("text/plain"), b"   \n\n"), Extracted::Empty);
+    assert_eq!(
+        extract("blank.txt", Some("text/plain"), b"   \n\n"),
+        Extracted::Empty
+    );
 }
 
 /// A legacy binary format names what to do about it, rather than falling into
@@ -80,7 +87,11 @@ fn an_unclosed_script_does_not_leak_its_body() {
 fn a_path_like_source_slugs_into_one_label_segment() {
     let label = label_for("Contracts/2026/acme msa.pdf");
     assert_eq!(label, "document/contracts-2026-acme-msa.pdf");
-    assert_eq!(label.matches('/').count(), 1, "one segment after the prefix");
+    assert_eq!(
+        label.matches('/').count(),
+        1,
+        "one segment after the prefix"
+    );
 }
 
 /// Every chunk names its document: a chunk surfaces from recall alone, and a

--- a/src/ingest/test.rs
+++ b/src/ingest/test.rs
@@ -120,7 +120,7 @@ fn a_long_document_splits_into_bounded_chunks() {
             chunk.body.chars().count() <= 3_100,
             "chunk of {} chars: {}",
             chunk.body.chars().count(),
-            &chunk.label
+            chunk.label
         );
     }
     // Labels stay ordered, so the console and recall both see the document in

--- a/src/ingest/test.rs
+++ b/src/ingest/test.rs
@@ -1,0 +1,183 @@
+//! Tests for extraction and chunking.
+
+use super::*;
+
+/// Markdown dropped from a folder tree arrives as `application/octet-stream`
+/// on every browser that has no mapping for the extension. Trusting the
+/// declared type would refuse the single most common thing dropped here.
+#[test]
+fn a_text_file_declared_as_octet_stream_is_still_extracted() {
+    let extracted = extract(
+        "notes.md",
+        Some("application/octet-stream"),
+        b"# Title\n\nBody text.",
+    );
+    assert_eq!(
+        extracted.text().map(str::to_string),
+        Some("# Title\n\nBody text.".to_string())
+    );
+}
+
+/// Binary bytes are refused rather than stored as replacement characters: a
+/// memory that says nothing is worse than an upload that reported why.
+#[test]
+fn binary_bytes_are_refused_rather_than_mangled() {
+    let extracted = extract("logo.png", Some("image/png"), &[0x89, b'P', b'N', b'G', 0x00]);
+    assert!(
+        matches!(extracted, Extracted::Unsupported(_)),
+        "got {extracted:?}"
+    );
+}
+
+/// An empty file is `Empty`, not `Text("")` — "we read it and it said nothing"
+/// must be distinguishable from a stored memory.
+#[test]
+fn an_empty_file_extracts_as_empty() {
+    assert_eq!(extract("blank.txt", Some("text/plain"), b"   \n\n"), Extracted::Empty);
+}
+
+/// A legacy binary format names what to do about it, rather than falling into
+/// the generic "not UTF-8" refusal.
+#[test]
+fn a_legacy_office_format_says_how_to_convert_it() {
+    let Extracted::Unsupported(reason) = extract("contract.doc", None, b"\xd0\xcf\x11\xe0") else {
+        panic!("a .doc must be refused");
+    };
+    assert!(reason.contains("export it"), "{reason}");
+}
+
+/// Script and style bodies never reach memory: a page's inline analytics would
+/// otherwise be the first thing recall finds in it.
+#[test]
+fn html_extraction_drops_scripts_and_tags() {
+    let Extracted::Text(text) = text::from_html(
+        "<html><head><style>p{color:red}</style></head><body><script>track('x')</script>\
+         <h1>Pricing</h1><p>Enterprise is &pound;40&nbsp;per seat.</p></body></html>",
+    ) else {
+        panic!("expected text");
+    };
+    assert!(text.contains("Pricing"), "{text}");
+    assert!(text.contains("Enterprise is"), "{text}");
+    assert!(!text.contains("track"), "the script body leaked: {text}");
+    assert!(!text.contains("color:red"), "the style body leaked: {text}");
+}
+
+/// An unclosed `<script>` swallows the rest of the document — what a browser
+/// does with it too — rather than leaking code into memory.
+#[test]
+fn an_unclosed_script_does_not_leak_its_body() {
+    let extracted = text::from_html("<body><p>Keep</p><script>secret_token='abc'");
+    let Extracted::Text(text) = extracted else {
+        panic!("expected text");
+    };
+    assert!(text.contains("Keep"), "{text}");
+    assert!(!text.contains("secret_token"), "{text}");
+}
+
+/// Chunk labels are addressing keys, so a folder drop's relative path must not
+/// nest one document's chunks under another's prefix.
+#[test]
+fn a_path_like_source_slugs_into_one_label_segment() {
+    let label = label_for("Contracts/2026/acme msa.pdf");
+    assert_eq!(label, "document/contracts-2026-acme-msa.pdf");
+    assert_eq!(label.matches('/').count(), 1, "one segment after the prefix");
+}
+
+/// Every chunk names its document: a chunk surfaces from recall alone, and a
+/// paragraph of a contract is only useful if you know which contract.
+#[test]
+fn every_chunk_names_its_source() {
+    let text = "Alpha paragraph.\n\nBeta paragraph.";
+    let chunks = chunk_document("msa.pdf", text);
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].body.starts_with("msa.pdf\n\n"));
+    assert!(chunks[0].label.starts_with("document/msa.pdf/"));
+}
+
+/// A long document splits, and the split is bounded — the property that keeps
+/// one dropped file from flooding a turn's context.
+#[test]
+fn a_long_document_splits_into_bounded_chunks() {
+    let paragraph = "Sentence about revenue. ".repeat(60);
+    let text = std::iter::repeat_n(paragraph.trim(), 6)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let chunks = chunk_document("report.txt", &text);
+    assert!(chunks.len() > 1, "expected a split, got {}", chunks.len());
+    for chunk in &chunks {
+        assert!(
+            chunk.body.chars().count() <= 3_100,
+            "chunk of {} chars: {}",
+            chunk.body.chars().count(),
+            &chunk.label
+        );
+    }
+    // Labels stay ordered, so the console and recall both see the document in
+    // reading order.
+    let labels: Vec<&str> = chunks.iter().map(|c| c.label.as_str()).collect();
+    let mut sorted = labels.clone();
+    sorted.sort_unstable();
+    assert_eq!(labels, sorted);
+}
+
+/// A single paragraph longer than the hard cap is cut rather than emitted
+/// whole — the case a spreadsheet export or minified prose produces.
+#[test]
+fn one_enormous_paragraph_is_hard_split() {
+    let text = "word ".repeat(2_000);
+    let chunks = chunk_document("rows.csv", &text);
+    assert!(chunks.len() > 1);
+    assert!(chunks.iter().all(|c| !c.body.trim().is_empty()));
+    // Nothing is lost in the cut: every word survives somewhere.
+    let joined: String = chunks
+        .iter()
+        .map(|c| c.body.replace("rows.csv\n\n", ""))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(joined.matches("word").count(), 2_000);
+}
+
+/// Extraction of a real OOXML archive, built here rather than checked in as a
+/// fixture so the test says what it is asserting about.
+#[cfg(feature = "documents")]
+#[test]
+fn a_docx_yields_its_paragraphs_in_order() {
+    let document = r#"<?xml version="1.0"?>
+<w:document xmlns:w="x"><w:body>
+<w:p><w:r><w:t>First heading</w:t></w:r></w:p>
+<w:p><w:r><w:t>Second </w:t></w:r><w:r><w:t>paragraph.</w:t></w:r></w:p>
+</w:body></w:document>"#;
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut buffer);
+        let options: zip::write::FileOptions<'_, ()> =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        writer.start_file("word/document.xml", options).unwrap();
+        std::io::Write::write_all(&mut writer, document.as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+    let Extracted::Text(text) = extract("spec.docx", None, &buffer.into_inner()) else {
+        panic!("expected text");
+    };
+    assert!(text.starts_with("First heading"), "{text}");
+    assert!(
+        text.contains("Second paragraph."),
+        "runs inside one paragraph join without a break: {text}"
+    );
+    assert!(
+        text.contains("First heading\n\nSecond"),
+        "paragraphs keep their break: {text:?}"
+    );
+}
+
+/// A build without the parsers refuses by naming the feature, so an operator
+/// learns why their PDF produced nothing.
+#[cfg(not(feature = "documents"))]
+#[test]
+fn a_pdf_without_the_feature_names_the_feature() {
+    let Extracted::Unsupported(reason) = extract("contract.pdf", Some("application/pdf"), b"%PDF-")
+    else {
+        panic!("expected a refusal");
+    };
+    assert!(reason.contains("documents"), "{reason}");
+}

--- a/src/ingest/text.rs
+++ b/src/ingest/text.rs
@@ -40,7 +40,11 @@ pub fn from_bytes(name: &str, declared: &str, bytes: &[u8]) -> Extracted {
         Ok(text) => Extracted::Text(normalize(text)),
         Err(_) => Extracted::Unsupported(format!(
             "`{name}` is not UTF-8 text, and its type ({}) names no format this build can parse",
-            if declared.is_empty() { "unset" } else { declared }
+            if declared.is_empty() {
+                "unset"
+            } else {
+                declared
+            }
         )),
     }
 }

--- a/src/ingest/text.rs
+++ b/src/ingest/text.rs
@@ -1,0 +1,162 @@
+//! Plain-text and HTML extraction — the formats that need no parser.
+//!
+//! Always compiled, whatever feature set: a build without `documents` still
+//! ingests Markdown, notes, CSV exports, JSON and source files, which is the
+//! bulk of what a drop zone on a memory page receives.
+
+use super::Extracted;
+
+/// Content types that are text whatever their extension says.
+const TEXT_MIME_PREFIXES: [&str; 2] = ["text/", "message/"];
+
+/// Structured content types that are text but do not say `text/`.
+const TEXT_MIME_EXACT: [&str; 6] = [
+    "application/json",
+    "application/xml",
+    "application/x-yaml",
+    "application/yaml",
+    "application/toml",
+    "application/javascript",
+];
+
+/// Decodes `bytes` as UTF-8 text, refusing anything that is not.
+///
+/// The refusal is the point. A `.bin` renamed `.txt`, or an image dropped with
+/// no extension, decodes into replacement characters — storing that would put
+/// a memory in the company's brain that says nothing and can never be
+/// recalled usefully, while looking exactly like a real one in the list.
+pub fn from_bytes(name: &str, declared: &str, bytes: &[u8]) -> Extracted {
+    let looks_textual = TEXT_MIME_PREFIXES.iter().any(|p| declared.starts_with(p))
+        || TEXT_MIME_EXACT.contains(&declared)
+        || declared.is_empty()
+        || declared == "application/octet-stream";
+    if !looks_textual {
+        return Extracted::Unsupported(format!(
+            "`{declared}` is not a format this build can read as text"
+        ));
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(text) if text.trim().is_empty() => Extracted::Empty,
+        Ok(text) => Extracted::Text(normalize(text)),
+        Err(_) => Extracted::Unsupported(format!(
+            "`{name}` is not UTF-8 text, and its type ({}) names no format this build can parse",
+            if declared.is_empty() { "unset" } else { declared }
+        )),
+    }
+}
+
+/// Extracts the visible text of an HTML document.
+pub fn from_html_bytes(bytes: &[u8]) -> Extracted {
+    match std::str::from_utf8(bytes) {
+        Ok(html) => from_html(html),
+        Err(_) => Extracted::Unsupported("the HTML is not UTF-8".to_string()),
+    }
+}
+
+/// Strips tags, `<script>`/`<style>` bodies, and HTML entities.
+///
+/// A hand-written scanner rather than a parser dependency: what memory needs
+/// from a web page is its prose, the failure mode of getting a tag boundary
+/// slightly wrong is a stray angle bracket in a chunk, and neither justifies
+/// pulling a full HTML tree into the default build.
+pub fn from_html(html: &str) -> Extracted {
+    let mut out = String::with_capacity(html.len() / 2);
+    let mut rest = html;
+    // Drop the two elements whose *content* is code rather than prose. Left in,
+    // a page's inline analytics script becomes the first thing recall finds.
+    for element in ["script", "style"] {
+        rest = &*Box::leak(strip_element(rest, element).into_boxed_str());
+    }
+    let mut in_tag = false;
+    for ch in rest.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                // Tags are element boundaries, so they are whitespace to the
+                // text — without this `<p>a</p><p>b</p>` reads as `ab`.
+                out.push(' ');
+            }
+            '>' => in_tag = false,
+            _ if in_tag => {}
+            _ => out.push(ch),
+        }
+    }
+    let decoded = decode_entities(&out);
+    if decoded.trim().is_empty() {
+        return Extracted::Empty;
+    }
+    Extracted::Text(normalize(&decoded))
+}
+
+/// Removes `<name>…</name>` including its content, case-insensitively.
+fn strip_element(html: &str, name: &str) -> String {
+    let lower = html.to_ascii_lowercase();
+    let open = format!("<{name}");
+    let close = format!("</{name}>");
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+    while let Some(start) = lower[cursor..].find(&open) {
+        let start = cursor + start;
+        out.push_str(&html[cursor..start]);
+        match lower[start..].find(&close) {
+            Some(end) => cursor = start + end + close.len(),
+            // An unclosed `<script>` runs to the end of the document, which is
+            // what a browser does with it too.
+            None => return out,
+        }
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+/// Decodes the handful of entities that actually appear in prose.
+fn decode_entities(text: &str) -> String {
+    text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&mdash;", "—")
+        .replace("&ndash;", "–")
+        .replace("&hellip;", "…")
+}
+
+/// Collapses runs of blank lines and trailing spaces.
+///
+/// Extraction output is full of layout artefacts — a PDF page break, a table
+/// cell's padding — and every one of them costs chunk budget that could hold
+/// another sentence.
+pub fn normalize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut blank_run = 0;
+    for line in text.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.trim().is_empty() {
+            blank_run += 1;
+            if blank_run > 1 {
+                continue;
+            }
+            out.push('\n');
+            continue;
+        }
+        blank_run = 0;
+        // Interior runs of spaces collapse too: PDF extraction pads columns
+        // with dozens of them.
+        let mut last_space = false;
+        for ch in trimmed.chars() {
+            if ch.is_whitespace() {
+                if !last_space {
+                    out.push(' ');
+                }
+                last_space = true;
+            } else {
+                out.push(ch);
+                last_space = false;
+            }
+        }
+        out.push('\n');
+    }
+    out.trim().to_string()
+}

--- a/src/ingest/text.rs
+++ b/src/ingest/text.rs
@@ -61,11 +61,11 @@ pub fn from_html_bytes(bytes: &[u8]) -> Extracted {
 /// pulling a full HTML tree into the default build.
 pub fn from_html(html: &str) -> Extracted {
     let mut out = String::with_capacity(html.len() / 2);
-    let mut rest = html;
     // Drop the two elements whose *content* is code rather than prose. Left in,
     // a page's inline analytics script becomes the first thing recall finds.
+    let mut rest = html.to_string();
     for element in ["script", "style"] {
-        rest = &*Box::leak(strip_element(rest, element).into_boxed_str());
+        rest = strip_element(&rest, element);
     }
     let mut in_tag = false;
     for ch in rest.chars() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ pub mod globals;
 /// echo-brained, offline behaviour unchanged.
 #[cfg(feature = "openhuman")]
 pub mod harness;
+/// Turning dropped files and links into memory: extraction, then chunking.
+/// The console's Brain drop zone is the caller; the ports are unchanged.
+pub mod ingest;
 /// Dynamic ledgers: the company's own record — goals, decisions, and whatever
 /// axis a workspace declares — as a folded append-only log rendered into the
 /// `derived/` folder. The task board is registered here as a native ledger so

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -102,6 +102,13 @@ enum MemoryOrigin {
     AgentMemory,
     /// A stored task outcome the harness wrote (ContextStore). Read-only.
     TaskOutcome,
+    /// A chunk of a document or link an operator dropped on the Brain page
+    /// (`crate::server::ops::memory_ingest`). Its own origin rather than
+    /// folded into [`AgentMemory`](MemoryOrigin::AgentMemory): an operator has
+    /// to be able to see what their upload became, and rendering it as
+    /// something a teammate learned would say the wrong thing about where the
+    /// knowledge came from.
+    Document,
 }
 
 /// A durable memory entry as the console renders it.
@@ -193,6 +200,7 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
     let needle = query.map(|q| q.to_lowercase());
     let mirror_prefix = format!("{OPERATOR_FACT_PREFIX}/");
     let outcome_prefix = format!("{OUTCOME_LABEL_PREFIX}/");
+    let document_prefix = format!("{}/", crate::ingest::DOCUMENT_LABEL_PREFIX);
 
     let mut entries: Vec<MemoryEntry> = Vec::new();
 
@@ -209,7 +217,20 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
         }
 
         let (origin, source): (MemoryOrigin, String) =
-            if let Some(agent) = chunk.label.strip_prefix(&outcome_prefix) {
+            if chunk.label.starts_with(&document_prefix) {
+                // The document's own name, which `ingest::chunk_document`
+                // writes as the chunk's first line for exactly this reason: a
+                // label is slugged and truncated, so it cannot be rendered
+                // back as the file the operator dropped.
+                let named = chunk
+                    .body
+                    .lines()
+                    .next()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .unwrap_or("a document");
+                (MemoryOrigin::Document, named.to_string())
+            } else if let Some(agent) = chunk.label.strip_prefix(&outcome_prefix) {
                 let who = if agent.is_empty() { "an agent" } else { agent };
                 (MemoryOrigin::TaskOutcome, who.to_string())
             } else {
@@ -231,6 +252,7 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
         if title.is_empty() {
             title = match origin {
                 MemoryOrigin::TaskOutcome => "Task outcome".to_string(),
+                MemoryOrigin::Document => "Document".to_string(),
                 _ => "Agent memory".to_string(),
             };
         }

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -126,7 +126,8 @@ struct MemoryEntry {
     kind: Option<FactKind>,
     /// Which backend the row came from; drives editable-vs-read-only rendering.
     origin: MemoryOrigin,
-    /// Whether the operator may edit/delete this row (true only for facts).
+    /// Whether the operator may delete this row: facts, and the documents
+    /// they dropped on the Brain page. Never the agents' own memory.
     editable: bool,
     title: String,
     body: String,
@@ -263,7 +264,12 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
             id: format!("ctx:{}", chunk.addr),
             kind: None,
             origin,
-            editable: false,
+            // A document is material the operator supplied, so they may take
+            // it back — through `…/memory/document/{slug}`, which forgets the
+            // whole document rather than this one chunk of it. The two agent
+            // origins stay read-only: they are the record of what the company
+            // did, not something anybody typed.
+            editable: matches!(origin, MemoryOrigin::Document),
             title,
             body,
             source,

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -216,37 +216,37 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
             continue;
         }
 
-        let (origin, source): (MemoryOrigin, String) =
-            if chunk.label.starts_with(&document_prefix) {
-                // The document's own name, which `ingest::chunk_document`
-                // writes as the chunk's first line for exactly this reason: a
-                // label is slugged and truncated, so it cannot be rendered
-                // back as the file the operator dropped.
-                let named = chunk
-                    .body
-                    .lines()
-                    .next()
-                    .map(str::trim)
-                    .filter(|line| !line.is_empty())
-                    .unwrap_or("a document");
-                (MemoryOrigin::Document, named.to_string())
-            } else if let Some(agent) = chunk.label.strip_prefix(&outcome_prefix) {
-                let who = if agent.is_empty() { "an agent" } else { agent };
-                (MemoryOrigin::TaskOutcome, who.to_string())
-            } else {
-                // Deliberate memories live one segment deeper —
-                // `agent-memory/<agent>/<slug>` — so the naive first-segment
-                // parse attributed every one of them to the literal
-                // "agent-memory" (the #1290 review's M2).
-                let who = match chunk.label.strip_prefix(const_format_prefix()) {
-                    Some(rest) => rest.split('/').next().filter(|s| !s.is_empty()),
-                    None => chunk.label.split('/').next().filter(|s| !s.is_empty()),
-                };
-                (
-                    MemoryOrigin::AgentMemory,
-                    who.unwrap_or("an agent").to_string(),
-                )
+        let (origin, source): (MemoryOrigin, String) = if chunk.label.starts_with(&document_prefix)
+        {
+            // The document's own name, which `ingest::chunk_document`
+            // writes as the chunk's first line for exactly this reason: a
+            // label is slugged and truncated, so it cannot be rendered
+            // back as the file the operator dropped.
+            let named = chunk
+                .body
+                .lines()
+                .next()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .unwrap_or("a document");
+            (MemoryOrigin::Document, named.to_string())
+        } else if let Some(agent) = chunk.label.strip_prefix(&outcome_prefix) {
+            let who = if agent.is_empty() { "an agent" } else { agent };
+            (MemoryOrigin::TaskOutcome, who.to_string())
+        } else {
+            // Deliberate memories live one segment deeper —
+            // `agent-memory/<agent>/<slug>` — so the naive first-segment
+            // parse attributed every one of them to the literal
+            // "agent-memory" (the #1290 review's M2).
+            let who = match chunk.label.strip_prefix(const_format_prefix()) {
+                Some(rest) => rest.split('/').next().filter(|s| !s.is_empty()),
+                None => chunk.label.split('/').next().filter(|s| !s.is_empty()),
             };
+            (
+                MemoryOrigin::AgentMemory,
+                who.unwrap_or("an agent").to_string(),
+            )
+        };
 
         let (mut title, body) = split_title_body(&chunk.body);
         if title.is_empty() {

--- a/src/server/ops/memory_engine.rs
+++ b/src/server/ops/memory_engine.rs
@@ -351,7 +351,10 @@ fn saved_selection(state: &AppState) -> Result<(MemorySelection, &'static str), 
     }
     let file = ConfigFile::load(state.config_root())?;
     let section = file.map(|f| f.memory).unwrap_or_default();
-    let named = section.backend.as_deref().is_some_and(|b| !b.trim().is_empty());
+    let named = section
+        .backend
+        .as_deref()
+        .is_some_and(|b| !b.trim().is_empty());
     let selection = MemorySelection::from_section(&section)?;
     Ok((selection, if named { "config.toml" } else { "default" }))
 }

--- a/src/server/ops/memory_engine.rs
+++ b/src/server/ops/memory_engine.rs
@@ -1,0 +1,634 @@
+//! Memory-engine selection: which engine this instance binds, chosen from the
+//! console instead of only from the process environment.
+//!
+//! ```text
+//! GET  …/memory/engine        what is bound, what is saved, what can be picked
+//! POST …/memory/engine/test   probe a candidate engine without saving it
+//! PUT  …/memory/engine        save it, bind it, and put it in force
+//! ```
+//!
+//! ## Why a route and not just `OPENCOMPANY_MEMORY`
+//!
+//! The engine was selectable only by whoever controls the process environment,
+//! which on a self-hosted box means editing a unit file and restarting. The
+//! Brain page could *show* the bound engine (`docs/spec/runtime/memory-engine.md`)
+//! and nothing else. This is the write half: the choice persists to the
+//! `[memory]` section of `config.toml` — the instance's own second
+//! configuration layer, not a company's manifest, because one instance binds
+//! one engine.
+//!
+//! ## It applies live, and says so honestly when it cannot
+//!
+//! A saved-but-not-applied engine is the failure this surface exists to avoid:
+//! an operator who picks Supermemory and is then shown their old memory has no
+//! way to tell whether the choice landed. So [`apply`] opens the replacement
+//! overlay, probes it, swaps it onto the [`AppState`], and rebuilds every
+//! registered company so the new ports are actually the ones a turn will use
+//! ([`rebuild_company`](crate::runtime::rebuild_company)). A host with no
+//! rebuilder wired is the only case that still needs a restart, and it is
+//! reported per-company rather than assumed — the same contract
+//! `crate::server::setup` keeps for `auth_mode`.
+//!
+//! ## An engine that does not answer is refused, not bound
+//!
+//! Boot binds an unreachable engine and warns, because a transient vendor
+//! outage must not crash-loop a tenant. An interactive apply is the opposite
+//! case: the operator is right there, a typo'd URL or a revoked key is the
+//! overwhelmingly likely cause, and binding it anyway would swap a working
+//! engine out for a dead one. So a failed probe refuses the change and the old
+//! overlay stays in force. `?force=true` is the escape hatch for an engine the
+//! operator knows is down and wants bound anyway.
+//!
+//! ## The environment still outranks it
+//!
+//! `env ⟵ config.toml`, exactly as every other key resolves
+//! (`docs/spec/runtime/config.md`). A hosted tenant has `OPENCOMPANY_MEMORY*`
+//! injected by the control plane; accepting an edit there would write a file,
+//! report success, and change nothing at the next boot. [`read`] therefore
+//! reports `editable: false` with the owning layer, and [`apply`] refuses with
+//! `409` rather than pretending. See
+//! [`MemorySection`](crate::app::config::MemorySection).
+
+use axum::extract::Query;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::app::config::{ConfigFile, ConfigValue, write_config_toml};
+use crate::error::OpenCompanyError;
+use crate::server::error::ApiError;
+use crate::server::ops::scope::{AdminScopedCompany, scoped};
+use crate::store::{MemoryBackend, MemorySelection, StorageSettings};
+
+/// How long an interactive probe waits for the engine to answer.
+///
+/// Shorter than boot's five seconds on purpose: a human is watching this one,
+/// and a hosted engine that needs more than three seconds to answer a health
+/// check is not one an operator should be told is fine.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Builds the memory-engine route fragment.
+pub fn router() -> Router<AppState> {
+    scoped("/memory/engine", get(read).put(apply))
+        .merge(scoped("/memory/engine/test", post(test_engine)))
+}
+
+/// One selectable engine, as the console draws it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EngineOption {
+    /// What a `PUT` sends back: `store`, `embedded`, `namespace`,
+    /// `supermemory`, `mem0`, `cognee`, `null`.
+    ///
+    /// Deliberately flatter than the `(backend, driver)` pair the runtime
+    /// takes: "embedded, driver namespace" and "remote, driver mem0" are one
+    /// choice to an operator and two knobs to the host, and asking a console
+    /// to model that correctly is how a UI ends up offering `remote` with no
+    /// driver — a combination the host refuses at bind.
+    id: &'static str,
+    /// Human label for the tile.
+    label: &'static str,
+    /// One line on what picking it means.
+    description: &'static str,
+    /// Whether this build can actually construct it. A `false` tile renders
+    /// disabled with `unavailableReason` rather than vanishing: an operator
+    /// looking for Supermemory should learn their build lacks the feature, not
+    /// conclude the product has no such thing.
+    available: bool,
+    /// Which Cargo feature it needs, when `available` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unavailable_reason: Option<String>,
+    /// Whether the engine needs an endpoint.
+    requires_url: bool,
+    /// Whether the engine needs a credential.
+    requires_key: bool,
+    /// Whether anything this engine stores survives a restart. `false` for
+    /// `null` alone, which the console warns on.
+    durable: bool,
+}
+
+/// The engine surface: what is bound now, what is saved, and what may be picked.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EngineDto {
+    /// The engine id currently in force — derived from the live overlay, not
+    /// from the file, so a saved-but-unapplied change is visible as a
+    /// difference between this and [`Self::selected`].
+    active: String,
+    /// The capability families the live engine negotiated at bind time.
+    capabilities: Vec<String>,
+    /// The last probe's verdict; absent when the engine was never probed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    healthy: Option<bool>,
+    /// The engine id the saved selection names (the file, or the environment
+    /// when it owns the choice).
+    selected: String,
+    /// The saved endpoint, when the selected engine has one. Topology, not a
+    /// secret — the credential never comes back out.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    /// Whether a credential is stored. The bytes are never served.
+    api_key_set: bool,
+    /// Which layer owns the choice: `env`, `config.toml`, or `default`.
+    layer: &'static str,
+    /// Whether this instance may change it from here.
+    editable: bool,
+    /// The file a change is written to, so the console can name it.
+    config_path: String,
+    /// Every engine this build knows about, selectable or not.
+    options: Vec<EngineOption>,
+}
+
+/// A submitted engine choice.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EngineRequest {
+    /// One of [`EngineOption::id`].
+    engine: String,
+    /// The endpoint, for an engine that needs one.
+    #[serde(default)]
+    url: Option<String>,
+    /// The credential. Absent means "keep the stored one" — a console that
+    /// re-sent a redacted key would otherwise save the redaction. An explicit
+    /// empty string clears it.
+    #[serde(default)]
+    api_key: Option<String>,
+}
+
+/// Whether to bind an engine whose probe failed.
+#[derive(Debug, Default, Deserialize)]
+struct ApplyQuery {
+    #[serde(default)]
+    force: bool,
+}
+
+/// What an apply did.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AppliedDto {
+    /// The engine now in force.
+    engine: String,
+    /// Whether the probe found it usable (absent when there was nothing to
+    /// probe — the base store, or the in-pod engine overlay).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    healthy: Option<bool>,
+    /// Companies whose runtime could not be rebuilt in place, and therefore
+    /// still hold the previous engine's ports until the process restarts.
+    /// Empty means the swap is fully in force.
+    restart_required_for: Vec<String>,
+    /// The file the choice was written to.
+    config_path: String,
+    /// The engine surface again, so the console re-renders from one answer.
+    engine_state: EngineDto,
+}
+
+/// What a probe found, without saving anything.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProbeDto {
+    /// Whether the candidate answered a health check.
+    healthy: bool,
+    /// The families it negotiated, so an operator sees what it does NOT do
+    /// before committing to it.
+    capabilities: Vec<String>,
+    /// Why it failed, when it did.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+/// The engine catalog.
+///
+/// The remote ids mirror `store::memory::driver::SUPPORTED_REMOTE_DRIVERS`,
+/// duplicated because that module is `tinymemory`-gated while this route is
+/// always compiled — the same duplication, for the same reason, that
+/// `ops::memory` keeps for the outcome label prefix. The
+/// `catalog_matches_driver_registry` test under the feature keeps them honest.
+fn catalog() -> Vec<EngineOption> {
+    // Feature availability, resolved once. `cfg!` rather than `#[cfg]` blocks
+    // so the catalog is one list in one order in every build — an option that
+    // disappears entirely reads as "this product has no such engine".
+    let tinymemory = cfg!(feature = "tinymemory");
+    let embedded_contract = cfg!(feature = "tinymemory-embedded");
+    let engine = cfg!(feature = "tinycortex");
+    let feature = |on: bool, name: &str| {
+        (!on).then(|| format!("this build was compiled without the `{name}` feature"))
+    };
+    vec![
+        EngineOption {
+            id: "store",
+            label: "Built-in store",
+            description: "Memory lives in this instance's own storage backend. No engine, no \
+                          network call, nothing to configure.",
+            available: true,
+            unavailable_reason: None,
+            requires_url: false,
+            requires_key: false,
+            durable: true,
+        },
+        EngineOption {
+            id: "embedded",
+            label: "TinyCortex",
+            description: "The in-pod engine: vector-first recall over a persistent per-company \
+                          store, with lexical and recency fallback.",
+            available: engine,
+            unavailable_reason: feature(engine, "tinycortex"),
+            requires_url: false,
+            requires_key: false,
+            durable: true,
+        },
+        EngineOption {
+            id: "namespace",
+            label: "TinyMemory (in-pod)",
+            description: "The memory contract's own durable store, in this pod. Graph and \
+                          keyword recall; starts empty — nothing migrates from TinyCortex.",
+            available: embedded_contract,
+            unavailable_reason: feature(embedded_contract, "tinymemory-embedded"),
+            requires_url: false,
+            requires_key: false,
+            durable: true,
+        },
+        EngineOption {
+            id: "supermemory",
+            label: "Supermemory",
+            description: "A hosted memory engine. Your company's memory is stored by Supermemory \
+                          under this instance's namespace.",
+            available: tinymemory,
+            unavailable_reason: feature(tinymemory, "tinymemory"),
+            requires_url: true,
+            requires_key: true,
+            durable: true,
+        },
+        EngineOption {
+            id: "mem0",
+            label: "Mem0",
+            description: "A hosted memory engine. Your company's memory is stored by Mem0 under \
+                          this instance's namespace.",
+            available: tinymemory,
+            unavailable_reason: feature(tinymemory, "tinymemory"),
+            requires_url: true,
+            requires_key: true,
+            durable: true,
+        },
+        EngineOption {
+            id: "cognee",
+            label: "Cognee",
+            description: "A hosted memory engine with a knowledge graph. Stored by Cognee under \
+                          this instance's namespace.",
+            available: tinymemory,
+            unavailable_reason: feature(tinymemory, "tinymemory"),
+            requires_url: true,
+            requires_key: true,
+            durable: true,
+        },
+        EngineOption {
+            id: "null",
+            label: "No memory",
+            description: "Every write is accepted and discarded, every read is empty. For \
+                          testing what the company does without memory.",
+            available: tinymemory,
+            unavailable_reason: feature(tinymemory, "tinymemory"),
+            requires_url: false,
+            requires_key: false,
+            durable: false,
+        },
+    ]
+}
+
+/// Looks an engine id up in the catalog.
+fn option_for(engine: &str) -> Option<EngineOption> {
+    catalog().into_iter().find(|o| o.id == engine)
+}
+
+/// The `(backend, driver)` pair an engine id resolves to.
+///
+/// This is the whole reason the wire carries one id: `embedded` with no driver
+/// is the incumbent engine and `embedded` with `namespace` is the contract
+/// store, a distinction no console should have to encode.
+fn split_engine(engine: &str) -> Option<(MemoryBackend, Option<&'static str>)> {
+    match engine {
+        "store" => Some((MemoryBackend::Store, None)),
+        "embedded" => Some((MemoryBackend::Tinycortex, None)),
+        "namespace" => Some((MemoryBackend::Tinycortex, Some("namespace"))),
+        "supermemory" => Some((MemoryBackend::Remote, Some("supermemory"))),
+        "mem0" => Some((MemoryBackend::Remote, Some("mem0"))),
+        "cognee" => Some((MemoryBackend::Remote, Some("cognee"))),
+        "null" => Some((MemoryBackend::Null, None)),
+        _ => None,
+    }
+}
+
+/// The inverse of [`split_engine`]: the console-facing id for a selection.
+///
+/// Total rather than fallible: a selection assembled outside this module (an
+/// environment naming `remote` with no driver, say) still has to render, and
+/// falling back to the backend's own name says something true rather than
+/// erroring a read that is only describing what is there.
+fn engine_id(selection: &MemorySelection) -> String {
+    match (selection.backend, selection.driver.as_deref()) {
+        (MemoryBackend::Store, _) => "store".to_string(),
+        (MemoryBackend::Tinycortex, None) => "embedded".to_string(),
+        (MemoryBackend::Tinycortex, Some(driver)) => driver.to_string(),
+        (MemoryBackend::Remote, Some(driver)) => driver.to_string(),
+        (MemoryBackend::Remote, None) => "remote".to_string(),
+        (MemoryBackend::Null, _) => "null".to_string(),
+    }
+}
+
+/// The saved selection and which layer owns it.
+fn saved_selection(state: &AppState) -> Result<(MemorySelection, &'static str), OpenCompanyError> {
+    if StorageSettings::memory_is_env_owned() {
+        let settings = StorageSettings::from_env()?;
+        return Ok((
+            MemorySelection {
+                backend: settings.memory_backend,
+                driver: settings.memory_driver,
+                url: settings.memory_url,
+                api_key: settings.memory_api_key,
+            },
+            "env",
+        ));
+    }
+    let file = ConfigFile::load(state.config_root())?;
+    let section = file.map(|f| f.memory).unwrap_or_default();
+    let named = section.backend.as_deref().is_some_and(|b| !b.trim().is_empty());
+    let selection = MemorySelection::from_section(&section)?;
+    Ok((selection, if named { "config.toml" } else { "default" }))
+}
+
+/// Renders the whole engine surface.
+fn snapshot(state: &AppState) -> Result<EngineDto, OpenCompanyError> {
+    let (selection, layer) = saved_selection(state)?;
+    let live = state.memory_overlay();
+    // The live overlay is the honest answer to "what is bound"; its absence
+    // means the base store serves memory, which is exactly `store`.
+    let (active, capabilities, healthy) = match &live {
+        Some(overlay) => (
+            engine_id(&MemorySelection {
+                backend: overlay.descriptor.backend,
+                driver: Some(overlay.descriptor.driver_id.clone()),
+                url: None,
+                api_key: None,
+            }),
+            overlay.descriptor.capabilities.clone(),
+            overlay.descriptor.healthy,
+        ),
+        None => ("store".to_string(), Vec::new(), None),
+    };
+    Ok(EngineDto {
+        active,
+        capabilities,
+        healthy,
+        selected: engine_id(&selection),
+        url: selection.url.clone(),
+        api_key_set: selection.api_key.is_some(),
+        layer,
+        editable: layer != "env",
+        config_path: state
+            .config_root()
+            .join("config.toml")
+            .display()
+            .to_string(),
+        options: catalog(),
+    })
+}
+
+/// `GET …/memory/engine`.
+async fn read(
+    company: AdminScopedCompany,
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Result<Json<EngineDto>, ApiError> {
+    // The company is resolved for authorization only: the engine is an
+    // instance-level choice, and every company on this host shares it.
+    let _ = company.id();
+    Ok(Json(snapshot(&state)?))
+}
+
+/// Turns a submitted choice into a validated [`MemorySelection`], carrying the
+/// stored credential forward when the request omits one.
+fn selection_from(
+    request: &EngineRequest,
+    stored: &MemorySelection,
+) -> Result<MemorySelection, OpenCompanyError> {
+    let engine = request.engine.trim();
+    let option = option_for(engine).ok_or_else(|| {
+        OpenCompanyError::InvalidRequest(format!(
+            "`{engine}` is not a memory engine this host knows. Pick one of: {}.",
+            catalog()
+                .iter()
+                .map(|o| o.id)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    })?;
+    if !option.available {
+        return Err(OpenCompanyError::Conflict(format!(
+            "{} cannot be bound here: {}.",
+            option.label,
+            option
+                .unavailable_reason
+                .unwrap_or_else(|| "it is not compiled into this build".to_string())
+        )));
+    }
+    let (backend, driver) = split_engine(engine).ok_or_else(|| {
+        OpenCompanyError::InvalidRequest(format!("`{engine}` has no runtime mapping"))
+    })?;
+
+    let trimmed = |value: Option<&String>| {
+        value
+            .map(|v| v.trim())
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+    };
+    let url = trimmed(request.url.as_ref());
+    // Absent means keep; present-but-empty means clear. A console that re-sent
+    // the redacted key it was shown would otherwise store the redaction as the
+    // credential, which fails at the next call with an authentication error
+    // nobody can trace back to this screen.
+    let api_key = match &request.api_key {
+        None => stored.api_key.clone(),
+        Some(raw) if raw.trim().is_empty() => None,
+        Some(raw) => Some(raw.trim().to_string()),
+    };
+
+    // Refused here rather than at bind, because the bind-time messages name
+    // environment variables an operator working from the console never set.
+    if option.requires_url && url.is_none() {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "{} needs an endpoint URL.",
+            option.label
+        )));
+    }
+    if option.requires_key && api_key.is_none() {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "{} needs an API key.",
+            option.label
+        )));
+    }
+    if let Some(url) = &url
+        && !(url.starts_with("http://") || url.starts_with("https://"))
+    {
+        return Err(OpenCompanyError::InvalidRequest(
+            "the endpoint must be an http:// or https:// URL.".to_string(),
+        ));
+    }
+
+    Ok(MemorySelection {
+        backend,
+        driver: driver.map(str::to_string),
+        // Carried only for the engines that use them: leaving a stale URL on a
+        // selection that switched to the built-in store would write dead keys
+        // into `config.toml` and confuse the next reader of the file.
+        url: option.requires_url.then_some(url).flatten(),
+        api_key: option.requires_key.then_some(api_key).flatten(),
+    })
+}
+
+/// Opens a candidate selection and probes it, without touching live state.
+///
+/// `Ok(None)` is the `store` default — nothing to open, nothing to probe.
+async fn open_and_probe(
+    selection: &MemorySelection,
+) -> Result<Option<crate::store::MemoryOverlay>, OpenCompanyError> {
+    let settings = StorageSettings::from_env()?.with_memory_selection(selection.clone());
+    let Some(mut overlay) = crate::store::open_memory_overlay(&settings)? else {
+        return Ok(None);
+    };
+    overlay.refresh_health(PROBE_TIMEOUT).await;
+    Ok(Some(overlay))
+}
+
+/// `POST …/memory/engine/test` — probe a candidate without saving it.
+async fn test_engine(
+    company: AdminScopedCompany,
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Json(request): Json<EngineRequest>,
+) -> Result<Json<ProbeDto>, ApiError> {
+    let _ = company.id();
+    let (stored, _) = saved_selection(&state)?;
+    let selection = selection_from(&request, &stored)?;
+    // A failed *open* is a configuration answer, not a 500: a bad URL, a
+    // driver this build cannot construct, a missing credential. The operator
+    // is testing precisely to find that out, so it comes back as a verdict
+    // rather than an error page.
+    match open_and_probe(&selection).await {
+        Ok(None) => Ok(Json(ProbeDto {
+            healthy: true,
+            capabilities: Vec::new(),
+            detail: None,
+        })),
+        Ok(Some(overlay)) => Ok(Json(ProbeDto {
+            // `None` means there was no provider seam to ask (the in-pod
+            // engine overlay). It opened, so it is usable.
+            healthy: overlay.descriptor.healthy.unwrap_or(true),
+            capabilities: overlay.descriptor.capabilities.clone(),
+            detail: (overlay.descriptor.healthy == Some(false))
+                .then(|| "the engine did not answer a health check".to_string()),
+        })),
+        Err(error) => Ok(Json(ProbeDto {
+            healthy: false,
+            capabilities: Vec::new(),
+            detail: Some(error.to_string()),
+        })),
+    }
+}
+
+/// `PUT …/memory/engine` — save it, bind it, and put it in force.
+async fn apply(
+    company: AdminScopedCompany,
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Query(query): Query<ApplyQuery>,
+    Json(request): Json<EngineRequest>,
+) -> Result<Json<AppliedDto>, ApiError> {
+    let _ = company.id();
+    let (stored, layer) = saved_selection(&state)?;
+    if layer == "env" {
+        return Err(ApiError(OpenCompanyError::Conflict(
+            "the memory engine on this host is set by `OPENCOMPANY_MEMORY`, which outranks \
+             config.toml. Writing it here would have no effect at the next boot — change the \
+             deployment's environment instead."
+                .to_string(),
+        )));
+    }
+    let selection = selection_from(&request, &stored)?;
+
+    // Bind the replacement BEFORE anything is written or swapped. A refusal
+    // here leaves the instance exactly as it was, which is the whole reason
+    // this route probes at all.
+    let overlay = open_and_probe(&selection).await?;
+    if !query.force
+        && let Some(overlay) = &overlay
+        && overlay.descriptor.healthy == Some(false)
+    {
+        return Err(ApiError(OpenCompanyError::Conflict(format!(
+            "`{}` did not answer a health check, so it was not bound and your current engine is \
+             untouched. Check the endpoint and the API key.",
+            request.engine.trim()
+        ))));
+    }
+
+    // Persist next, for the reason `server::setup` persists before mutating:
+    // a write failure must not leave a live host reflecting a change its
+    // configuration does not record.
+    let dir = state.config_root().to_path_buf();
+    let edits: Vec<(&'static str, ConfigValue)> = vec![
+        (
+            "memory.backend",
+            ConfigValue::Str(selection.backend.as_str().to_string()),
+        ),
+        (
+            "memory.driver",
+            selection
+                .driver
+                .clone()
+                .map_or(ConfigValue::Unset, ConfigValue::Str),
+        ),
+        (
+            "memory.url",
+            selection
+                .url
+                .clone()
+                .map_or(ConfigValue::Unset, ConfigValue::Str),
+        ),
+        (
+            "memory.api_key",
+            selection
+                .api_key
+                .clone()
+                .map_or(ConfigValue::Unset, ConfigValue::Str),
+        ),
+    ];
+    let config_path = write_config_toml(&dir, &edits)?;
+
+    let healthy = overlay.as_ref().and_then(|o| o.descriptor.healthy);
+    state.set_memory_overlay(overlay);
+
+    // Companies already in the registry hold the previous engine's ports on
+    // their cached runtime, so rebuild them in place. Reported per-company
+    // rather than assumed either way: "restart required" must name what is
+    // genuinely still pending, never a guess.
+    let mut restart_required_for = Vec::new();
+    for id in state.registry().list() {
+        match crate::runtime::rebuild_company(&state, &id).await {
+            Ok(_) => tracing::info!(company = %id, "rebuilt for the new memory engine"),
+            Err(error) => {
+                tracing::warn!(
+                    company = %id, %error,
+                    "could not rebuild for the new memory engine; it needs a restart",
+                );
+                restart_required_for.push(id.as_ref().to_string());
+            }
+        }
+    }
+
+    Ok(Json(AppliedDto {
+        engine: engine_id(&selection),
+        healthy,
+        restart_required_for,
+        config_path: config_path.display().to_string(),
+        engine_state: snapshot(&state)?,
+    }))
+}
+
+#[cfg(test)]
+mod test;

--- a/src/server/ops/memory_engine.rs
+++ b/src/server/ops/memory_engine.rs
@@ -404,32 +404,52 @@ async fn read(
     Ok(Json(snapshot(&state)?))
 }
 
+/// Refuses an engine this build cannot construct, before its fields are
+/// checked.
+///
+/// Ahead of [`selection_from`] on purpose: telling an operator their endpoint
+/// is missing, when the engine could not be bound with any endpoint, sends
+/// them to fix the wrong thing.
+fn ensure_available(engine: &str) -> Result<(), OpenCompanyError> {
+    let option = option_for(engine.trim()).ok_or_else(|| unknown_engine(engine))?;
+    if option.available {
+        return Ok(());
+    }
+    Err(OpenCompanyError::Conflict(format!(
+        "{} cannot be bound here: {}.",
+        option.label,
+        option
+            .unavailable_reason
+            .unwrap_or_else(|| "it is not compiled into this build".to_string())
+    )))
+}
+
+/// The refusal for an id the catalog does not carry, listing what may be
+/// picked instead.
+fn unknown_engine(engine: &str) -> OpenCompanyError {
+    OpenCompanyError::InvalidRequest(format!(
+        "`{}` is not a memory engine this host knows. Pick one of: {}.",
+        engine.trim(),
+        catalog()
+            .iter()
+            .map(|o| o.id)
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
 /// Turns a submitted choice into a validated [`MemorySelection`], carrying the
 /// stored credential forward when the request omits one.
+///
+/// Field rules only — whether this *build* can bind the engine is
+/// [`ensure_available`]'s question, kept separate so these rules are the same
+/// in every feature set and are therefore testable in every lane.
 fn selection_from(
     request: &EngineRequest,
     stored: &MemorySelection,
 ) -> Result<MemorySelection, OpenCompanyError> {
     let engine = request.engine.trim();
-    let option = option_for(engine).ok_or_else(|| {
-        OpenCompanyError::InvalidRequest(format!(
-            "`{engine}` is not a memory engine this host knows. Pick one of: {}.",
-            catalog()
-                .iter()
-                .map(|o| o.id)
-                .collect::<Vec<_>>()
-                .join(", ")
-        ))
-    })?;
-    if !option.available {
-        return Err(OpenCompanyError::Conflict(format!(
-            "{} cannot be bound here: {}.",
-            option.label,
-            option
-                .unavailable_reason
-                .unwrap_or_else(|| "it is not compiled into this build".to_string())
-        )));
-    }
+    let option = option_for(engine).ok_or_else(|| unknown_engine(engine))?;
     let (backend, driver) = split_engine(engine).ok_or_else(|| {
         OpenCompanyError::InvalidRequest(format!("`{engine}` has no runtime mapping"))
     })?;
@@ -506,6 +526,7 @@ async fn test_engine(
 ) -> Result<Json<ProbeDto>, ApiError> {
     let _ = company.id();
     let (stored, _) = saved_selection(&state)?;
+    ensure_available(&request.engine)?;
     let selection = selection_from(&request, &stored)?;
     // A failed *open* is a configuration answer, not a 500: a bad URL, a
     // driver this build cannot construct, a missing credential. The operator
@@ -550,6 +571,7 @@ async fn apply(
                 .to_string(),
         )));
     }
+    ensure_available(&request.engine)?;
     let selection = selection_from(&request, &stored)?;
 
     // Bind the replacement BEFORE anything is written or swapped. A refusal

--- a/src/server/ops/memory_engine/test.rs
+++ b/src/server/ops/memory_engine/test.rs
@@ -91,7 +91,12 @@ async fn state_at(dir: &std::path::Path) -> AppState {
 }
 
 /// Issues one authenticated request against the whole router.
-async fn call(state: &AppState, method: &str, uri: &str, body: Option<Value>) -> (StatusCode, Value) {
+async fn call(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
     let builder = Request::builder()
         .method(method)
         .uri(uri)
@@ -106,7 +111,10 @@ async fn call(state: &AppState, method: &str, uri: &str, body: Option<Value>) ->
     let response = router(state.clone()).oneshot(request).await.unwrap();
     let status = response.status();
     let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
 }
 
 /// The catalog is the console's whole menu, so an id it offers must be one the

--- a/src/server/ops/memory_engine/test.rs
+++ b/src/server/ops/memory_engine/test.rs
@@ -27,6 +27,27 @@ const MEMORY_ENV: [&str; 5] = [
     "OPENCOMPANY_DATA_DIR",
 ];
 
+/// A rebuilder that rebuilds a company over its live handover, so the apply
+/// path's live swap is exercised rather than reported as needing a restart.
+struct TestRebuilder {
+    home: std::path::PathBuf,
+}
+
+#[async_trait::async_trait]
+impl crate::runtime::RuntimeRebuilder for TestRebuilder {
+    async fn rebuild(
+        &self,
+        _state: &AppState,
+        request: crate::runtime::RebuildRequest,
+    ) -> crate::Result<crate::CompanyRuntime> {
+        RuntimeBuilder::new(self.home.clone(), request.manifest)
+            .with_id(request.id)
+            .with_handover(request.handover)
+            .build()
+            .await
+    }
+}
+
 /// A one-company host whose `config.toml` lives under `dir`.
 async fn state_at(dir: &std::path::Path) -> AppState {
     let manifest: CompanyManifest =
@@ -60,7 +81,10 @@ async fn state_at(dir: &std::path::Path) -> AppState {
         .unwrap();
     let state = AppState::new(AppConfig::default())
         .with_home(dir.to_path_buf())
-        .with_config_root(dir.to_path_buf());
+        .with_config_root(dir.to_path_buf())
+        .with_rebuilder(Arc::new(TestRebuilder {
+            home: dir.to_path_buf(),
+        }));
     state.registry().insert(id, Arc::new(runtime));
     crate::server::test_support::seed_fixed_admin(&state, "acme").await;
     state
@@ -129,6 +153,27 @@ fn catalog_matches_driver_registry() {
     assert_eq!(
         offered,
         crate::store::memory::driver::SUPPORTED_REMOTE_DRIVERS.to_vec()
+    );
+}
+
+/// Whether this build can bind an engine is answered separately from whether
+/// the operator filled the form in — so a build without the feature refuses
+/// with the reason that actually blocks it.
+#[test]
+fn an_engine_this_build_cannot_bind_is_refused_by_availability() {
+    let refused = ensure_available("supermemory");
+    if cfg!(feature = "tinymemory") {
+        assert!(refused.is_ok());
+    } else {
+        let error = refused.unwrap_err().to_string();
+        assert!(error.contains("tinymemory"), "unexpected message: {error}");
+    }
+    assert!(
+        ensure_available("pinecone")
+            .unwrap_err()
+            .to_string()
+            .contains("supermemory"),
+        "an unknown id lists the catalog"
     );
 }
 
@@ -281,7 +326,7 @@ async fn applying_an_engine_persists_it_to_config_toml() {
     assert_eq!(
         body["restartRequiredFor"].as_array().unwrap().len(),
         0,
-        "a one-company host with a rebuilder applies live"
+        "a host with a rebuilder wired applies the swap live: {body}"
     );
 
     let written = std::fs::read_to_string(dir.path().join("config.toml")).unwrap();

--- a/src/server/ops/memory_engine/test.rs
+++ b/src/server/ops/memory_engine/test.rs
@@ -1,0 +1,319 @@
+//! Tests for the memory-engine selection route.
+
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use super::*;
+use crate::company::CompanyManifest;
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::runtime::RuntimeBuilder;
+use crate::server::router;
+use crate::store::FsCompanyStore;
+use crate::test_support::EnvVarGuard;
+use crate::{AppConfig, AppState};
+
+/// Every environment key the engine surface reads, so a guarded test restores
+/// all of them however it fails.
+const MEMORY_ENV: [&str; 5] = [
+    "OPENCOMPANY_MEMORY",
+    "OPENCOMPANY_MEMORY_DRIVER",
+    "OPENCOMPANY_MEMORY_URL",
+    "OPENCOMPANY_MEMORY_API_KEY",
+    "OPENCOMPANY_DATA_DIR",
+];
+
+/// A one-company host whose `config.toml` lives under `dir`.
+async fn state_at(dir: &std::path::Path) -> AppState {
+    let manifest: CompanyManifest =
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
+    let store = FsCompanyStore::new(dir.to_path_buf());
+    let id = CompanyId::new("acme");
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(dir.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default())
+        .with_home(dir.to_path_buf())
+        .with_config_root(dir.to_path_buf());
+    state.registry().insert(id, Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+    state
+}
+
+/// Issues one authenticated request against the whole router.
+async fn call(state: &AppState, method: &str, uri: &str, body: Option<Value>) -> (StatusCode, Value) {
+    let builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"));
+    let request = match body {
+        Some(value) => builder
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&value).unwrap()))
+            .unwrap(),
+        None => builder.body(Body::empty()).unwrap(),
+    };
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+}
+
+/// The catalog is the console's whole menu, so an id it offers must be one the
+/// runtime can resolve. A tile whose id maps to nothing would render, accept a
+/// click, and fail the apply.
+#[test]
+fn every_offered_engine_resolves_to_a_runtime_selection() {
+    for option in catalog() {
+        assert!(
+            split_engine(option.id).is_some(),
+            "`{}` is offered but has no (backend, driver) mapping",
+            option.id
+        );
+    }
+}
+
+/// And the round trip holds: the id a selection renders as is the id that
+/// produced it. Without this the console could apply `mem0` and be shown
+/// `remote` afterwards, which reads as a failed save.
+#[test]
+fn engine_ids_round_trip_through_a_selection() {
+    for option in catalog() {
+        let (backend, driver) = split_engine(option.id).unwrap();
+        let selection = MemorySelection {
+            backend,
+            driver: driver.map(str::to_string),
+            url: None,
+            api_key: None,
+        };
+        assert_eq!(engine_id(&selection), option.id);
+    }
+}
+
+/// The remote catalog must not drift from the driver ids the host can actually
+/// construct — the duplication this module documents.
+#[cfg(feature = "tinymemory")]
+#[test]
+fn catalog_matches_driver_registry() {
+    let offered: Vec<&str> = catalog()
+        .iter()
+        .filter(|o| split_engine(o.id).is_some_and(|(b, _)| b == MemoryBackend::Remote))
+        .map(|o| o.id)
+        .collect();
+    assert_eq!(
+        offered,
+        crate::store::memory::driver::SUPPORTED_REMOTE_DRIVERS.to_vec()
+    );
+}
+
+/// A hosted engine with no endpoint is refused before anything is written,
+/// with a message naming the field rather than an environment variable the
+/// operator never set.
+#[test]
+fn a_hosted_engine_without_an_endpoint_is_refused() {
+    let error = selection_from(
+        &EngineRequest {
+            engine: "supermemory".to_string(),
+            url: None,
+            api_key: Some("k".to_string()),
+        },
+        &MemorySelection::default(),
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("endpoint"),
+        "unexpected message: {error}"
+    );
+}
+
+/// An omitted key keeps the stored one. A console showing a redacted key must
+/// be able to save an endpoint change without resending the credential — and
+/// must not store the redaction if it does.
+#[test]
+fn an_omitted_key_keeps_the_stored_credential() {
+    let stored = MemorySelection {
+        backend: MemoryBackend::Remote,
+        driver: Some("mem0".to_string()),
+        url: Some("https://old.example".to_string()),
+        api_key: Some("secret".to_string()),
+    };
+    let selection = selection_from(
+        &EngineRequest {
+            engine: "mem0".to_string(),
+            url: Some("https://new.example".to_string()),
+            api_key: None,
+        },
+        &stored,
+    )
+    .unwrap();
+    assert_eq!(selection.api_key.as_deref(), Some("secret"));
+    assert_eq!(selection.url.as_deref(), Some("https://new.example"));
+}
+
+/// Switching to an engine that needs neither drops both — a stale endpoint and
+/// a stale credential left in `config.toml` are dead keys the next reader of
+/// the file has to work out are inert.
+#[test]
+fn switching_to_the_built_in_store_drops_endpoint_and_credential() {
+    let stored = MemorySelection {
+        backend: MemoryBackend::Remote,
+        driver: Some("mem0".to_string()),
+        url: Some("https://old.example".to_string()),
+        api_key: Some("secret".to_string()),
+    };
+    let selection = selection_from(
+        &EngineRequest {
+            engine: "store".to_string(),
+            url: None,
+            api_key: None,
+        },
+        &stored,
+    )
+    .unwrap();
+    assert_eq!(selection.backend, MemoryBackend::Store);
+    assert!(selection.url.is_none());
+    assert!(selection.api_key.is_none());
+}
+
+/// The default host: nothing selected, the base store serving memory, and the
+/// choice editable from here.
+#[tokio::test]
+async fn the_default_host_reports_the_built_in_store_as_editable() {
+    let dir = tempfile::tempdir().unwrap();
+    let guard = EnvVarGuard::capture(&MEMORY_ENV);
+    guard.remove("OPENCOMPANY_MEMORY");
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = call(&state, "GET", "/api/v1/company/memory/engine", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["active"], "store");
+    assert_eq!(body["selected"], "store");
+    assert_eq!(body["layer"], "default");
+    assert_eq!(body["editable"], true);
+    assert_eq!(body["apiKeySet"], false);
+    assert!(
+        body["options"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|o| o["id"] == "supermemory"),
+        "the catalog is offered whether or not this build can bind it"
+    );
+}
+
+/// The refusal this surface exists for: a deployment that injects
+/// `OPENCOMPANY_MEMORY` owns the engine, so the console renders read-only and
+/// a write is refused rather than accepted-and-dropped.
+#[tokio::test]
+async fn an_env_owned_engine_is_read_only_and_refuses_a_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let guard = EnvVarGuard::capture(&MEMORY_ENV);
+    guard.set("OPENCOMPANY_MEMORY", "store");
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = call(&state, "GET", "/api/v1/company/memory/engine", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["layer"], "env");
+    assert_eq!(body["editable"], false);
+
+    let (status, body) = call(
+        &state,
+        "PUT",
+        "/api/v1/company/memory/engine",
+        Some(json!({ "engine": "store" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("OPENCOMPANY_MEMORY"),
+        "the refusal must name the variable that outranks the file: {body}"
+    );
+}
+
+/// An apply writes the file, and the read that follows reports the new
+/// selection — the console's own proof the choice landed.
+#[tokio::test]
+async fn applying_an_engine_persists_it_to_config_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    let guard = EnvVarGuard::capture(&MEMORY_ENV);
+    guard.remove("OPENCOMPANY_MEMORY");
+    guard.set("OPENCOMPANY_DATA_DIR", dir.path().to_str().unwrap());
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = call(
+        &state,
+        "PUT",
+        "/api/v1/company/memory/engine",
+        Some(json!({ "engine": "store" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["engine"], "store");
+    assert_eq!(
+        body["restartRequiredFor"].as_array().unwrap().len(),
+        0,
+        "a one-company host with a rebuilder applies live"
+    );
+
+    let written = std::fs::read_to_string(dir.path().join("config.toml")).unwrap();
+    assert!(written.contains("[memory]"), "written file: {written}");
+    assert!(written.contains("backend = \"store\""), "{written}");
+
+    let (_, body) = call(&state, "GET", "/api/v1/company/memory/engine", None).await;
+    assert_eq!(body["selected"], "store");
+    assert_eq!(body["layer"], "config.toml");
+}
+
+/// An engine id nothing in the catalog carries is a bad request, and the
+/// message lists what may be picked instead.
+#[tokio::test]
+async fn an_unknown_engine_is_refused_with_the_catalog() {
+    let dir = tempfile::tempdir().unwrap();
+    let guard = EnvVarGuard::capture(&MEMORY_ENV);
+    guard.remove("OPENCOMPANY_MEMORY");
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = call(
+        &state,
+        "PUT",
+        "/api/v1/company/memory/engine",
+        Some(json!({ "engine": "pinecone" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("supermemory"),
+        "{body}"
+    );
+}

--- a/src/server/ops/memory_engine/test.rs
+++ b/src/server/ops/memory_engine/test.rs
@@ -9,6 +9,7 @@ use tower::ServiceExt;
 
 use super::*;
 use crate::company::CompanyManifest;
+use crate::ports::store::CompanyStore;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::RuntimeBuilder;
 use crate::server::router;

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -1,0 +1,402 @@
+//! Dropping files, folders and links into a company's memory.
+//!
+//! ```text
+//! POST …/memory/ingest        multipart: one or many files (folder drops carry paths)
+//! POST …/memory/ingest/links  JSON: URLs to fetch and remember
+//! ```
+//!
+//! ## What a drop becomes
+//!
+//! Text, chunked, in the [`ContextStore`](crate::ports::ContextStore) the
+//! agents recall from — the same store an operator fact is mirrored into, so a
+//! dropped document reaches a teammate on its next turn with no further step.
+//! The extraction and chunking rules live in [`crate::ingest`]; this module is
+//! the transport and the reporting.
+//!
+//! The original bytes are **not** kept. See [`crate::ingest`] for why that is
+//! the design and not an omission — in short, the workspace tree is where
+//! files live, and a second copy of every upload there would make this page a
+//! silently diverging file manager.
+//!
+//! ## One answer per file, never one for the batch
+//!
+//! A folder drop is dozens of files, and some of them are always going to be
+//! `.DS_Store`, a PNG, or a scanned PDF with no text layer. Failing the whole
+//! request over one of them would make the feature unusable on any real
+//! folder, and silently skipping them would leave an operator believing their
+//! folder is in memory when a third of it is not. So every file gets a row in
+//! the response saying what happened to it, and the request itself succeeds as
+//! long as it was well-formed.
+//!
+//! ## Links are fetched by the host, so the guard is the host's too
+//!
+//! `POST …/memory/ingest/links` makes this server issue an outbound request to
+//! an operator-supplied URL — the shape of a server-side request forgery. The
+//! request is therefore restricted to `http`/`https` and refused for any host
+//! that resolves to a loopback, link-local, or private address, which is what
+//! stops "remember this page" from being a read primitive against the
+//! deployment's own network.
+
+use axum::extract::{DefaultBodyLimit, Multipart};
+use axum::extract::multipart::MultipartError;
+use axum::http::StatusCode;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::error::OpenCompanyError;
+use crate::ingest::{Extracted, MAX_DOCUMENT_BYTES, chunk_document, extract};
+use crate::ports::types::ContextChunk;
+use crate::server::error::ApiError;
+use crate::server::ops::scope::{ScopedCompany, scoped};
+
+/// How much one ingest request may carry.
+///
+/// A folder drop is many files in one request, so this is a multiple of the
+/// per-document cap rather than equal to it. The console still batches — this
+/// is the ceiling, not the expected size.
+const INGEST_BODY_LIMIT: usize = 8 * MAX_DOCUMENT_BYTES;
+
+/// The largest page body a link ingest will read.
+const MAX_LINK_BYTES: usize = 4 * 1024 * 1024;
+
+/// How long the host waits for a link to answer.
+const LINK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Builds the ingest route fragment.
+pub fn router() -> Router<AppState> {
+    scoped("/memory/ingest", post(ingest))
+        .layer(DefaultBodyLimit::max(INGEST_BODY_LIMIT))
+        .merge(scoped("/memory/ingest/links", post(ingest_links)))
+}
+
+/// What happened to one dropped file or link.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IngestedItem {
+    /// The name the operator will recognise — a file name, a relative path
+    /// inside a dropped folder, or a URL.
+    source: String,
+    /// `stored`, `empty`, `unsupported`, or `failed`.
+    status: &'static str,
+    /// How many memory chunks it became.
+    chunks: usize,
+    /// Why it is not `stored`, when it is not.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+impl IngestedItem {
+    fn failed(source: String, detail: String) -> Self {
+        Self {
+            source,
+            status: "failed",
+            chunks: 0,
+            detail: Some(detail),
+        }
+    }
+}
+
+/// The whole batch's outcome.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IngestedDto {
+    /// One row per file or link, in the order they were sent.
+    items: Vec<IngestedItem>,
+    /// Chunks written across the batch — what the Brain counter will move by.
+    chunks: usize,
+    /// How many sources actually landed in memory.
+    stored: usize,
+}
+
+impl IngestedDto {
+    fn of(items: Vec<IngestedItem>) -> Self {
+        Self {
+            chunks: items.iter().map(|i| i.chunks).sum(),
+            stored: items.iter().filter(|i| i.status == "stored").count(),
+            items,
+        }
+    }
+}
+
+/// Links to fetch and remember.
+#[derive(Debug, Deserialize)]
+struct LinksRequest {
+    urls: Vec<String>,
+}
+
+/// Extracts one source's bytes and writes its chunks, returning its row.
+///
+/// Per-source rather than per-batch failure handling: see the module doc.
+async fn store_source(
+    company: &ScopedCompany,
+    source: String,
+    declared: Option<&str>,
+    bytes: &[u8],
+) -> IngestedItem {
+    if bytes.len() > MAX_DOCUMENT_BYTES {
+        return IngestedItem::failed(
+            source,
+            format!(
+                "larger than the {} MiB this page reads from one document",
+                MAX_DOCUMENT_BYTES / (1024 * 1024)
+            ),
+        );
+    }
+    let text = match extract(&source, declared, bytes) {
+        Extracted::Text(text) => text,
+        Extracted::Empty => {
+            return IngestedItem {
+                source,
+                status: "empty",
+                chunks: 0,
+                detail: Some(
+                    "no text in it — a scanned document needs OCR before memory can hold it"
+                        .to_string(),
+                ),
+            };
+        }
+        Extracted::Unsupported(reason) => {
+            return IngestedItem {
+                source,
+                status: "unsupported",
+                chunks: 0,
+                detail: Some(reason),
+            };
+        }
+    };
+
+    let chunks = chunk_document(&source, &text);
+    let mut written = 0;
+    for chunk in chunks {
+        let put = company
+            .runtime
+            .context
+            .put(
+                company.id(),
+                ContextChunk {
+                    label: chunk.label,
+                    body: chunk.body,
+                },
+            )
+            .await;
+        match put {
+            Ok(_) => written += 1,
+            // Reported as a partial store rather than a silent success: some
+            // of the document is in memory and the operator has to know which
+            // state they are in before deciding to re-drop it.
+            Err(error) => {
+                tracing::warn!(company = %company.id(), %source, %error, "memory ingest chunk failed");
+                return IngestedItem {
+                    source,
+                    status: "failed",
+                    chunks: written,
+                    detail: Some(format!(
+                        "stored {written} chunks, then memory refused the next one: {error}"
+                    )),
+                };
+            }
+        }
+    }
+    IngestedItem {
+        source,
+        status: "stored",
+        chunks: written,
+        detail: None,
+    }
+}
+
+/// Classifies a multipart failure the way the workspace upload does: a body
+/// that overran the limit is a 413, anything else a malformed request.
+fn multipart_error(error: MultipartError, context: &str) -> ApiError {
+    if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        return ApiError(OpenCompanyError::InvalidRequest(format!(
+            "this drop is larger than the {} MiB one request may carry, so it was cut off before \
+             anything could be read. Nothing was stored — drop it in smaller batches.",
+            INGEST_BODY_LIMIT / (1024 * 1024)
+        )));
+    }
+    ApiError(OpenCompanyError::InvalidRequest(format!(
+        "{context}: {error}"
+    )))
+}
+
+/// `POST …/memory/ingest` — multipart file drop.
+///
+/// A folder drop sends each file with its **relative path** as the part's
+/// filename (`Contracts/2026/acme.pdf`). That path is kept as the source name
+/// rather than reduced to a basename, because it is what the operator sees in
+/// their own file manager and the only thing distinguishing the four
+/// `README.md`s a repository drop contains.
+async fn ingest(
+    company: ScopedCompany,
+    mut multipart: Multipart,
+) -> Result<Json<IngestedDto>, ApiError> {
+    let mut items = Vec::new();
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| multipart_error(e, "malformed multipart drop"))?
+    {
+        if field.name() != Some("file") {
+            // Ignored rather than refused: a browser's `FormData` carries
+            // fields this route has no use for, and failing the drop over one
+            // would be a puzzle to debug from the console side.
+            continue;
+        }
+        let name = field
+            .file_name()
+            .map(str::to_string)
+            .filter(|n| !n.trim().is_empty())
+            .unwrap_or_else(|| "untitled".to_string());
+        let declared = field.content_type().map(str::to_string);
+        // The read is the one place a body-limit overrun surfaces, and it
+        // aborts the whole request: a truncated part is indistinguishable from
+        // a malformed one, so there is nothing honest to report per file.
+        let bytes = field
+            .bytes()
+            .await
+            .map_err(|e| multipart_error(e, "unreadable file part"))?;
+        items.push(store_source(&company, name, declared.as_deref(), &bytes).await);
+    }
+
+    if items.is_empty() {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "the drop carried no files".to_string(),
+        )));
+    }
+    Ok(Json(IngestedDto::of(items)))
+}
+
+/// `POST …/memory/ingest/links`.
+#[cfg(feature = "documents")]
+async fn ingest_links(
+    company: ScopedCompany,
+    Json(request): Json<LinksRequest>,
+) -> Result<Json<IngestedDto>, ApiError> {
+    if request.urls.is_empty() {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "no links were sent".to_string(),
+        )));
+    }
+    let client = reqwest::Client::builder()
+        .timeout(LINK_TIMEOUT)
+        // No redirect chasing: a permitted URL that redirects to `localhost`
+        // would walk straight past the guard below, and following it is not
+        // worth re-implementing the check per hop.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| ApiError(OpenCompanyError::Config(format!("no HTTP client: {e}"))))?;
+
+    let mut items = Vec::new();
+    for url in request.urls {
+        let url = url.trim().to_string();
+        if let Err(refusal) = guard_link(&url) {
+            items.push(IngestedItem::failed(url, refusal));
+            continue;
+        }
+        items.push(fetch_link(&company, &client, url).await);
+    }
+    Ok(Json(IngestedDto::of(items)))
+}
+
+/// Fetches one link and stores what it said.
+#[cfg(feature = "documents")]
+async fn fetch_link(
+    company: &ScopedCompany,
+    client: &reqwest::Client,
+    url: String,
+) -> IngestedItem {
+    let response = match client.get(&url).send().await {
+        Ok(response) => response,
+        Err(error) => return IngestedItem::failed(url, format!("could not be fetched: {error}")),
+    };
+    if !response.status().is_success() {
+        return IngestedItem::failed(url, format!("answered {}", response.status()));
+    }
+    let declared = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.split(';').next().unwrap_or(v).trim().to_string());
+    let bytes = match response.bytes().await {
+        Ok(bytes) => bytes,
+        Err(error) => return IngestedItem::failed(url, format!("could not be read: {error}")),
+    };
+    if bytes.len() > MAX_LINK_BYTES {
+        return IngestedItem::failed(
+            url,
+            format!(
+                "the page is larger than the {} MiB this reads from one link",
+                MAX_LINK_BYTES / (1024 * 1024)
+            ),
+        );
+    }
+    // A URL has no extension to dispatch on, so the declared content type
+    // decides — with `text/html` the overwhelming case, and the extractor
+    // handling `application/pdf` and friends from the same signal.
+    let name = match declared.as_deref() {
+        Some("text/html") | Some("application/xhtml+xml") | None => format!("{url}#html"),
+        _ => url.clone(),
+    };
+    let mut item = store_source(company, name, declared.as_deref(), &bytes).await;
+    // Report the URL the operator typed, not the extension-bearing name the
+    // dispatch needed.
+    item.source = url;
+    item
+}
+
+/// Refuses a URL this host must not fetch on an operator's behalf.
+///
+/// Scheme and host only: DNS is resolved by the client at request time and
+/// re-resolving here to check the address would be a different lookup than the
+/// one that happens (a TOCTOU no host-level check closes). What this stops is
+/// the direct form — `http://localhost:8080/admin`, `http://169.254.169.254/`
+/// — which is the shape of every accidental and most deliberate attempts.
+#[cfg(feature = "documents")]
+fn guard_link(url: &str) -> Result<(), String> {
+    let parsed = url
+        .parse::<axum::http::Uri>()
+        .map_err(|_| "not a URL".to_string())?;
+    match parsed.scheme_str() {
+        Some("http") | Some("https") => {}
+        _ => return Err("only http:// and https:// links can be fetched".to_string()),
+    }
+    let host = parsed.host().ok_or_else(|| "no host in the URL".to_string())?;
+    let lowered = host.to_ascii_lowercase();
+    if lowered == "localhost" || lowered.ends_with(".localhost") || lowered.ends_with(".internal") {
+        return Err("that host is internal to this deployment".to_string());
+    }
+    if let Ok(address) = lowered.parse::<std::net::IpAddr>() {
+        let private = match address {
+            std::net::IpAddr::V4(v4) => {
+                v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified()
+            }
+            std::net::IpAddr::V6(v6) => {
+                v6.is_loopback() || v6.is_unspecified() || v6.segments()[0] & 0xfe00 == 0xfc00
+            }
+        };
+        if private {
+            return Err("that address is inside this deployment's own network".to_string());
+        }
+    }
+    Ok(())
+}
+
+/// Without the feature there is no HTTP client to fetch with, so the route
+/// exists and refuses rather than 404ing — a missing route reads to the
+/// console as an older host, which is a different thing to tell the operator.
+#[cfg(not(feature = "documents"))]
+async fn ingest_links(
+    _company: ScopedCompany,
+    Json(_request): Json<LinksRequest>,
+) -> Result<Json<IngestedDto>, ApiError> {
+    Err(ApiError(OpenCompanyError::InvalidRequest(
+        "remembering a link needs the `documents` feature, which this build was compiled without"
+            .to_string(),
+    )))
+}
+
+#[cfg(test)]
+mod test;

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -37,10 +37,11 @@
 //! stops "remember this page" from being a read primitive against the
 //! deployment's own network.
 
-use axum::extract::{DefaultBodyLimit, Multipart};
+use axum::extract::Path;
 use axum::extract::multipart::MultipartError;
+use axum::extract::{DefaultBodyLimit, Multipart};
 use axum::http::StatusCode;
-use axum::routing::post;
+use axum::routing::{delete, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
@@ -69,6 +70,7 @@ pub fn router() -> Router<AppState> {
     scoped("/memory/ingest", post(ingest))
         .layer(DefaultBodyLimit::max(INGEST_BODY_LIMIT))
         .merge(scoped("/memory/ingest/links", post(ingest_links)))
+        .merge(scoped("/memory/document/{source}", delete(forget_document)))
 }
 
 /// What happened to one dropped file or link.
@@ -205,6 +207,61 @@ async fn store_source(
         chunks: written,
         detail: None,
     }
+}
+
+/// The document whose chunks are to be forgotten, by its label slug.
+#[derive(Debug, Deserialize)]
+struct DocumentPath {
+    /// The `document/{slug}` label's slug half, as
+    /// [`label_for`](crate::ingest::label_for) derived it.
+    source: String,
+}
+
+/// `DELETE …/memory/document/{source}` — forget one dropped document.
+///
+/// The counterpart the drop zone needs to be usable: dropping the wrong folder
+/// is a mistake an operator makes once, and without this the only remedy is a
+/// company's whole memory. Scoped to `document/` labels alone — nothing here
+/// can reach an agent's own memory or a task outcome, which are records of
+/// what happened rather than material an operator supplied.
+async fn forget_document(
+    company: ScopedCompany,
+    Path(DocumentPath { source }): Path<DocumentPath>,
+) -> Result<Json<ForgottenDto>, ApiError> {
+    let prefix = format!("{}/{source}/", crate::ingest::DOCUMENT_LABEL_PREFIX);
+    let context = company.runtime.context.as_ref();
+    let all = context.list(company.id(), "").await?;
+    let mut forgotten = 0;
+    for meta in all.iter().filter(|m| m.label.starts_with(&prefix)) {
+        // Chunks are content-addressed, so one address can carry several
+        // labels: two identical paragraphs in one folder drop, or a document
+        // re-dropped under a new name. Deleting an address another label still
+        // points at would delete that row too — the shared-address rule the
+        // fact mirror's reap follows for the same reason.
+        let shared = all
+            .iter()
+            .any(|m| m.addr == meta.addr && !m.label.starts_with(&prefix));
+        if shared {
+            continue;
+        }
+        if context.delete(company.id(), &meta.addr).await? {
+            forgotten += 1;
+        }
+    }
+    if forgotten == 0 {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "no document memory under `{source}`"
+        ))));
+    }
+    Ok(Json(ForgottenDto { forgotten }))
+}
+
+/// How much of a document was forgotten.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ForgottenDto {
+    /// Chunks removed.
+    forgotten: usize,
 }
 
 /// Classifies a multipart failure the way the workspace upload does: a body
@@ -363,7 +420,9 @@ fn guard_link(url: &str) -> Result<(), String> {
         Some("http") | Some("https") => {}
         _ => return Err("only http:// and https:// links can be fetched".to_string()),
     }
-    let host = parsed.host().ok_or_else(|| "no host in the URL".to_string())?;
+    let host = parsed
+        .host()
+        .ok_or_else(|| "no host in the URL".to_string())?;
     let lowered = host.to_ascii_lowercase();
     if lowered == "localhost" || lowered.ends_with(".localhost") || lowered.ends_with(".internal") {
         return Err("that host is internal to this deployment".to_string());

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -60,9 +60,11 @@ use crate::server::ops::scope::{ScopedCompany, scoped};
 const INGEST_BODY_LIMIT: usize = 8 * MAX_DOCUMENT_BYTES;
 
 /// The largest page body a link ingest will read.
+#[cfg(feature = "documents")]
 const MAX_LINK_BYTES: usize = 4 * 1024 * 1024;
 
 /// How long the host waits for a link to answer.
+#[cfg(feature = "documents")]
 const LINK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Builds the ingest route fragment.
@@ -123,8 +125,16 @@ impl IngestedDto {
 }
 
 /// Links to fetch and remember.
+///
+/// Deserialized even in a build without the feature — the refusing handler
+/// still takes the body, so a console gets the honest "this build cannot" and
+/// not a deserialization error about a shape it sent correctly.
 #[derive(Debug, Deserialize)]
 struct LinksRequest {
+    #[cfg_attr(
+        not(feature = "documents"),
+        allow(dead_code, reason = "the refusing handler reads no field")
+    )]
     urls: Vec<String>,
 }
 

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -88,7 +88,10 @@ async fn drop_files(state: &AppState, files: &[(&str, &str, &[u8])]) -> (StatusC
     let response = router(state.clone()).oneshot(request).await.unwrap();
     let status = response.status();
     let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
 }
 
 /// Reads the company's Brain list back, which is where an operator will look
@@ -136,7 +139,10 @@ async fn a_dropped_document_becomes_recallable_memory() {
         .find(|row| row["origin"] == "document")
         .unwrap_or_else(|| panic!("no document row in {rows:#?}"));
     assert!(
-        document["body"].as_str().unwrap().contains("Receipts go to finance"),
+        document["body"]
+            .as_str()
+            .unwrap()
+            .contains("Receipts go to finance"),
         "{document}"
     );
     assert_eq!(
@@ -155,8 +161,16 @@ async fn a_folder_drop_keeps_each_file_apart_by_its_path() {
     let (status, body) = drop_files(
         &state,
         &[
-            ("docs/alpha/README.md", "text/markdown", b"Alpha service notes."),
-            ("docs/beta/README.md", "text/markdown", b"Beta service notes."),
+            (
+                "docs/alpha/README.md",
+                "text/markdown",
+                b"Alpha service notes.",
+            ),
+            (
+                "docs/beta/README.md",
+                "text/markdown",
+                b"Beta service notes.",
+            ),
         ],
     )
     .await;
@@ -188,7 +202,11 @@ async fn an_unreadable_file_is_reported_without_failing_the_batch() {
         &state,
         &[
             ("notes.txt", "text/plain", b"Keep this."),
-            ("logo.png", "image/png", &[0x89, b'P', b'N', b'G', 0x00, 0x01]),
+            (
+                "logo.png",
+                "image/png",
+                &[0x89, b'P', b'N', b'G', 0x00, 0x01],
+            ),
             ("blank.txt", "text/plain", b"   "),
         ],
     )
@@ -235,4 +253,62 @@ fn link_ingestion_refuses_this_deployments_own_network() {
         );
     }
     assert!(super::guard_link("https://example.com/pricing").is_ok());
+}
+
+/// Dropping the wrong folder is a mistake an operator makes once; without a
+/// forget, the only remedy would be the company's whole memory.
+#[tokio::test]
+async fn a_dropped_document_can_be_forgotten_again() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+    drop_files(
+        &state,
+        &[
+            ("private/salaries.csv", "text/csv", b"name,amount\nada,100"),
+            ("keep.md", "text/markdown", b"Keep this one."),
+        ],
+    )
+    .await;
+
+    let request = Request::builder()
+        .method("DELETE")
+        .uri(format!(
+            "/api/v1/company/memory/document/{}",
+            crate::ingest::label_for("private/salaries.csv")
+                .strip_prefix("document/")
+                .unwrap()
+        ))
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let rows = brain_rows(&state).await;
+    let documents: Vec<&str> = rows
+        .iter()
+        .filter(|r| r["origin"] == "document")
+        .map(|r| r["source"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        documents,
+        vec!["keep.md"],
+        "only the named document is forgotten"
+    );
+}
+
+/// Forgetting reaches document memory and nothing else: an agent's own memory
+/// is a record of what happened, not material an operator supplied.
+#[tokio::test]
+async fn forgetting_an_unknown_document_is_a_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+    let request = Request::builder()
+        .method("DELETE")
+        .uri("/api/v1/company/memory/document/never-uploaded")
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/src/server/ops/memory_ingest/test.rs
+++ b/src/server/ops/memory_ingest/test.rs
@@ -1,0 +1,238 @@
+//! Tests for the Brain drop zone.
+
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use crate::company::CompanyManifest;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::runtime::RuntimeBuilder;
+use crate::server::router;
+use crate::store::FsCompanyStore;
+use crate::{AppConfig, AppState};
+
+const BOUNDARY: &str = "----ingesttestboundary";
+
+/// A one-company host on a temporary home.
+async fn state_at(dir: &std::path::Path) -> AppState {
+    let manifest: CompanyManifest =
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
+    let store = FsCompanyStore::new(dir.to_path_buf());
+    let id = CompanyId::new("acme");
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(dir.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default()).with_home(dir.to_path_buf());
+    state.registry().insert(id, Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+    state
+}
+
+/// Builds a `multipart/form-data` body with one part per `(filename, type, bytes)`.
+fn multipart(files: &[(&str, &str, &[u8])]) -> Vec<u8> {
+    let mut body = Vec::new();
+    for (name, mime, bytes) in files {
+        body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!(
+                "Content-Disposition: form-data; name=\"file\"; filename=\"{name}\"\r\n\
+                 Content-Type: {mime}\r\n\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+    body
+}
+
+/// Drops files on `…/memory/ingest`.
+async fn drop_files(state: &AppState, files: &[(&str, &str, &[u8])]) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/company/memory/ingest")
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(Body::from(multipart(files)))
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+}
+
+/// Reads the company's Brain list back, which is where an operator will look
+/// for what they just dropped.
+async fn brain_rows(state: &AppState) -> Vec<Value> {
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/v1/company/memory")
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice::<Value>(&bytes)
+        .unwrap()
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// The whole point: a dropped document is in memory afterwards, and the Brain
+/// list shows it as a document rather than as something a teammate learned.
+#[tokio::test]
+async fn a_dropped_document_becomes_recallable_memory() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = drop_files(
+        &state,
+        &[(
+            "handbook.md",
+            "text/markdown",
+            b"# Expenses\n\nReceipts go to finance within 30 days.",
+        )],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["stored"], 1);
+    assert_eq!(body["items"][0]["status"], "stored");
+    assert_eq!(body["items"][0]["chunks"], 1);
+
+    let rows = brain_rows(&state).await;
+    let document = rows
+        .iter()
+        .find(|row| row["origin"] == "document")
+        .unwrap_or_else(|| panic!("no document row in {rows:#?}"));
+    assert!(
+        document["body"].as_str().unwrap().contains("Receipts go to finance"),
+        "{document}"
+    );
+    assert_eq!(
+        document["source"], "handbook.md",
+        "the row names the document it came from"
+    );
+}
+
+/// A folder drop is many files at once, and its relative paths are what
+/// distinguishes four `README.md`s from each other.
+#[tokio::test]
+async fn a_folder_drop_keeps_each_file_apart_by_its_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = drop_files(
+        &state,
+        &[
+            ("docs/alpha/README.md", "text/markdown", b"Alpha service notes."),
+            ("docs/beta/README.md", "text/markdown", b"Beta service notes."),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["stored"], 2);
+    let sources: Vec<&str> = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["source"].as_str().unwrap())
+        .collect();
+    assert_eq!(sources, vec!["docs/alpha/README.md", "docs/beta/README.md"]);
+
+    let rows = brain_rows(&state).await;
+    let documents: Vec<&Value> = rows.iter().filter(|r| r["origin"] == "document").collect();
+    assert_eq!(documents.len(), 2, "both files are their own memory");
+}
+
+/// One unreadable file in a folder must not fail the drop — a real folder
+/// always contains a `.DS_Store` or an image — but it must be *reported*,
+/// because silently skipping it leaves the operator believing the whole folder
+/// is in memory.
+#[tokio::test]
+async fn an_unreadable_file_is_reported_without_failing_the_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+
+    let (status, body) = drop_files(
+        &state,
+        &[
+            ("notes.txt", "text/plain", b"Keep this."),
+            ("logo.png", "image/png", &[0x89, b'P', b'N', b'G', 0x00, 0x01]),
+            ("blank.txt", "text/plain", b"   "),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["stored"], 1);
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items[0]["status"], "stored");
+    assert_eq!(items[1]["status"], "unsupported");
+    assert!(items[1]["detail"].is_string(), "the refusal says why");
+    assert_eq!(
+        items[2]["status"], "empty",
+        "a file that was read and said nothing is not a failure"
+    );
+}
+
+/// A drop with no file parts is a bad request rather than an empty success:
+/// reporting "0 stored" for a request that carried nothing hides a console bug.
+#[tokio::test]
+async fn a_drop_with_no_files_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = state_at(dir.path()).await;
+    let (status, _) = drop_files(&state, &[]).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// The server-side request forgery guard: this route makes the *host* fetch a
+/// URL, so the deployment's own network is off limits.
+#[cfg(feature = "documents")]
+#[test]
+fn link_ingestion_refuses_this_deployments_own_network() {
+    for refused in [
+        "http://localhost:8080/admin",
+        "http://127.0.0.1/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/",
+        "http://192.168.1.1/",
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+    ] {
+        assert!(
+            super::guard_link(refused).is_err(),
+            "{refused} must be refused"
+        );
+    }
+    assert!(super::guard_link("https://example.com/pricing").is_ok());
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -40,6 +40,7 @@ pub mod mcp;
 pub mod mcp_registry;
 pub mod memory;
 pub mod memory_engine;
+pub mod memory_ingest;
 pub mod pages;
 pub mod policy;
 pub mod read_state;
@@ -206,6 +207,7 @@ pub fn router() -> Router<AppState> {
         .merge(artifacts::router())
         .merge(memory::router())
         .merge(memory_engine::router())
+        .merge(memory_ingest::router())
         .merge(workspace::router())
         .merge(pages::router())
         .merge(skills::router())

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -39,6 +39,7 @@ pub mod mailer;
 pub mod mcp;
 pub mod mcp_registry;
 pub mod memory;
+pub mod memory_engine;
 pub mod pages;
 pub mod policy;
 pub mod read_state;
@@ -204,6 +205,7 @@ pub fn router() -> Router<AppState> {
         .merge(runs::router())
         .merge(artifacts::router())
         .merge(memory::router())
+        .merge(memory_engine::router())
         .merge(workspace::router())
         .merge(pages::router())
         .merge(skills::router())

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -265,7 +265,7 @@ async fn provision(
         builder = builder.with_stores(stores);
     }
     if let Some(overlay) = state.memory_overlay() {
-        builder = builder.with_memory_overlay(overlay);
+        builder = builder.with_memory_overlay(&overlay);
     }
     // Issue #1050: the durable owner row is written BEFORE the company exists.
     //

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -104,7 +104,7 @@ pub use layout::DataLayout;
 pub use migrate::migrate_legacy_nest_announced;
 pub use paths::{Bundle, DATA_DIR_ENV, home_divergence_warning, resolve_home};
 pub use select::{
-    MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,
+    MemoryBackend, MemoryOverlay, MemorySelection, StorageHandles, StorageKind, StorageSettings,
     open_memory_overlay, open_storage, plaintext_secret_refusal, refuse_bundle_env,
 };
 

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -460,11 +460,16 @@ pub struct StorageSettings {
     /// Which engine to bind for `OPENCOMPANY_MEMORY=remote`
     /// (`OPENCOMPANY_MEMORY_DRIVER`): `supermemory`, `mem0`, `cognee`.
     ///
-    /// Env is the only channel: memory selection is instance-level (one engine
-    /// per boot, like `OPENCOMPANY_STORAGE`), while manifests are per-company —
-    /// a company-scoped knob for an instance-wide choice would be incoherent.
+    /// Instance-level, never per-company: one engine per instance, like
+    /// `OPENCOMPANY_STORAGE`, while manifests are per-company — a
+    /// company-scoped knob for an instance-wide choice would be incoherent.
     /// This deliberately differs from `[inference].provider`, which *is*
     /// per-company and rightly lives in the manifest.
+    ///
+    /// Two channels, in the usual order: the environment, and — when the
+    /// deployment names no engine — the `[memory]` section of `config.toml`,
+    /// which is what lets an operator choose one from the console
+    /// ([`MemorySelection`], [`StorageSettings::with_memory_config`]).
     pub memory_driver: Option<String>,
     pub memory_url: Option<String>,
     /// The hosted engine's credential (`OPENCOMPANY_MEMORY_API_KEY`).
@@ -557,6 +562,103 @@ impl StorageSettings {
             memory_url: non_empty("OPENCOMPANY_MEMORY_URL"),
             memory_api_key: non_empty("OPENCOMPANY_MEMORY_API_KEY"),
         })
+    }
+
+    /// Whether the *deployment* named the memory engine
+    /// (`OPENCOMPANY_MEMORY`), in which case the `[memory]` section of
+    /// `config.toml` is inert and the console renders the engine read-only.
+    ///
+    /// Presence, not value: a control plane that injects `OPENCOMPANY_MEMORY`
+    /// owns the choice whichever engine it names, including `store`.
+    pub fn memory_is_env_owned() -> bool {
+        std::env::var("OPENCOMPANY_MEMORY").is_ok_and(|value| !value.trim().is_empty())
+    }
+
+    /// Layers a `config.toml` `[memory]` section under the environment.
+    ///
+    /// A no-op when [`Self::memory_is_env_owned`] — see [`MemorySection`] for
+    /// why the env layer wins rather than the more recent write.
+    ///
+    /// [`MemorySection`]: crate::app::config::MemorySection
+    pub fn with_memory_config(mut self, section: &crate::app::config::MemorySection) -> Result<Self> {
+        if Self::memory_is_env_owned() {
+            return Ok(self);
+        }
+        let selection = MemorySelection::from_section(section)?;
+        self.memory_backend = selection.backend;
+        self.memory_driver = selection.driver;
+        self.memory_url = selection.url;
+        self.memory_api_key = selection.api_key;
+        Ok(self)
+    }
+
+    /// Replaces the memory selection with `selection`, leaving the base
+    /// backend, data dir and durability assertion untouched.
+    ///
+    /// This is what a live engine swap rebinds through
+    /// ([`crate::server::ops::memory_engine`]): the rest of a running
+    /// instance's storage settings must survive a memory change unchanged.
+    pub fn with_memory_selection(mut self, selection: MemorySelection) -> Self {
+        self.memory_backend = selection.backend;
+        self.memory_driver = selection.driver;
+        self.memory_url = selection.url;
+        self.memory_api_key = selection.api_key;
+        self
+    }
+}
+
+/// One instance's memory-engine choice: everything `OPENCOMPANY_MEMORY*`
+/// names, parsed and validated, independent of where it came from (the
+/// environment, `config.toml`, or a console write that has not been persisted
+/// yet).
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct MemorySelection {
+    pub backend: MemoryBackend,
+    pub driver: Option<String>,
+    pub url: Option<String>,
+    pub api_key: Option<String>,
+}
+
+impl MemorySelection {
+    /// Parses a `config.toml` `[memory]` section.
+    ///
+    /// Blank strings are treated as absent — a TOML key written and then
+    /// emptied means "not set", the same rule `non_empty` applies to the
+    /// environment, and routing on bare presence would send `""` down a path
+    /// that binds nothing.
+    pub fn from_section(section: &crate::app::config::MemorySection) -> Result<Self> {
+        let trimmed = |value: &Option<String>| {
+            value
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string)
+        };
+        let backend = match trimmed(&section.backend) {
+            Some(raw) => raw.parse()?,
+            None => MemoryBackend::default(),
+        };
+        Ok(Self {
+            backend,
+            driver: trimmed(&section.driver),
+            url: trimmed(&section.url),
+            api_key: trimmed(&section.api_key),
+        })
+    }
+}
+
+/// Renders the credential as `<set>`, never its bytes — the same hand-written
+/// `Debug` [`StorageSettings`] carries, and for the same reason: this type is
+/// reachable from boot logging and from a route's error path, where a bare
+/// `{:?}` is one keystroke away.
+impl std::fmt::Debug for MemorySelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemorySelection")
+            .field("backend", &self.backend.as_str())
+            .field("driver", &self.driver)
+            .field("url", &self.url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<set>"))
+            .finish()
     }
 }
 

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -580,7 +580,10 @@ impl StorageSettings {
     /// why the env layer wins rather than the more recent write.
     ///
     /// [`MemorySection`]: crate::app::config::MemorySection
-    pub fn with_memory_config(mut self, section: &crate::app::config::MemorySection) -> Result<Self> {
+    pub fn with_memory_config(
+        mut self,
+        section: &crate::app::config::MemorySection,
+    ) -> Result<Self> {
         if Self::memory_is_env_owned() {
             return Ok(self);
         }


### PR DESCRIPTION
Two asks, one page: let an operator **choose the memory backend** (Supermemory, Mem0, Cognee, the in-pod engines, or none), and let them **drop files, folders and links** onto the Brain page to put them into memory.

## 1. Choosing the engine

The engine used to be selectable only through `OPENCOMPANY_MEMORY*`, read once at boot — i.e. only by whoever controls the process environment. The Brain page could show what was bound and nothing else. This adds the write half.

- **`[memory]` in `config.toml`** (`backend` / `driver` / `url` / `api_key`), layered under the environment like every other key (`src/app/config.rs`, `MemorySelection` + `StorageSettings::with_memory_config` in `src/store/select.rs`).
- **The overlay is swappable at runtime** — `AppState::memory_overlay` moved behind a lock, the same shape and for the same reason as `auth_mode_override`.
- **New routes** (`src/server/ops/memory_engine.rs`), both scope forms:

  ```text
  GET  …/memory/engine        what is bound, what is saved, what may be picked
  POST …/memory/engine/test   probe a candidate without saving it
  PUT  …/memory/engine        save it, bind it, and put it in force
  ```

Three refusals carry the design:

- **The environment still wins.** `OPENCOMPANY_MEMORY` set at all makes the file layer inert, the console read-only, and a `PUT` a `409` naming the variable. A hosted tenant's control plane injects those variables, so accepting the edit would write a file, report success, and change nothing at the next boot.
- **An engine that does not answer is not bound.** The route opens the candidate, probes it, and refuses on a failed probe, leaving the previous overlay in force — the opposite of boot, which binds and warns because a transient vendor outage must not crash-loop a tenant. `?force=true` is the escape hatch.
- **It applies live, or names what it missed.** The new overlay is swapped in and every registered company is rebuilt through the existing `RuntimeRebuilder`; a company that could not be rebuilt is listed in `restartRequiredFor` rather than covered by a blanket "restart required".

The credential is never read back out — the route reports whether a key is set, never its bytes — and an omitted `apiKey` means "keep the stored one", so an endpoint edit cannot wipe a key.

Console: `EngineSection.tsx` renders one tile per engine with an inline SVG mark. The marks are tinted from the `--tone-*` identity ramp rather than brand hexes: a hex cannot theme (`assert-design-tokens.sh`) and Supermemory's near-black is invisible on the dark canvas. A build without a feature shows its tile disabled with the feature named, rather than hiding it — an operator looking for Supermemory should learn their build lacks the parser, not conclude the product has no such thing.

## 2. Dropping documents in

`src/ingest/` turns arbitrary operator bytes into memory: extraction per format, then chunking into `document/{slug}/{index}` labels in the `ContextStore` agents recall from, so a dropped handbook reaches a teammate on its next turn.

```text
POST   …/memory/ingest              multipart; folder drops carry relative paths
POST   …/memory/ingest/links        URLs, fetched host-side
DELETE …/memory/document/{slug}     forget one dropped document
```

- **The text is stored, the file is not.** The workspace tree is where files live; a second copy of every upload there would make the Brain page a silently diverging file manager.
- **Extraction never guesses.** Text, Markdown, HTML, JSON, CSV and source need no parser; PDF, `.docx`, `.xlsx` and `.pptx` ride a new `documents` feature that **ships in `default`** (the `oauth` precedent: a shipped build where dropping a PDF stores nothing is a feature only people who compile their own binary have). An unreadable format is reported, never stored as decoded noise that would count as a memory and recall as nothing. A scanned PDF is *empty*, which is a different answer from *failed*.
- **One row per file, never one for the batch.** A real folder always has a `.DS_Store`, an image, or a scanned page — failing the whole drop over one makes folders unusable, and skipping it silently leaves the operator believing the folder is in memory.
- **A drop can be taken back.** Document rows are the one context origin an operator authored, so they are deletable; forgetting honours the shared-address rule, leaving a byte-identical chunk indexed under another label alone.
- **Links are fetched by the host**, so the guard is the host's: `http`/`https` only, no loopback / link-local / private addresses, no redirect chasing — "remember this page" must not become a read primitive against the deployment's own network.

Console `DropZone.tsx` walks dropped folders with `webkitGetAsEntry` (paginating `readEntries`, so a folder over 100 files is not silently truncated), keeps each file's relative path as its document name, batches uploads, filters `.git`/`node_modules`/build output client-side, and shows a per-file report of what was skipped and why. A file picker and an Add-link button sit beside it for anyone driving the console from a keyboard.

## Commands run locally

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 3299 pass
- `cargo test --features acp,runner,tinymemory --lib -- memory_engine store::memory store::select` — 125 pass, including the catalog↔`SUPPORTED_REMOTE_DRIVERS` agreement test
- `cargo check --no-default-features`, `cargo check --all-features --all-targets`
- `scripts/ci/assert-feature-lanes.sh`, `scripts/ci/assert-design-tokens.sh`
- `npm run typecheck`, `npm run test` — 1922 pass

## Behaviour and API changes

- `MemoryEntry.origin` gains `document`, and those rows are `editable` (the delete goes to `…/memory/document/{slug}`, forgetting the whole document rather than the one chunk the card shows).
- `AppState::memory_overlay()` returns an owned `Option<MemoryOverlay>` rather than a borrow; `set_memory_overlay` is new.
- New default-set feature `documents` (`pdf-extract`, `calamine`, `quick-xml`, `zip`, and `reqwest` for links) with its row in `scripts/ci/feature-lanes.txt`.
- The read-only `EnginePanel` and its `/spec`-shaped helpers are gone; `frontend/test/unit/memory-engine-panel.test.ts` is replaced by `memory-engine.test.ts`, which tests the same properties (the null engine's warning, who owns the choice) against the state the picker actually renders. The page now reads the engine route rather than `/spec`, because `/spec` reports what *boot* bound and stops being the answer the moment a console change rebinds it live.

## Not covered

- Extraction is tested against a synthesized `.docx` plus the text/HTML/chunking paths. There are no real PDF/`.xlsx`/`.pptx` binary fixtures, so those parsers are exercised only by their own crates' tests.
- No event is journalled for an ingest or a forget; the `EventLog` has no variant for it and adding one was outside this change.
- `scripts/ci/assert-md-line-cap.sh` fails on `docs/spec/runtime/desktop.md` (524 lines). Pre-existing on `main` and untouched here.

Docs: `docs/spec/runtime/memory-engine.md` (console selection, live rebind, revised selection-scope section), `docs/spec/runtime/config.md` (`[memory]`), `docs/spec/company-brain/memory.md` (the drop zone, normatively).