### PR TITLE
ci(memory): strict clippy lane for the tinymemory gate + the two comments the pin falsified (#1524 PR 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,6 +848,30 @@ jobs:
       - name: Clippy (openhuman, tinycortex)
         run: cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
 
+      # Issue #1524 (PR 1). `pub mod memory` is gated on `tinymemory`
+      # (`store/mod.rs`), and neither strict lane enabled that gate: the
+      # default-features clippy lints a tree where the module does not exist,
+      # and the step above compiles without it. `store::memory` was therefore
+      # linted by NO `-D warnings` lane at all — the silent-uncoverage class
+      # this job's own comments keep warning about. Same `--no-deps` reasoning
+      # as the step above; the union set matches the test steps below, so the
+      # compile is shared with them via the cache.
+      - name: Clippy (acp, runner, tinymemory)
+        run: cargo clippy --locked --no-deps --features acp,runner,tinymemory --all-targets -- -D warnings
+
+      # Issue #1524 (PR 1). The nested-vendor path deps must stay
+      # byte-identical to openhuman's own, or cargo resolves the same crate
+      # from two directories and two `MemoryProvider` traits exist in one
+      # process (the hazard recorded at `Cargo.toml:249-252`). `-d` prints
+      # duplicate versions of a package; any `tinymemory` line in that report
+      # is the failure.
+      - name: Assert no duplicated tinymemory crates
+        run: |
+          if cargo tree --locked -e normal --features openhuman,tinycortex,tinymemory-embedded -d | grep -E "^tinymemory"; then
+            echo "::error::duplicated tinymemory-* package in the resolve graph"
+            exit 1
+          fi
+
       # `--tests` is LOAD-BEARING IN BOTH DIRECTIONS. Do not narrow it back to
       # `--lib`, and do not widen it to a bare `cargo test`.
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,7 +867,13 @@ jobs:
       # is the failure.
       - name: Assert no duplicated tinymemory crates
         run: |
-          if cargo tree --locked -e normal --features openhuman,tinycortex,tinymemory-embedded -d | grep -E "^tinymemory"; then
+          # Two separate failures, checked separately: a broken resolve must
+          # fail loudly, not read as "no duplicates" through an empty pipe.
+          if ! report="$(cargo tree --locked -e normal --features openhuman,tinycortex,tinymemory-embedded -d)"; then
+            echo "::error::cargo tree failed to resolve the graph"
+            exit 1
+          fi
+          if grep -E "^tinymemory" <<< "$report"; then
             echo "::error::duplicated tinymemory-* package in the resolve graph"
             exit 1
           fi

--- a/src/store/memory/driver.rs
+++ b/src/store/memory/driver.rs
@@ -329,10 +329,14 @@ fn require<'a>(value: Option<&'a str>, refusal: &str) -> Result<&'a str> {
 ///    under the checks meant for the other class — so it is refused rather than
 ///    quietly resolved in the registry's favour.
 fn admit(driver_id: &str, expected: DriverClass) -> Result<DriverClass> {
-    // `namespace` is `tinymemory-core`'s own durable store; the vendored
-    // registry does not know it, and `with_reserved` is the registry's door
-    // for exactly that ("a host that bundles an adapter this crate does not
-    // know about"). Reserved unconditionally — with the `tinymemory-embedded`
+    // `namespace` is `tinymemory-core`'s own durable store. Since the v1.1.0
+    // pin the vendored registry reserves the id itself
+    // (`registry/mod.rs:182`), so this `with_reserved` restates the same
+    // class the builtin table already carries — kept deliberately: repeating
+    // a reserved id's class is the one thing the registry's own rule permits
+    // ("may repeat, never override"), and the host-side line keeps the
+    // reservation visible where the driver is routed rather than only inside
+    // the vendor. Reserved unconditionally — with the `tinymemory-embedded`
     // feature off, nothing reaches this function with that id.
     let registry =
         DriverRegistry::builtin().with_reserved(NAMESPACE_DRIVER_ID, DriverClass::Embedded);
@@ -428,6 +432,10 @@ pub const NAMESPACE_DRIVER_ID: &str = "namespace";
 /// `EngineCortex` mints a subdirectory per company under its own, so sharing
 /// one directory would interleave the two schemas and put a company named
 /// anything that sanitises to `namespaces` on top of the store's own layout.
+// Gated with its only consumer (`namespace_provider`): the new strict
+// `acp,runner,tinymemory` clippy lane compiles this file without
+// `tinymemory-embedded`, where an ungated const is dead code.
+#[cfg(feature = "tinymemory-embedded")]
 const NAMESPACE_STORE_SUBDIR: &str = "memory-namespace";
 
 /// Builds the in-pod contract driver over `tinymemory-core`'s durable store.

--- a/src/store/memory/driver.rs
+++ b/src/store/memory/driver.rs
@@ -336,8 +336,10 @@ fn admit(driver_id: &str, expected: DriverClass) -> Result<DriverClass> {
     // a reserved id's class is the one thing the registry's own rule permits
     // ("may repeat, never override"), and the host-side line keeps the
     // reservation visible where the driver is routed rather than only inside
-    // the vendor. Reserved unconditionally — with the `tinymemory-embedded`
-    // feature off, nothing reaches this function with that id.
+    // the vendor. Reserved unconditionally: with `tinymemory-embedded`
+    // disabled this function still runs for the id — admission comes first —
+    // and the feature-off `namespace_provider` fallback then rejects the
+    // bind, which is the fail-closed half of the pair.
     let registry =
         DriverRegistry::builtin().with_reserved(NAMESPACE_DRIVER_ID, DriverClass::Embedded);
     // Trust is asserted by the host for a driver the host itself selected from

--- a/src/store/memory/migrate.rs
+++ b/src/store/memory/migrate.rs
@@ -12,12 +12,13 @@
 //!
 //! # Failure is a stop, never a guess
 //!
-//! The contract's error type is still one coarse variant (`MemoryError::Other`
-//! — tinymemory#18 §A4), so mid-migration this code cannot tell a transient
-//! 500 from a real rejection. It therefore never retries (an import retried
-//! into a driver that half-applied the page could double-write) and instead
-//! stops at the first failed page, reporting the cursor that *started* that
-//! page. `--resume-cursor` re-enters there safely because import is
+//! The contract's §A4 taxonomy (13 wire-named `MemoryError` variants since
+//! tinymemory v1.1.0) means a transient `Timeout`/`Unavailable`/`Unreachable`
+//! is now distinguishable from a real rejection — but this code still never
+//! retries, and that decision does not rest on the taxonomy: an import
+//! retried into a driver that half-applied the page could double-write, and
+//! no error class proves how much of a page landed. It stops at the first
+//! failed page, reporting the cursor that *started* that page. `--resume-cursor` re-enters there safely because import is
 //! idempotent by `(namespace, key)`: a driver that recognises a present
 //! record reports it `skipped`, and one that does not simply overwrites in
 //! place — either way, re-running the failed page cannot duplicate.


### PR DESCRIPTION
## Summary

**Stacked on #1532** — the diff below includes the bump until it merges; this PR's own change is the top commit (`705037ef`).

The PR-1 remainder of #1524 (the bump half landed as #1532):

- **New strict clippy lane `acp,runner,tinymemory`**: `store::memory` is gated on `tinymemory`, and neither existing `-D warnings` lane enabled that gate — the seam was linted by no strict lane at all. The lane caught its first real find before ever running in CI: `NAMESPACE_STORE_SUBDIR` was ungated while its only consumer sits behind `tinymemory-embedded` — dead code in every non-embedded build. Now gated with its consumer.
- **Duplicate-crate assert**: `cargo tree -d` must report no duplicated `tinymemory-*` package — the resolve-level pin of the seven-path atomicity property (the two-`MemoryProvider`-traits hazard at `Cargo.toml:249-252`). Grep matches column-0 duplicate headers only, since `-d` prints each duplicate's whole inverse subtree.
- **Two comments the pin falsified**: `migrate.rs` claimed the contract still had one coarse error variant (§A4 has 13 wire-named variants since v1.1.0 — never-retry stands, but on idempotence grounds); `driver.rs` claimed the vendored registry does not know `namespace` (it reserves it itself since v1.1.0 — the host-side `with_reserved` deliberately restates the class, the one repetition the registry rule permits).

## API Or Behavior Changes

None. One `const` moved behind the feature gate of its only consumer; comments and CI only.

## Tests

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --locked --no-deps --features acp,runner,tinymemory --all-targets -- -D warnings` — zero (the new lane, run locally end to end)
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex,tinymemory-embedded --all-targets -- -D warnings` — zero (proves the cfg move breaks nothing on the embedded side)
- [x] `cargo test --features acp,runner,tinymemory -- store::memory store::select` — 112 passed / 0 failed
- [x] `cargo tree -d` column-0 assert — zero duplicated `tinymemory-*`

## Documentation

The two corrected doc-comments are the documentation change; #1524's tree-state section already reflects this split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to detect duplicate memory-store components during continuous integration.
  * Updated memory-store configuration for embedded deployments.

* **Documentation**
  * Clarified migration error handling, including transient failures, rejected operations, stopping behavior, and resume support.
  * Updated guidance to reflect the latest memory-store behavior and migration outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->