### PR TITLE
fix(console): strengthen board drag feedback

### DIFF
--- a/frontend/src/views/LedgerBoard.tsx
+++ b/frontend/src/views/LedgerBoard.tsx
@@ -457,7 +457,11 @@ export function LedgerBoard<T extends BoardRow>({
                 "flex min-h-0 shrink-0 flex-col rounded-xl border bg-gradient-to-b from-card to-muted/60 transition-colors",
                 collapsed ? RAIL_WIDTH : COLUMN_WIDTH,
                 over === column.id &&
-                  "border-primary/40 from-accent/50 to-accent/50",
+                  // A populated target has no empty-state copy to announce
+                  // itself, so its surface has to carry the same clear landing
+                  // affordance: a primary border, a full accent wash, and a
+                  // visible focus ring.
+                  "border-primary from-accent/80 to-accent/50 ring-2 ring-primary/25",
               )}
             >
               {collapsed ? (

--- a/frontend/src/views/TaskCard.tsx
+++ b/frontend/src/views/TaskCard.tsx
@@ -145,8 +145,11 @@ export function TaskItem({
         }
       }}
       className={cn(
-        "cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-shadow hover:shadow active:cursor-grabbing",
-        dragging && "opacity-50",
+        "cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-[transform,box-shadow] hover:shadow active:cursor-grabbing",
+        // A card being carried needs to read as being in the operator's hand,
+        // not as unavailable. The small rise, rotation, and shadow make that
+        // state distinct from a disabled card without changing the gesture.
+        dragging && "-translate-y-1 rotate-1 shadow-xl",
       )}
     >
       <div className="flex items-start justify-between gap-2">

--- a/frontend/test/unit/board-collapsed-columns.test.ts
+++ b/frontend/test/unit/board-collapsed-columns.test.ts
@@ -227,6 +227,17 @@ describe("a board whose work has moved to the later columns", () => {
 });
 
 describe("dragging a card into a collapsed column", () => {
+  it("makes a populated target visibly ready for the drop", async () => {
+    await render(laterColumnsOnly());
+    await pickUp("p0");
+
+    await fire(column("in_review"), "dragover");
+
+    expect(column("in_review").className).toContain("border-primary");
+    expect(column("in_review").className).toContain("from-accent/80");
+    expect(column("in_review").className).toContain("ring-2");
+  });
+
   it("opens the rail under the drag and takes the drop", async () => {
     await render(laterColumnsOnly());
     await pickUp("p0");

--- a/frontend/test/unit/task-blocked-card.test.ts
+++ b/frontend/test/unit/task-blocked-card.test.ts
@@ -62,13 +62,13 @@ let container: HTMLDivElement;
 let root: Root;
 let resumes: number;
 
-async function render(approvals: ApprovalSummary[]) {
+async function render(approvals: ApprovalSummary[], dragging = false) {
   resumes = 0;
   await act(async () => {
     root.render(
       createElement(TaskItem, {
         task: card(),
-        dragging: false,
+        dragging,
         block: taskApprovalBlock(approvals, "task-1"),
         now: NOW,
         onOpen: () => {},
@@ -102,6 +102,17 @@ afterEach(async () => {
 });
 
 describe("a paused card with approvals outstanding", () => {
+  it("looks lifted while the board is carrying it", async () => {
+    await render([], true);
+
+    const card = container.firstElementChild;
+    expect(card).not.toBeNull();
+    expect(card?.className).toContain("-translate-y-1");
+    expect(card?.className).toContain("rotate-1");
+    expect(card?.className).toContain("shadow-xl");
+    expect(card?.className).not.toContain("opacity-50");
+  });
+
   it("names the one call it is blocked on, rather than the mechanism", async () => {
     await render([parked("a1", "web_fetch")]);
     // `approvalAction`'s words — the same function the Approvals page and the


### PR DESCRIPTION
## Summary
- lift active task cards with a small rise, rotation, and pronounced shadow instead of dimming them like disabled content
- give populated drop targets a primary border, stronger accent wash, and visible ring
- cover both rendered drag states with focused unit assertions

Closes #1485

## Validation
- npm test
- npm run typecheck:unit
- npm run typecheck
- npm run typecheck:e2e
- npm run build
- cargo build --locked --bin opencompany

I also attempted npm run e2e -- board-drag.spec.ts, but Playwright could not create its transform cache because the hosted sandbox quota was exhausted (OS error 122), before any browser test started. The change deliberately preserves the existing native drag/drop, miss-toast, and optimistic-revert paths; it only strengthens the lifted-card and populated-target feedback.