### PR TITLE
Scope the console hash to the host it is showing (#1358)

### DIFF
--- a/docs/spec/runtime/desktop-hosts.md
+++ b/docs/spec/runtime/desktop-hosts.md
@@ -83,6 +83,21 @@ An address naming a connection this client no longer holds is not an error: it
 resolves to whatever `App` would otherwise have opened, and the bar is corrected
 to say so.
 
+### What a failure may say
+
+A host that cannot be reached renders its own full-screen error, with the
+switcher over it. What that screen says depends on how many hosts this console
+holds, because the two situations are not the same one.
+
+Alone, it keeps the boot hint — *set the host with `?api=`, or run `opencompany
+serve`* — which is advice for a console that has not found its host yet. With a
+roster, that hint tells somebody who picked a row out of a switcher to configure
+a host they already configured, so it is dropped, and **Forget this host** is
+offered beside Retry instead. Forgetting is local to this client (see
+`removeConnection`); it is never offered for the only host, because a console
+with no connections at all is a worse place to be left than one with a host that
+is down.
+
 ## Authenticating as a person
 
 **About remote hosts.** The embedded host on this machine has no sign-in to

--- a/docs/spec/runtime/desktop-hosts.md
+++ b/docs/spec/runtime/desktop-hosts.md
@@ -47,6 +47,42 @@ left: this client's own label for its host, at a loopback address. Narrow on
 purpose — a host an operator added by hand is labelled by authority
 (`127.0.0.1:8080`), never with that string.
 
+### Which host the address names
+
+Selection is a **filter over N live things** — choosing a host changes what is
+rendered and tears nothing down — but it is not private state. A console holding
+more than one host scopes its hash: `#/ledgers/tasks?host=<connectionId>`.
+
+Three things follow, and each was a defect without it (issue #1358):
+
+- **Back undoes a switch.** Selection used to be plain React state, so nothing
+  was pushed and the most natural recovery from "I picked the wrong host and it
+  is down" did nothing at all.
+- **The address stops lying.** The hash used to keep naming a page of the host
+  you had just left for the whole time the failed host's "Can't connect" screen
+  was up.
+- **Nothing rewinds silently.** Those two combined into the symptom that was
+  actually reported: a Back pressed on the error screen popped an entry
+  belonging to the *working* host. Its console is not mounted, so no pixel
+  changed — and switching back landed two pages shallower than where the
+  operator had been, with nothing having told them.
+
+One host writes no scope. There is nothing ambiguous about its address, and
+connection ids are minted per client, so an opaque id in a copied link means
+nothing to whoever receives it. The scope appears with the second host, and
+`selectHost` stamps the entry being left on the way out so even the first switch
+is undoable.
+
+The scope is a *scope*, not a page, so a view change carries it and the
+transient hash flags (`?new`, see `use-hash-flag.ts`) do not. Writers that
+replace the hash wholesale must carry it themselves — a `replaceState` fires no
+`hashchange`, so there is no event to repair it on; `useHostAddress` covers the
+writers that merely assign.
+
+An address naming a connection this client no longer holds is not an error: it
+resolves to whatever `App` would otherwise have opened, and the bar is corrected
+to say so.
+
 ## Authenticating as a person
 
 **About remote hosts.** The embedded host on this machine has no sign-in to

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -42,6 +42,13 @@ Which applies is **derived, not configured**: `needsCarriedSession` compares the
 host's origin with the document's, so a console cannot be told to hold a token
 where a cookie would have worked.
 
+Which of the N is on screen is part of the **address**, not private state: a
+console holding more than one host writes `#/<view>?host=<connectionId>`, so
+switching is a history entry Back can undo and the bar names the host being
+looked at even when that host answers nothing. `src/hooks/use-host-route.ts`
+owns the rule; see
+[desktop-hosts.md](../docs/spec/runtime/desktop-hosts.md#which-host-the-address-names).
+
 Every surface is built to one pattern so the backend can land incrementally:
 
 1. **Real** — the endpoint exists; the console uses it directly. **This is now

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import {
 import { HostsProvider, useHosts, type HostsValue } from "@/connections/HostsContext";
 import { firstHostCopy } from "@/connections/first-host";
 import type { ConnectionId } from "@/connections/types";
+import { useHostAddress, useHostRoute } from "@/hooks/use-host-route";
 import { ConnectionConsole } from "@/views/ConnectionConsole";
 import { AddHostPage } from "@/views/setup/AddHostPage";
 import { cn } from "@/lib/utils";
@@ -333,8 +334,14 @@ function Console() {
    * no bootstrap connection to seed this with. What is on screen then is
    * decided by `active` below, not by leaving this pointing at a host that does
    * not exist.
+   *
+   * Local, but no longer *only* local: it is seeded from and mirrored into the
+   * address, so a switch is a history entry Back can undo and the bar names the
+   * host being looked at. That is issue #1358, and `use-host-route.ts` is the
+   * whole of it. The registry is still untouched — every connection stays
+   * registered and probed regardless of what the address says.
    */
-  const [selected, setSelected] = useState<ConnectionId | null>(bootstrapId);
+  const { selected, selectHost, resettleHost } = useHostRoute(bootstrapId);
 
   // A pure read, so StrictMode's double render is harmless.
   const magicLink = useMemo(() => readMagicLink(), []);
@@ -440,14 +447,6 @@ function Console() {
     }
   }, [auth.ready, connectionIds]);
 
-  if (!auth.ready) {
-    return (
-      <FullScreen>
-        <Waiting>Signing in…</Waiting>
-      </FullScreen>
-    );
-  }
-
   /**
    * Which connection is rendered, in the order these questions get answers.
    *
@@ -472,6 +471,24 @@ function Console() {
     (embedded.resolved ? connections[0] : undefined);
   const client = active ? clientFor(active.id) : undefined;
 
+  /**
+   * The address names the host on screen, and only while there is a choice.
+   *
+   * One host is unambiguous, so its console keeps clean addresses; the scope
+   * appears with the second. Declared here, above the sign-in gate, because it
+   * is a hook and that gate returns early — and `active` is a pure derivation,
+   * so resolving it first costs nothing.
+   */
+  useHostAddress(active?.id ?? null, connectionIds, connections.length > 1);
+
+  if (!auth.ready) {
+    return (
+      <FullScreen>
+        <Waiting>Signing in…</Waiting>
+      </FullScreen>
+    );
+  }
+
   // Everything the switcher needs, assembled once and carried down by context.
   //
   // Context rather than props because the switcher now lives in the sidebar
@@ -481,10 +498,15 @@ function Console() {
   const hosts: HostsValue = {
     connections,
     selected: active?.id ?? null,
-    onSelect: setSelected,
+    // A navigation, not a mode change: `selectHost` pushes a history entry, so
+    // Back returns to the host that was on screen. `active?.id` rather than
+    // `selected` is what the entry being left gets stamped with — the desktop
+    // leaves `selected` null until someone chooses, and a stamp of `null` would
+    // leave that entry naming nobody.
+    onSelect: (id) => selectHost(id, active?.id ?? null),
     onAdd: (baseUrl, connector) => {
       const id = addConnection({ baseUrl, connector });
-      setSelected(id);
+      selectHost(id, active?.id ?? null);
       void probe(id);
     },
     localInstances: embedded.instances,
@@ -501,7 +523,7 @@ function Console() {
             const opened = listConnections().find(
               (c) => c.identity?.instanceId === created.instanceId,
             );
-            if (opened) setSelected(opened.id);
+            if (opened) selectHost(opened.id, active?.id ?? null);
           }
         }
       : undefined,
@@ -521,7 +543,7 @@ function Console() {
             label: target.destination,
             connector: { kind: "ssh", target },
           });
-          setSelected(id);
+          selectHost(id, active?.id ?? null);
           void probe(id);
         }
       : undefined,
@@ -538,11 +560,16 @@ function Console() {
     // row's client for a frame — and in the desktop, where `selected` is
     // ordinarily null, it would keep rendering whatever came next without ever
     // recording the choice.
+    //
+    // `resettleHost`, not `selectHost`: a host that has been forgotten is not
+    // somewhere Back should be able to return to, and the entry would name a
+    // connection this client no longer holds. `useHostAddress` takes the dead
+    // id out of the bar for the same reason.
     onRemoveHost: (id) => {
       removeConnection(id);
       const remaining = listConnections();
-      setSelected((current) =>
-        remaining.some((c) => c.id === current) ? current : (remaining[0]?.id ?? null),
+      resettleHost(
+        remaining.some((c) => c.id === selected) ? selected : (remaining[0]?.id ?? null),
       );
     },
     onStopLocal: isDesktopRuntime()

--- a/frontend/src/hooks/use-hash-view.ts
+++ b/frontend/src/hooks/use-hash-view.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { withHostParam } from "@/hooks/use-host-route";
+
 /** The hash split into path segments: `#/settings/people` → `["settings", "people"]`. */
 function readSegments(): string[] {
   return window.location.hash
@@ -59,11 +61,16 @@ export function useHashView<T extends string>(
    * Replace semantics, never push: pushing leaves the unknown hash in the
    * history stack, so Back returns to it, this rewrite bounces forward again,
    * and the operator is stuck in a ping-pong they cannot Back out of.
+   *
+   * `withHostParam` carries the connection scope across the rewrite. The host
+   * is part of the address (`use-host-route.ts`), and a `replaceState` fires no
+   * `hashchange` — so a scope dropped here has nothing to put it back, and the
+   * console would go on rendering one host under an address naming none.
    */
   const canonicalize = useCallback((next: [T, string | null]) => {
     const path = next[1] ? `${next[0]}/${next[1]}` : next[0];
     if (readSegments().join("/") === path) return;
-    window.history.replaceState(null, "", `#/${path}`);
+    window.history.replaceState(null, "", withHostParam(path));
   }, []);
 
   // Reflect the resolved view into the URL when the page arrived with no hash
@@ -84,9 +91,14 @@ export function useHashView<T extends string>(
     return () => window.removeEventListener("hashchange", onHash);
   }, [resolve, canonicalize]);
 
+  // The host scope rides along; every other query key is dropped, which is what
+  // `useHashFlag`'s flags want — `?new` belongs to the screen it was opened
+  // over, not to the one being navigated to.
   const navigate = useCallback((next: T, nextSub?: string) => {
     const path = nextSub ? `${next}/${nextSub}` : next;
-    if (readSegments().join("/") !== path) window.location.hash = `/${path}`;
+    if (readSegments().join("/") !== path) {
+      window.location.hash = withHostParam(path).slice(1);
+    }
     setRoute([next, nextSub ?? null]);
   }, []);
 

--- a/frontend/src/hooks/use-host-route.ts
+++ b/frontend/src/hooks/use-host-route.ts
@@ -1,0 +1,214 @@
+// Which host's console the address names, and how a switch reaches history
+// (issue #1358).
+//
+// ## Why the hash carries a host at all
+//
+// Host selection used to be plain React state — `onSelect: setSelected` in
+// `App` — while the hash named a page without saying whose. Two defects
+// followed, and they compounded into a third that was invisible:
+//
+//  1. **Back could not undo a switch.** Nothing was pushed, so the most natural
+//     recovery from "I picked the wrong host and it is down" did nothing to the
+//     selection. The only way back was to find the switcher again.
+//  2. **The address lied.** While a failed host's "Can't connect" screen was
+//     up, the bar went on naming a page of the host just left. Copying it
+//     handed somebody a Tasks board rather than the failure being looked at.
+//  3. **So Back silently spent the other host's place.** A Back pressed on the
+//     error screen popped an entry belonging to the *working* host. Nothing on
+//     screen changed — the failed host's console does not read the route — so
+//     it read as inert, and two presses later switching back landed on Overview
+//     instead of the Tasks board it had been rewound from.
+//
+// Making the host part of the address fixes all three: `#/ledgers/tasks?host=…`
+// says whose page it is, a switch becomes an ordinary push that Back undoes,
+// and no Back is inert any more because the entry it returns to names a host.
+//
+// ## Why a query companion rather than a path segment
+//
+// `useHashView`'s segment parsing already strips everything from `?` onward
+// (`readSegments` in `use-hash-view.ts`), so a query companion coexists with
+// the view/sub routing untouched — the same seam `useHashFlag` uses for `?new`.
+// A path segment would instead rewrite every address the console has emitted.
+//
+// The scope is not a transient flag, though, and that is the one way it differs
+// from `useHashFlag`: a view change carries it forward, where `?new` is meant
+// to be dropped by the next navigation. Every writer that replaces the hash
+// wholesale therefore has to carry it — see {@link withHostParam} — and
+// {@link useHostAddress} re-asserts it after the ones that cannot.
+//
+// ## Only when there is something to disambiguate
+//
+// A console holding one host writes no `?host=`. There is nothing ambiguous
+// about its address, and connection ids are minted per browser
+// (`registry.mintId`), so an opaque id in every copied link means nothing to
+// whoever receives it. The scope appears the moment a second host is
+// registered, and `selectHost` stamps the entry being left on the way out — so
+// even the first switch, made from an era of the history stack that predates
+// the second host, is undoable.
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { ConnectionId } from "@/connections/types";
+
+/** The hash query key naming the connection whose console is on screen. */
+export const HOST_PARAM = "host";
+
+/** The current hash, split into its path and its query. */
+function readHash(): { path: string; params: URLSearchParams } {
+  const [path = "", query = ""] = window.location.hash.replace(/^#/, "").split("?");
+  return { path, params: new URLSearchParams(query) };
+}
+
+/**
+ * Serialises a hash back, leaving value-less flags bare.
+ *
+ * `URLSearchParams` always writes a `=`, and `useHashFlag` deliberately writes
+ * `?new` rather than `?new=`. Round-tripping the query to change one key must
+ * not quietly rewrite the flags standing next to it.
+ */
+function formatHash(path: string, params: URLSearchParams): string {
+  const query = params.toString().replace(/=(?=&|$)/g, "");
+  // An address with no path yet — a bare `/` landing, before the shell's router
+  // canonicalizes it — still gets a readable one rather than `#?host=…`.
+  return `#${path || "/"}${query ? `?${query}` : ""}`;
+}
+
+/** The host the address currently names, if it names one. */
+export function readHostParam(): ConnectionId | null {
+  return readHash().params.get(HOST_PARAM) || null;
+}
+
+/** The current hash with the host scope set to `id`, or removed when `null`. */
+export function hashWithHost(id: ConnectionId | null): string {
+  const { path, params } = readHash();
+  if (id) params.set(HOST_PARAM, id);
+  else params.delete(HOST_PARAM);
+  return formatHash(path, params);
+}
+
+/**
+ * `#/<path>` with the host scope carried over from the current address.
+ *
+ * `path` is the hash path with no `#` and no leading `/` — `"ledgers/tasks"`.
+ *
+ * For the writers that replace the hash wholesale rather than editing it. The
+ * host rides along because it is a scope and not a page; every other query key
+ * is dropped, which is what `useHashFlag`'s flags want — `?new` belongs to the
+ * screen it was opened over, not to the next one.
+ *
+ * `replaceState` callers need this most: replacing fires no `hashchange`, so a
+ * scope dropped there has no event for {@link useHostAddress} to repair it on.
+ */
+export function withHostParam(path: string): string {
+  const host = readHostParam();
+  return `#/${path}${host ? `?${HOST_PARAM}=${host}` : ""}`;
+}
+
+export interface HostRoute {
+  /** The host the address names, or the fallback when it names none. */
+  selected: ConnectionId | null;
+  /**
+   * Puts another host's console on screen.
+   *
+   * A navigation, so it pushes and Back undoes it. `from` is the host actually
+   * on screen — not `selected`, which is `null` on a desktop that has never
+   * been asked — and is what the entry being left gets stamped with.
+   */
+  selectHost: (id: ConnectionId | null, from: ConnectionId | null) => void;
+  /**
+   * Moves the selection without touching history.
+   *
+   * For a host that stopped existing: forgetting one is not somewhere Back
+   * should be able to return to, and the entry left behind would name a
+   * connection this client no longer holds.
+   */
+  resettleHost: (id: ConnectionId | null) => void;
+}
+
+/**
+ * The host whose console is on screen, read from and written to the address.
+ *
+ * `fallback` is what to open when the address names no host: the bootstrap
+ * connection in a browser, `null` on a desktop that has not yet heard back
+ * about its own.
+ */
+export function useHostRoute(fallback: ConnectionId | null): HostRoute {
+  const [selected, setSelected] = useState<ConnectionId | null>(
+    () => readHostParam() ?? fallback,
+  );
+
+  // Follow Back, Forward, and a host typed into the address bar.
+  //
+  // An address carrying no scope leaves the selection alone rather than
+  // resetting it. That is what an ordinary view navigation looks like for the
+  // moment before the scope is stamped back on, and what every address in a
+  // one-host console looks like permanently — treating it as "no host chosen"
+  // would bounce the console back to the bootstrap connection on every click.
+  useEffect(() => {
+    const onHash = () => {
+      const named = readHostParam();
+      if (named) setSelected(named);
+    };
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+
+  const selectHost = useCallback((id: ConnectionId | null, from: ConnectionId | null) => {
+    // Stamp the entry being left with the host it was showing, before pushing
+    // the one being opened. A console that held one host until a moment ago
+    // wrote no scope at all, so without this the entry Back returns to names
+    // nobody — and Back is inert for exactly the first switch, which is the
+    // gesture issue #1358 was reported from.
+    if (from && !readHostParam()) {
+      window.history.replaceState(null, "", hashWithHost(from));
+    }
+    const next = hashWithHost(id);
+    // A plain assignment, not `replaceState`: a real entry the Back button pops
+    // is the entire point.
+    if (next !== window.location.hash) window.location.hash = next;
+    setSelected(id);
+  }, []);
+
+  const resettleHost = useCallback((id: ConnectionId | null) => setSelected(id), []);
+
+  return { selected, selectHost, resettleHost };
+}
+
+/**
+ * Keeps the address naming the host actually on screen.
+ *
+ * A standing repair rather than a one-off write, because two things move
+ * underneath it. The console has writers that replace the hash wholesale — a
+ * company switch clearing a stale entity id, a workflow reconciling itself off
+ * a graph that was deleted — and while those carry the scope themselves, the
+ * ones that merely *assign* the hash do not, and only an event puts it back.
+ * And the roster moves: a host forgotten from Manage hosts leaves its id in a
+ * bar that now names nothing.
+ *
+ * **Never overwrites a scope that names a live host.** That entry is the
+ * authority — it is what a Back just restored and what `useHostRoute` is
+ * following — so a rewrite here would fight the browser and undo the Back.
+ *
+ * `connectionIds` is the joined id list rather than the connection array for
+ * the reason `App`'s probe effect joins it too: every status change emits a
+ * fresh array, and depending on the array would re-register this listener on
+ * each one.
+ */
+export function useHostAddress(
+  activeId: ConnectionId | null,
+  connectionIds: string,
+  scoped: boolean,
+): void {
+  useEffect(() => {
+    const known = new Set(connectionIds.split(",").filter(Boolean));
+    const assert = () => {
+      const named = readHostParam();
+      if (named && known.has(named)) return;
+      const next = hashWithHost(scoped ? activeId : null);
+      if (next !== window.location.hash) window.history.replaceState(null, "", next);
+    };
+    assert();
+    window.addEventListener("hashchange", assert);
+    return () => window.removeEventListener("hashchange", assert);
+  }, [activeId, connectionIds, scoped]);
+}

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -19,6 +19,7 @@ import { ConsoleChrome } from "@/components/host-switcher";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { useHosts } from "@/connections/HostsContext";
 import { adoptSession, probe, useConnection } from "@/connections/registry";
 import type { ConnectionId } from "@/connections/types";
 import { withHostParam } from "@/hooks/use-host-route";
@@ -75,6 +76,10 @@ export function ConnectionConsole({
   // (every other connection's stream died with it).
   const [bootEpoch, setBootEpoch] = useState(0);
   const connection = useConnection(connectionId);
+  // Read unconditionally, though only the `error` phase uses it: a hook cannot
+  // hide inside a switch arm. What it decides is what a failure is allowed to
+  // say — see the `error` case below.
+  const { connections, onRemoveHost } = useHosts();
 
   // The registry marks this connection `unauthenticated` when its client sees a
   // 401 — that is the *only* 401 handler, so one host refusing a credential
@@ -248,7 +253,22 @@ export function ConnectionConsole({
         </ConsoleChrome>
       );
 
-    case "error":
+    // The failure of ONE host, said to somebody who may hold several.
+    //
+    // Both halves of this used to address a console with exactly one host, and
+    // both were wrong the moment there were two (issue #1358). The hint is the
+    // single-host boot message — telling an operator who reached this screen by
+    // picking a row out of a switcher to "set the host with ?api=" asks them to
+    // configure a host they already configured. And Retry was the only way off
+    // the screen, so a host that is simply gone had no disposal: the switcher
+    // above can move them elsewhere, but the dead row stays in the roster
+    // forever.
+    //
+    // `connections.length` is what separates the two situations, and it is
+    // known here rather than in `connectionError` — which sees a client and an
+    // error, not a roster.
+    case "error": {
+      const alone = connections.length <= 1;
       return (
         <FullScreen>
           <div className="w-full max-w-md space-y-4" data-testid="connection-error">
@@ -256,17 +276,36 @@ export function ConnectionConsole({
               <AlertTitle>Can&apos;t connect</AlertTitle>
               <AlertDescription>
                 {phase.message}
-                {phase.hint && (
+                {alone && phase.hint && (
                   <span className="mt-1 block font-mono text-xs opacity-80">{phase.hint}</span>
                 )}
               </AlertDescription>
             </Alert>
-            <Button className="w-full" onClick={() => location.reload()}>
-              Retry
-            </Button>
+            <div className="flex gap-2">
+              <Button className="flex-1" onClick={() => location.reload()}>
+                Retry
+              </Button>
+              {/* Forgetting is local to this client — the host itself is
+                  untouched — so it is offered beside Retry rather than behind
+                  Manage hosts, which is two screens away from the failure it
+                  answers. Never when it is the only host: a console with no
+                  connections at all is a worse place to be left than one with a
+                  host that is down. */}
+              {!alone && (
+                <Button
+                  variant="outline"
+                  className="flex-1"
+                  data-testid="connection-error-forget"
+                  onClick={() => onRemoveHost(connectionId)}
+                >
+                  Forget this host
+                </Button>
+              )}
+            </div>
           </div>
         </FullScreen>
       );
+    }
 
     case "no-company":
       return (

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
 import { adoptSession, probe, useConnection } from "@/connections/registry";
 import type { ConnectionId } from "@/connections/types";
+import { withHostParam } from "@/hooks/use-host-route";
 import { Login } from "@/views/Login";
 import { SetupWizard } from "@/views/setup/SetupWizard";
 
@@ -326,7 +327,11 @@ function clearEntityHash() {
   // A hash sub-route names an entity within the current company. The shell
   // remounts for a company switch, so remove that stale identity before the
   // new shell reads the route as an intentional deep link.
-  window.history.replaceState(null, "", `#/${view}`);
+  //
+  // The connection scope survives it: the company changed, the host did not,
+  // and a `replaceState` fires no `hashchange` for `useHostAddress` to put it
+  // back with (`use-host-route.ts`).
+  window.history.replaceState(null, "", withHostParam(view));
 }
 
 /**

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -49,6 +49,7 @@ import {
   workflowRunOutput,
 } from "@/api/workflows";
 import type { CompanyStreamEvent } from "@/hooks/use-events";
+import { withHostParam } from "@/hooks/use-host-route";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import type { ApprovalSummary, GrantScope, TeamMemberDto, Verdict } from "@/api/types";
@@ -203,7 +204,10 @@ function readWorkflowHash(): {
 function clearWorkflowFromHash(): void {
   const { onWorkflows, workflowId } = readWorkflowHash();
   if (!onWorkflows || workflowId === null) return;
-  window.history.replaceState(null, "", "#/workflows");
+  // `withHostParam` because this replaces the hash rather than editing it, and
+  // a replace fires no `hashchange` — so a connection scope dropped here has
+  // nothing to put it back (`use-host-route.ts`).
+  window.history.replaceState(null, "", withHostParam("workflows"));
 }
 
 /**
@@ -886,7 +890,8 @@ export function WorkflowsView({
   // selected workflow this early-returns and never touches the URL, so an
   // arriving `#/workflows/x?run=r` keeps its run id; when the selection moves
   // to a different workflow the query is dropped, which is correct — that run
-  // belongs to the graph being left behind.
+  // belongs to the graph being left behind. The connection scope is the one key
+  // that does carry over (`withHostParam`): it names the host, not the graph.
   //
   // Replace vs push is decided by whether the view moved the selection on the
   // operator's behalf.
@@ -930,7 +935,7 @@ export function WorkflowsView({
     // effect): rewriting it would drag the operator back here.
     if (!onWorkflows) return;
     if (workflowId === selectedId) return;
-    const next = `#/workflows/${encodeURIComponent(selectedId)}`;
+    const next = withHostParam(`workflows/${encodeURIComponent(selectedId)}`);
     if (reconciled) window.history.replaceState(null, "", next);
     else window.location.hash = next.slice(1);
   }, [selectedId]);

--- a/frontend/test/e2e/host-switch-history.spec.ts
+++ b/frontend/test/e2e/host-switch-history.spec.ts
@@ -163,3 +163,26 @@ test("a copied address reopens the host it named, failure and all", async ({ pag
   await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(0);
 });
+
+test("a host that cannot be reached can be forgotten from the failure itself", async ({
+  page,
+}) => {
+  // The adjacent half of the issue. This screen used to offer Retry and the
+  // single-host boot hint — telling somebody who picked a row out of a switcher
+  // to "set the host with ?api=" — and no way to dispose of a host that is
+  // simply gone.
+  await seedTwoHosts(page);
+  await page.goto("/#/ledgers/tasks?host=conn-dead");
+  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("connection-error")).not.toContainText("?api=");
+
+  await page.getByTestId("connection-error-forget").click();
+
+  // Forgetting selects what is left, and the console it lands on is a working
+  // one. The switcher drops to a single host, so the address stops carrying a
+  // scope there is no longer anything to disambiguate.
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("host-switcher")).toHaveAttribute("data-host-count", "1");
+});

--- a/frontend/test/e2e/host-switch-history.spec.ts
+++ b/frontend/test/e2e/host-switch-history.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { openHostMenu } from "./host-switcher";
+
+/**
+ * Switching hosts is a navigation, and the address says whose page it is
+ * (issue #1358).
+ *
+ * ## The report
+ *
+ * Two hosts, the second one down. On the Tasks board of the working host, pick
+ * the dead one from the switcher: a full-screen "Can't connect" comes up and
+ * the address bar goes on reading `#/ledgers/tasks` — a page of the host just
+ * left. Press Back to undo the switch and **nothing appears to happen**: the
+ * failed host's console does not read the route, so no pixel changes. Press it
+ * again, same. Then switch back to the working host and land on Overview,
+ * because those two inert-looking presses were popping *its* history.
+ *
+ * Two defects with one symptom, and the sequence below is the only way to see
+ * either of them:
+ *
+ *   1. selection was plain React state, so Back could not undo a switch;
+ *   2. the hash named a page without naming a host, so Back on the failed
+ *      host's screen spent the working host's route stack instead.
+ *
+ * Together they made the natural recovery gesture the thing that destroyed
+ * your place, silently.
+ *
+ * ## Why this is an e2e spec
+ *
+ * `test/unit/host-route.test.ts` pins the scope helpers and the hooks against a
+ * synthetic hash. It cannot reach the thing that was actually broken: a real
+ * `history` stack, a real Back, and a console whose shell is not mounted for
+ * the host on screen. The bug lives exactly in that gap — every piece worked
+ * on its own.
+ *
+ * The dead host is an address nothing listens on, for the reason
+ * `connection-degrade.spec.ts` gives: a spec that needs two live servers is a
+ * spec nobody runs.
+ */
+
+/** A port nothing is listening on, so the second connection is always down. */
+const DEAD_HOST = "http://127.0.0.1:8451";
+
+/** The tour modal covers the board and swallows clicks. */
+async function silenceTour(page: Page) {
+  await page.addInitScript(() => {
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, JSON.stringify({ skipped: true, seenAt: Date.now() }));
+    }
+  });
+}
+
+/** Seeds a working host and an unreachable one, the way the app persists them. */
+async function seedTwoHosts(page: Page) {
+  await silenceTour(page);
+  await page.addInitScript((dead) => {
+    window.localStorage.setItem(
+      "oc.connections.v1",
+      JSON.stringify([
+        {
+          id: "conn-primary",
+          baseUrl: "",
+          label: "Primary",
+          defaultCompany: null,
+          credential: { kind: "cookie" },
+        },
+        {
+          id: "conn-dead",
+          baseUrl: dead,
+          label: "Offline host",
+          defaultCompany: null,
+          credential: { kind: "cookie" },
+        },
+      ]),
+    );
+  }, DEAD_HOST);
+}
+
+/** The hash, which is where the whole of this issue is visible. */
+function hash(page: Page): string {
+  return new URL(page.url()).hash;
+}
+
+test("Back undoes a host switch instead of silently spending the other host's route", async ({
+  page,
+}) => {
+  await seedTwoHosts(page);
+  await page.goto("/#/ledgers/tasks");
+
+  // The board of the working host, and an address that says so. Before this
+  // fix the `?host=` half simply did not exist.
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(page).toHaveURL(/#\/ledgers\/tasks\?host=conn-primary$/);
+
+  // Step 2 of the report: pick the host that is down.
+  await openHostMenu(page);
+  await page.getByTestId("host-row-conn-dead").click();
+  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
+
+  // Defect 2. The bar named `conn-primary`'s Tasks board for the whole time
+  // this failure was on screen; now it names the host the failure belongs to,
+  // so the URL can be copied and reloaded onto what is actually being looked
+  // at. The path is *frozen*, not rewritten — going back to a working host
+  // returns to the page that was open, which was already correct and must stay
+  // so.
+  expect(hash(page)).toBe("#/ledgers/tasks?host=conn-dead");
+
+  // Steps 3–4, and defect 1. One Back, and the working host's Tasks board is
+  // back — the switch is undone. Before this, Back consumed
+  // `#/ledgers/tasks` → `#/ledgers` while the screen stayed on "Can't connect",
+  // and it took a second press and a manual switch to discover the damage.
+  await page.goBack();
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("connection-error")).toHaveCount(0);
+  expect(hash(page)).toBe("#/ledgers/tasks?host=conn-primary");
+});
+
+test("the working host's own route stack is intact after a trip through the failure", async ({
+  page,
+}) => {
+  // The damage the operator could not see. Two views deep on the working host,
+  // then out to the dead one and back: the entries behind them must still be
+  // the ones they walked in on, not two shallower.
+  await seedTwoHosts(page);
+  await page.goto("/#/overview");
+  await expect(page.getByTestId("host-switcher")).toBeVisible({ timeout: 30_000 });
+
+  await page.evaluate(() => {
+    window.location.hash = "/ledgers/tasks";
+  });
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(page).toHaveURL(/#\/ledgers\/tasks\?host=conn-primary$/);
+
+  await openHostMenu(page);
+  await page.getByTestId("host-row-conn-dead").click();
+  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
+
+  // Back out of the failure, then back through the page that was open before
+  // it. Each press moves one step, and the steps are the working host's —
+  // which is the whole of "nothing was spent while the error screen was up".
+  // Before this, the first press was silently the second: it popped
+  // `#/ledgers/tasks` while the error screen stayed put, so this Overview was
+  // one press closer than the operator believed.
+  await page.goBack();
+  expect(hash(page)).toBe("#/ledgers/tasks?host=conn-primary");
+  await page.goBack();
+  await expect(page).toHaveURL(/#\/overview\?host=conn-primary$/);
+});
+
+test("a copied address reopens the host it named, failure and all", async ({ page }) => {
+  // The other half of defect 2. Reloading the failure screen used to drop back
+  // to the bootstrap connection, so "Retry" on a non-bootstrap host quietly
+  // moved you to a different one — the address carried no host to return to.
+  await seedTwoHosts(page);
+  await page.goto("/#/ledgers/tasks?host=conn-dead");
+  await expect(page.getByTestId("connection-error")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(0);
+});

--- a/frontend/test/unit/host-route.test.ts
+++ b/frontend/test/unit/host-route.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment jsdom
+//
+// The connection scope on the hash (issue #1358).
+//
+// What the reported bug actually was: selecting a host wrote no history entry
+// and the hash named a page without naming whose. On the "Can't connect" screen
+// of an unreachable host, Back therefore looked completely inert — while
+// popping entries belonging to the host still working, so switching back landed
+// on Overview rather than the Tasks board it had been rewound from.
+//
+// The three properties these pin are the three halves of that, and each one
+// fails on its own:
+//
+//   - a switch is a push, so Back undoes it;
+//   - the scope survives an ordinary view navigation, so the entries Back
+//     returns through keep naming their host;
+//   - the address is repaired towards the host on screen, never away from a
+//     host the address already names — the second is what would undo a Back.
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useHashView } from "@/hooks/use-hash-view";
+import {
+  hashWithHost,
+  readHostParam,
+  useHostAddress,
+  useHostRoute,
+  withHostParam,
+  type HostRoute,
+} from "@/hooks/use-host-route";
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** Puts the address at `hash` without recording a history entry. */
+function at(hash: string) {
+  window.history.replaceState(null, "", hash);
+}
+
+/** Dispatches what the browser dispatches after Back moves the hash. */
+async function back(hash: string) {
+  await act(async () => {
+    window.history.replaceState(null, "", hash);
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  at("#/overview");
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  at("#/overview");
+});
+
+describe("reading and writing the scope", () => {
+  it("reads the host the address names, and null when it names none", () => {
+    at("#/ledgers/tasks");
+    expect(readHostParam()).toBeNull();
+    at("#/ledgers/tasks?host=conn-a");
+    expect(readHostParam()).toBe("conn-a");
+  });
+
+  it("coexists with a value-less flag, and leaves it bare", () => {
+    // `useHashFlag` writes `?new`, not `?new=`. Round-tripping the query to
+    // change the host must not rewrite the flag standing next to it.
+    at("#/ledgers/goals?new");
+    expect(readHostParam()).toBeNull();
+    expect(hashWithHost("conn-a")).toBe("#/ledgers/goals?new&host=conn-a");
+  });
+
+  it("replaces an existing scope, and removes it when given null", () => {
+    at("#/ledgers/tasks?host=conn-a");
+    expect(hashWithHost("conn-b")).toBe("#/ledgers/tasks?host=conn-b");
+    expect(hashWithHost(null)).toBe("#/ledgers/tasks");
+  });
+
+  it("gives a landing with no path a readable one rather than `#?host=`", () => {
+    at("#");
+    expect(hashWithHost("conn-a")).toBe("#/?host=conn-a");
+  });
+
+  it("carries the scope onto a new path and drops every other key", () => {
+    // The rule the two differ by: the host is a scope and survives a view
+    // change; `?new` belongs to the screen it was opened over and does not.
+    at("#/ledgers/goals?new&host=conn-a");
+    expect(withHostParam("tasks")).toBe("#/tasks?host=conn-a");
+    at("#/ledgers/goals?new");
+    expect(withHostParam("tasks")).toBe("#/tasks");
+  });
+});
+
+describe("useHostRoute", () => {
+  let route: HostRoute | null = null;
+
+  function Probe({ fallback }: { fallback: string | null }) {
+    route = useHostRoute(fallback);
+    return null;
+  }
+
+  async function mount(fallback: string | null) {
+    await act(async () => {
+      root.render(createElement(Probe, { fallback }));
+    });
+  }
+
+  it("opens the host the address names, over the fallback", async () => {
+    at("#/ledgers/tasks?host=conn-b");
+    await mount("conn-a");
+    expect(route?.selected).toBe("conn-b");
+  });
+
+  it("falls back when the address names no host", async () => {
+    at("#/ledgers/tasks");
+    await mount("conn-a");
+    expect(route?.selected).toBe("conn-a");
+  });
+
+  it("pushes a scoped entry when a host is selected", async () => {
+    at("#/ledgers/tasks?host=conn-a");
+    await mount("conn-a");
+    await act(async () => {
+      route?.selectHost("conn-b", "conn-a");
+    });
+    expect(window.location.hash).toBe("#/ledgers/tasks?host=conn-b");
+    expect(route?.selected).toBe("conn-b");
+  });
+
+  it("stamps the entry being left when it carries no scope yet", async () => {
+    // The console writes no scope while it holds one host, so the entry a first
+    // switch leaves behind names nobody — and Back from the host just opened
+    // would be inert, which is the gesture the issue was reported from.
+    at("#/ledgers/tasks");
+    await mount("conn-a");
+    await act(async () => {
+      route?.selectHost("conn-b", "conn-a");
+    });
+    expect(window.location.hash).toBe("#/ledgers/tasks?host=conn-b");
+    // `replaceState` rewrote the entry left behind before the push, so Back
+    // now returns to a `#/ledgers/tasks?host=conn-a`.
+    await back("#/ledgers/tasks?host=conn-a");
+    expect(route?.selected).toBe("conn-a");
+  });
+
+  it("follows Back onto an entry that names another host", async () => {
+    at("#/ledgers/tasks?host=conn-b");
+    await mount("conn-a");
+    expect(route?.selected).toBe("conn-b");
+    await back("#/ledgers/tasks?host=conn-a");
+    expect(route?.selected).toBe("conn-a");
+  });
+
+  it("leaves the selection alone on an address that names no host", async () => {
+    // Every ordinary view navigation looks like this for the moment before the
+    // scope is stamped back on, and every address in a one-host console looks
+    // like it permanently. Reading it as "no host chosen" would bounce the
+    // console to the bootstrap connection on each click.
+    at("#/ledgers/tasks?host=conn-b");
+    await mount("conn-a");
+    await back("#/tasks");
+    expect(route?.selected).toBe("conn-b");
+  });
+
+  it("resettles onto another host without recording an entry", async () => {
+    at("#/ledgers/tasks?host=conn-b");
+    await mount("conn-a");
+    await act(async () => {
+      route?.resettleHost("conn-a");
+    });
+    expect(route?.selected).toBe("conn-a");
+    // Forgetting a host is not somewhere Back should return to, so the address
+    // is left for `useHostAddress` to correct rather than pushed.
+    expect(window.location.hash).toBe("#/ledgers/tasks?host=conn-b");
+  });
+});
+
+describe("useHostAddress", () => {
+  function Probe({
+    activeId,
+    ids,
+    scoped,
+  }: {
+    activeId: string | null;
+    ids: string;
+    scoped: boolean;
+  }) {
+    useHostAddress(activeId, ids, scoped);
+    return null;
+  }
+
+  async function mount(props: { activeId: string | null; ids: string; scoped: boolean }) {
+    await act(async () => {
+      root.render(createElement(Probe, props));
+    });
+  }
+
+  it("names the host on screen once there is a choice to disambiguate", async () => {
+    at("#/ledgers/tasks");
+    await mount({ activeId: "conn-a", ids: "conn-a,conn-b", scoped: true });
+    expect(window.location.hash).toBe("#/ledgers/tasks?host=conn-a");
+  });
+
+  it("writes nothing while the console holds one host", async () => {
+    at("#/ledgers/tasks");
+    await mount({ activeId: "conn-a", ids: "conn-a", scoped: false });
+    expect(window.location.hash).toBe("#/ledgers/tasks");
+  });
+
+  it("never overwrites a scope that names a live host", async () => {
+    // THE assertion. This runs on every `hashchange`, so a Back that restored
+    // `?host=conn-b` would be undone one tick later if this repaired towards
+    // the host still rendered — which is the render `active` is one behind on.
+    at("#/ledgers/tasks?host=conn-b");
+    await mount({ activeId: "conn-a", ids: "conn-a,conn-b", scoped: true });
+    expect(window.location.hash).toBe("#/ledgers/tasks?host=conn-b");
+  });
+
+  it("replaces a scope naming a host this client no longer holds", async () => {
+    at("#/ledgers/tasks?host=conn-gone");
+    await mount({ activeId: "conn-a", ids: "conn-a,conn-b", scoped: true });
+    expect(window.location.hash).toBe("#/ledgers/tasks?host=conn-a");
+  });
+
+  it("repairs a scope dropped by a bare hash assignment", async () => {
+    at("#/ledgers/tasks");
+    await mount({ activeId: "conn-a", ids: "conn-a,conn-b", scoped: true });
+    // A view writing `location.hash` directly (`TaskDetailRoute`, `ChatView`)
+    // drops the query. The event it fires is what puts the scope back.
+    await back("#/tasks/abc");
+    expect(window.location.hash).toBe("#/tasks/abc?host=conn-a");
+  });
+});
+
+describe("useHashView carries the scope across a view change", () => {
+  let navigate: ((view: string, sub?: string) => void) | null = null;
+  const VIEWS = ["overview", "ledgers", "tasks"] as const;
+
+  function Probe() {
+    const [, , go] = useHashView<(typeof VIEWS)[number]>(VIEWS, "overview");
+    navigate = go as (view: string, sub?: string) => void;
+    return null;
+  }
+
+  it("keeps the host when navigating to another view", async () => {
+    at("#/ledgers/tasks?host=conn-b");
+    await act(async () => {
+      root.render(createElement(Probe));
+    });
+    await act(async () => {
+      navigate?.("overview");
+    });
+    expect(window.location.hash).toBe("#/overview?host=conn-b");
+  });
+
+  it("keeps the host when canonicalizing an address the shell cannot render", async () => {
+    // An unknown head resolves to the fallback and the URL is rewritten to say
+    // so — with `replaceState`, which fires no event, so the scope has to ride
+    // along here or it is gone with nothing to notice.
+    at("#/finances?host=conn-b");
+    await act(async () => {
+      root.render(createElement(Probe));
+    });
+    expect(window.location.hash).toBe("#/overview?host=conn-b");
+  });
+});


### PR DESCRIPTION
Fixes #1358.

## RCA

Two independent defects that only became visible when combined.

**1. Host selection never reached history.** `App`'s switcher handler was
`onSelect: setSelected` — plain React state. Nothing was pushed, so Back
could not undo a switch. The only way back was to find the switcher again.

**2. The hash named a page without naming whose.** `useHashView` writes
`#/<view>/<sub>` and nothing in it was scoped to a connection, so the address
went on naming a page of the host you had just left for the whole time the
failed host's "Can't connect" screen was up.

**The symptom is what those two do together.** On the error screen, Back pops
an entry belonging to the *working* host — whose console is not mounted, so
nothing on screen changes. It reads as inert. Two presses later the operator
switches back and lands on Overview instead of the Tasks board they were on,
with nothing having told them their place was being spent. Step 2 → step 5
directly is correct, which is why this only reproduces through the Back
presses.

## The fix

A console holding more than one host scopes its hash:
`#/ledgers/tasks?host=<connectionId>`.

- A switch is an ordinary push, so **Back undoes it**.
- The address **names the host being looked at**, failure and all — reloading
  or copying it returns to that host rather than to the bootstrap connection.
- **Nothing rewinds silently**, because every Back now moves something visible.

`src/hooks/use-host-route.ts` is the whole rule. It rides the hash's query
suffix — the same seam `useHashFlag` uses for `?new`, which `useHashView`'s
segment parsing already strips — so the existing view/sub routing is untouched
and no address the console has ever emitted is rewritten.

Two details worth review:

- **One host writes no scope.** Nothing is ambiguous about a single-host
  console's address, and connection ids are minted per client, so an opaque id
  in a copied link means nothing to whoever receives it. `selectHost` stamps
  the entry being left on the way out, so even the first switch after a second
  host appears is undoable.
- **The scope is a scope, not a page.** A view change carries it; the transient
  hash flags do not. Writers that `replaceState` the hash wholesale carry it
  themselves — a replace fires no `hashchange`, so there is no event to repair
  it on. `useHostAddress` covers the writers that merely assign, and never
  overwrites a scope naming a live host: that entry is what a Back just
  restored, and fighting it would undo the Back.

## The adjacent half

The "Can't connect" panel spoke to a console with exactly one host. Its hint is
the single-host boot message, so an operator who arrived by picking a row out of
a switcher was told to configure a host they already configured — and Retry was
the only way off it. With a roster the hint is dropped and **Forget this host**
stands beside Retry; never for the only host.

## Commands run locally

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e`
- `npm run test` — 2130 passed (19 new in `test/unit/host-route.test.ts`)
- `npm run build`
- Full Playwright suite against a local host — **256 passed, 21 skipped
  (feature-gated), 0 failed**
- The four new specs in `test/e2e/host-switch-history.spec.ts` were run against
  a pre-fix build first: **all four fail**, and test 3 fails by opening the
  *primary* host from `#/ledgers/tasks?host=conn-dead` — the reported defect
  exactly.

## Behaviour changes

- Multi-host consoles gain `?host=<connectionId>` on the hash. Single-host
  consoles are byte-identical to before.
- An address naming a connection this client no longer holds is not an error:
  it resolves to whatever `App` would otherwise have opened, and the bar is
  corrected to say so.
- Docs: `docs/spec/runtime/desktop-hosts.md` gains "Which host the address
  names" and "What a failure may say"; `frontend/ARCHITECTURE.md` links to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)