### PR TITLE
feat(desk-create): add teammate filter and selection checkmarks

### DIFF
--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -9,7 +9,7 @@
 // dialog at all, so creating a desk was impossible outside the manifest.
 
 import { useEffect, useId, useRef, useState } from "react";
-import { Crown } from "lucide-react";
+import { Check, Crown } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { DeskDto, TeamMemberDto } from "@/api/types";
@@ -48,6 +48,7 @@ export function DeskCreateDialog({
   // The chosen member ids, in selection order — the first is the desk lead.
   const [members, setMembers] = useState<string[]>([]);
   const [roster, setRoster] = useState<TeamMemberDto[]>([]);
+  const [memberFilter, setMemberFilter] = useState("");
   const [submitting, setSubmitting] = useState(false);
   // Two kinds of message, deliberately kept apart (issue #1100). `nameError` is
   // about one field and renders at that field; `error` is the host's refusal of
@@ -67,6 +68,7 @@ export function DeskCreateDialog({
     setName("");
     setDescription("");
     setMembers([]);
+    setMemberFilter("");
     setNameError(null);
     setError(null);
     let live = true;
@@ -95,6 +97,12 @@ export function DeskCreateDialog({
     const member = roster.find((r) => r.id === id);
     return member?.name ?? member?.role ?? id;
   }
+
+  const memberFilterNeedle = memberFilter.trim().toLowerCase();
+  const visibleRoster = roster.filter((member) => {
+    const label = member.name ?? member.role ?? member.id;
+    return !memberFilterNeedle || label.toLowerCase().includes(memberFilterNeedle);
+  });
 
   async function submit() {
     if (!name.trim()) {
@@ -191,7 +199,17 @@ export function DeskCreateDialog({
             </p>
           ) : (
             <div className="flex flex-col gap-1.5">
-              {roster.map((member) => {
+              {roster.length > 8 && (
+                <Input
+                  value={memberFilter}
+                  onChange={(e) => setMemberFilter(e.target.value)}
+                  placeholder="Filter teammates…"
+                  aria-label="Filter teammates"
+                  data-testid="desk-member-filter"
+                  className="h-8 text-sm"
+                />
+              )}
+              {visibleRoster.map((member) => {
                 const order = members.indexOf(member.id);
                 const selected = order !== -1;
                 return (
@@ -208,6 +226,17 @@ export function DeskCreateDialog({
                     )}
                   >
                     <span className="flex min-w-0 items-center gap-1.5">
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          "flex size-4 shrink-0 items-center justify-center rounded-sm border",
+                          selected
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-muted-foreground/50",
+                        )}
+                      >
+                        {selected && <Check className="size-3" />}
+                      </span>
                       <TeammateAvatar
                         name={member.name ?? member.role}
                         avatar={avatarFor(member.id ?? member.name ?? "")}
@@ -221,12 +250,17 @@ export function DeskCreateDialog({
                     </span>
                     {selected && (
                       <span className="shrink-0 text-xs text-muted-foreground">
-                        {order === 0 ? "lead" : order + 1}
+                        {order === 0 ? "1 · Lead" : order + 1}
                       </span>
                     )}
                   </button>
                 );
               })}
+              {visibleRoster.length === 0 && (
+                <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
+                  No teammates match “{memberFilter.trim()}”.
+                </p>
+              )}
             </div>
           )}
           {members.length > 0 && (

--- a/frontend/test/unit/desk-create-name-error.test.ts
+++ b/frontend/test/unit/desk-create-name-error.test.ts
@@ -62,6 +62,14 @@ function createButton(): HTMLButtonElement {
   return match as HTMLButtonElement;
 }
 
+function rosterButton(name: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-slot="dialog-content"] [aria-pressed]'),
+  ).find((button) => button.textContent?.includes(name));
+  expect(match, `no roster button for ${name}`).toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
 /** Sets a controlled input the way a keystroke would: through the native value
  * setter, so React's own descriptor sees the change and `onChange` fires. */
 function type(input: HTMLInputElement, value: string) {
@@ -204,5 +212,39 @@ describe("the desk creator when the host refuses", () => {
     expect(nameInput().value).toBe("Engineering");
     expect(onOpenChange).not.toHaveBeenCalled();
     expect(createButton().disabled).toBe(false);
+  });
+});
+
+describe("the desk creator teammate picker", () => {
+  it("filters a long roster and makes the chosen order visible", async () => {
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+
+    const filter = inDialog<HTMLInputElement>('[data-testid="desk-member-filter"]');
+    expect(filter, "long rosters need a name filter").toBeTruthy();
+    expect(rosterButton("Teammate 0").getAttribute("aria-pressed")).toBe("false");
+
+    await act(async () => {
+      rosterButton("Teammate 0").click();
+      rosterButton("Teammate 2").click();
+    });
+
+    const lead = rosterButton("Teammate 0");
+    const second = rosterButton("Teammate 2");
+    expect(lead.getAttribute("aria-pressed")).toBe("true");
+    expect(lead.textContent).toContain("1 · Lead");
+    expect(lead.querySelector(".lucide-check")).toBeTruthy();
+    expect(second.getAttribute("aria-pressed")).toBe("true");
+    expect(second.textContent).toContain("2");
+
+    await act(async () => {
+      type(filter!, "Teammate 2");
+    });
+
+    expect(rosterButton("Teammate 2")).toBeTruthy();
+    expect(
+      Array.from(document.querySelectorAll('[data-slot="dialog-content"] [aria-pressed]')).some((button) =>
+        button.textContent?.includes("Teammate 0"),
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add a name filter for desk rosters longer than eight teammates
- add checkbox-style selection indicators and render selection order as 1 · Lead, 2, 3
- cover filtering, visible selection state, and lead ordering in the desk-create dialog unit test

Closes #1438

## Validation
- pnpm --dir frontend test -- desk-create-name-error (the configured Vitest command ran the full unit suite)
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Interpretation
The issue does not set a roster-length threshold, so the filter appears at nine or more teammates. Existing avatars from #1430 are preserved; no avatar work was duplicated.