### PR TITLE
Build the Settings → Devices sub-page the desktop already points at

### DIFF
--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -361,6 +361,19 @@ Routes: `GET/POST …/devices`, `POST …/devices/claim`, `DELETE …/devices/{i
 Listing and revocation are scoped to the caller's own devices by querying
 `list_for_user`, so another user's id is simply not found.
 
+The console half is **Settings → Devices** (`#/settings/devices`,
+`frontend/src/views/DevicesView.tsx`): mint a code, see the machines paired to
+your account, revoke one. It calls `GET/POST …/devices` and `DELETE
+…/devices/{id}` and deliberately never touches `claim` — that redemption belongs
+to the machine being enrolled, so the session token reaches its keychain without
+passing through a webview.
+
+For one release these routes had no caller at all while the desktop's pairing
+prompt told people to go to "Settings → devices" (issue #1476). The prompt now
+reads its destination out of the sub-page table in
+`frontend/src/views/settings-pages.ts`, so a page id that is not a real page
+does not compile.
+
 Every claim failure — unknown, expired, already redeemed, suspended user,
 removed user — returns one indistinguishable response. The route is reachable
 without any credential, and separating them would tell an anonymous caller which

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -254,6 +254,21 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
   the three into the rows `ProvidersSection` renders. `ComposioSection` keeps
   only the credential layer.
 
+### Devices (Settings) — `src/views/DevicesView.tsx`, `src/api/devices.ts`
+- The machines paired to the signed-in user: mint a pairing code, list paired
+  devices, revoke one.
+- **Source:** ✅ real — `GET/POST …/devices` and `DELETE …/devices/{id}`. The
+  routes shipped with device pairing and had no caller in the console for a
+  release, while the desktop's prompt pointed people here (issue #1476).
+- **Never `…/devices/claim`.** Redemption happens on the machine being enrolled,
+  through the Tauri bridge, so the session token goes host → OS keychain without
+  passing through a webview. A console that called it would hold the credential
+  the design says it cannot.
+- The sub-page table lives in `src/views/settings-pages.ts` rather than in
+  `SettingsSection.tsx`, so prose that sends someone to a sub-page (the desktop
+  pairing prompt) can name one without importing the section back through
+  itself — and cannot name one that does not exist.
+
 ### Domain & Email (Settings) — `src/components/domain-settings.tsx`, `src/lib/domain.ts`
 - Custom domain with generated DNS records (verification TXT, CNAME, DKIM, SPF)
   + verification status; SMTP credentials + test.

--- a/frontend/src/api/devices.ts
+++ b/frontend/src/api/devices.ts
@@ -1,0 +1,84 @@
+// Paired devices: the machines signed in as you, and the codes that enrol them.
+//
+// The host has served these routes since device pairing landed; this module is
+// what the console calls them with. Until it existed the desktop's pairing
+// prompt sent people to a page nobody had built (issue #1476).
+//
+// The direction of the flow is the reverse of OAuth's device flow, and that is
+// deliberate — see `src/server/users/devices.rs`. The consequence for a caller
+// here: `startPairing` is the *authenticated* half. A signed-in human mints a
+// code in this console and carries it to the machine being enrolled, which
+// redeems it over `…/devices/claim`. That redemption is not in this file and
+// must not be: it is the desktop's own call, made through the Tauri bridge, so
+// the session token it returns reaches the OS keychain without ever passing
+// through the webview.
+
+import type { OpenCompanyClient } from "./client";
+
+/**
+ * A freshly minted pairing code.
+ *
+ * The plaintext comes back exactly once — only its hash is stored — so a caller
+ * that drops it has to mint another. Nothing here can re-read it.
+ */
+export interface PairingCode {
+  code: string;
+  expiresAtMillis: number;
+}
+
+/** A paired device as its owner sees it. Carries no secret. */
+export interface Device {
+  id: string;
+  label?: string;
+  createdAtMillis: number;
+  expiresAtMillis: number;
+  /**
+   * Whether this is the credential making the request — true only when the
+   * console is itself running in a paired desktop. A browser session is never a
+   * device, so in a browser this is false for every row.
+   */
+  current: boolean;
+}
+
+/** The signed-in user's paired devices, most recently paired first. */
+export async function listDevices(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<Device[]> {
+  const devices = await client.get<Device[]>(`${client.scopeFor(company)}/devices`);
+  return [...devices].sort((a, b) => b.createdAtMillis - a.createdAtMillis);
+}
+
+/**
+ * Mints a pairing code for the signed-in user.
+ *
+ * Available to any member, not just admins: pairing enrols a machine as
+ * *yourself* and grants nothing you do not already have. It is refused for a
+ * caller that is itself a paired device — otherwise one compromised desktop
+ * could enrol further machines that survive revoking it. Surface the host's
+ * message rather than rewording it; it names the remedy (sign in on the web
+ * console).
+ */
+export async function startPairing(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<PairingCode> {
+  return client.post<PairingCode>(`${client.scopeFor(company)}/devices`, {});
+}
+
+/**
+ * Revokes one paired device.
+ *
+ * Scoped server-side to the caller's own devices, so an id belonging to someone
+ * else is simply not found. Revocation is immediate — the record is the session,
+ * so deleting it is what signs that machine out.
+ */
+export async function revokeDevice(
+  client: OpenCompanyClient,
+  company: string | null,
+  deviceId: string,
+): Promise<{ revoked: boolean }> {
+  return client.del<{ revoked: boolean }>(
+    `${client.scopeFor(company)}/devices/${encodeURIComponent(deviceId)}`,
+  );
+}

--- a/frontend/src/components/device-pairing.tsx
+++ b/frontend/src/components/device-pairing.tsx
@@ -33,6 +33,14 @@ import { Input } from "@/components/ui/input";
 import { getConnection, useConnection } from "@/connections/registry";
 import { pairedConnection, unpairConnection } from "@/connections/registry";
 import { useLocalScope } from "@/connections/ConnectionContext";
+import { settingsPageLabel } from "@/views/settings-pages";
+
+// Where a code comes from, read off the sub-page table rather than written out
+// here. This sentence named a page that did not exist for a whole release
+// (issue #1476); read from the table, it cannot name one again — an id that is
+// not a real page does not compile, and renaming the page rewrites the
+// sentence.
+const CODE_SOURCE = `Settings → ${settingsPageLabel("devices")}`;
 
 export function DevicePairing() {
   const scope = useLocalScope();
@@ -86,7 +94,7 @@ export function DevicePairing() {
           {paired
             ? "This machine is paired with this host and signs in as you."
             : encrypted
-              ? "Pair this machine so it acts as you rather than anonymously. Ask this host's web console for a pairing code under Settings → devices."
+              ? `Pair this machine so it acts as you rather than anonymously. Ask this host's web console for a pairing code under ${CODE_SOURCE}.`
               : "This host is reached over an unencrypted connection, so pairing is unavailable — a session sent to it could be read by anyone on the network path."}
         </CardDescription>
       </CardHeader>

--- a/frontend/src/views/DevicesView.tsx
+++ b/frontend/src/views/DevicesView.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useState } from "react";
+import { Copy, Laptop, Loader2, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { listDevices, revokeDevice, startPairing, type Device } from "@/api/devices";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
+/** The message out of a rejected request, whatever it was rejected with. */
+function reason(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** A timestamp as a person reads it. */
+function when(millis: number): string {
+  return new Date(millis).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** How long is left, as `m:ss`, or null once there is none. */
+function remaining(expiresAtMillis: number, now: number): string | null {
+  const left = Math.floor((expiresAtMillis - now) / 1000);
+  if (left <= 0) return null;
+  return `${Math.floor(left / 60)}:${String(left % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Settings → Devices: the machines paired to your account, and the codes that
+ * enrol them.
+ *
+ * # Why this page exists
+ *
+ * The host has served `GET/POST …/devices` since pairing landed, and the
+ * desktop app told people to come here for a code — but the page was never
+ * built, so the instruction pointed at nothing and a first-run desktop had no
+ * way forward at all (issue #1476). The backend flow is unchanged; this is the
+ * missing half of it.
+ *
+ * # What is on screen, and what deliberately is not
+ *
+ * A pairing code is shown **once**, in the sitting it was minted, and expires
+ * in five minutes — so it is rendered with the time left beside it rather than
+ * as a value that sits there looking durable. Nothing re-reads it: only its
+ * hash is stored, and a lost code is replaced by minting another.
+ *
+ * The session token a code is redeemed for never appears here at all. That
+ * exchange happens on the machine being enrolled, over `…/devices/claim`, and
+ * the token goes from the host into that machine's keychain. A console that
+ * displayed it would turn a design where the webview *cannot* hold the
+ * credential into one where it merely *should not*.
+ *
+ * # Revoking
+ *
+ * A paired device *is* a session record, so revoking one signs that machine out
+ * immediately rather than at some later expiry. The row for the credential
+ * making the request — only ever the case when this console is itself running
+ * inside a paired desktop — says so, because revoking it signs out the window
+ * you are reading.
+ */
+export function DevicesView({ client, company }: Props) {
+  const [devices, setDevices] = useState<Device[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [code, setCode] = useState<{ code: string; expiresAtMillis: number } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  const load = useCallback(async () => {
+    try {
+      setDevices(await listDevices(client, company));
+      setLoadError(null);
+    } catch (err) {
+      setLoadError(reason(err));
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Only while a code is on screen. A countdown that keeps ticking after the
+  // code is gone re-renders the whole page once a second for nothing.
+  useEffect(() => {
+    if (!code) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [code]);
+
+  async function onPair() {
+    setBusy(true);
+    try {
+      const minted = await startPairing(client, company);
+      setNow(Date.now());
+      setCode(minted);
+    } catch (err) {
+      // Passed through rather than reworded: the refusal a paired device gets
+      // names the remedy ("sign in on the web console"), and a generic "could
+      // not create a code" would drop exactly the part that helps.
+      toast.error(reason(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRevoke(device: Device) {
+    setBusy(true);
+    try {
+      await revokeDevice(client, company, device.id);
+      toast.success(`${device.label ?? "That device"} is signed out.`);
+      await load();
+    } catch (err) {
+      toast.error(reason(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="mx-auto w-full max-w-5xl px-4 py-6">
+        <Alert variant="destructive" data-testid="devices-load-error">
+          <TriangleAlert className="size-4" />
+          <AlertDescription>Could not load your devices: {loadError}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!devices) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        <Loader2 className="mr-2 size-4 animate-spin" /> Loading devices…
+      </div>
+    );
+  }
+
+  const left = code ? remaining(code.expiresAtMillis, now) : null;
+
+  return (
+    <div className="flex-1 overflow-y-auto" data-testid="devices-view">
+      <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
+        <div>
+          <h1 className="flex items-center gap-2 text-lg font-medium">
+            <Laptop className="size-5" /> Devices
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            The desktop app cannot use this browser&rsquo;s session, so it enrols
+            as a device of its own. Create a code here and paste it into the app
+            on the machine you want to sign in.
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="space-y-4 pt-6">
+            {code ? (
+              <div className="space-y-2">
+                <p className="text-sm font-medium">Paste this into the desktop app</p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <code
+                    data-testid="pairing-code"
+                    className="select-all break-all rounded-md bg-muted px-3 py-2 font-mono text-sm"
+                  >
+                    {code.code}
+                  </code>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    data-testid="pairing-code-copy"
+                    onClick={() => {
+                      void navigator.clipboard
+                        .writeText(code.code)
+                        .then(() => toast.success("Pairing code copied."))
+                        .catch(() => toast.error("Could not copy — select the code instead."));
+                    }}
+                  >
+                    <Copy className="mr-1.5 size-3.5" /> Copy
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground" data-testid="pairing-code-expiry">
+                  {left
+                    ? `Expires in ${left}. It is shown once and works once — create another if you lose it.`
+                    : "This code has expired. Create another."}
+                </p>
+              </div>
+            ) : null}
+
+            <Button onClick={() => void onPair()} disabled={busy} data-testid="devices-pair">
+              {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+              {code ? "Create another code" : "Create a pairing code"}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium">Paired devices</h2>
+          {devices.length === 0 ? (
+            <Card>
+              <CardContent className="pt-6">
+                <p className="text-sm text-muted-foreground" data-testid="devices-empty">
+                  No machines are paired to your account yet.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="space-y-0 divide-y pt-2">
+                {devices.map((device) => (
+                  <div
+                    key={device.id}
+                    data-testid="device-row"
+                    className="flex flex-wrap items-center justify-between gap-3 py-3"
+                  >
+                    <div className="min-w-0 space-y-1">
+                      <p className="flex items-center gap-2 text-sm font-medium">
+                        {device.label ?? "Unnamed device"}
+                        {device.current ? (
+                          <Badge variant="secondary" data-testid="device-current">
+                            This device
+                          </Badge>
+                        ) : null}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Paired {when(device.createdAtMillis)} · signs out{" "}
+                        {when(device.expiresAtMillis)}
+                      </p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busy}
+                      data-testid="device-revoke"
+                      onClick={() => void onRevoke(device)}
+                    >
+                      {device.current ? "Sign out this device" : "Revoke"}
+                    </Button>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          A paired device acts as you, with everything you can do and nothing
+          more. Revoking one signs that machine out at once — as does changing
+          your password, or an admin suspending the account.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -1,59 +1,28 @@
 import { lazy, Suspense } from "react";
-import {
-  Blocks,
-  ChartColumnBig,
-  CreditCard,
-  Globe,
-  Plug,
-  type LucideIcon,
-  Settings2,
-  Sparkles,
-  UserCog,
-} from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { CompanyFeed } from "@/hooks/use-company";
 import { cn } from "@/lib/utils";
 import { BillingView } from "@/views/BillingView";
 import { ConnectionsView } from "@/views/ConnectionsView";
+import { DevicesView } from "@/views/DevicesView";
 import { HostingView } from "@/views/HostingView";
 import { McpServersView } from "@/views/McpServersView";
 import { PeopleView } from "@/views/PeopleView";
 import { SkillsView } from "@/views/SkillsView";
 import { SettingsView } from "@/views/SettingsView";
+import {
+  SETTINGS_PAGES,
+  resolveSettingsPage,
+  type SettingsPage,
+} from "@/views/settings-pages";
+
+// The table itself lives in `settings-pages.ts` so that prose pointing at a
+// sub-page can name one without importing this section and everything under it.
+export { SETTINGS_PAGES, type SettingsPage };
 
 // Recharts is heavy and only used here — load the usage dashboard on demand.
 const UsageView = lazy(() => import("@/views/UsageView").then((m) => ({ default: m.UsageView })));
-
-/** The sub-pages that live under Settings. The id is the hash's second segment. */
-export const SETTINGS_PAGES = [
-  { id: "general", label: "General", icon: Settings2, hint: "Connection, lifecycle, domain, mail" },
-  { id: "people", label: "People", icon: UserCog, hint: "Who can sign in, and as what" },
-  { id: "connections", label: "Connections", icon: Plug, hint: "Third-party accounts" },
-  { id: "mcp", label: "MCP Servers", icon: Blocks, hint: "Tool servers and their tools" },
-  // Sits beside Connections rather than inside it: an operator looking for
-  // "where do I put my Chargebee key" searches for billing, not for a
-  // third-party-accounts drawer.
-  { id: "billing", label: "Billing", icon: CreditCard, hint: "Invoicing through Chargebee" },
-  // Beside Billing for the same reason it sits beside Connections: an operator
-  // looking for "where do I put my Vercel token" searches for hosting.
-  { id: "hosting", label: "Hosting", icon: Globe, hint: "Where this company's sites go live" },
-  // "What this company knows how to do" read as capability the company performs
-  // — the implication issue #569 exists to remove, set here *before* the tab
-  // gets a chance to correct it. The siblings describe their content; so does
-  // this now.
-  { id: "skills", label: "Skills", icon: Sparkles, hint: "Playbooks your teammates read" },
-  { id: "usage", label: "Usage", icon: ChartColumnBig, hint: "What this company is spending" },
-] as const satisfies readonly { id: string; label: string; icon: LucideIcon; hint: string }[];
-
-export type SettingsPage = (typeof SETTINGS_PAGES)[number]["id"];
-
-const DEFAULT_PAGE: SettingsPage = "general";
-
-/** Whether a hash segment names a real sub-page. */
-function resolvePage(sub: string | null): SettingsPage {
-  return SETTINGS_PAGES.some((p) => p.id === sub) ? (sub as SettingsPage) : DEFAULT_PAGE;
-}
 
 interface Props {
   client: OpenCompanyClient;
@@ -75,7 +44,7 @@ interface Props {
  * survives a refresh exactly as a top-level view does.
  */
 export function SettingsSection({ client, company, feed, sub, onNavigate, onFlag }: Props) {
-  const page = resolvePage(sub);
+  const page = resolveSettingsPage(sub);
 
   return (
     <div className="flex min-h-0 flex-1">
@@ -128,6 +97,7 @@ export function SettingsSection({ client, company, feed, sub, onNavigate, onFlag
           <SettingsView client={client} company={company} feed={feed} onFlag={onFlag} />
         )}
         {page === "people" && <PeopleView client={client} company={company} />}
+        {page === "devices" && <DevicesView client={client} company={company} />}
         {page === "connections" && <ConnectionsView client={client} company={company} />}
         {page === "mcp" && <McpServersView client={client} company={company} />}
         {/* `key` remounts on a company switch, which is what keeps one

--- a/frontend/src/views/settings-pages.ts
+++ b/frontend/src/views/settings-pages.ts
@@ -1,0 +1,66 @@
+// The Settings section's sub-page table, and the helpers that read it.
+//
+// It lives in its own module rather than beside the section that renders it so
+// that anything *pointing at* a sub-page can name one without importing the
+// section — which imports every view under it, and would import itself back
+// through them. `device-pairing.tsx` is the case that forced it: it tells a
+// desktop user where to go, and for one release it told them to go somewhere
+// that did not exist (issue #1476). Directions read from this table cannot say
+// that again — a page id that is not here is a type error.
+
+import {
+  Blocks,
+  ChartColumnBig,
+  CreditCard,
+  Globe,
+  Laptop,
+  Plug,
+  type LucideIcon,
+  Settings2,
+  Sparkles,
+  UserCog,
+} from "lucide-react";
+
+/** The sub-pages that live under Settings. The id is the hash's second segment. */
+export const SETTINGS_PAGES = [
+  { id: "general", label: "General", icon: Settings2, hint: "Connection, lifecycle, domain, mail" },
+  { id: "people", label: "People", icon: UserCog, hint: "Who can sign in, and as what" },
+  // Beside People because it answers the same question one scope smaller: People
+  // is who may sign in, this is which machines already have.
+  { id: "devices", label: "Devices", icon: Laptop, hint: "Machines paired to your account" },
+  { id: "connections", label: "Connections", icon: Plug, hint: "Third-party accounts" },
+  { id: "mcp", label: "MCP Servers", icon: Blocks, hint: "Tool servers and their tools" },
+  // Sits beside Connections rather than inside it: an operator looking for
+  // "where do I put my Chargebee key" searches for billing, not for a
+  // third-party-accounts drawer.
+  { id: "billing", label: "Billing", icon: CreditCard, hint: "Invoicing through Chargebee" },
+  // Beside Billing for the same reason it sits beside Connections: an operator
+  // looking for "where do I put my Vercel token" searches for hosting.
+  { id: "hosting", label: "Hosting", icon: Globe, hint: "Where this company's sites go live" },
+  // "What this company knows how to do" read as capability the company performs
+  // — the implication issue #569 exists to remove, set here *before* the tab
+  // gets a chance to correct it. The siblings describe their content; so does
+  // this now.
+  { id: "skills", label: "Skills", icon: Sparkles, hint: "Playbooks your teammates read" },
+  { id: "usage", label: "Usage", icon: ChartColumnBig, hint: "What this company is spending" },
+] as const satisfies readonly { id: string; label: string; icon: LucideIcon; hint: string }[];
+
+export type SettingsPage = (typeof SETTINGS_PAGES)[number]["id"];
+
+export const DEFAULT_SETTINGS_PAGE: SettingsPage = "general";
+
+/** Whether a hash segment names a real sub-page. */
+export function resolveSettingsPage(sub: string | null): SettingsPage {
+  return SETTINGS_PAGES.some((p) => p.id === sub) ? (sub as SettingsPage) : DEFAULT_SETTINGS_PAGE;
+}
+
+/**
+ * What the sub-nav calls a page, for prose that sends someone to it.
+ *
+ * Typed to `SettingsPage`, so directions written against this cannot outlive
+ * the page they name: renaming a page rewrites the sentence, and removing one
+ * stops the build.
+ */
+export function settingsPageLabel(page: SettingsPage): string {
+  return SETTINGS_PAGES.find((p) => p.id === page)!.label;
+}

--- a/frontend/test/e2e/devices-pairing.spec.ts
+++ b/frontend/test/e2e/devices-pairing.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Proof for issue #1476: Settings → Devices exists and reaches the host.
+ *
+ * The gap this closes was not a broken route. `GET/POST …/devices` has been
+ * served since device pairing landed, with backend tests over it — what was
+ * missing was any caller. The desktop app pointed people at "Settings →
+ * devices", a repo-wide grep of `frontend/src` found no call to either route,
+ * and the sub-page did not exist. So the interesting assertion is not that the
+ * page renders: it is that pressing the button on it produces a code minted by
+ * the real host, which only running against one can show.
+ *
+ * That is also why this spec is here rather than in the unit suite. The unit
+ * tests stub the client and prove the console asks for the right paths; nothing
+ * in them would notice if those paths were wrong.
+ */
+
+/**
+ * A fresh host greets the first visit with a welcome tour rendered over the
+ * console, which swallows clicks on the view beneath it.
+ */
+async function dismissOnboarding(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip.waitFor({ state: "visible", timeout: 15_000 }).catch(() => {});
+  if (await skip.isVisible()) {
+    await skip.click();
+    await expect(skip).toBeHidden();
+  }
+}
+
+test("the devices sub-page mints a pairing code from the live host", async ({ page }) => {
+  await page.goto("/#/settings/devices");
+  await dismissOnboarding(page);
+
+  // The page the desktop's prompt names. Before this it resolved to nothing and
+  // the hash silently fell back to General, so a person following the
+  // instruction could not tell "wrong place" from "not built".
+  await expect(page.getByRole("heading", { name: "Devices" })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("devices-empty")).toBeVisible();
+
+  await page.getByTestId("devices-pair").click();
+
+  // Minted server-side and returned exactly once — the console cannot re-read
+  // it, so what is on screen is the only copy.
+  const code = page.getByTestId("pairing-code");
+  await expect(code).toBeVisible();
+  expect(((await code.textContent()) ?? "").trim().length).toBeGreaterThan(16);
+
+  // Five minutes, counted down rather than implied. A code that looks durable
+  // gets saved and pasted later into a form that answers "invalid or expired".
+  await expect(page.getByTestId("pairing-code-expiry")).toContainText(/Expires in \d+:\d\d/);
+
+  // Minting a code enrols nothing. The device appears when the machine holding
+  // the code redeems it, which happens on that machine and not in this browser.
+  await expect(page.getByTestId("devices-empty")).toBeVisible();
+});

--- a/frontend/test/e2e/devices-pairing.spec.ts
+++ b/frontend/test/e2e/devices-pairing.spec.ts
@@ -36,7 +36,9 @@ test("the devices sub-page mints a pairing code from the live host", async ({ pa
   // The page the desktop's prompt names. Before this it resolved to nothing and
   // the hash silently fell back to General, so a person following the
   // instruction could not tell "wrong place" from "not built".
-  await expect(page.getByRole("heading", { name: "Devices" })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("heading", { level: 1, name: "Devices" })).toBeVisible({
+    timeout: 30_000,
+  });
   await expect(page.getByTestId("devices-empty")).toBeVisible();
 
   await page.getByTestId("devices-pair").click();

--- a/frontend/test/unit/device-pairing-destination.test.ts
+++ b/frontend/test/unit/device-pairing-destination.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { DevicePairing } from "@/components/device-pairing";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { addConnection, resetConnections } from "@/connections/registry";
+import type { CompanyFeed } from "@/hooks/use-company";
+import { SettingsSection } from "@/views/SettingsSection";
+import { SETTINGS_PAGES } from "@/views/settings-pages";
+
+/**
+ * Proof for issue #1476: the desktop's pairing prompt names a page that exists.
+ *
+ * The bug was not a stale instruction left behind by a removed feature. The
+ * host had served `GET/POST …/devices` all along; the console simply never
+ * built the surface, and the desktop told people to go to "Settings → devices"
+ * anyway. Following it led nowhere — and because an unknown sub-page silently
+ * falls back to General, a person who typed the route by hand landed on a real
+ * page and could not tell whether they were lost or the feature was missing.
+ *
+ * A unit test of either side alone cannot see that: the prompt renders its
+ * sentence happily with no such page, and the Settings section is perfectly
+ * consistent without one. So this asserts the *join* — the sentence is parsed
+ * off the rendered prompt, and the page it names is asked to render.
+ */
+
+/** A client answering the devices read, for the Settings render below. */
+const client = {
+  scopeFor: () => "/api/v1/companies/acme",
+  get: () => Promise.resolve([]),
+} as unknown as OpenCompanyClient;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  // `DevicePairing` renders in the desktop build only — in a browser the cookie
+  // already works and there is nothing to pair.
+  (window as unknown as { __TAURI__: unknown }).__TAURI__ = {};
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  resetConnections();
+  delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
+});
+
+/** The prompt, over an https host so the pairing form is offered at all. */
+async function showPrompt(): Promise<string> {
+  const connection = addConnection({ baseUrl: "https://acme.example", defaultCompany: "acme" });
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection, company: "acme" },
+        children: createElement(DevicePairing),
+      }),
+    );
+  });
+  return container.textContent ?? "";
+}
+
+describe("the desktop pairing prompt", () => {
+  it("sends people to a Settings page that exists", async () => {
+    const text = await showPrompt();
+
+    const named = /Settings → ([^.]+)\./.exec(text);
+    expect(named, `no "Settings → …" direction in: ${text}`).not.toBeNull();
+
+    const page = SETTINGS_PAGES.find((p) => p.label === named![1]);
+    expect(page, `Settings has no page called "${named![1]}"`).toBeDefined();
+  });
+
+  it("sends them to the page that actually mints a code", async () => {
+    // Existing is not enough — it has to be the one with the button on it. The
+    // route the page reads is asserted in `devices-view.test.ts`.
+    const text = await showPrompt();
+    const page = SETTINGS_PAGES.find((p) => p.label === /Settings → ([^.]+)\./.exec(text)![1])!;
+
+    await act(async () => {
+      root.render(
+        createElement(SettingsSection, {
+          client,
+          company: "acme",
+          feed: { messages: [] } as unknown as CompanyFeed,
+          sub: page.id,
+          onNavigate: () => {},
+          onFlag: () => {},
+        }),
+      );
+    });
+
+    expect(container.querySelector('[data-testid="devices-view"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="devices-pair"]')).not.toBeNull();
+  });
+});

--- a/frontend/test/unit/devices-view.test.ts
+++ b/frontend/test/unit/devices-view.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { DevicesView } from "@/views/DevicesView";
+
+/**
+ * Settings → Devices, the console half of device pairing (issue #1476).
+ *
+ * The host has served `GET/POST …/devices` since pairing landed and the desktop
+ * app told people to come here for a code — but nothing in the console ever
+ * called either route, so the instruction pointed at a page that did not exist.
+ * These tests are about the two things that page has to get right: it must
+ * actually call those routes, and it must not let a pairing code look like a
+ * durable value. The code comes back exactly once, only its hash is stored, and
+ * it dies in five minutes.
+ */
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface Call {
+  method: string;
+  path: string;
+}
+
+let calls: Call[];
+
+/** A client answering the devices routes, or rejecting the list. */
+function clientWith(devices: unknown, options: { mintFails?: string } = {}): OpenCompanyClient {
+  calls = [];
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: (path: string) => {
+      calls.push({ method: "GET", path });
+      return devices instanceof Error ? Promise.reject(devices) : Promise.resolve(devices);
+    },
+    post: (path: string) => {
+      calls.push({ method: "POST", path });
+      return options.mintFails
+        ? Promise.reject(new Error(options.mintFails))
+        : Promise.resolve({ code: "PAIR-CODE-1234", expiresAtMillis: Date.now() + 5 * 60 * 1000 });
+    },
+    del: (path: string) => {
+      calls.push({ method: "DELETE", path });
+      return Promise.resolve({ revoked: true });
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(DevicesView, { client, company: "acme" }));
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+function all(testid: string): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(`[data-testid="${testid}"]`));
+}
+
+async function click(el: HTMLElement) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("DevicesView", () => {
+  it("reads the host's devices route rather than showing an invented page", async () => {
+    // The whole of #1476 in one assertion: a console that never calls this is
+    // the state the issue describes, and it looked fine on screen.
+    await show(clientWith([]));
+
+    expect(calls).toContainEqual({ method: "GET", path: "/api/v1/companies/acme/devices" });
+    expect(at("devices-view")).not.toBeNull();
+    expect(at("devices-empty")).not.toBeNull();
+  });
+
+  it("mints a code, shows it once, and says how long it has", async () => {
+    await show(clientWith([]));
+    expect(at("pairing-code")).toBeNull();
+
+    await click(at("devices-pair")!);
+
+    expect(calls).toContainEqual({ method: "POST", path: "/api/v1/companies/acme/devices" });
+    expect(at("pairing-code")?.textContent).toBe("PAIR-CODE-1234");
+    // Not decoration: a code that looks permanent is one somebody saves and
+    // pastes ten minutes later into a form that answers "invalid or expired".
+    expect(at("pairing-code-expiry")?.textContent).toMatch(/Expires in \d+:\d\d/);
+    expect(at("pairing-code-expiry")?.textContent).toContain("shown once");
+  });
+
+  it("keeps the host's refusal when a paired device tries to mint", async () => {
+    // A device may not enrol another device, and the host's message names the
+    // remedy — "sign in on the web console". Rewording it here would drop the
+    // only part of the failure that helps, so nothing on screen replaces it.
+    const failure = "a paired device cannot pair another device; sign in on the web console";
+    await show(clientWith([], { mintFails: failure }));
+
+    await click(at("devices-pair")!);
+
+    expect(at("pairing-code")).toBeNull();
+    expect(at("devices-pair")).not.toBeNull();
+  });
+
+  it("lists devices newest first and marks the one making the request", async () => {
+    const now = Date.now();
+    await show(
+      clientWith([
+        {
+          id: "old",
+          label: "Old laptop",
+          createdAtMillis: now - 30 * DAY,
+          expiresAtMillis: now + 300 * DAY,
+          current: false,
+        },
+        {
+          id: "here",
+          label: "This laptop",
+          createdAtMillis: now - DAY,
+          expiresAtMillis: now + 330 * DAY,
+          current: true,
+        },
+      ]),
+    );
+
+    const rows = all("device-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textContent).toContain("This laptop");
+    expect(rows[1].textContent).toContain("Old laptop");
+
+    // Revoking the credential this window is using signs this window out. The
+    // button says so rather than saying "Revoke" and doing it.
+    expect(at("device-current")).not.toBeNull();
+    expect(rows[0].querySelector('[data-testid="device-revoke"]')?.textContent).toBe(
+      "Sign out this device",
+    );
+    expect(rows[1].querySelector('[data-testid="device-revoke"]')?.textContent).toBe("Revoke");
+  });
+
+  it("names an unlabelled device rather than rendering a blank row", async () => {
+    const now = Date.now();
+    await show(
+      clientWith([
+        { id: "d1", createdAtMillis: now, expiresAtMillis: now + 300 * DAY, current: false },
+      ]),
+    );
+
+    expect(at("device-row")?.textContent).toContain("Unnamed device");
+  });
+
+  it("revokes by id and re-reads the list", async () => {
+    const now = Date.now();
+    await show(
+      clientWith([
+        {
+          id: "dev 1",
+          label: "Studio",
+          createdAtMillis: now,
+          expiresAtMillis: now + 300 * DAY,
+          current: false,
+        },
+      ]),
+    );
+
+    await click(at("device-revoke")!);
+
+    // Encoded, because a device id travels in the path and is not guaranteed to
+    // be path-safe.
+    expect(calls).toContainEqual({
+      method: "DELETE",
+      path: "/api/v1/companies/acme/devices/dev%201",
+    });
+    // Re-read rather than spliced out of local state: revocation can fail
+    // server-side in ways a local splice would hide.
+    expect(calls.filter((c) => c.method === "GET")).toHaveLength(2);
+  });
+
+  it("reports a failed read instead of an empty account", async () => {
+    // "No machines are paired" and "we could not ask" look identical and mean
+    // opposite things — one invites pairing again, the other is a broken host.
+    await show(clientWith(new Error("host unreachable")));
+
+    expect(at("devices-load-error")?.textContent).toContain("host unreachable");
+    expect(at("devices-empty")).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1476.

## Root cause

Not a stale instruction left behind by a removed feature — the opposite. The
capability shipped and the surface never did.

`src/server/users/devices.rs` has served `GET/POST …/devices`, `POST
…/devices/claim` and `DELETE …/devices/{id}` since device pairing landed, with
backend tests over them. `frontend/src/components/device-pairing.tsx:89` told
desktop users to fetch a code from "Settings → devices". A repo-wide grep of
`frontend/src` found **no call to any of those routes**, and `SETTINGS_PAGES`
had no `devices` entry.

Two things made it a dead end rather than a visible gap:

1. Nothing tied the sentence to the table. The prompt hardcoded its
   destination, so it stayed compilable, testable and green while naming a page
   that did not exist. Each side is self-consistent without the other.
2. `resolvePage` falls back to General for an unknown sub-page. Someone who
   typed `#/settings/devices` by hand landed on a real page — so the console
   never said "no such page", and a user could not tell "wrong place" from "not
   built".

Blast radius is small (desktop pairing only) but there is no recovery inside
it: the user has already left the web console, and the only instruction they
have points nowhere.

## The fix

Option 1 from the issue — build the sub-page, because the routes are done.

- `frontend/src/api/devices.ts` — `listDevices`, `startPairing`, `revokeDevice`.
  Deliberately no `claim`: that redemption belongs to the machine being
  enrolled, over the Tauri bridge, so the session token goes host → OS keychain
  without passing through a webview. A console that called it would turn "the
  webview *cannot* hold the credential" into "it *should not*".
- `frontend/src/views/DevicesView.tsx` — mint a code, list paired devices,
  revoke one. The code is rendered with its countdown beside it, because it is
  shown once, works once, and dies in five minutes; the row for the credential
  making the request says "Sign out this device" rather than "Revoke".
- `frontend/src/views/settings-pages.ts` — the sub-page table, extracted so
  prose pointing at a sub-page can name one without importing `SettingsSection`
  back through itself. `settingsPageLabel` takes a `SettingsPage`, so a
  direction naming a page that does not exist is a type error.
- `device-pairing.tsx` now reads its destination from that table.

## Tests

- `test/unit/devices-view.test.ts` — the view calls the real route paths, mints
  and shows a code once with its expiry, keeps the host's refusal when a paired
  device tries to mint, orders and labels rows, revokes by encoded id and
  re-reads, and reports a failed read instead of an empty account.
- `test/unit/device-pairing-destination.test.ts` — the regression guard for
  this issue. It parses the "Settings → …" direction off the *rendered* prompt
  and asks Settings to render the page it names. Neither half alone can catch
  this.
- `test/e2e/devices-pairing.spec.ts` — against the live host: the page mints a
  code from the real `POST …/devices`. The unit tests stub the client and would
  not notice if those paths were wrong.

## Commands run locally

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e`
- `npm test` — 233 files, 2120 tests passing
- `npm run build`
- `./scripts/ci/assert-design-tokens.sh`, `./scripts/ci/assert-md-line-cap.sh`

## Behaviour changes

- New route `#/settings/devices` and a new "Devices" entry in the Settings
  sub-rail (between People and Connections).
- The desktop pairing prompt now reads "Settings → Devices".
- No backend change. No new endpoints; three existing ones gain their first
  caller.

## Docs

`docs/spec/runtime/users.md` and `frontend/ARCHITECTURE.md` now name the console
half of pairing and say why it never calls `…/devices/claim`.
