### PR TITLE
setup: give designed teammates standing instructions, and re-cut the curated mandates

### DIFF
--- a/docs/spec/runtime/company-setup-guarantees.md
+++ b/docs/spec/runtime/company-setup-guarantees.md
@@ -1,7 +1,7 @@
 # First-run setup: what the host enforces
 
 The product decisions behind first-run setup live in
-[company-setup.md](company-setup.md). This file holds the four things the host
+[company-setup.md](company-setup.md). This file holds the five things the host
 *enforces* rather than requests, and why each is a boundary instead of a line in
 a prompt.
 
@@ -83,6 +83,42 @@ one holding a spend authority.
 
 The curated templates declare a focus too. An operator with no credential must
 not end up with the *wider* company.
+
+## A teammate is told how to work, and the host writes it
+
+**Decision D9: the focus that picks a belt also picks a set of standing
+instructions, and the model authors none of them.**
+
+`manifest_from_setup` set `id`, `role`, `description` and `tools` and left
+`prompt` unset. So everything a setup-built teammate was ever told was what
+`persona_prompt` assembles — "You are Ops, the Operations Manager at Acme. Speak
+in the first person as this role." plus a mandate capped at 200 characters.
+Around 150 characters of instruction, sitting on the same roster as a globals
+teammate carrying 500–600 (`globals/agents/*.toml`). The mandate says what a
+teammate owns; nothing said how it works.
+
+`AgentFocus::instructions` supplies that, keyed on the same closed enum that
+already picks the belt, for the same reason D7 gives: an agent's prompt is the
+single field that decides how it behaves, so letting the pass author it would put
+a stranger's free text — read by a model, written into a system prompt —
+inside the prompt's blast radius. The model names a work shape; the host owns
+every word the teammate is told.
+
+The instructions describe the *shape* of the work and never the business. The
+mandate already carries the business, and a second copy in the same prompt would
+be a staler one. They are written in the globals' register without reusing its
+sentences: a global teammate is on the same roster, and two agents given the
+same instructions are one agent twice.
+
+An unrecognised focus is instructed with **nothing**, which is the opposite of
+what the belt does with the same input — and deliberately. A belt substitutes
+because a permission has a safe direction to fail in; instructions have none.
+Telling an analyst "never invent a detail to make a sentence work" is worse
+guidance than the role framing it already has, so an unknown shape keeps exactly
+the pre-instruction behaviour.
+
+The curated templates declare a focus, so the fallback team is instructed too —
+an operator with no credential must not end up with the *less directed* company.
 
 ## A fallback says which fallback
 

--- a/docs/spec/runtime/company-setup-guarantees.md
+++ b/docs/spec/runtime/company-setup-guarantees.md
@@ -64,14 +64,25 @@ three sentences. The globals teammates sitting next to them already do the
 opposite, and `globals/agents/researcher.toml` says why: a request is intersected
 with `[tools].allow`, so naming one can only ever narrow.
 
-Each proposed agent now carries an `AgentFocus` — `research`, `writing`,
-`operations` or `analysis` — and the host maps it to a belt. The model never
+Each proposed agent now carries an `AgentFocus`, named for what the teammate
+*produces* — `research`, `writing`, `design`, `analysis`, `build`, `operations`,
+`coordination`, `support` — and the host maps it to a belt. The model never
 names a tool. Tool grants are a permission boundary, and letting free text a
 stranger typed reach `[tools]` would put that boundary inside the prompt's blast
 radius; a closed enum means the worst a hostile answer achieves is the wrong belt
-from a list of four the host wrote. `media`, `composio`, `search`, `repo` and
+from a list the host wrote. `media`, `composio`, `search`, `repo` and
 `shell` are unreachable from every focus, and a test quantifies over the whole
 vocabulary so a focus added later cannot quietly widen it.
+
+Six of the eight share one belt, which is what let the vocabulary grow without
+moving anybody's reach. The enum does two jobs — it picks a belt and it picks
+the standing instructions below — and the second wants a finer grain than the
+first: `operations` alone covered 13 of the 30 curated profiles, so a QA
+engineer and an account manager were told the same thing. Splitting it is a
+change to instructions only; every belt is byte-identical either side of it.
+`build` is the case worth naming: the obvious reading of "makes the product" is
+`repo` and `shell`, and it gets neither, because a teammate invented from three
+sentences does not get a shell on the strength of a word the model chose.
 
 An unrecognised focus gets the narrowest working belt, never an empty list. It
 used to inherit, on the reasoning that an unknown value should degrade to the
@@ -102,7 +113,16 @@ already picks the belt, for the same reason D7 gives: an agent's prompt is the
 single field that decides how it behaves, so letting the pass author it would put
 a stranger's free text — read by a model, written into a system prompt —
 inside the prompt's blast radius. The model names a work shape; the host owns
-every word the teammate is told.
+every word of the standing instructions.
+
+Not every word the teammate is told, which is worth stating exactly because the
+looser claim is easy to write and false: `persona_prompt` already appends the
+**mandate**, and the model wrote that. Model text reaches the system prompt
+today. What it reaches under is a 200-character cap, a field whose only job is
+to name what the teammate owns, and a review screen the operator reads before
+anything is created — a much smaller surface than a free-form instruction block,
+and the reason a per-teammate instruction field is a separate decision rather
+than an obvious extension of this one.
 
 The instructions describe the *shape* of the work and never the business. The
 mandate already carries the business, and a second copy in the same prompt would

--- a/docs/spec/runtime/company-setup.md
+++ b/docs/spec/runtime/company-setup.md
@@ -297,11 +297,12 @@ reach behind a value a model chose from free text — what D7's enum prevents.
 
 ## What the host enforces, rather than asks for
 
-Four guarantees hold whatever a model returns — coverage checked against the
-host's own job list, a tool belt asked for rather than inherited, a copy of the
-reference team refused the name "designed", and a fallback that says which
-fallback it is. Each is a boundary rather than a line in a prompt, and each has
-a test that fails when it stops holding:
+Five guarantees hold whatever a model returns — coverage checked against the
+host's own job list, a tool belt asked for rather than inherited, standing
+instructions the host writes rather than the model, a copy of the reference team
+refused the name "designed", and a fallback that says which fallback it is. Each
+is a boundary rather than a line in a prompt, and each has a test that fails when
+it stops holding:
 [company-setup-guarantees.md](company-setup-guarantees.md).
 
 ## Nobody gets stuck

--- a/src/company/setup.rs
+++ b/src/company/setup.rs
@@ -122,8 +122,20 @@ pub enum AgentFocus {
     Research,
     /// Produces the written work. Writes the workspace; no web.
     Writing,
-    /// Keeps work moving. Same belt as [`Writing`](Self::Writing) today.
+    /// Produces the visual and interface work. Same belt as
+    /// [`Writing`](Self::Writing).
+    Design,
+    /// Runs a recurring process end to end. Same belt as
+    /// [`Writing`](Self::Writing).
     Operations,
+    /// Keeps people and work moving. Same belt as [`Writing`](Self::Writing).
+    Coordination,
+    /// Makes and maintains the product itself. Same belt as
+    /// [`Writing`](Self::Writing) — deliberately **not** `repo` or `shell`,
+    /// which no focus reaches.
+    Build,
+    /// Answers customers. Same belt as [`Writing`](Self::Writing).
+    Support,
     /// Measures and reports. Writes the workspace, and browses to source the
     /// numbers.
     Analysis,
@@ -131,11 +143,15 @@ pub enum AgentFocus {
 
 impl AgentFocus {
     /// Every focus, so a test can quantify over the whole vocabulary rather
-    /// than over the four a reader happened to remember.
-    pub const ALL: [Self; 4] = [
+    /// than over the handful a reader happened to remember.
+    pub const ALL: [Self; 8] = [
         Self::Research,
         Self::Writing,
+        Self::Design,
         Self::Operations,
+        Self::Coordination,
+        Self::Build,
+        Self::Support,
         Self::Analysis,
     ];
 
@@ -144,7 +160,11 @@ impl AgentFocus {
         match self {
             Self::Research => "research",
             Self::Writing => "writing",
+            Self::Design => "design",
             Self::Operations => "operations",
+            Self::Coordination => "coordination",
+            Self::Build => "build",
+            Self::Support => "support",
             Self::Analysis => "analysis",
         }
     }
@@ -159,7 +179,11 @@ impl AgentFocus {
         match value.trim().to_ascii_lowercase().as_str() {
             "research" => Some(Self::Research),
             "writing" => Some(Self::Writing),
+            "design" => Some(Self::Design),
             "operations" => Some(Self::Operations),
+            "coordination" => Some(Self::Coordination),
+            "build" => Some(Self::Build),
+            "support" => Some(Self::Support),
             "analysis" => Some(Self::Analysis),
             _ => None,
         }
@@ -167,14 +191,27 @@ impl AgentFocus {
 
     /// This focus's tool belt.
     ///
-    /// `Writing` and `Operations` return the same list today, and that is not an
-    /// oversight: they differ in mandate and in what the prompt routes to them,
-    /// not in the tools they need. Keeping them distinct is what lets the belts
-    /// diverge later without re-deciding which agents are which.
+    /// Six of the eight return the same list, and that is not an oversight:
+    /// they differ in mandate and in what the prompt routes to them, not in the
+    /// tools they need. Keeping them distinct is what lets the belts diverge
+    /// later without re-deciding which agents are which — and it is what let
+    /// the vocabulary be widened for instruction purposes without moving a
+    /// single teammate's reach.
+    ///
+    /// `Build` sharing the writing belt is a decision, not an omission. The
+    /// obvious reading of "makes the product" is `repo` and `shell`, and no
+    /// focus reaches either: a teammate a stranger's three sentences invented
+    /// does not get a shell on the strength of a word the model chose. A
+    /// company that wants that grants it.
     pub fn tools(self) -> Vec<String> {
         let belt: &[&str] = match self {
             Self::Research => &["workspace.read", "docs.*", "files.*", "web.*"],
-            Self::Writing | Self::Operations => &["workspace.*", "docs.*", "files.*"],
+            Self::Writing
+            | Self::Design
+            | Self::Operations
+            | Self::Coordination
+            | Self::Build
+            | Self::Support => &["workspace.*", "docs.*", "files.*"],
             Self::Analysis => &["workspace.*", "docs.*", "files.*", "web.*"],
         };
         belt.iter().map(|t| (*t).to_string()).collect()
@@ -190,7 +227,16 @@ impl AgentFocus {
     /// behaves, and letting the setup pass author it would put a stranger's free
     /// text — read by a model, written into a system prompt — inside the blast
     /// radius of "what does your company do?". The model names a work *shape*
-    /// from a closed enum; the host owns every word the teammate is told.
+    /// from a closed enum; the host owns every word of the standing
+    /// instructions.
+    ///
+    /// Not every word the teammate is told, and the difference is worth being
+    /// exact about: `persona_prompt` already appends the **mandate**, which the
+    /// model wrote. So model text does reach the system prompt today. What it
+    /// reaches under is a 200-character cap and a field whose job is to name
+    /// what the teammate owns — a much smaller surface than a free-form
+    /// instruction block, and one an operator reads on the review screen before
+    /// anything is created.
     ///
     /// ## Why they exist at all
     ///
@@ -222,11 +268,35 @@ impl AgentFocus {
                  point. Where a sentence needs a fact you do not have, mark it for whoever does \
                  rather than writing around the hole."
             }
+            Self::Design => {
+                "Design for the job the screen has to do, not for how it looks on its own. Cover \
+                 the states that actually occur — nothing yet, still loading, far too much, and \
+                 the error — because a flow that only handles the good case is half a flow. Reach \
+                 for an existing pattern before inventing one, and say which you did."
+            }
             Self::Operations => {
-                "Move the work rather than reporting on it. Where the next step is yours, take \
-                 it and say what you did; where it is not, name the person or the thing it waits \
-                 on and what would release it. Prefer finishing one thing to advancing three. A \
-                 handoff is not done until somebody has picked it up."
+                "Run the process the same way each time, and notice when it stops behaving. Carry \
+                 a case to its end rather than stopping at the first snag — chase the exception \
+                 yourself. When a run goes wrong, say what it was meant to do, what happened \
+                 instead, and what you changed."
+            }
+            Self::Coordination => {
+                "Hold the shape of the work: who has what, what it waits on, and what is late. \
+                 Settle the small calls yourself and put the large ones in front of whoever owns \
+                 them, with the options already laid out. Chase a thing once, then record the \
+                 answer instead of asking again later."
+            }
+            Self::Build => {
+                "Make the smallest correct version, then say plainly what it does not cover. Try \
+                 your own work before handing it on — the ordinary input, the empty one, and the \
+                 one you expect to break it. Where you touch something you did not write, leave \
+                 it behaving as its callers already expect."
+            }
+            Self::Support => {
+                "Answer the person in front of you first, then deal with the reason they had to \
+                 ask. Say what you know and what you are still checking rather than going quiet. \
+                 Never promise a date or a remedy you cannot deliver — an honest \"not yet\" \
+                 costs less than a commitment that is missed."
             }
             Self::Analysis => {
                 "Show the number and where it came from before interpreting it. Say what moved \
@@ -379,7 +449,7 @@ const ECOMMERCE: RosterTemplate = RosterTemplate {
             name: "Ops",
             role: "Operations Manager",
             description: "Suppliers, stock levels, and what the shop needs to keep selling.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Coordination,
         },
         TemplateAgent {
             name: "Accounts",
@@ -461,13 +531,13 @@ const AGENCY: RosterTemplate = RosterTemplate {
             name: "Accounts",
             role: "Account Manager",
             description: "Owns the client relationship and the brief.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Coordination,
         },
         TemplateAgent {
             name: "Creative",
             role: "Creative Director",
             description: "Concepts, art direction, and sign-off on what ships.",
-            focus: AgentFocus::Writing,
+            focus: AgentFocus::Design,
         },
         TemplateAgent {
             name: "Copy",
@@ -509,7 +579,7 @@ const CONSULTING: RosterTemplate = RosterTemplate {
             name: "Engagement",
             role: "Engagement Manager",
             description: "Runs the engagement and keeps it on scope.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Coordination,
         },
         TemplateAgent {
             name: "Research",
@@ -527,7 +597,7 @@ const CONSULTING: RosterTemplate = RosterTemplate {
             name: "Decks",
             role: "Deck Builder",
             description: "Slides, charts, and the story that runs through them.",
-            focus: AgentFocus::Writing,
+            focus: AgentFocus::Design,
         },
         TemplateAgent {
             name: "Writer",
@@ -558,31 +628,31 @@ const SOFTWARE: RosterTemplate = RosterTemplate {
             name: "Product",
             role: "Product Manager",
             description: "Decides what gets built, and in what order.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Coordination,
         },
         TemplateAgent {
             name: "Engineer",
             role: "Software Engineer",
             description: "Features, bug fixes, and code review.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Build,
         },
         TemplateAgent {
             name: "QA",
             role: "QA Engineer",
             description: "Tests changes before they reach anyone.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Build,
         },
         TemplateAgent {
             name: "Design",
             role: "Product Designer",
             description: "The product's screens, flows, and the design system they come from.",
-            focus: AgentFocus::Writing,
+            focus: AgentFocus::Design,
         },
         TemplateAgent {
             name: "Support",
             role: "Support Specialist",
             description: "Tickets, escalations, and the bugs they turn into.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Support,
         },
     ],
 };
@@ -600,7 +670,7 @@ const GENERIC: RosterTemplate = RosterTemplate {
             name: "Ops",
             role: "Operations Lead",
             description: "Vendors, tools, and the recurring admin nobody else owns.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Coordination,
         },
         TemplateAgent {
             name: "Research",
@@ -624,7 +694,7 @@ const GENERIC: RosterTemplate = RosterTemplate {
             name: "Support",
             role: "Support Specialist",
             description: "Answers customers and closes the loop.",
-            focus: AgentFocus::Operations,
+            focus: AgentFocus::Support,
         },
     ],
 };
@@ -1708,7 +1778,57 @@ mod tests {
         assert_eq!(manifest.validate(), Vec::<String>::new());
     }
 
-    /// Four shapes, four different sets of instructions. Two teammates given
+    /// Widening the vocabulary moved nobody's reach.
+    ///
+    /// The enum does two jobs — it picks a belt and it picks the standing
+    /// instructions — and the second wants a finer grain than the first, which
+    /// is why `operations` was split once it was covering 13 of the 30 curated
+    /// profiles. The split is only defensible if it is instruction-only, so
+    /// that is pinned here rather than asserted in the commit message: every
+    /// shape that exists to say something different about *how* the work is
+    /// done carries the identical belt it had before.
+    #[test]
+    fn the_widened_vocabulary_is_instruction_only() {
+        let writing = AgentFocus::Writing.tools();
+        for shape in [
+            AgentFocus::Design,
+            AgentFocus::Operations,
+            AgentFocus::Coordination,
+            AgentFocus::Build,
+            AgentFocus::Support,
+        ] {
+            assert_eq!(shape.tools(), writing, "{shape:?} moved a belt");
+        }
+        // The two that genuinely differ still do, or the split would have
+        // flattened the distinction it was meant to leave alone.
+        assert_ne!(AgentFocus::Research.tools(), writing);
+        assert_ne!(AgentFocus::Analysis.tools(), writing);
+        // `build` is the one whose name invites a wider belt. It gets neither
+        // `repo` nor `shell`, like every other focus.
+        let build = AgentFocus::Build.tools();
+        for denied in ["repo", "shell", "media", "composio", "search"] {
+            assert!(
+                !build.iter().any(|g| g.starts_with(denied)),
+                "build reaches {denied}"
+            );
+        }
+    }
+
+    /// Every shape round-trips its wire spelling, so a focus added to the enum
+    /// but forgotten in `from_wire` cannot silently become `None` — which would
+    /// cost that teammate its belt narrowing *and* its instructions.
+    #[test]
+    fn every_focus_round_trips_its_wire_spelling() {
+        for focus in AgentFocus::ALL {
+            assert_eq!(
+                AgentFocus::from_wire(focus.as_str()),
+                Some(focus),
+                "{focus:?} does not round-trip"
+            );
+        }
+    }
+
+    /// Eight shapes, eight different sets of instructions. Two teammates given
     /// the same instructions are one teammate twice — the collision the
     /// mandates themselves are written to avoid.
     #[test]

--- a/src/company/setup.rs
+++ b/src/company/setup.rs
@@ -305,7 +305,7 @@ const ECOMMERCE: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Ops",
             role: "Operations Manager",
-            description: "Keeps the rest of the team moving and unblocks them.",
+            description: "Suppliers, stock levels, and what the shop needs to keep selling.",
             focus: AgentFocus::Operations,
         },
         TemplateAgent {
@@ -339,7 +339,7 @@ const CONTENT: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Strategy",
             role: "Content Strategist",
-            description: "Decides what to publish, and when.",
+            description: "Which topics to bet on, and what the week's plan is.",
             focus: AgentFocus::Analysis,
         },
         TemplateAgent {
@@ -351,19 +351,19 @@ const CONTENT: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Editor",
             role: "Editor",
-            description: "Reviews everything before it goes out.",
+            description: "The line edit, the fact-check, and the last read before publishing.",
             focus: AgentFocus::Writing,
         },
         TemplateAgent {
             name: "Social",
             role: "Social Media Manager",
-            description: "Schedules posts and works the comments.",
+            description: "Posting, replies, and the comment threads.",
             focus: AgentFocus::Operations,
         },
         TemplateAgent {
             name: "Analyst",
             role: "Analytics Analyst",
-            description: "Measures what landed and reports back.",
+            description: "Reach, engagement, and which posts earned their slot.",
             focus: AgentFocus::Analysis,
         },
     ],
@@ -393,7 +393,7 @@ const AGENCY: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Creative",
             role: "Creative Director",
-            description: "Holds the concept and the creative bar.",
+            description: "Concepts, art direction, and sign-off on what ships.",
             focus: AgentFocus::Writing,
         },
         TemplateAgent {
@@ -405,13 +405,13 @@ const AGENCY: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Media",
             role: "Paid Media Buyer",
-            description: "Plans and runs paid acquisition.",
+            description: "Channel mix, budgets, and bids.",
             focus: AgentFocus::Operations,
         },
         TemplateAgent {
             name: "Analyst",
             role: "Analytics Analyst",
-            description: "Reports performance back to the client.",
+            description: "Campaign performance, spend efficiency, and the client-facing numbers.",
             focus: AgentFocus::Analysis,
         },
     ],
@@ -441,7 +441,7 @@ const CONSULTING: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Research",
             role: "Research Analyst",
-            description: "Gathers facts, sources, and context.",
+            description: "Market sizing, comparables, and the data room for the engagement in hand.",
             focus: AgentFocus::Research,
         },
         TemplateAgent {
@@ -453,13 +453,13 @@ const CONSULTING: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Decks",
             role: "Deck Builder",
-            description: "Turns findings into something presentable.",
+            description: "Slides, charts, and the story that runs through them.",
             focus: AgentFocus::Writing,
         },
         TemplateAgent {
             name: "Writer",
             role: "Report Writer",
-            description: "Drafts the written deliverable.",
+            description: "The written report — findings, recommendations, appendix.",
             focus: AgentFocus::Writing,
         },
     ],
@@ -490,7 +490,7 @@ const SOFTWARE: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Engineer",
             role: "Software Engineer",
-            description: "Builds and ships the product.",
+            description: "Features, bug fixes, and code review.",
             focus: AgentFocus::Operations,
         },
         TemplateAgent {
@@ -502,13 +502,13 @@ const SOFTWARE: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Design",
             role: "Product Designer",
-            description: "Creates the interface and holds the brand.",
+            description: "The product's screens, flows, and the design system they come from.",
             focus: AgentFocus::Writing,
         },
         TemplateAgent {
             name: "Support",
             role: "Support Specialist",
-            description: "Answers customers and closes the loop.",
+            description: "Tickets, escalations, and the bugs they turn into.",
             focus: AgentFocus::Operations,
         },
     ],
@@ -526,25 +526,25 @@ const GENERIC: RosterTemplate = RosterTemplate {
         TemplateAgent {
             name: "Ops",
             role: "Operations Lead",
-            description: "Keeps work moving and unblocks the team.",
+            description: "Vendors, tools, and the recurring admin nobody else owns.",
             focus: AgentFocus::Operations,
         },
         TemplateAgent {
             name: "Research",
             role: "Researcher",
-            description: "Gathers facts, sources, and context.",
+            description: "Background on customers, competitors, and the market this company sells into.",
             focus: AgentFocus::Research,
         },
         TemplateAgent {
             name: "Writer",
             role: "Writer",
-            description: "Drafts copy, docs, and outbound messages.",
+            description: "Site copy, docs, and whatever this company publishes under its own name.",
             focus: AgentFocus::Writing,
         },
         TemplateAgent {
             name: "Analyst",
             role: "Analyst",
-            description: "Measures performance and reports back.",
+            description: "The numbers, what moved them, and the weekly summary.",
             focus: AgentFocus::Analysis,
         },
         TemplateAgent {

--- a/src/company/setup.rs
+++ b/src/company/setup.rs
@@ -179,6 +179,63 @@ impl AgentFocus {
         };
         belt.iter().map(|t| (*t).to_string()).collect()
     }
+
+    /// How a teammate with this focus works — the standing instructions that
+    /// become its `[[agent]].prompt`.
+    ///
+    /// ## Why the host writes these and the model does not
+    ///
+    /// The same argument that keeps `[tools]` out of the model's reach (see the
+    /// type docs): an agent's prompt is the one field that decides how it
+    /// behaves, and letting the setup pass author it would put a stranger's free
+    /// text — read by a model, written into a system prompt — inside the blast
+    /// radius of "what does your company do?". The model names a work *shape*
+    /// from a closed enum; the host owns every word the teammate is told.
+    ///
+    /// ## Why they exist at all
+    ///
+    /// [`manifest_from_setup`] left `prompt` unset, so a setup-built teammate's
+    /// entire instruction was what
+    /// [`persona_prompt`](crate::company::prompt::persona_prompt) assembles from
+    /// its role and its one-line mandate — around 150 characters, next to a
+    /// globals teammate carrying 500–600 of standing instruction. The four
+    /// `globals/agents/*.toml` prompts are the register these are written in,
+    /// deliberately without reusing their sentences: a global teammate is on the
+    /// same roster, and two agents given the same instructions are one agent
+    /// twice.
+    ///
+    /// Kept to the *shape* of the work, never the business: the mandate says
+    /// what this teammate owns, and repeating it here would put a second,
+    /// staler copy of the description in the same prompt.
+    pub fn instructions(self) -> &'static str {
+        match self {
+            Self::Research => {
+                "Go and look rather than recalling. Prefer a primary source to somebody's \
+                 summary of one, and say which of the two you actually used. Keep what you found \
+                 apart from what you conclude from it, and mark the second as yours. Hand a \
+                 finding on in a form the next person can act on without repeating your search."
+            }
+            Self::Writing => {
+                "Produce the finished thing, not an outline of it. Match the register this \
+                 company already uses elsewhere instead of inventing a new voice per piece. Put \
+                 the useful part first, so a reader who stops after two lines still has the \
+                 point. Where a sentence needs a fact you do not have, mark it for whoever does \
+                 rather than writing around the hole."
+            }
+            Self::Operations => {
+                "Move the work rather than reporting on it. Where the next step is yours, take \
+                 it and say what you did; where it is not, name the person or the thing it waits \
+                 on and what would release it. Prefer finishing one thing to advancing three. A \
+                 handoff is not done until somebody has picked it up."
+            }
+            Self::Analysis => {
+                "Show the number and where it came from before interpreting it. Say what moved \
+                 and by how much, then what you believe caused it — and keep those two apart, so \
+                 a reader can disagree with the second without losing the first. When the data is \
+                 too thin to carry a conclusion, report the thinness instead of the conclusion."
+            }
+        }
+    }
 }
 
 /// The belt for an optional focus. An unreadable or absent one gets the
@@ -203,6 +260,22 @@ impl AgentFocus {
 /// teammate that cannot browse, not one holding a spend authority.
 pub fn tools_for_focus(focus: Option<AgentFocus>) -> Vec<String> {
     focus.unwrap_or(AgentFocus::Writing).tools()
+}
+
+/// The standing instructions for an optional focus, or `None` when the work
+/// shape is unknown.
+///
+/// **Deliberately not [`tools_for_focus`]'s fallback.** That one substitutes
+/// [`Writing`](AgentFocus::Writing) because a tool belt is a permission
+/// boundary and an unreadable value must never buy more authority than a
+/// readable one — there is a safe direction to fail in. Instructions have no
+/// such direction. Guessing a work shape would put the wrong job's instructions
+/// in a teammate's head, and telling an analyst to "never invent a detail to
+/// make a sentence work" is worse guidance than the role framing it already
+/// has. So an unknown focus keeps exactly today's behaviour: the persona prompt
+/// and its mandate, and nothing invented on top.
+pub fn prompt_for_focus(focus: Option<AgentFocus>) -> Option<String> {
+    focus.map(|f| f.instructions().to_string())
 }
 
 /// Reads a focus off the wire, treating anything unrecognised as absent.
@@ -883,6 +956,12 @@ pub fn manifest_from_setup(
             // media and per-tenant Composio credentials. Intersected with
             // `[tools].allow`, so this can only ever narrow.
             built.tools = tools_for_focus(agent.focus);
+            // Standing instructions for the shape of work this teammate does.
+            // Without them a setup-built teammate carried only its role and its
+            // one-line mandate — around 150 characters of instruction, beside a
+            // globals teammate holding 500–600. The mandate says what it owns;
+            // this says how it works. See `AgentFocus::instructions`.
+            built.prompt = prompt_for_focus(agent.focus);
             built
         })
         .collect();
@@ -1583,6 +1662,157 @@ mod tests {
             assert!(!agent.tools.is_empty(), "{} inherits the lot", agent.id);
         }
         assert_eq!(manifest.validate(), Vec::<String>::new());
+    }
+
+    /// A setup-built teammate carries standing instructions, not only a mandate.
+    ///
+    /// The gap this closes: `manifest_from_setup` left `prompt` unset, so the
+    /// whole of what a teammate was ever told was `persona_prompt`'s role
+    /// framing plus its one-line description — beside a globals teammate
+    /// holding 500–600 characters of standing instruction on the same roster.
+    #[test]
+    fn a_designed_teammate_carries_standing_instructions() {
+        let roster = vec![ProposedAgent {
+            name: "Research".into(),
+            role: "Research Analyst".into(),
+            description: "Finds things out.".into(),
+            focus: Some(AgentFocus::Research),
+        }];
+        let manifest = manifest_from_setup(&answers("a shop", ""), &roster, None);
+        let prompt = manifest.agents[0]
+            .prompt
+            .as_deref()
+            .expect("a focused teammate is instructed");
+        assert_eq!(prompt, AgentFocus::Research.instructions());
+        assert_eq!(manifest.validate(), Vec::<String>::new());
+    }
+
+    /// The asymmetry with [`tools_for_focus`], pinned. A belt substitutes
+    /// because a permission has a safe direction to fail in; instructions have
+    /// none, so an unknown shape keeps exactly the pre-instruction behaviour
+    /// rather than being told the wrong job's rules.
+    #[test]
+    fn an_unreadable_focus_gets_no_invented_instructions() {
+        assert_eq!(prompt_for_focus(None), None);
+        let roster = vec![ProposedAgent {
+            name: "A".into(),
+            role: "Analyst".into(),
+            description: "d".into(),
+            focus: None,
+        }];
+        let manifest = manifest_from_setup(&answers("a shop", ""), &roster, None);
+        assert!(manifest.agents[0].prompt.is_none());
+        // The belt still fails closed on the same input, which is the point of
+        // the contrast.
+        assert!(!manifest.agents[0].tools.is_empty());
+        assert_eq!(manifest.validate(), Vec::<String>::new());
+    }
+
+    /// Four shapes, four different sets of instructions. Two teammates given
+    /// the same instructions are one teammate twice — the collision the
+    /// mandates themselves are written to avoid.
+    #[test]
+    fn every_focus_is_instructed_and_no_two_alike() {
+        let all = AgentFocus::ALL;
+        for focus in all {
+            assert!(
+                !focus.instructions().trim().is_empty(),
+                "{focus:?} has no instructions"
+            );
+        }
+        for (i, a) in all.iter().enumerate() {
+            for b in &all[i + 1..] {
+                assert_ne!(
+                    a.instructions(),
+                    b.instructions(),
+                    "{a:?} and {b:?} share instructions"
+                );
+            }
+        }
+    }
+
+    /// And distinct from every globals prompt, because a global teammate sits
+    /// on the same roster. `globals/agents/*.toml` is the register these are
+    /// written in, never the text to copy.
+    ///
+    /// Checked as a shared **run of words** rather than string equality, which
+    /// is the check this needs: the first draft of these four was written by
+    /// reading the globals prompts, and three came back as sentence-for-sentence
+    /// paraphrases — "cut anything that is there only because it was already
+    /// written" beside "cut anything that survives only because it was already
+    /// written". Equality passes that happily. Six words is short enough to
+    /// catch a paraphrase and long enough that shared phrasing like "the next
+    /// person" is not a failure.
+    #[test]
+    fn focus_instructions_do_not_reuse_a_globals_prompt() {
+        const RUN: usize = 6;
+        let runs = |text: &str| -> Vec<String> {
+            let words: Vec<String> = text
+                .split_whitespace()
+                .map(|w| {
+                    w.chars()
+                        .filter(|c| c.is_alphanumeric())
+                        .flat_map(char::to_lowercase)
+                        .collect::<String>()
+                })
+                .filter(|w| !w.is_empty())
+                .collect();
+            words.windows(RUN).map(|w| w.join(" ")).collect()
+        };
+
+        for focus in AgentFocus::ALL {
+            let mine = runs(focus.instructions());
+            for global in crate::globals::agents() {
+                let Some(prompt) = global.prompt.as_deref() else {
+                    continue;
+                };
+                let theirs = runs(prompt);
+                if let Some(shared) = mine.iter().find(|run| theirs.contains(run)) {
+                    panic!(
+                        "{focus:?} reuses the global `{}`'s phrasing: \"{shared}\"",
+                        global.id
+                    );
+                }
+            }
+        }
+    }
+
+    /// The curated fallback is instructed too, for the same reason it is scoped
+    /// too: an operator with no credential must not end up with the *less*
+    /// directed company.
+    #[test]
+    fn the_curated_fallback_is_instructed_too() {
+        let a = answers("I sell homeware online", "");
+        let proposal = template_proposal(&a, FallbackReason::NoModel);
+        let manifest = manifest_from_setup(&a, &proposal.agents, None);
+        for agent in &manifest.agents {
+            assert!(agent.prompt.is_some(), "{} is uninstructed", agent.id);
+        }
+        assert_eq!(manifest.validate(), Vec::<String>::new());
+    }
+
+    /// The payoff, composed: the mandate says what this teammate owns and the
+    /// instructions say how it works, and the agent is told both.
+    #[test]
+    fn the_persona_prompt_carries_the_mandate_and_the_instructions() {
+        let roster = vec![ProposedAgent {
+            name: "Writer".into(),
+            role: "Report Writer".into(),
+            description: "The written report.".into(),
+            focus: Some(AgentFocus::Writing),
+        }];
+        let manifest = manifest_from_setup(&answers("consulting", ""), &roster, None);
+        let persona = crate::company::prompt::persona_prompt("Acme", &manifest.agents[0]);
+        assert!(persona.contains("Report Writer"), "{persona}");
+        assert!(persona.contains("The written report."), "{persona}");
+        // Compared against the instructions themselves rather than a copy of
+        // their text: the first version of this assertion quoted the template
+        // verbatim, the template was reworded, and the test failed for saying
+        // something stale rather than for anything being wrong.
+        assert!(
+            persona.contains(AgentFocus::Writing.instructions()),
+            "{persona}"
+        );
     }
 
     /// Focus survives the round trip through the review screen, which is the

--- a/src/harness/roster_build.rs
+++ b/src/harness/roster_build.rs
@@ -500,9 +500,11 @@ fn system_prompt() -> String {
          to show you the register to write in, never the text to copy. A mandate that could sit \
          on any company's roster has told this operator nothing.\n\
          - `focus` is the shape of the work, one of: {focuses}. It decides which tools the \
-         teammate is given, so choose the closest fit: `research` finds things out, `writing` \
-         produces the written work, `operations` keeps work moving, `analysis` measures and \
-         reports.\n\
+         teammate is given and how it is told to work, so choose by what the teammate PRODUCES: \
+         `research` findings, `writing` written material, `design` interface and visual work, \
+         `analysis` numbers and what moved them, `build` the product itself, `operations` a \
+         recurring process run end to end, `coordination` people and work kept moving, `support` \
+         answered customers.\n\
          - `covers` is a list of numbers from the job list. Only claim a number when that agent \
          genuinely owns it — a claim you cannot justify is worse than an honest gap, because \
          the operator is shown what was left unowned.\n\


### PR DESCRIPTION
## Summary

Three related changes to first-run setup, one commit each.

**1. Re-cut the curated roster mandates.** The six templates in `src/company/setup.rs` are not only the offline fallback — `user_prompt` ships the matched one into the design pass as the reference team, so their phrasing is the register every model-authored roster imitates. Several read as job titles restated ("Builds and ships the product.") or as two clauses saying one thing ("Keeps the rest of the team moving and unblocks them.") — the "handles logistics" failure the prompt's own rule warns against two paragraphs above. Two mandates were byte-identical across templates, and four sat on top of a globals teammate's job. Each now names concrete artifacts and, where it shares a cluster with a global, says what the global does not.

**2. Give a designed teammate standing instructions (D9).** `manifest_from_setup` set `id`, `role`, `description` and `tools` and left `prompt` unset. So everything a setup-built teammate was ever told was what `persona_prompt` assembles — a role framing plus a mandate capped at 200 characters. Around 150 characters of instruction, sitting on the same roster as a globals teammate carrying 500–600 (`globals/agents/*.toml`). The mandate says what a teammate owns; nothing said how it works. `AgentFocus::instructions` supplies that, keyed on the closed enum that already picks the tool belt and for the same reason D7 gives.

An unrecognised focus is instructed with **nothing**, deliberately the opposite of what `tools_for_focus` does with the same input. A belt substitutes because a permission has a safe direction to fail in; instructions have none, and the wrong job's rules are worse guidance than the role framing already present.

**3. Split the focus vocabulary.** `AgentFocus` was cut for picking a belt, where four shapes is plenty. Once it also picks instructions, four collapses: `operations` alone covered **13 of the 30** curated profiles, so a QA engineer, an account manager and a logistics coordinator were told the same thing — and on the `software` template four of five teammates shared one instruction set.

The shapes are now named for what a teammate *produces*: `research`, `writing`, `design`, `analysis`, `build`, `operations`, `coordination`, `support`. Largest bucket falls **13 → 7**; `software` goes from 2 distinct sets to 4, `agency` from 3 to 5. Model-designed rosters get the finer vocabulary too, since the model picks from the same enum.

This is **instruction-only and pinned by a test**: the six shapes that exist to say something different about *how* work is done all carry the identical belt they had before, so no teammate gains or loses reach. Only profiles already on `operations` or `writing` were re-keyed, which is what keeps that true. `build` is the case worth naming — the obvious reading of "makes the product" is `repo` and `shell`, and it gets neither.

## API Or Behavior Changes

- New public `AgentFocus::instructions()` and `prompt_for_focus()`; four new `AgentFocus` variants (`design`, `build`, `coordination`, `support`).
- **Behaviour:** a company created through the host wizard now has `[[agent]].prompt` set on each designed teammate, from its focus. Existing companies are unaffected — nothing rewrites a stored manifest.
- **No tool-belt change for anybody**, asserted by `the_widened_vocabulary_is_instruction_only`.
- No route or DTO shape changes. The console already treats `focus` as an opaque `string | null`, so the wider vocabulary needs no frontend change; the setup prompt's focus list is generated from `AgentFocus::ALL`.
- Curated template mandates changed (18 strings) and 12 profiles were re-keyed to a new focus. No id or role changed.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 3321 + 14 + 1 passed, 0 failed

Eight new tests in `company::setup::tests`. The ones worth reviewing on purpose:

- `focus_instructions_do_not_reuse_a_globals_prompt` compares **six-word runs**, not string equality. The first draft of these texts was written by reading the globals prompts and came back as sentence-for-sentence paraphrases — "cut anything that is there only because it was already written" beside globals' "cut anything that survives only because it was already written". Equality passes that happily.
- `the_widened_vocabulary_is_instruction_only` pins the no-reach-change claim above, so a later edit cannot quietly widen a belt through the new vocabulary.
- `every_focus_round_trips_its_wire_spelling` — a variant added to the enum but forgotten in `from_wire` would silently become `None`, costing that teammate both its narrowing and its instructions.

Everything that quantifies over `AgentFocus::ALL` — including the existing assertion that `media`, `composio`, `search`, `repo` and `shell` are unreachable — picked up the four new variants automatically.

## Documentation

- `docs/spec/runtime/company-setup-guarantees.md` — new **D9** section; "four things the host enforces" → five; D7's focus list and the rationale for the split.
- `docs/spec/runtime/company-setup.md` — the guarantee list updated to match.

One correction the third commit makes to the second: the D9 text originally claimed the host owns "every word the teammate is told". That is false — `persona_prompt` already appends the model-authored mandate. What the host owns is every word of the *standing instructions*, and the doc now says so, because the looser claim is exactly what would make a per-teammate instruction field look like an obvious extension rather than a separate decision.

## Follow-ups, not in this PR

- **Per-profile instruction sets.** Instructions are keyed per *shape*, so profiles sharing one still share its text (`analysis` covers 7). Giving each of the 30 curated profiles its own line is the next step, composed on top of the focus text rather than replacing it. Separate PR.
- **The in-console dialog cannot carry any of this.** `AddMember` and `OverlayAgent` have no `prompt` field, so a company staffed from inside the console gets uninstructed teammates while a host-wizard company gets instructed ones. Same two-paths-disagree shape as the id minting, where `manifest_from_setup` derives ids from the role and `add_member` from the display name — identical answers yield a globals supersede on one path and a `writer_2` duplicate on the other. Both want fixing together, in a change that touches the durable overlay record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup-generated teammates now support eight work focuses, including design, coordination, build, and support.
  * Host-defined, focus-specific standing instructions describe how teammates should work.
  * Curated fallback teammates include clearer, more specific responsibilities while preserving existing tool access boundaries.
  * Teammates with unknown focuses receive no additional standing instructions.

* **Documentation**
  * Updated company setup guarantees to document five enforced boundaries, including host-authored standing instructions.
  * Clarified that these instructions complement, rather than duplicate, existing business mandates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->