### PR TITLE
Include memory engines in the desktop build

### DIFF
--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -55,6 +55,7 @@ The desktop links the host with an explicit feature set, declared on the
 ```toml
 opencompany = { path = "..", default-features = false, features = [
   "sqlite", "platform-jwt", "oauth", "mcp",
+  "tinycortex", "tinymemory", "tinymemory-embedded",
 ] }
 ```
 
@@ -64,15 +65,19 @@ a company, serves the console — and cannot think. The visible symptom was the
 setup wizard's inference test answering *"This build cannot reach a model — the
 agent harness is not compiled in."* for every provider, however good the key.
 
-The belt a desktop agent gets is deliberately the minimal one. The host declares
+The belt a desktop agent gets is deliberately compact. The host declares
 `openhuman_core` with `default-features = false, features = ["skills", "mcp",
 "hosting"]`, so what a company can use is **built-in tools, MCP servers and
-skills** — no memory engine, no TokenJuice, no voice or inference stack out of
-the vendored runtime. Features left off, each on purpose:
+skills**. OpenCompany additionally compiles all three of its memory feature
+layers into the desktop: `tinycortex` for the embedded engine, `tinymemory` for
+hosted and null drivers, and `tinymemory-embedded` for the in-process namespace
+driver. The packaged app therefore never tells an operator to obtain a
+differently compiled build from its memory configuration screen.
+
+Features left off, each on purpose:
 
 | Off | Why |
 | --- | --- |
-| `tinycortex`, `tinymemory*` | In-pod memory engines. They carry tinycortex, `tinyagents/sqlite` and a second bundled SQLite into the bundle for a surface the desktop does not offer; the runtime keeps its fs-backed memory stores. |
 | `media`, `composio`, and the other managed backends | Each needs a platform credential the desktop has no way to hold, and each fails closed without one. |
 | `acp` | `src-tauri/src/acp/` is an ACP *client* and compiles without it (see below). Turning it on additionally wires `RuntimeBuilder::with_acp_agents`, which is a separate decision from having a harness. |
 | `mongodb` | A per-tenant cluster is a hosting concern. |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3617,7 +3617,13 @@ dependencies = [
  "swc_core",
  "thiserror 2.0.20",
  "tinyagents",
+ "tinycortex",
  "tinyflows",
+ "tinymemory",
+ "tinymemory-api",
+ "tinymemory-core",
+ "tinymemory-remote",
+ "tinymemory-tinycortex",
  "tokio",
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
@@ -6437,6 +6443,21 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "tinymemory-remote"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tinymemory-api",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,12 +47,15 @@ path = "src/main.rs"
 # a desktop agent gets is exactly the minimal belt: built-in tools, MCP servers
 # and skills.
 #
+# The desktop includes every memory engine the console offers. A packaged app
+# has no alternate server binary an operator can switch to, so showing disabled
+# TinyCortex/TinyMemory tiles with "this build was compiled without ..." would
+# make the configuration surface a dead end. `tinycortex` provides the incumbent
+# embedded overlay, `tinymemory` provides the hosted/null driver seam, and
+# `tinymemory-embedded` provides its in-process namespace driver.
+#
 # Deliberately NOT here, and each for a reason rather than an oversight:
 #
-# * `tinycortex` / `tinymemory*` — the in-pod memory engines. They carry
-#   tinycortex, `tinyagents/sqlite` and a second bundled SQLite build into the
-#   bundle for a surface the desktop does not offer; the runtime keeps its
-#   fs-backed memory stores.
 # * `media`, `composio`, `search` and the rest of the managed backends — they
 #   need a platform credential the desktop has no way to hold, and each fails
 #   closed anyway.
@@ -60,7 +63,15 @@ path = "src/main.rs"
 #   and compiles without it; turning it on would additionally wire
 #   `RuntimeBuilder::with_acp_agents`, which is a separate decision from having
 #   a harness at all.
-opencompany = { path = "..", default-features = false, features = ["sqlite", "platform-jwt", "oauth", "mcp"] }
+opencompany = { path = "..", default-features = false, features = [
+    "sqlite",
+    "platform-jwt",
+    "oauth",
+    "mcp",
+    "tinycortex",
+    "tinymemory",
+    "tinymemory-embedded",
+] }
 
 tauri = { version = "2", features = [] }
 # The OS credential store, so a device session token never has to live in the

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -356,6 +356,42 @@ mod test {
         );
     }
 
+    /// Memory is a desktop surface, so every engine the console offers must be
+    /// constructible by the host linked into the app. A disabled tile that
+    /// tells the operator to find a differently compiled build is not useful in
+    /// a packaged desktop application: there is no alternate binary to pick.
+    #[tokio::test]
+    async fn the_desktop_build_includes_every_memory_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let host = start(dir.path().to_path_buf()).await.expect("host starts");
+        let response = reqwest::get(format!("{}/api/v1/company/memory/engine", host.base_url()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        let body: serde_json::Value = response.json().await.unwrap();
+        let unavailable = body["options"]
+            .as_array()
+            .expect("the engine route returns its catalog")
+            .iter()
+            .filter(|option| option["available"] != true)
+            .map(|option| {
+                format!(
+                    "{}: {}",
+                    option["id"].as_str().unwrap_or("unknown"),
+                    option["unavailableReason"]
+                        .as_str()
+                        .unwrap_or("no reason reported")
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            unavailable.is_empty(),
+            "the packaged desktop must not offer disabled memory engines: {unavailable:?}"
+        );
+    }
+
     /// A `none`-mode desktop is the **default**, not a ceiling.
     ///
     /// The setup wizard offers all three modes on a loopback host, and an


### PR DESCRIPTION
## Summary

- compile TinyCortex, TinyMemory hosted/null drivers, and the embedded namespace driver into the desktop host
- update the desktop lockfile and runtime documentation for the expanded feature graph
- add an embedded-host regression test proving every memory engine offered by the console is available

## Behavior change

The packaged desktop app no longer disables memory configuration with “this build was compiled without” messages. TinyCortex, TinyMemory (in-pod), Supermemory, Mem0, Cognee, and null memory are compiled into the desktop build.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --no-deps -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` (127 passed, 5 ignored)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop builds now include TinyCortex, TinyMemory, and embedded TinyMemory engines.
  * Packaged desktop applications support embedded, hosted/null, and in-process memory drivers.

* **Documentation**
  * Updated desktop documentation to describe the available memory engines and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->