### PR TITLE
test(e2e): simulate the full orchestration loop, scripted and against a real model

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -232,6 +232,7 @@ statement about that host rather than a debt. Against a gated one they run:
 | `chat-to-card.spec.ts` (card chip) | an orchestrator opens a board card, and the chip survives a reload | a scripted tool choice (`SPAWNONE`) |
 | `workflow-run-history.spec.ts` (durable history) | a run is journaled and outlives the console | the workflow runner |
 | `mcp-agent.spec.ts` | an agent calls a tool on a registered MCP server | `mcp-server.mjs` |
+| `orchestration-simulation.spec.ts` | **the whole loop**: a goal stated in chat is delegated to two teammates, dispatched from the board, worked, and closed out by review | scripted turns (`__MOCK_PLAN__`) |
 
 To run them:
 
@@ -252,8 +253,13 @@ host at them:
   makes it call `spawn_task` **once**, and one carrying `__MOCK_TOOL_CALL__ {…}`
   makes it call exactly the named tool, once. "Once" is the part with teeth: one
   operator message reaches several agents and several model calls, so the server
-  tracks directive identity rather than trusting the transcript. Bind with
-  `PW_MOCK_BRAIN_BIND` (default `127.0.0.1:8099`).
+  tracks directive identity rather than trusting the transcript. A message
+  carrying `__MOCK_PLAN__ [[…],[…]]` scripts a whole **turn** instead of a single
+  call — several calls in one assistant message, and several steps across the
+  turn's tool loop — which is what lets one goal fan out to two teammates and be
+  closed out afterwards. Set `MOCK_BRAIN_DEBUG=1` to have it dump each request
+  it receives, which is the fastest way to find out why an arm stopped matching.
+  Bind with `PW_MOCK_BRAIN_BIND` (default `127.0.0.1:8099`).
 
 * [`test/e2e/mcp-server.mjs`](test/e2e/mcp-server.mjs) — an HTTP MCP server with
   two tools. HTTP, not stdio: this host rejects any MCP declaration carrying a
@@ -263,6 +269,44 @@ host at them:
 Against a host you brought up yourself (`PW_BASE_URL`), the flag still enables
 the four specs, but starting the fixtures and pointing the host at them is
 yours to do — this config will not reconfigure a host it did not launch.
+
+### The lane with a real model in it
+
+```sh
+cargo build --locked --features openhuman,tinycortex,mcp --bin opencompany
+npm --prefix frontend run e2e:live-llm    # PW_LIVE_LLM=1 npm run e2e
+```
+
+One spec, `orchestration-live.spec.ts`, and one claim the scripted lane cannot
+make: that a **model**, handed a goal and this company's real roster and tool
+descriptions, decides to break the goal up, give the pieces to the right people,
+and accept the results afterwards. A prompt that stopped describing the board, a
+tool description that stopped saying what it is for, a roster the orchestrator
+can no longer see — every one of those leaves the scripted lane green, because
+the scripted lane never reads them.
+
+The run narrows itself to that spec, exactly as the first-run lane does and for
+the same reason: every other spec asserts on the mock's answers, and a host
+thinking with a real model gives none of them.
+
+* [`test/e2e/live-brain-proxy.mjs`](test/e2e/live-brain-proxy.mjs) sits between
+  the host and the router. It forwards `/chat/completions` untouched — nothing
+  is scripted, filtered or retried — and supplies the two things a plain
+  upstream will not: `/embeddings`, which those routers answer `404` for and the
+  host validates the width of, and the model name, so the rung is named once
+  here rather than through the host's own `OPENCOMPANY_INFERENCE_MODEL`. It logs
+  one line per turn naming the tool calls the model chose, because "never asked"
+  and "asked and chose nothing" are otherwise the same silence.
+* Point it with `PW_LIVE_LLM_URL` (default `http://127.0.0.1:6969/v1`),
+  `PW_LIVE_LLM_MODEL` (default `flash`) and `PW_LIVE_LLM_KEY` (default
+  `$LADDER_API_KEY`); bind with `PW_LIVE_LLM_BIND` (default `127.0.0.1:8096`).
+
+**CI does not run it**, deliberately: it spends tokens and its verdict is a
+model's judgement, so a model having a bad day would turn unrelated pull
+requests red. Run it by hand before changing an orchestrator prompt, a
+delegation tool's description, or the delegation drain — and let
+`orchestration-simulation.spec.ts`, which asserts the same chain against
+scripted choices, be what guards it on every push.
 
 Some specs skip **the other way**, in the live lane only, and say so where they
 sit: three in `chat-live-events.spec.ts`, which find the reply to their own turn

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "e2e:headed": "playwright test --headed",
     "e2e:live": "PW_LIVE_BRAIN=1 playwright test",
     "e2e:first-run": "PW_FIRST_RUN=1 playwright test",
+    "e2e:live-llm": "PW_LIVE_LLM=1 playwright test",
     "tauri:dev": "../scripts/desktop-dev.sh",
     "tauri:build": "npm run build && cd ../src-tauri && ../frontend/node_modules/.bin/tauri build"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,8 @@ import {
   FIRST_RUN,
   FIRST_RUN_COMPANY,
   LIVE_BRAIN,
+  LIVE_LLM,
+  LIVE_LLM_BIND,
   MCP_FIXTURE_BIND,
   MOCK_BRAIN_BIND,
 } from "./test/e2e/capabilities";
@@ -62,6 +64,17 @@ const here = dirname(fileURLToPath(import.meta.url));
  * Against a host you brought yourself (`PW_BASE_URL`), the flag still enables
  * the four specs but the fixtures are yours to start too — this config will not
  * reconfigure a host it did not launch.
+ *
+ * # `PW_LIVE_LLM=1` — the lane with a real model in it
+ *
+ * `npm run e2e:live-llm`. Same feature-gated binary, but the inference behind
+ * it is `test/e2e/live-brain-proxy.mjs` in front of a real router rather than
+ * `mock-brain.mjs`, and the selection below narrows the run to
+ * `orchestration-live.spec.ts` — the one spec whose claim is that a *model*,
+ * given a goal and this company's real tool descriptions, delegates it and
+ * closes it out. Every other spec asserts on the mock's scripted answers and
+ * cannot pass against it. Not run by CI: it spends tokens and its verdict
+ * depends on a model's judgement. See `LIVE_LLM` in `test/e2e/capabilities.ts`.
  */
 
 /**
@@ -71,6 +84,13 @@ const here = dirname(fileURLToPath(import.meta.url));
  * is a second run rather than a skip inside the spec — issue #1404.
  */
 const FIRST_RUN_SPEC = /company-setup\.spec\.ts$/;
+
+/**
+ * The one spec that needs a host thinking with a **real model** rather than
+ * with the scripted mock, and which therefore cannot share a host with the rest
+ * of the suite either. See `LIVE_LLM` in `test/e2e/capabilities.ts`.
+ */
+const LIVE_LLM_SPEC = /orchestration-live\.spec\.ts$/;
 
 const providedBaseURL = process.env.PW_BASE_URL;
 
@@ -119,12 +139,24 @@ const managesFixtures = managesHost && LIVE_BRAIN;
  * from an empty environment and copies in an allowlist, so a variable set here
  * and not named there reaches nothing.
  */
-const inferenceEnv: Record<string, string> = managesFixtures
+/** Whether this run also brings up the real-model proxy (the live-LLM lane). */
+const managesLiveLlm = managesHost && LIVE_LLM;
+
+const inferenceEnv: Record<string, string> = managesLiveLlm
   ? {
-      OPENCOMPANY_INFERENCE_KEY: "mock-brain",
-      OPENCOMPANY_INFERENCE_URL: `http://${MOCK_BRAIN_BIND}/v1`,
+      // The bearer is still a placeholder and still unchecked — the *upstream*
+      // credential belongs to the proxy, which is the only process that talks
+      // to the router. The host needs one only because a configured credential
+      // is what makes it choose a live harness over the offline echo brain.
+      OPENCOMPANY_INFERENCE_KEY: "live-brain-proxy",
+      OPENCOMPANY_INFERENCE_URL: `http://${LIVE_LLM_BIND}/v1`,
     }
-  : {};
+  : managesFixtures
+    ? {
+        OPENCOMPANY_INFERENCE_KEY: "mock-brain",
+        OPENCOMPANY_INFERENCE_URL: `http://${MOCK_BRAIN_BIND}/v1`,
+      }
+    : {};
 
 /** Whether this run also brings up the Composio fixture backend (issue #820). */
 const managesComposio = managesHost && COMPOSIO;
@@ -179,6 +211,18 @@ const hostEnv: Record<string, string> = {
  * turn runs, well after every server here is ready.
  */
 const fixtureServers = [
+  ...(managesLiveLlm
+    ? [
+        {
+          command: `node ./test/e2e/live-brain-proxy.mjs --bind ${LIVE_LLM_BIND}`,
+          url: `http://${LIVE_LLM_BIND}/healthz`,
+          reuseExistingServer: !process.env.CI,
+          timeout: 30_000,
+          stdout: "pipe" as const,
+          stderr: "pipe" as const,
+        },
+      ]
+    : []),
   ...(managesComposio
     ? [
         {
@@ -222,7 +266,19 @@ export default defineConfig({
   // pointed at a host it cannot pass against, and — because Playwright exits
   // non-zero when a selection matches nothing — an empty selection is a
   // failure rather than a silent zero (issue #1404).
-  ...(FIRST_RUN ? { testMatch: FIRST_RUN_SPEC } : { testIgnore: FIRST_RUN_SPEC }),
+  // Three disjoint selections, one per kind of host. A first-run run drives a
+  // host serving an unstaffed company; a live-LLM run drives one thinking with
+  // a real model; an ordinary run drives the harness company on the scripted
+  // mock. Each spec is unpassable against the other two hosts, so the selection
+  // — rather than a guard inside a spec — is what keeps a run from being
+  // pointed at a host it cannot pass against. Playwright exits non-zero when a
+  // selection matches nothing, so an empty one is a failure rather than a
+  // silent zero (issue #1404).
+  ...(FIRST_RUN
+    ? { testMatch: FIRST_RUN_SPEC }
+    : LIVE_LLM
+      ? { testMatch: LIVE_LLM_SPEC }
+      : { testIgnore: [FIRST_RUN_SPEC, LIVE_LLM_SPEC] }),
   globalSetup: storageState ? "./test/e2e/global-setup.ts" : undefined,
   fullyParallel: false,
   workers: 1,

--- a/frontend/test/e2e/capabilities.ts
+++ b/frontend/test/e2e/capabilities.ts
@@ -114,6 +114,43 @@ export const LIVE_BRAIN_REASON =
   "(issue #467).";
 
 /**
+ * A host built with the harness features and pointed at a **real model**
+ * (`test/e2e/live-brain-proxy.mjs`) rather than at the scripted mock.
+ *
+ * Set `PW_LIVE_LLM=1`, or run `npm run e2e:live-llm`, which sets it and — when
+ * this config manages the host — starts the proxy and points the host at it.
+ *
+ * ## Why this is a run of its own rather than a flag inside a spec
+ *
+ * The same reason {@link FIRST_RUN} is: the two lanes need different hosts.
+ * Every other spec in this suite asserts on the mock's scripted answers, and a
+ * host whose inference is a real model answers none of them — a `__MOCK_LLM__`
+ * marker no longer appears, a `SPAWNONE` no longer opens exactly one card.
+ * Conversely `orchestration-live.spec.ts` asserts that a model *decided*
+ * something, which is unpassable against a fixture that decides nothing. So
+ * `playwright.config.ts` selects that spec only in this run, and every other
+ * spec only outside one, and neither can be pointed at a host it cannot pass
+ * against.
+ *
+ * The lane is **not** run by CI, and deliberately: it spends real tokens and its
+ * verdict depends on a model's judgement, which is the one thing a required
+ * check must not. It exists to be run by a person — before changing an
+ * orchestrator prompt, a tool description, or the delegation seam — and its
+ * scripted twin, `orchestration-simulation.spec.ts`, is what guards the same
+ * chain on every push.
+ */
+export const LIVE_LLM = process.env.PW_LIVE_LLM === "1";
+
+/** Where `live-brain-proxy.mjs` listens when this run starts it. */
+export const LIVE_LLM_BIND = process.env.PW_LIVE_LLM_BIND || "127.0.0.1:8096";
+
+/** The reason string a `LIVE_LLM` skip carries, so no skip is ever bare. */
+export const LIVE_LLM_REASON =
+  "needs a --features openhuman,tinycortex,mcp host pointed at a real model; " +
+  "run `npm run e2e:live-llm` (which sets PW_LIVE_LLM=1 and starts " +
+  "test/e2e/live-brain-proxy.mjs in front of the configured router).";
+
+/**
  * Whether this run's host serves the **unstaffed first-run fixture**
  * (`companies/e2e_setup`) rather than the suite's usual harness company.
  *

--- a/frontend/test/e2e/embedding.mjs
+++ b/frontend/test/e2e/embedding.mjs
@@ -1,0 +1,62 @@
+//
+// The deterministic `/embeddings` the two inference fixtures both answer with.
+//
+// It lives on its own because there are now two servers in front of the host —
+// `mock-brain.mjs`, which scripts every answer, and `live-brain-proxy.mjs`,
+// which forwards the thinking to a real model — and only one of those two
+// things is the model's job. Embeddings are not: the routers this suite is
+// pointed at serve chat completions and answer `404` for `/v1/embeddings`, and
+// a host whose memory writes 404 fails for a reason that has nothing to do with
+// the behaviour under test.
+//
+// So both fixtures serve the same vectors from here. Deterministic ones, never
+// random: two runs of the suite must not disagree about what a note means, and
+// a proxy run and a mock run must not disagree with each other either.
+//
+
+/**
+ * Width of every vector returned. `HostedEmbeddings` compares this against its
+ * declared dimensionality and errors on a mismatch rather than truncating, and
+ * its default is 1024 (`embedding-v1`'s only allowed size).
+ */
+export const EMBEDDING_DIM = 1024;
+
+/**
+ * A deterministic unit-ish vector for one input.
+ *
+ * @param {string} input
+ * @returns {number[]}
+ */
+export function embedding(input) {
+  let seed = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    seed = Math.imul(seed ^ input.charCodeAt(i), 16777619) >>> 0;
+  }
+  const vector = new Array(EMBEDDING_DIM);
+  for (let i = 0; i < EMBEDDING_DIM; i += 1) {
+    seed = (Math.imul(seed, 1103515245) + 12345) >>> 0;
+    vector[i] = seed / 4294967295 - 0.5;
+  }
+  return vector;
+}
+
+/**
+ * The embeddings reply for one request, in input order.
+ *
+ * @param {any} body
+ * @returns {any}
+ */
+export function embeddings(body) {
+  const raw = body?.input;
+  const inputs = Array.isArray(raw) ? raw : [raw ?? ""];
+  return {
+    object: "list",
+    model: typeof body?.model === "string" ? body.model : "mock-embedding",
+    data: inputs.map((input, index) => ({
+      object: "embedding",
+      index,
+      embedding: embedding(String(input)),
+    })),
+    usage: { prompt_tokens: 0, total_tokens: 0 },
+  };
+}

--- a/frontend/test/e2e/live-brain-proxy.mjs
+++ b/frontend/test/e2e/live-brain-proxy.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+//
+// The inference fixture for the **live-LLM** lane: a real model, reached
+// through the same seam `mock-brain.mjs` occupies.
+//
+// `mock-brain.mjs` proves the chain runs by scripting every choice in it. That
+// is the right default and it is also its limit: what it cannot show is that a
+// model, handed a goal and this company's real tool descriptions, *decides* to
+// break the goal up, hand the pieces to the right teammates, and close them out
+// afterwards. Nothing in the scripted lane would notice if the orchestrator's
+// prompt stopped describing its own tools, because the scripted lane never
+// reads them.
+//
+// So this lane points the host at a real chat-completions endpoint, and this
+// process sits in between for the two things the host needs that a plain
+// upstream will not do:
+//
+//   1. **`/embeddings`.** The routers this is pointed at (a local llm-ladder,
+//      an OpenRouter-style gateway) serve chat completions and answer `404` for
+//      embeddings. The host's embeddings client shares one base URL with its
+//      chat client and validates the returned width, so an unanswered
+//      `/embeddings` fails a memory write in the middle of a turn. Served from
+//      `./embedding.mjs`, exactly as the mock does.
+//   2. **The model name.** The lane names the rung once, here, rather than
+//      through the host's own `OPENCOMPANY_INFERENCE_MODEL` — so pointing a run
+//      at a different rung is one variable and never a question of which of two
+//      names won.
+//
+// It also writes one line per turn to stderr naming the tool calls the model
+// chose, because "the model answered but called nothing" and "the model was
+// never asked" are the two failures of this lane and they are otherwise the
+// same silence.
+//
+// Nothing here scripts, filters or retries a decision. Whatever the model says
+// is what the host gets — the point of the lane is that the decisions are not
+// ours.
+//
+// Usage:
+//   node live-brain-proxy.mjs [--bind HOST:PORT]
+// Env:
+//   PW_LIVE_LLM_BIND      same as --bind        (default 127.0.0.1:8096)
+//   PW_LIVE_LLM_URL       upstream base URL     (default http://127.0.0.1:6969/v1)
+//   PW_LIVE_LLM_MODEL     the rung to ask for   (default flash)
+//   PW_LIVE_LLM_KEY       upstream bearer       (default $LADDER_API_KEY)
+//
+// A `:0` port binds an ephemeral one; the chosen address is always printed to
+// stderr as `[live brain] listening on http://HOST:PORT`.
+//
+
+import { createServer } from "node:http";
+
+import { embeddings } from "./embedding.mjs";
+
+const bindArg = process.argv.indexOf("--bind");
+const BIND = (bindArg >= 0 ? process.argv[bindArg + 1] : undefined) ||
+  process.env.PW_LIVE_LLM_BIND ||
+  "127.0.0.1:8096";
+
+/** Where the real model lives. */
+const UPSTREAM = (process.env.PW_LIVE_LLM_URL || "http://127.0.0.1:6969/v1").replace(/\/+$/, "");
+
+/** The rung asked for, whatever the host asked for. */
+const MODEL = process.env.PW_LIVE_LLM_MODEL || "flash";
+
+/** The upstream credential. Absent is allowed — some routers want none. */
+const KEY = process.env.PW_LIVE_LLM_KEY || process.env.LADDER_API_KEY || "";
+
+/**
+ * How long one upstream turn may take.
+ *
+ * Generous on purpose: a reasoning model deciding a fan-out over a company's
+ * whole toolbelt is tens of seconds, and a proxy that gave up at the usual
+ * `fetch` default would surface as "the agent never replied" — a failure that
+ * reads as the product's and is not.
+ */
+const UPSTREAM_TIMEOUT_MS = Number.parseInt(process.env.PW_LIVE_LLM_TIMEOUT_MS || "180000", 10);
+
+/**
+ * Reads a whole request body.
+ *
+ * @param {import("node:http").IncomingMessage} request
+ * @returns {Promise<string>}
+ */
+function readBody(request) {
+  return new Promise((resolve, reject) => {
+    /** @type {Buffer[]} */
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    request.on("error", reject);
+  });
+}
+
+/**
+ * @param {import("node:http").ServerResponse} response
+ * @param {number} status
+ * @param {any} payload
+ */
+function sendJson(response, status, payload) {
+  const body = JSON.stringify(payload);
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body),
+  });
+  response.end(body);
+}
+
+/** One readable line about what the model just decided. */
+function describe(reply) {
+  const message = reply?.choices?.[0]?.message;
+  const calls = Array.isArray(message?.tool_calls) ? message.tool_calls : [];
+  if (calls.length > 0) {
+    return `tool calls: ${calls.map((call) => call?.function?.name ?? "?").join(" + ")}`;
+  }
+  const text = typeof message?.content === "string" ? message.content : "";
+  return `text reply (${text.length} chars)`;
+}
+
+/**
+ * Forwards one chat-completions request upstream, with the lane's model.
+ *
+ * @param {any} body the parsed request
+ * @returns {Promise<{status: number, payload: any}>}
+ */
+async function forward(body) {
+  const asked = { ...body, model: MODEL };
+  // `stream` is refused rather than forwarded: the host does not ask for it,
+  // and a streamed body would arrive here as something this proxy does not
+  // reassemble — better a loud 400 than a silently empty reply.
+  if (asked.stream) {
+    return {
+      status: 400,
+      payload: { error: { message: "live-brain-proxy does not forward streaming requests" } },
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${UPSTREAM}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(KEY ? { authorization: `Bearer ${KEY}` } : {}),
+      },
+      body: JSON.stringify(asked),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      // An upstream that answered with prose (a gateway error page, usually) is
+      // reported as itself. Swallowing it into a fabricated completion would
+      // put words in the model's mouth.
+      return {
+        status: 502,
+        payload: { error: { message: `upstream sent a non-JSON body: ${text.slice(0, 500)}` } },
+      };
+    }
+    return { status: response.status, payload };
+  } catch (error) {
+    return {
+      status: 504,
+      payload: { error: { message: `upstream did not answer: ${String(error)}` } },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const server = createServer((request, response) => {
+  const path = new URL(request.url ?? "/", "http://localhost").pathname;
+
+  if (path === "/healthz") {
+    sendJson(response, 200, { ok: true, upstream: UPSTREAM, model: MODEL });
+    return;
+  }
+
+  if (request.method !== "POST") {
+    sendJson(response, 405, { error: { message: "POST only" } });
+    return;
+  }
+
+  void (async () => {
+    let body;
+    try {
+      body = JSON.parse((await readBody(request)) || "{}");
+    } catch {
+      sendJson(response, 400, { error: { message: "body was not JSON" } });
+      return;
+    }
+
+    // Matching on the suffix, as the mock does: a base URL with or without a
+    // `/v1` both work, which is one fewer way for the lane's configuration and
+    // this server to disagree.
+    if (path.endsWith("/chat/completions")) {
+      const started = Date.now();
+      const { status, payload } = await forward(body);
+      const turns = Array.isArray(body?.messages) ? body.messages.length : 0;
+      const belt = Array.isArray(body?.tools) ? body.tools.length : 0;
+      process.stderr.write(
+        `[live brain] ${status} in ${Date.now() - started}ms ` +
+          `(${turns} messages, ${belt} tools) — ${describe(payload)}\n`,
+      );
+      sendJson(response, status, payload);
+      return;
+    }
+
+    if (path.endsWith("/embeddings")) {
+      sendJson(response, 200, embeddings(body));
+      return;
+    }
+
+    sendJson(response, 404, { error: { message: `no route for ${path}` } });
+  })();
+});
+
+const [host, port] = BIND.split(":");
+server.listen(Number(port), host, () => {
+  const chosen = server.address();
+  const shown = typeof chosen === "object" && chosen ? `${chosen.address}:${chosen.port}` : BIND;
+  process.stderr.write(`[live brain] listening on http://${shown}\n`);
+  process.stderr.write(`[live brain] forwarding to ${UPSTREAM} as model "${MODEL}"\n`);
+  if (!KEY) process.stderr.write("[live brain] no upstream credential set\n");
+});

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -228,7 +228,25 @@ function textOf(message) {
  * @returns {any | null} the parsed value, or null if nothing balanced parses
  */
 function readJsonObject(text, from) {
-  const start = text.indexOf("{", from);
+  return readJsonValue(text, from, "{", "}");
+}
+
+/**
+ * The balance scanner both directive payloads are read with: an object for
+ * `__MOCK_TOOL_CALL__`, an array for `__MOCK_PLAN__`.
+ *
+ * Parameterised over the delimiters rather than duplicated, because the string
+ * handling is the part that has to be right and a second copy of it is a second
+ * place for it to be wrong.
+ *
+ * @param {string} text
+ * @param {number} from
+ * @param {string} open
+ * @param {string} close
+ * @returns {any | null} the parsed value, or null if nothing balanced parses
+ */
+function readJsonValue(text, from, open, close) {
+  const start = text.indexOf(open, from);
   if (start < 0) return null;
 
   let depth = 0;
@@ -243,8 +261,8 @@ function readJsonObject(text, from) {
       continue;
     }
     if (ch === '"') inString = true;
-    else if (ch === "{") depth += 1;
-    else if (ch === "}") {
+    else if (ch === open) depth += 1;
+    else if (ch === close) {
       depth -= 1;
       if (depth === 0) {
         try {

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -196,11 +196,12 @@ const SPAWN_DIRECTIVE = "SPAWNONE";
  * message reaches the orchestrator and then every teammate the turn hands work
  * to, each inside its own wrapper — so a plan naming `spawn_task` is in the
  * *engineer's* prompt too, and the engineer has no such tool. A step is
- * therefore served only when every tool it names is on the belt the request
- * actually carries ({@link offeredTools}); otherwise it is left alone,
- * unconsumed, and the teammate answers with prose like any other turn. This is
- * a check on the request rather than on the prompt's wording, which is the only
- * form of it that cannot be fooled by a re-wrapping.
+ * therefore served only to a request that could actually make its calls: one
+ * whose `tools[]` carries every name ({@link offeredTools}), or one that is the
+ * orchestrator's own turn ({@link isOrchestratorTurn}) — because the delegation
+ * tools are dispatched through the runtime's own seam and never appear in
+ * `tools[]` at all. Otherwise the step is left alone, unconsumed, and the
+ * teammate answers with prose like any other turn.
  *
  * **A step must not be served twice.** `spawn_task` is serviced by the
  * runtime's delegation seam rather than the agent's own tool loop, so its
@@ -446,8 +447,32 @@ function findPlan(messages) {
 }
 
 /**
- * The tool names this request actually offers, which is what tells an
- * orchestrator turn from a teammate's turn on the same operator message.
+ * The sentence the orchestrator's persona opens its charter with
+ * (`src/harness/prompt.rs`, visible in `scripts/dump-prompt.sh` output).
+ *
+ * Coupling a fixture to prose is ordinarily a smell, and this file already
+ * carries two of them ({@link isTriageRequest}, {@link isPlanningRequest}) for
+ * the same reason it carries a third here: there is nothing else to key on.
+ * The delegation tools are **intrinsic** — dispatched by name through the
+ * runtime's own seam rather than exposed in the request's `tools[]` array — so
+ * a request that can open a board card looks, on the wire, exactly like one
+ * that cannot. That is not a detail worth being surprised by twice: it is why
+ * the belt check below is an *alternative* to this one rather than the whole
+ * guard.
+ *
+ * @param {any[]} messages
+ * @returns {boolean}
+ */
+function isOrchestratorTurn(messages) {
+  const first = textOf(messages[0]);
+  return typeof first === "string" && first.includes("this company's orchestrator");
+}
+
+/**
+ * The tool names this request actually offers.
+ *
+ * Only the *non*-intrinsic ones appear here — see {@link isOrchestratorTurn} —
+ * so an empty intersection is not proof of anything on its own.
  *
  * @param {any} body the parsed request
  * @returns {Set<string>}
@@ -693,19 +718,21 @@ function chatCompletion(body) {
     const calls = Array.isArray(step) ? step : [];
     if (calls.length > 0) {
       const offered = offeredTools(body);
-      const missing = calls
-        .map((call) => call?.name)
-        .filter((name) => !offered.has(name));
-      if (missing.length > 0) {
+      const missing = calls.map((call) => call?.name).filter((name) => !offered.has(name));
+      // Either the request offers every tool the step names, or it is the
+      // orchestrator's own turn — whose delegation tools are intrinsic and
+      // therefore never in `tools[]` at all.
+      const canServe = missing.length === 0 || isOrchestratorTurn(messages);
+      if (!canServe) {
         // NOT consumed: this is a teammate reading the operator's message
         // second-hand, not the orchestrator. Answering with prose is the same
         // thing a real model does when it is offered no such tool.
-        // The belt is named as well as the gap: "this agent is not the
-        // orchestrator" and "the orchestrator lost a tool" are the same line
-        // otherwise, and they are opposite bugs.
+        // The belt is named as well as the gap: "this agent is not the one the
+        // plan was written for" and "the agent lost a tool it should have" are
+        // the same line otherwise, and they are opposite bugs.
         process.stderr.write(
-          `[mock brain] plan step ${served} left unserved; this belt has no ` +
-            `${missing.join(", ")} — it carries [${[...offered].join(", ")}]\n`,
+          `[mock brain] plan step ${served} left unserved; not an orchestrator turn and ` +
+            `this belt has no ${missing.join(", ")} — it carries [${[...offered].join(", ")}]\n`,
         );
       } else {
         servedPlans.set(plan.id, served + 1);

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -700,8 +700,12 @@ function chatCompletion(body) {
         // NOT consumed: this is a teammate reading the operator's message
         // second-hand, not the orchestrator. Answering with prose is the same
         // thing a real model does when it is offered no such tool.
+        // The belt is named as well as the gap: "this agent is not the
+        // orchestrator" and "the orchestrator lost a tool" are the same line
+        // otherwise, and they are opposite bugs.
         process.stderr.write(
-          `[mock brain] plan step ${served} left unserved; this belt has no ${missing.join(", ")}\n`,
+          `[mock brain] plan step ${served} left unserved; this belt has no ` +
+            `${missing.join(", ")} — it carries [${[...offered].join(", ")}]\n`,
         );
       } else {
         servedPlans.set(plan.id, served + 1);

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -675,6 +675,55 @@ function chatCompletion(body) {
     );
   }
 
+  // The scripted-turn arm, ahead of the single-call directives: a plan is the
+  // whole turn, and a message carrying one carries nothing else.
+  const plan = findPlan(messages);
+  if (plan) {
+    const served = servedPlans.get(plan.id) ?? 0;
+    const step = plan.steps[served];
+    const calls = Array.isArray(step) ? step : [];
+    if (calls.length > 0) {
+      const offered = offeredTools(body);
+      const missing = calls
+        .map((call) => call?.name)
+        .filter((name) => !offered.has(name));
+      if (missing.length > 0) {
+        // NOT consumed: this is a teammate reading the operator's message
+        // second-hand, not the orchestrator. Answering with prose is the same
+        // thing a real model does when it is offered no such tool.
+        process.stderr.write(
+          `[mock brain] plan step ${served} left unserved; this belt has no ${missing.join(", ")}\n`,
+        );
+      } else {
+        servedPlans.set(plan.id, served + 1);
+        process.stderr.write(
+          `[mock brain] plan step ${served}: ${calls.map((c) => c.name).join(" + ")}\n`,
+        );
+        return completion(
+          model,
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: calls.map((call, index) => ({
+              id: `mock-plan-${served}-${index}`,
+              type: "function",
+              function: {
+                name: call.name,
+                arguments: JSON.stringify(call.arguments ?? {}),
+              },
+            })),
+          },
+          "tool_calls",
+        );
+      }
+    } else if (Array.isArray(step)) {
+      // An explicitly empty step: the turn is meant to answer in prose here.
+      // Consumed, so the next call moves on rather than re-reading this one.
+      servedPlans.set(plan.id, served + 1);
+      process.stderr.write(`[mock brain] plan step ${served}: text reply\n`);
+    }
+  }
+
   const directive = findDirective(messages);
 
   if (

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -164,6 +164,54 @@ function slowMillis(messages) {
 const SPAWN_DIRECTIVE = "SPAWNONE";
 
 /**
+ * A whole scripted **turn**, for the orchestration simulation (this is what
+ * `orchestration-simulation.spec.ts` drives).
+ *
+ * `SPAWNONE` and `__MOCK_TOOL_CALL__` can each buy exactly one tool call from
+ * one turn, which is enough to prove a chat message reaches a card and no more.
+ * An orchestrator pursuing a goal does something they cannot express: it fans
+ * out to several teammates in **one** turn, and then keeps going across the
+ * several turns a goal takes to close. So this directive carries a plan —
+ *
+ *   __MOCK_PLAN__ [[{"name":"spawn_task","arguments":{…}},
+ *                   {"name":"spawn_task","arguments":{…}}],
+ *                  []]
+ *
+ * — an array of steps, each step an array of calls to emit together in one
+ * assistant message. Step *n* answers the *n*th time this plan is asked for;
+ * past the end (or on an empty step) the turn falls through to the ordinary
+ * text reply, which is how a turn *ends* rather than looping forever.
+ *
+ * # Two things it must not do, and how each is prevented
+ *
+ * **It must not fire for an agent that cannot make the call.** One operator
+ * message reaches the orchestrator and then every teammate the turn hands work
+ * to, each inside its own wrapper — so a plan naming `spawn_task` is in the
+ * *engineer's* prompt too, and the engineer has no such tool. A step is
+ * therefore served only when every tool it names is on the belt the request
+ * actually carries ({@link offeredTools}); otherwise it is left alone,
+ * unconsumed, and the teammate answers with prose like any other turn. This is
+ * a check on the request rather than on the prompt's wording, which is the only
+ * form of it that cannot be fooled by a re-wrapping.
+ *
+ * **A step must not be served twice.** `spawn_task` is serviced by the
+ * runtime's delegation seam rather than the agent's own tool loop, so its
+ * result never enters the model-visible transcript — the history looks
+ * untouched on the next call of the same turn (the same trap
+ * {@link servedDirectives} exists for). Progress is therefore counted here,
+ * per plan, in {@link servedPlans}. Every plan a spec writes carries a
+ * `Date.now()` marker, so a genuinely new plan is always a new key.
+ */
+const PLAN_DIRECTIVE = "__MOCK_PLAN__";
+
+/**
+ * How many steps of each plan have been served, keyed by the plan's own text.
+ *
+ * @type {Map<string, number>}
+ */
+const servedPlans = new Map();
+
+/**
  * The host's own re-issue instruction, sent to the agent when an operator
  * approves a parked tool call (`src/harness/brain.rs`):
  *
@@ -356,6 +404,52 @@ function findDirective(messages) {
     }
   }
   return null;
+}
+
+/**
+ * The last {@link PLAN_DIRECTIVE} in the thread, or null.
+ *
+ * Scanned from the end so the newest plan wins: a goal takes several operator
+ * messages to close, and each of them carries the plan for the turn it opens.
+ *
+ * @param {any[]} messages
+ * @returns {{id: string, steps: any[][]} | null}
+ */
+function findPlan(messages) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const text = textOf(messages[i]);
+    const at = text.indexOf(PLAN_DIRECTIVE);
+    if (at < 0) continue;
+    const steps = readJsonValue(text, at + PLAN_DIRECTIVE.length, "[", "]");
+    if (!Array.isArray(steps)) {
+      // A broken spec, not a plain turn. Say so loudly rather than answering
+      // with text the spec will then fail on obscurely.
+      process.stderr.write(
+        `[mock brain] ${PLAN_DIRECTIVE} found but its JSON payload did not parse\n`,
+      );
+      return null;
+    }
+    // The plan's own text is its identity, so two spec runs — or two goals in
+    // one run — never share a cursor.
+    return { id: JSON.stringify(steps), steps };
+  }
+  return null;
+}
+
+/**
+ * The tool names this request actually offers, which is what tells an
+ * orchestrator turn from a teammate's turn on the same operator message.
+ *
+ * @param {any} body the parsed request
+ * @returns {Set<string>}
+ */
+function offeredTools(body) {
+  const tools = Array.isArray(body?.tools) ? body.tools : [];
+  return new Set(
+    tools
+      .map((tool) => tool?.function?.name ?? tool?.name)
+      .filter((name) => typeof name === "string"),
+  );
 }
 
 /**

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -57,12 +57,18 @@
 //      emit the named call with the arguments the instruction dictates. The
 //      directive that produced the parked call has already been served, so
 //      without this arm no approval-gated tool can run in this lane at all.
-//   3. a message carrying `__MOCK_TOOL_CALL__ {"name":…,"arguments":{…}}` —
+//   3. a message carrying `__MOCK_PLAN__ [[{…},{…}],[…]]` — a whole scripted
+//      turn: several calls in one assistant message, and several steps across
+//      one turn's tool loop. `orchestration-simulation.spec.ts` drives a goal
+//      to completion with it. Served only when the request's own `tools` carry
+//      every name the step uses, which is what stops a teammate reading the
+//      operator's message second-hand from honouring the orchestrator's plan.
+//   4. a message carrying `__MOCK_TOOL_CALL__ {"name":…,"arguments":{…}}` —
 //      emit exactly that tool call, once. `mcp.spec.ts` uses it to make an
 //      agent call a named MCP tool without a model that might decide not to.
-//   4. a message carrying `SPAWNONE` — call `spawn_task` once, which is what
+//   5. a message carrying `SPAWNONE` — call `spawn_task` once, which is what
 //      `chat-to-card.spec.ts` needs an orchestrator to do.
-//   5. anything else — a fixed line carrying the `__MOCK_LLM__` marker.
+//   6. anything else — a fixed line carrying the `__MOCK_LLM__` marker.
 //
 // # Why the plain reply quotes nothing
 //

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -130,6 +130,8 @@
 
 import { createServer } from "node:http";
 
+import { embeddings } from "./embedding.mjs";
+
 /** The marker every text reply carries, so a spec can prove the reply is ours. */
 const MARKER = "__MOCK_LLM__";
 
@@ -205,8 +207,10 @@ const SPAWN_DIRECTIVE = "SPAWNONE";
  * result never enters the model-visible transcript — the history looks
  * untouched on the next call of the same turn (the same trap
  * {@link servedDirectives} exists for). Progress is therefore counted here,
- * per plan, in {@link servedPlans}. Every plan a spec writes carries a
- * `Date.now()` marker, so a genuinely new plan is always a new key.
+ * per plan, in {@link servedPlans}, keyed by the directive and the rest of its
+ * line. So a spec writes its `Date.now()` marker AFTER the payload —
+ * `__MOCK_PLAN__ [[…]] goal-1787…` — and two plans holding identical steps
+ * stay two plans rather than sharing one cursor.
  */
 const PLAN_DIRECTIVE = "__MOCK_PLAN__";
 
@@ -238,13 +242,6 @@ const servedPlans = new Map();
  */
 const REISSUE_PATTERN =
   /Operator approved your `([^`]+)` call\. Re-issue it now with EXACTLY these arguments: /;
-
-/**
- * Width of every vector `/embeddings` returns. `HostedEmbeddings` compares this
- * against its declared dimensionality and errors on a mismatch rather than
- * truncating, and its default is 1024 (`embedding-v1`'s only allowed size).
- */
-const EMBEDDING_DIM = 1024;
 
 /** How much of a tool result is quoted back in the reply that follows it. */
 const TOOL_ECHO_LIMIT = 2000;
@@ -435,9 +432,15 @@ function findPlan(messages) {
       );
       return null;
     }
-    // The plan's own text is its identity, so two spec runs — or two goals in
-    // one run — never share a cursor.
-    return { id: JSON.stringify(steps), steps };
+    // Identity is the directive and the rest of its LINE — the same key shape
+    // `SPAWNONE` uses, and for both of its reasons. It is stable across the
+    // wrappers each agent's prompt puts in FRONT of the message, and it keeps
+    // two plans that happen to hold identical steps apart, because the marker a
+    // spec writes after the payload is part of the key. Keying on the parsed
+    // steps alone would have made "the same two cards, opened by a later goal"
+    // share a cursor with the first goal and silently start half way through.
+    const line = text.slice(at).split("\n")[0].trim();
+    return { id: `plan:${line}`, steps };
   }
   return null;
 }
@@ -784,47 +787,6 @@ function completion(model, message, finishReason) {
     model,
     choices: [{ index: 0, message, finish_reason: finishReason }],
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
-  };
-}
-
-/**
- * A deterministic unit-ish vector for one input. Never random: two runs of the
- * suite must not disagree about what a note means.
- *
- * @param {string} input
- * @returns {number[]}
- */
-function embedding(input) {
-  let seed = 2166136261;
-  for (let i = 0; i < input.length; i += 1) {
-    seed = Math.imul(seed ^ input.charCodeAt(i), 16777619) >>> 0;
-  }
-  const vector = new Array(EMBEDDING_DIM);
-  for (let i = 0; i < EMBEDDING_DIM; i += 1) {
-    seed = (Math.imul(seed, 1103515245) + 12345) >>> 0;
-    vector[i] = seed / 4294967295 - 0.5;
-  }
-  return vector;
-}
-
-/**
- * The embeddings reply for one request, in input order.
- *
- * @param {any} body
- * @returns {any}
- */
-function embeddings(body) {
-  const raw = body?.input;
-  const inputs = Array.isArray(raw) ? raw : [raw ?? ""];
-  return {
-    object: "list",
-    model: typeof body?.model === "string" ? body.model : "mock-embedding",
-    data: inputs.map((input, index) => ({
-      object: "embedding",
-      index,
-      embedding: embedding(String(input)),
-    })),
-    usage: { prompt_tokens: 0, total_tokens: 0 },
   };
 }
 

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -650,6 +650,22 @@ function chatCompletion(body) {
   const messages = Array.isArray(body?.messages) ? body.messages : [];
   const model = typeof body?.model === "string" ? body.model : "mock-brain";
 
+  // `MOCK_BRAIN_DEBUG=1` dumps what actually arrived. Three of the arms below
+  // key on the *shape* of a request — the opening words of a system prompt, the
+  // names in `tools[]` — and when one of them stops matching, the only useful
+  // next question is what the host really sent. Guessing at that from a spec
+  // failure forty seconds downstream is how an afternoon goes.
+  if (process.env.MOCK_BRAIN_DEBUG === "1") {
+    process.stderr.write(
+      `[mock brain] REQUEST roles=[${messages.map((m) => m?.role).join(", ")}] ` +
+        `tools=[${(body?.tools ?? []).map((t) => t?.function?.name).join(", ")}]\n` +
+        messages
+          .map((m, i) => `  [${i}] ${m?.role}: ${textOf(m).slice(0, 400).replace(/\n/g, " ")}`)
+          .join("\n") +
+        "\n",
+    );
+  }
+
   // A triage escalation is a classification, not a turn (issue #678). It is
   // handed the operator's RAW message, so it carries any `__MOCK_TOOL_CALL__`
   // the message carried — and `servedDirectives` is per-process, so serving it

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -196,12 +196,11 @@ const SPAWN_DIRECTIVE = "SPAWNONE";
  * message reaches the orchestrator and then every teammate the turn hands work
  * to, each inside its own wrapper — so a plan naming `spawn_task` is in the
  * *engineer's* prompt too, and the engineer has no such tool. A step is
- * therefore served only to a request that could actually make its calls: one
- * whose `tools[]` carries every name ({@link offeredTools}), or one that is the
- * orchestrator's own turn ({@link isOrchestratorTurn}) — because the delegation
- * tools are dispatched through the runtime's own seam and never appear in
- * `tools[]` at all. Otherwise the step is left alone, unconsumed, and the
- * teammate answers with prose like any other turn.
+ * therefore served only when every tool it names is on the belt the request
+ * actually carries ({@link offeredTools}); otherwise it is left alone,
+ * unconsumed, and the teammate answers with prose like any other turn. This is
+ * a check on the request rather than on the prompt's wording, which is the only
+ * form of it that cannot be fooled by a re-wrapping.
  *
  * **A step must not be served twice.** `spawn_task` is serviced by the
  * runtime's delegation seam rather than the agent's own tool loop, so its
@@ -447,32 +446,16 @@ function findPlan(messages) {
 }
 
 /**
- * The sentence the orchestrator's persona opens its charter with
- * (`src/harness/prompt.rs`, visible in `scripts/dump-prompt.sh` output).
+ * The tool names this request actually offers, which is what tells an
+ * orchestrator turn from a teammate's turn on the same operator message.
  *
- * Coupling a fixture to prose is ordinarily a smell, and this file already
- * carries two of them ({@link isTriageRequest}, {@link isPlanningRequest}) for
- * the same reason it carries a third here: there is nothing else to key on.
- * The delegation tools are **intrinsic** — dispatched by name through the
- * runtime's own seam rather than exposed in the request's `tools[]` array — so
- * a request that can open a board card looks, on the wire, exactly like one
- * that cannot. That is not a detail worth being surprised by twice: it is why
- * the belt check below is an *alternative* to this one rather than the whole
- * guard.
- *
- * @param {any[]} messages
- * @returns {boolean}
- */
-function isOrchestratorTurn(messages) {
-  const first = textOf(messages[0]);
-  return typeof first === "string" && first.includes("this company's orchestrator");
-}
-
-/**
- * The tool names this request actually offers.
- *
- * Only the *non*-intrinsic ones appear here — see {@link isOrchestratorTurn} —
- * so an empty intersection is not proof of anything on its own.
+ * The orchestrator's belt really does carry `spawn_task`, `review_task` and the
+ * rest on the wire — 27 tools on the harness company, against the teammate's
+ * fourteen — so this is a sufficient check and not a heuristic. It was worth
+ * confirming rather than assuming: the delegation tools are *intrinsic*, in the
+ * sense that the runtime services them rather than the agent's own tool loop,
+ * and it would have been reasonable to guess they were therefore absent from
+ * `tools[]`.
  *
  * @param {any} body the parsed request
  * @returns {Set<string>}
@@ -735,11 +718,7 @@ function chatCompletion(body) {
     if (calls.length > 0) {
       const offered = offeredTools(body);
       const missing = calls.map((call) => call?.name).filter((name) => !offered.has(name));
-      // Either the request offers every tool the step names, or it is the
-      // orchestrator's own turn — whose delegation tools are intrinsic and
-      // therefore never in `tools[]` at all.
-      const canServe = missing.length === 0 || isOrchestratorTurn(messages);
-      if (!canServe) {
+      if (missing.length > 0) {
         // NOT consumed: this is a teammate reading the operator's message
         // second-hand, not the orchestrator. Answering with prose is the same
         // thing a real model does when it is offered no such tool.
@@ -747,8 +726,8 @@ function chatCompletion(body) {
         // plan was written for" and "the agent lost a tool it should have" are
         // the same line otherwise, and they are opposite bugs.
         process.stderr.write(
-          `[mock brain] plan step ${served} left unserved; not an orchestrator turn and ` +
-            `this belt has no ${missing.join(", ")} — it carries [${[...offered].join(", ")}]\n`,
+          `[mock brain] plan step ${served} left unserved; this belt has no ` +
+            `${missing.join(", ")} — it carries [${[...offered].join(", ")}]\n`,
         );
       } else {
         servedPlans.set(plan.id, served + 1);

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -10,6 +10,7 @@ import {
   openMainLine,
   say,
   silenceTour,
+  waitForTurn,
 } from "./orchestration";
 
 /**
@@ -152,23 +153,13 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
     })
     .toBeGreaterThanOrEqual(1);
 
-  // Let the turn *finish* before reading the board, and wait for it rather than
-  // sleeping through it. A fan-out arrives one card at a time — the first run of
-  // this spec read the board five seconds in, found one of the two cards, and
-  // then reported on half a goal while the other half was still being written.
-  // Two equal readings, the same shape `settledMarkerCount` uses.
-  let last = -1;
-  await expect
-    .poll(
-      async () => {
-        const current = (await newCards(request, before)).length;
-        const settled = current === last;
-        last = current;
-        return settled;
-      },
-      { message: "the orchestrator kept opening cards", timeout: 120_000, intervals: [4_000] },
-    )
-    .toBe(true);
+  // Let the turn *finish* before reading the board. This is the assertion two
+  // runs of this spec were quietly wrong without: a turn's delegations are
+  // drained **after** it, so a board read taken while the company is still
+  // answering sees whichever cards happen to exist at that instant. Both runs
+  // then dispatched, settled and closed out one card of a two-card goal — and
+  // reported green over the half they never looked at.
+  await waitForTurn(page);
   const opened = await newCards(request, before);
   // The cap is the host's own (`MAX_DELEGATIONS_PER_TURN`), so more than three
   // means something other than this turn wrote to the board.

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -111,9 +111,11 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
   await openMainLine(page);
   await say(
     page,
-    "I want a short market digest published this week. Break it into two pieces of " +
-      "work, open a card on the board for each, and give each one to whichever " +
-      "teammate should own it. Do not do the work yourself in this message.",
+    "Our workspace has a Standards note. I want a short \"How we write\" one-pager " +
+      "for new teammates based on it, saved into the workspace, and then checked by " +
+      "somebody else for clarity. Break that into two pieces of work, give each one " +
+      "to whichever teammate should own it, and do not do the work yourself in this " +
+      "message.",
   );
 
   // The first failure this lane can have: the model was never reached, or was
@@ -129,9 +131,23 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
     })
     .toBeGreaterThanOrEqual(1);
 
-  // Let the turn finish before reading the board: a fan-out arrives one card at
-  // a time, and a run read at the first one would dispatch half a goal.
-  await page.waitForTimeout(5_000);
+  // Let the turn *finish* before reading the board, and wait for it rather than
+  // sleeping through it. A fan-out arrives one card at a time — the first run of
+  // this spec read the board five seconds in, found one of the two cards, and
+  // then reported on half a goal while the other half was still being written.
+  // Two equal readings, the same shape `settledMarkerCount` uses.
+  let last = -1;
+  await expect
+    .poll(
+      async () => {
+        const current = (await newCards(request, before)).length;
+        const settled = current === last;
+        last = current;
+        return settled;
+      },
+      { message: "the orchestrator kept opening cards", timeout: 120_000, intervals: [4_000] },
+    )
+    .toBe(true);
   const opened = await newCards(request, before);
   // The cap is the host's own (`MAX_DELEGATIONS_PER_TURN`), so more than three
   // means something other than this turn wrote to the board.
@@ -190,13 +206,23 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
     opened.some((card) => card.id === held.id),
   );
   const reviewable = settled.filter((card) => (card.stage ?? card.column) === "in_review");
-  test.skip(
-    reviewable.length === 0,
-    `nothing reached review — the run parked instead (${settled
-      .map((card) => `${card.title}: ${card.stage ?? card.column}`)
-      .join("; ")}). That is a legitimate landing, but the close-out below has ` +
-      "nothing to accept.",
-  );
+  // A hard failure rather than a skip, deliberately. `paused` is a legitimate
+  // landing for a single run — a turn that needed a tool it has no credential
+  // for, or an approval nobody has decided — but a goal where *nothing* came
+  // back for acceptance did not close, and that is the whole claim of this
+  // lane. Skipping here would report green over exactly the outcome the spec
+  // exists to notice, which is the pathology `CLAUDE.md` names for Rust targets
+  // ("builds, runs and reports zero without failing anything").
+  //
+  // The landings are named in the message because the next question is always
+  // which one it was: `paused` sends you to the approvals queue, `pending` to a
+  // dispatch that never happened.
+  expect(
+    reviewable.length,
+    `no card came back for acceptance — the run landed as ${settled
+      .map((card) => `"${card.title}": ${card.stage ?? card.column}`)
+      .join("; ")}`,
+  ).toBeGreaterThan(0);
 
   await openMainLine(page);
   await say(

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -7,7 +7,7 @@ import {
   column,
   dispatch,
   openBoard,
-  openChannel,
+  openMainLine,
   say,
   silenceTour,
 } from "./orchestration";
@@ -108,7 +108,7 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
   // Specific about the *outcome* (cards on the board, owned by teammates) and
   // silent about the mechanism, because which tool to reach for is exactly the
   // decision under test.
-  await openChannel(page);
+  await openMainLine(page);
   await say(
     page,
     "I want a short market digest published this week. Break it into two pieces of " +
@@ -198,7 +198,7 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
       "nothing to accept.",
   );
 
-  await openChannel(page);
+  await openMainLine(page);
   await say(
     page,
     `The work is back and it looks good to me. Please review and approve ` +

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -224,16 +224,23 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
       .join("; ")}`,
   ).toBeGreaterThan(0);
 
-  await openMainLine(page);
-  await say(
-    page,
-    `The work is back and it looks good to me. Please review and approve ` +
-      `${reviewable.length === 1 ? "this card" : "these cards"}, so ` +
-      `${reviewable.length === 1 ? "it is" : "they are"} marked done: ` +
-      reviewable.map((card) => `${card.id} ("${card.title}")`).join(", "),
-  );
-
+  // **One card per message**, and that is not fastidiousness. Asked to accept
+  // two cards in one sentence, the model under test approved the first, wrote a
+  // paragraph about both, and never called `review_task` again — so the second
+  // card sat in review while the reply said it was finished. Nothing is broken
+  // there: the host's own cap allows three delegations per turn, and the tool
+  // was reachable the whole time. It is simply not a claim about the product
+  // that a model will always finish a batched instruction, and a lane that
+  // asserted it would be measuring the model's diligence rather than the
+  // company's plumbing.
   for (const card of reviewable) {
+    await openMainLine(page);
+    await say(
+      page,
+      `The work on card ${card.id} ("${card.title}") is back and it looks good to ` +
+        "me. Please review and approve that card so it is marked done.",
+    );
+
     await expect
       .poll(
         async () => {

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -211,7 +211,10 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
           // A card that has gone missing keeps the poll waiting rather than
           // concluding: the alternative reads as "settled" for a card that no
           // longer exists.
-          return held ? landing(held) : "in_progress";
+          // Reduced to a boolean here rather than asserted with a set matcher,
+          // because `expect.poll` has no `toBeOneOf`. The landing itself is
+          // read back below for the message, so nothing is lost by it.
+          return held ? SETTLED.includes(landing(held)) : false;
         },
         {
           message: `card "${card.title}" never settled`,
@@ -219,7 +222,7 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
           intervals: [5_000],
         },
       )
-      .toBeOneOf(SETTLED);
+      .toBe(true);
   }
 
   // ── 4. The operator asks for it to be closed out ───────────────────────

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -76,6 +76,27 @@ async function newCards(request: APIRequestContext, before: Set<string>) {
   return (await allCards(request)).filter((task) => !before.has(task.id));
 }
 
+/**
+ * Where a card is, in the one vocabulary that covers every case: the stage when
+ * it has one, the phase otherwise (`stage` is omitted for a pending or done
+ * card, because there is only one way to be either — issue #1512).
+ */
+function landing(card: { column: string; stage?: string }): string {
+  return card.stage ?? card.column;
+}
+
+/**
+ * The landings a run has actually stopped in.
+ *
+ * Written as an allow-list of *stopped* states rather than as "anything but
+ * `in_progress`", which is the same shape `CLAUDE.md` warns about one level up:
+ * a card the orchestrator has not dispatched yet reads `pending`, which is not
+ * `in_progress`, so the loose form let a card that had not started count as one
+ * that had finished. The first run of this spec passed that way — one card
+ * accepted, the other still working, and a green tick over it.
+ */
+const SETTLED = ["in_review", "paused", "done"];
+
 /** The roster ids an orchestrator may hand work to, read from the host. */
 async function roster(request: APIRequestContext): Promise<string[]> {
   const response = await request.get(`${SCOPE}/team`);
@@ -187,7 +208,10 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
       .poll(
         async () => {
           const held = (await allCards(request)).find((row) => row.id === card.id);
-          return held?.stage ?? held?.column ?? "in_progress";
+          // A card that has gone missing keeps the poll waiting rather than
+          // concluding: the alternative reads as "settled" for a card that no
+          // longer exists.
+          return held ? landing(held) : "in_progress";
         },
         {
           message: `card "${card.title}" never settled`,
@@ -195,7 +219,7 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
           intervals: [5_000],
         },
       )
-      .not.toBe("in_progress");
+      .toBeOneOf(SETTLED);
   }
 
   // ── 4. The operator asks for it to be closed out ───────────────────────
@@ -205,7 +229,7 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
   const settled = (await allCards(request)).filter((held) =>
     opened.some((card) => card.id === held.id),
   );
-  const reviewable = settled.filter((card) => (card.stage ?? card.column) === "in_review");
+  const reviewable = settled.filter((card) => landing(card) === "in_review");
   // A hard failure rather than a skip, deliberately. `paused` is a legitimate
   // landing for a single run — a turn that needed a tool it has no credential
   // for, or an approval nobody has decided — but a goal where *nothing* came
@@ -220,7 +244,7 @@ test("a real model takes a goal, gives it to its team, and closes it out", async
   expect(
     reviewable.length,
     `no card came back for acceptance — the run landed as ${settled
-      .map((card) => `"${card.title}": ${card.stage ?? card.column}`)
+      .map((card) => `"${card.title}": ${landing(card)}`)
       .join("; ")}`,
   ).toBeGreaterThan(0);
 

--- a/frontend/test/e2e/orchestration-live.spec.ts
+++ b/frontend/test/e2e/orchestration-live.spec.ts
@@ -1,0 +1,234 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+import { LIVE_LLM, LIVE_LLM_REASON } from "./capabilities";
+import {
+  DONE,
+  SCOPE,
+  column,
+  dispatch,
+  openBoard,
+  openChannel,
+  say,
+  silenceTour,
+} from "./orchestration";
+
+/**
+ * **The same loop as `orchestration-simulation.spec.ts`, with a real model
+ * making the decisions.**
+ *
+ * The scripted lane proves the machinery runs: a goal reaches the orchestrator,
+ * `spawn_task` opens cards, a dispatch runs a teammate's turn, `review_task`
+ * closes them. What it cannot prove is that any of that is *reachable* — that a
+ * model, handed this company's roster and the real descriptions of these tools,
+ * decides to break a goal up, give the pieces to the right people, and accept
+ * the results afterwards. A prompt that stopped describing the board, a tool
+ * description that stopped saying what it is for, a roster the orchestrator can
+ * no longer see: every one of those leaves the scripted lane green, because the
+ * scripted lane never reads them.
+ *
+ * This lane reads them. Nothing here scripts a choice — `live-brain-proxy.mjs`
+ * forwards the turn to a real router and returns whatever comes back.
+ *
+ * # Why it is not in CI, and what that costs
+ *
+ * It spends tokens and its verdict is a model's judgement, which is the one
+ * thing a required check must not depend on: a model having a bad day would
+ * turn every unrelated pull request red. So it is run by a person — before
+ * changing an orchestrator prompt, a delegation tool's description, or the
+ * drain — with `npm run e2e:live-llm`.
+ *
+ * The cost is that it can rot silently, which is why it is written to fail
+ * *legibly*: every wait names what it was waiting for, and the two failures
+ * this lane actually has — "the model was never asked" and "the model was asked
+ * and chose nothing" — are separated by the first assertion below.
+ *
+ * # What is asserted, given that the answers are not ours
+ *
+ * Outcomes, never wording, and never *which* tool was used. An orchestrator
+ * that opens cards with `spawn_task` and one that hands work over with
+ * `delegate_to_teammate` (which opens its own card) are both doing the job; a
+ * spec that demanded one would be asserting a preference. So what is checked is
+ * the shape of the board afterwards: work appeared, somebody on the roster owns
+ * it, dispatching it runs a turn, and asking for it to be closed out closes it.
+ *
+ * Cards are identified by **what was not there before**, not by title: the
+ * model writes the titles, and a spec that grepped for its own words would be
+ * testing the model's obedience rather than the company's behaviour.
+ */
+
+/** The board's own record for every card the company holds. */
+async function allCards(
+  request: APIRequestContext,
+): Promise<{ id: string; title: string; column: string; stage?: string; assignee?: string }[]> {
+  const response = await request.get(`${SCOPE}/tasks`);
+  expect(response.ok(), `listing cards failed: ${response.status()}`).toBeTruthy();
+  const body = await response.json();
+  return (body.tasks ?? body) as never[];
+}
+
+/** The ids on the board right now — the baseline a goal is measured against. */
+async function cardIds(request: APIRequestContext): Promise<Set<string>> {
+  return new Set((await allCards(request)).map((task) => task.id));
+}
+
+/** The cards that appeared since `before`. */
+async function newCards(request: APIRequestContext, before: Set<string>) {
+  return (await allCards(request)).filter((task) => !before.has(task.id));
+}
+
+/** The roster ids an orchestrator may hand work to, read from the host. */
+async function roster(request: APIRequestContext): Promise<string[]> {
+  const response = await request.get(`${SCOPE}/team`);
+  expect(response.ok(), `reading the team failed: ${response.status()}`).toBeTruthy();
+  const body = await response.json();
+  const members = (body.members ?? body.team ?? body) as { id: string }[];
+  return members.map((member) => member.id);
+}
+
+test.beforeEach(async ({ page }) => {
+  await silenceTour(page);
+});
+
+test("a real model takes a goal, gives it to its team, and closes it out", async ({
+  page,
+  request,
+}) => {
+  test.skip(!LIVE_LLM, LIVE_LLM_REASON);
+  // Every turn here is a real model round trip, and there are at least five of
+  // them: the goal, two dispatched teammate turns, and the close-out. Timed for
+  // a slow rung rather than a fast one — a lane that fails on latency teaches
+  // nobody anything.
+  test.setTimeout(900_000);
+
+  const before = await cardIds(request);
+  const team = await roster(request);
+  expect(team.length, "a company with no roster has nobody to delegate to").toBeGreaterThan(1);
+
+  // ── 1. The goal, in the operator's own words ────────────────────────────
+  // Specific about the *outcome* (cards on the board, owned by teammates) and
+  // silent about the mechanism, because which tool to reach for is exactly the
+  // decision under test.
+  await openChannel(page);
+  await say(
+    page,
+    "I want a short market digest published this week. Break it into two pieces of " +
+      "work, open a card on the board for each, and give each one to whichever " +
+      "teammate should own it. Do not do the work yourself in this message.",
+  );
+
+  // The first failure this lane can have: the model was never reached, or was
+  // reached and chose nothing. A board that grew is the proof it decided.
+  await expect
+    .poll(() => newCards(request, before).then((cards) => cards.length), {
+      message:
+        "the orchestrator opened no cards for the goal — either the model was not " +
+        "reached (check the proxy's stderr for a non-200) or it answered in prose " +
+        "without calling a delegation tool",
+      timeout: 300_000,
+      intervals: [3_000],
+    })
+    .toBeGreaterThanOrEqual(1);
+
+  // Let the turn finish before reading the board: a fan-out arrives one card at
+  // a time, and a run read at the first one would dispatch half a goal.
+  await page.waitForTimeout(5_000);
+  const opened = await newCards(request, before);
+  // The cap is the host's own (`MAX_DELEGATIONS_PER_TURN`), so more than three
+  // means something other than this turn wrote to the board.
+  expect(opened.length, "more cards than one turn can open").toBeLessThanOrEqual(3);
+
+  // Somebody real owns the work. An unassigned card is a to-do list entry; the
+  // claim this lane exists for is that the orchestrator *delegated*.
+  const owned = opened.filter((card) => card.assignee && team.includes(card.assignee));
+  expect(
+    owned.length,
+    `no card was given to anyone on the roster (${opened
+      .map((card) => `${card.title} → "${card.assignee ?? ""}"`)
+      .join("; ")})`,
+  ).toBeGreaterThanOrEqual(1);
+
+  // The reply is a model's, not the fixture's. Cheap, and it is the one line
+  // that tells a confused reader which lane they are actually running.
+  await expect(page.getByText("__MOCK_LLM__")).toHaveCount(0);
+
+  // ── 2. The operator starts the work ────────────────────────────────────
+  // Whatever is still unstarted gets dispatched by hand, on the board. A card
+  // the orchestrator already ran (a `delegate_to_teammate` hand-off opens one
+  // mid-turn) is left alone rather than re-run.
+  for (const card of opened) {
+    const current = (await allCards(request)).find((held) => held.id === card.id);
+    if ((current?.stage ?? current?.column) === "pending") {
+      await dispatch(page, card.title);
+    }
+  }
+
+  // ── 3. …and the team does it ───────────────────────────────────────────
+  // Settled, not finished-in-a-particular-way: a real turn can land in review,
+  // or park on an approval, and which of those happens is the model's business.
+  // What must not happen is a card left running forever.
+  for (const card of opened) {
+    await expect
+      .poll(
+        async () => {
+          const held = (await allCards(request)).find((row) => row.id === card.id);
+          return held?.stage ?? held?.column ?? "in_progress";
+        },
+        {
+          message: `card "${card.title}" never settled`,
+          timeout: 420_000,
+          intervals: [5_000],
+        },
+      )
+      .not.toBe("in_progress");
+  }
+
+  // ── 4. The operator asks for it to be closed out ───────────────────────
+  // The ids are named because an operator naming them is the realistic ask —
+  // "the two you opened" would be a test of the model's memory of its own turn,
+  // which is a different claim from the one this spec makes.
+  const settled = (await allCards(request)).filter((held) =>
+    opened.some((card) => card.id === held.id),
+  );
+  const reviewable = settled.filter((card) => (card.stage ?? card.column) === "in_review");
+  test.skip(
+    reviewable.length === 0,
+    `nothing reached review — the run parked instead (${settled
+      .map((card) => `${card.title}: ${card.stage ?? card.column}`)
+      .join("; ")}). That is a legitimate landing, but the close-out below has ` +
+      "nothing to accept.",
+  );
+
+  await openChannel(page);
+  await say(
+    page,
+    `The work is back and it looks good to me. Please review and approve ` +
+      `${reviewable.length === 1 ? "this card" : "these cards"}, so ` +
+      `${reviewable.length === 1 ? "it is" : "they are"} marked done: ` +
+      reviewable.map((card) => `${card.id} ("${card.title}")`).join(", "),
+  );
+
+  for (const card of reviewable) {
+    await expect
+      .poll(
+        async () => {
+          const held = (await allCards(request)).find((row) => row.id === card.id);
+          return held?.column ?? "";
+        },
+        {
+          message:
+            `card "${card.title}" was never accepted — the orchestrator did not ` +
+            "call review_task, or called it with a different id",
+          timeout: 300_000,
+          intervals: [5_000],
+        },
+      )
+      .toBe("done");
+  }
+
+  // ── 5. The board an operator comes back to ─────────────────────────────
+  await page.reload();
+  await openBoard(page);
+  for (const card of reviewable) {
+    await expect(column(page, DONE)).toContainText(card.title, { timeout: 60_000 });
+  }
+});

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -15,6 +15,7 @@ import {
   say,
   settledMarkerCount,
   silenceTour,
+  waitForTurn,
 } from "./orchestration";
 
 /**
@@ -148,6 +149,14 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   });
 
   // ── 2. The board holds the work, unstarted ──────────────────────────────
+  // After the turn has *finished*, not merely after its first card appeared:
+  // delegations are drained at the end of a turn, so a board read taken mid-turn
+  // sees whichever cards exist at that instant. It costs nothing here — the chip
+  // above is already proof the drain ran — and it is what keeps this spec from
+  // teaching the pattern that made `orchestration-live.spec.ts` report on half
+  // a goal.
+  await waitForTurn(page);
+
   await openBoard(page);
   await expect(column(page, PENDING)).toContainText(gather, { timeout: 60_000 });
   await expect(column(page, PENDING)).toContainText(write);

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -157,6 +157,14 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // a goal.
   await waitForTurn(page);
 
+  // The markers this thread already holds, counted **here** — on the transcript
+  // this test has been watching all along, rather than after a fresh navigation
+  // that would have to be waited on again. The suite shares one data root, so a
+  // marker an earlier test left in the main line is legitimately in it, and a
+  // baseline taken before a hydration has landed reads zero for a thread that
+  // holds three.
+  const markersBefore = await settledMarkerCount(page);
+
   await openBoard(page);
   await expect(column(page, PENDING)).toContainText(gather, { timeout: 60_000 });
   await expect(column(page, PENDING)).toContainText(write);
@@ -177,13 +185,6 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // while having taken the operator's decision away.
   expect(await stageOf(request, gatherId), "spawn_task must not dispatch").toBe("pending");
   expect(await stageOf(request, writeId), "spawn_task must not dispatch").toBe("pending");
-
-  // The markers this thread already holds, before anything of this test's can
-  // land in it. Counted from a settled reading rather than assumed to be zero:
-  // the suite shares one data root, so a marker an earlier test left in the
-  // main line is legitimately here.
-  await openMainLine(page);
-  const markersBefore = await settledMarkerCount(page);
 
   // ── 3. The operator starts the work ─────────────────────────────────────
   // The real gesture on the real board: entering Working is dispatch.
@@ -212,7 +213,21 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // than addressed by card, because this surface renders a marker as a plain
   // system pill — see `markers` in `./orchestration`.
   await openMainLine(page);
-  await expect(markers(page)).toHaveCount(markersBefore + 2, { timeout: 120_000 });
+  await expect
+    .poll(() => markers(page).count(), {
+      message: "the two settled cards did not mark the thread they were raised in",
+      timeout: 120_000,
+      intervals: [1_000],
+    })
+    .toBeGreaterThanOrEqual(markersBefore + 2);
+  // `at least`, not `exactly`. Both halves of that are deliberate. Two is the
+  // floor because two cards settled and each must say so. It is not a ceiling
+  // because this surface renders a marker as a plain system pill with no card
+  // id on it (see `markers` in `./orchestration`), so a third marker cannot be
+  // told apart from ours — and in a full-suite run there is one: a card an
+  // earlier spec raised in this same thread, settling on its own schedule while
+  // this test runs. An exact count made this spec pass alone and fail in the
+  // suite, which is the worst of both.
   await expect(markers(page).last()).toHaveText("finished → In review");
 
   // ── 6. The orchestrator closes the goal out ─────────────────────────────

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -13,6 +13,7 @@ import {
   openCard,
   openMainLine,
   say,
+  settledMarkerCount,
   silenceTour,
 } from "./orchestration";
 
@@ -168,6 +169,13 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   expect(await stageOf(request, gatherId), "spawn_task must not dispatch").toBe("pending");
   expect(await stageOf(request, writeId), "spawn_task must not dispatch").toBe("pending");
 
+  // The markers this thread already holds, before anything of this test's can
+  // land in it. Counted from a settled reading rather than assumed to be zero:
+  // the suite shares one data root, so a marker an earlier test left in the
+  // main line is legitimately here.
+  await openMainLine(page);
+  const markersBefore = await settledMarkerCount(page);
+
   // ── 3. The operator starts the work ─────────────────────────────────────
   // The real gesture on the real board: entering Working is dispatch.
   await dispatch(page, gather);
@@ -195,8 +203,8 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // than addressed by card, because this surface renders a marker as a plain
   // system pill — see `markers` in `./orchestration`.
   await openMainLine(page);
-  await expect(markers(page)).toHaveCount(2, { timeout: 120_000 });
-  await expect(markers(page).first()).toHaveText("finished → In review");
+  await expect(markers(page)).toHaveCount(markersBefore + 2, { timeout: 120_000 });
+  await expect(markers(page).last()).toHaveText("finished → In review");
 
   // ── 6. The orchestrator closes the goal out ─────────────────────────────
   // The second half of the loop, and the half nothing else covers: work that

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+import {
+  DONE,
+  PENDING,
+  SCOPE,
+  WORKING,
+  column,
+  dispatch,
+  markers,
+  openBoard,
+  openCard,
+  openChannel,
+  say,
+  silenceTour,
+} from "./orchestration";
+
+/**
+ * **The whole orchestration loop, driven from the console** — a goal stated in
+ * chat, broken up by the orchestrator, worked by two teammates, and closed out
+ * on the board.
+ *
+ * Every other spec in this suite owns one link of that chain: `chat-to-card`
+ * proves a message can become a card, `chat-dispatch-marker` proves a settled
+ * card marks the channel it came from, `board-drag` proves the gesture that
+ * dispatches one. None of them runs the loop, and the loop is the product —
+ * a company that opens cards and never closes them is not doing the job the
+ * chat promises, and nothing here would have said so.
+ *
+ * So this is one long test rather than several short ones. That is deliberate:
+ * the claims are ordered in time and each is only meaningful after the one
+ * before it landed. Splitting them would mean re-establishing the state at the
+ * top of each, and the re-establishment (writing a card straight into
+ * `in_review`, say) is precisely the part the loop is supposed to have done.
+ *
+ * # What is real and what is scripted
+ *
+ * Everything except the cognition. The console, the HTTP surface, the harness,
+ * the toolbelt, the delegation queue and its drain, the board's write
+ * boundary, the journal and the SSE stream are all the shipped ones. What is
+ * scripted is which tools the orchestrator decides to call, through
+ * `mock-brain.mjs`'s `__MOCK_PLAN__` directive — because a decision is the one
+ * thing a test cannot assert on and a model is the one thing a required check
+ * must not depend on.
+ *
+ * `orchestration-live.spec.ts` is the other half of this: the same loop with a
+ * real model making those choices, run by a person rather than by CI.
+ *
+ * # The spend gate is the operator's, and this spec keeps it that way
+ *
+ * `spawn_task` opens a card in **Pending**, not Working (issue #1512). Nothing
+ * an agent says starts paid work; a person drags the card into Working. So the
+ * dispatch below is a real drag on the real board, and the assertion before it
+ * — that nothing has run yet — is as load-bearing as the ones after it.
+ */
+
+/** One call in a `__MOCK_PLAN__` step. */
+function call(name: string, args: Record<string, unknown>) {
+  return { name, arguments: args };
+}
+
+/**
+ * The plan directive for `steps`, with this run's marker after the payload.
+ *
+ * After, because that is where `mock-brain.mjs` keys its cursor off: the
+ * directive plus the rest of its line. A marker in front of it would leave two
+ * runs of this spec sharing one cursor, and the second would start half way
+ * through the first one's plan.
+ */
+function plan(steps: unknown[][], marker: string): string {
+  return `__MOCK_PLAN__ ${JSON.stringify(steps)} ${marker}`;
+}
+
+/** The host's own record for one card: the truth a rendered column reports on. */
+async function record(
+  request: APIRequestContext,
+  id: string,
+): Promise<{ column: string; stage?: string; assignee?: string }> {
+  const response = await request.get(`${SCOPE}/tasks/${id}`);
+  expect(response.ok(), `reading card ${id} failed: ${response.status()}`).toBeTruthy();
+  return (await response.json()).task;
+}
+
+/** The stage word, which is finer than the phase: `in_review` inside Working. */
+async function stageOf(request: APIRequestContext, id: string): Promise<string> {
+  const task = await record(request, id);
+  return task.stage ?? task.column;
+}
+
+test.beforeEach(async ({ page }) => {
+  await silenceTour(page);
+});
+
+test("a goal becomes delegated cards, the team works them, and review closes them", async ({
+  page,
+  request,
+}) => {
+  // Without the harness compiled in there is no orchestrator, no delegation
+  // drain and no teammate turn — the message would be answered by nothing and
+  // every claim below would be about a card that was never opened.
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+  // Two agent turns, two dispatched runs and two settles, each a real round
+  // trip through the harness. The suite's 60s default expires inside the first
+  // wait and reports a *timeout*, which is the least useful failure this spec
+  // could produce.
+  test.setTimeout(420_000);
+
+  const run = Date.now();
+  const gather = `sim gather the sources ${run}`;
+  const write = `sim write the digest ${run}`;
+
+  // ── 1. The goal ─────────────────────────────────────────────────────────
+  // One sentence, in the one place an operator says anything. The plan riding
+  // on it is the orchestrator's decision, scripted: two cards, one per
+  // teammate, each with the brief it should carry.
+  await openChannel(page);
+  const goal =
+    `Ship a short market digest this week: find what is being said and write it up. ` +
+    plan(
+      [
+        [
+          call("spawn_task", {
+            title: gather,
+            note: "Search and collect what is current, newest first.",
+            assignee: "engineer",
+          }),
+          call("spawn_task", {
+            title: write,
+            note: "Turn the collected sources into a short digest with links.",
+            assignee: "writer",
+          }),
+        ],
+        // An empty second step: the turn answers in prose and ends, rather than
+        // looping until the harness caps it.
+        [],
+      ],
+      `goal-${run}`,
+    );
+  await say(page, goal);
+
+  // The conversation says a card was opened, and links to it. This is the chat
+  // half of the chain — the card knows which thread raised it, which is what
+  // later lets its completion answer back here (issue #151 §3.2).
+  await expect(page.getByRole("link", { name: /Card opened/ }).last()).toBeVisible({
+    timeout: 180_000,
+  });
+
+  // ── 2. The board holds the work, unstarted ──────────────────────────────
+  await openBoard(page);
+  await expect(column(page, PENDING)).toContainText(gather, { timeout: 60_000 });
+  await expect(column(page, PENDING)).toContainText(write);
+
+  const gatherId = await openCard(page, gather);
+  // The brief travelled with the card, not just the title: a teammate reading
+  // "gather the sources" and one reading the note are doing different work.
+  await expect(page.getByText("Search and collect what is current")).toBeVisible();
+  // …and it is owned by the teammate the orchestrator named, which is what
+  // decides whose turn the dispatch below runs.
+  await expect(page.getByText("engineer").first()).toBeVisible();
+  const writeId = await openCard(page, write);
+  await expect(page.getByText("writer").first()).toBeVisible();
+
+  // The spend gate, before anything is spent. An orchestrator cannot start paid
+  // work by asking for it (issue #1512) — these cards are open and idle, and a
+  // build that dispatched them here would pass every assertion after this one
+  // while having taken the operator's decision away.
+  expect(await stageOf(request, gatherId), "spawn_task must not dispatch").toBe("pending");
+  expect(await stageOf(request, writeId), "spawn_task must not dispatch").toBe("pending");
+
+  // ── 3. The operator starts the work ─────────────────────────────────────
+  // The real gesture on the real board: entering Working is dispatch.
+  await dispatch(page, gather);
+  await dispatch(page, write);
+
+  // ── 4. The team works them, and stops for a decision ────────────────────
+  // A finished run lands in `in_review`, never `done` — accepting work is the
+  // operator's call and a run does not make it for them.
+  for (const [id, title] of [
+    [gatherId, gather],
+    [writeId, write],
+  ] as const) {
+    await expect
+      .poll(() => stageOf(request, id), {
+        message: `card "${title}" never settled`,
+        timeout: 180_000,
+        intervals: [2_000],
+      })
+      .toBe("in_review");
+  }
+
+  // ── 5. …and the conversation the goal was stated in is told ─────────────
+  // Addressed by each card's own href rather than by the marker text, so a
+  // marker an earlier test left in this channel cannot be mistaken for one of
+  // these — the harness company's data root outlives a single test.
+  await openChannel(page);
+  await expect(markers(page).first()).toBeVisible({ timeout: 60_000 });
+  for (const id of [gatherId, writeId]) {
+    await expect(page.locator(`a[href="#/tasks/${id}"]`)).toHaveCount(1, { timeout: 60_000 });
+  }
+
+  // ── 6. The orchestrator closes the goal out ─────────────────────────────
+  // The second half of the loop, and the half nothing else covers: work that
+  // was delegated coming back and being *accepted*. `review_task` with
+  // `approve` is the `in_review → done` transition (issue #171, PR #179).
+  await say(
+    page,
+    `Both pieces are back — take a look and close them out. ` +
+      plan(
+        [
+          [
+            call("review_task", {
+              task_id: gatherId,
+              decision: "approve",
+              note: "Sources look current.",
+            }),
+            call("review_task", {
+              task_id: writeId,
+              decision: "approve",
+              note: "Reads well; shipping it.",
+            }),
+          ],
+          [],
+        ],
+        `close-${run}`,
+      ),
+  );
+
+  for (const [id, title] of [
+    [gatherId, gather],
+    [writeId, write],
+  ] as const) {
+    await expect
+      .poll(() => record(request, id).then((task) => task.column), {
+        message: `card "${title}" was never accepted`,
+        timeout: 180_000,
+        intervals: [2_000],
+      })
+      .toBe("done");
+  }
+
+  // ── 7. The board an operator would come back to ─────────────────────────
+  // Read from a reload rather than from the session that made the changes: the
+  // columns above were written through the API, and a console that only moved
+  // them in its own React state would still show them here.
+  await page.reload();
+  await openBoard(page);
+  await expect(column(page, DONE)).toContainText(gather, { timeout: 60_000 });
+  await expect(column(page, DONE)).toContainText(write);
+  await expect(column(page, PENDING)).not.toContainText(gather);
+  await expect(column(page, WORKING)).not.toContainText(gather);
+});

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -228,7 +228,13 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // earlier spec raised in this same thread, settling on its own schedule while
   // this test runs. An exact count made this spec pass alone and fail in the
   // suite, which is the worst of both.
-  await expect(markers(page).last()).toHaveText("finished → In review");
+  // …and they say where the work landed, which is the half the relay prose
+  // cannot carry: "finished" alone would leave a reader with the same wrong
+  // impression issue #377 is about. Counted rather than read off the last pill,
+  // because a straggler from another spec can arrive after ours.
+  await expect(
+    page.getByRole("main").getByText("finished → In review", { exact: true }),
+  ).toHaveCount(2, { timeout: 30_000 });
 
   // ── 6. The orchestrator closes the goal out ─────────────────────────────
   // The second half of the loop, and the half nothing else covers: work that

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -232,9 +232,12 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // cannot carry: "finished" alone would leave a reader with the same wrong
   // impression issue #377 is about. Counted rather than read off the last pill,
   // because a straggler from another spec can arrive after ours.
-  await expect(
-    page.getByRole("main").getByText("finished → In review", { exact: true }),
-  ).toHaveCount(2, { timeout: 30_000 });
+  await expect
+    .poll(
+      () => page.getByRole("main").getByText("finished → In review", { exact: true }).count(),
+      { message: "neither settled card said where it landed", timeout: 30_000 },
+    )
+    .toBeGreaterThanOrEqual(2);
 
   // ── 6. The orchestrator closes the goal out ─────────────────────────────
   // The second half of the loop, and the half nothing else covers: work that

--- a/frontend/test/e2e/orchestration-simulation.spec.ts
+++ b/frontend/test/e2e/orchestration-simulation.spec.ts
@@ -11,7 +11,7 @@ import {
   markers,
   openBoard,
   openCard,
-  openChannel,
+  openMainLine,
   say,
   silenceTour,
 } from "./orchestration";
@@ -114,7 +114,7 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   // One sentence, in the one place an operator says anything. The plan riding
   // on it is the orchestrator's decision, scripted: two cards, one per
   // teammate, each with the brief it should carry.
-  await openChannel(page);
+  await openMainLine(page);
   const goal =
     `Ship a short market digest this week: find what is being said and write it up. ` +
     plan(
@@ -190,14 +190,13 @@ test("a goal becomes delegated cards, the team works them, and review closes the
   }
 
   // ── 5. …and the conversation the goal was stated in is told ─────────────
-  // Addressed by each card's own href rather than by the marker text, so a
-  // marker an earlier test left in this channel cannot be mistaken for one of
-  // these — the harness company's data root outlives a single test.
-  await openChannel(page);
-  await expect(markers(page).first()).toBeVisible({ timeout: 60_000 });
-  for (const id of [gatherId, writeId]) {
-    await expect(page.locator(`a[href="#/tasks/${id}"]`)).toHaveCount(1, { timeout: 60_000 });
-  }
+  // The structural line a reader needs and the relay prose cannot give them:
+  // the run *stopped*, and here is where it landed (issue #377). Counted rather
+  // than addressed by card, because this surface renders a marker as a plain
+  // system pill — see `markers` in `./orchestration`.
+  await openMainLine(page);
+  await expect(markers(page)).toHaveCount(2, { timeout: 120_000 });
+  await expect(markers(page).first()).toHaveText("finished → In review");
 
   // ── 6. The orchestrator closes the goal out ─────────────────────────────
   // The second half of the loop, and the half nothing else covers: work that

--- a/frontend/test/e2e/orchestration.ts
+++ b/frontend/test/e2e/orchestration.ts
@@ -107,6 +107,32 @@ export function markers(page: Page): Locator {
   return page.getByRole("main").getByText(/^finished → /);
 }
 
+/**
+ * The marker count, once the thread's rehydration has stopped adding to it.
+ *
+ * A thread opens empty and fills from `chat/history` a moment later, so a count
+ * taken on arrival is a count of nothing — and "two new markers appeared" would
+ * be measuring the hydration instead. Waits for two equal readings rather than
+ * for a fixed time, the same shape `chat-dispatch-marker.spec.ts` uses and for
+ * the same reason: this suite shares one host and one data root across tests,
+ * so an earlier test's marker is legitimately in this thread's history.
+ */
+export async function settledMarkerCount(page: Page): Promise<number> {
+  let last = -1;
+  await expect
+    .poll(
+      async () => {
+        const current = await markers(page).count();
+        const settled = current === last;
+        last = current;
+        return settled;
+      },
+      { intervals: [400, 400, 400, 400, 400, 400, 400, 400], timeout: 20_000 },
+    )
+    .toBe(true);
+  return last;
+}
+
 /** The board, with every phase pinned open. */
 export async function openBoard(page: Page) {
   await page.goto(BOARD);

--- a/frontend/test/e2e/orchestration.ts
+++ b/frontend/test/e2e/orchestration.ts
@@ -1,0 +1,174 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * The console gestures an orchestration run is made of, shared by the two specs
+ * that drive one: `orchestration-simulation.spec.ts` (scripted answers) and
+ * `orchestration-live.spec.ts` (a real model).
+ *
+ * The two specs assert very different things — one that the chain *runs* in a
+ * fixed shape, the other that a model *chooses* to use it — but they drive the
+ * same console the same way, and a chat composer or a board column that moved
+ * should break one edit here rather than two specs quietly.
+ *
+ * Everything below is a gesture an operator can actually perform. Reads of the
+ * host's own record belong in the specs (through `request`), where they can be
+ * read beside the claim they settle.
+ */
+
+/** The single-company alias the host answers on. */
+export const SCOPE = "/api/v1/company";
+
+/** The main line — the General desk, which is the orchestrator's thread. */
+export const MAIN_LINE = "main";
+
+/** The board, now that it is the `tasks` ledger rather than a screen of its own. */
+export const BOARD = "/#/ledgers/tasks";
+
+/** The board's phases, in board order (issue #1512). */
+export const PENDING = 0;
+export const WORKING = 1;
+export const DONE = 2;
+
+/**
+ * Answers "already skipped" for whatever tour key the console asks about.
+ *
+ * The first-run tour renders a modal over the whole console and swallows the
+ * first click on every screen. Keyed on the company id, which this suite does
+ * not want to hard-code, so the prefix is matched instead — the same shape
+ * `chat-dispatch-marker.spec.ts` uses.
+ */
+export async function silenceTour(page: Page) {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+}
+
+/** Opens one channel by id and waits for its composer, i.e. for the view. */
+export async function openChannel(page: Page, channelId: string = MAIN_LINE) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+/** Says one thing in the open channel. */
+export async function say(page: Page, text: string) {
+  await page.getByPlaceholder(/^Message /).fill(text);
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+}
+
+/**
+ * Every dispatch marker in the open transcript, as links.
+ *
+ * A link rather than any element carrying the text: the channel rail renders a
+ * one-line preview of the last message as a *button*, so an unscoped match
+ * counts one extra intermittently, depending on which rendered first — the trap
+ * `chat-live-events.spec.ts` documents and `chat-dispatch-marker.spec.ts`
+ * inherits.
+ */
+export function markers(page: Page): Locator {
+  return page.getByRole("link", { name: /^finished → / });
+}
+
+/** The board, with every phase pinned open. */
+export async function openBoard(page: Page) {
+  await page.goto(BOARD);
+  // The columns are a read off the `tasks` ledger, not a literal: the board is
+  // not itself until it has them, and a card located before that resolves to
+  // nothing for reasons that look like the card never being opened.
+  await expect(column(page, DONE)).toHaveCount(1, { timeout: 30_000 });
+  await expandAll(page);
+}
+
+export const board = (page: Page) => page.getByTestId("ledger-board");
+
+export const column = (page: Page, index: number) =>
+  board(page).getByTestId("board-column").nth(index);
+
+/**
+ * Opens every phase that has collapsed itself to a rail (issue #1101).
+ *
+ * An empty phase folds to a ~40px strip, and dropping a card onto a rail is a
+ * different gesture from dropping it onto a column — the rail opens under the
+ * pointer and the board reflows mid-drop. Every dispatch below therefore starts
+ * from a board whose phases are all open, which is also the state an operator
+ * reaches by clicking a rail.
+ */
+export async function expandAll(page: Page) {
+  const rails = board(page).locator("button[aria-label^='Expand ']");
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    if ((await rails.count()) === 0) return;
+    await rails.first().click();
+  }
+  await expect(rails).toHaveCount(0);
+}
+
+/** One card on the board, by the title it carries. */
+export function card(page: Page, title: string): Locator {
+  return board(page).locator("[draggable=true]").filter({ hasText: title }).first();
+}
+
+/**
+ * A real pointer drag from `card` to the middle of `target`.
+ *
+ * Walked in steps rather than jumped: Chromium promotes a press-and-move to a
+ * drag session only after the pointer has actually moved, and a single
+ * `mouse.move` to the destination is not a drag as far as the board's
+ * `dragover` handlers are concerned.
+ */
+export async function dragCard(page: Page, from: Locator, target: Locator) {
+  const start = await from.boundingBox();
+  const end = await target.boundingBox();
+  if (!start) throw new Error("the card has no box to grab");
+  if (!end) throw new Error("the target column has no box");
+  const fromX = start.x + start.width / 2;
+  const fromY = start.y + start.height / 2;
+  const toX = end.x + end.width / 2;
+  const toY = end.y + Math.min(end.height / 2, 160);
+
+  await page.mouse.move(fromX, fromY);
+  await page.mouse.down();
+  for (let step = 1; step <= 12; step += 1) {
+    await page.mouse.move(fromX + ((toX - fromX) * step) / 12, fromY + ((toY - fromY) * step) / 12);
+    await page.waitForTimeout(40);
+  }
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+}
+
+/**
+ * Dispatches one card the way an operator does: dragging it into Working.
+ *
+ * This is the spend gate, and it is deliberately the operator's move rather
+ * than the orchestrator's (issue #1512). `spawn_task` opens a card in Pending;
+ * entering Working is what fires the assignee's turn, so a company cannot spend
+ * money on work nobody asked it to start.
+ */
+export async function dispatch(page: Page, title: string) {
+  await openBoard(page);
+  const dragging = card(page, title);
+  await expect(dragging, `the card "${title}" is not on the board`).toBeVisible({
+    timeout: 30_000,
+  });
+  await dragCard(page, dragging, column(page, WORKING));
+  await expect(column(page, WORKING)).toContainText(title, { timeout: 30_000 });
+}
+
+/**
+ * Opens one card's detail screen and returns its id, read off the address.
+ *
+ * The id is needed to say anything precise afterwards — which card settled,
+ * which one the orchestrator was asked to approve — and clicking the card is
+ * how an operator gets it. Nothing here reads the host's task list to find it,
+ * because a spec that asked the API which cards exist would pass against a
+ * board that rendered none of them.
+ */
+export async function openCard(page: Page, title: string): Promise<string> {
+  await openBoard(page);
+  await card(page, title).click();
+  await expect(page).toHaveURL(/#\/tasks\/[^/]+$/, { timeout: 30_000 });
+  const id = page.url().split("#/tasks/")[1];
+  await expect(page.getByText(title).first()).toBeVisible({ timeout: 30_000 });
+  return id;
+}

--- a/frontend/test/e2e/orchestration.ts
+++ b/frontend/test/e2e/orchestration.ts
@@ -18,7 +18,20 @@ import { expect, type Locator, type Page } from "@playwright/test";
 /** The single-company alias the host answers on. */
 export const SCOPE = "/api/v1/company";
 
-/** The main line — the General desk, which is the orchestrator's thread. */
+/**
+ * The main line's thread id, as both the console and the host spell it.
+ *
+ * It is **not** a channel in the `#/chat/<id>` workspace, and that is the trap
+ * this constant exists to document: that view builds its channels from the
+ * company's real desks (issue #368 deliberately removed the `"main"` literal
+ * from it), so `#/chat/main` resolves to no channel and falls back to the first
+ * desk — whose lead is an ordinary teammate with no delegation tools. A goal
+ * sent there is answered politely and delegates nothing, which reads as the
+ * orchestrator having ignored it.
+ *
+ * The orchestrator's thread is the **conversation** view's main line, which is
+ * where {@link openMainLine} goes.
+ */
 export const MAIN_LINE = "main";
 
 /** The board, now that it is the `tasks` ledger rather than a screen of its own. */
@@ -46,8 +59,27 @@ export async function silenceTour(page: Page) {
   });
 }
 
-/** Opens one channel by id and waits for its composer, i.e. for the view. */
-export async function openChannel(page: Page, channelId: string = MAIN_LINE) {
+/**
+ * Opens the company's main line — the thread the orchestrator answers on.
+ *
+ * The thread is selected by name from the list rather than trusted to be the
+ * default, so a company that grows another thread cannot silently move this.
+ * Scoped to the thread list: the sidebar's company switcher is also a button
+ * carrying the company's name and precedes the list in the DOM, so an unscoped
+ * `.first()` opens the switcher and no thread at all.
+ */
+export async function openMainLine(page: Page) {
+  await page.goto("/#/conversation");
+  await page
+    .getByRole("complementary")
+    .getByRole("button", { name: /Your company/ })
+    .first()
+    .click();
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+/** Opens one desk channel by id in the chat workspace, and waits for the view. */
+export async function openChannel(page: Page, channelId: string) {
   await page.goto(`/#/chat/${channelId}`);
   await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
 }
@@ -59,16 +91,20 @@ export async function say(page: Page, text: string) {
 }
 
 /**
- * Every dispatch marker in the open transcript, as links.
+ * Every dispatch marker in the open main line.
  *
- * A link rather than any element carrying the text: the channel rail renders a
- * one-line preview of the last message as a *button*, so an unscoped match
- * counts one extra intermittently, depending on which rendered first — the trap
- * `chat-live-events.spec.ts` documents and `chat-dispatch-marker.spec.ts`
- * inherits.
+ * Matched as **text**, not as a link, and that difference is a property of this
+ * surface rather than an oversight: the conversation view renders a system line
+ * as a centred pill of plain text, where the `#/chat` workspace renders the
+ * same marker as an anchor to the card. So a marker here says *that* a card
+ * settled and where it landed, and `chat-dispatch-marker.spec.ts` — which drives
+ * a desk channel — is where the per-card `href` is asserted.
+ *
+ * Scoped to the transcript, because the thread list renders a one-line preview
+ * of each thread's last message and would otherwise be counted too.
  */
 export function markers(page: Page): Locator {
-  return page.getByRole("link", { name: /^finished → / });
+  return page.getByRole("main").getByText(/^finished → /);
 }
 
 /** The board, with every phase pinned open. */

--- a/frontend/test/e2e/orchestration.ts
+++ b/frontend/test/e2e/orchestration.ts
@@ -108,6 +108,33 @@ export function markers(page: Page): Locator {
 }
 
 /**
+ * Waits for the turn the last message started to **finish**.
+ *
+ * The one honest "it is done" signal this surface has: the working indicator is
+ * up for exactly as long as the company is answering, and it is the same
+ * component the chat workspace uses (`WorkingIndicator`, issue #787).
+ *
+ * It matters more than it looks. A turn's *delegations are drained after the
+ * turn*, so a board read taken while the indicator is still up sees however
+ * many cards happen to exist at that instant — which is how a run of
+ * `orchestration-live.spec.ts` came to dispatch, settle and close out one card
+ * of a two-card goal and report green: the second card was opened by the drain
+ * a few seconds after the read.
+ *
+ * Both waits are tolerant of a turn that is already over: a fast one can come
+ * and go between the send and the first poll, and that is a finished turn, not
+ * a missing indicator.
+ */
+export async function waitForTurn(page: Page, timeout = 600_000) {
+  const working = page.getByTestId("working-indicator");
+  await working
+    .first()
+    .waitFor({ state: "visible", timeout: 30_000 })
+    .catch(() => {});
+  await expect(working).toHaveCount(0, { timeout });
+}
+
+/**
  * The marker count, once the thread's rehydration has stopped adding to it.
  *
  * A thread opens empty and fills from `chat/history` a moment later, so a count

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -58,15 +58,33 @@ afterAll(() => {
   server?.kill();
 });
 
-/** POSTs a chat-completions request and returns the parsed reply. */
-async function chat(messages: unknown[]): Promise<any> {
+/**
+ * POSTs a chat-completions request and returns the parsed reply.
+ *
+ * `tools` is the belt the request offers, and it is optional because most arms
+ * do not read it — but `__MOCK_PLAN__` does: a step is served only to a request
+ * that could actually make the calls it names. Passing none is therefore the
+ * same as asking as an agent with an empty belt.
+ */
+async function chat(messages: unknown[], tools: string[] = []): Promise<any> {
   const response = await fetch(`${origin}/v1/chat/completions`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ model: "chat-v1", messages }),
+    body: JSON.stringify({
+      model: "chat-v1",
+      messages,
+      ...(tools.length
+        ? { tools: tools.map((name) => ({ type: "function", function: { name } })) }
+        : {}),
+    }),
   });
   expect(response.status).toBe(200);
   return response.json();
+}
+
+/** The plan directive for `steps`, with a marker so each test owns its cursor. */
+function plan(marker: string, steps: unknown[][]): string {
+  return `close this out ${marker} __MOCK_PLAN__ ${JSON.stringify(steps)}`;
 }
 
 describe("the mock inference backend", () => {
@@ -241,6 +259,99 @@ describe("the mock inference backend", () => {
     ]);
 
     expect(reply.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
+  });
+
+  it("emits every call in one plan step together, then walks to the next step", async () => {
+    // The shape a fan-out actually has: one assistant message, two calls. An
+    // orchestrator that could only make one call per turn could not delegate a
+    // goal to two teammates without two operator messages.
+    const directive = plan("p-101", [
+      [
+        { name: "spawn_task", arguments: { title: "gather", assignee: "engineer" } },
+        { name: "spawn_task", arguments: { title: "write", assignee: "writer" } },
+      ],
+      [{ name: "review_task", arguments: { task_id: "t-1", decision: "approve" } }],
+    ]);
+    const belt = ["spawn_task", "review_task"];
+    const history = [{ role: "user", content: directive }];
+
+    const first = await chat(history, belt);
+    const calls = first.choices[0].message.tool_calls;
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c: any) => c.function.name)).toEqual(["spawn_task", "spawn_task"]);
+    expect(JSON.parse(calls[1].function.arguments)).toEqual({
+      title: "write",
+      assignee: "writer",
+    });
+    expect(first.choices[0].finish_reason).toBe("tool_calls");
+
+    // The SAME history again — which is what the host sends, because a
+    // delegation tool's result never enters the model-visible transcript. The
+    // cursor is what makes this the second step rather than the first one over.
+    const second = await chat(history, belt);
+    expect(second.choices[0].message.tool_calls).toHaveLength(1);
+    expect(second.choices[0].message.tool_calls[0].function.name).toBe("review_task");
+
+    // Past the end the turn ends: prose, not a loop.
+    const third = await chat(history, belt);
+    expect(third.choices[0].message.tool_calls).toBeUndefined();
+    expect(third.choices[0].message.content).toContain("__MOCK_LLM__");
+  });
+
+  it("leaves a plan unserved for an agent whose belt cannot make the call", async () => {
+    // The teammate case. One operator message reaches the orchestrator and then
+    // everyone it hands work to, so this exact directive is in the engineer's
+    // prompt as well — and the engineer has no `spawn_task`. Serving it there
+    // would spend the step on an agent that cannot make the call, and the
+    // orchestrator would then get the step after it.
+    const directive = plan("p-202", [
+      [{ name: "spawn_task", arguments: { title: "gather" } }],
+    ]);
+
+    const teammate = await chat([{ role: "user", content: `The operator asked: ${directive}` }], [
+      "workspace_read",
+    ]);
+    expect(teammate.choices[0].message.tool_calls).toBeUndefined();
+    expect(teammate.choices[0].message.content).toContain("__MOCK_LLM__");
+
+    // …and the step is still there for the agent that can.
+    const orchestrator = await chat([{ role: "user", content: directive }], ["spawn_task"]);
+    expect(orchestrator.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
+  });
+
+  it("does not let a triage classification consume a plan step", async () => {
+    // The same hazard #678 fixed for `__MOCK_TOOL_CALL__`, one directive later.
+    const directive = plan("p-303", [
+      [{ name: "spawn_task", arguments: { title: "gather" } }],
+    ]);
+
+    const classification = await chat(
+      [
+        {
+          role: "system",
+          content: "You classify one message an operator sent to their company's chat.",
+        },
+        { role: "user", content: directive },
+      ],
+      ["spawn_task"],
+    );
+    expect(classification.choices[0].message.content).toBe("chatter");
+
+    const turn = await chat([{ role: "user", content: directive }], ["spawn_task"]);
+    expect(turn.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
+  });
+
+  it("answers in prose for an explicitly empty plan step", async () => {
+    // How a spec says "and then just reply": the step is consumed rather than
+    // re-read, so a turn that follows it moves on.
+    const directive = plan("p-404", [[], [{ name: "spawn_task", arguments: { title: "later" } }]]);
+    const history = [{ role: "user", content: directive }];
+
+    const first = await chat(history, ["spawn_task"]);
+    expect(first.choices[0].message.tool_calls).toBeUndefined();
+
+    const second = await chat(history, ["spawn_task"]);
+    expect(second.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
   });
 
   it("returns embeddings at the width the host validates against", async () => {

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -306,11 +306,14 @@ describe("the mock inference backend", () => {
   });
 
   it("leaves a plan unserved for an agent whose belt cannot make the call", async () => {
-    // The teammate case. One operator message reaches the orchestrator and then
-    // everyone it hands work to, so this exact directive is in the engineer's
-    // prompt as well — and the engineer has no `spawn_task`. Serving it there
-    // would spend the step on an agent that cannot make the call, and the
-    // orchestrator would then get the step after it.
+    // The teammate case, and the reason the belt is the key. One operator
+    // message reaches the orchestrator and then everyone it hands work to, so
+    // this exact directive is in the engineer's prompt as well — and the
+    // engineer's belt really is narrower: fourteen tools on the harness
+    // company against the orchestrator's twenty-seven, with no `spawn_task`
+    // among them. Serving it there would spend the step on an agent that
+    // cannot make the call, and the orchestrator would then get the step
+    // after it.
     const directive = plan("p-202", [
       [{ name: "spawn_task", arguments: { title: "gather" } }],
     ]);
@@ -324,34 +327,6 @@ describe("the mock inference backend", () => {
     // …and the step is still there for the agent that can.
     const orchestrator = await chat([{ role: "user", content: directive }], ["spawn_task"]);
     expect(orchestrator.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
-  });
-
-  it("serves an orchestrator turn whose delegation tools are not in the belt", async () => {
-    // The shape the real host actually sends. `spawn_task` and friends are
-    // **intrinsic** — dispatched through the runtime's own seam rather than
-    // exposed in `tools[]` — so the orchestrator's request carries a belt of
-    // workspace and MCP tools and nothing else, and a guard that only looked at
-    // the belt would leave every plan in this suite unserved. That is not a
-    // hypothesis: it is what the first run of `orchestration-simulation.spec.ts`
-    // did, with the mock logging a nineteen-tool belt holding no `spawn_task`.
-    const directive = plan("p-505", [
-      [{ name: "spawn_task", arguments: { title: "gather" } }],
-    ]);
-
-    const reply = await chat(
-      [
-        {
-          role: "system",
-          content:
-            "You are the Chief Executive of E2E Harness Co. You are also this " +
-            "company's orchestrator: the single point of contact for the operator.",
-        },
-        { role: "user", content: directive },
-      ],
-      ["workspace_read", "mcp_call_tool"],
-    );
-
-    expect(reply.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
   });
 
   it("does not let a triage classification consume a plan step", async () => {

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -326,6 +326,34 @@ describe("the mock inference backend", () => {
     expect(orchestrator.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
   });
 
+  it("serves an orchestrator turn whose delegation tools are not in the belt", async () => {
+    // The shape the real host actually sends. `spawn_task` and friends are
+    // **intrinsic** — dispatched through the runtime's own seam rather than
+    // exposed in `tools[]` — so the orchestrator's request carries a belt of
+    // workspace and MCP tools and nothing else, and a guard that only looked at
+    // the belt would leave every plan in this suite unserved. That is not a
+    // hypothesis: it is what the first run of `orchestration-simulation.spec.ts`
+    // did, with the mock logging a nineteen-tool belt holding no `spawn_task`.
+    const directive = plan("p-505", [
+      [{ name: "spawn_task", arguments: { title: "gather" } }],
+    ]);
+
+    const reply = await chat(
+      [
+        {
+          role: "system",
+          content:
+            "You are the Chief Executive of E2E Harness Co. You are also this " +
+            "company's orchestrator: the single point of contact for the operator.",
+        },
+        { role: "user", content: directive },
+      ],
+      ["workspace_read", "mcp_call_tool"],
+    );
+
+    expect(reply.choices[0].message.tool_calls[0].function.name).toBe("spawn_task");
+  });
+
   it("does not let a triage classification consume a plan step", async () => {
     // The same hazard #678 fixed for `__MOCK_TOOL_CALL__`, one directive later.
     const directive = plan("p-303", [

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -82,9 +82,16 @@ async function chat(messages: unknown[], tools: string[] = []): Promise<any> {
   return response.json();
 }
 
-/** The plan directive for `steps`, with a marker so each test owns its cursor. */
+/**
+ * The plan directive for `steps`, with a marker so each test owns its cursor.
+ *
+ * The marker goes AFTER the payload, which is where the fixture keys off it:
+ * two of the tests below script the same single `spawn_task`, and a key taken
+ * from the parsed steps alone would hand the second one the first one's spent
+ * cursor.
+ */
 function plan(marker: string, steps: unknown[][]): string {
-  return `close this out ${marker} __MOCK_PLAN__ ${JSON.stringify(steps)}`;
+  return `close this out __MOCK_PLAN__ ${JSON.stringify(steps)} ${marker}`;
 }
 
 describe("the mock inference backend", () => {


### PR DESCRIPTION
## What this adds

An end-to-end **simulation of the full orchestration loop, driven from the console**: an operator states a goal in the main line, the orchestrator breaks it up and hands the pieces to its team, the operator dispatches the work on the board, the teammates run it, and the orchestrator closes it out by review.

Two lanes, because the loop has two different things worth proving.

### 1. `orchestration-simulation.spec.ts` — the chain runs (scripted, ~10s, every push)

Joins the existing `Console E2E (live brain)` lane. Everything is the shipped code except the cognition: console, HTTP surface, harness, toolbelt, delegation queue and drain, the board's write boundary, the journal and the SSE stream are all real.

```
goal in the main line
  → orchestrator opens two cards, one per teammate, each with its brief
  → NOTHING has run yet          ← the spend gate (#1512), asserted before it can be violated
  → operator drags each card into Working on the real board
  → both teammate turns run, land in `in_review`
  → the thread shows `finished → In review` per card (#377)
  → operator asks for a close-out
  → `review_task` approve → both cards Done, still Done after a reload
```

One long test rather than several short ones, deliberately: the claims are ordered in time, and re-establishing the state at the top of each (writing a card straight into `in_review`, say) is exactly the part the loop is supposed to have done.

Existing specs each own one link of this chain — `chat-to-card` proves a message can become a card, `chat-dispatch-marker` proves a settled card marks its channel, `board-drag` proves the dispatch gesture. None of them ran the loop, and a company that opens cards and never closes them is not doing the job the chat promises.

### 2. `orchestration-live.spec.ts` — the chain is *reachable* (a real model, by hand)

`npm run e2e:live-llm`. The scripted lane can't show that a model, handed this company's roster and the real tool descriptions, *decides* to delegate. A prompt that stopped describing the board, a tool description that stopped saying what it is for, a roster the orchestrator can no longer see: every one of those leaves the scripted lane green, because the scripted lane never reads them.

Asserts outcomes only, never wording and never *which* tool was used — `spawn_task` and `delegate_to_*` are both the orchestrator doing its job. Cards are identified by what was not on the board before, not by title, because the model writes the titles.

**Not run by CI**, deliberately: it spends tokens and its verdict is a model's judgement, so a model having a bad day would turn unrelated PRs red.

## Supporting changes

- **`__MOCK_PLAN__`** in `mock-brain.mjs` — scripts a whole *turn*: several calls in one assistant message, several steps across the tool loop. `SPAWNONE` and `__MOCK_TOOL_CALL__` can each buy one call from one turn, which cannot express a fan-out. A step is served only to a request whose `tools[]` carries every name it uses, so a teammate reading the operator's message second-hand cannot honour the orchestrator's plan. Progress is counted per plan in-process, because a delegation tool's result never enters the model-visible transcript. `MOCK_BRAIN_DEBUG=1` dumps each request.
- **`live-brain-proxy.mjs`** — sits between the host and a real router. Forwards `/chat/completions` untouched (nothing scripted, filtered or retried) and supplies the two things a plain upstream will not: `/embeddings`, which those routers 404 and the host validates the width of, and the model name. Logs one line per turn naming the tool calls the model chose, because "never asked" and "asked and chose nothing" are otherwise the same silence.
- **`embedding.mjs`** — the deterministic vectors both fixtures now share, rather than a second copy of the part that has to be right.
- Lane wiring (`PW_LIVE_LLM=1`), `npm run e2e:live-llm`, and a `frontend/README.md` section.
- Six new unit tests over the plan arm in `test/unit/mock-brain.test.ts`.

## Commands run locally

| Command | Result |
|---|---|
| `npx vitest run test/unit/mock-brain.test.ts` | 16 passed |
| `npx tsc -p tsconfig.e2e.json` | clean |
| `PW_LIVE_BRAIN=1 npx playwright test test/e2e/orchestration-simulation.spec.ts` | 1 passed (9.5s) |
| `PW_LIVE_LLM=1 npx playwright test` (real model) | 1 passed, four separate runs |
| `npm run e2e:live` (whole suite, 288 tests) | 269 passed, 16 skipped, **3 failed** — see below |

### About those three failures

`orchestration-simulation.spec.ts` was one of them, and it is fixed in this branch: it asserted an *exact* marker count, which passed alone and failed in the suite when a card an earlier spec had raised in the same thread settled while this test ran. It is a floor now, and it passes in both.

The other two are **pre-existing on `main`** and reproduce in isolation with these changes reverted from the equation entirely:

- `mcp-agent.spec.ts` locates the reply by `article[data-message-id]` — the pre-assistant-ui markup, stale since the transcript rewrite (#1559). The mock brain log shows the tool call firing and the reply arriving; only the locator misses.
- `mcp.spec.ts` fails on `mcp-bridge-absent` being present, which is a property of the host build, not of anything here.

Neither is touched by this PR. Flagging rather than fixing, so this change stays about one thing.

## Two bugs this found in its own specs

Worth stating, because both are the shape `CLAUDE.md` warns about — green over something never checked:

1. **Reading the board mid-turn.** A turn's delegations are drained *after* it, so a board read taken while the company is still answering sees whichever cards happen to exist at that instant. Two runs of the live spec dispatched, settled and closed out one card of a two-card goal and reported green over the half they never looked at. Fixed by waiting on the working indicator (`waitForTurn`).
2. **A settle check of `not.toBe("in_progress")`.** A card nobody has dispatched reads `pending`, which is not `in_progress` — so a card that had never started counted as one that had finished. It is an allow-list of stopped landings now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive orchestration testing covering delegation, dispatch, execution, approvals, persistence, and completion.
  - Added an optional live-model testing lane for validating model-driven workflows.
  - Added deterministic embedding support for reliable end-to-end test scenarios.

- **Documentation**
  - Expanded testing guidance for simulated and live-model orchestration runs, configuration, logging, and troubleshooting.

- **Tests**
  - Added shared testing utilities and broader validation of multi-step plans, tool usage, and workflow state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->