### PR TITLE
fix(setup): require credentials before testing connection

### DIFF
--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -1118,8 +1118,12 @@ function PowerStep({
   // The house already holds one, and this operator may have no way to get their
   // own. The key box is then optional rather than the point of the screen.
   const onTheHouse = status.inference.ready && provider === status.inference.provider;
+  // "Use my own" flips the gate: the host credential is only testable while
+  // that is the operator's actual choice. Once they opt to supply their own
+  // key, an empty box must not test anything — a test with no key probes the
+  // host credential and would report a pass for a key they never provided.
   const canTest =
-    (!spec.needsKey || onTheHouse || value.trim().length > 0) &&
+    (!spec.needsKey || (onTheHouse && !override) || value.trim().length > 0) &&
     (!spec.needsUrl || baseUrl.trim().length > 0);
 
   const run = async () => {

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -1118,8 +1118,16 @@ function PowerStep({
   // The house already holds one, and this operator may have no way to get their
   // own. The key box is then optional rather than the point of the screen.
   const onTheHouse = status.inference.ready && provider === status.inference.provider;
+  const canTest =
+    (!spec.needsKey || onTheHouse || value.trim().length > 0) &&
+    (!spec.needsUrl || baseUrl.trim().length > 0);
 
   const run = async () => {
+    // This also protects the Enter shortcut on the inputs. A disabled button
+    // alone would still leave that route to a request the provider cannot
+    // answer usefully.
+    if (!canTest) return;
+
     onTested({ kind: "testing" });
     try {
       const result = await testInference(client, {
@@ -1287,7 +1295,7 @@ function PowerStep({
         <Button
           type="button"
           variant={tested.kind === "ok" ? "outline" : "default"}
-          disabled={tested.kind === "testing"}
+          disabled={tested.kind === "testing" || !canTest}
           onClick={() => void run()}
           data-testid="setup-test-connection"
         >

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -311,6 +311,7 @@ describe("finishing setup with no companies on the host", () => {
       }),
     );
 
+    await fill("setup-field-key", "rejected-key");
     await act(async () => {
       (
         container.querySelector('[data-testid="setup-test-connection"]') as HTMLElement
@@ -340,6 +341,7 @@ describe("finishing setup with no companies on the host", () => {
       }),
     );
 
+    await fill("setup-field-key", "working-key");
     await act(async () => {
       (
         container.querySelector('[data-testid="setup-test-connection"]') as HTMLElement
@@ -354,6 +356,44 @@ describe("finishing setup with no companies on the host", () => {
     ).toContain("https://example.test/v1");
     await next();
     expect(container.querySelector('[data-testid="setup-field-industry"]')).toBeTruthy();
+  });
+
+  it("requires the selected provider's credential before testing", async () => {
+    let requests = 0;
+    await show(
+      clientWith(status(), {
+        post: async () => {
+          requests += 1;
+          return { ok: true, baseUrl: "https://example.test/v1" };
+        },
+      }),
+    );
+
+    expect(button("Test connection").disabled).toBe(true);
+    await act(async () => {
+      button("Test connection").click();
+    });
+    expect(requests).toBe(0);
+
+    await fill("setup-field-key", "working-key");
+    expect(button("Test connection").disabled).toBe(false);
+    await act(async () => {
+      button("Test connection").click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(requests).toBe(1);
+  });
+
+  it("requires an endpoint before testing Ollama", async () => {
+    await show(clientWith(status()));
+
+    await act(async () => {
+      (container.querySelector('[data-testid="setup-provider-ollama"]') as HTMLElement).click();
+    });
+    expect(button("Test connection").disabled).toBe(true);
+
+    await fill("setup-field-base-url", "http://127.0.0.1:11434/v1");
+    expect(button("Test connection").disabled).toBe(false);
   });
 
 
@@ -385,6 +425,7 @@ describe("finishing setup with no companies on the host", () => {
     ).toBeTruthy();
     // No empty input pretending to be the question.
     expect(container.querySelector('[data-testid="setup-field-key"]')).toBeNull();
+    expect(button("Test connection").disabled).toBe(false);
 
     // Someone who wants their own key can still get the field.
     await act(async () => {

--- a/frontend/test/unit/setup-wizard-finish-gate.test.ts
+++ b/frontend/test/unit/setup-wizard-finish-gate.test.ts
@@ -437,6 +437,39 @@ describe("finishing setup with no companies on the host", () => {
   });
 
   /**
+   * The "Use my own" escape hatch switches the gate too. Once the operator
+   * opts to supply their own key, an empty box must not test anything — a
+   * test with no key probes the host credential and would report a pass for a
+   * key they never provided.
+   */
+  it("requires a key once the operator opts to use their own", async () => {
+    await show(
+      clientWith({
+        ...status(),
+        inference: {
+          ready: true,
+          provider: "managed",
+          base_url: "https://api.tinyhumans.ai/openai/v1",
+        },
+      }),
+    );
+
+    // The host credential is testable as-is.
+    expect(button("Test connection").disabled).toBe(false);
+
+    await act(async () => {
+      (
+        container.querySelector('[data-testid="setup-key-override"]') as HTMLElement
+      ).click();
+    });
+    // Their own key, not yet provided, is nothing to test.
+    expect(button("Test connection").disabled).toBe(true);
+
+    await fill("setup-field-key", "own-key");
+    expect(button("Test connection").disabled).toBe(false);
+  });
+
+  /**
    * A regression guard for a bug that reached a screenshot: `\u2014` written
    * into JSX text, where nothing interprets it, so the operator read a literal
    * escape sequence where an em dash belonged.


### PR DESCRIPTION
## Summary

- Disable connection testing until the selected provider has its required key and endpoint.
- Guard the probe itself so the input Enter shortcut cannot send an incomplete request.
- Preserve testing with a host-resolved key and cover managed-key and Ollama endpoint readiness.

Closes #1432

## Validation

- `npm run typecheck:unit`
- `npm test -- --run test/unit/setup-wizard-finish-gate.test.ts`
- `npm run build`
- `npm test` *(not green: `test/unit/mock-brain.test.ts` times out starting its mock-server subprocess; reproduced when run alone. The full run also reported delayed `client.post is not a function` errors from unrelated workflow-editor tests.)*

## Scope

This takes the issue's disable-and-explain interpretation: required credentials and endpoints gate the probe; a host-provided credential remains a valid ready state. I left the adjacent skip-link viewport observation unchanged because it needs a separate browser-layout verification.