### PR TITLE
settings: stop offering Suspend and Archive to a console that can never invoke them (#1401)

### DIFF
--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -92,10 +92,18 @@ workload or committed.
 | GET | `…/{id}/approvals` | parked approvals |
 | POST | `…/{id}/approvals/{approvalId}` | `{verdict, note?}` → follow-up reply |
 | POST | `…/{id}/feedback` | scrub-then-preview feedback |
-| POST | `…/{id}/{pause\|resume\|suspend\|archive}` | lifecycle control |
+| POST | `…/{id}/{pause\|resume}` | lifecycle control (company-scoped) |
+| POST | `…/{id}/{suspend\|archive}` | lifecycle control (**platform-scoped**) |
 
 These back Overview, Conversation (send/reply), Approvals, Feedback, Settings
-(connection + lifecycle). Everything below is now **delivered** too — the
+(connection + lifecycle). The two scopes are not interchangeable, and the
+Settings lifecycle card renders accordingly: `suspend` and `archive` resolve
+through `resolve_claims`, which cannot return a human, so a console
+authenticating with a session cookie can never reach them — it offers them only
+when it carries a platform bearer, and otherwise says so in the page rather than
+failing after the confirmation (issue #1401). `resume` is company-scoped but the
+handler refuses a non-platform caller on a `suspended` company, so that button is
+withheld there too. Everything below is now **delivered** too — the
 sections document the surface, its read (GraphQL) and its writes (REST).
 
 ---

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -145,6 +145,26 @@ export class OpenCompanyClient {
     return this.defaultCompany === null;
   }
 
+  /**
+   * Whether this client sends a **platform** bearer.
+   *
+   * Asked by the surfaces that offer `PlatformScope` routes — `suspend` and
+   * `archive` (issue #1401). Those resolve through `resolve_claims`, which
+   * cannot return a human, so a console authenticating as a person through the
+   * session cookie is refused by construction rather than by policy: there is
+   * no credential it could hold, and no setting an operator could change, that
+   * would let the call through. A control for one of them is only honest on a
+   * client that answers `true` here.
+   *
+   * True does not promise the call succeeds — the bearer still has to carry the
+   * `platform` scope, and a tenant token without it gets a `403`. That is a
+   * configuration mistake with a legible answer, which is a different thing
+   * from an unreachable button.
+   */
+  get carriesPlatformBearer(): boolean {
+    return Boolean(this.token);
+  }
+
   /** The route prefix for `company`, for callers building their own paths. */
   scopeFor(company: string | null | undefined): string {
     return this.scope(company);

--- a/frontend/src/lib/lifecycle-controls.ts
+++ b/frontend/src/lib/lifecycle-controls.ts
@@ -1,0 +1,84 @@
+import type { LifecycleAction } from "@/api/client";
+
+/**
+ * Which lifecycle controls the console may honestly offer (issue #1401).
+ *
+ * The four buttons in `Settings → General → Lifecycle` do not share an
+ * authorization story, and the console used to render them as if they did:
+ *
+ * - `pause` / `resume` are `CompanyAuth` routes. A person signed in with a
+ *   magic link reaches them, which is the whole point — this is the operator's
+ *   reversible stop.
+ * - `suspend` / `archive` are `PlatformScope` routes. That extractor resolves
+ *   through `resolve_claims`, which cannot return a human, so a session cookie
+ *   can never reach them *whatever it contains*. The console only ever holds
+ *   platform scope when it was handed a platform bearer (`?token=` /
+ *   `VITE_OC_TOKEN`), which is not how somebody signing in with a magic link
+ *   arrives.
+ *
+ * So `Archive` — styled `destructive`, behind a dialog calling itself
+ * permanent — took the confirmation and then answered `401 unauthorized`. That
+ * is the one failure mode this console is otherwise careful about: Billing and
+ * Hosting both say, in the page, when a control cannot work here. Lifecycle
+ * instead invited an irreversible decision it could not carry out.
+ *
+ * `platform` here means *this client sends a platform bearer*, not *that bearer
+ * carries the scope* — a tenant token without `platform` still gets a `403`.
+ * That residue is deliberate: a wrong-scope token is a **configuration**
+ * mistake an operator can fix, whereas a session cookie is refused **by
+ * construction**, and only the second one is worth hiding a button over.
+ */
+export interface LifecycleAffordances {
+  /** The actions whose buttons may be rendered, in display order. */
+  actions: LifecycleAction[];
+  /**
+   * Whether to explain that suspend and archive were withheld.
+   *
+   * Withholding them silently would trade a dishonest button for a missing
+   * one, and an operator who read the docs would go looking for the control
+   * rather than learning it is not theirs.
+   */
+  explainPlatformOnly: boolean;
+  /**
+   * Whether to explain that this company's `suspended` state is not the
+   * operator's to lift.
+   *
+   * `resume` is a `CompanyAuth` route, so the button is reachable — but the
+   * handler refuses a non-platform caller specifically when the lifecycle is
+   * `suspended`, because that state is a platform-forced pause. Rendering
+   * `Resume` there is the same dishonesty as `Archive`, one layer deeper.
+   */
+  explainPlatformSuspended: boolean;
+  /** Whether the company is past the end of its lifecycle. */
+  archived: boolean;
+}
+
+/**
+ * @param lifecycle the host's `status.lifecycle` (or the optimistic pending one)
+ * @param platform whether this client carries a platform bearer
+ */
+export function lifecycleAffordances(lifecycle: string, platform: boolean): LifecycleAffordances {
+  const archived = lifecycle === "archived";
+  const suspended = lifecycle === "suspended";
+  if (archived) {
+    return {
+      actions: [],
+      explainPlatformOnly: false,
+      explainPlatformSuspended: false,
+      archived: true,
+    };
+  }
+
+  const actions: LifecycleAction[] = [];
+  if (lifecycle === "running") actions.push("pause");
+  // A paused company is anyone's to restart; a suspended one is the platform's.
+  if (lifecycle === "paused" || (suspended && platform)) actions.push("resume");
+  if (platform) actions.push("suspend", "archive");
+
+  return {
+    actions,
+    explainPlatformOnly: !platform,
+    explainPlatformSuspended: suspended && !platform,
+    archived: false,
+  };
+}

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -1,9 +1,19 @@
 import { useEffect, useState } from "react";
-import { Compass, Flag, Globe, Pause, Play, Power, Archive as ArchiveIcon } from "lucide-react";
+import {
+  Compass,
+  Flag,
+  Globe,
+  Pause,
+  Play,
+  Power,
+  TriangleAlert,
+  Archive as ArchiveIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import type { LifecycleAction, OpenCompanyClient } from "@/api/client";
 import { ApiError, type MemorySpec } from "@/api/types";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,6 +43,7 @@ import type { CompanyFeed } from "@/hooks/use-company";
 import { restartTour } from "@/tour/state";
 import { preloadTour } from "@/tour/TourController";
 import { useLocalScope } from "@/connections/ConnectionContext";
+import { lifecycleAffordances } from "@/lib/lifecycle-controls";
 
 interface Props {
   client: OpenCompanyClient;
@@ -207,9 +218,6 @@ function LifecycleControls({
    */
   const [pending, setPending] = useState<string | null>(null);
   const state = pending ?? feed.status.lifecycle;
-  const archived = state === "archived";
-  const running = state === "running";
-  const paused = state === "paused";
 
   async function run(action: LifecycleAction) {
     if (busy) return;
@@ -233,53 +241,95 @@ function LifecycleControls({
     }
   }
 
+  const platform = client.carriesPlatformBearer;
+  const { actions, explainPlatformOnly, explainPlatformSuspended, archived } =
+    lifecycleAffordances(state, platform);
+  const offers = (action: LifecycleAction) => actions.includes(action);
+
   return (
     <Card>
       <CardHeader>
+        {/* Four verbs, and the card used to name three of them. `Pause` and
+          `Suspend` in particular were indistinguishable to a reader — the
+          suspend dialog described what anyone would assume pause did. Only the
+          controls this console can actually reach are named here. */}
         <CardTitle className="text-base">Lifecycle</CardTitle>
-        <CardDescription>Pause, resume, or retire this company.</CardDescription>
+        <CardDescription>
+          Pause stops this company taking new work; resume starts it again.
+          {platform ? " Suspend and archive are the platform's own, heavier stops." : ""}
+        </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-wrap gap-2">
-        {running && (
-          <Button variant="outline" disabled={busy} onClick={() => void run("pause")}>
-            <Pause className="size-4" /> Pause
-          </Button>
+      <CardContent className="space-y-4">
+        {/* Said before the buttons, in the register Billing and Hosting use for
+          the same problem: a control that cannot work here explains itself in
+          the page rather than failing after the click. */}
+        {explainPlatformOnly && (
+          <Alert data-testid="lifecycle-platform-only">
+            <TriangleAlert className="size-4" />
+            <AlertDescription>
+              Suspending and archiving a company are the hosting platform&rsquo;s to do, not this
+              console&rsquo;s. They need a platform credential, which a person signed in here never
+              holds — so the controls are left out rather than shown failing. Pause is the
+              reversible stop that is yours.
+            </AlertDescription>
+          </Alert>
         )}
-        {(paused || state === "suspended") && !archived && (
-          <Button variant="outline" disabled={busy} onClick={() => void run("resume")}>
-            <Play className="size-4" /> Resume
-          </Button>
+        {explainPlatformSuspended && (
+          <Alert data-testid="lifecycle-platform-suspended">
+            <TriangleAlert className="size-4" />
+            <AlertDescription>
+              The platform suspended this company. Only the platform can lift a suspension — an
+              admin here cannot resume it, so there is no Resume button to offer.
+            </AlertDescription>
+          </Alert>
         )}
-        {!archived && (
-          <ConfirmAction
-            trigger={
-              <Button variant="outline" disabled={busy}>
-                <Power className="size-4" /> Suspend
-              </Button>
-            }
-            title="Suspend this company?"
-            description="It will stop handling work until you resume it. In-flight tasks are paused, not lost."
-            confirmLabel="Suspend"
-            onConfirm={() => void run("suspend")}
-          />
-        )}
-        {!archived && (
-          <ConfirmAction
-            trigger={
-              <Button variant="destructive" disabled={busy}>
-                <ArchiveIcon className="size-4" /> Archive
-              </Button>
-            }
-            title="Archive this company?"
-            description="Archiving retires the company. This is meant to be permanent — you won't be able to operate it afterward."
-            confirmLabel="Archive"
-            destructive
-            onConfirm={() => void run("archive")}
-          />
-        )}
-        {archived && (
-          <p className="text-sm text-muted-foreground">This company is archived.</p>
-        )}
+        <div className="flex flex-wrap gap-2">
+          {offers("pause") && (
+            <Button variant="outline" disabled={busy} onClick={() => void run("pause")}>
+              <Pause className="size-4" /> Pause
+            </Button>
+          )}
+          {offers("resume") && (
+            <Button variant="outline" disabled={busy} onClick={() => void run("resume")}>
+              <Play className="size-4" /> Resume
+            </Button>
+          )}
+          {offers("suspend") && (
+            <ConfirmAction
+              trigger={
+                <Button variant="outline" disabled={busy}>
+                  <Power className="size-4" /> Suspend
+                </Button>
+              }
+              title="Suspend this company?"
+              // The old copy promised "until you resume it". The handler
+              // refuses exactly that: a suspension is a platform-forced pause,
+              // and neither an owner token nor the company's own admins may
+              // lift it. Saying so is the difference between a heavy stop and
+              // a trap.
+              description="It stops handling work, and only the platform can start it again — the company's own admins cannot. For a stop you can undo, use Pause."
+              confirmLabel="Suspend"
+              onConfirm={() => void run("suspend")}
+            />
+          )}
+          {offers("archive") && (
+            <ConfirmAction
+              trigger={
+                <Button variant="destructive" disabled={busy}>
+                  <ArchiveIcon className="size-4" /> Archive
+                </Button>
+              }
+              title="Archive this company?"
+              description="Archiving retires the company. This is meant to be permanent — you won't be able to operate it afterward."
+              confirmLabel="Archive"
+              destructive
+              onConfirm={() => void run("archive")}
+            />
+          )}
+          {archived && (
+            <p className="text-sm text-muted-foreground">This company is archived.</p>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/frontend/test/e2e/alert-dialog-confirm.spec.ts
+++ b/frontend/test/e2e/alert-dialog-confirm.spec.ts
@@ -23,11 +23,17 @@ import { expect, test, type Page, type Route } from "@playwright/test";
  * actionability checks on: an intercepting backdrop fails that click rather than
  * passing silently.
  *
- * Two of the three call sites on `main` are exercised, because the fix lives in
- * the shared primitive (`components/ui/alert-dialog.tsx`) and not at any one
- * call site: the task delete inside `TaskEditDialog`, and the lifecycle
- * `ConfirmAction` in `SettingsView` (the same shape as `TaskDetailView`'s
- * `ConfirmButton`, whose own confirm needs a live in-flight run to reach).
+ * The call site exercised is the task delete inside `TaskEditDialog`. It used to
+ * be joined by `SettingsView`'s lifecycle `ConfirmAction`, on the argument that
+ * the fix lives in the shared primitive (`components/ui/alert-dialog.tsx`) and
+ * not at any one caller — but that confirm guarded `Suspend`, and issue #1401
+ * removed it from a console signed in as a person: `suspend` is a
+ * `PlatformScope` route, so the dialog took a confirmation and then answered
+ * `401`. A spec cannot drive a button that is correctly no longer there, and
+ * `lifecycle-platform-scope.spec.ts` now covers why it is gone. The remaining
+ * confirms all need state this spec would have to build first — a live
+ * in-flight run (`TaskDetailView`), a declared list (`ManageListsView`) — so the
+ * primitive is proven once here rather than badly twice.
  *
  * Like the rest of `test/e2e`, this drives a *running* host and is not wired
  * into CI — the Playwright config declares no `webServer`. It is a reproduction
@@ -136,36 +142,4 @@ test("confirming a task delete dismisses the dialog before the request lands", a
     0,
     { timeout: 30_000 },
   );
-});
-
-test("confirming a lifecycle change dismisses the dialog from a second call site", async ({
-  page,
-}) => {
-  await page.goto("/#/settings");
-
-  const suspend = page.getByRole("button", { name: "Suspend", exact: true });
-  await expect(suspend).toBeVisible({ timeout: 30_000 });
-  await suspend.click();
-
-  // `SettingsView`'s shared `ConfirmAction` — same primitive, different caller.
-  await expect(dialog(page)).toContainText("Suspend this company?");
-
-  // Suspending for real ends the session, so the request is held and then
-  // failed: the console reports "couldn't suspend", the harness company stays
-  // running for the specs after this one, and the dialog's behaviour on confirm
-  // — the only thing under test — is unaffected either way.
-  const release = await holdNextRequest(page, /\/companies\/[^/]+\/suspend$/, "POST");
-
-  await dialog(page).getByRole("button", { name: "Suspend", exact: true }).click();
-
-  await expectDismissed(page);
-  await expectConsoleInteractive(page);
-
-  // Fail the held request, then confirm the company is still running — the
-  // specs after this one drive a live company.
-  release("abort");
-  await page.goto("/#/settings");
-  await expect(page.getByRole("button", { name: "Suspend", exact: true })).toBeVisible({
-    timeout: 30_000,
-  });
 });

--- a/frontend/test/e2e/lifecycle-platform-scope.spec.ts
+++ b/frontend/test/e2e/lifecycle-platform-scope.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #1401 — Settings must not offer a lifecycle control it cannot reach.
+ *
+ * `Settings → General → Lifecycle` used to render four buttons. Two of them,
+ * `Suspend` and `Archive`, are `PlatformScope` routes: that extractor resolves
+ * through `resolve_claims`, which cannot return a human, so a session cookie
+ * can never reach them whatever it contains. The console holds platform scope
+ * only when it was handed a platform bearer through `?token=`, which is not how
+ * an operator signing in with a magic link arrives.
+ *
+ * So `Archive` — styled `destructive`, behind a dialog calling itself permanent
+ * — took the operator's confirmation and answered `Couldn't archive —
+ * unauthorized`. That is the failure this console is otherwise careful about:
+ * Billing and Hosting both explain, in the page, when a control cannot work on
+ * this deployment.
+ *
+ * This spec is deliberately two halves that have to agree. Asserting only that
+ * the buttons are gone would pass just as well if somebody deleted them for the
+ * wrong reason, and would keep passing if the routes were later opened up to
+ * company admins — at which point hiding them becomes the bug. So the second
+ * half asks the host directly, with this browser's own session, and pins the
+ * `401` the missing buttons are standing in for.
+ */
+
+/** The first-run tour opens a modal over a fresh console and intercepts clicks. */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+test("the lifecycle card offers pause, withholds suspend and archive, and says why", async ({
+  page,
+}) => {
+  await page.goto("/#/settings");
+
+  // The card is there and operable — the fix must not have emptied it. `Pause`
+  // is a `CompanyAuth` route and is the operator's real, reversible stop.
+  await expect(page.getByRole("button", { name: "Pause", exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Absent, not disabled. A disabled `Archive` would still assert that
+  // archiving is something this console does, and an operator would go looking
+  // for the permission that enables it. There is none.
+  await expect(page.getByRole("button", { name: "Suspend", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Archive", exact: true })).toHaveCount(0);
+
+  // And the omission explains itself, in the page, the way Billing and Hosting
+  // do — not as a toast after a click that failed.
+  const banner = page.getByTestId("lifecycle-platform-only");
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("platform");
+});
+
+test("the host really does refuse suspend and archive to this session", async ({
+  request,
+}) => {
+  // The company the console is operating, read the way the console reads it —
+  // rather than hard-coding the harness id, so this holds against a
+  // single-company host and a scoped one alike.
+  const status = (await (await request.get("/api/v1/company")).json()) as {
+    id: string;
+    lifecycle: string;
+  };
+  expect(status.id, "the harness host must serve a company").toBeTruthy();
+
+  // The reason the buttons are gone. `request` carries the same signed-in
+  // storage state the page does, so these are the exact calls the Archive
+  // button used to make *after* taking an operator's confirmation.
+  for (const action of ["suspend", "archive"]) {
+    const res = await request.post(`/api/v1/companies/${status.id}/${action}`);
+    expect(res.status(), `${action} must refuse a human session`).toBe(401);
+  }
+
+  // And the refusal really was a refusal: nothing above may have archived the
+  // company the specs after this one drive.
+  const after = (await (await request.get("/api/v1/company")).json()) as { lifecycle: string };
+  expect(after.lifecycle).toBe(status.lifecycle);
+});

--- a/frontend/test/e2e/lifecycle-platform-scope.spec.ts
+++ b/frontend/test/e2e/lifecycle-platform-scope.spec.ts
@@ -61,25 +61,30 @@ test("the lifecycle card offers pause, withholds suspend and archive, and says w
 test("the host really does refuse suspend and archive to this session", async ({
   request,
 }) => {
-  // The company the console is operating, read the way the console reads it —
-  // rather than hard-coding the harness id, so this holds against a
-  // single-company host and a scoped one alike.
-  const status = (await (await request.get("/api/v1/company")).json()) as {
-    id: string;
-    lifecycle: string;
-  };
-  expect(status.id, "the harness host must serve a company").toBeTruthy();
+  // The company this session can see, rather than the harness id hard-coded.
+  // `GET /api/v1/companies` is `CompanyAuth` and filtered by `visible_companies`,
+  // so it answers a signed-in person with exactly the companies they operate —
+  // unlike `/api/v1/company`, which has no status alias and 404s with an empty
+  // body that reads as a JSON parse error rather than as a wrong URL.
+  const list = await request.get("/api/v1/companies");
+  expect(list.ok(), `listing companies failed: ${list.status()}`).toBeTruthy();
+  const companies = (await list.json()) as { id: string; lifecycle: string }[];
+  const company = companies[0];
+  expect(company?.id, "the harness host must serve a company").toBeTruthy();
 
   // The reason the buttons are gone. `request` carries the same signed-in
   // storage state the page does, so these are the exact calls the Archive
   // button used to make *after* taking an operator's confirmation.
   for (const action of ["suspend", "archive"]) {
-    const res = await request.post(`/api/v1/companies/${status.id}/${action}`);
+    const res = await request.post(`/api/v1/companies/${company.id}/${action}`);
     expect(res.status(), `${action} must refuse a human session`).toBe(401);
   }
 
   // And the refusal really was a refusal: nothing above may have archived the
   // company the specs after this one drive.
-  const after = (await (await request.get("/api/v1/company")).json()) as { lifecycle: string };
-  expect(after.lifecycle).toBe(status.lifecycle);
+  const after = (await (await request.get("/api/v1/companies")).json()) as {
+    id: string;
+    lifecycle: string;
+  }[];
+  expect(after.find((c) => c.id === company.id)?.lifecycle).toBe(company.lifecycle);
 });

--- a/frontend/test/unit/lifecycle-affordances.test.ts
+++ b/frontend/test/unit/lifecycle-affordances.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenCompanyClient } from "@/api/client";
+import { lifecycleAffordances } from "@/lib/lifecycle-controls";
+
+/**
+ * Which lifecycle buttons the console is allowed to offer (issue #1401).
+ *
+ * The bug this pins was not a wrong result, it was a *reachable* control: the
+ * console rendered `Archive` — destructive, behind a dialog calling itself
+ * permanent — to an operator signed in with a magic link, took the
+ * confirmation, and then answered `401 unauthorized`, because `archive` is a
+ * `PlatformScope` route a session cookie can never reach. So every assertion
+ * here is about a button *not* existing, which is the only form the fix can
+ * take.
+ */
+
+/** A client as the console builds one for a person: cookie session, no bearer. */
+function humanClient(): OpenCompanyClient {
+  return new OpenCompanyClient({
+    baseUrl: "",
+    company: "acme",
+    operatorToken: null,
+    sessionHeader: null,
+  });
+}
+
+/** A client as a hosting console builds one: `?token=` / `VITE_OC_TOKEN`. */
+function platformClient(): OpenCompanyClient {
+  return new OpenCompanyClient({
+    baseUrl: "",
+    company: "acme",
+    operatorToken: "platform-jwt",
+    sessionHeader: null,
+  });
+}
+
+describe("what the console knows about its own credential", () => {
+  it("reports no platform bearer for the ordinary signed-in human", () => {
+    // The normal deployment. The session rides in an HttpOnly cookie that
+    // nothing in the bundle can read, and `resolve_claims` cannot turn it into
+    // platform claims whatever it contains.
+    expect(humanClient().carriesPlatformBearer).toBe(false);
+  });
+
+  it("reports a platform bearer when one was configured", () => {
+    expect(platformClient().carriesPlatformBearer).toBe(true);
+  });
+
+  it("treats an empty token as no token", () => {
+    // `?token=` with nothing after it resolves to `""`, which would be sent as
+    // `Bearer ` and refused. A truthiness check keeps the button decision and
+    // the header decision reading the same value the same way.
+    const blank = new OpenCompanyClient({
+      baseUrl: "",
+      company: "acme",
+      operatorToken: "",
+      sessionHeader: null,
+    });
+    expect(blank.carriesPlatformBearer).toBe(false);
+  });
+});
+
+describe("a console without a platform bearer", () => {
+  it("never offers suspend or archive, in any lifecycle", () => {
+    // The regression test proper. Not "archive is disabled" — disabled would
+    // still assert the action belongs here.
+    for (const state of ["running", "paused", "suspended"]) {
+      const { actions } = lifecycleAffordances(state, false);
+      expect(actions).not.toContain("suspend");
+      expect(actions).not.toContain("archive");
+    }
+  });
+
+  it("still offers pause on a running company", () => {
+    // The point of the fix is not to empty the card. `pause` is `CompanyAuth`
+    // and is the operator's real, reversible stop.
+    expect(lifecycleAffordances("running", false).actions).toEqual(["pause"]);
+  });
+
+  it("still offers resume on a paused company", () => {
+    expect(lifecycleAffordances("paused", false).actions).toEqual(["resume"]);
+  });
+
+  it("withholds resume on a platform-suspended company, and says why", () => {
+    // `resume` is a `CompanyAuth` route, so the button *is* reachable — and the
+    // handler refuses a non-platform caller specifically when the lifecycle is
+    // `suspended`. Rendering it there is the same dishonesty as Archive.
+    const { actions, explainPlatformSuspended } = lifecycleAffordances("suspended", false);
+    expect(actions).toEqual([]);
+    expect(explainPlatformSuspended).toBe(true);
+  });
+
+  it("explains the withheld controls rather than dropping them silently", () => {
+    // A missing button with no explanation sends an operator who read the docs
+    // hunting for a control that was never theirs.
+    expect(lifecycleAffordances("running", false).explainPlatformOnly).toBe(true);
+  });
+});
+
+describe("a console holding a platform bearer", () => {
+  it("offers suspend and archive", () => {
+    const { actions, explainPlatformOnly } = lifecycleAffordances("running", true);
+    expect(actions).toEqual(["pause", "suspend", "archive"]);
+    expect(explainPlatformOnly).toBe(false);
+  });
+
+  it("offers resume on a suspended company, because it can lift one", () => {
+    expect(lifecycleAffordances("suspended", true).actions).toContain("resume");
+    expect(lifecycleAffordances("suspended", true).explainPlatformSuspended).toBe(false);
+  });
+});
+
+describe("an archived company", () => {
+  it("offers nothing to anyone, and explains nothing away", () => {
+    // Terminal: the host removes it from the registry. Even a platform bearer
+    // has no transition left, and the banners would be noise next to the
+    // "This company is archived." line the card already shows.
+    for (const platform of [false, true]) {
+      const shown = lifecycleAffordances("archived", platform);
+      expect(shown.actions).toEqual([]);
+      expect(shown.archived).toBe(true);
+      expect(shown.explainPlatformOnly).toBe(false);
+      expect(shown.explainPlatformSuspended).toBe(false);
+    }
+  });
+});
+
+describe("a lifecycle string the console does not know", () => {
+  it("offers no transition rather than guessing one", () => {
+    // A host newer than this bundle can report a state that is not in the set.
+    // Showing nothing is recoverable; showing Archive is not.
+    expect(lifecycleAffordances("provisioning", true).actions).toEqual(["suspend", "archive"]);
+    expect(lifecycleAffordances("provisioning", false).actions).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #1401.

## RCA

`Settings → General → Lifecycle` rendered four buttons that do not share an authorization story, as if they did.

- `pause` / `resume` are `CompanyAuth` routes (`src/server/provision.rs:444`, `:466`). A person signed in with a magic link reaches them.
- `suspend` / `archive` are `PlatformScope` routes (`:679`, `:694`). That extractor resolves through `resolve_claims`, which cannot return a human (`src/server/platform_auth.rs:442-452`), so **a session cookie can never reach them whatever it contains**. The console only ever holds platform scope when it was handed a platform bearer through `?token=` / `VITE_OC_TOKEN` (`frontend/src/config.ts:79`) — not how an operator signing in with a magic link arrives.

So `Archive` — `variant="destructive"`, behind a dialog calling itself permanent — took the operator's confirmation and answered `Couldn't archive — unauthorized`. Unreachable **by construction**, not by configuration, which made it the one control in Settings that could not be fixed by any permission an operator could be granted.

A second, quieter instance in the same card: `Suspend`'s dialog promised "until you resume it", while `resume`'s own handler refuses a non-platform caller specifically when the lifecycle is `suspended` (`provision.rs:478-480`) — "neither an owner token nor a company's own admin may resume a company the platform suspended". The console also rendered a `Resume` button for `state === "suspended"`, refused for the same reason.

## Fix

Frontend only, as the issue proposed.

1. `client.carriesPlatformBearer` — a getter for the question the card has to ask. New `lib/lifecycle-controls.ts` turns that plus the lifecycle into the set of buttons that can honestly be rendered.
2. `Suspend` / `Archive` render only with a platform bearer. Otherwise omitted, with an in-page `Alert` saying why — the register Billing and Hosting already use for a control that cannot work on this deployment. **Omitted, not disabled**: a disabled `Archive` still asserts that archiving is something this console does.
3. `Pause` / `Resume` kept unconditionally — except `Resume` on a `suspended` company, which gets its own banner rather than a button the handler refuses.
4. `Suspend`'s copy no longer promises a resume the clicker cannot perform, and the card description distinguishes it from `Pause` ("Pause stops this company taking new work; resume starts it again").

## Tests

`test/unit/lifecycle-affordances.test.ts` (12 tests) — every assertion is about a button *not* existing, which is the only form this fix can take. Covers each lifecycle × credential, the empty-`?token=` edge, and an unknown lifecycle from a newer host.

`test/e2e/lifecycle-platform-scope.spec.ts` — deliberately two halves that have to agree: the card offers Pause and withholds the other two with a banner, **and** the host really answers `401` to `suspend`/`archive` for this browser's own session. Asserting only the missing buttons would keep passing if those routes were later opened to company admins, at which point hiding them becomes the bug.

`test/e2e/alert-dialog-confirm.spec.ts` drove `Suspend` as its second call site for the shared `AlertDialog` primitive. That button is correctly gone, so the test is removed and the docblock records why — the remaining confirms all need state that spec would have to build first (a live in-flight run, a declared list), so the primitive is proven once well rather than badly twice.

## Behaviour changes

- A console without a platform bearer no longer shows `Suspend` or `Archive` in Settings, and no longer shows `Resume` on a platform-suspended company. Each omission is explained in the page.
- No API, route, or backend change. A hosting console carrying a platform bearer sees exactly what it did before.

## Commands run locally

```
npm run typecheck          # frontend, clean
npm run typecheck:unit     # clean
npm run typecheck:e2e      # clean
npm test                   # 232 files, 2123 tests, all passing
npm run build              # clean
```

The e2e specs need a running host and were not executed locally; they typecheck and run in the `Console E2E` lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)