### PR TITLE
test(e2e): make expandAll wait for the state its callers assert

### DIFF
--- a/frontend/test/e2e/board-drag.spec.ts
+++ b/frontend/test/e2e/board-drag.spec.ts
@@ -111,12 +111,30 @@ const column = (page: Page, index: number) => board(page).getByTestId("board-col
  */
 async function expandAll(page: Page) {
   const rails = board(page).locator("button[aria-label^='Expand ']");
+  const collapsed = board(page).locator('[data-collapsed="true"]');
   // Bounded: each click removes one rail, and the board has three phases.
+  //
+  // The loop exits on COLLAPSED COLUMNS, not on rails. Those are different
+  // conditions, and the difference is why this helper used to return with the
+  // board still collapsed: a column carries `data-collapsed` while its Expand
+  // rail is a separate element that need not be rendered in the same frame.
+  // Waiting for the rails to disappear therefore said "expanded" one render too
+  // early, and the caller's own `[data-collapsed="true"]` assertion failed five
+  // seconds later and forty lines away from the cause — intermittently, on pull
+  // requests that touched none of this.
   for (let attempt = 0; attempt < 8; attempt += 1) {
-    if ((await rails.count()) === 0) return;
+    if ((await collapsed.count()) === 0) return;
+    if ((await rails.count()) === 0) {
+      // Collapsed with nothing to click: the render is mid-flight. Give it the
+      // turn it needs rather than spending an attempt clicking nothing.
+      await page.waitForTimeout(100);
+      continue;
+    }
     await rails.first().click();
   }
-  await expect(rails).toHaveCount(0);
+  // The postcondition callers actually depend on, so a genuine failure names
+  // the board's state rather than the rails' absence.
+  await expect(collapsed).toHaveCount(0);
 }
 
 /** Opens the board and waits for the host's columns to arrive. */

--- a/frontend/test/e2e/board-drag.spec.ts
+++ b/frontend/test/e2e/board-drag.spec.ts
@@ -122,15 +122,27 @@ async function expandAll(page: Page) {
   // early, and the caller's own `[data-collapsed="true"]` assertion failed five
   // seconds later and forty lines away from the cause — intermittently, on pull
   // requests that touched none of this.
-  for (let attempt = 0; attempt < 8; attempt += 1) {
+  // Bounded twice, because two different things can go wrong and one bound
+  // cannot cover both. The click budget counts CLICKS: each one removes a rail
+  // and the board has three phases, so eight is already generous. Counting
+  // loop passes instead would let a run that never clicked anything exhaust
+  // the budget — eight transient 100 ms waits are eight passes and zero
+  // progress, and the assertion below would then fail on columns this helper
+  // had no chance to expand, which is the same intermittent shape it exists to
+  // remove. The deadline covers what the click budget then cannot: a rail that
+  // never arrives at all, which would otherwise spin here forever.
+  const deadline = Date.now() + 10_000;
+  let clicks = 0;
+  while (clicks < 8 && Date.now() < deadline) {
     if ((await collapsed.count()) === 0) return;
     if ((await rails.count()) === 0) {
       // Collapsed with nothing to click: the render is mid-flight. Give it the
-      // turn it needs rather than spending an attempt clicking nothing.
+      // turn it needs rather than spending click budget on nothing.
       await page.waitForTimeout(100);
       continue;
     }
     await rails.first().click();
+    clicks += 1;
   }
   // The postcondition callers actually depend on, so a genuine failure names
   // the board's state rather than the rails' absence.


### PR DESCRIPTION
## The failure

`board-drag.spec.ts:235` fails intermittently on pull requests that touch none of this:

```
Error: expect(locator).toHaveCount(expected) failed
Locator:  getByTestId('ledger-board').locator('[data-collapsed="true"]')
Expected: 0
Received: 1
Timeout:  5000ms
```

Same test, same line, same `277 passed / 1 failed / 9 skipped` — seen on #1557 (Rust memory ports), on #1550 (the memory module driver), and on a recent `main` run. None of those changes can reach the ledger board.

## The cause

`expandAll` and its callers wait on **two different conditions**:

```ts
// the helper returns when no Expand RAILS remain
if ((await rails.count()) === 0) return;

// the caller then asserts no COLLAPSED COLUMNS remain
await expect(board(page).locator('[data-collapsed="true"]')).toHaveCount(0);
```

A column carries `data-collapsed` while its Expand rail is a separate element that need not render in the same frame. So the helper can report "expanded" one render early, and the mismatch surfaces five seconds later and forty lines away from the thing that returned too soon.

The 14 retries in the failing log all resolving to `1` say the same thing: it was not a slow animation the assertion needed to out-wait, it was the helper handing back a board that was still collapsed.

## The change

The loop now exits on collapsed columns, and tolerates the transient state where a column is collapsed but its rail has not rendered — waiting a turn instead of spending an attempt clicking nothing. The final assertion is the postcondition callers depend on, so a genuine failure names the board's state rather than the rails' absence.

Behaviour on a healthy board is unchanged: rails are clicked exactly as before, and the bound is still eight attempts over a three-phase board.

## Why it is its own PR

It surfaced while running review cycles on the memory work, and it is unrelated to it — the repo's guidance is not to bundle unrelated changes, and a one-file test fix is easier to review and revert on its own.

## Commands run

```
npx prettier --check frontend/test/e2e/board-drag.spec.ts   # unchanged formatting
```

No formatter was run over the file: this repo has no prettier config and CI does not run prettier, so reformatting would have been 80 lines of churn around a 20-line fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board expansion behavior during end-to-end interactions.
  * Added handling for transient rendering states so expansion waits for columns to appear before clicking.
  * Ensured successful clicks are tracked accurately, preventing premature stopping or indefinite expansion attempts.
  * Added a time limit to keep board expansion responsive when expected columns are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->