### PR TITLE
fix(runtime): link publish pull requests to runs

### DIFF
--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1716,7 +1716,7 @@ async fn perform_effect(rt: &CompanyRuntime, effect: &Effect) -> Result<()> {
         // is on the remote regardless. It is reported instead: the operator is
         // told, on the task itself, that the branch is up but the PR did not open.
         let title = repo_publish_pr_title(message);
-        let body = repo_publish_pr_body(agent, task, message);
+        let body = repo_publish_pr_body(agent, task, effect.run_id.as_deref(), message);
         match repos.open_pull_request(repo, branch, &title, &body).await {
             Ok(pr) => tracing::info!(
                 number = pr.number,
@@ -1814,10 +1814,10 @@ fn repo_publish_pr_title(message: &str) -> String {
     }
 }
 
-/// The body of that pull request (issue #736): the agent's message, then task
-/// and agent linkage so an operator landing on the PR can get back to the card
-/// and the seat that produced it.
-fn repo_publish_pr_body(agent: &str, task: &str, message: &str) -> String {
+/// The body of that pull request (issue #736): the agent's message, then task,
+/// run, and agent linkage so an operator landing on the PR can get back to the
+/// card, attempt, and seat that produced it.
+fn repo_publish_pr_body(agent: &str, task: &str, run_id: Option<&str>, message: &str) -> String {
     let mut body = String::new();
     let message = message.trim();
     if !message.is_empty() {
@@ -1831,6 +1831,9 @@ fn repo_publish_pr_body(agent: &str, task: &str, message: &str) -> String {
     }
     if !task.is_empty() {
         body.push_str(&format!(" for task `{task}`"));
+    }
+    if let Some(run_id) = run_id.filter(|run_id| !run_id.is_empty()) {
+        body.push_str(&format!(" in run `{run_id}`"));
     }
     body.push('.');
     body

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -3064,6 +3064,22 @@ mod test {
         }
     }
 
+    /// Issue #247: a publish PR carries both the task and the concrete run that
+    /// produced its approved effect, letting an operator trace it back to the
+    /// exact attempt rather than only the card.
+    #[test]
+    fn a_publish_pr_body_links_its_task_and_run() {
+        let body = repo_publish_pr_body(
+            "developer",
+            "task-247",
+            Some("run-247"),
+            "Add run linkage to publish pull requests.",
+        );
+
+        assert!(body.contains("task `task-247`"), "{body}");
+        assert!(body.contains("run `run-247`"), "{body}");
+    }
+
     /// A publish-failure note lands only on a real card — never on a DM's `dm-*`
     /// work key, which no card owns (issue #815).
     #[test]


### PR DESCRIPTION
## Summary

- carry the approved publish effect's stamped run ID into the host-side pull-request body
- preserve existing task and agent linkage, push ordering, best-effort PR creation, and failure reporting
- add a regression test covering task and run linkage

Closes #247

## Validation

- `cargo fmt --all -- --check`
- `cargo test a_publish_pr_body_links_its_task_and_run`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings`

## Scope

This completes the remaining task-and-run PR-body linkage. It deliberately does not expand the existing write tier or implement cryptographic commit signing, which #247 tracks as deferred issue #738.