### PR TITLE
ContextStore: label-scoped delete, one claim per (addr, label)

### DIFF
--- a/docs/spec/company-brain/memory.md
+++ b/docs/spec/company-brain/memory.md
@@ -44,11 +44,12 @@ The console's Brain header needs it: agents write memory **only** through the
 `GET /memory/stats` therefore reports `lastUpdatedAtMillis` as the max across
 both ports, alongside the facts-only `factsUpdatedAtMillis`.
 
-Read that stamp as a max across chunks, not as one row per body: the backends
-differ on a re-`put` of an identical body (sqlite and mongo dedupe on the
-content address and keep the first write; the fs index appends a second line),
-and neither the export bundle nor a restore preserves it — a restored chunk is
-stamped when it lands.
+Read that stamp as a max across chunks, not as one row per body: one address
+carries one row per *label* claiming it (issue #1300), a new label on an
+existing body stamps per-label on fs/sqlite and keeps the address's first
+stamp on the single-record backends (mongodb, the provider facade, the
+tinycortex engine), and neither the export bundle nor a restore preserves it
+— a restored chunk is stamped when it lands.
 
 **TinyCortex is the intended backend for `MemoryStore` and `ContextStore`**
 ([integrations/tinycortex.md](../integrations/tinycortex.md)) but is a
@@ -106,9 +107,11 @@ Four properties are normative, because each is a way this could quietly lie:
   operator believing the whole folder is in memory.
 - **A drop can be taken back.** `DELETE …/memory/document/{slug}` forgets every
   chunk of one document — the Delete right below, applied to the one context
-  origin an operator authored. It honours the shared-address rule: a chunk
-  whose byte-identical body is also indexed under another label is left alone
-  rather than deleting somebody else's row.
+  origin an operator authored. The delete is label-scoped (#1300): a chunk
+  whose byte-identical body is also indexed under another label loses only
+  this document's claim on it, so somebody else's row survives and the body
+  is reaped with its last claim. It previously *skipped* such a chunk, which
+  left a forgotten document's own rows listed for good.
 
 Links are fetched **by the host** (a browser cannot, cross-origin), so the URL
 path is guarded server-side: `http`/`https` only, and never a loopback,

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -392,11 +392,15 @@ re-derives them:
   `memory_recall`, `memory_forget` — over the company's own `ContextStore`,
   company and agent captured at build time, never a model-supplied
   namespace. Forget reaches only the agent's own `agent-memory/<id>/` rows;
-  task outcomes and operator facts are not an agent's to delete. And because
-  chunks are content-addressed with an ADDRESS-level `ContextStore::delete`,
-  a forget whose identical content is indexed under any other label (another
-  agent's byte-identical memory, a task outcome with the same text) refuses
-  rather than deleting theirs too — store a correction instead. The
+  task outcomes and operator facts are not an agent's to delete. Chunks are
+  content-addressed, and since #1300 every backend keeps one claim per
+  (addr, label) with a **label-scoped** `ContextStore::delete_label`: a
+  forget whose identical content is indexed under other labels (another
+  agent's byte-identical memory, a task outcome with the same text) removes
+  exactly the agent's own claims, the other labels keep the body, and the
+  body is reaped — atomically inside the port — only with its last claim.
+  (Before #1300 this case refused outright, which let anyone make an
+  agent's memory permanently un-forgettable by storing identical text.) The
   vendored upstream memory tools stay unwired: they resolve their store
   ambiently, which under multi-tenant-in-one-process is a cross-company
   leak (`src/harness/built_in/build.rs`, `memory_tools`).

--- a/docs/spec/runtime/ports-state.md
+++ b/docs/spec/runtime/ports-state.md
@@ -210,10 +210,25 @@ pub trait ContextStore: Send + Sync {
     async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>>;
     async fn peek(&self, id: &CompanyId, addr: &ChunkAddr, range: Option<Range<usize>>)
         -> Result<String>;
+    async fn peek_many(&self, id: &CompanyId, addrs: &[ChunkAddr])
+        -> Result<Vec<Option<String>>>; // defaulted: loops peek
     async fn search(&self, id: &CompanyId, query: &str, limit: usize)
         -> Result<Vec<ChunkHit>>;
+    async fn delete(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool>;
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str)
+        -> Result<bool>;
 }
 ```
+
+Chunks are content-addressed: byte-identical bodies share one address, and
+every backend keeps one claim per `(addr, label)` (issue #1300 — a re-`put`
+of an identical body under a new label lands that label's claim; under an
+identical label it is a no-op). `delete` is address-level and takes every
+claim with the body — the operator's hard-delete. `delete_label` removes one
+claim and reaps the body only with the last one, decided atomically inside
+the backend, which is what lets `memory_forget` and the fact-mirror reap
+remove their own claim on a shared address without racing a concurrent
+identical-content write.
 
 ## SecretStore
 

--- a/src/harness/built_in/build.rs
+++ b/src/harness/built_in/build.rs
@@ -1809,6 +1809,14 @@ mod tests {
         ) -> crate::Result<bool> {
             Ok(false)
         }
+        async fn delete_label(
+            &self,
+            _: &CompanyId,
+            _: &crate::ports::types::ChunkAddr,
+            _: &str,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
     }
 
     /// A no-op company store — `build_agent` only needs a handle; nothing here

--- a/src/harness/built_in/confine.rs
+++ b/src/harness/built_in/confine.rs
@@ -136,6 +136,16 @@ impl ContextStore for ConfinedContext {
         Ok(false)
     }
 
+    async fn delete_label(
+        &self,
+        _id: &CompanyId,
+        _addr: &crate::ports::types::ChunkAddr,
+        _label: &str,
+    ) -> crate::Result<bool> {
+        // Same truth as `delete`: no claim was ever stored.
+        Ok(false)
+    }
+
     async fn peek(
         &self,
         _id: &CompanyId,

--- a/src/harness/built_in/memory.rs
+++ b/src/harness/built_in/memory.rs
@@ -373,6 +373,18 @@ mod tests {
             Ok(guard.len() < before)
         }
 
+        async fn delete_label(
+            &self,
+            _id: &CompanyId,
+            addr: &ChunkAddr,
+            label: &str,
+        ) -> crate::Result<bool> {
+            let mut guard = self.chunks.lock().unwrap();
+            let before = guard.len();
+            guard.retain(|(a, c)| !(a == addr && c.label == label));
+            Ok(guard.len() < before)
+        }
+
         async fn search(
             &self,
             _id: &CompanyId,

--- a/src/harness/built_in/memory_tools.rs
+++ b/src/harness/built_in/memory_tools.rs
@@ -38,9 +38,12 @@
 //! surfaces everything — task outcomes, operator-fact mirrors, other agents'
 //! memories — but delete is scoped to what this agent deliberately stored:
 //! task outcomes are the loop's record, and operator facts are the operator's.
-//! The guard is a list-membership check against the agent's own prefix before
-//! the port delete, so a hallucinated or copied address cannot reach anyone
-//! else's rows.
+//! The guard is a list-membership check against the agent's own prefix, and
+//! the delete itself is **label-scoped** (`ContextStore::delete_label`, issue
+//! #1300): it removes exactly this agent's own claims, so a hallucinated or
+//! copied address cannot reach anyone else's rows even when byte-identical
+//! content put their label on the same content address — the other labels
+//! keep the body, which is reaped only with its last claim.
 
 use std::sync::Arc;
 
@@ -331,8 +334,9 @@ impl Tool for MemoryForgetTool {
     fn description(&self) -> &str {
         "Discard one memory YOU deliberately stored with `memory_store`, by the addr \
          `memory_recall` reported — for something that stopped being true or was stored in \
-         error. Cannot touch task outcomes, operator facts, or other agents' memories. \
-         Forgetting an already-forgotten addr is a no-op, not an error."
+         error. Cannot touch task outcomes, operator facts, or other agents' memories; if \
+         someone else stored identical text, only your own copy is forgotten. Forgetting an \
+         already-forgotten addr is a no-op, not an error."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -362,21 +366,21 @@ impl Tool for MemoryForgetTool {
         if addr.is_empty() {
             return Ok(ToolResult::error("`addr` is required.".to_string()));
         }
-        // The scope guard: the addr must belong to THIS agent's own
+        // The scope guard: the addr must carry a label under THIS agent's own
         // deliberate-memory prefix. Checked against the store's own index at
         // call time — not against anything the model asserted — so a copied or
         // hallucinated address outside the prefix is refused, never deleted.
         //
-        // KNOWN RACE (#1300): this check is a snapshot — see
-        // reap_fact_mirror's twin note; the label-scoped delete tracked
-        // there closes it by construction.
-        //
-        // And checked against the WHOLE index, not just the agent's slice:
-        // chunks are content-addressed, so `ContextStore::delete` removes the
-        // address — every label pointing at that body goes with it. If any
-        // OTHER row (another agent's byte-identical memory, a task outcome
-        // with the same text) shares this address, deleting it would delete
-        // theirs too; refuse instead, naming why.
+        // The delete below is label-scoped (`ContextStore::delete_label`,
+        // issue #1300): it removes exactly this agent's own claims on the
+        // address, so a shared address — another agent's byte-identical
+        // memory, a task outcome with the same text — keeps every other row,
+        // and the body is reaped only with its last claim, atomically inside
+        // the port. That closes the two holes the old address-level delete
+        // had: a shared address no longer forces a refusal (which let anyone
+        // make an agent's memory un-forgettable by storing identical text),
+        // and the list below is advisory rather than a racy snapshot guard (a
+        // concurrent identical-content write can no longer lose its row).
         let all = self.mem.context.list(&self.mem.company, "").await?;
         let own_prefix = self.mem.own_prefix();
         let at_addr: Vec<&str> = all
@@ -395,7 +399,12 @@ impl Tool for MemoryForgetTool {
                 "`{addr}` was already gone; nothing to forget."
             )));
         }
-        if !at_addr.iter().any(|label| label.starts_with(&own_prefix)) {
+        let own: Vec<String> = at_addr
+            .iter()
+            .filter(|label| label.starts_with(&own_prefix))
+            .map(|label| label.to_string())
+            .collect();
+        if own.is_empty() {
             return Ok(ToolResult::error(format!(
                 "`{addr}` is not one of your own stored memories, so it cannot be forgotten from \
                  here. Task outcomes are the turn loop's record, and operator facts belong to \
@@ -403,23 +412,26 @@ impl Tool for MemoryForgetTool {
                  ones under `{own_prefix}`."
             )));
         }
-        if at_addr.iter().any(|label| !label.starts_with(&own_prefix)) {
-            return Ok(ToolResult::error(format!(
-                "`{addr}` is shared: this content is stored under other labels too (memory is \
-                 content-addressed, and identical text shares one address), so deleting it would \
-                 delete theirs as well. It stays. If your copy stops being true, store a \
-                 correction with `memory_store` instead."
-            )));
+        let shared = at_addr.iter().any(|label| !label.starts_with(&own_prefix));
+        let chunk_addr = ChunkAddr::new(addr.to_string());
+        let mut removed = false;
+        for label in &own {
+            removed |= self
+                .mem
+                .context
+                .delete_label(&self.mem.company, &chunk_addr, label)
+                .await?;
         }
-        let removed = self
-            .mem
-            .context
-            .delete(&self.mem.company, &ChunkAddr::new(addr.to_string()))
-            .await?;
-        Ok(ToolResult::success(if removed {
-            format!("Forgotten: `{addr}`. It will no longer surface in recall.")
-        } else {
+        Ok(ToolResult::success(if !removed {
             format!("`{addr}` was already gone; nothing to forget.")
+        } else if shared {
+            format!(
+                "Forgotten: `{addr}`. Your memory is gone. The same text is also stored under \
+                 other labels (a task record or another agent's memory), which keep their own \
+                 copies — recall may still surface it from those rows."
+            )
+        } else {
+            format!("Forgotten: `{addr}`. It will no longer surface in recall.")
         }))
     }
 }
@@ -528,12 +540,14 @@ mod test {
         }
     }
 
-    /// Content addressing means byte-identical bodies share ONE address, and
-    /// the port deletes by address. A forget whose address is shared with any
-    /// other row — another agent's identical memory here — must refuse, and
-    /// both rows must survive.
+    /// Content addressing means byte-identical bodies share ONE address. A
+    /// forget of a shared address removes exactly the caller's own claim
+    /// (label-scoped delete, #1300): the other agent's row and the body both
+    /// survive, and the caller is told the text lives on under other labels.
+    /// This replaces the old refusal, which let any agent make another's
+    /// memory permanently un-forgettable by storing identical text.
     #[tokio::test]
-    async fn forget_refuses_a_shared_address_instead_of_deleting_both() {
+    async fn forget_of_a_shared_address_removes_only_the_callers_claim() {
         let dir = tempfile::tempdir().unwrap();
         let company = CompanyId::new("acme");
         let context = ctx(dir.path());
@@ -550,22 +564,37 @@ mod test {
             .await
             .unwrap();
 
-        let refused = ceo_forget
+        let forgotten = ceo_forget
             .execute(json!({"addr": addr.clone()}))
             .await
             .unwrap();
-        assert!(refused.is_error, "shared address must refuse: {refused:?}");
-        assert!(refused.text().contains("shared"));
-        // Both label rows survive.
+        assert!(
+            !forgotten.is_error,
+            "a shared address must forget the caller's own claim: {forgotten:?}"
+        );
+        assert!(
+            forgotten.text().contains("other labels"),
+            "the reply must say the text lives on elsewhere: {forgotten:?}"
+        );
+        // Exactly the researcher's row remains, and the body with it.
         let rows = context
             .list(&company, AGENT_MEMORY_LABEL_PREFIX)
             .await
             .unwrap();
-        assert_eq!(
-            rows.iter().filter(|m| m.addr.as_ref() == addr).count(),
-            2,
-            "no row may vanish on a refusal"
+        let labels: Vec<&str> = rows
+            .iter()
+            .filter(|m| m.addr.as_ref() == addr)
+            .map(|m| m.label.as_str())
+            .collect();
+        assert_eq!(labels.len(), 1, "only the ceo's claim may go: {labels:?}");
+        assert!(
+            labels[0].starts_with("agent-memory/researcher/"),
+            "{labels:?}"
         );
+        context
+            .peek(&company, &ChunkAddr::new(addr), None)
+            .await
+            .expect("the body must survive under the researcher's claim");
     }
 
     /// The regression lock the #1290 review found missing: deleting the

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -3681,6 +3681,17 @@ mod tests {
             guard.retain(|(a, _)| a != addr);
             Ok(guard.len() < before)
         }
+        async fn delete_label(
+            &self,
+            _id: &CompanyId,
+            addr: &ChunkAddr,
+            label: &str,
+        ) -> crate::Result<bool> {
+            let mut guard = self.chunks.lock().unwrap();
+            let before = guard.len();
+            guard.retain(|(a, c)| !(a == addr && c.label == label));
+            Ok(guard.len() < before)
+        }
         async fn search(
             &self,
             _id: &CompanyId,

--- a/src/ports/context.rs
+++ b/src/ports/context.rs
@@ -46,14 +46,37 @@ pub trait ContextStore: Send + Sync {
     async fn search(&self, id: &CompanyId, query: &str, limit: usize) -> Result<Vec<ChunkHit>>;
     /// Permanently removes the chunk at `addr`, returning whether it existed.
     ///
-    /// Address-level: chunks are content-addressed, so on backends where one
-    /// address can carry several index entries (fs), the whole address goes —
-    /// every label that pointed at that body. `false` means nothing was there,
-    /// which callers surface honestly rather than treating as an error: a
-    /// forget of something already gone is a no-op, not a fault.
+    /// Address-level: chunks are content-addressed, and one address can carry
+    /// several labels (a byte-identical body stored under each — see
+    /// [`Self::delete_label`] for the semantics that made every backend keep
+    /// them), so the whole address goes — every label that pointed at that
+    /// body. `false` means nothing was there, which callers surface honestly
+    /// rather than treating as an error: a forget of something already gone is
+    /// a no-op, not a fault.
     ///
     /// Required, no default — a defaulted `Ok(false)` would let a backend
     /// silently serve a forget that forgets nothing, the exact dishonesty the
     /// null-engine warnings exist to prevent.
     async fn delete(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool>;
+    /// Removes `label`'s claim on the chunk at `addr`, returning whether that
+    /// (addr, label) pairing existed.
+    ///
+    /// Label-scoped where [`Self::delete`] is address-level (issue #1300).
+    /// Chunks are content-addressed, so byte-identical bodies from different
+    /// writers share one address under different labels; every backend keeps
+    /// one index entry per (addr, label) — set semantics, a re-`put` of an
+    /// identical (body, label) adds nothing — and this call removes exactly
+    /// one such entry. The body is reaped when, and only when, the last label
+    /// goes, and that reap is conditional *inside* the backend (a lock, a
+    /// transaction, or a predicated delete): a concurrent `put` of identical
+    /// content under another label can never lose its row to this call, which
+    /// is the check-then-delete race the callers' old snapshot guards carried.
+    ///
+    /// `false` means the pairing was not there (wrong label, or already
+    /// removed) — a no-op for idempotent retries, same as [`Self::delete`].
+    ///
+    /// Required, no default, for [`Self::delete`]'s reason: a defaulted
+    /// `Ok(false)` would let a backend silently serve a forget that forgets
+    /// nothing.
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool>;
 }

--- a/src/ports/context.rs
+++ b/src/ports/context.rs
@@ -75,8 +75,165 @@ pub trait ContextStore: Send + Sync {
     /// `false` means the pairing was not there (wrong label, or already
     /// removed) — a no-op for idempotent retries, same as [`Self::delete`].
     ///
-    /// Required, no default, for [`Self::delete`]'s reason: a defaulted
-    /// `Ok(false)` would let a backend silently serve a forget that forgets
-    /// nothing.
-    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool>;
+    /// # The default, and why it is not `Ok(false)`
+    ///
+    /// This port is publicly re-exported and `RuntimeBuilder::with_context`
+    /// is an operator injection seam, so a required method here would be a
+    /// source break for a backend maintained outside this crate. It is
+    /// defaulted instead — but a defaulted `Ok(false)` would let such a
+    /// backend silently serve a forget that forgets nothing, and a defaulted
+    /// `delete` would let it delete a label the caller never owned, which is
+    /// the griefing vector this method exists to close.
+    ///
+    /// So the default does the honest thing with only the other port methods:
+    /// it reads the index, removes the address when `label` is its **only**
+    /// claim, answers `false` when the pairing is not there, and refuses when
+    /// the address is shared — the exact behaviour the callers had before
+    /// label-scoped delete existed, and never worse than it. Its weakness is
+    /// the one that motivated this method: the read and the delete are two
+    /// steps, so a byte-identical write landing between them loses its row.
+    /// **Every backend in this crate overrides it** with a version where the
+    /// claim removal and the last-claim reap are one atomic step; a backend
+    /// that does not should treat the override as the fix, not the default.
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool> {
+        let index = self.list(id, "").await?;
+        let at_addr: Vec<&ChunkMeta> = index.iter().filter(|meta| &meta.addr == addr).collect();
+        if !at_addr.iter().any(|meta| meta.label == label) {
+            return Ok(false);
+        }
+        if at_addr.iter().all(|meta| meta.label == label) {
+            return self.delete(id, addr).await;
+        }
+        Err(crate::error::OpenCompanyError::Store(format!(
+            "this context backend cannot remove one label's claim on `{}`, and the address is \
+             shared with another label, so removing it would take that one too; the backend \
+             needs to implement ContextStore::delete_label",
+            addr.as_ref()
+        )))
+    }
+}
+
+#[cfg(test)]
+mod default_delete_label_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A backend that implements the port as it stood BEFORE label-scoped
+    /// delete existed — no `delete_label` override. This is the shape an
+    /// operator-supplied store injected through `RuntimeBuilder::with_context`
+    /// has, and the reason the method is defaulted rather than required.
+    #[derive(Default)]
+    struct LegacyStore {
+        rows: Mutex<Vec<(ChunkAddr, String)>>,
+    }
+
+    #[async_trait]
+    impl ContextStore for LegacyStore {
+        async fn put(&self, _: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
+            let addr = ChunkAddr::new(crate::store::content_address(&chunk.body));
+            self.rows.lock().unwrap().push((addr.clone(), chunk.label));
+            Ok(addr)
+        }
+        async fn list(&self, _: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(_, label)| label.starts_with(prefix))
+                .map(|(addr, label)| ChunkMeta {
+                    addr: addr.clone(),
+                    label: label.clone(),
+                    len: 0,
+                    stored_at_millis: 0,
+                })
+                .collect())
+        }
+        async fn peek(
+            &self,
+            _: &CompanyId,
+            _: &ChunkAddr,
+            _: Option<Range<usize>>,
+        ) -> Result<String> {
+            Ok(String::new())
+        }
+        async fn search(&self, _: &CompanyId, _: &str, _: usize) -> Result<Vec<ChunkHit>> {
+            Ok(Vec::new())
+        }
+        async fn delete(&self, _: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
+            let mut rows = self.rows.lock().unwrap();
+            let before = rows.len();
+            rows.retain(|(have, _)| have != addr);
+            Ok(rows.len() < before)
+        }
+    }
+
+    fn company() -> CompanyId {
+        CompanyId::new("acme")
+    }
+
+    async fn put(store: &LegacyStore, label: &str, body: &str) -> ChunkAddr {
+        store
+            .put(
+                &company(),
+                ContextChunk {
+                    label: label.to_string(),
+                    body: body.to_string(),
+                },
+            )
+            .await
+            .unwrap()
+    }
+
+    /// The sole claim is removed with its body — the same outcome an
+    /// overriding backend gives, so a legacy store keeps working.
+    #[tokio::test]
+    async fn the_default_removes_a_sole_claim() {
+        let store = LegacyStore::default();
+        let addr = put(&store, "notes/one", "body").await;
+        assert!(
+            store
+                .delete_label(&company(), &addr, "notes/one")
+                .await
+                .unwrap()
+        );
+        assert!(store.list(&company(), "").await.unwrap().is_empty());
+    }
+
+    /// A pairing that is not there answers `false`, not an error — the
+    /// idempotent-retry contract every backend shares.
+    #[tokio::test]
+    async fn the_default_answers_false_for_an_absent_pairing() {
+        let store = LegacyStore::default();
+        let addr = put(&store, "notes/one", "body").await;
+        assert!(
+            !store
+                .delete_label(&company(), &addr, "notes/other")
+                .await
+                .unwrap()
+        );
+        assert_eq!(store.list(&company(), "").await.unwrap().len(), 1);
+    }
+
+    /// The case the griefing vector lives in: a shared address REFUSES rather
+    /// than taking the other label's row with it. Never worse than the
+    /// pre-#1300 callers, which refused here too — and emphatically not the
+    /// over-delete a `delete`-shaped default would have produced.
+    #[tokio::test]
+    async fn the_default_refuses_a_shared_address_rather_than_over_deleting() {
+        let store = LegacyStore::default();
+        let addr = put(&store, "notes/mine", "same body").await;
+        assert_eq!(put(&store, "notes/theirs", "same body").await, addr);
+
+        let refused = store.delete_label(&company(), &addr, "notes/mine").await;
+        assert!(
+            refused.is_err(),
+            "a shared address must refuse: {refused:?}"
+        );
+        assert_eq!(
+            store.list(&company(), "").await.unwrap().len(),
+            2,
+            "neither claim may be removed by a refusal"
+        );
+    }
 }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2012,10 +2012,13 @@ pub struct ChunkMeta {
     /// (see `server::ops::memory::memory_stats`).
     ///
     /// Chunks are append-only and never rewritten, so this only ever moves for
-    /// a *new* chunk. Backends differ on a re-`put` of an identical body —
-    /// sqlite/mongo dedupe on the content address and keep the first write,
-    /// the fs index appends a second line — so read freshness as the max
-    /// across chunks rather than assuming one row per body.
+    /// a *new* claim: every backend keeps one row per (addr, label) — a
+    /// re-`put` of an identical (body, label) is a no-op everywhere (#1300).
+    /// A *new* label on an existing body stamps per-label on fs/sqlite and
+    /// reports the address's first-write stamp on the single-record backends
+    /// (mongodb, the provider facade, the tinycortex engine) — so read
+    /// freshness as the max across chunks rather than assuming one row per
+    /// body.
     #[serde(default)]
     pub stored_at_millis: u64,
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -3752,6 +3752,15 @@ mod test {
         async fn delete(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
             self.inner.delete(id, addr).await
         }
+
+        async fn delete_label(
+            &self,
+            id: &CompanyId,
+            addr: &ChunkAddr,
+            label: &str,
+        ) -> Result<bool> {
+            self.inner.delete_label(id, addr, label).await
+        }
     }
 
     /// Issue #1175: a cycle used to load 32 recent traces *and the whole context

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -10,15 +10,16 @@
 //! the `EventLog` per the Operator-rights section of
 //! `docs/spec/company-brain/memory.md`.
 //!
-//! ## Known limitation (flagged seam)
+//! ## The delete → reap seam
 //!
 //! Deleting a fact removes it from the `FactStore` AND reaps its mirrored
 //! `operator-fact/{id}` context chunk — the delete port this comment once
 //! said was missing landed with #1290, and leaving the reap unwired would
 //! have kept showing the operator "deleted" while agents still recalled it.
-//! The reap honors the shared-address rule: chunks are content-addressed, so
-//! a mirror whose byte-identical body is indexed under any OTHER label is
-//! left in place rather than deleting someone else's row.
+//! The reap is label-scoped since #1300: chunks are content-addressed, so a
+//! mirror whose byte-identical body is indexed under any OTHER label loses
+//! exactly the mirror's own claim — the other label keeps the body, and the
+//! body goes only with its last claim, atomically inside the port.
 
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
@@ -62,8 +63,8 @@ mod label_lockstep_test {
 }
 
 /// Label prefix for the [`ContextStore`](crate::ports::ContextStore) mirror of
-/// an operator-authored fact. Keyed by fact id so a future delete port can reap
-/// the mirror when the fact is deleted (today it lingers — see the module doc).
+/// an operator-authored fact. Keyed by fact id so [`reap_fact_mirror`] can
+/// find and remove the mirror's claim when the fact is deleted.
 const OPERATOR_FACT_PREFIX: &str = "operator-fact";
 
 /// Label prefix under which the harness stores completed task outcomes.
@@ -195,8 +196,9 @@ fn split_title_body(body: &str) -> (String, String) {
 /// symptom reached by a second route, and past the cap the sort in
 /// [`capped_newest_first`] was the only thing keeping it out of the list at
 /// all. The console filters by origin client-side, so the grouping bought
-/// nothing. The `id` tie-break carries the addr, so chunks sharing a
-/// millisecond keep a total, call-stable order, as the cap's sort does.
+/// nothing. The `id` tie-break carries the addr AND the label, so chunks
+/// sharing a millisecond — including two labels claiming one address (#1300)
+/// — keep a total, call-stable order, as the cap's sort does.
 fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntry> {
     let needle = query.map(|q| q.to_lowercase());
     let mirror_prefix = format!("{OPERATOR_FACT_PREFIX}/");
@@ -261,7 +263,12 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
         entries.push(MemoryEntry {
             // Prefix so a context row's id can never collide with a fact id
             // (delete targets fact ids only; this keeps React keys unique too).
-            id: format!("ctx:{}", chunk.addr),
+            // The LABEL is part of the id, not just the address: chunks are
+            // content-addressed and one address carries one row per label
+            // claiming it (#1300), so two rows here can share an address —
+            // byte-identical text two agents both remembered. Keyed by address
+            // alone they would collide, and the console renders these by id.
+            id: format!("ctx:{}:{}", chunk.addr, chunk.label),
             kind: None,
             origin,
             // A document is material the operator supplied, so they may take
@@ -433,8 +440,10 @@ async fn list_facts(
 /// Every backend lists oldest-first, so capping the head would pin the Brain
 /// view to the oldest `cap` chunks forever — once a company crossed the cap, a
 /// new memory could never appear again. Sort newest-first BEFORE capping; the
-/// addr tie-break keeps the order total, so chunks stamped in the same
-/// millisecond cannot swap places between calls.
+/// (addr, label) tie-break keeps the order total, so chunks stamped in the
+/// same millisecond cannot swap places between calls. The label is part of
+/// that tie-break because one address carries one row per label claiming it
+/// (#1300), so the addr alone no longer separates two rows.
 fn capped_newest_first(metas: Vec<ChunkMeta>, mirror_prefix: &str, cap: usize) -> Vec<ChunkMeta> {
     let mut metas: Vec<ChunkMeta> = metas
         .into_iter()
@@ -444,6 +453,7 @@ fn capped_newest_first(metas: Vec<ChunkMeta>, mirror_prefix: &str, cap: usize) -
         b.stored_at_millis
             .cmp(&a.stored_at_millis)
             .then_with(|| a.addr.as_ref().cmp(b.addr.as_ref()))
+            .then_with(|| a.label.cmp(&b.label))
     });
     metas.truncate(cap);
     metas
@@ -545,7 +555,7 @@ async fn delete_fact(
                 fact_id = %fact_id,
                 error = %err,
                 "fact deleted but its context mirror could not be reaped; \
-                 recall may keep serving it until a retry or #1300's reaper"
+                 recall may keep serving it until a retry"
             );
         }
         // Journal the operator deletion to the event log (audit trail).
@@ -567,17 +577,15 @@ async fn delete_fact(
     }
 }
 
-/// Removes the `operator-fact/{fact_id}` mirror chunk(s), shared-address
-/// aware: an address also carrying any label OUTSIDE this mirror's own is
-/// skipped — deleting it would delete that other row too (content
-/// addressing; the same rule `memory_forget` enforces).
-///
-/// KNOWN RACE (#1300): the shared-label check is a snapshot; a write of
-/// byte-identical content landing between the check and the delete loses its
-/// row. The port has no conditional delete to close this — that is exactly
-/// the label-scoped-delete work item in #1300, which fixes it by
-/// construction. Until then the window is one operator HTTP call wide and
-/// requires an adversarially-timed identical-content write.
+/// Removes the `operator-fact/{fact_id}` mirror's claim on its chunk(s),
+/// label-scoped (`ContextStore::delete_label`, issue #1300): exactly the
+/// mirror's own index entry goes, and the body is reaped only when no other
+/// label claims it — decided atomically inside the port, so a write of
+/// byte-identical content landing mid-reap keeps its row by construction
+/// (this function used to snapshot-check for shared labels and then delete
+/// the whole address, which both raced that write and left a shared mirror's
+/// row behind forever; now the shared case removes the mirror's claim and
+/// the other label keeps the body).
 pub(crate) async fn reap_fact_mirror(
     context: &dyn crate::ports::ContextStore,
     company: &crate::ports::CompanyId,
@@ -586,12 +594,9 @@ pub(crate) async fn reap_fact_mirror(
     let mirror_label = format!("{OPERATOR_FACT_PREFIX}/{fact_id}");
     let all = context.list(company, "").await?;
     for meta in all.iter().filter(|m| m.label == mirror_label) {
-        let shared = all
-            .iter()
-            .any(|m| m.addr == meta.addr && m.label != mirror_label);
-        if !shared {
-            context.delete(company, &meta.addr).await?;
-        }
+        context
+            .delete_label(company, &meta.addr, &mirror_label)
+            .await?;
     }
     Ok(())
 }
@@ -604,10 +609,13 @@ mod reap_test {
     use crate::store::FsContextStore;
     use std::sync::Arc;
 
-    /// Deleting a fact reaps its mirror; a mirror whose content is shared
-    /// with another label survives (the other row must not vanish).
+    /// Deleting a fact reaps its mirror. A mirror whose content is shared
+    /// with another label loses exactly the mirror's own claim (label-scoped
+    /// delete, #1300): the other label keeps the body, and — unlike the old
+    /// shared-address skip — the mirror row itself no longer lingers in the
+    /// index serving a deleted fact.
     #[tokio::test]
-    async fn the_mirror_is_reaped_unless_its_address_is_shared() {
+    async fn the_mirror_is_reaped_and_a_shared_body_survives_under_its_other_label() {
         let dir = tempfile::tempdir().unwrap();
         let context: Arc<dyn ContextStore> =
             Arc::new(FsContextStore::new(dir.path().to_path_buf()));
@@ -631,7 +639,8 @@ mod reap_test {
             "the unshared mirror must be reaped"
         );
 
-        // Identical bodies share one address: the reap must leave it.
+        // Identical bodies share one address: the reap removes the mirror's
+        // claim, and the agent's row keeps the body.
         let shared = context
             .put(
                 &company,
@@ -658,7 +667,20 @@ mod reap_test {
         context
             .peek(&company, &shared, None)
             .await
-            .expect("a shared-address mirror must survive the reap");
+            .expect("the body must survive under the agent's label");
+        let labels: Vec<String> = context
+            .list(&company, "")
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|m| m.addr == shared)
+            .map(|m| m.label)
+            .collect();
+        assert_eq!(
+            labels,
+            ["agent-memory/ceo/note"],
+            "the mirror's claim must be gone; only the agent's remains"
+        );
     }
 }
 
@@ -833,7 +855,35 @@ mod combined_list_tests {
             None,
         );
         let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
-        assert_eq!(ids, vec!["ctx:a", "ctx:z"]);
+        assert_eq!(
+            ids,
+            vec!["ctx:a:task-outcome/agent-1", "ctx:z:agent-1/z"],
+            "the id carries addr then label, so the tie-break stays addr-first"
+        );
+    }
+
+    /// One address, two labels — the #1300 shape — renders as two rows with
+    /// DISTINCT ids. Keyed by address alone they collided, and the console
+    /// renders these rows by id (React keys, row identity).
+    #[test]
+    fn two_labels_on_one_address_render_as_two_distinct_rows() {
+        let entries = context_entries(
+            vec![
+                chunk_at_addr("shared", "agent-memory/ann/note", "same text", 500),
+                chunk_at_addr("shared", "agent-memory/bob/note", "same text", 500),
+            ],
+            None,
+        );
+        let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "ctx:shared:agent-memory/ann/note",
+                "ctx:shared:agent-memory/bob/note"
+            ],
+        );
+        let sources: Vec<&str> = entries.iter().map(|e| e.source.as_str()).collect();
+        assert_eq!(sources, vec!["ann", "bob"], "each row keeps its own author");
     }
 
     #[test]
@@ -1047,6 +1097,15 @@ mod route_tests {
         }
 
         async fn delete(&self, _id: &CompanyId, _addr: &ChunkAddr) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn delete_label(
+            &self,
+            _id: &CompanyId,
+            _addr: &ChunkAddr,
+            _label: &str,
+        ) -> crate::Result<bool> {
             Ok(false)
         }
     }

--- a/src/server/ops/memory_ingest.rs
+++ b/src/server/ops/memory_ingest.rs
@@ -245,16 +245,16 @@ async fn forget_document(
     for meta in all.iter().filter(|m| m.label.starts_with(&prefix)) {
         // Chunks are content-addressed, so one address can carry several
         // labels: two identical paragraphs in one folder drop, or a document
-        // re-dropped under a new name. Deleting an address another label still
-        // points at would delete that row too — the shared-address rule the
-        // fact mirror's reap follows for the same reason.
-        let shared = all
-            .iter()
-            .any(|m| m.addr == meta.addr && !m.label.starts_with(&prefix));
-        if shared {
-            continue;
-        }
-        if context.delete(company.id(), &meta.addr).await? {
+        // re-dropped under a new name. The delete is label-scoped (#1300):
+        // exactly this document's claim goes, any other label keeps the body,
+        // and the body is reaped with its last claim atomically inside the
+        // port — the same shape the fact mirror's reap uses, minus the old
+        // snapshot guard that skipped shared chunks entirely (which left a
+        // deleted document's claims listed forever).
+        if context
+            .delete_label(company.id(), &meta.addr, &meta.label)
+            .await?
+        {
             forgotten += 1;
         }
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -33,8 +33,8 @@ use crate::ports::skills_state::{SkillSource, SkillState, SkillStateStore};
 use crate::ports::store::CompanyStore;
 use crate::ports::tasks::{TaskRecord, TaskStore};
 use crate::ports::types::{
-    ChunkAddr, CompanyEvent, CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq,
-    LedgerEntry, TemplateProvenance,
+    ChunkAddr, ChunkMeta, CompanyEvent, CompanyId, CompanyRecord, CompressedTrace, ContextChunk,
+    EventSeq, LedgerEntry, TemplateProvenance,
 };
 use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
 use crate::ports::users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore};
@@ -2345,11 +2345,13 @@ pub async fn assert_fact_store(facts: Arc<dyn FactStore>) {
 /// so without a per-chunk stamp the stat can only reflect operator-authored
 /// facts (see `server::ops::memory::memory_stats`).
 ///
-/// Deliberately says nothing about re-`put`ting an identical body: the backends
-/// genuinely differ there (sqlite/mongo dedupe on the content address and keep
-/// the first write, the fs index appends a second line), and pinning one
-/// behaviour here would assert a contract the suite's own backends do not share.
-/// Readers of the stamp take the max across chunks for that reason.
+/// Deliberately says nothing about a re-`put`'s effect on the stamp: every
+/// backend keeps one claim per (addr, label) since #1300 (see
+/// [`assert_identical_body_two_labels`]), but a *new* label on an existing
+/// body stamps per-label on fs/sqlite and keeps the address's first-write
+/// stamp on the single-record backends (mongodb, the provider facade, the
+/// tinycortex engine). Readers of the stamp take the max across chunks for
+/// that reason.
 pub async fn assert_context_chunk_stamps(context: Arc<dyn ContextStore>) {
     let alpha = CompanyId::new("alpha");
     let beta = CompanyId::new("beta");
@@ -2473,6 +2475,291 @@ pub async fn assert_multibyte_bodies_survive_search_and_ranged_peek(
 
     // A range ending inside the first "é" widens to its boundary.
     assert_eq!(context.peek(&alpha, &addr, Some(0..1)).await.unwrap(), "é");
+}
+
+/// Asserts byte-identical bodies under two labels both land (issue #1300):
+/// one content address, one claim per (addr, label), on every backend.
+///
+/// Before #1300 the backends diverged exactly here — the fs index appended a
+/// row per put (including duplicates), while sqlite/mongodb/the provider
+/// facade were first-write-wins on the address, answering a success receipt
+/// for a second label that never landed. A caller listing by their label then
+/// found nothing on those backends and everything on fs, and nothing pinned
+/// either behaviour because every other case in this suite uses distinct
+/// bodies.
+pub async fn assert_identical_body_two_labels(context: Arc<dyn ContextStore>) {
+    let company = CompanyId::new("alpha");
+    let twin = "twin body: byte-identical under two labels";
+    let first = context
+        .put(
+            &company,
+            ContextChunk {
+                label: "labels/first".to_string(),
+                body: twin.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    let second = context
+        .put(
+            &company,
+            ContextChunk {
+                label: "labels/second".to_string(),
+                body: twin.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(first, second, "identical bodies share one content address");
+
+    let labels_at = |metas: &[ChunkMeta]| -> Vec<String> {
+        metas
+            .iter()
+            .filter(|m| m.addr == first)
+            .map(|m| m.label.clone())
+            .collect()
+    };
+    let mut labels = labels_at(&context.list(&company, "labels/").await.unwrap());
+    labels.sort();
+    assert_eq!(
+        labels,
+        ["labels/first", "labels/second"],
+        "both labels must claim the shared address"
+    );
+
+    // And each label's claim is findable through its own prefix — the exact
+    // read that used to answer empty on the first-write-wins backends.
+    let second_only = context.list(&company, "labels/second").await.unwrap();
+    assert_eq!(labels_at(&second_only), ["labels/second"]);
+
+    // Set semantics: a re-put of an identical (body, label) adds nothing.
+    context
+        .put(
+            &company,
+            ContextChunk {
+                label: "labels/first".to_string(),
+                body: twin.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    let again = labels_at(&context.list(&company, "labels/").await.unwrap());
+    assert_eq!(
+        again
+            .iter()
+            .filter(|l| l.as_str() == "labels/first")
+            .count(),
+        1,
+        "a re-put of an identical (body, label) must not duplicate the claim: {again:?}"
+    );
+}
+
+/// Asserts [`ContextStore::delete_label`] removes one claim, reaps the body
+/// with the last claim, and answers `false` for claims that are not there
+/// (issue #1300) — and that address-level [`ContextStore::delete`] still
+/// takes every claim at once.
+pub async fn assert_delete_label_scoped(context: Arc<dyn ContextStore>) {
+    let company = CompanyId::new("alpha");
+    let body = "shared claim body for the label-scoped delete";
+    let addr = context
+        .put(
+            &company,
+            ContextChunk {
+                label: "scoped/mine".to_string(),
+                body: body.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    context
+        .put(
+            &company,
+            ContextChunk {
+                label: "scoped/theirs".to_string(),
+                body: body.to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !context
+            .delete_label(&company, &addr, "scoped/absent")
+            .await
+            .unwrap(),
+        "an absent label answers false"
+    );
+    assert!(
+        context
+            .delete_label(&company, &addr, "scoped/mine")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !context
+            .delete_label(&company, &addr, "scoped/mine")
+            .await
+            .unwrap(),
+        "a second delete of the same claim answers false"
+    );
+
+    let labels: Vec<String> = context
+        .list(&company, "scoped/")
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|m| m.addr == addr)
+        .map(|m| m.label)
+        .collect();
+    assert_eq!(
+        labels,
+        ["scoped/theirs"],
+        "only the named label's claim goes"
+    );
+    assert_eq!(
+        context.peek(&company, &addr, None).await.unwrap(),
+        body,
+        "the body survives while any label claims it"
+    );
+
+    assert!(
+        context
+            .delete_label(&company, &addr, "scoped/theirs")
+            .await
+            .unwrap()
+    );
+    assert!(
+        context
+            .list(&company, "scoped/")
+            .await
+            .unwrap()
+            .iter()
+            .all(|m| m.addr != addr),
+        "no claim may remain after the last label goes"
+    );
+    assert!(
+        context.peek(&company, &addr, None).await.is_err(),
+        "the body is reaped with its last claim"
+    );
+    assert!(
+        !context
+            .delete_label(&company, &addr, "scoped/theirs")
+            .await
+            .unwrap(),
+        "a fully-reaped address answers false"
+    );
+
+    // Address-level delete still takes every claim at once — the operator
+    // semantics `delete_label` deliberately is not.
+    let addr = context
+        .put(
+            &company,
+            ContextChunk {
+                label: "scoped/a".to_string(),
+                body: "whole-address body".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    context
+        .put(
+            &company,
+            ContextChunk {
+                label: "scoped/b".to_string(),
+                body: "whole-address body".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(context.delete(&company, &addr).await.unwrap());
+    assert!(
+        context
+            .list(&company, "scoped/")
+            .await
+            .unwrap()
+            .iter()
+            .all(|m| m.addr != addr),
+        "address-level delete takes every label's claim"
+    );
+    assert!(!context.delete(&company, &addr).await.unwrap());
+}
+
+/// Asserts a `delete_label` cannot lose a byte-identical write that lands
+/// beside it (issue #1300's TOCTOU half).
+///
+/// The defect this locks: both shared-address guards used to read a snapshot,
+/// decide nothing else claimed the address, and then delete it — so a write
+/// of identical content under another label landing in that window lost its
+/// row. `delete_label` closes it *by construction* only if each backend makes
+/// the claim-removal and the last-claim reap one atomic step (a lock, a
+/// transaction, or a conditional delete). This drives both operations
+/// concurrently, many times, and demands the second writer's claim and body
+/// survive every round.
+pub async fn assert_delete_label_survives_a_concurrent_identical_put(
+    context: Arc<dyn ContextStore>,
+) {
+    let company = CompanyId::new("alpha");
+    // Each round uses a fresh body, so a round can never be satisfied by the
+    // previous round's surviving row.
+    for round in 0..32 {
+        let body = format!("racing body {round}");
+        let addr = context
+            .put(
+                &company,
+                ContextChunk {
+                    label: "race/first".to_string(),
+                    body: body.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let deleter = {
+            let context = Arc::clone(&context);
+            let company = company.clone();
+            let addr = addr.clone();
+            tokio::spawn(async move { context.delete_label(&company, &addr, "race/first").await })
+        };
+        let writer = {
+            let context = Arc::clone(&context);
+            let company = company.clone();
+            let body = body.clone();
+            tokio::spawn(async move {
+                context
+                    .put(
+                        &company,
+                        ContextChunk {
+                            label: "race/second".to_string(),
+                            body,
+                        },
+                    )
+                    .await
+            })
+        };
+        deleter.await.unwrap().unwrap();
+        writer.await.unwrap().unwrap();
+
+        let labels: Vec<String> = context
+            .list(&company, "race/")
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|m| m.addr == addr)
+            .map(|m| m.label)
+            .collect();
+        assert!(
+            labels.iter().any(|label| label == "race/second"),
+            "round {round}: the concurrent writer's claim was lost to the delete: {labels:?}"
+        );
+        assert_eq!(
+            context.peek(&company, &addr, None).await.unwrap(),
+            body,
+            "round {round}: the body was reaped while a claim still held it"
+        );
+
+        // Leave nothing behind for the next round.
+        context.delete(&company, &addr).await.unwrap();
+    }
 }
 
 /// Asserts the [`UsageMeter`] contract: isolation, record, and windowed query.

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2695,6 +2695,17 @@ pub async fn assert_delete_label_scoped(context: Arc<dyn ContextStore>) {
 /// transaction, or a conditional delete). This drives both operations
 /// concurrently, many times, and demands the second writer's claim and body
 /// survive every round.
+///
+/// What it can and cannot prove, stated plainly: the backends that serialise
+/// the two calls against each other (fs on its index lock, sqlite on its
+/// connection, the facade and the engine on their own locks) satisfy this
+/// whatever the interleaving, so here it is a **regression lock** — it fails
+/// if someone removes that serialisation. Only mongodb runs the two against a
+/// server that can genuinely interleave them, and it is the backend whose
+/// atomicity rests on a conditional delete rather than a lock, which is the
+/// case most worth driving. The tasks are spawned rather than awaited in
+/// order, so they interleave at every `.await` even on a current-thread
+/// runtime.
 pub async fn assert_delete_label_survives_a_concurrent_identical_put(
     context: Arc<dyn ContextStore>,
 ) {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -7,7 +7,7 @@
 //! Those locks live in one process-wide registry (`path_lock`) rather than on
 //! each store, so two instances over one bundle actually meet (issue #388).
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -1293,6 +1293,25 @@ impl FsContextStore {
     }
 }
 
+/// Removes the unreferenced blob for `addr`, best-effort: the index rows are
+/// already gone, so a blob that will not delete is orphaned and invisible
+/// (list and search are index-driven) rather than turned into an error that
+/// would tell the caller nothing was deleted after the index half already was.
+async fn reap_blob(bundle: &Bundle, addr: &str) {
+    let blob_path = bundle.context_blob(addr);
+    match tokio::fs::remove_file(&blob_path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::warn!(
+            addr = %addr,
+            path = %blob_path.display(),
+            error = %e,
+            "context index rows removed but the blob would not delete; \
+             leaving an orphaned, unreferenced blob"
+        ),
+    }
+}
+
 #[async_trait]
 impl ContextStore for FsContextStore {
     async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
@@ -1315,6 +1334,13 @@ impl ContextStore for FsContextStore {
         // rename publish guarantees the reader full old bytes or full new
         // bytes, never a truncated file.
         write_atomic(&blob_path, &chunk.body).await?;
+        // A plain append, deliberately: the (addr, label) set semantics #1300
+        // pins are applied when the index is READ (see `list`), not by
+        // checking membership here. Checking here would read and parse the
+        // whole index on every write — and the ingest path writes one chunk
+        // per document fragment, so a single folder drop would turn into a
+        // quadratic scan. Appending keeps a write O(1), as it has always
+        // been; a duplicate line costs one row and reads back as one claim.
         let entry = IndexEntry {
             addr: addr.clone(),
             label: chunk.label,
@@ -1327,16 +1353,29 @@ impl ContextStore for FsContextStore {
 
     async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
         let index = read_jsonl::<IndexEntry>(&self.bundle(id).context_index_jsonl()).await?;
-        Ok(index
-            .into_iter()
-            .filter(|e| e.label.starts_with(prefix))
-            .map(|e| ChunkMeta {
-                addr: ChunkAddr::new(e.addr),
-                label: e.label,
-                len: e.len,
-                stored_at_millis: e.stored_at_millis,
-            })
-            .collect())
+        // One claim per (addr, label) — the set semantics #1300 pins on every
+        // backend — applied here rather than in `put`, which stays an O(1)
+        // append (see its comment). The FIRST row for a pair wins, so the
+        // stamp reported is the first write's, matching the other backends'
+        // first-write-wins; later duplicate rows are a re-`put` of content
+        // already claimed under that label and carry nothing new.
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        let mut out = Vec::new();
+        for entry in index {
+            if !entry.label.starts_with(prefix) {
+                continue;
+            }
+            if !seen.insert((entry.addr.clone(), entry.label.clone())) {
+                continue;
+            }
+            out.push(ChunkMeta {
+                addr: ChunkAddr::new(entry.addr),
+                label: entry.label,
+                len: entry.len,
+                stored_at_millis: entry.stored_at_millis,
+            });
+        }
+        Ok(out)
     }
 
     async fn peek(
@@ -1376,7 +1415,7 @@ impl ContextStore for FsContextStore {
         }
         crate::store::fs_ops::rewrite_jsonl(&index_path, &kept).await?;
         // The blob is shared by every index entry bearing this address (put
-        // appends an entry per write, all pointing at one content-addressed
+        // appends an entry per label, all pointing at one content-addressed
         // file). The filter above removed all of them, so the blob is
         // unreferenced and goes too — best-effort, because the index is the
         // source of truth and its rows are already gone: an orphaned blob is
@@ -1386,17 +1425,35 @@ impl ContextStore for FsContextStore {
         // already held the body — nothing new is reachable. An `Err` here
         // would instead tell the caller nothing was deleted after the index
         // half already was.
-        let blob_path = bundle.context_blob(addr.as_ref());
-        match tokio::fs::remove_file(&blob_path).await {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => tracing::warn!(
-                addr = %addr,
-                path = %blob_path.display(),
-                error = %e,
-                "context index rows removed but the blob would not delete; \
-                 leaving an orphaned, unreferenced blob"
-            ),
+        reap_blob(&bundle, addr.as_ref()).await;
+        Ok(true)
+    }
+
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool> {
+        let bundle = self.bundle(id);
+        let index_path = bundle.context_index_jsonl();
+        let lock = path_lock(&index_path);
+        let _guard = lock.lock().await;
+        // Strict read, same rule as `delete`: this is a read-modify-write, and
+        // a damaged line must abort the rewrite, not be laundered out.
+        let index = read_jsonl::<IndexEntry>(&index_path).await?;
+        let before = index.len();
+        let kept: Vec<IndexEntry> = index
+            .into_iter()
+            .filter(|e| !(e.addr == addr.as_ref() && e.label == label))
+            .collect();
+        if kept.len() == before {
+            return Ok(false);
+        }
+        crate::store::fs_ops::rewrite_jsonl(&index_path, &kept).await?;
+        // Label-scoped (#1300): only this label's row went. The blob is reaped
+        // exactly when no row references the address any more — decided under
+        // the same lock every put and delete holds, so a concurrent put of
+        // identical content under another label either lands its row before
+        // this read (and keeps the blob) or after this call completes (and
+        // rewrites the blob it needs). Best-effort, per `delete`'s reasoning.
+        if !kept.iter().any(|e| e.addr == addr.as_ref()) {
+            reap_blob(&bundle, addr.as_ref()).await;
         }
         Ok(true)
     }
@@ -1404,10 +1461,19 @@ impl ContextStore for FsContextStore {
     async fn search(&self, id: &CompanyId, query: &str, limit: usize) -> Result<Vec<ChunkHit>> {
         let bundle = self.bundle(id);
         let index = read_jsonl::<IndexEntry>(&bundle.context_index_jsonl()).await?;
+        // One hit per ADDRESS, not per index row: a hit carries no label, and
+        // one address can be claimed by several labels (#1300) — or repeated
+        // by a duplicate row, since `put` appends without reading. Without
+        // this, recall would report the same body once per claim, where every
+        // other backend (which scans bodies, not claims) reports it once.
+        let mut seen: HashSet<String> = HashSet::new();
         let mut hits = Vec::new();
         for entry in index {
             if hits.len() >= limit {
                 break;
+            }
+            if !seen.insert(entry.addr.clone()) {
+                continue;
             }
             let blob_path = bundle.context_blob(&entry.addr);
             let Ok(body) = tokio::fs::read_to_string(&blob_path).await else {
@@ -2214,6 +2280,72 @@ mod test {
             FsContextStore::new(&root),
         ))
         .await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_identical_body_two_labels() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_identical_body_two_labels(Arc::new(FsContextStore::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_scoped() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_delete_label_scoped(Arc::new(FsContextStore::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_survives_a_concurrent_identical_put() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_delete_label_survives_a_concurrent_identical_put(Arc::new(
+            FsContextStore::new(&root),
+        ))
+        .await;
+    }
+
+    /// This backend keeps `put` an O(1) append and applies the (addr, label)
+    /// set semantics on the read side (#1300), so the two halves need pinning
+    /// together: a duplicate row on disk, exactly one claim through `list`,
+    /// one hit through `search`, and a `delete_label` that takes every
+    /// duplicate row with it — a survivor would resurrect a forgotten claim.
+    #[tokio::test]
+    async fn a_duplicate_index_row_reads_back_as_one_claim_and_deletes_whole() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        let context = FsContextStore::new(&root);
+        let id = CompanyId::new("acme");
+        let chunk = || ContextChunk {
+            label: "notes/one".to_string(),
+            body: "remembered twice".to_string(),
+        };
+
+        let addr = context.put(&id, chunk()).await.unwrap();
+        assert_eq!(context.put(&id, chunk()).await.unwrap(), addr);
+
+        // The append really did write a second row — this is the cost the
+        // read-side dedupe exists to absorb, so assert it rather than assume.
+        let index_path = Bundle::new(root.clone(), &id).context_index_jsonl();
+        let rows = read_jsonl::<IndexEntry>(&index_path).await.unwrap();
+        assert_eq!(rows.len(), 2, "put appends without reading the index");
+
+        let metas = context.list(&id, "").await.unwrap();
+        assert_eq!(metas.len(), 1, "the duplicate row is one claim: {metas:?}");
+        assert_eq!(metas[0].stored_at_millis, rows[0].stored_at_millis);
+        assert_eq!(
+            context.search(&id, "remembered", 10).await.unwrap().len(),
+            1,
+            "recall reports the body once, not once per row"
+        );
+
+        assert!(context.delete_label(&id, &addr, "notes/one").await.unwrap());
+        assert!(context.list(&id, "").await.unwrap().is_empty());
+        assert!(
+            context.peek(&id, &addr, None).await.is_err(),
+            "every duplicate row went, so the body is unreferenced and reaped"
+        );
     }
 
     /// The deterministic half of the atomicity guarantee: a re-`put` publishes

--- a/src/store/memory/driver.rs
+++ b/src/store/memory/driver.rs
@@ -98,6 +98,8 @@ pub enum MemoryMode {
     Null,
 }
 
+pub use crate::store::select::RemoteDeployment;
+
 /// Everything needed to open a driver, already resolved from env + manifest.
 ///
 /// Holds the credential, so it is not `Debug` — see the manual impl below.
@@ -122,6 +124,9 @@ pub struct MemoryDriverConfig {
     /// `<data_dir>/memory-namespace/` — deliberately beside, never inside, the
     /// incumbent engine's `<data_dir>/memory/`.
     pub data_dir: Option<PathBuf>,
+    /// Which deployment of the named remote engine to speak to. Ignored by
+    /// every mode but [`MemoryMode::Remote`].
+    pub deployment: RemoteDeployment,
 }
 
 impl std::fmt::Debug for MemoryDriverConfig {
@@ -241,7 +246,10 @@ pub fn open_driver(
                 — the key is a secret and env is its only channel",
             )?;
             let class = admit(driver_id, DriverClass::External)?;
-            (remote_provider(driver_id, url, key)?, class)
+            (
+                remote_provider(driver_id, url, key, config.deployment)?,
+                class,
+            )
         }
     };
     audit_capabilities(bound.0.as_ref())?;
@@ -372,16 +380,35 @@ fn admit(driver_id: &str, expected: DriverClass) -> Result<DriverClass> {
 /// and leaves every optional accessor `None`. That is the truth about a hosted
 /// service — no summary tree, no graph, no taint tier — and it is what makes
 /// `audit_provider` pass at bind rather than a call fail later.
-fn remote_provider(driver_id: &str, url: &str, key: &str) -> Result<Arc<dyn MemoryProvider>> {
+fn remote_provider(
+    driver_id: &str,
+    url: &str,
+    key: &str,
+    deployment: RemoteDeployment,
+) -> Result<Arc<dyn MemoryProvider>> {
+    let managed = deployment == RemoteDeployment::Managed;
     let provider: Arc<dyn MemoryProvider> = match driver_id {
+        // Supermemory serves one API to both deployments on one bearer
+        // credential — its own `self_hosted` delegates to `api` — so the
+        // deployment does not change the client.
         SUPERMEMORY_DRIVER_ID => Arc::new(tinymemory_remote::supermemory_provider(
-            tinymemory_remote::SupermemoryMemory::new(url, Some(key)).map_err(open_failed)?,
+            tinymemory_remote::SupermemoryMemory::api(url, key).map_err(open_failed)?,
         )),
         MEM0_DRIVER_ID => Arc::new(tinymemory_remote::mem0_provider(
-            tinymemory_remote::Mem0Memory::new(url, Some(key)).map_err(open_failed)?,
+            if managed {
+                tinymemory_remote::Mem0Memory::api(url, key)
+            } else {
+                tinymemory_remote::Mem0Memory::self_hosted(url, Some(key))
+            }
+            .map_err(open_failed)?,
         )),
         COGNEE_DRIVER_ID => Arc::new(tinymemory_remote::cognee_provider(
-            tinymemory_remote::CogneeMemory::new(url, Some(key)).map_err(open_failed)?,
+            if managed {
+                tinymemory_remote::CogneeMemory::api(url, key)
+            } else {
+                tinymemory_remote::CogneeMemory::self_hosted(url, Some(key))
+            }
+            .map_err(open_failed)?,
         )),
         // Unreachable in practice: `admit` has already rejected any id the
         // registry does not reserve as External. Kept as a refusal rather than
@@ -505,6 +532,7 @@ mod test {
             url: None,
             api_key: None,
             data_dir: None,
+            deployment: Default::default(),
         }
     }
 
@@ -850,6 +878,7 @@ mod test {
             url: Some("https://memory.internal.example".into()),
             api_key: Some("sk-super-secret-value".into()),
             data_dir: None,
+            deployment: Default::default(),
         };
         let rendered = format!("{cfg:?}");
         assert!(!rendered.contains("sk-super-secret-value"), "{rendered}");

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -59,13 +59,50 @@ struct Envelope<T> {
     record: T,
 }
 
+/// Characters a hosted engine removes from `content`, escaped on the way out.
+///
+/// Supermemory strips `U+FFFD` server-side (tinymemory#80, measured against
+/// the live API rather than inferred). An engine is within its rights to
+/// sanitise text it is handed; what breaks is that this host does not hand it
+/// text, it hands it a JSON envelope, and a character removed from the middle
+/// of that envelope comes back as a record whose body is quietly one character
+/// shorter than it was written.
+///
+/// `U+0000` is deliberately absent: RFC 8259 requires escaping `U+0000`
+/// through `U+001F`, so `serde_json` already emits it as `\u0000` and it never
+/// reaches an engine as a literal. Measured, not assumed — a NUL survives this
+/// path against live Supermemory today, and a `U+FFFD` does not. Listing it
+/// here would be dead weight implying a protection that JSON already provides.
+const CHARACTERS_ENGINES_STRIP: [char; 1] = ['\u{FFFD}'];
+
 /// Encodes a typed record for the provider's `content` field.
+///
+/// The escaping pass exists because the envelope has to survive engines that
+/// sanitise content. `\ufffd` and a literal `U+FFFD` are the same string to
+/// every JSON reader, so this changes nothing a decoder sees — including for
+/// records already written the other way, which keep decoding unchanged.
+///
+/// Rewriting the serialized text is safe here in a way it would not be in
+/// general: JSON's structural characters are all ASCII, so a character from
+/// [`CHARACTERS_ENGINES_STRIP`] can only ever occur inside a string literal,
+/// and `serde_json` has already escaped any backslash around it. Substituting
+/// its `\uXXXX` form therefore yields an equivalent document and cannot
+/// introduce or terminate an escape sequence.
 fn encode<T: Serialize>(record: &T) -> Result<String> {
-    serde_json::to_string(&Envelope {
+    let json = serde_json::to_string(&Envelope {
         v: ENVELOPE_VERSION,
         record,
     })
-    .map_err(|error| OpenCompanyError::Store(format!("could not encode memory record: {error}")))
+    .map_err(|error| OpenCompanyError::Store(format!("could not encode memory record: {error}")))?;
+    Ok(CHARACTERS_ENGINES_STRIP
+        .iter()
+        .fold(json, |text, character| {
+            if text.contains(*character) {
+                text.replace(*character, &format!("\\u{:04x}", *character as u32))
+            } else {
+                text
+            }
+        }))
 }
 
 /// Decodes one entry, or `None` when it is not ours to read.
@@ -859,6 +896,54 @@ mod test {
         assert_eq!(decoded.body, chunk.body);
         assert_eq!(decoded.stored_at_millis, chunk.stored_at_millis);
         assert_eq!(decoded.labels, chunk.labels);
+    }
+
+    #[test]
+    fn the_encoding_leaves_no_character_a_hosted_engine_would_strip() {
+        // The escape is only worth anything if it removes every literal from
+        // the serialized text; an engine sanitises the bytes it receives, not
+        // the record they represent.
+        let chunk = StoredChunk {
+            label: "notes/one".into(),
+            body: "before\u{FFFD}after".into(),
+            stored_at_millis: 1,
+            labels: vec!["notes/one".into()],
+        };
+        let json = encode(&chunk).unwrap();
+        for character in CHARACTERS_ENGINES_STRIP {
+            assert!(
+                !json.contains(character),
+                "the encoded envelope still carries U+{:04X} as a literal: {json:?}",
+                character as u32
+            );
+        }
+        assert!(
+            json.contains("\\ufffd"),
+            "the character must be escaped rather than dropped: {json:?}"
+        );
+    }
+
+    #[test]
+    fn escaping_preserves_the_record_including_around_a_backslash() {
+        // The escape rewrites serialized JSON rather than the record, which is
+        // safe only because a stripped character can appear solely inside a
+        // string literal and `serde_json` has already escaped any backslash
+        // beside it. A body that puts the two together is where a naive
+        // substitution would corrupt the document, so pin it: this must decode
+        // back to exactly what went in.
+        let context = ns("acme", Scope::Context);
+        let chunk = StoredChunk {
+            label: "notes/one".into(),
+            body: "a\\\u{FFFD}b\u{FFFD}\\u{FFFD}c\u{0}d".into(),
+            stored_at_millis: 7,
+            labels: vec!["notes/one".into()],
+        };
+        let entry = entry_in(&context, &encode(&chunk).unwrap());
+        let decoded: StoredChunk = decode(&entry, &context).unwrap();
+        assert_eq!(
+            decoded.body, chunk.body,
+            "every character must survive the escape and the decode"
+        );
     }
 
     #[test]

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -353,20 +353,49 @@ impl FactStore for ProviderFactStore {
 /// - **`list` by label prefix** is a host-side filter, for the same reason.
 pub struct ProviderContextStore {
     bound: Bound,
+    /// Serializes the label-set read-merge-writes (`put`, `delete_label`) on
+    /// the stored envelope (#1300). The contract's `store` is a whole-value
+    /// upsert with no compare-and-set, so two concurrent puts of one body
+    /// under different labels would otherwise both read the same envelope and
+    /// one label would silently lose — the same reasoning as the fs backend's
+    /// per-path lock, and process-local for the same reason it is there: this
+    /// facade is the company's only writer of its partition.
+    label_lock: tokio::sync::Mutex<()>,
 }
 
 impl ProviderContextStore {
     pub(super) fn new(bound: Bound) -> Self {
-        Self { bound }
+        Self {
+            bound,
+            label_lock: tokio::sync::Mutex::new(()),
+        }
     }
 }
 
 /// A stored chunk: the port's [`ContextChunk`] plus the metadata `list` reports.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct StoredChunk {
+    /// The first label to claim this address — kept meaningful on its own so
+    /// an envelope written by (or later read by) a binary from before
+    /// `labels` existed still carries a real claim.
     label: String,
     body: String,
     stored_at_millis: u64,
+    /// Every label claiming this address (#1300); envelopes from before the
+    /// field decode empty, and [`stored_labels`] unions the scalar back in.
+    #[serde(default)]
+    labels: Vec<String>,
+}
+
+/// Every label claiming `chunk`, deduped, scalar (first-stored) label first.
+fn stored_labels(chunk: &StoredChunk) -> Vec<String> {
+    let mut labels = vec![chunk.label.clone()];
+    for label in &chunk.labels {
+        if !labels.iter().any(|have| have == label) {
+            labels.push(label.clone());
+        }
+    }
+    labels
 }
 
 #[async_trait]
@@ -375,12 +404,16 @@ impl ContextStore for ProviderContextStore {
         // The shared content address, so this backend mints the same addr for
         // the same body as fs / sqlite / mongodb do.
         let addr = content_address(&chunk.body);
+        // Under the label lock: the merge below is a read-merge-write over a
+        // plain upsert (#1300).
+        let _guard = self.label_lock.lock().await;
         // Chunks are append-only and never rewritten. `store` is an upsert, so
         // without this check a re-`put` of an identical body would restamp
         // `stored_at_millis` and move the Brain header's "last updated" backwards
         // in meaning — it would start reporting when a chunk was last *re-seen*
         // rather than when it was first written. sqlite and mongodb keep the
-        // first write; match them.
+        // first write; match them. A new label on an existing body is folded
+        // into the envelope's label set instead — one claim per (addr, label).
         if let Some(existing) = self.bound.get::<StoredChunk>(company, &addr).await? {
             // A hit is almost always the same body written twice. It can also be
             // a content-address collision: `content_address` is a 64-bit
@@ -404,10 +437,19 @@ impl ContextStore for ProviderContextStore {
                      address. The first body is kept and this write is dropped, so reads of this \
                      address return the earlier chunk. See crate::store::content_address."
                 );
+                return Ok(ChunkAddr::new(addr));
+            }
+            let labels = stored_labels(&existing);
+            if !labels.iter().any(|have| have == &chunk.label) {
+                let mut updated = existing;
+                updated.labels = labels;
+                updated.labels.push(chunk.label);
+                self.bound.put(company, &addr, &updated, "chunk").await?;
             }
             return Ok(ChunkAddr::new(addr));
         }
         let stored = StoredChunk {
+            labels: vec![chunk.label.clone()],
             label: chunk.label,
             body: chunk.body,
             stored_at_millis: crate::ports::now_millis(),
@@ -420,18 +462,33 @@ impl ContextStore for ProviderContextStore {
         let chunks: Vec<StoredChunk> = self.bound.list(company).await?;
         let mut metas: Vec<ChunkMeta> = chunks
             .into_iter()
-            .filter(|chunk| chunk.label.starts_with(prefix))
-            .map(|chunk| ChunkMeta {
-                addr: ChunkAddr::new(content_address(&chunk.body)),
-                label: chunk.label,
-                len: chunk.body.len(),
-                stored_at_millis: chunk.stored_at_millis,
+            .flat_map(|chunk| {
+                // One meta per label claiming the address (#1300); the stamp
+                // is the address's first write, since the envelope is one
+                // record however many labels claim it.
+                let addr = content_address(&chunk.body);
+                let len = chunk.body.len();
+                let stored_at_millis = chunk.stored_at_millis;
+                stored_labels(&chunk)
+                    .into_iter()
+                    .filter(|label| label.starts_with(prefix))
+                    .map(move |label| ChunkMeta {
+                        addr: ChunkAddr::new(addr.clone()),
+                        label,
+                        len,
+                        stored_at_millis,
+                    })
+                    .collect::<Vec<_>>()
             })
             .collect();
         metas.sort_by(|a, b| {
             a.stored_at_millis
                 .cmp(&b.stored_at_millis)
                 .then_with(|| a.addr.as_ref().cmp(b.addr.as_ref()))
+                // The label completes the order: two labels claiming one
+                // address (#1300) share a stamp and an addr, so without it
+                // their relative order would rest on enumeration order alone.
+                .then_with(|| a.label.cmp(&b.label))
         });
         Ok(metas)
     }
@@ -475,12 +532,64 @@ impl ContextStore for ProviderContextStore {
     }
 
     async fn delete(&self, company: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
+        // Under the label lock so an interleaved `put`'s read-merge-write
+        // cannot resurrect an envelope this is removing.
+        let _guard = self.label_lock.lock().await;
         // The engine keys chunks by their content address (see `put`), so the
-        // port's addr IS the engine key. On an address collision (64-bit
-        // non-cryptographic hash — see `put`'s comment) the single stored body
-        // goes, whichever writer minted it first; that is the same
-        // first-write-wins property every backend already has.
+        // port's addr IS the engine key — the envelope goes with every label
+        // claiming it. On an address collision (64-bit non-cryptographic hash
+        // — see `put`'s comment) the single stored body goes, whichever writer
+        // minted it first; that is the same first-write-wins property every
+        // backend already has.
         self.bound.forget(company, addr.as_ref()).await
+    }
+
+    async fn delete_label(
+        &self,
+        company: &CompanyId,
+        addr: &ChunkAddr,
+        label: &str,
+    ) -> Result<bool> {
+        // Label-scoped (#1300): remove one claim from the envelope's label
+        // set, and forget the envelope exactly when the last claim goes. The
+        // read-merge-write and the reap decision sit under the same lock every
+        // put holds, so a concurrent put of identical content under another
+        // label either lands its claim before this read or re-creates the
+        // envelope after the forget — never loses its claim in between.
+        let _guard = self.label_lock.lock().await;
+        let Some(existing) = self
+            .bound
+            .get::<StoredChunk>(company, addr.as_ref())
+            .await?
+        else {
+            return Ok(false);
+        };
+        let mut labels = stored_labels(&existing);
+        let before = labels.len();
+        labels.retain(|have| have != label);
+        if labels.len() == before {
+            return Ok(false);
+        }
+        if labels.is_empty() {
+            // The claim existed and is gone either way: `forget` answering
+            // false here means another writer (a second process on a remote
+            // driver, outside this process-local lock) reaped the envelope
+            // first, which is the same end state.
+            self.bound.forget(company, addr.as_ref()).await?;
+            return Ok(true);
+        }
+        let updated = StoredChunk {
+            // The scalar stays a real label so an envelope read by a binary
+            // from before `labels` still carries a live claim.
+            label: labels[0].clone(),
+            labels,
+            body: existing.body,
+            stored_at_millis: existing.stored_at_millis,
+        };
+        self.bound
+            .put(company, addr.as_ref(), &updated, "chunk")
+            .await?;
+        Ok(true)
     }
 
     async fn search(
@@ -703,12 +812,14 @@ mod test {
             label: "notes/one".into(),
             body: "the quick brown fox".into(),
             stored_at_millis: 99,
+            labels: vec!["notes/one".into()],
         };
         let entry = entry_in(&context, &encode(&chunk).unwrap());
         let decoded: StoredChunk = decode(&entry, &context).unwrap();
         assert_eq!(decoded.label, chunk.label);
         assert_eq!(decoded.body, chunk.body);
         assert_eq!(decoded.stored_at_millis, chunk.stored_at_millis);
+        assert_eq!(decoded.labels, chunk.labels);
     }
 
     #[test]
@@ -731,6 +842,7 @@ mod test {
             label: "l".into(),
             body: "b".into(),
             stored_at_millis: 1,
+            labels: vec!["l".into()],
         };
         let entry = entry_in(&scratch, &encode(&chunk).unwrap());
         assert!(decode::<StoredChunk>(&entry, &context).is_none());

--- a/src/store/memory/facades.rs
+++ b/src/store/memory/facades.rs
@@ -234,6 +234,25 @@ impl Bound {
             .and_then(|entry| decode(&entry, &namespace)))
     }
 
+    /// Whether the engine holds a record at `key` at all, **without decoding
+    /// it**.
+    ///
+    /// [`Self::get`] answers `None` for two different facts: the engine has no
+    /// such record, and the engine has one this build cannot read (a foreign
+    /// envelope version, or the corrupted-write shape #1201 was). Callers that
+    /// only read may treat those alike. A caller that reports "there was
+    /// nothing there" to a user must not — that turns an unreadable record
+    /// into a silent no-op and leaves it serving recall forever.
+    async fn exists(&self, company: &CompanyId, key: &str) -> Result<bool> {
+        let namespace = self.namespace(company);
+        Ok(self
+            .provider
+            .get(namespace.as_str(), key)
+            .await
+            .map_err(store_error)?
+            .is_some())
+    }
+
     /// Lists every typed record in this company's partition.
     async fn list<T: DeserializeOwned>(&self, company: &CompanyId) -> Result<Vec<T>> {
         let namespace = self.namespace(company);
@@ -562,6 +581,26 @@ impl ContextStore for ProviderContextStore {
             .get::<StoredChunk>(company, addr.as_ref())
             .await?
         else {
+            // `get` answering `None` is two different facts, and only one of
+            // them is "nothing to forget". If the engine DOES hold a record
+            // here, this build simply cannot read its envelope — and returning
+            // `Ok(false)` would tell `memory_forget` to reply "already gone"
+            // about a chunk recall keeps serving, with nothing anywhere saying
+            // otherwise. Refuse instead, naming the address, so the operator
+            // gets a report rather than a lie.
+            //
+            // Deliberately NOT a forget-by-key fallback: the envelope is what
+            // says which labels claim this address, so an unreadable one means
+            // an unknown claim set, and removing the record could take a label
+            // this caller never owned.
+            if self.bound.exists(company, addr.as_ref()).await? {
+                return Err(OpenCompanyError::Store(format!(
+                    "context chunk {} exists but its envelope could not be decoded, so its \
+                     label claims are unknown and `{label}` cannot be removed safely; the \
+                     record needs repair or an operator-level delete",
+                    addr.as_ref()
+                )));
+            }
             return Ok(false);
         };
         let mut labels = stored_labels(&existing);

--- a/src/store/memory/migrate.rs
+++ b/src/store/memory/migrate.rs
@@ -282,6 +282,7 @@ pub fn resolve_migrate_configs(
         url: settings.memory_url.clone(),
         api_key: settings.memory_api_key.clone(),
         data_dir: settings.data_dir.clone(),
+        deployment: Default::default(),
     };
 
     let to_config = match to {
@@ -318,6 +319,7 @@ pub fn resolve_migrate_configs(
                 url: None,
                 api_key: None,
                 data_dir,
+                deployment: Default::default(),
             }
         }
         "supermemory" | "mem0" | "cognee" => {
@@ -339,6 +341,7 @@ pub fn resolve_migrate_configs(
                 url: to_url,
                 api_key: to_api_key,
                 data_dir: None,
+                deployment: Default::default(),
             }
         }
         "null" => {

--- a/src/store/memory/mod.rs
+++ b/src/store/memory/mod.rs
@@ -85,7 +85,9 @@ use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::{CompanyId, ContextStore, FactStore, MemoryStore};
 
-pub use driver::{MemoryDriverConfig, MemoryDriverError, MemoryMode, open_driver};
+pub use driver::{
+    MemoryDriverConfig, MemoryDriverError, MemoryMode, RemoteDeployment, open_driver,
+};
 
 /// A bound memory engine, and the only way to get a memory port out of one.
 ///

--- a/src/store/memory/test.rs
+++ b/src/store/memory/test.rs
@@ -669,6 +669,21 @@ async fn conformance_context_multibyte_bodies() {
     conformance::assert_multibyte_bodies_survive_search_and_ranged_peek(engine().context()).await;
 }
 
+#[tokio::test]
+async fn conformance_context_identical_body_two_labels() {
+    conformance::assert_identical_body_two_labels(engine().context()).await;
+}
+
+#[tokio::test]
+async fn conformance_context_delete_label_scoped() {
+    conformance::assert_delete_label_scoped(engine().context()).await;
+}
+
+#[tokio::test]
+async fn conformance_context_delete_label_survives_a_concurrent_identical_put() {
+    conformance::assert_delete_label_survives_a_concurrent_identical_put(engine().context()).await;
+}
+
 /// The port conformance suite over the REAL `namespace` driver — not the fake.
 ///
 /// Everything above proves the decorator against `FakeEngine`; the driver
@@ -754,6 +769,20 @@ mod namespace_driver_conformance {
     async fn multibyte_bodies_survive_search_and_peek_on_the_namespace_driver() {
         let (store_dir, engine) = real_engine();
         conformance::assert_multibyte_bodies_survive_search_and_ranged_peek(engine.context()).await;
+        drop(store_dir);
+    }
+
+    #[tokio::test]
+    async fn identical_body_two_labels_holds_on_the_namespace_driver() {
+        let (store_dir, engine) = real_engine();
+        conformance::assert_identical_body_two_labels(engine.context()).await;
+        drop(store_dir);
+    }
+
+    #[tokio::test]
+    async fn delete_label_is_scoped_on_the_namespace_driver() {
+        let (store_dir, engine) = real_engine();
+        conformance::assert_delete_label_scoped(engine.context()).await;
         drop(store_dir);
     }
 

--- a/src/store/memory/test.rs
+++ b/src/store/memory/test.rs
@@ -709,6 +709,7 @@ mod namespace_driver_conformance {
             url: None,
             api_key: None,
             data_dir: Some(dir.path().to_path_buf()),
+            deployment: Default::default(),
         };
         let (provider, class) = crate::store::memory::open_driver(&config)
             .expect("the namespace driver binds")

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -703,6 +703,32 @@ mod cognee {
 /// forget under the `oc-live-test` company's namespace and clean up after
 /// themselves, but a shared production account is the wrong thing to point
 /// them at — use a scratch project or a free tier.
+///
+/// # What the first live run found, and why the split below exists
+///
+/// Run against the real Supermemory API on 2026-08-22, the **provider
+/// contract** failed and the **host ports** passed. Both results are correct,
+/// and the difference between them is the point.
+///
+/// Supermemory strips the NUL character (U+0000) from content, server-side.
+/// That is not inferred from a read-back: posting a two-letter string with a
+/// NUL between the letters to `POST /v4/memories` answers `201` and echoes the
+/// stored memory back as the two letters alone, in the creation response
+/// itself. The conformance suite hands raw content through, so it sees the
+/// character vanish and fails — correctly, because the engine really does
+/// alter what it is given.
+///
+/// It does not reach this host, because this host never sends a raw NUL. The
+/// facades JSON-encode every record into `content` (see `encode`), so a NUL
+/// inside a trace, fact or chunk crosses the wire as the six ASCII characters
+/// of its JSON escape and arrives as text there is nothing to strip.
+/// `facade_round_trip` passing against the live service — label semantics
+/// included — is that reasoning checked rather than argued.
+///
+/// The lesson generalises past this one character: an engine's contract
+/// failures only matter to OpenCompany where the failing shape is a shape the
+/// facades actually produce. Keep the two tests apart so the next divergence
+/// lands on whichever of those questions it belongs to.
 #[cfg(test)]
 mod live_hosted {
     use super::*;
@@ -746,14 +772,9 @@ mod live_hosted {
         }
     }
 
-    /// Drives one live engine through the provider contract AND this host's
-    /// port suite — the same two claims the doubles make, so a divergence
-    /// between a vendor and its documentation shows up as a diff between this
-    /// test and its double-backed twin rather than as a mystery in production.
-    async fn live(engine: &str) {
-        let Some((url, key)) = credentials(engine) else {
-            return;
-        };
+    /// Binds the live engine named by the environment, or `None` to skip.
+    fn live_driver(engine: &str) -> Option<(Arc<dyn MemoryProvider>, DriverClass)> {
+        let (url, key) = credentials(engine)?;
         let config = MemoryDriverConfig {
             mode: MemoryMode::Remote,
             driver_id: Some(engine.into()),
@@ -761,25 +782,68 @@ mod live_hosted {
             api_key: Some(key),
             data_dir: None,
         };
-        let (provider, class) = open_driver(&config)
-            .expect("the live driver binds")
-            .expect("remote with a driver named yields a provider");
-        assert_retains_then_conforms(Arc::clone(&provider)).await;
+        Some(
+            open_driver(&config)
+                .expect("the live driver binds")
+                .expect("remote with a driver named yields a provider"),
+        )
+    }
+
+    /// The **provider contract** against the live service: what the engine
+    /// promises about raw content it is handed.
+    ///
+    /// Kept separate from the port suite below, because the two can disagree
+    /// and the difference decides who has to act. A vendor that alters raw
+    /// content fails here; whether that reaches this host depends on what this
+    /// host actually sends, which is the next test's question.
+    async fn live_provider_contract(engine: &str) {
+        let Some((provider, _)) = live_driver(engine) else {
+            return;
+        };
+        assert_retains_then_conforms(provider).await;
+    }
+
+    /// The **host's ports** against the live service: what OpenCompany itself
+    /// depends on, through the facades it really uses.
+    ///
+    /// This is the claim that decides whether a tenant can run on this engine.
+    /// It is deliberately not the same as the provider contract: the facades
+    /// JSON-encode every record into `content`, so a byte that an engine
+    /// mangles in raw text may never reach it as raw text at all.
+    async fn live_host_ports(engine: &str) {
+        let Some((provider, class)) = live_driver(engine) else {
+            return;
+        };
         facade_round_trip(provider, class).await;
     }
 
     #[tokio::test]
-    async fn the_live_supermemory_service_upholds_the_contract_and_the_ports() {
-        live("supermemory").await;
+    async fn the_live_supermemory_service_upholds_the_provider_contract() {
+        live_provider_contract("supermemory").await;
     }
 
     #[tokio::test]
-    async fn the_live_mem0_service_upholds_the_contract_and_the_ports() {
-        live("mem0").await;
+    async fn the_live_supermemory_service_upholds_the_host_ports() {
+        live_host_ports("supermemory").await;
     }
 
     #[tokio::test]
-    async fn the_live_cognee_service_upholds_the_contract_and_the_ports() {
-        live("cognee").await;
+    async fn the_live_mem0_service_upholds_the_provider_contract() {
+        live_provider_contract("mem0").await;
+    }
+
+    #[tokio::test]
+    async fn the_live_mem0_service_upholds_the_host_ports() {
+        live_host_ports("mem0").await;
+    }
+
+    #[tokio::test]
+    async fn the_live_cognee_service_upholds_the_provider_contract() {
+        live_provider_contract("cognee").await;
+    }
+
+    #[tokio::test]
+    async fn the_live_cognee_service_upholds_the_host_ports() {
+        live_host_ports("cognee").await;
     }
 }

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -672,3 +672,114 @@ mod cognee {
         facade_round_trip(provider, class).await;
     }
 }
+
+// ── The same suites, against the REAL hosted services ────────────────────────
+
+/// Everything above runs against doubles: HTTP servers this repo writes to the
+/// vendors' documented request and response shapes. That is the right default —
+/// `cargo test` stays offline, and a shape change in a vendor's docs is caught
+/// here rather than in a tenant.
+///
+/// It is also not the same claim as "this works against supermemory". A double
+/// agrees with the documentation; a service agrees with itself. The gap between
+/// those is exactly where an integration breaks — pagination that stops early,
+/// a delete that is eventually consistent, a namespace filter the server
+/// applies more loosely than the docs say — and none of it is visible from a
+/// double, because the double was written from the same reading of the docs
+/// that the adapter was.
+///
+/// So the identical suites run against a live endpoint when one is offered:
+///
+/// ```sh
+/// OPENCOMPANY_TEST_SUPERMEMORY_URL=https://api.supermemory.ai \
+/// OPENCOMPANY_TEST_SUPERMEMORY_KEY=sk-... \
+///   cargo test --features tinymemory --lib live_hosted
+/// ```
+///
+/// Same for `MEM0` and `COGNEE`. Without the pair, each test skips, so this
+/// costs an offline run nothing.
+///
+/// **These tests write to the account they are given.** They store, recall and
+/// forget under the `oc-live-test` company's namespace and clean up after
+/// themselves, but a shared production account is the wrong thing to point
+/// them at — use a scratch project or a free tier.
+#[cfg(test)]
+mod live_hosted {
+    use super::*;
+
+    /// Whether a missing endpoint must FAIL rather than skip.
+    ///
+    /// Same shape and same reasoning as the MongoDB suite's
+    /// `OPENCOMPANY_TEST_MONGODB_REQUIRED` (issue #555): the skip is right for
+    /// a laptop with no vendor keys and wrong for a lane whose entire purpose
+    /// is running these. There, an unset pair is a misconfigured job, and the
+    /// skip would report it as a pass — the whole suite silently absent behind
+    /// a green tick.
+    ///
+    /// `0` and the empty string read as unset, so it can be threaded through a
+    /// workflow matrix that always defines it.
+    fn required() -> bool {
+        matches!(
+            std::env::var("OPENCOMPANY_TEST_HOSTED_REQUIRED").as_deref(),
+            Ok(value) if !value.is_empty() && value != "0"
+        )
+    }
+
+    /// The `(url, key)` pair for one engine, or `None` to skip.
+    fn credentials(engine: &str) -> Option<(String, String)> {
+        let upper = engine.to_uppercase();
+        let url = std::env::var(format!("OPENCOMPANY_TEST_{upper}_URL")).ok();
+        let key = std::env::var(format!("OPENCOMPANY_TEST_{upper}_KEY")).ok();
+        match (url, key) {
+            (Some(url), Some(key)) if !url.is_empty() && !key.is_empty() => Some((url, key)),
+            _ => {
+                assert!(
+                    !required(),
+                    "OPENCOMPANY_TEST_HOSTED_REQUIRED is set but \
+                     OPENCOMPANY_TEST_{upper}_URL / _KEY are not. This lane exists to run \
+                     the port suite against the real {engine} service, so a skip here is a \
+                     misconfigured job rather than a pass."
+                );
+                eprintln!("skipping {engine}: OPENCOMPANY_TEST_{upper}_URL / _KEY are not set");
+                None
+            }
+        }
+    }
+
+    /// Drives one live engine through the provider contract AND this host's
+    /// port suite — the same two claims the doubles make, so a divergence
+    /// between a vendor and its documentation shows up as a diff between this
+    /// test and its double-backed twin rather than as a mystery in production.
+    async fn live(engine: &str) {
+        let Some((url, key)) = credentials(engine) else {
+            return;
+        };
+        let config = MemoryDriverConfig {
+            mode: MemoryMode::Remote,
+            driver_id: Some(engine.into()),
+            url: Some(url),
+            api_key: Some(key),
+            data_dir: None,
+        };
+        let (provider, class) = open_driver(&config)
+            .expect("the live driver binds")
+            .expect("remote with a driver named yields a provider");
+        assert_retains_then_conforms(Arc::clone(&provider)).await;
+        facade_round_trip(provider, class).await;
+    }
+
+    #[tokio::test]
+    async fn the_live_supermemory_service_upholds_the_contract_and_the_ports() {
+        live("supermemory").await;
+    }
+
+    #[tokio::test]
+    async fn the_live_mem0_service_upholds_the_contract_and_the_ports() {
+        live("mem0").await;
+    }
+
+    #[tokio::test]
+    async fn the_live_cognee_service_upholds_the_contract_and_the_ports() {
+        live("cognee").await;
+    }
+}

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -119,6 +119,46 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].body, "lathe parts come from Initech");
 
+    // Characters a hosted engine sanitises out of `content` (tinymemory#80).
+    // The envelope escapes them precisely so this assertion can hold, and the
+    // assertion lives here — in the shared facade path — rather than beside
+    // the escaping, because the escaping is only worth anything if the record
+    // survives the whole way to an engine and back. Against live Supermemory
+    // this failed before the escape landed: `U+FFFD` came back missing from
+    // the middle of the body, so the record decoded to a string one character
+    // shorter than the one that was stored, with nothing raising an error.
+    //
+    // `U+0000` rides along as the control. JSON already escapes it, so it
+    // survived even before the fix — which is what makes it useful here: if a
+    // later change to the envelope broke escaping wholesale, the two would
+    // fail together, and if only `U+FFFD` fails then the strip is engine-side.
+    for (label, character) in [("nul", '\u{0}'), ("replacement", '\u{FFFD}')] {
+        let body = format!("before{character}after");
+        let id = format!("fact-awkward-{label}");
+        facts
+            .upsert(
+                &company,
+                &FactRecord {
+                    id: id.clone(),
+                    kind: FactKind::Fact,
+                    title: format!("awkward {label}"),
+                    body: body.clone(),
+                    source: "cto".into(),
+                    updated_at_millis: 1_700_000_000_002,
+                },
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{label} fact upsert: {error}"));
+        let listed = facts.list(&company, None, None).await.expect("fact list");
+        let stored = listed.iter().find(|fact| fact.id == id);
+        assert_eq!(
+            stored.map(|fact| fact.body.as_str()),
+            Some(body.as_str()),
+            "{label}: the record must read back as it was written, not with the \
+             character removed from the middle of it"
+        );
+    }
+
     let context = bound.context();
     context
         .put(
@@ -710,25 +750,37 @@ mod cognee {
 /// contract** failed and the **host ports** passed. Both results are correct,
 /// and the difference between them is the point.
 ///
-/// Supermemory strips the NUL character (U+0000) from content, server-side.
-/// That is not inferred from a read-back: posting a two-letter string with a
-/// NUL between the letters to `POST /v4/memories` answers `201` and echoes the
-/// stored memory back as the two letters alone, in the creation response
-/// itself. The conformance suite hands raw content through, so it sees the
-/// character vanish and fails — correctly, because the engine really does
-/// alter what it is given.
+/// Supermemory strips two characters from content, server-side: `U+0000` and
+/// `U+FFFD`. That is not inferred from a read-back — `POST /v4/memories`
+/// answers `201` and echoes the stored memory back already missing them, in
+/// the creation response itself. Everything else offered to it survives,
+/// including every other C0 control, so it is not a control-character policy.
+/// The conformance suite hands raw content through, so it sees them vanish and
+/// fails — correctly, because the engine really does alter what it is given.
+/// Filed and fixed upstream as tinymemory#80; the provider-contract test here
+/// stays red until the vendored pin picks that fix up.
 ///
-/// It does not reach this host, because this host never sends a raw NUL. The
-/// facades JSON-encode every record into `content` (see `encode`), so a NUL
-/// inside a trace, fact or chunk crosses the wire as the six ASCII characters
-/// of its JSON escape and arrives as text there is nothing to strip.
-/// `facade_round_trip` passing against the live service — label semantics
-/// included — is that reasoning checked rather than argued.
+/// Only one of the two was insulated by this host, and the difference is worth
+/// keeping because the wrong half of it is the intuitive one. The facades
+/// JSON-encode every record into `content` (see `encode`), and RFC 8259
+/// requires escaping `U+0000`, so a NUL crosses the wire as the six ASCII
+/// characters of its escape and arrives as text there is nothing to strip.
+/// `U+FFFD` is not a control character, nothing required it to be escaped, and
+/// it therefore crossed as itself and was eaten — every affected record read
+/// back one character shorter than it was written, with no error anywhere.
+/// `encode` now escapes it deliberately for exactly that reason.
 ///
-/// The lesson generalises past this one character: an engine's contract
-/// failures only matter to OpenCompany where the failing shape is a shape the
-/// facades actually produce. Keep the two tests apart so the next divergence
-/// lands on whichever of those questions it belongs to.
+/// So the reasoning "the envelope insulates us" was right in form and wrong in
+/// fact, and it was wrong in the direction that loses data quietly. It held for
+/// the character that had been measured and failed for the one that had only
+/// been argued about. A live lane is what separates those two states; keep the
+/// facade assertions running real characters through it rather than trusting
+/// the shape of the argument.
+///
+/// The split still generalises: an engine's contract failures reach OpenCompany
+/// only where the failing shape is one the facades actually produce. Keep the
+/// two tests apart so the next divergence lands on whichever question it
+/// belongs to — and answer "does this shape reach us?" by sending it.
 #[cfg(test)]
 mod live_hosted {
     use super::*;

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -34,7 +34,7 @@ use tinymemory::registry::DriverClass;
 use tinymemory_api::provider::MemoryProvider;
 
 use super::BoundMemory;
-use super::driver::{MemoryDriverConfig, MemoryMode, open_driver};
+use super::driver::{MemoryDriverConfig, MemoryMode, RemoteDeployment, open_driver};
 use crate::ports::{CompanyId, CompressedTrace, ContextChunk, FactKind, FactRecord};
 
 /// Opens a driver through the production path and fails the test on refusal.
@@ -132,12 +132,19 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
     // survived even before the fix — which is what makes it useful here: if a
     // later change to the envelope broke escaping wholesale, the two would
     // fail together, and if only `U+FFFD` fails then the strip is engine-side.
+    //
+    // Under its OWN company, and deleted afterwards. A hosted engine retains
+    // what this writes, so a fact left in `acme` is still there on the next
+    // run — and the `listed.len() == 1` above would then fail on a second run
+    // of a suite that passed on the first, blaming the engine for the test's
+    // own litter.
+    let awkward = CompanyId::new("acme-awkward-content");
     for (label, character) in [("nul", '\u{0}'), ("replacement", '\u{FFFD}')] {
         let body = format!("before{character}after");
         let id = format!("fact-awkward-{label}");
         facts
             .upsert(
-                &company,
+                &awkward,
                 &FactRecord {
                     id: id.clone(),
                     kind: FactKind::Fact,
@@ -149,7 +156,7 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
             )
             .await
             .unwrap_or_else(|error| panic!("{label} fact upsert: {error}"));
-        let listed = facts.list(&company, None, None).await.expect("fact list");
+        let listed = facts.list(&awkward, None, None).await.expect("fact list");
         let stored = listed.iter().find(|fact| fact.id == id);
         assert_eq!(
             stored.map(|fact| fact.body.as_str()),
@@ -157,6 +164,10 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
             "{label}: the record must read back as it was written, not with the \
              character removed from the middle of it"
         );
+        facts
+            .delete(&awkward, &id)
+            .await
+            .unwrap_or_else(|error| panic!("{label} cleanup: {error}"));
     }
 
     let context = bound.context();
@@ -212,6 +223,7 @@ mod embedded {
             url: None,
             api_key: None,
             data_dir: Some(dir.to_path_buf()),
+            deployment: Default::default(),
         }
     }
 
@@ -294,6 +306,94 @@ fn remote_config(driver: &str, endpoint: &str) -> MemoryDriverConfig {
         url: Some(endpoint.into()),
         api_key: Some("test-key".into()),
         data_dir: None,
+        // The doubles below speak each vendor's SELF-HOSTED dialect, ported
+        // from the adapters' own tests — un-prefixed paths, `X-API-Key` where
+        // the platform would want `Authorization: Token`. So the config has to
+        // say so: pointing the managed client at them would 404 on paths that
+        // exist only on the platform, and the failure would read as a broken
+        // adapter rather than a mismatched double.
+        //
+        // Managed is what production defaults to, and it is covered against
+        // the real services in `live_hosted` plus, offline, by
+        // `the_managed_deployment_speaks_the_platform_dialect` below.
+        deployment: RemoteDeployment::SelfHosted,
+    }
+}
+
+/// The deployment knob must actually change the wire conversation.
+///
+/// This is the offline guard for a defect the live lane found: OpenCompany
+/// built every remote engine with the self-hosted constructor, so a tenant
+/// pointed at Mem0's or Cognee's managed platform spoke the wrong protocol
+/// entirely — `X-API-Key` and un-prefixed paths at Mem0 (HTTP 404), a bearer
+/// token at Cognee Cloud (HTTP 401 `Invalid header`). Supermemory hid it,
+/// because it serves the same API to both deployments on one bearer
+/// credential, so the one engine anybody tested against kept working.
+///
+/// Asserting on the *credential header* rather than the path is deliberate:
+/// it is the half that cannot be papered over by a permissive router, and it
+/// is what each vendor actually distinguishes its two products by.
+#[tokio::test]
+async fn the_deployment_selects_each_vendors_dialect() {
+    use axum::http::HeaderMap;
+
+    /// Captures the first request's headers, then fails the call.
+    async fn capture(
+        State(seen): State<Arc<Mutex<Vec<String>>>>,
+        headers: HeaderMap,
+    ) -> (axum::http::StatusCode, Json<Value>) {
+        let rendered: Vec<String> = ["authorization", "x-api-key"]
+            .iter()
+            .filter_map(|name| {
+                headers
+                    .get(*name)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|v| format!("{name}: {v}"))
+            })
+            .collect();
+        seen.lock().expect("lock").extend(rendered);
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"detail": "capture double"})),
+        )
+    }
+
+    for (driver, deployment, expected) in [
+        (
+            "mem0",
+            RemoteDeployment::Managed,
+            "authorization: Token test-key",
+        ),
+        ("mem0", RemoteDeployment::SelfHosted, "x-api-key: test-key"),
+        ("cognee", RemoteDeployment::Managed, "x-api-key: test-key"),
+        (
+            "cognee",
+            RemoteDeployment::SelfHosted,
+            "authorization: Bearer test-key",
+        ),
+    ] {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .fallback(axum::routing::any(capture))
+            .with_state(seen.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move { axum::serve(listener, app).await.expect("serve") });
+
+        let mut config = remote_config(driver, &endpoint);
+        config.deployment = deployment;
+        let (provider, _) = open(&config);
+        // The call is expected to fail — the double refuses everything. What
+        // is under test is the credential it carried getting there.
+        let _ = provider.get("any", "thing").await;
+
+        let headers = seen.lock().expect("lock").clone();
+        assert!(
+            headers.iter().any(|h| h.eq_ignore_ascii_case(expected)),
+            "{driver} as {deployment:?} must authenticate with `{expected}`; sent {headers:?}"
+        );
     }
 }
 
@@ -833,6 +933,10 @@ mod live_hosted {
             url: Some(url),
             api_key: Some(key),
             data_dir: None,
+            // Every engine reachable this way is the vendor's managed
+            // platform; a self-hosted instance is not something this lane can
+            // reach from CI.
+            deployment: RemoteDeployment::Managed,
         };
         Some(
             open_driver(&config)

--- a/src/store/memory/upstream_conformance_test.rs
+++ b/src/store/memory/upstream_conformance_test.rs
@@ -139,6 +139,24 @@ async fn facade_round_trip(provider: Arc<dyn MemoryProvider>, class: DriverClass
         1,
         "context must be recallable through the engine"
     );
+
+    // The port-level `(addr, label)` contract, over whatever engine is bound
+    // (issue #1300). Every backend that implements `ContextStore` directly —
+    // fs, sqlite, mongodb — proves these in its own test module; the engines
+    // reached through `ProviderContextStore` did not, because nothing ran the
+    // HOST's port suite against them. That gap matters precisely for the
+    // hosted drivers: `delete_label` is a read-merge-write over `get`/`put`,
+    // which on supermemory, mem0 and cognee is three HTTP calls against an
+    // engine whose `get` and `list` shapes this host does not control. A
+    // divergence there is a claim silently lost or a body reaped while
+    // another label still points at it — and it would have been invisible
+    // until an operator noticed a memory missing.
+    //
+    // Run against `bound.context()` rather than a fresh binding so the
+    // envelope, namespace and decode path under test are the ones the rest of
+    // this function already exercised.
+    crate::store::conformance::assert_identical_body_two_labels(bound.context()).await;
+    crate::store::conformance::assert_delete_label_scoped(bound.context()).await;
 }
 
 // ── The embedded `namespace` driver, on a real store ─────────────────────────

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -114,6 +114,27 @@ fn get_i64(doc: &Document, key: &str) -> Result<i64> {
         .map_err(|e| mongo_err(format!("missing field {key}: {e}")))
 }
 
+/// Every label claiming a context document (issue #1300): the `labels` set,
+/// plus the legacy scalar `label` field — documents written before the set
+/// existed carry only the scalar, and new writes keep it as the first label so
+/// a downgraded binary still reads what it always read. Deduped, scalar first.
+fn doc_labels(doc: &Document) -> Vec<String> {
+    let mut labels = Vec::new();
+    if let Ok(scalar) = doc.get_str("label") {
+        labels.push(scalar.to_string());
+    }
+    if let Ok(set) = doc.get_array("labels") {
+        for value in set {
+            if let Some(label) = value.as_str()
+                && !labels.iter().any(|have| have == label)
+            {
+                labels.push(label.to_string());
+            }
+        }
+    }
+    labels
+}
+
 /// A unique index restricted to the documents that carry `present` at all
 /// (issue #697).
 ///
@@ -944,17 +965,27 @@ impl ContextStore for MongoStore {
         let addr = content_address(&chunk.body);
         // Insertion order stands in for the sqlite backend's rowid ordering.
         let ord = self.next_seq(id, "context_ord").await?;
+        // Body + metadata land once (`$setOnInsert`, first-write-wins per
+        // address); every put also folds its label into the `labels` set
+        // (`$addToSet` — one claim per (addr, label), #1300), so a
+        // byte-identical body stored under a second label keeps both claims.
+        // The scalar `label` field stays the first write's label so a
+        // downgraded binary keeps reading what it always read; `doc_labels`
+        // unions the two shapes on every read.
         let result = self
             .collection("context_chunks")
             .update_one(
                 doc! {"company_id": id.as_ref(), "addr": &addr},
-                doc! {"$setOnInsert": {
-                    "label": &chunk.label,
-                    "body": &chunk.body,
-                    "len": chunk.body.len() as i64,
-                    "ord": ord as i64,
-                    "stored_ms": now_millis() as i64,
-                }},
+                doc! {
+                    "$setOnInsert": {
+                        "label": &chunk.label,
+                        "body": &chunk.body,
+                        "len": chunk.body.len() as i64,
+                        "ord": ord as i64,
+                        "stored_ms": now_millis() as i64,
+                    },
+                    "$addToSet": {"labels": &chunk.label},
+                },
             )
             .with_options(UpdateOptions::builder().upsert(true).build())
             .await;
@@ -973,29 +1004,111 @@ impl ContextStore for MongoStore {
             .map_err(mongo_err)?;
         let mut out = Vec::new();
         while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
-            let label = get_str(&doc, "label")?;
-            if label.starts_with(prefix) {
-                out.push(ChunkMeta {
-                    addr: ChunkAddr::new(get_str(&doc, "addr")?),
-                    label,
-                    len: get_i64(&doc, "len")? as usize,
-                    // Absent on documents written before the field existed;
-                    // those read as an unknown (`0`) store time rather than
-                    // failing the whole list.
-                    stored_at_millis: doc.get_i64("stored_ms").unwrap_or(0).max(0) as u64,
-                });
+            let addr = get_str(&doc, "addr")?;
+            let len = get_i64(&doc, "len")? as usize;
+            // Absent on documents written before the field existed; those
+            // read as an unknown (`0`) store time rather than failing the
+            // whole list. One document carries every label claiming its
+            // address, so the stamp is the address's first write — per-label
+            // stamps are an fs/sqlite refinement this backend does not keep.
+            let stored_at_millis = doc.get_i64("stored_ms").unwrap_or(0).max(0) as u64;
+            for label in doc_labels(&doc) {
+                if label.starts_with(prefix) {
+                    out.push(ChunkMeta {
+                        addr: ChunkAddr::new(addr.clone()),
+                        label,
+                        len,
+                        stored_at_millis,
+                    });
+                }
             }
         }
         Ok(out)
     }
 
     async fn delete(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
+        // Address-level: the one document carries the body and every label
+        // claim, so they go together.
         let result = self
             .collection("context_chunks")
             .delete_one(doc! {"company_id": id.as_ref(), "addr": addr.as_ref()})
             .await
             .map_err(mongo_err)?;
         Ok(result.deleted_count > 0)
+    }
+
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool> {
+        let chunks = self.collection("context_chunks");
+        // Label-scoped (#1300), in two single-document steps: one pipeline
+        // update that removes the claim from both shapes it can live in (the
+        // `labels` set and the legacy scalar `label` field) and re-points the
+        // scalar in the same atomic write, then a conditional reap of a body
+        // nothing claims any more.
+        // Both shapes a claim can live in, in read order: the legacy scalar
+        // first, then the set. Deduped by `$reduce` rather than `$setUnion`,
+        // which would not preserve that order.
+        let claims = doc! {"$reduce": {
+            "input": {"$filter": {
+                "input": {"$concatArrays": [
+                    {"$cond": [{"$ifNull": ["$label", false]}, ["$label"], []]},
+                    {"$ifNull": ["$labels", []]},
+                ]},
+                "cond": {"$ne": ["$$this", label]},
+            }},
+            "initialValue": [],
+            "in": {"$cond": [
+                {"$in": ["$$this", "$$value"]},
+                "$$value",
+                {"$concatArrays": ["$$value", ["$$this"]]},
+            ]},
+        }};
+        let removed = chunks
+            .update_one(
+                doc! {
+                    "company_id": id.as_ref(),
+                    "addr": addr.as_ref(),
+                    // Only a document this label actually claims, so a match
+                    // IS the answer to "did the pairing exist" — and so the
+                    // pipeline can never add a `labels` field to a legacy
+                    // document it has no claim to change.
+                    "$or": [{"label": label}, {"labels": label}],
+                },
+                // ONE update, so the document is never briefly without a
+                // scalar `label`: a pre-#1300 binary's `list` reads that field
+                // with a hard error on absence, and a rollback landing inside
+                // a two-step edit would meet exactly that. The second stage
+                // re-points the scalar at a surviving claim, or `$$REMOVE`s it
+                // when the last claim just went — which is the state the
+                // conditional delete below looks for.
+                vec![
+                    doc! {"$set": {"labels": claims}},
+                    doc! {"$set": {"label": {"$cond": [
+                        {"$gt": [{"$size": "$labels"}, 0]},
+                        {"$first": "$labels"},
+                        "$$REMOVE",
+                    ]}}},
+                ],
+            )
+            .await
+            .map_err(mongo_err)?;
+        let existed = removed.matched_count > 0;
+        if existed {
+            // Reap the body **conditionally**: this matches only a document
+            // no label claims any more, so a concurrent put's `$addToSet`
+            // landing in between makes the reap match nothing instead of
+            // losing that writer's claim — the check-then-delete race the
+            // callers' old snapshot guards carried.
+            chunks
+                .delete_one(doc! {
+                    "company_id": id.as_ref(),
+                    "addr": addr.as_ref(),
+                    "label": {"$exists": false},
+                    "$or": [{"labels": {"$exists": false}}, {"labels": {"$size": 0}}],
+                })
+                .await
+                .map_err(mongo_err)?;
+        }
+        Ok(existed)
     }
 
     async fn peek(
@@ -4672,6 +4785,117 @@ mod test {
     async fn conformance_context_multibyte_bodies() {
         let Some(s) = store().await else { return };
         conformance::assert_multibyte_bodies_survive_search_and_ranged_peek(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_identical_body_two_labels() {
+        let Some(s) = store().await else { return };
+        conformance::assert_identical_body_two_labels(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_scoped() {
+        let Some(s) = store().await else { return };
+        conformance::assert_delete_label_scoped(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_survives_a_concurrent_identical_put() {
+        let Some(s) = store().await else { return };
+        conformance::assert_delete_label_survives_a_concurrent_identical_put(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    /// The legacy scalar-`label` document shape (written before the `labels`
+    /// set existed) keeps working through every read and through the
+    /// label-scoped delete — `doc_labels` unions the two shapes, and the
+    /// `$unset` leg of `delete_label` is what removes a scalar claim.
+    #[tokio::test]
+    async fn legacy_scalar_label_documents_list_and_label_delete() {
+        let Some(s) = store().await else { return };
+        let id = CompanyId::new("acme");
+        let body = "written before the labels set";
+        // Seed the pre-#1300 shape directly: scalar label, no labels array —
+        // at the body's real content address, so a later put folds into it.
+        s.collection("context_chunks")
+            .insert_one(doc! {
+                "company_id": id.as_ref(),
+                "addr": content_address(body),
+                "label": "agent/ceo",
+                "body": body,
+                "len": body.len() as i64,
+                "ord": 1_i64,
+                "stored_ms": 7_i64,
+            })
+            .await
+            .expect("seed a legacy document");
+
+        let metas = ContextStore::list(s.as_ref(), &id, "").await.expect("list");
+        assert_eq!(
+            metas.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+            ["agent/ceo"],
+            "the scalar label is a claim"
+        );
+
+        // A second label on the same body folds into the set beside it.
+        let addr = s
+            .put(
+                &id,
+                ContextChunk {
+                    label: "agent/ops".to_string(),
+                    body: body.to_string(),
+                },
+            )
+            .await
+            .expect("put an identical body under a new label");
+        let mut labels: Vec<String> = ContextStore::list(s.as_ref(), &id, "")
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|m| m.addr == addr)
+            .map(|m| m.label)
+            .collect();
+        labels.sort();
+        assert_eq!(labels, ["agent/ceo", "agent/ops"]);
+
+        // Deleting the scalar claim leaves the set claim and the body.
+        assert!(
+            s.delete_label(&id, &addr, "agent/ceo")
+                .await
+                .expect("delete the scalar claim")
+        );
+        let after: Vec<String> = ContextStore::list(s.as_ref(), &id, "")
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|m| m.addr == addr)
+            .map(|m| m.label)
+            .collect();
+        assert_eq!(after, ["agent/ops"]);
+        s.peek(&id, &addr, None).await.expect("the body survives");
+
+        // The rollback contract, read from the raw document: while any claim
+        // remains the scalar `label` is present AND names a live claim. A
+        // pre-#1300 binary reads that field with a hard error on absence, so
+        // a document left without one would fail its whole `list`.
+        let raw = s
+            .collection("context_chunks")
+            .find_one(doc! {"company_id": id.as_ref(), "addr": addr.as_ref()})
+            .await
+            .unwrap()
+            .expect("the document survives");
+        assert_eq!(
+            raw.get_str("label").ok(),
+            Some("agent/ops"),
+            "the scalar must re-point at a surviving claim: {raw:?}"
+        );
+
+        // And the last claim takes the document with it.
+        assert!(s.delete_label(&id, &addr, "agent/ops").await.unwrap());
+        assert!(s.peek(&id, &addr, None).await.is_err());
         drop_db(&s).await;
     }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -118,6 +118,22 @@ fn get_i64(doc: &Document, key: &str) -> Result<i64> {
 /// plus the legacy scalar `label` field — documents written before the set
 /// existed carry only the scalar, and new writes keep it as the first label so
 /// a downgraded binary still reads what it always read. Deduped, scalar first.
+/// Wraps an array-valued aggregation expression in a `$reduce` that drops
+/// duplicates while **preserving order** — `$setUnion` dedupes but reorders,
+/// and the context-chunk label list is read in order (the first claim is the
+/// one the legacy scalar `label` names).
+fn dedupe_preserving_order(input: Document) -> Document {
+    doc! {"$reduce": {
+        "input": input,
+        "initialValue": [],
+        "in": {"$cond": [
+            {"$in": ["$$this", "$$value"]},
+            "$$value",
+            {"$concatArrays": ["$$value", ["$$this"]]},
+        ]},
+    }}
+}
+
 fn doc_labels(doc: &Document) -> Vec<String> {
     let mut labels = Vec::new();
     if let Ok(scalar) = doc.get_str("label") {
@@ -965,27 +981,37 @@ impl ContextStore for MongoStore {
         let addr = content_address(&chunk.body);
         // Insertion order stands in for the sqlite backend's rowid ordering.
         let ord = self.next_seq(id, "context_ord").await?;
-        // Body + metadata land once (`$setOnInsert`, first-write-wins per
-        // address); every put also folds its label into the `labels` set
-        // (`$addToSet` — one claim per (addr, label), #1300), so a
-        // byte-identical body stored under a second label keeps both claims.
-        // The scalar `label` field stays the first write's label so a
-        // downgraded binary keeps reading what it always read; `doc_labels`
-        // unions the two shapes on every read.
+        // Body + metadata land once and never move (first-write-wins per
+        // address); every put folds its label into the `labels` set — one
+        // claim per (addr, label), #1300 — so a byte-identical body stored
+        // under a second label keeps both claims.
+        //
+        // A pipeline rather than `$setOnInsert` + `$addToSet`, for the scalar
+        // `label`: `$setOnInsert` is skipped on a document that already
+        // exists, so a document that has somehow lost its scalar would gain a
+        // claim while staying scalar-less — and a pre-#1300 `list` reads that
+        // field with a hard error on absence, so a rollback would meet a
+        // document it cannot read. `$ifNull` restores it from this write
+        // instead, and keeps the existing one untouched when there is one.
+        let claims = dedupe_preserving_order(doc! {"$concatArrays": [
+            {"$ifNull": ["$labels", []]},
+            [chunk.label.as_str()],
+        ]});
         let result = self
             .collection("context_chunks")
             .update_one(
                 doc! {"company_id": id.as_ref(), "addr": &addr},
-                doc! {
-                    "$setOnInsert": {
-                        "label": &chunk.label,
-                        "body": &chunk.body,
-                        "len": chunk.body.len() as i64,
-                        "ord": ord as i64,
-                        "stored_ms": now_millis() as i64,
-                    },
-                    "$addToSet": {"labels": &chunk.label},
-                },
+                vec![doc! {"$set": {
+                    "labels": claims,
+                    // `$ifNull` IS the first-write-wins rule: on an upsert
+                    // insert every field is missing and takes this write's
+                    // value; on an existing document each keeps what it has.
+                    "label": {"$ifNull": ["$label", chunk.label.as_str()]},
+                    "body": {"$ifNull": ["$body", chunk.body.as_str()]},
+                    "len": {"$ifNull": ["$len", chunk.body.len() as i64]},
+                    "ord": {"$ifNull": ["$ord", ord as i64]},
+                    "stored_ms": {"$ifNull": ["$stored_ms", now_millis() as i64]},
+                }}],
             )
             .with_options(UpdateOptions::builder().upsert(true).build())
             .await;
@@ -1039,29 +1065,46 @@ impl ContextStore for MongoStore {
 
     async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool> {
         let chunks = self.collection("context_chunks");
-        // Label-scoped (#1300), in two single-document steps: one pipeline
-        // update that removes the claim from both shapes it can live in (the
-        // `labels` set and the legacy scalar `label` field) and re-points the
-        // scalar in the same atomic write, then a conditional reap of a body
-        // nothing claims any more.
-        // Both shapes a claim can live in, in read order: the legacy scalar
-        // first, then the set. Deduped by `$reduce` rather than `$setUnion`,
-        // which would not preserve that order.
-        let claims = doc! {"$reduce": {
-            "input": {"$filter": {
-                "input": {"$concatArrays": [
-                    {"$cond": [{"$ifNull": ["$label", false]}, ["$label"], []]},
-                    {"$ifNull": ["$labels", []]},
-                ]},
-                "cond": {"$ne": ["$$this", label]},
-            }},
-            "initialValue": [],
-            "in": {"$cond": [
-                {"$in": ["$$this", "$$value"]},
-                "$$value",
-                {"$concatArrays": ["$$value", ["$$this"]]},
-            ]},
-        }};
+        // Every label claiming this document, as an expression over both
+        // shapes a claim lives in: the legacy scalar `label` first, then the
+        // `labels` set.
+        let claim_union = doc! {"$concatArrays": [
+            {"$cond": [{"$ifNull": ["$label", false]}, ["$label"], []]},
+            {"$ifNull": ["$labels", []]},
+        ]};
+
+        // Label-scoped (#1300), as ONE atomic document operation per outcome
+        // — never a read followed by a write, and never an intermediate state
+        // a concurrent reader or writer can observe.
+        //
+        // First outcome: this label is the ONLY claim, so the whole document
+        // goes. `$setEquals` ignores order and duplicates, and the condition
+        // is evaluated by the server as part of the delete, so a concurrent
+        // put that adds a second claim first simply makes this match nothing
+        // — the check-then-delete race the callers' old snapshot guards
+        // carried, closed by construction rather than by a snapshot.
+        let reaped = chunks
+            .delete_one(doc! {
+                "company_id": id.as_ref(),
+                "addr": addr.as_ref(),
+                "$expr": {"$setEquals": [claim_union.clone(), [label]]},
+            })
+            .await
+            .map_err(mongo_err)?;
+        if reaped.deleted_count > 0 {
+            return Ok(true);
+        }
+
+        // Second outcome: other claims remain, so only this one is removed.
+        // The scalar is re-pointed at a survivor in the SAME update, and this
+        // branch can only run while a survivor exists — so the document is
+        // never left without a scalar `label`, which a pre-#1300 `list` reads
+        // with a hard error on absence. Deduped by `$reduce` rather than
+        // `$setUnion`, which would not preserve read order.
+        let survivors = dedupe_preserving_order(doc! {"$filter": {
+            "input": claim_union,
+            "cond": {"$ne": ["$$this", label]},
+        }});
         let removed = chunks
             .update_one(
                 doc! {
@@ -1069,46 +1112,17 @@ impl ContextStore for MongoStore {
                     "addr": addr.as_ref(),
                     // Only a document this label actually claims, so a match
                     // IS the answer to "did the pairing exist" — and so the
-                    // pipeline can never add a `labels` field to a legacy
-                    // document it has no claim to change.
+                    // pipeline can never touch a document it has no claim on.
                     "$or": [{"label": label}, {"labels": label}],
                 },
-                // ONE update, so the document is never briefly without a
-                // scalar `label`: a pre-#1300 binary's `list` reads that field
-                // with a hard error on absence, and a rollback landing inside
-                // a two-step edit would meet exactly that. The second stage
-                // re-points the scalar at a surviving claim, or `$$REMOVE`s it
-                // when the last claim just went — which is the state the
-                // conditional delete below looks for.
-                vec![
-                    doc! {"$set": {"labels": claims}},
-                    doc! {"$set": {"label": {"$cond": [
-                        {"$gt": [{"$size": "$labels"}, 0]},
-                        {"$first": "$labels"},
-                        "$$REMOVE",
-                    ]}}},
-                ],
+                vec![doc! {"$set": {
+                    "labels": survivors.clone(),
+                    "label": {"$first": survivors},
+                }}],
             )
             .await
             .map_err(mongo_err)?;
-        let existed = removed.matched_count > 0;
-        if existed {
-            // Reap the body **conditionally**: this matches only a document
-            // no label claims any more, so a concurrent put's `$addToSet`
-            // landing in between makes the reap match nothing instead of
-            // losing that writer's claim — the check-then-delete race the
-            // callers' old snapshot guards carried.
-            chunks
-                .delete_one(doc! {
-                    "company_id": id.as_ref(),
-                    "addr": addr.as_ref(),
-                    "label": {"$exists": false},
-                    "$or": [{"labels": {"$exists": false}}, {"labels": {"$size": 0}}],
-                })
-                .await
-                .map_err(mongo_err)?;
-        }
-        Ok(existed)
+        Ok(removed.matched_count > 0)
     }
 
     async fn peek(
@@ -4896,6 +4910,65 @@ mod test {
         // And the last claim takes the document with it.
         assert!(s.delete_label(&id, &addr, "agent/ops").await.unwrap());
         assert!(s.peek(&id, &addr, None).await.is_err());
+        drop_db(&s).await;
+    }
+
+    /// A document carrying claims but no scalar `label` heals on the next
+    /// `put`, rather than gaining a claim and staying unreadable to a
+    /// pre-#1300 `list` (which reads that field with a hard error on
+    /// absence). `$setOnInsert` could not do this — it is skipped entirely on
+    /// a document that already exists — which is why `put` is a pipeline.
+    ///
+    /// Seeded directly rather than raced for: `delete_label` no longer leaves
+    /// this state (it either deletes the document atomically or re-points the
+    /// scalar in the same update), so the only honest way to test the healing
+    /// is to construct the state a rollback or an older build could leave.
+    #[tokio::test]
+    async fn a_put_restores_a_missing_scalar_label_and_keeps_first_write_wins() {
+        let Some(s) = store().await else { return };
+        let id = CompanyId::new("acme");
+        let body = "a document that lost its scalar label";
+        s.collection("context_chunks")
+            .insert_one(doc! {
+                "company_id": id.as_ref(),
+                "addr": content_address(body),
+                "body": body,
+                "len": body.len() as i64,
+                "ord": 1_i64,
+                "stored_ms": 7_i64,
+                "labels": [],
+            })
+            .await
+            .expect("seed a scalar-less document");
+
+        let addr = s
+            .put(
+                &id,
+                ContextChunk {
+                    label: "agent/ops".to_string(),
+                    body: body.to_string(),
+                },
+            )
+            .await
+            .expect("put onto the scalar-less document");
+
+        let raw = s
+            .collection("context_chunks")
+            .find_one(doc! {"company_id": id.as_ref(), "addr": addr.as_ref()})
+            .await
+            .unwrap()
+            .expect("the document is still there");
+        assert_eq!(
+            raw.get_str("label").ok(),
+            Some("agent/ops"),
+            "the write restores the scalar it found missing: {raw:?}"
+        );
+        assert_eq!(doc_labels(&raw), ["agent/ops"], "and claims it once");
+        assert_eq!(
+            raw.get_i64("stored_ms").ok(),
+            Some(7),
+            "first-write-wins still holds for the fields that were present"
+        );
         drop_db(&s).await;
     }
 

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -422,6 +422,41 @@ impl std::fmt::Debug for StorageHandles {
     }
 }
 
+/// Which deployment of a hosted engine the credential belongs to.
+///
+/// Not cosmetic, and not inferable from the URL. Mem0 and Cognee each expose
+/// two products that speak *different protocols* under the same driver id:
+/// Mem0's platform authenticates with `Authorization: Token` and serves v3/v1
+/// paths while its open-source server uses `X-API-Key` and un-prefixed ones;
+/// Cognee Cloud uses `X-Api-Key` where an authenticated self-hosted instance
+/// takes a bearer token. Pointing the wrong one at a live service fails at the
+/// first request — a 404 on paths that do not exist there, or a 401 whose body
+/// says `Invalid header` — and neither error names the real cause.
+///
+/// Supermemory is the exception that made this easy to miss: it serves the
+/// same API with the same bearer credential either way, so the single
+/// constructor OpenCompany used worked against it and against nothing else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RemoteDeployment {
+    /// The vendor's managed platform. The default, because that is what
+    /// `remote` mode is for; a self-hosted engine is the deliberate case.
+    #[default]
+    Managed,
+    /// An instance the operator runs themselves.
+    SelfHosted,
+}
+
+impl RemoteDeployment {
+    /// Parses the wire value, or `None` when it names neither deployment.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "managed" | "cloud" | "hosted" | "platform" => Some(Self::Managed),
+            "self-hosted" | "selfhosted" | "self" => Some(Self::SelfHosted),
+            _ => None,
+        }
+    }
+}
+
 /// Connection settings for [`open_storage`]. `fs` needs nothing beyond the
 /// runtime's home directory (handled by the builder's defaults), so it yields
 /// `None` handles.
@@ -485,6 +520,14 @@ pub struct StorageSettings {
     /// The hosted manager injects environment rather than manifests, which is
     /// what makes env sufficient.
     pub memory_api_key: Option<String>,
+    /// Which deployment of the named remote engine the credential belongs to
+    /// (`OPENCOMPANY_MEMORY_DEPLOYMENT`: `managed` or `self-hosted`).
+    ///
+    /// Defaults to managed. Mem0 and Cognee serve different protocols to their
+    /// platform and their self-hosted server under one driver id, so this is
+    /// not inferable from the URL, and getting it wrong fails at the first
+    /// request with an error that names neither the cause nor this setting.
+    pub memory_deployment: RemoteDeployment,
 }
 
 impl std::fmt::Debug for StorageSettings {
@@ -561,6 +604,10 @@ impl StorageSettings {
             memory_driver: non_empty("OPENCOMPANY_MEMORY_DRIVER"),
             memory_url: non_empty("OPENCOMPANY_MEMORY_URL"),
             memory_api_key: non_empty("OPENCOMPANY_MEMORY_API_KEY"),
+            memory_deployment: non_empty("OPENCOMPANY_MEMORY_DEPLOYMENT")
+                .as_deref()
+                .and_then(RemoteDeployment::parse)
+                .unwrap_or_default(),
         })
     }
 
@@ -806,6 +853,7 @@ fn open_provider(settings: &StorageSettings) -> Result<Option<MemoryOverlay>> {
         url: settings.memory_url.clone(),
         api_key: settings.memory_api_key.clone(),
         data_dir: settings.data_dir.clone(),
+        deployment: settings.memory_deployment,
     };
     let Some((provider, class)) = open_driver(&config)? else {
         // Only `embedded` can answer "no driver to bind", and the caller only

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -98,6 +98,18 @@ CREATE TABLE IF NOT EXISTS context_chunks (
     stored_ms  INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (company_id, addr)
 );
+-- The context index: one row per (addr, label) claim, the shape the fs
+-- backend's JSONL index always had (issue #1300). `context_chunks` keeps one
+-- body row per address (its `label` column stays the first write's label so a
+-- downgraded binary keeps reading what it always read); this table is what
+-- `list` and the label-scoped delete read and mutate.
+CREATE TABLE IF NOT EXISTS context_chunk_labels (
+    company_id TEXT NOT NULL,
+    addr       TEXT NOT NULL,
+    label      TEXT NOT NULL,
+    stored_ms  INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (company_id, addr, label)
+);
 CREATE TABLE IF NOT EXISTS secrets (
     company_id TEXT NOT NULL,
     key        TEXT NOT NULL,
@@ -416,6 +428,40 @@ fn relax_runs_task_id_nullability(conn: &Connection) -> Result<()> {
     .map_err(sql_err)
 }
 
+/// Heals `context_chunk_labels` against `context_chunks` at open (issue #1300).
+///
+/// Two idempotent steps, one transaction, covering every mixed-version
+/// history a database can have:
+///
+/// - **Backfill**: a body row whose (addr, label) has no index row — a
+///   database from before the labels table existed, or a row an older binary
+///   wrote since — gets one, carrying the body row's stamp. `INSERT OR
+///   IGNORE` on the full primary key makes re-running a no-op, and a
+///   label-scoped delete can never be undone by it: when the last label goes
+///   the body row goes in the same transaction, so there is nothing left to
+///   backfill from.
+/// - **Orphan sweep**: an index row whose body row is gone — an older
+///   binary's address-level delete removed only `context_chunks` — is
+///   dropped, so `list` never names a chunk `peek` cannot read.
+///
+/// Both run on every open rather than behind a version flag, matching the
+/// other heals in this file, which read the live schema instead of trusting a
+/// stamp. The cost is two anti-joins against a primary-key index, once per
+/// process, and neither writes anything on an already-healed database.
+fn sync_context_chunk_labels(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "BEGIN;
+         INSERT OR IGNORE INTO context_chunk_labels (company_id, addr, label, stored_ms)
+             SELECT company_id, addr, label, stored_ms FROM context_chunks;
+         DELETE FROM context_chunk_labels WHERE NOT EXISTS (
+             SELECT 1 FROM context_chunks c
+             WHERE c.company_id = context_chunk_labels.company_id
+               AND c.addr = context_chunk_labels.addr);
+         COMMIT;",
+    )
+    .map_err(sql_err)
+}
+
 /// Runs `write` with `synchronous=FULL`, so its commit is fsynced, and restores
 /// `NORMAL` afterwards no matter how `write` ended.
 ///
@@ -489,6 +535,10 @@ impl SqliteStore {
         // insert on a constraint the record no longer has. Idempotent: it reads
         // the live schema and does nothing once the constraint is gone.
         relax_runs_task_id_nullability(&conn)?;
+        // Issue #1300: the context index moved into `context_chunk_labels`
+        // (one row per (addr, label) claim). Runs after the `stored_ms`
+        // column heal above, whose column it reads.
+        sync_context_chunk_labels(&conn)?;
         Ok(Self {
             conn: Arc::new(StdMutex::new(conn)),
             senders: Arc::new(StdMutex::new(HashMap::new())),
@@ -956,8 +1006,18 @@ impl MemoryStore for SqliteStore {
 impl ContextStore for SqliteStore {
     async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
         let addr = content_address(&chunk.body);
-        let conn = self.conn();
-        conn.execute(
+        // One clock read for both rows: a body row and the claim that lands
+        // with it describe the same write and must not disagree by a
+        // millisecond the caller can observe through `list`.
+        let stored_ms = now_millis() as i64;
+        let mut conn = self.conn();
+        // Body row first-write-wins per address; the labels index accumulates
+        // one row per (addr, label) — set semantics, so a byte-identical body
+        // stored under a second label keeps both claims, and a re-put of an
+        // identical (body, label) is a no-op (#1300). One transaction, so a
+        // body row can never land without its index row.
+        let tx = conn.transaction().map_err(sql_err)?;
+        tx.execute(
             "INSERT OR IGNORE INTO context_chunks (company_id, addr, label, body, len, stored_ms) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
@@ -966,19 +1026,31 @@ impl ContextStore for SqliteStore {
                 chunk.label,
                 chunk.body,
                 chunk.body.len() as i64,
-                now_millis() as i64
+                stored_ms
             ],
         )
         .map_err(sql_err)?;
+        tx.execute(
+            "INSERT OR IGNORE INTO context_chunk_labels (company_id, addr, label, stored_ms) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![id.as_ref(), addr, chunk.label, stored_ms],
+        )
+        .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
         Ok(ChunkAddr::new(addr))
     }
 
     async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
         let conn = self.conn();
+        // The labels table is the index (#1300); the join carries each claim's
+        // body length from the one body row. `l.rowid` keeps insertion order,
+        // the same order the single-table `rowid` scan used to give.
         let mut stmt = conn
             .prepare(
-                "SELECT addr, label, len, stored_ms FROM context_chunks \
-                 WHERE company_id = ?1 ORDER BY rowid",
+                "SELECT l.addr, l.label, c.len, l.stored_ms \
+                 FROM context_chunk_labels l \
+                 JOIN context_chunks c ON c.company_id = l.company_id AND c.addr = l.addr \
+                 WHERE l.company_id = ?1 ORDER BY l.rowid",
             )
             .map_err(sql_err)?;
         let rows = stmt
@@ -1060,13 +1132,59 @@ impl ContextStore for SqliteStore {
     }
 
     async fn delete(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
-        let conn = self.conn();
-        let removed = conn
+        let mut conn = self.conn();
+        // Address-level: the body row and every label claim go together, in
+        // one transaction so no half can survive the other.
+        let tx = conn.transaction().map_err(sql_err)?;
+        let removed_labels = tx
+            .execute(
+                "DELETE FROM context_chunk_labels WHERE company_id = ?1 AND addr = ?2",
+                params![id.as_ref(), addr.as_ref()],
+            )
+            .map_err(sql_err)?;
+        let removed = tx
             .execute(
                 "DELETE FROM context_chunks WHERE company_id = ?1 AND addr = ?2",
                 params![id.as_ref(), addr.as_ref()],
             )
             .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
+        Ok(removed > 0 || removed_labels > 0)
+    }
+
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool> {
+        let mut conn = self.conn();
+        // Label-scoped (#1300): remove exactly one (addr, label) claim, and
+        // reap the body row when — and only when — no claim remains. The
+        // check and both deletes are one transaction, so a concurrent put of
+        // identical content under another label either commits its claim
+        // before this transaction (and keeps the body) or after it.
+        let tx = conn.transaction().map_err(sql_err)?;
+        let removed = tx
+            .execute(
+                "DELETE FROM context_chunk_labels \
+                 WHERE company_id = ?1 AND addr = ?2 AND label = ?3",
+                params![id.as_ref(), addr.as_ref(), label],
+            )
+            .map_err(sql_err)?;
+        if removed > 0 {
+            let remaining: i64 = tx
+                .query_row(
+                    "SELECT COUNT(*) FROM context_chunk_labels \
+                     WHERE company_id = ?1 AND addr = ?2",
+                    params![id.as_ref(), addr.as_ref()],
+                    |r| r.get(0),
+                )
+                .map_err(sql_err)?;
+            if remaining == 0 {
+                tx.execute(
+                    "DELETE FROM context_chunks WHERE company_id = ?1 AND addr = ?2",
+                    params![id.as_ref(), addr.as_ref()],
+                )
+                .map_err(sql_err)?;
+            }
+        }
+        tx.commit().map_err(sql_err)?;
         Ok(removed > 0)
     }
 
@@ -3711,6 +3829,21 @@ mod test {
         conformance::assert_multibyte_bodies_survive_search_and_ranged_peek(store()).await;
     }
 
+    #[tokio::test]
+    async fn conformance_context_identical_body_two_labels() {
+        conformance::assert_identical_body_two_labels(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_scoped() {
+        conformance::assert_delete_label_scoped(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_survives_a_concurrent_identical_put() {
+        conformance::assert_delete_label_survives_a_concurrent_identical_put(store()).await;
+    }
+
     /// The migration path a fresh database never exercises.
     ///
     /// [`MIGRATIONS`] is all `CREATE TABLE IF NOT EXISTS`, which is a no-op
@@ -3790,6 +3923,79 @@ mod test {
             "INTEGER NOT NULL DEFAULT 0",
         )
         .expect("adding an existing column is a no-op, not an error");
+    }
+
+    /// Issue #1300's open-time heals on a mixed-version database: the
+    /// backfill gives a row an older binary wrote its label claim (so the
+    /// label-scoped delete can reach it), and the orphan sweep drops an index
+    /// row whose body row an older binary's address-level delete removed.
+    #[tokio::test]
+    async fn legacy_context_rows_gain_label_claims_and_orphans_are_swept_on_open() {
+        let conn = Connection::open_in_memory().expect("open in-memory sqlite");
+        conn.execute_batch(
+            "CREATE TABLE context_chunks (
+                 company_id TEXT NOT NULL,
+                 addr       TEXT NOT NULL,
+                 label      TEXT NOT NULL,
+                 body       TEXT NOT NULL,
+                 len        INTEGER NOT NULL,
+                 stored_ms  INTEGER NOT NULL DEFAULT 0,
+                 PRIMARY KEY (company_id, addr)
+             );
+             CREATE TABLE context_chunk_labels (
+                 company_id TEXT NOT NULL,
+                 addr       TEXT NOT NULL,
+                 label      TEXT NOT NULL,
+                 stored_ms  INTEGER NOT NULL DEFAULT 0,
+                 PRIMARY KEY (company_id, addr, label)
+             );
+             -- A row an older binary wrote after the labels table existed: the
+             -- body row is there, its claim is not.
+             INSERT INTO context_chunks (company_id, addr, label, body, len, stored_ms)
+             VALUES ('acme', 'old-binary-addr', 'agent/ceo', 'written by an old binary', 24, 7);
+             -- And the reverse: a claim whose body row an older binary's
+             -- address-level delete removed.
+             INSERT INTO context_chunk_labels (company_id, addr, label, stored_ms)
+             VALUES ('acme', 'reaped-addr', 'agent/ops', 9);",
+        )
+        .expect("seed a mixed-version database");
+
+        let store = SqliteStore::from_conn(conn).expect("migrations run");
+        let id = CompanyId::new("acme");
+
+        let metas = ContextStore::list(&store, &id, "")
+            .await
+            .expect("list after the heals");
+        assert_eq!(
+            metas.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+            ["agent/ceo"],
+            "the old binary's row gains its claim; the orphaned claim is swept"
+        );
+        assert_eq!(
+            metas[0].stored_at_millis, 7,
+            "the backfilled claim carries the body row's stamp"
+        );
+
+        // The backfilled claim is label-deletable, and takes the body with it
+        // as the last claim.
+        let addr = ChunkAddr::new("old-binary-addr".to_string());
+        assert!(
+            store
+                .delete_label(&id, &addr, "agent/ceo")
+                .await
+                .expect("label-scoped delete on a backfilled claim")
+        );
+        assert!(
+            ContextStore::list(&store, &id, "")
+                .await
+                .unwrap()
+                .is_empty(),
+            "no claim may remain"
+        );
+        assert!(
+            store.peek(&id, &addr, None).await.is_err(),
+            "the body row went with its last claim"
+        );
     }
 
     /// Issue #983: a database created while `runs.task_id` was `NOT NULL` must

--- a/src/store/tinycortex.rs
+++ b/src/store/tinycortex.rs
@@ -92,6 +92,10 @@ pub trait CortexClient: Send + Sync {
     /// Permanently removes the chunk at `addr`, returning whether it existed.
     /// Propagates to the backing store.
     async fn hard_delete_chunk(&self, company: &str, addr: &str) -> Result<bool>;
+    /// Removes `label`'s claim on the chunk at `addr` (issue #1300), reaping
+    /// the chunk when the last claim goes; returns whether that (addr, label)
+    /// pairing existed. Propagates to the backing store.
+    async fn delete_chunk_label(&self, company: &str, addr: &str, label: &str) -> Result<bool>;
     /// Rewrites every occurrence of `needle` with `replacement` across a
     /// company's traces (live and archived) and chunk bodies, returning the
     /// number of occurrences replaced. Propagates to the backing store.
@@ -200,8 +204,14 @@ impl CortexClient for InMemoryCortex {
 
     async fn put_chunk(&self, company: &str, addr: &str, chunk: ContextChunk) -> Result<()> {
         self.with_company(company, |c| {
-            // Content-addressed: an identical body is stored once.
-            if !c.chunks.iter().any(|s| s.addr == addr) {
+            // Content-addressed, one row per (addr, label) claim (#1300): an
+            // identical body under a new label lands its row, a re-put of an
+            // identical (addr, label) is a no-op.
+            if !c
+                .chunks
+                .iter()
+                .any(|s| s.addr == addr && s.label == chunk.label)
+            {
                 c.chunks.push(StoredChunk {
                     addr: addr.to_string(),
                     label: chunk.label,
@@ -262,6 +272,17 @@ impl CortexClient for InMemoryCortex {
         Ok(self.with_company(company, |c| {
             let before = c.chunks.len();
             c.chunks.retain(|s| s.addr != addr);
+            before != c.chunks.len()
+        }))
+    }
+
+    async fn delete_chunk_label(&self, company: &str, addr: &str, label: &str) -> Result<bool> {
+        // One row per (addr, label), so removing the claim IS removing the
+        // row; the body is gone exactly when the last row goes. Atomic under
+        // the cells mutex, like every other mutation here.
+        Ok(self.with_company(company, |c| {
+            let before = c.chunks.len();
+            c.chunks.retain(|s| !(s.addr == addr && s.label == label));
             before != c.chunks.len()
         }))
     }
@@ -480,6 +501,12 @@ impl ContextStore for CortexContextStore {
             .hard_delete_chunk(id.as_ref(), addr.as_ref())
             .await
     }
+
+    async fn delete_label(&self, id: &CompanyId, addr: &ChunkAddr, label: &str) -> Result<bool> {
+        self.client
+            .delete_chunk_label(id.as_ref(), addr.as_ref(), label)
+            .await
+    }
 }
 
 /// Builds a [`MemoryStore`] + [`ContextStore`] pair over one shared
@@ -561,6 +588,27 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
         let (_store, _events, _mem, ctx) = stores(dir.path());
         conformance::assert_multibyte_bodies_survive_search_and_ranged_peek(ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_identical_body_two_labels() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_identical_body_two_labels(ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_delete_label_scoped(ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_survives_a_concurrent_identical_put() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_delete_label_survives_a_concurrent_identical_put(ctx).await;
     }
 
     fn company() -> CompanyId {

--- a/src/store/tinycortex_engine.rs
+++ b/src/store/tinycortex_engine.rs
@@ -107,12 +107,31 @@ fn embed_text(label: &str, body: &str) -> String {
     format!("{label}\n{body}")
 }
 
-/// A persisted context chunk: its label, body, and first-stored wall-clock.
+/// A persisted context chunk: its label(s), body, and first-stored wall-clock.
 #[derive(Clone, Serialize, Deserialize)]
 struct StoredChunk {
+    /// The first label to claim this address — kept meaningful on its own so a
+    /// binary from before `labels` existed still reads what it always read.
     label: String,
     body: String,
     stored_at_millis: u64,
+    /// Every label claiming this address (#1300) — content addressing means a
+    /// byte-identical body stored under a second label lands here rather than
+    /// as a second record. Records written before the field existed decode to
+    /// an empty vec; [`labels_of`] unions the scalar back in.
+    #[serde(default)]
+    labels: Vec<String>,
+}
+
+/// Every label claiming `chunk`, deduped, scalar (first-stored) label first.
+fn labels_of(chunk: &StoredChunk) -> Vec<String> {
+    let mut labels = vec![chunk.label.clone()];
+    for label in &chunk.labels {
+        if !labels.iter().any(|have| have == label) {
+            labels.push(label.clone());
+        }
+    }
+    labels
 }
 
 // ---------------------------------------------------------------------------
@@ -524,21 +543,32 @@ impl CortexClient for EngineCortex {
 
     async fn put_chunk(&self, company: &str, addr: &str, chunk: ContextChunk) -> Result<()> {
         let engine = self.engine(company).await?;
+        // Serialize the read-merge-write on the chunk record: two concurrent
+        // puts of one body under different labels must both land their claim
+        // (#1300), not both read the same record and drop one.
+        let _guard = engine.write_lock.lock().await;
         let key = format!("{KEY_CHUNK_PREFIX}{addr}");
-        // Content-addressed: an identical body is stored once.
-        if engine
-            .kv
-            .get_global(&key)
-            .map_err(|e| OpenCompanyError::Store(format!("kv get {key}: {e}")))?
-            .is_some()
-        {
-            return Ok(());
+        // Content-addressed: an identical body is stored once, and each label
+        // claiming it is folded into the record's label set. No re-embed on a
+        // label-only fold: the vector row was built from the first label and
+        // the body, and every label stays lexically findable through the KV
+        // record either way.
+        if let Some(existing) = engine.get_json::<StoredChunk>(&key)? {
+            let labels = labels_of(&existing);
+            if labels.iter().any(|have| have == &chunk.label) {
+                return Ok(());
+            }
+            let mut updated = existing;
+            updated.labels = labels;
+            updated.labels.push(chunk.label);
+            return engine.put_json(&key, &updated);
         }
         // The text used for the meaning tier, captured before the fields move.
         let text = embed_text(&chunk.label, &chunk.body);
         engine.put_json(
             &key,
             &StoredChunk {
+                labels: vec![chunk.label.clone()],
                 label: chunk.label,
                 body: chunk.body,
                 stored_at_millis: now_millis(),
@@ -562,12 +592,23 @@ impl CortexClient for EngineCortex {
         Ok(engine
             .all_chunks()?
             .into_iter()
-            .filter(|(_, chunk)| chunk.label.starts_with(prefix))
-            .map(|(addr, chunk)| ChunkMeta {
-                addr: ChunkAddr::new(addr),
-                len: chunk.body.len(),
-                label: chunk.label,
-                stored_at_millis: chunk.stored_at_millis,
+            .flat_map(|(addr, chunk)| {
+                // One meta per label claiming the address (#1300). The stamp
+                // is the address's first write: the record is one row however
+                // many labels claim it, so per-label stamps (an fs/sqlite
+                // refinement) are not kept here.
+                let len = chunk.body.len();
+                let stored_at_millis = chunk.stored_at_millis;
+                labels_of(&chunk)
+                    .into_iter()
+                    .filter(|label| label.starts_with(prefix))
+                    .map(move |label| ChunkMeta {
+                        addr: ChunkAddr::new(addr.clone()),
+                        len,
+                        label,
+                        stored_at_millis,
+                    })
+                    .collect::<Vec<_>>()
             })
             .collect())
     }
@@ -638,6 +679,48 @@ impl CortexClient for EngineCortex {
             tracing::warn!(company, addr, error = %e, "[tinycortex] deleting vector row failed");
         }
         Ok(deleted)
+    }
+
+    async fn delete_chunk_label(&self, company: &str, addr: &str, label: &str) -> Result<bool> {
+        let engine = self.engine(company).await?;
+        // Serialize against concurrent puts of the same address: the reap
+        // decision (last label gone → record goes) must see every claim a
+        // committed put landed (#1300).
+        let _guard = engine.write_lock.lock().await;
+        let key = format!("{KEY_CHUNK_PREFIX}{addr}");
+        let Some(chunk) = engine.get_json::<StoredChunk>(&key)? else {
+            return Ok(false);
+        };
+        let mut labels = labels_of(&chunk);
+        let before = labels.len();
+        labels.retain(|have| have != label);
+        if labels.len() == before {
+            return Ok(false);
+        }
+        if labels.is_empty() {
+            // Last claim gone: reap the record and its vector row, exactly as
+            // `hard_delete_chunk` does.
+            engine
+                .kv
+                .delete_global(&key)
+                .map_err(|e| OpenCompanyError::Store(format!("kv delete {key}: {e}")))?;
+            if let Some(vectors) = &engine.vectors
+                && let Err(e) = vectors.delete(company, addr)
+            {
+                tracing::warn!(company, addr, error = %e, "[tinycortex] deleting vector row failed");
+            }
+            return Ok(true);
+        }
+        let updated = StoredChunk {
+            // The scalar stays a real label so a pre-`labels` binary keeps
+            // reading a claim that still exists.
+            label: labels[0].clone(),
+            labels,
+            body: chunk.body,
+            stored_at_millis: chunk.stored_at_millis,
+        };
+        engine.put_json(&key, &updated)?;
+        Ok(true)
     }
 
     async fn redact(&self, company: &str, needle: &str, replacement: &str) -> Result<u64> {
@@ -932,6 +1015,105 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
         let (_store, _events, _mem, ctx) = stores(dir.path());
         conformance::assert_context_chunk_stamps(ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_identical_body_two_labels() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_identical_body_two_labels(ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_delete_label_scoped(ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_delete_label_survives_a_concurrent_identical_put() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_delete_label_survives_a_concurrent_identical_put(ctx).await;
+    }
+
+    /// A chunk record persisted before the `labels` set existed (scalar label
+    /// only) keeps its claim through the union read, folds a second label in
+    /// beside it, and stays label-deletable — the mixed-version story the
+    /// serde default alone does not prove.
+    #[tokio::test]
+    async fn legacy_scalar_label_records_fold_and_label_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let cortex = EngineCortex::new(dir.path().to_path_buf());
+        let body = "written before the labels set";
+        let addr = crate::store::content_address(body);
+        // Seed the pre-#1300 record shape directly at the KV tier — as a
+        // structured value, the same rule `put_json` documents.
+        {
+            let engine = cortex.engine("acme").await.unwrap();
+            engine
+                .kv
+                .set_global(
+                    &format!("{KEY_CHUNK_PREFIX}{addr}"),
+                    &serde_json::json!({
+                        "label": "agent/ceo",
+                        "body": body,
+                        "stored_at_millis": 7,
+                    }),
+                )
+                .unwrap();
+        }
+
+        let labels =
+            |metas: Vec<ChunkMeta>| -> Vec<String> { metas.into_iter().map(|m| m.label).collect() };
+        assert_eq!(
+            labels(cortex.list_chunks("acme", "").await.unwrap()),
+            ["agent/ceo"],
+            "the scalar label is a claim"
+        );
+
+        cortex
+            .put_chunk(
+                "acme",
+                &addr,
+                ContextChunk {
+                    label: "agent/ops".to_string(),
+                    body: body.to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let mut both = labels(cortex.list_chunks("acme", "").await.unwrap());
+        both.sort();
+        assert_eq!(both, ["agent/ceo", "agent/ops"]);
+
+        assert!(
+            cortex
+                .delete_chunk_label("acme", &addr, "agent/ceo")
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            labels(cortex.list_chunks("acme", "").await.unwrap()),
+            ["agent/ops"]
+        );
+        assert_eq!(
+            cortex.peek_chunk("acme", &addr).await.unwrap().as_deref(),
+            Some(body),
+            "the body survives under the remaining claim"
+        );
+        assert!(
+            cortex
+                .delete_chunk_label("acme", &addr, "agent/ops")
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            cortex.peek_chunk("acme", &addr).await.unwrap(),
+            None,
+            "the record goes with its last claim"
+        );
     }
 
     fn company() -> CompanyId {


### PR DESCRIPTION
Closes #1300.

## What this changes

`ContextStore` gains **`delete_label(company, addr, label)`** beside the existing address-level `delete`, and every backend now keeps **one claim per `(addr, label)`** — the semantics the fs index always had, and the ones sqlite/mongodb/the provider facade silently did not.

Of the three options the issue put up, this is the first (label-scoped delete). Salting the address would kill dedup and move every existing addr; documenting first-write-wins would have made fs lose its multi-label listing and thrown away data on migration. Label-scoping is also the only one the addendum's TOCTOU falls out of for free.

## The two defects

**1. Backend divergence on the second label.** A byte-identical body stored under a second label returned a success receipt (the addr) for a row that never landed on sqlite (`INSERT OR IGNORE`), mongodb (`$setOnInsert`) and the provider facade — a caller listing by their own label found nothing there and everything on fs. Now every backend lands the claim:

| backend | how a claim is stored |
|---|---|
| fs | one index row per `(addr, label)` — `put` still appends O(1), the set semantics are applied on read (see below) |
| sqlite | new `context_chunk_labels (company_id, addr, label, stored_ms)` table; body row unchanged, `list` joins |
| mongodb | `$addToSet` into a `labels` array on the one document; the scalar `label` stays the first claim |
| provider facade / tinycortex engine | `labels` vec on the stored envelope, `#[serde(default)]` |
| tinycortex in-memory | one `StoredChunk` row per claim |

**2. Shared addresses made memories permanently un-forgettable.** `memory_forget` and `reap_fact_mirror` refused to delete any address another label shared — so any agent could make another agent's memory (or an operator-fact mirror) undeletable forever by storing byte-identical text. Both now remove **their own claim**; the body is reaped only with its last claim, decided atomically inside the backend (fs: under the index lock; sqlite: one transaction; mongo: a conditional delete that cannot match a document a concurrent `$addToSet` just touched; facade/engine: a per-store lock).

That atomicity is what closes the addendum's **TOCTOU**: the old guards read a snapshot and then deleted, so an identical-content write landing in the window lost its row. `assert_delete_label_survives_a_concurrent_identical_put` drives delete and put concurrently for 32 rounds on every backend and demands the writer's claim and body survive each one.

`memory_ingest`'s `forget_document` had the same snapshot guard and gets the same treatment — it previously *skipped* shared chunks, leaving a forgotten document's claims listed forever.

## Compatibility

- **`delete` is unchanged** and still address-level: the operator hard-delete takes the body and every claim.
- **sqlite** heals at open, in one transaction: backfills a claim for any body row that lacks one (a pre-#1300 database, or a row an older binary wrote since) and sweeps claims whose body row an older binary's address-level delete removed. Idempotent, and a label-scoped delete can never be undone by it.
- **mongodb / the facade / the engine** union the legacy scalar `label` with the new set on every read, and keep the scalar pointing at a live claim — so a rollback to a pre-#1300 binary still reads what it always read. Tests seed the legacy shape directly rather than assuming.
- No new cargo feature, no migration to run, no config.

## Why `put` still appends on fs

Checking `(addr, label)` membership at write time would read and parse the whole index on every write — and the ingest path writes one chunk per document fragment, so a single folder drop becomes a quadratic scan. `put` stays an O(1) append and `list` collapses duplicates (first row wins, so the stamp matches the other backends' first-write-wins); `search` dedupes by address, which also fixes fs reporting one hit per claim where every other backend reports one per body. `a_duplicate_index_row_reads_back_as_one_claim_and_deletes_whole` pins both halves together, including that `delete_label` takes every duplicate row (a survivor would resurrect a forgotten claim).

## Conformance

The suite used distinct bodies everywhere, which is why nothing pinned either behaviour. Three new shared asserts, run on **fs, sqlite, mongodb, the provider facade, the real namespace driver, the tinycortex in-memory client and the tinycortex engine**:

- `assert_identical_body_two_labels` — one address, both claims listed, each findable by its own prefix, and a re-`put` of an identical `(body, label)` adds nothing.
- `assert_delete_label_scoped` — one claim goes, the body survives while another claims it, the body is reaped with the last claim, absent/repeat claims answer `false`, and address-level `delete` still takes everything.
- `assert_delete_label_survives_a_concurrent_identical_put` — the interleaving regression above.

Plus per-backend mixed-version tests (sqlite heal, mongo legacy scalar document, engine legacy record) and the Brain-view row-id case.

## Console

A context row's id was `ctx:{addr}`, whose own comment promised unique React keys — two labels on one address collided. It is now `ctx:{addr}:{label}`, and the newest-first cap tie-breaks on `(addr, label)` so the order stays total. The console treats the id as opaque (no parsing), so nothing else moves.

## Commands run

```
cargo fmt --all -- --check
cargo clippy --locked --all-targets --features mongodb,sqlite,tinymemory,tinymemory-embedded -- -D warnings
cargo clippy --locked --all-targets --features openhuman,tinycortex -- -D warnings
cargo test --locked --features mongodb,sqlite,tinymemory,tinymemory-embedded --lib store::
cargo test --locked --lib server::ops::memory
cargo test --locked --features openhuman,tinycortex --lib -- store::tinycortex memory_tools server::ops::memory memory_ingest
```

The mongodb backend's tests skip themselves without `OPENCOMPANY_TEST_MONGODB_URI`, so they were also run locally against a real `mongod` — 48 passed, including the three new conformance asserts and `legacy_scalar_label_documents_list_and_label_delete`. In CI the `Rust (mongodb)` job runs them against its `mongo:7` service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared memory content can now be associated with multiple labels.
  * Deleting a memory removes only the selected label, preserving shared content used elsewhere.
  * Shared content is automatically cleaned up after its final label is removed.
  * Memory listings and search results now handle shared content consistently.

* **Bug Fixes**
  * Prevented shared memories from being incorrectly skipped or deleted entirely.
  * Improved duplicate-write handling and preserved backward compatibility across storage backends.

* **Tests**
  * Added coverage for multi-label storage, scoped deletion, concurrency, migrations, and legacy records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->