### PR TITLE
fix(approvals): decide-below-evidence + freeze queue under pointer (#1406, #1414)

### DIFF
--- a/frontend/src/hooks/use-stable-list.ts
+++ b/frontend/src/hooks/use-stable-list.ts
@@ -30,17 +30,20 @@ import type { FocusEvent } from "react";
  * operator is about to press does not move, yet still shows its spinner.
  *
  * Spread {@link StableList.containerProps} onto the element wrapping the rows —
- * the region whose bounds define "over the queue".
+ * the region whose bounds define "over the queue". It also carries a `ref`:
+ * see the note on `focusInsideNow` below for why the thaw check needs the
+ * actual container node rather than trusting the focus flag alone.
  */
 export interface StableList<T> {
   /** The rows to render, in a pointer-stable order. */
   items: T[];
-  /** Handlers for the queue container that detect operator interaction. */
+  /** Handlers (and a `ref`) for the queue container that detect operator interaction. */
   containerProps: {
     onPointerEnter: () => void;
     onPointerLeave: () => void;
     onFocusCapture: () => void;
     onBlurCapture: (event: FocusEvent) => void;
+    ref: (node: HTMLElement | null) => void;
   };
 }
 
@@ -61,6 +64,13 @@ export function useStableList<T>(live: T[]): StableList<T> {
   const pointerInside = useRef(false);
   const focusInside = useRef(false);
 
+  // The container node, so the thaw check can ask the DOM directly rather
+  // than trust `focusInside` alone — see `focusInsideNow`.
+  const containerRef = useRef<HTMLElement | null>(null);
+  const setContainerRef = useCallback((node: HTMLElement | null) => {
+    containerRef.current = node;
+  }, []);
+
   const freeze = useCallback(() => {
     // Capture the list as it is *now* — which equals live, because a frozen
     // list never reaches here twice (the guard `?? liveRef.current` keeps the
@@ -68,9 +78,33 @@ export function useStableList<T>(live: T[]): StableList<T> {
     setFrozen((prev) => prev ?? liveRef.current);
   }, []);
 
-  const thawIfIdle = useCallback(() => {
-    if (!pointerInside.current && !focusInside.current) setFrozen(null);
+  /**
+   * Whether focus is *actually* still inside the container right now.
+   *
+   * `focusInside` is set from `onFocusCapture`/`onBlurCapture`, but disabling
+   * a focused element clears `document.activeElement` — to `<body>` — without
+   * firing `blur`/`focusout` at all (verified against Chromium; the browser
+   * drops focus as a side effect of the `disabled` attribute, not as a focus
+   * transition). This queue is the textbook trigger: every decide button sets
+   * its own `disabled` the instant it is clicked (the caller's in-flight
+   * `deciding` state), and clicking focuses the button first. So the row the
+   * operator just decided freezes on click, `onBlurCapture` never runs to
+   * clear `focusInside`, and — because nothing else ever calls it again —
+   * the queue stayed frozen permanently, surviving even the pointer leaving.
+   * Re-deriving from the live DOM here, at every thaw check, closes that gap
+   * without depending on an event that this specific case never sends.
+   */
+  const focusInsideNow = useCallback(() => {
+    const active = document.activeElement;
+    return active !== null && containerRef.current !== null && containerRef.current.contains(active);
   }, []);
+
+  const thawIfIdle = useCallback(() => {
+    if (pointerInside.current) return;
+    if (focusInsideNow()) return;
+    focusInside.current = false;
+    setFrozen(null);
+  }, [focusInsideNow]);
 
   const onPointerEnter = useCallback(() => {
     pointerInside.current = true;
@@ -100,6 +134,12 @@ export function useStableList<T>(live: T[]): StableList<T> {
 
   return {
     items: frozen ?? live,
-    containerProps: { onPointerEnter, onPointerLeave, onFocusCapture, onBlurCapture },
+    containerProps: {
+      onPointerEnter,
+      onPointerLeave,
+      onFocusCapture,
+      onBlurCapture,
+      ref: setContainerRef,
+    },
   };
 }

--- a/frontend/src/hooks/use-stable-list.ts
+++ b/frontend/src/hooks/use-stable-list.ts
@@ -1,0 +1,105 @@
+import { useCallback, useRef, useState } from "react";
+import type { FocusEvent } from "react";
+
+/**
+ * Holds a polled list's on-screen order stable while the operator is
+ * interacting with it (issue #1414).
+ *
+ * The Approvals queue is replaced wholesale every 5s poll (`use-company.ts`),
+ * and the view maps it straight to cards in host order. So the list mutates
+ * under the pointer whenever a card is decided elsewhere, the host sweeper
+ * retires an expired one, or an agent turn parks new ones above the card being
+ * read. Because every card's Approve button sits at the same fixed x on the
+ * right edge, removing a card *above* the pointer slides the next card's button
+ * to exactly where the previous one was — and a click already in flight lands
+ * on a different request. There is no undo: the host journals the verdict
+ * durably before anything slow happens.
+ *
+ * The fix (option 1 in the issue, the cheapest and the one with no false
+ * positives): freeze the rendered order — and hold removals — for as long as
+ * the operator is interacting with the queue, then reconcile to the latest poll
+ * the instant they are not. "Interacting" is the pointer being over the queue
+ * OR keyboard focus being inside it, so both a mouse user clicking down a column
+ * and a keyboard user tabbing through it are protected. When nothing is
+ * happening the freeze is invisible: `frozen` is `null` and the live list flows
+ * straight through.
+ *
+ * Content updates to cards that survive are deliberately held too while frozen:
+ * a card resolving its own in-flight state is driven by the caller's own
+ * `deciding` map keyed on id, not by this snapshot, so the button a hovering
+ * operator is about to press does not move, yet still shows its spinner.
+ *
+ * Spread {@link StableList.containerProps} onto the element wrapping the rows —
+ * the region whose bounds define "over the queue".
+ */
+export interface StableList<T> {
+  /** The rows to render, in a pointer-stable order. */
+  items: T[];
+  /** Handlers for the queue container that detect operator interaction. */
+  containerProps: {
+    onPointerEnter: () => void;
+    onPointerLeave: () => void;
+    onFocusCapture: () => void;
+    onBlurCapture: (event: FocusEvent) => void;
+  };
+}
+
+export function useStableList<T>(live: T[]): StableList<T> {
+  // The held snapshot, or `null` when the list is flowing live. Kept as the
+  // actual rows rather than a set of ids so a card removed by the host stays on
+  // screen — in place — until the operator moves away, instead of vanishing and
+  // pulling the queue up under the pointer.
+  const [frozen, setFrozen] = useState<T[] | null>(null);
+
+  // Live is read inside the interaction callbacks, which are memoised and must
+  // not close over a stale render. A ref updated every render is the current
+  // value without re-creating the handlers.
+  const liveRef = useRef(live);
+  liveRef.current = live;
+
+  // Two independent reasons to be frozen; the list thaws only when BOTH clear.
+  const pointerInside = useRef(false);
+  const focusInside = useRef(false);
+
+  const freeze = useCallback(() => {
+    // Capture the list as it is *now* — which equals live, because a frozen
+    // list never reaches here twice (the guard `?? liveRef.current` keeps the
+    // first snapshot for the whole interaction).
+    setFrozen((prev) => prev ?? liveRef.current);
+  }, []);
+
+  const thawIfIdle = useCallback(() => {
+    if (!pointerInside.current && !focusInside.current) setFrozen(null);
+  }, []);
+
+  const onPointerEnter = useCallback(() => {
+    pointerInside.current = true;
+    freeze();
+  }, [freeze]);
+
+  const onPointerLeave = useCallback(() => {
+    pointerInside.current = false;
+    thawIfIdle();
+  }, [thawIfIdle]);
+
+  const onFocusCapture = useCallback(() => {
+    focusInside.current = true;
+    freeze();
+  }, [freeze]);
+
+  const onBlurCapture = useCallback(
+    (event: FocusEvent) => {
+      // Focus moving between two cards inside the queue is not leaving it —
+      // only a blur whose destination is outside the container thaws.
+      if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+      focusInside.current = false;
+      thawIfIdle();
+    },
+    [thawIfIdle],
+  );
+
+  return {
+    items: frozen ?? live,
+    containerProps: { onPointerEnter, onPointerLeave, onFocusCapture, onBlurCapture },
+  };
+}

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -588,7 +588,7 @@ function granterLabel(g: StandingGrant, granterNames: Map<string, string>): stri
  * line simply do not render and what is left is the headline, the amount and
  * the relative time — exactly what shipped before.
  */
-function ApprovalCard({
+export function ApprovalCard({
   approval: a,
   now,
   askerNames,
@@ -626,43 +626,16 @@ function ApprovalCard({
   return (
     <Card data-approval-id={a.id}>
       <CardContent className="flex flex-col gap-3 py-4">
-        <ApprovalHeadline
-          approval={a}
-          /* Disabled on THIS card's own state only — a decision in flight on
-             another card leaves these live. That is the whole of #373's
-             first cause. */
-          actions={
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={deciding !== null}
-                /* A decline never carries a scope — there is nothing to grant,
-                   and the host refuses the pairing anyway. */
-                onClick={() => onDecide("deny", { kind: "once" })}
-              >
-                {deciding === "deny" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <X className="size-4" />
-                )}{" "}
-                Decline
-              </Button>
-              <Button
-                size="sm"
-                disabled={deciding !== null}
-                onClick={() => onDecide("approve", scope)}
-              >
-                {deciding === "approve" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Check className="size-4" />
-                )}{" "}
-                Approve
-              </Button>
-            </>
-          }
-        />
+        {/* Issue #1406: the headline no longer carries the decide buttons.
+            Approve and Decline used to sit here, level with the title and above
+            everything an operator reads to decide — the payload, and the scope
+            control that changes what Approve even means. On a tall card the
+            scope control was ~200px below the button, or off-screen entirely,
+            so the commit affordance was reachable before the evidence was seen.
+            The buttons now live in a footer row below the scope control, so the
+            card reads what will happen → what it will do → who asked and by
+            when → decide, the order every working consent pattern uses. */}
+        <ApprovalHeadline approval={a} />
 
         {/* Issue #596: for a workflow pre-publish gate, show the VERBATIM content
             the run is about to publish — the draft awaiting sign-off — above the
@@ -701,6 +674,43 @@ function ApprovalCard({
                 : undefined
           }
         />
+
+        {/* The decide footer (#1406) — deliberately the LAST thing in the card,
+            after the scope control it depends on. Disabled on THIS card's own
+            state only; a decision in flight on another card leaves these live,
+            which is the whole of #373's first cause. */}
+        <div
+          data-testid="approval-decide"
+          className="flex flex-wrap justify-end gap-2 border-t border-border pt-3"
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={deciding !== null}
+            /* A decline never carries a scope — there is nothing to grant,
+               and the host refuses the pairing anyway. */
+            onClick={() => onDecide("deny", { kind: "once" })}
+          >
+            {deciding === "deny" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <X className="size-4" />
+            )}{" "}
+            Decline
+          </Button>
+          <Button
+            size="sm"
+            disabled={deciding !== null}
+            onClick={() => onDecide("approve", scope)}
+          >
+            {deciding === "approve" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Check className="size-4" />
+            )}{" "}
+            Approve
+          </Button>
+        </div>
       </CardContent>
     </Card>
   );

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
+import { useStableList } from "@/hooks/use-stable-list";
 import {
   approvedByRuntimeLine,
   approvedLine,
@@ -154,6 +155,19 @@ export function ApprovalsView({
     () => (focusTaskId === null ? approvals : approvalsForTask(approvals, focusTaskId)),
     [approvals, focusTaskId],
   );
+  /**
+   * The same rows, but in a pointer-stable order (#1414).
+   *
+   * A poll swaps `visible` wholesale every 5s, and mapping that straight to
+   * cards let the queue reflow under the operator's pointer — a card removed
+   * above the pointer slid the next card's Approve button under an in-flight
+   * click. `useStableList` holds the rendered order (and holds removals) for as
+   * long as the pointer is over the queue or focus is inside it, then
+   * reconciles to the latest poll the moment the operator moves away. Every
+   * branch below reads `rows` rather than `visible` so the count, the empty
+   * state and the list all agree on the one frozen view.
+   */
+  const { items: rows, containerProps: queueHold } = useStableList(visible);
   const askerNames = useAskerNames(client, company, approvals);
   const { grants, granterNames, refreshGrants } = useStandingGrants(client, company);
   /**
@@ -333,7 +347,7 @@ export function ApprovalsView({
           ) : (
             <UnreadableApprovals onRetry={() => void feed.refresh()} />
           )
-        ) : visible.length === 0 ? (
+        ) : rows.length === 0 ? (
           focusTaskId !== null ? (
             <ClearedForTask />
           ) : (
@@ -343,9 +357,9 @@ export function ApprovalsView({
           <>
             <div className="mb-4 flex items-baseline justify-between">
               <h2 className="text-sm font-medium text-muted-foreground">
-                {visible.length === 1
+                {rows.length === 1
                   ? "1 thing needs your approval"
-                  : `${visible.length} things need your approval`}
+                  : `${rows.length} things need your approval`}
               </h2>
             </div>
             {/* #971: nothing may vanish unannounced. Requests now age out on
@@ -357,8 +371,8 @@ export function ApprovalsView({
               Each one has a deadline. Anything still undecided by then is
               declined on its own, and the work behind it moves on.
             </p>
-            <div className="flex flex-col gap-3">
-              {visible.map((a) => (
+            <div className="flex flex-col gap-3" {...queueHold}>
+              {rows.map((a) => (
                 <ApprovalCard
                   key={a.id}
                   approval={a}

--- a/frontend/test/e2e/approval-timeout-honesty.spec.ts
+++ b/frontend/test/e2e/approval-timeout-honesty.spec.ts
@@ -185,6 +185,25 @@ async function openApprovals(page: Page) {
   await expect(approvalCard(page)).toBeVisible({ timeout: 15_000 });
 }
 
+/**
+ * Move the operator's attention off the queue.
+ *
+ * `useStableList` (#1414, `frontend/src/hooks/use-stable-list.ts`) freezes the
+ * rendered order — and holds removals, deliberately, including the row the
+ * operator just decided — for as long as the pointer is over the queue OR
+ * keyboard focus is inside it, thawing only once BOTH clear. Clicking a decide
+ * button leaves both true: the click puts the pointer over the container, and
+ * Chromium focuses a `<button>` on click, so focus is inside it too. Neither
+ * this test nor a real operator has to do anything special to *cause* the
+ * freeze — the click already did. This mirrors what "moving away" means to the
+ * hook: the mouse leaves the container, and focus is dropped rather than
+ * merely moved to a still-inside sibling.
+ */
+async function leaveQueue(page: Page) {
+  await page.mouse.move(0, 0);
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+}
+
 test("a proxy timeout does not claim the decision failed, and clears the card", async ({
   page,
 }) => {
@@ -216,9 +235,11 @@ test("a proxy timeout does not claim the decision failed, and clears the card", 
   // Defect 2, on the exact body that produced the field report.
   expect(text).not.toContain("<");
 
-  // The queue reconciles. The bound is deliberately under the feed's 5s poll
-  // (`POLL_MS` in `use-company.ts`) so that passing means the fix's own
+  // The queue reconciles once the operator is no longer interacting with it
+  // (#1414 — see `leaveQueue`). The bound is deliberately under the feed's 5s
+  // poll (`POLL_MS` in `use-company.ts`) so that passing means the fix's own
   // `feed.refresh()` cleared the card, not the next scheduled tick.
+  await leaveQueue(page);
   await expect(approvalCard(page)).toHaveCount(0, { timeout: 2_500 });
 });
 
@@ -248,6 +269,8 @@ test("a declined approval that times out reads as recorded, not failed", async (
   // must not imply otherwise.
   expect(text).not.toContain("may still be working");
   expect(text).not.toContain("<");
+  // Same reconciliation gate as the timeout test above — see `leaveQueue`.
+  await leaveQueue(page);
   await expect(approvalCard(page)).toHaveCount(0, { timeout: 2_500 });
 });
 

--- a/frontend/test/unit/approval-card-decide-order.test.ts
+++ b/frontend/test/unit/approval-card-decide-order.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { ApprovalCard } from "@/views/ApprovalsView";
+
+/**
+ * Issue #1406: Approve and Decline must not sit above the evidence and the
+ * scope control that changes what Approve does.
+ *
+ * This suite is normally for pure functions — see `vitest.config.ts` — and it
+ * earns the exception the same way `approval-batch-card` does: the claim is
+ * about the DOM the operator's pointer travels through, and only a render can
+ * show whether the commit affordance comes before or after the control that
+ * redefines it. The old card put Approve in the headline's `actions` slot, level
+ * with the title and ~200px above the "If you approve" fieldset; a pure test of
+ * any helper cannot see that ordering at all.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+// `broadly_grantable` so the scope control renders — it is the whole point of
+// the issue — and a multi-line payload so the card is tall, the condition under
+// which the scope control used to fall off-screen below the button.
+const APPROVAL: ApprovalSummary = {
+  id: "a1",
+  kind: "shell",
+  amount_usd: null,
+  at_millis: T0,
+  agent: "ops",
+  broadly_grantable: true,
+  payload: { command: "rm -rf /tmp/build && make release", cwd: "/srv/app" },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(approval: ApprovalSummary) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalCard, {
+        approval,
+        now: T0 + 60_000,
+        askerNames: new Map([["ops", "Ops"]]),
+        deciding: null,
+        batchIndex: 1,
+        batchTotal: 1,
+        onDecide: (_verdict: Verdict, _scope: GrantScope) => {},
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** The Approve button, wherever it ended up. */
+function approveButton(): HTMLButtonElement {
+  const btn = Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Approve"),
+  );
+  if (!btn) throw new Error("no Approve button rendered");
+  return btn as HTMLButtonElement;
+}
+
+describe("ApprovalCard decide ordering (#1406)", () => {
+  it("renders the scope control before the decide buttons in DOM order", async () => {
+    await render(APPROVAL);
+
+    const scope = container.querySelector("fieldset");
+    const approve = approveButton();
+    expect(scope, "the scope control should render for a broadly-grantable card").not.toBeNull();
+
+    // `DOCUMENT_POSITION_FOLLOWING` on the scope element, tested against the
+    // Approve button, means the button comes *after* the scope control — the
+    // reading order #1406 requires: evidence and scope first, commit last.
+    const position = scope!.compareDocumentPosition(approve);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps both decide buttons in the footer, below the scope control", async () => {
+    await render(APPROVAL);
+
+    const footer = container.querySelector('[data-testid="approval-decide"]');
+    expect(footer, "the decide footer should exist").not.toBeNull();
+    // Both verbs live in the footer — not one moved and one left behind.
+    expect(footer!.textContent).toContain("Approve");
+    expect(footer!.textContent).toContain("Decline");
+
+    const scope = container.querySelector("fieldset")!;
+    const position = scope.compareDocumentPosition(footer!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/frontend/test/unit/stable-list.test.ts
+++ b/frontend/test/unit/stable-list.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useStableList, type StableList } from "@/hooks/use-stable-list";
+
+/**
+ * Issue #1414: the approvals queue must not reflow under the pointer on the 5s
+ * poll. `useStableList` freezes the rendered order — and holds removals — while
+ * the operator is interacting with the queue, so a poll that reorders or drops
+ * a card cannot slide a different card's button under an in-flight click.
+ *
+ * A jsdom render rather than a pure test because the invariant is "the rendered
+ * order does not change across a prop update", which only a rendered list has.
+ * The interaction handlers are called directly rather than dispatched as DOM
+ * events — they are plain callbacks, and calling them avoids jsdom's synthetic
+ * pointer-event gaps while exercising exactly the freeze/thaw the view wires up.
+ */
+
+let captured: StableList<string>;
+
+function Harness({ items }: { items: string[] }) {
+  const stable = useStableList(items);
+  captured = stable;
+  return createElement(
+    "div",
+    { "data-testid": "queue", ...stable.containerProps },
+    stable.items.map((id) => createElement("div", { key: id, "data-id": id }, id)),
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderItems(items: string[]) {
+  await act(async () => {
+    root.render(createElement(Harness, { items }));
+  });
+}
+
+/** The ids the DOM is actually showing, top to bottom. */
+function domOrder(): string[] {
+  return Array.from(container.querySelectorAll("[data-id]")).map((el) =>
+    el.getAttribute("data-id"),
+  ) as string[];
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useStableList (#1414)", () => {
+  it("holds the rendered order while the pointer is over the queue", async () => {
+    await renderItems(["a", "b", "c"]);
+    expect(domOrder()).toEqual(["a", "b", "c"]);
+
+    // Pointer enters the queue — the operator is now aiming a click.
+    await act(async () => captured.containerProps.onPointerEnter());
+
+    // A poll arrives that removes the top card and reorders the rest. Left to
+    // React this would pull every card up under the pointer.
+    await renderItems(["c", "b"]);
+
+    // Frozen: the DOM must still show exactly what it did before the poll.
+    expect(domOrder()).toEqual(["a", "b", "c"]);
+  });
+
+  it("reconciles to the latest poll once the pointer leaves", async () => {
+    await renderItems(["a", "b", "c"]);
+    await act(async () => captured.containerProps.onPointerEnter());
+    await renderItems(["c", "b"]);
+    expect(domOrder()).toEqual(["a", "b", "c"]);
+
+    // Pointer leaves — nothing is being aimed at, so the held order is dropped
+    // and the newest poll takes over.
+    await act(async () => captured.containerProps.onPointerLeave());
+    expect(domOrder()).toEqual(["c", "b"]);
+  });
+
+  it("flows live when nothing is interacting", async () => {
+    await renderItems(["a", "b", "c"]);
+    // No pointer, no focus: a poll updates the list immediately.
+    await renderItems(["c", "b"]);
+    expect(domOrder()).toEqual(["c", "b"]);
+  });
+});


### PR DESCRIPTION
## Summary

Two P0 fixes on the Approvals surface (`frontend/src/views/ApprovalsView.tsx`), frontend-only. Both are about a click landing on a decision the operator did not mean to make.

**#1406 — decide buttons above the evidence.** Approve/Decline sat in the headline's `actions` slot, level with the title and ~200px above the "If you approve" scope control that changes what Approve grants (and above the payload/content it signs off). On a tall card the scope control was off-screen, so the commit affordance was reachable before the evidence and scope were ever seen. The buttons now live in a footer row at the bottom of the card, below the scope control and the meta line, so the card reads: what will happen → what it will do → who asked and by when → decide.

**#1414 — queue reflows under the pointer.** `useCompany` polls every 5s and replaces the queue wholesale; the view mapped it straight to cards in host order. A card removed above the pointer (decided elsewhere, swept on expiry, or re-sorted by a new turn) slid the next card's Approve button to exactly where the previous one was — an in-flight click landed on a different request, with no undo. A new `useStableList` hook (`frontend/src/hooks/use-stable-list.ts`) freezes the rendered order — and holds removals — while the pointer is over the queue or keyboard focus is inside it, then reconciles to the latest poll the instant the operator moves away. When nothing is interacting the list flows live exactly as before.

Both are option (1) / the re-slot the issues recommend — no evidence was shrunk, no confirmation friction added.

## API Or Behavior Changes

Console-only, no API changes.

- Approvals cards render Approve/Decline as a bottom footer row instead of in the top headline row. Button roles/labels are unchanged (`getByRole("button", { name: "Approve" | "Decline" })` still resolves).
- The approvals queue no longer re-orders or drops cards while the pointer is over it or focus is inside it; it catches up on `pointerleave` / focus leaving.

## Tests

Frontend gates, all green from `frontend/`:

- `npm run typecheck` — pass
- `npm run typecheck:unit` — pass
- `npm run typecheck:e2e` — pass
- `npx vitest run` — 2078 passed (229 files), incl. the two new suites below
- `npm run build` — pass

New unit tests (both red-proved by reverting their fix):

- `test/unit/approval-card-decide-order.test.ts` (#1406) — asserts the scope control precedes the decide buttons in DOM order, and that both verbs live in the footer below the scope control.
- `test/unit/stable-list.test.ts` (#1414) — asserts a poll update that removes/reorders cards while "interacting" does not reorder the rendered list, and that it reconciles once the pointer leaves.

Rust checklist N/A — this change touches no Rust:

- [ ] `cargo fmt --all -- --check` — N/A (frontend-only)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A (frontend-only)
- [ ] `cargo build --all-targets` — N/A (frontend-only)
- [ ] `cargo test` — N/A (frontend-only)

Manual UI verification at 768–1024px on staging is still pending.

## Documentation

No docs affected — behavioral fixes to an existing console surface, no public API or architecture change.

## Related

Closes #1406
Closes #1414
