### PR TITLE
fix(usage): distinguish unavailable usage from zero spend

### DIFF
--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -313,7 +313,7 @@ export function UsageView({ client, company }: Props) {
                   <CapabilityRow key={tier.namespace} tier={tier} />
                 ))}
               </div>
-            ) : capsLoaded && caps?.configured && caps.total ? null : (
+            ) : capsLoaded && caps?.configured && caps.total ? null : capsUnavailable ? null : (
               <p className="py-2 text-sm text-muted-foreground">
                 {capsLoaded ? "No token plan configured." : "Loading budgets…"}
               </p>

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -9,11 +9,12 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { Coins, CreditCard, Gauge, Plug, Search, Zap } from "lucide-react";
+import { Coins, CreditCard, Gauge, Plug, Search, TriangleAlert, Zap } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { CapabilityStatusDto, UsageDto } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Card,
   CardContent,
@@ -73,9 +74,8 @@ interface Props {
   company: string | null;
 }
 
-// The empty usage read — shown before the first fetch resolves and as the
-// fallback when a host doesn't expose the surface yet (404). Real-or-zero: an
-// empty series renders flat rather than inventing numbers.
+// A successful usage read with no activity. Failed reads deliberately do not
+// use this shape: zero is a fact about spend, not a fallback for an unknown.
 const EMPTY_USAGE: UsageDto = {
   series: [],
   byAgent: [],
@@ -94,38 +94,43 @@ const EMPTY_USAGE: UsageDto = {
 /** In-depth usage: token burn over time, by agent, and OAuth calls by provider. */
 export function UsageView({ client, company }: Props) {
   const [range, setRange] = useState("30d");
-  const [data, setData] = useState<UsageDto>(EMPTY_USAGE);
+  const [data, setData] = useState<UsageDto | null>(null);
+  const [usageUnavailable, setUsageUnavailable] = useState(false);
   useEffect(() => {
     let alive = true;
+    setData(null);
+    setUsageUnavailable(false);
     client
       .usage(range, company)
       .then((usage) => {
         if (alive) setData(usage);
       })
-      // Hosts without the surface (older builds) 404 — show the empty state
-      // rather than fabricating a series.
       .catch(() => {
-        if (alive) setData(EMPTY_USAGE);
+        if (alive) setUsageUnavailable(true);
       });
     return () => {
       alive = false;
     };
   }, [client, company, range]);
-  const { totals } = data;
+  const displayedData = data ?? EMPTY_USAGE;
+  const { totals } = displayedData;
 
   // Capability budgets (issue #108) — the one live-wired card on this view.
   const [caps, setCaps] = useState<CapabilityStatusDto | null>(null);
   const [capsLoaded, setCapsLoaded] = useState(false);
+  const [capsUnavailable, setCapsUnavailable] = useState(false);
   useEffect(() => {
     let alive = true;
+    setCaps(null);
+    setCapsLoaded(false);
+    setCapsUnavailable(false);
     client
       .capabilityStatus(company)
       .then((status) => {
         if (alive) setCaps(status);
       })
-      // Hosts without the surface (older builds) 404 — treat as unconfigured.
       .catch(() => {
-        if (alive) setCaps({ configured: false });
+        if (alive) setCapsUnavailable(true);
       })
       .finally(() => {
         if (alive) setCapsLoaded(true);
@@ -159,25 +164,36 @@ export function UsageView({ client, company }: Props) {
           </Select>
         </div>
 
+        {usageUnavailable ? (
+          <Alert data-testid="usage-unavailable">
+            <TriangleAlert className="size-4" />
+            <AlertDescription>
+              This host does not report usage, so totals and charts are unavailable.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
         {/* KPIs */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
-          <Kpi icon={Coins} label="Total tokens" value={compact(totals.tokens)} hint={`${compact(totals.inputTokens)} in · ${compact(totals.outputTokens)} out`} />
+          <Kpi icon={Coins} label="Total tokens" value={data ? compact(totals.tokens) : "—"} hint={data ? `${compact(totals.inputTokens)} in · ${compact(totals.outputTokens)} out` : "—"} />
           <Kpi
             icon={CreditCard}
             label="Cost"
             value={
-              data.costHidden
+              !data
+                ? "—"
+                : data.costHidden
                 ? "Cost hidden"
                 : formatUsdCost({ amountUsd: totals.costUsd }, "total") ?? "$0.00"
             }
-            hint="Source USD · tokens plus metered calls"
+            hint={data ? "Source USD · tokens plus metered calls" : "—"}
           />
-          <Kpi icon={Zap} label="OAuth calls" value={compact(totals.oauthCalls)} hint={`Across ${totals.connections} providers`} />
-          <Kpi icon={Plug} label="Connections" value={String(totals.connections)} hint="Active integrations" />
+          <Kpi icon={Zap} label="OAuth calls" value={data ? compact(totals.oauthCalls) : "—"} hint={data ? `Across ${totals.connections} providers` : "—"} />
+          <Kpi icon={Plug} label="Connections" value={data ? String(totals.connections) : "—"} hint={data ? "Active integrations" : "—"} />
           {/* Issue #238. Its own KPI rather than a line inside "OAuth calls":
               a search is a priced call on the managed platform, not a connected
               account, and folding it in would overstate integrations. */}
-          <Kpi icon={Search} label="Web searches" value={compact(totals.searchCalls ?? 0)} hint="Billed per search" />
+          <Kpi icon={Search} label="Web searches" value={data ? compact(totals.searchCalls ?? 0) : "—"} hint={data ? "Billed per search" : "—"} />
         </div>
 
         {/* Tokens over time */}
@@ -188,7 +204,7 @@ export function UsageView({ client, company }: Props) {
           </CardHeader>
           <CardContent>
             <ChartContainer config={chartConfig} className="h-64 w-full">
-              <AreaChart data={data.series} margin={{ left: 4, right: 8, top: 4 }}>
+              <AreaChart data={displayedData.series} margin={{ left: 4, right: 8, top: 4 }}>
                 <CartesianGrid vertical={false} />
                 <XAxis
                   dataKey="date"
@@ -217,7 +233,7 @@ export function UsageView({ client, company }: Props) {
             </CardHeader>
             <CardContent>
               <ChartContainer config={chartConfig} className="h-64 w-full">
-                <BarChart data={data.byAgent} layout="vertical" margin={{ left: 8, right: 40 }}>
+                <BarChart data={displayedData.byAgent} layout="vertical" margin={{ left: 8, right: 40 }}>
                   <XAxis type="number" dataKey="tokens" hide />
                   <YAxis type="category" dataKey="name" tickLine={false} axisLine={false} width={96} />
                   <ChartTooltip content={<ChartTooltipContent formatter={(v) => `${compact(Number(v))} tokens`} />} />
@@ -227,11 +243,11 @@ export function UsageView({ client, company }: Props) {
                 </BarChart>
               </ChartContainer>
               <div className="mt-3 divide-y rounded-md border">
-                {data.byAgent.map((agent) => (
+                {displayedData.byAgent.map((agent) => (
                   <div key={agent.name} className="flex items-center justify-between gap-3 px-3 py-2 text-xs">
                     <span className="min-w-0 truncate">{agent.name}</span>
                     <span className="shrink-0 font-medium tabular-nums">
-                      {data.costHidden
+                      {displayedData.costHidden
                         ? "Cost hidden"
                         : formatUsdCost({ amountUsd: agent.costUsd }, "total") ?? "$0.00"}
                     </span>
@@ -249,7 +265,7 @@ export function UsageView({ client, company }: Props) {
             </CardHeader>
             <CardContent>
               <ChartContainer config={chartConfig} className="h-64 w-full">
-                <BarChart data={data.byProvider} layout="vertical" margin={{ left: 8, right: 40 }}>
+                <BarChart data={displayedData.byProvider} layout="vertical" margin={{ left: 8, right: 40 }}>
                   <XAxis type="number" dataKey="calls" hide />
                   <YAxis type="category" dataKey="provider" tickLine={false} axisLine={false} width={96} />
                   <ChartTooltip content={<ChartTooltipContent formatter={(v) => `${compact(Number(v))} calls`} />} />
@@ -276,6 +292,14 @@ export function UsageView({ client, company }: Props) {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
+            {capsUnavailable ? (
+              <Alert data-testid="capability-status-unavailable">
+                <TriangleAlert className="size-4" />
+                <AlertDescription>
+                  This host does not report capability status, so grants and budgets are unavailable.
+                </AlertDescription>
+              </Alert>
+            ) : null}
             {/* Plan-level total token ceiling (issue #188): a HARD stop — once
                 spend crosses it the harness refuses to dispatch further turns,
                 unlike the soft per-namespace bars below. Rendered first, and on

--- a/frontend/test/unit/usage-view-unavailable.test.ts
+++ b/frontend/test/unit/usage-view-unavailable.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { UsageDto } from "@/api/types";
+import { UsageView } from "@/views/UsageView";
+
+const ZERO_USAGE: UsageDto = {
+  series: [],
+  byAgent: [],
+  byProvider: [],
+  totals: {
+    inputTokens: 0,
+    outputTokens: 0,
+    tokens: 0,
+    costUsd: 0,
+    oauthCalls: 0,
+    connections: 0,
+    searchCalls: 0,
+  },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(UsageView, { client, company: null }));
+  });
+}
+
+function text(): string {
+  return document.body.textContent ?? "";
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("UsageView on a host without usage surfaces", () => {
+  it("does not present rejected usage and capability reads as zero or unconfigured", async () => {
+    await render({
+      usage: async () => {
+        throw new Error("usage route not found");
+      },
+      capabilityStatus: async () => {
+        throw new Error("capability route not found");
+      },
+    } as unknown as OpenCompanyClient);
+
+    expect(document.querySelector('[data-testid="usage-unavailable"]')?.textContent).toContain(
+      "does not report usage",
+    );
+    expect(document.querySelector('[data-testid="capability-status-unavailable"]')?.textContent).toContain(
+      "does not report capability status",
+    );
+    expect(text()).toContain("Total tokens—");
+    expect(text()).toContain("Cost—");
+    expect(text()).not.toContain("No token plan configured.");
+  });
+
+  it("keeps a successful zero-usage read distinct from an unavailable one", async () => {
+    await render({
+      usage: async () => ZERO_USAGE,
+      capabilityStatus: async () => ({ configured: false }),
+    } as unknown as OpenCompanyClient);
+
+    expect(document.querySelector('[data-testid="usage-unavailable"]')).toBeNull();
+    expect(text()).toContain("Total tokens0");
+    expect(text()).toContain("Cost$0.00");
+    expect(text()).toContain("No token plan configured.");
+  });
+});


### PR DESCRIPTION
## Summary
- show an explicit unavailable state instead of zero usage KPIs when a host does not serve the usage endpoint
- keep a successful zero-usage response unchanged, and distinguish an unavailable capability-status endpoint from an unconfigured plan
- add DOM regression coverage for unavailable and genuine-zero responses

Closes #1425

## Validation
- npm run typecheck
- npm run typecheck:e2e
- npm run typecheck:unit
- npm test
- npm run build

## Scope
I treated rejected usage and capability-status reads as unavailable, regardless of whether the host reports a 404 or another request failure, because the client does not expose an HTTP-status-specific branch. No backend behavior was changed.