### PR TITLE
fix(ledgers): hide empty notices on boards

### DIFF
--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -911,7 +911,8 @@ export function LedgersView({
                   indistinguishably — the read is filtered server-side. The two
                   are not the same claim, and saying the stronger one over a
                   ledger the nav is counting 14 rows for is simply false. */}
-              {read &&
+              {mode === "list" &&
+                read &&
                 read.entries.length === 0 &&
                 !reading &&
                 (emptyNotice ? (

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -113,6 +113,55 @@ test("the board renders the three phases in order, and none of the retired colum
   }
 });
 
+test("an empty board leaves its column affordances to explain the empty state", async ({
+  page,
+  request,
+}) => {
+  // A ledger declared just for this assertion makes the empty condition
+  // independent of cards that earlier specs may have added to the shared host.
+  const marker = Date.now();
+  const slug = `e2e-empty-board-${marker}`;
+  const declared = await request.post(`${API}/ledgers`, {
+    data: {
+      slug,
+      title: `E2E empty board ${marker}`,
+      purpose: "A list used to verify empty board copy.",
+      fields: [
+        { name: "id", role: "id" },
+        { name: "title", role: "title", required: true },
+        { name: "status", role: "status", required: true },
+      ],
+      statuses: [{ name: "open" }, { name: "closed", closed: true }],
+      checks: ["required-field", "known-status"],
+    },
+  });
+  expect(declared.ok()).toBeTruthy();
+
+  try {
+    await page.goto(`/#/ledgers/${slug}`);
+    await dismissTour(page);
+    await expect(page.getByTestId("ledger-board")).toBeVisible({ timeout: 15_000 });
+
+    // Board columns already say what an empty board is for. A second status
+    // line above them repeats the fact instead of helping the operator act.
+    await expect(page.getByTestId("ledger-empty")).toHaveCount(0);
+    await expect(page.getByTestId("ledger-filtered-empty")).toHaveCount(0);
+
+    const search = page.getByPlaceholder("Search every field");
+    await search.fill("no matching row");
+    await expect(page.getByTestId("ledger-filtered-empty")).toHaveCount(0);
+
+    // The list has no per-status-column affordance, so it retains both forms
+    // of the above-list notice.
+    await page.getByRole("button", { name: "List" }).click();
+    await expect(page.getByTestId("ledger-filtered-empty")).toBeVisible({ timeout: 15_000 });
+    await search.fill("");
+    await expect(page.getByTestId("ledger-empty")).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await request.delete(`${API}/ledgers/${slug}`);
+  }
+});
+
 test("new work enters through one prompt box and lands in Pending", async ({ page, request }) => {
   await page.goto("/#/ledgers/tasks");
   await dismissTour(page);


### PR DESCRIPTION
## Summary
- Hide the above-view empty and filtered-empty notices in board mode, where each column already provides its empty-state affordance.
- Retain both notices in list mode, where there are no columns to communicate the state.
- Add a live-host browser regression covering empty and filtered-empty board and list views using an isolated declared ledger.

Closes #1486

## Validation
- `npm run typecheck:e2e`
- `npm run typecheck`
- `npm test`
- `npm run build`

I attempted the focused Playwright regression, but the environment's `/tmp` quota prevented the required host-binary probe from starting (the sandbox could not mount `/tmp/.git`). The regression is included for CI's live-host suite.