### PR TITLE
Fix onboarding template and local model setup

### DIFF
--- a/docs/spec/runtime/company-setup.md
+++ b/docs/spec/runtime/company-setup.md
@@ -266,6 +266,13 @@ nothing: finding out a key is wrong must not require having stored it. Provider
 errors are summarised to one actionable line rather than forwarded, since a
 failure body can echo request material into a browser on an unauthenticated host.
 
+Local endpoints get one onboarding-only convenience before that shared
+resolution: a bare `localhost:port` gains `http://` and `/v1`. Setup reads the
+OpenAI-compatible `/models` catalog and probes its concrete model rather than
+sending the abstract `agentic-v1` tier to a server that cannot resolve it. The
+successful provider, endpoint and tier mapping are persisted only when Finish
+creates the company; the probe itself remains write-free.
+
 The step is a **gate with an escape**. `GET /api/v1/setup` reports whether the
 host already holds a credential, so a hosted tenant — whose operator has no key
 and no way to get one — arrives with the step already answered and only needs to

--- a/docs/spec/runtime/setup.md
+++ b/docs/spec/runtime/setup.md
@@ -53,6 +53,10 @@ chosen template when the registry is empty, and stamps `setup_completed_at`.
 Validation happens before anything is written — a partial apply is worse than a
 refused one, because nothing tells the operator which half landed.
 
+The Business step renders that catalog as a dropdown. The selected preset is
+sent with the optional details to the roster pass, so matching is anchored to a
+real shipped company type instead of inferred from a free-text keyword alone.
+
 `GET /spec` additionally carries `setup_complete`. It is reported on that
 unauthenticated handshake because an instance nobody has configured has nobody
 who *can* sign in; gating the answer behind auth would make the wizard
@@ -67,6 +71,14 @@ Model is first because its failure is silent everywhere else — the design pass
 falls back to a curated team on a missing or bad credential, so an untested key
 produces a *plausible* company and the operator finds out several screens later,
 if at all. It is a gate, not a wall: skipping is a first-class answer.
+
+For a local OpenAI-compatible provider, setup accepts the address local model
+apps normally display (`localhost:6969`), normalizes it to
+`http://localhost:6969/v1`, reads `/models`, and probes a concrete model id.
+That provider, normalized endpoint, model mapping, and optional write-only key
+are then persisted on the company the wizard creates. The roster-design pass
+uses the same tested provider before the company exists; a green test is not a
+temporary connection that setup forgets at Finish.
 
 Sign-in comes before the address, and that is the point of it having a step. It
 used to be the first card inside Advanced — one screen *after* the wizard asked

--- a/frontend/src/api/setup.ts
+++ b/frontend/src/api/setup.ts
@@ -176,6 +176,8 @@ export interface InferenceTestResult {
   ok: boolean;
   /** The endpoint actually reached — a tick from the wrong URL is not a pass. */
   baseUrl: string;
+  /** Concrete model discovered from the endpoint's OpenAI-compatible catalog. */
+  model?: string | null;
   /** Present only on failure, already summarised into one actionable line. */
   error?: string;
 }
@@ -237,6 +239,16 @@ export interface DesignedCompany {
    * nobody. Omitted only on a host that needs no sign-in at all.
    */
   adminEmail?: string | null;
+  /** The tested provider to persist onto the new company. */
+  inference?: SetupInferenceInput | null;
+}
+
+export interface SetupInferenceInput {
+  provider: string;
+  baseUrl?: string | null;
+  model?: string | null;
+  /** Write-only; stored in the company's secret store. */
+  key?: string | null;
 }
 
 export interface DesignedAgent {  name: string;
@@ -325,7 +337,11 @@ export function proposeSetupRoster(
     industry: string;
     teamHint: string;
     automate: string;
+    template?: string | null;
     inferenceKey?: string | null;
+    inferenceProvider?: string | null;
+    inferenceBaseUrl?: string | null;
+    inferenceModel?: string | null;
   },
 ): Promise<SetupRoster> {
   return client.post<SetupRoster>("/api/v1/setup/roster", body);

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -188,6 +188,8 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
 
   /** The three answers. */
   const [draft, setDraft] = useState<SetupDraft>(emptySetupDraft);
+  /** The shipped company template the operator explicitly chose. */
+  const [template, setTemplate] = useState("");
   /** The address that will be able to sign in. */
   const [email, setEmail] = useState("");
   /** Whether the operator has been shown a problem on the current step yet. */
@@ -213,7 +215,11 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
    * that traps them.
    */
   const [tested, setTested] = useState<
-    { kind: "untested" } | { kind: "testing" } | { kind: "ok"; baseUrl: string } | { kind: "failed"; error: string } | { kind: "skipped" }
+    | { kind: "untested" }
+    | { kind: "testing" }
+    | { kind: "ok"; baseUrl: string; model?: string | null }
+    | { kind: "failed"; error: string }
+    | { kind: "skipped" }
   >({ kind: "untested" });
   /**
    * The team, once the host has designed one — and `null` until then.
@@ -372,10 +378,14 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
   // See `changedFields`: unchanged fields are omitted, env-owned ones are never
   // sent (the host refuses them and an apply is all-or-nothing), and a secret
   // goes only when the operator typed one.
-  const changed = useMemo(
-    () => (status ? changedFields(status, values) : {}),
-    [status, values],
-  );
+  const changed = useMemo(() => {
+    const fields = status ? changedFields(status, values) : {};
+    // BYOK/local credentials belong to the new company's write-only inference
+    // store. Writing the same bytes into the host-wide TinyHumans key would
+    // both duplicate the secret and falsely report a process restart.
+    if (provider !== "managed") delete fields.tinyhumans_api_key;
+    return fields;
+  }, [status, values, provider]);
 
   /**
    * The steps this host actually shows. `STEPS` stays the source of order.
@@ -423,7 +433,11 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
         industry: draft.industry,
         teamHint: draft.teamHint,
         automate: draft.automate,
+        template: template || null,
         inferenceKey: values.tinyhumans_api_key || null,
+        inferenceProvider: tested.kind === "ok" ? provider : null,
+        inferenceBaseUrl: tested.kind === "ok" ? tested.baseUrl : null,
+        inferenceModel: tested.kind === "ok" ? tested.model : null,
       });
       // The host is contracted never to answer with an empty roster, so a
       // missing or empty one is a failure rather than a team of nobody — and
@@ -438,7 +452,7 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
     } finally {
       setDesigning(false);
     }
-  }, [client, draft, values.tinyhumans_api_key]);
+  }, [client, draft, template, provider, tested, values.tinyhumans_api_key]);
 
   const submit = useCallback(async () => {
     if (!status) return;
@@ -461,6 +475,15 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
                 // As reviewed, not as proposed.
                 agents: roster.agents,
                 adminEmail: email.trim() || null,
+                inference:
+                  tested.kind === "ok" && provider !== "managed"
+                    ? {
+                        provider,
+                        baseUrl: tested.baseUrl,
+                        model: tested.model ?? null,
+                        key: values.tinyhumans_api_key?.trim() || null,
+                      }
+                    : null,
               }
             : null,
       });
@@ -471,7 +494,7 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [client, status, changed, roster, draft, email]);
+  }, [client, status, changed, roster, draft, email, provider, tested, values.tinyhumans_api_key]);
 
   if (loadError) {
     return (
@@ -625,7 +648,15 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
         ? "That connection did not work. Fix it, or continue without a model."
         : "Test the connection first, or continue without a model.";
     }
-    if (current.id === "business" && !draft.industry.trim()) {
+    if (current.id === "business" && needsCompany && status.templates.length > 0 && !template) {
+      return "Choose the kind of company you want to start with.";
+    }
+    if (
+      current.id === "business" &&
+      needsCompany &&
+      status.templates.length === 0 &&
+      !draft.industry.trim()
+    ) {
       return "Tell us a little about the company first.";
     }
     if (current.id === "account" && needsCompany) {
@@ -735,7 +766,21 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
     >
       <div className="space-y-6" data-testid="setup-wizard">
         {current.id === "business" && (
-          <BusinessStep draft={draft} onChange={setDraft} onEnter={advance} />
+          <BusinessStep
+            draft={draft}
+            templates={status.templates}
+            template={template}
+            onTemplate={(id) => {
+              setTemplate(id);
+              const selected = status.templates.find((candidate) => candidate.id === id);
+              if (selected && !draft.industry.trim()) {
+                setDraft((current) => ({ ...current, industry: selected.name }));
+              }
+              setRoster(null);
+            }}
+            onChange={setDraft}
+            onEnter={advance}
+          />
         )}
 
         {current.id === "signin" && (
@@ -1084,7 +1129,7 @@ function PowerStep({
       });
       onTested(
         result.ok
-          ? { kind: "ok", baseUrl: result.baseUrl }
+          ? { kind: "ok", baseUrl: result.baseUrl, model: result.model }
           : { kind: "failed", error: result.error ?? "Could not reach the provider." },
       );
     } catch (err: unknown) {
@@ -1144,7 +1189,8 @@ function PowerStep({
             Endpoint
           </Label>
           <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
-            The base URL of the chat API, ending in <code>/v1</code>.
+            Paste the local address as shown, for example <code>localhost:6969</code>. We&apos;ll
+            add <code>http://</code> and <code>/v1</code> when needed.
           </p>
           <Input
             id="setup-base-url"
@@ -1263,7 +1309,8 @@ function PowerStep({
             watched us produce. */}
         {tested.kind === "ok" && (
           <p className="text-sm leading-snug text-status-done-text" data-testid="setup-test-ok">
-            Reached {tested.baseUrl} and got a reply.
+            Reached {tested.baseUrl}
+            {tested.model ? ` using ${tested.model}` : ""} and got a reply.
           </p>
         )}
         {tested.kind === "failed" && (
@@ -1304,7 +1351,7 @@ function PowerStep({
 type TestState =
   | { kind: "untested" }
   | { kind: "testing" }
-  | { kind: "ok"; baseUrl: string }
+  | { kind: "ok"; baseUrl: string; model?: string | null }
   | { kind: "failed"; error: string }
   | { kind: "skipped" };
 
@@ -1625,10 +1672,16 @@ function AdvancedStep({
  */
 function BusinessStep({
   draft,
+  templates,
+  template,
+  onTemplate,
   onChange,
   onEnter,
 }: {
   draft: SetupDraft;
+  templates: SetupStatus["templates"];
+  template: string;
+  onTemplate: (id: string) => void;
   onChange: (update: (d: SetupDraft) => SetupDraft) => void;
   onEnter: () => void;
 }) {
@@ -1641,24 +1694,57 @@ function BusinessStep({
             breathing room belongs *before the field*, not inside the sentence.
             A uniform `space-y` gave all three the same gap and the question
             read as three unrelated lines. */}
-        <Label htmlFor="setup-industry" className="text-base font-medium leading-snug">
+        <Label htmlFor="setup-template" className="text-base font-medium leading-snug">
           What kind of company are you setting up?
         </Label>
         <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
-          A sentence is plenty. What you sell, or what you do.
+          Pick one of the teams bundled with OpenCompany. You can tailor it below.
         </p>
-        <Input
-          id="setup-industry"
-          autoFocus
-          value={draft.industry}
-          placeholder="e.g. E-commerce — I sell homeware online"
-          data-testid="setup-field-industry"
-          className="mt-2.5"
-          onChange={(e) => onChange((d) => ({ ...d, industry: e.target.value }))}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") onEnter();
-          }}
-        />
+        {templates.length > 0 ? (
+          <select
+            id="setup-template"
+            autoFocus
+            value={template}
+            data-testid="setup-field-template"
+            className="mt-2.5 h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+            onChange={(event) => onTemplate(event.target.value)}
+          >
+            <option value="" disabled>
+              Choose a company template…
+            </option>
+            {templates.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name} ({option.agent_count} teammates)
+              </option>
+            ))}
+          </select>
+        ) : (
+          <Input
+            id="setup-industry"
+            autoFocus
+            value={draft.industry}
+            placeholder="e.g. E-commerce — I sell homeware online"
+            data-testid="setup-field-industry"
+            className="mt-2.5"
+            onChange={(e) => onChange((d) => ({ ...d, industry: e.target.value }))}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onEnter();
+            }}
+          />
+        )}
+        {template && (
+          <Input
+            id="setup-industry"
+            value={draft.industry}
+            placeholder="Optional details about what makes yours different"
+            data-testid="setup-field-industry"
+            className="mt-2"
+            onChange={(e) => onChange((d) => ({ ...d, industry: e.target.value }))}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onEnter();
+            }}
+          />
+        )}
       </div>
 
       <div>

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -29,9 +29,7 @@ function status(over: Partial<SetupStatus> = {}): SetupStatus {
     complete: false,
     config_path: "/data/config.toml",
     fields: [],
-    templates: [
-      { id: "starter", name: "Starter", agent_count: 2, output: null },
-    ],
+    templates: [],
     auth_modes: ["email"],
     build: {
       acp_in_build: false,
@@ -167,6 +165,36 @@ const finishButton = () =>
   container.querySelector('[data-testid="setup-finish"]') as HTMLButtonElement | null;
 
 describe("finishing setup with no companies on the host", () => {
+  it("offers the shipped company templates as a dropdown", async () => {
+    await show(
+      clientWith(
+        status({
+          templates: [
+            { id: "agentic_software_company", name: "Agentic Software Company", agent_count: 5, output: "Software" },
+            { id: "agentic_law_firm", name: "Agentic Law Firm", agent_count: 4, output: "Legal work" },
+          ],
+        }),
+      ),
+    );
+    await skipModel();
+
+    const picker = container.querySelector(
+      '[data-testid="setup-field-template"]',
+    ) as HTMLSelectElement;
+    expect(picker).toBeTruthy();
+    expect(Array.from(picker.options).map((option) => option.textContent)).toContain(
+      "Agentic Software Company (5 teammates)",
+    );
+
+    await act(async () => {
+      picker.value = "agentic_software_company";
+      picker.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(
+      (container.querySelector('[data-testid="setup-field-industry"]') as HTMLInputElement).value,
+    ).toBe("Agentic Software Company");
+  });
+
   /**
    * The design call fails in this environment (no host behind the client), so
    * Review renders its error rather than a roster — which is precisely the

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -454,6 +454,31 @@ pub fn effective_base_url(provider: &str, override_url: Option<&str>) -> String 
     }
 }
 
+/// Normalizes an endpoint typed by a person during setup.
+///
+/// Local model applications commonly advertise themselves as `localhost:1234`
+/// even though the OpenAI-compatible client needs
+/// `http://localhost:1234/v1`. Accept that familiar spelling while preserving
+/// explicit schemes and non-root paths.
+pub fn normalize_setup_base_url(provider: &str, raw: Option<&str>) -> Option<String> {
+    let raw = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    if !matches!(normalize_provider(provider), "ollama" | "openai_compatible") {
+        return Some(raw.trim_end_matches('/').to_string());
+    }
+
+    let mut url = if raw.starts_with("http://") || raw.starts_with("https://") {
+        raw.to_string()
+    } else {
+        format!("http://{raw}")
+    };
+    url = url.trim_end_matches('/').to_string();
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or("");
+    if !after_scheme.contains('/') {
+        url.push_str("/v1");
+    }
+    Some(url)
+}
+
 /// Loads the runtime inference override, or `None` when unset/blank. A malformed
 /// blob is a store error (surfaced, not silently dropped).
 pub async fn load_runtime_config(
@@ -1532,6 +1557,22 @@ mod tests {
         assert_eq!(
             effective_base_url("openrouter", Some("https://proxy/v1")),
             "https://proxy/v1"
+        );
+    }
+
+    #[test]
+    fn setup_accepts_the_localhost_spelling_local_model_apps_display() {
+        assert_eq!(
+            normalize_setup_base_url("ollama", Some("localhost:6969")),
+            Some("http://localhost:6969/v1".to_string())
+        );
+        assert_eq!(
+            normalize_setup_base_url("openai_compatible", Some("http://127.0.0.1:1234/v1/")),
+            Some("http://127.0.0.1:1234/v1".to_string())
+        );
+        assert_eq!(
+            normalize_setup_base_url("openai_compatible", Some("https://llm.test/api")),
+            Some("https://llm.test/api".to_string())
         );
     }
 }

--- a/src/harness/built_in/composio_turn_test.rs
+++ b/src/harness/built_in/composio_turn_test.rs
@@ -378,6 +378,7 @@ async fn harness(
         run_supervisor: crate::runtime::RunSupervisor::default(),
         delivery: None,
         search: None,
+        tenant_search: None,
         workspace: None,
         repos: None,
         repo_bindings: Vec::new(),

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -735,6 +735,8 @@ pub struct HostedProviderConfig {
 pub struct HostedProvider {
     config: HostedProviderConfig,
     client: reqwest::Client,
+    product_identity: bool,
+    telemetry_provider: &'static str,
 }
 
 impl HostedProvider {
@@ -743,6 +745,20 @@ impl HostedProvider {
         Self {
             config,
             client: reqwest::Client::new(),
+            product_identity: true,
+            telemetry_provider: "subscription",
+        }
+    }
+
+    /// Builds the short-lived direct provider used before a company exists in
+    /// onboarding. It speaks the same wire format without attaching the
+    /// TinyHumans product header to a third-party or local endpoint.
+    pub fn new_direct(config: HostedProviderConfig, provider: &str) -> Self {
+        Self {
+            config,
+            client: reqwest::Client::new(),
+            product_identity: false,
+            telemetry_provider: inference::provider_slug(provider),
         }
     }
 }
@@ -782,20 +798,14 @@ impl ChatModel<()> for HostedProvider {
             "{}/chat/completions",
             self.config.base_url.trim_end_matches('/')
         );
-        let (product_header_name, product_header_value) = crate::product::product_identity_header();
-        let mut http = self
-            .client
-            .post(&url)
-            .json(&body)
-            // `HostedProvider` always speaks to the TinyHumans-owned managed
-            // endpoint (`DEFAULT_TINYHUMANS_INFERENCE_URL`), never a
-            // third-party BYOK host, so tagging it with our product identity
-            // is unconditional. This client is a bespoke `reqwest::Client`,
-            // not one built through `openhuman_core`'s `IntegrationClient`,
-            // so it does not inherit the header set by
-            // `set_product_identity` and must attach it itself — see
-            // `crate::product`.
-            .header(product_header_name, product_header_value);
+        let mut http = self.client.post(&url).json(&body);
+        if self.product_identity {
+            // The normal constructor is the managed TinyHumans path. The
+            // direct setup constructor deliberately skips this on local/BYOK
+            // endpoints, matching `request_plan`'s privacy boundary.
+            let (name, value) = crate::product::product_identity_header();
+            http = http.header(name, value);
+        }
         // Resolved per request, never captured: on the hosted platform this reads
         // a token file the cluster rewrites in place every few minutes.
         let bearer = self.config.credential.current().await.map_err(|e| {
@@ -835,10 +845,11 @@ impl ChatModel<()> for HostedProvider {
 
 impl HarnessModel for HostedProvider {
     fn telemetry_provider_id(&self) -> String {
-        // `HostedProvider` is the platform-credentialed path by construction —
-        // it exists only where the env default supplied both endpoint and key —
-        // so its spend is the subscription's.
-        "subscription".to_string()
+        // The normal constructor is the subscription path. First-run setup has
+        // no tenant store to hang `TenantProvider` from, so its direct
+        // constructor carries the selected provider's slug for that one
+        // unmetered roster-design call.
+        self.telemetry_provider.to_string()
     }
 }
 

--- a/src/harness/roster_build.rs
+++ b/src/harness/roster_build.rs
@@ -126,12 +126,54 @@ impl RosterBuilder {
     /// the honest trade.
     pub fn for_setup(
         env: &dyn crate::app::config::EnvSource,
+        provider: Option<&str>,
+        base_url: Option<&str>,
         credential: Option<&str>,
+        model: Option<&str>,
     ) -> Option<Self> {
         use crate::harness::provider::{
             DEFAULT_HOSTED_MODEL, DEFAULT_TINYHUMANS_INFERENCE_URL, HostedProvider,
             HostedProviderConfig, harness_inference_from_env,
         };
+
+        let selected_provider = provider.map(str::trim).filter(|value| !value.is_empty());
+        if let Some(provider) = selected_provider.filter(|provider| *provider != "managed") {
+            let base_url = crate::company::inference::normalize_setup_base_url(provider, base_url)
+                .unwrap_or_else(|| crate::company::inference::effective_base_url(provider, None));
+            let credential = credential
+                .map(str::trim)
+                .filter(|key| !key.is_empty())
+                .map_or(crate::company::Credential::None, |key| {
+                    crate::company::Credential::from_value(key.to_string())
+                });
+            let extra_headers =
+                if crate::company::inference::normalize_provider(provider) == "openrouter" {
+                    vec![
+                        (
+                            "HTTP-Referer".to_string(),
+                            "https://opencompany.ai".to_string(),
+                        ),
+                        ("X-Title".to_string(), "OpenCompany".to_string()),
+                    ]
+                } else {
+                    Vec::new()
+                };
+            let model_name = model
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+                .unwrap_or(DEFAULT_HOSTED_MODEL);
+            return Some(Self::new(
+                Arc::new(HostedProvider::new_direct(
+                    HostedProviderConfig {
+                        base_url,
+                        credential,
+                        extra_headers,
+                    },
+                    provider,
+                )),
+                model_name,
+            ));
+        }
 
         let typed = credential
             .map(str::trim)
@@ -151,7 +193,12 @@ impl RosterBuilder {
             });
 
         let (config, model_override) = typed.or_else(|| harness_inference_from_env(env))?;
-        let model_name = model_override.unwrap_or_else(|| DEFAULT_HOSTED_MODEL.to_string());
+        let model_name = model
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .map(str::to_string)
+            .or(model_override)
+            .unwrap_or_else(|| DEFAULT_HOSTED_MODEL.to_string());
         Some(Self::new(Arc::new(HostedProvider::new(config)), model_name))
     }
 

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -286,6 +286,19 @@ pub struct SetupCompany {
     /// which is the only reason a laptop operator who chose email sign-in is
     /// not locked out of the company they just made.
     admin_email: Option<String>,
+    /// The provider that passed the setup probe. Persisted with the company so
+    /// the first agent turn uses the same endpoint the operator tested.
+    inference: Option<SetupInference>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SetupInference {
+    provider: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    /// Write-only credential. Never appears in a response or manifest.
+    key: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -770,6 +783,42 @@ async fn apply_inner(
         _ => None,
     };
 
+    // Validate the model choice before writing setup state. The endpoint that
+    // passed the probe is normalized once more at this trust boundary, then
+    // stored on the company rather than forgotten after the green tick.
+    let designed_inference = req
+        .company
+        .as_ref()
+        .and_then(|company| company.inference.as_ref())
+        .map(|input| {
+            let mut models = std::collections::BTreeMap::new();
+            if let Some(model) = input
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+            {
+                for tier in crate::company::INFERENCE_TIERS {
+                    models.insert((*tier).to_string(), model.to_string());
+                }
+            }
+            let config = crate::company::inference::RuntimeInference {
+                provider: input.provider.trim().to_string(),
+                base_url: crate::company::inference::normalize_setup_base_url(
+                    &input.provider,
+                    input.base_url.as_deref(),
+                ),
+                models,
+            };
+            let problems = crate::company::inference::validate_runtime(&config);
+            if problems.is_empty() {
+                Ok(config)
+            } else {
+                Err(OpenCompanyError::InvalidRequest(problems.join(" ")))
+            }
+        })
+        .transpose()?;
+
     // Persist before anything live is mutated. The module doc promises "writes
     // it in one transaction" and `AppliedDto::complete` promises a partial
     // apply is an error, not a result — both break if a later step (auth
@@ -826,12 +875,27 @@ async fn apply_inner(
             // operator edited it, so neither the bounds nor the de-duplication
             // can be assumed to have survived.
             let agents = crate::company::setup::validate_roster(agents);
-            let manifest = crate::company::setup::manifest_from_setup(
+            let mut manifest = crate::company::setup::manifest_from_setup(
                 &answers,
                 &agents,
                 designed.admin_email.as_deref(),
             );
+            if let Some(inference) = &designed_inference {
+                manifest.inference.provider = Some(inference.provider.clone());
+                manifest.inference.base_url = inference.base_url.clone();
+                manifest.inference.models = inference.models.clone();
+            }
             let id = crate::desktop::seed_generated_company(state, manifest, Some(answers)).await?;
+            if let Some(key) = designed
+                .inference
+                .as_ref()
+                .and_then(|inference| inference.key.as_deref())
+                .map(str::trim)
+                .filter(|key| !key.is_empty())
+                && let Some(runtime) = state.registry().get(&id)
+            {
+                crate::company::inference::store_key(&id, runtime.secrets().as_ref(), key).await?;
+            }
             Some(id.as_ref().to_string())
         }
         (None, Some(template), true) => {
@@ -951,10 +1015,15 @@ pub struct SetupRosterRequest {
     industry: String,
     team_hint: String,
     automate: String,
+    /// A shipped preset chosen explicitly in the wizard.
+    template: Option<String>,
     /// The inference credential from the wizard's own field, when the operator
     /// has just supplied one. Absent falls back to whatever the host already
     /// has; neither yielding one ships the curated team.
     inference_key: Option<String>,
+    inference_provider: Option<String>,
+    inference_base_url: Option<String>,
+    inference_model: Option<String>,
 }
 
 /// One proposed teammate, shaped for the wizard's review step.
@@ -1020,6 +1089,9 @@ pub struct InferenceTestDto {
     /// An operator who mistypes a base URL and gets a tick from the *default*
     /// endpoint has been told the wrong thing.
     base_url: String,
+    /// Concrete model discovered from the endpoint catalog, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
     /// Present only on failure, in the operator's language.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
@@ -1073,12 +1145,27 @@ async fn probe_inference<E: EnvSource + Sync>(
                 credential: config.credential,
             }
         });
-    let decl = crate::company::inference::decl_for_probe(
+    let normalized_base_url =
+        crate::company::inference::normalize_setup_base_url(&req.provider, req.base_url.as_deref());
+    let mut decl = crate::company::inference::decl_for_probe(
         &req.provider,
-        req.base_url.as_deref(),
+        normalized_base_url.as_deref(),
         req.key.as_deref(),
         env_default.as_ref(),
     );
+    let model = if matches!(
+        crate::company::inference::normalize_provider(&req.provider),
+        "ollama" | "openai_compatible"
+    ) {
+        discover_local_model(&decl).await
+    } else {
+        None
+    };
+    if let Some(model) = &model {
+        for tier in crate::company::INFERENCE_TIERS {
+            decl.models.insert((*tier).to_string(), model.clone());
+        }
+    }
     let base_url = decl.base_url.clone();
 
     // `openai_compatible` has no default endpoint, so a blank URL resolves to
@@ -1088,6 +1175,7 @@ async fn probe_inference<E: EnvSource + Sync>(
         return InferenceTestDto {
             ok: false,
             base_url,
+            model: None,
             error: Some("This provider needs an endpoint URL.".to_string()),
         };
     }
@@ -1096,6 +1184,7 @@ async fn probe_inference<E: EnvSource + Sync>(
         Ok(()) => InferenceTestDto {
             ok: true,
             base_url,
+            model,
             error: None,
         },
         Err(err) => {
@@ -1109,6 +1198,7 @@ async fn probe_inference<E: EnvSource + Sync>(
             InferenceTestDto {
                 ok: false,
                 base_url,
+                model,
                 error: Some(summarise_probe_failure(&err.to_string())),
             }
         }
@@ -1127,10 +1217,33 @@ async fn probe_inference<E: EnvSource + Sync>(
             &req.provider,
             req.base_url.as_deref(),
         ),
+        model: None,
         error: Some(
             "This build cannot reach a model — the agent harness is not compiled in.".to_string(),
         ),
     }
+}
+
+/// Reads the standard OpenAI-compatible model catalog and picks its first
+/// concrete model. Local servers generally require that id rather than the
+/// abstract `agentic-v1` tier OpenCompany uses internally.
+#[cfg(feature = "openhuman")]
+async fn discover_local_model(decl: &crate::company::inference::InferenceDecl) -> Option<String> {
+    let url = format!("{}/models", decl.base_url.trim_end_matches('/'));
+    let mut request = reqwest::Client::new().get(url);
+    if let Ok(Some(bearer)) = decl.bearer().await {
+        request = request.bearer_auth(bearer);
+    }
+    let response = request.send().await.ok()?.error_for_status().ok()?;
+    let payload: serde_json::Value = response.json().await.ok()?;
+    payload
+        .get("data")?
+        .as_array()?
+        .iter()
+        .filter_map(|entry| entry.get("id")?.as_str())
+        .map(str::trim)
+        .find(|id| !id.is_empty())
+        .map(str::to_string)
 }
 
 /// Turns a provider failure into one line an operator can act on.
@@ -1177,12 +1290,38 @@ async fn propose_roster(
 ) -> Result<Json<SetupRosterDto>, Response> {
     authorize(&state, &headers, peer).await?;
 
+    let template_name = req
+        .template
+        .as_deref()
+        .map(|id| {
+            crate::desktop::preset(id)
+                .map(|preset| preset.name)
+                .ok_or_else(|| {
+                    ApiError::from(OpenCompanyError::InvalidRequest(format!(
+                        "unknown company template `{id}`"
+                    )))
+                    .into_response()
+                })
+        })
+        .transpose()?;
     let answers = crate::company::setup::SetupAnswers {
-        industry: req.industry,
+        industry: match template_name {
+            Some(name) if req.industry.trim().is_empty() => name.to_string(),
+            Some(name) if req.industry.trim().eq_ignore_ascii_case(name) => name.to_string(),
+            Some(name) => format!("{name} — {}", req.industry.trim()),
+            None => req.industry,
+        },
         team_hint: req.team_hint,
         automate: req.automate,
     };
-    let proposal = propose_for_setup(&answers, req.inference_key.as_deref()).await;
+    let proposal = propose_for_setup(
+        &answers,
+        req.inference_provider.as_deref(),
+        req.inference_base_url.as_deref(),
+        req.inference_key.as_deref(),
+        req.inference_model.as_deref(),
+    )
+    .await;
 
     tracing::info!(
         template = proposal.template_key,
@@ -1215,9 +1354,18 @@ async fn propose_roster(
 #[cfg(feature = "openhuman")]
 async fn propose_for_setup(
     answers: &crate::company::setup::SetupAnswers,
+    provider: Option<&str>,
+    base_url: Option<&str>,
     credential: Option<&str>,
+    model: Option<&str>,
 ) -> crate::company::setup::RosterProposal {
-    match crate::harness::roster_build::RosterBuilder::for_setup(&ProcessEnv, credential) {
+    match crate::harness::roster_build::RosterBuilder::for_setup(
+        &ProcessEnv,
+        provider,
+        base_url,
+        credential,
+        model,
+    ) {
         // Unmetered on purpose — there is no company to charge yet. See
         // `RosterBuilder::for_setup`.
         Some(builder) => builder.propose(answers).await.0,
@@ -1234,7 +1382,10 @@ async fn propose_for_setup(
 #[cfg(not(feature = "openhuman"))]
 async fn propose_for_setup(
     answers: &crate::company::setup::SetupAnswers,
+    _provider: Option<&str>,
+    _base_url: Option<&str>,
     _credential: Option<&str>,
+    _model: Option<&str>,
 ) -> crate::company::setup::RosterProposal {
     crate::company::setup::template_proposal(
         answers,

--- a/src/server/setup/test.rs
+++ b/src/server/setup/test.rs
@@ -1195,6 +1195,72 @@ async fn an_apply_seeds_the_company_the_wizard_designed() {
     );
 }
 
+#[tokio::test]
+async fn onboarding_persists_the_local_model_it_tested() {
+    let home = home();
+    let state = fresh_state(home.path());
+    let mut company = designed_company(None);
+    company["inference"] = serde_json::json!({
+        "provider": "ollama",
+        "baseUrl": "localhost:6969",
+        "model": "qwen3:8b"
+    });
+
+    let (status, body) = post_setup(state.clone(), serde_json::json!({ "company": company })).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let seeded = body["seeded_company"].as_str().expect("seeded");
+    let manifest = seeded_manifest(home.path(), seeded).await;
+    assert_eq!(manifest.inference.provider.as_deref(), Some("ollama"));
+    assert_eq!(
+        manifest.inference.base_url.as_deref(),
+        Some("http://localhost:6969/v1")
+    );
+    for tier in crate::company::INFERENCE_TIERS {
+        assert_eq!(
+            manifest.inference.models.get(*tier).map(String::as_str),
+            Some("qwen3:8b")
+        );
+    }
+}
+
+#[cfg(feature = "openhuman")]
+#[tokio::test]
+async fn local_model_probe_normalizes_the_address_and_detects_its_model() {
+    let app = axum::Router::new()
+        .route(
+            "/v1/models",
+            axum::routing::get(|| async {
+                axum::Json(serde_json::json!({ "data": [{ "id": "qwen3:8b" }] }))
+            }),
+        )
+        .route(
+            "/v1/chat/completions",
+            axum::routing::post(|| async {
+                axum::Json(serde_json::json!({
+                    "choices": [{ "message": { "content": "pong" } }]
+                }))
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let result = super::probe_inference(
+        &super::InferenceTestRequest {
+            provider: "ollama".to_string(),
+            base_url: Some(address.to_string()),
+            ..Default::default()
+        },
+        &MapEnv::default(),
+    )
+    .await;
+    server.abort();
+
+    assert!(result.ok, "{:?}", result.error);
+    assert_eq!(result.base_url, format!("http://{address}/v1"));
+    assert_eq!(result.model.as_deref(), Some("qwen3:8b"));
+}
+
 /// A designed company beats a template slug. An operator who answered three
 /// questions and edited a roster has expressed a preference a preset cannot
 /// override — and sending both must never produce two companies.


### PR DESCRIPTION
## Summary

- replace the free-text-only company-type choice with a dropdown backed by the shipped template catalog, while retaining optional tailoring details
- accept local model addresses such as `localhost:6969`, normalize them to an OpenAI-compatible `/v1` endpoint, discover the concrete model from `/models`, and probe that model
- use the tested provider for roster design and persist its provider, endpoint, model-tier mapping, and write-only key on the company created by onboarding
- keep product identity headers off local and third-party setup calls, and document the onboarding behavior

## Validation

- `npm run typecheck`
- `npm test -- --run` (250 files, 2,275 tests)
- `cargo test server::setup --lib` (44 tests)
- `cargo test setup_accepts_the_localhost_spelling --lib`
- `cargo test --features openhuman local_model_probe_normalizes_the_address_and_detects_its_model --lib`
- `cargo clippy --all-targets --features openhuman -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Behavior changes

A local Ollama or OpenAI-compatible endpoint entered as `localhost:6969` is now tested as `http://localhost:6969/v1`. The detected model is shown in the successful test result and saved for all abstract inference tiers on the generated company.