### PR TITLE
test(console): locate unplaced teammate by role

### DIFF
--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -559,7 +559,12 @@ test("#839 creates a teammate with no desk as unplaced", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "Not on a desk" }),
   ).toContainText("Not on a desk");
-  await expect(page.getByText("No Desk", { exact: true })).toBeVisible();
+  await expect(
+    page
+      .getByRole("heading", { name: "Not on a desk" })
+      .locator("xpath=following-sibling::ul[1]")
+      .getByRole("link", { name: "No Desk", exact: true }),
+  ).toBeVisible();
   expect(writes.some((write) => write.path.includes("/members"))).toBe(false);
 });
 


### PR DESCRIPTION
## Summary
- scope the unplaced-teammate assertion to the "Not on a desk" list
- locate the teammate by semantic link role/name so avatar fallback initials do not break exact text matching

## Verification
- `npm run typecheck:e2e`
- `npx playwright test test/e2e/org-tree.spec.ts --grep '#839 creates a teammate with no desk as unplaced'`\n- `npm run typecheck:unit`\n- `npm test`\n- `cargo test --locked`\n\n## Behavior\nNo product behavior change; this repairs the E2E assertion exposed by the teammate-avatar UI.