### PR TITLE
fix(console): keep Send reachable and SMTP legible in the 768-1023px two-rail band (#1383)

### DIFF
--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -971,18 +971,25 @@ export function ChatView({
 
   return (
     <div className="flex min-h-0 flex-1">
+      {/* The channel rail and the chat pane share the viewport with the app
+          sidebar. That sidebar is on from `md` (≥768), so a rail that also came
+          in at `md` gave two rails plus content a ~290px pane from 768–1023px —
+          Send fell off the right edge with no scroll to reach it (issue #1383).
+          The rail now waits for `lg` (≥1024); from 768–1023 the pane runs
+          single-column and the "Show channels" toggle in the header (also
+          `lg:hidden`) swaps to the rail, mirroring the sub-`md` mobile flow. */}
       <ChannelRail
         sections={sections}
         activeId={channel.id}
         unread={unread ?? {}}
         onSelect={selectChannel}
-        className={cn("md:flex", mobilePane === "rail" ? "flex" : "hidden")}
+        className={cn("lg:flex", mobilePane === "rail" ? "flex" : "hidden")}
       />
 
       <div
         className={cn(
           "min-w-0 flex-1 flex-col",
-          mobilePane === "chat" ? "flex" : "hidden md:flex",
+          mobilePane === "chat" ? "flex" : "hidden lg:flex",
         )}
       >
         <ChatHeader

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -81,7 +81,7 @@ export function SettingsSection({ client, company, feed, sub, onNavigate, onFlag
     <div className="flex min-h-0 flex-1">
       <nav
         aria-label="Settings"
-        className="hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 sm:flex"
+        className="hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 lg:flex"
       >
         <h2 className="px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">Settings</h2>
         {SETTINGS_PAGES.map((item) => (
@@ -104,10 +104,14 @@ export function SettingsSection({ client, company, feed, sub, onNavigate, onFlag
         ))}
       </nav>
 
-      {/* On a narrow screen the rail collapses to a scrolling row of chips, so
-          the sub-pages stay reachable without a second drawer. */}
+      {/* Below `lg` the rail collapses to a scrolling row of chips, so the
+          sub-pages stay reachable without a second drawer. The breakpoint is
+          `lg`, not `sm`: from 768–1023px the app sidebar is still on, and a
+          second `w-60` rail here would squeeze the settings pane below the
+          width its widest card (SMTP) needs, clipping it on both sides
+          (issue #1383). */}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <div className="flex gap-1 overflow-x-auto border-b p-2 sm:hidden">
+        <div className="flex gap-1 overflow-x-auto border-b p-2 lg:hidden">
           {SETTINGS_PAGES.map((item) => (
             <button
               key={item.id}

--- a/frontend/src/views/chat/ChatHeader.tsx
+++ b/frontend/src/views/chat/ChatHeader.tsx
@@ -56,7 +56,7 @@ export function ChatHeader({
         <Button
           variant="ghost"
           size="icon"
-          className="size-8 md:hidden"
+          className="size-8 lg:hidden"
           onClick={onOpenRail}
           aria-label="Show channels"
         >

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -169,7 +169,12 @@ export function MessageComposer({
           className="field-sizing-content max-h-48 min-h-10 w-full resize-none bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground"
         />
 
-        <div className="flex items-center gap-0.5 px-2 pb-1.5">
+        {/* `flex-wrap` keeps Send reachable in a narrow pane (issue #1383):
+            when the intent group and icon buttons can't share a line with it,
+            the row wraps and Send drops to its own line — still `ml-auto`, so
+            right-aligned and in-flow — rather than overflowing off-screen with
+            no way to scroll to it. On a roomy composer it stays a single row. */}
+        <div className="flex flex-wrap items-center gap-0.5 px-2 pb-1.5">
           {deliverableChoice && !compact && (
             <div
               className="mr-1 flex items-center gap-0.5 rounded-lg border p-0.5"

--- a/frontend/test/unit/responsive-two-rail-band.test.ts
+++ b/frontend/test/unit/responsive-two-rail-band.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The 768–1023px two-rail band (issue #1383).
+ *
+ * The app sidebar comes on at `md` (≥768). Chat's channel rail and Settings'
+ * sub-rail used to come on *earlier or at the same* breakpoint, so from
+ * 768–1023px the window carried two rails plus content and the working pane
+ * collapsed to ~290px. In Chat that stranded the composer's Send button off
+ * the right edge with no scroll to reach it; in Settings it clipped the SMTP
+ * card on both sides. The fix pushes both second rails to `lg` (≥1024) — so
+ * 768–1023 is single-rail — and lets the composer's action row wrap so Send
+ * can never leave the flow.
+ *
+ * A jsdom render cannot prove this: the whole failure is a media query, and
+ * jsdom does not evaluate them. So this guards the *class contract* the fix
+ * rests on — the same source-contract idiom as `shell-chrome-tokens.test.ts`.
+ * The pixel-accurate proof (Send clickable, SMTP legible across 768–1024px)
+ * is a manual/e2e concern noted in the PR.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+describe("chat rails collapse to single-rail below lg (issue #1383)", () => {
+  const chatView = read("views/ChatView.tsx");
+  const chatHeader = read("views/chat/ChatHeader.tsx");
+
+  it("shows the channel rail only from lg, toggled below it", () => {
+    // The rail: on from lg, otherwise governed by the mobile pane toggle.
+    expect(chatView).toContain(
+      'cn("lg:flex", mobilePane === "rail" ? "flex" : "hidden")',
+    );
+    // Regression guard: the `md` rail is what produced the two-rail band.
+    expect(chatView).not.toContain(
+      'cn("md:flex", mobilePane === "rail" ? "flex" : "hidden")',
+    );
+  });
+
+  it("shows the chat pane full-width below lg (single pane), split at lg", () => {
+    expect(chatView).toContain('mobilePane === "chat" ? "flex" : "hidden lg:flex"');
+    expect(chatView).not.toContain('mobilePane === "chat" ? "flex" : "hidden md:flex"');
+  });
+
+  it("keeps the header's rail toggle visible across the single-rail band", () => {
+    // The "Show channels" affordance must reach up to lg, matching the rail.
+    expect(chatHeader).toContain("size-8 lg:hidden");
+    expect(chatHeader).not.toContain("size-8 md:hidden");
+  });
+});
+
+describe("settings sub-rail collapses to chips below lg (issue #1383)", () => {
+  const settings = read("views/SettingsSection.tsx");
+
+  it("shows the sub-rail only from lg", () => {
+    expect(settings).toContain(
+      "hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 lg:flex",
+    );
+    // Regression guard: the `sm` rail overlapped the app sidebar at 768–1023.
+    expect(settings).not.toContain(
+      "hidden w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r p-3 sm:flex",
+    );
+  });
+
+  it("shows the chip-row fallback below lg, so the pane gets full width", () => {
+    expect(settings).toContain("flex gap-1 overflow-x-auto border-b p-2 lg:hidden");
+    expect(settings).not.toContain("flex gap-1 overflow-x-auto border-b p-2 sm:hidden");
+  });
+});
+
+describe("composer keeps Send in-flow in a narrow pane (issue #1383)", () => {
+  const composer = read("views/chat/MessageComposer.tsx");
+
+  it("lets the action row wrap instead of overflowing", () => {
+    expect(composer).toContain('className="flex flex-wrap items-center gap-0.5 px-2 pb-1.5"');
+    // Regression guard: the non-wrapping row pushed Send off-screen.
+    expect(composer).not.toContain('className="flex items-center gap-0.5 px-2 pb-1.5"');
+  });
+
+  it("keeps Send in normal flow (ml-auto), never absolutely positioned", () => {
+    // Anchor on the Send button and read the className just above its
+    // `aria-label`: it must right-align with `ml-auto` and carry no out-of-flow
+    // escape. If Send were pulled from the flow it could clip again exactly the
+    // way #1383 describes.
+    const idx = composer.indexOf('aria-label="Send"');
+    expect(idx).toBeGreaterThan(-1);
+    const sendButton = composer.slice(Math.max(0, idx - 300), idx);
+    expect(sendButton).toContain("ml-auto");
+    expect(sendButton).not.toMatch(/\babsolute\b|\bfixed\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1383.

Between ~768px and ~1023px the console rendered **two navigation rails plus
content**. The app sidebar comes on at `md` (≥768), but Chat's channel rail was
also on at `md` and Settings' sub-rail came on even earlier at `sm` (≥640). With
both rails up, the working pane collapsed to ~290px — narrow enough that Chat's
composer pushed its **Send** button off the right edge with no way to scroll to
it, and Settings clipped the **SMTP card on both sides** (labels read as "TP
host" / "ername" / "m name"). The document never scrolled horizontally, so there
was no recovery.

**Problem.** The two rails were on different breakpoints and overlapped in the
768–1023 band, and the composer's action row did not wrap.

**Solution.** Hold both *second* rails until `lg` (≥1024), so 768–1023 is
single-rail with the app sidebar, and let the composer wrap:

- **Chat** — the channel rail is now `lg:flex` (was `md:flex`) and the chat pane
  runs single-column below `lg`; the header's "Show channels" toggle follows at
  `lg:hidden`, so the rail stays reachable through the mobile-pane flow that
  already existed below `md`. This mirrors the app's existing
  `showExplorer`/`md:` collapse idiom in the Workspace view.
- **Settings** — the sub-rail is now `lg:flex` (was `sm:flex`) and its
  scrolling **chip-row** fallback shows below `lg` (was `sm:hidden`), giving the
  pane full width so the SMTP card fits.
- **Composer** — the action row is `flex-wrap`, so when the intent group and
  icon buttons can't share a line with Send, the row wraps and Send drops to its
  own line (still `ml-auto`, right-aligned, in flow) rather than overflowing
  off-screen. No visual change on a roomy composer.

Above `lg` the two rails return exactly as before; the change is confined to the
narrow band.

## API Or Behavior Changes

No API changes. Responsive-layout behavior only: in the 768–1023px band the
Chat channel rail and Settings sub-rail now collapse to their existing
narrow-width fallbacks (mobile-pane toggle / chip row) instead of standing
alongside the app sidebar. ≥1024px and <768px are unchanged.

## Tests

Console gates run locally from `frontend/`, all green:

- `npm run typecheck` — exit 0
- `npm run typecheck:unit` — exit 0
- `npm run typecheck:e2e` — exit 0
- `npx vitest run` — 228 files / 2080 tests passed
- `npm run build` — exit 0

Added `test/unit/responsive-two-rail-band.test.ts` — a source class-contract
test (the same idiom as `shell-chrome-tokens.test.ts`) locking the responsive
classes: the channel rail / chat pane / header toggle at `lg`, the Settings
sub-rail and chip row at `lg`, and the composer action row's `flex-wrap` with
Send kept in-flow. Red-proved by reverting the fixes (6 of 7 contracts fail).

A media query cannot be evaluated in jsdom, so **manual UI verification across
768–1024px on staging is still pending** (Send clickable, SMTP legible) and is
the pixel-accurate complement to this class contract.

Rust checklist items are N/A — this PR is frontend-only and touches no Rust:

- [ ] `cargo fmt --all -- --check` — N/A (no Rust changes)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A (no Rust changes)
- [ ] `cargo build --all-targets` — N/A (no Rust changes)
- [ ] `cargo test` — N/A (no Rust changes)

## Documentation

No doc changes needed — this is a responsive-layout fix with no public API,
route, or architecture change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layouts for Chat and Settings on medium-sized screens.
  * Chat now keeps the conversation pane visible while channel navigation is toggled as needed.
  * Message composer actions wrap on narrow panes, keeping the Send button accessible.
  * Updated navigation controls to appear at the appropriate screen size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->