### PR TITLE
feat(agent-detail): surface desks and open work

### DIFF
--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { setInboxEnabled } from "@/api/inbox";
-import { listTasks } from "@/api/tasks";
+import { listTasks, type Task } from "@/api/tasks";
 import { ApiError, type AgentDetailDto } from "@/api/types";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Badge } from "@/components/ui/badge";
@@ -135,6 +135,8 @@ export function AgentDetailView({
    * than an invented "idle · 0 open".
    */
   const [workload, setWorkload] = useState<Workload | null>(null);
+  /** The open cards assigned directly to this teammate, when the board is readable. */
+  const [openTasks, setOpenTasks] = useState<Task[] | null>(null);
   /** An inbox write is in flight; the switch is held until the host answers. */
   const [inboxSaving, setInboxSaving] = useState(false);
   /**
@@ -216,6 +218,7 @@ export function AgentDetailView({
     let live = true;
     if (!company) {
       setWorkload(null);
+      setOpenTasks(null);
       return;
     }
     void (async () => {
@@ -226,10 +229,15 @@ export function AgentDetailView({
       if (!live) return;
       // Empty columns is a host whose ledger list carries no board — an absence,
       // not a vocabulary. Same rule as the roster's cards.
-      setWorkload(
-        tasks && columns?.length
-          ? (workloadByAssignee(tasks, columns).get(agentId) ?? { open: 0, status: "idle" })
-          : null,
+      if (!tasks || !columns?.length) {
+        setWorkload(null);
+        setOpenTasks(null);
+        return;
+      }
+      setWorkload(workloadByAssignee(tasks, columns).get(agentId) ?? { open: 0, status: "idle" });
+      const closed = new Set(columns.filter((column) => column.closed).map((column) => column.id));
+      setOpenTasks(
+        tasks.filter((task) => task.assignee.trim() === agentId && !closed.has(task.column)),
       );
     })();
     return () => {
@@ -488,6 +496,7 @@ export function AgentDetailView({
               }
             />
             <FactLine agent={agent} workload={workload} />
+            <OpenTasks tasks={openTasks} />
 
             {/* The Edit action sits on the teammate's name row (issue #1434) —
                 one editing action, in the place a page's actions live, rather
@@ -597,7 +606,6 @@ export function AgentDetailView({
               onRemoveCap={() => void applyBudget(null)}
               onResetBudget={() => void resetBudget()}
             />
-            <Desks agent={agent} />
           </>
         )}
       </div>
@@ -613,7 +621,7 @@ export function AgentDetailView({
   );
 }
 
-/** Name, role, id, and the two facts that classify an agent. */
+/** Name, role, id, desks, and the two facts that classify an agent. */
 function Identity({ agent, action }: { agent: AgentDetailDto; action?: ReactNode }) {
   const display = agent.name?.trim() || agent.role;
   const seed = agent.id || display;
@@ -656,6 +664,19 @@ function Identity({ agent, action }: { agent: AgentDetailDto; action?: ReactNode
             <Badge variant="outline" data-testid="agent-source">
               {agent.source === "manifest" ? "Company blueprint" : "Added here"}
             </Badge>
+            {agent.desks.map((desk) => (
+              <a
+                key={desk.id}
+                href={`#/company/${encodeURIComponent(desk.id)}`}
+                className="inline-flex"
+                data-testid={`agent-desk-${desk.id}`}
+              >
+                <Badge variant="secondary" className="gap-1">
+                  <Users className="size-3" aria-hidden /> {desk.name}
+                  {desk.lead && <span className="text-xs opacity-70">(lead)</span>}
+                </Badge>
+              </a>
+            ))}
             {agent.inboxEnabled && (
               <Badge variant="outline" className="gap-1">
                 <Mail className="size-3" /> Inbox
@@ -731,6 +752,28 @@ function FactLine({
           {(agent.budgetUsdDaily ?? 0).toFixed(2)}
         </span>
       )}
+    </div>
+  );
+}
+
+/** The open cards assigned to this teammate, linked to the work behind the count. */
+function OpenTasks({ tasks }: { tasks: Task[] | null }) {
+  if (!tasks?.length) return null;
+  return (
+    <div className="space-y-1" data-testid="agent-open-tasks">
+      <p className="text-xs font-medium text-muted-foreground">Open tasks</p>
+      <div className="flex flex-wrap gap-x-3 gap-y-1">
+        {tasks.map((task) => (
+          <a
+            key={task.id}
+            href={`#/tasks/${encodeURIComponent(task.id)}`}
+            className="text-sm text-primary underline-offset-4 hover:underline"
+            data-testid={`agent-open-task-${task.id}`}
+          >
+            {task.title}
+          </a>
+        ))}
+      </div>
     </div>
   );
 }
@@ -1012,31 +1055,6 @@ function BudgetDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-/** Desk membership, with the lead named. */
-function Desks({ agent }: { agent: AgentDetailDto }) {
-  return (
-    <Section
-      title="Desks"
-      subtitle="The desks this teammate works on. A desk hands its work to its lead first."
-    >
-      {agent.desks.length === 0 ? (
-        <p className="text-sm text-muted-foreground" data-testid="agent-desks-empty">
-          This teammate is not on any desk.
-        </p>
-      ) : (
-        <div className="flex flex-wrap gap-2" data-testid="agent-desks">
-          {agent.desks.map((desk) => (
-            <Badge key={desk.id} variant="secondary" className="gap-1">
-              <Users className="size-3" /> {desk.name}
-              {desk.lead && <span className="text-xs opacity-70">(lead)</span>}
-            </Badge>
-          ))}
-        </div>
-      )}
-    </Section>
   );
 }
 

--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -216,11 +216,13 @@ export function AgentDetailView({
    */
   useEffect(() => {
     let live = true;
-    if (!company) {
-      setWorkload(null);
-      setOpenTasks(null);
-      return;
-    }
+    // Drop the previous teammate's board reading before the new one is read.
+    // The view stays mounted across a hash change, and the agent-detail request
+    // races this one — without this the ready view can render agent B beside
+    // agent A's task links until (or unless) the board request lands.
+    setWorkload(null);
+    setOpenTasks(null);
+    if (!company) return;
     void (async () => {
       const [tasks, columns] = await Promise.all([
         listTasks(client, company).catch(() => null),

--- a/frontend/test/e2e/agent-detail.spec.ts
+++ b/frontend/test/e2e/agent-detail.spec.ts
@@ -109,8 +109,8 @@ test("a company agent opens from its card and shows what it is", async ({ page }
   await expect(tools).toContainText("composio");
   await expect(tools).toContainText("mcp:*");
 
-  // This agent sits on no desk, and says so rather than rendering nothing.
-  await expect(page.getByTestId("agent-desks-empty")).toBeVisible();
+  // This agent sits on no desk, so the identity row carries no desk chip.
+  await expect(page.locator('[data-testid^="agent-desk-"]')).toHaveCount(0);
 
   // `ceo` is a blueprint teammate, and this is the assertion that used to pin
   // the opposite. The Edit affordance was *present and disabled* (#1141) with a
@@ -150,7 +150,9 @@ test("desk membership is on the agent, and an agent is reachable by link", async
 
   await expect(page.getByTestId("agent-name")).toHaveText("Engineer", { timeout: 30_000 });
   await expect(page.getByTestId("agent-tier")).toContainText("Worker");
-  await expect(page.getByTestId("agent-desks")).toContainText("Engineering desk");
+  const desk = page.getByTestId("agent-desk-engineering");
+  await expect(desk).toContainText("Engineering desk");
+  await expect(desk).toHaveAttribute("href", "#/company/engineering");
 });
 
 test("an agent defined in the console can be read back and edited", async ({ page }) => {

--- a/frontend/test/e2e/company-cards.spec.ts
+++ b/frontend/test/e2e/company-cards.spec.ts
@@ -407,6 +407,19 @@ test("#1141 a card opens a teammate, breadcrumbed and editable", async ({ page }
   await expect(page.getByTestId("agent-status")).toHaveText("Working");
   await expect(page.getByTestId("agent-tasks")).toHaveText("2 open tasks");
 
+  // The desk is identity, not a final detail section. Its chip goes to the
+  // desk's shareable chart address, and the workload names each open card so
+  // the count is not a dead end (issue #1433).
+  const desk = page.getByTestId("agent-desk-research");
+  await expect(desk).toContainText("Research");
+  await expect(desk).toContainText("(lead)");
+  await expect(desk).toHaveAttribute("href", "#/company/research");
+  await expect(page.getByTestId("agent-open-task-t1")).toHaveText("Scan competitor pricing");
+  await expect(page.getByTestId("agent-open-task-t1")).toHaveAttribute("href", "#/tasks/t1");
+  await expect(page.getByTestId("agent-open-task-t2")).toHaveText("Draft the weekly brief");
+  await expect(page.getByTestId("agent-open-task-t2")).toHaveAttribute("href", "#/tasks/t2");
+  await expect(page.getByTestId("agent-open-task-t3")).toHaveCount(0);
+
   // Edit is on the header row, not buried in a card halfway down, and this
   // teammate is an overlay so it is live.
   const edit = page.getByTestId("agent-edit");

--- a/frontend/test/e2e/company-cards.spec.ts
+++ b/frontend/test/e2e/company-cards.spec.ts
@@ -432,3 +432,49 @@ test("#1141 a card opens a teammate, breadcrumbed and editable", async ({ page }
   await expect(card(page, "Maya")).toBeVisible({ timeout: 30_000 });
   await expect.poll(() => page.url()).toContain("#/company");
 });
+
+test("#1433 switching teammates drops the previous one's open tasks", async ({ page }) => {
+  await mockApi(page);
+
+  // The board read, under the test's control. `AgentDetailView` stays mounted
+  // across a hash change — `TeamView` renders it without a `key` — so the
+  // agent-detail request for the teammate being opened races the board request
+  // independently. Stalling the board on the second read is what makes that
+  // race deterministic: it is the "and indefinitely if that request hangs" half
+  // of the failure, and it is the half a real slow host produces.
+  //
+  // Registered after `mockApi`, so it wins: Playwright gives the most recently
+  // added handler priority.
+  let stall = false;
+  await page.route("**/tasks", async (route) => {
+    // Deliberately neither fulfilled nor aborted — the board read never lands.
+    if (stall) return;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(TASKS),
+    });
+  });
+
+  await page.goto("/#/team/maya");
+  await expect(page.getByTestId("agent-open-task-t1")).toBeVisible({ timeout: 30_000 });
+
+  // Same-document navigation, which is what the operator's click does and what
+  // keeps the view mounted. A full `goto` would remount it and prove nothing.
+  stall = true;
+  await page.evaluate(() => {
+    window.location.hash = "#/team/ravi";
+  });
+
+  // Ravi's page is ready…
+  await expect(page.getByTestId("agent-name")).toHaveText("Ravi", { timeout: 30_000 });
+
+  // …and carries no reading of the board at all, rather than Maya's. Before the
+  // fix the previous teammate's task links and workload survived here, because
+  // the effect cleared them only when `company` went falsy — so Ravi rendered
+  // with links to cards that are not his, for as long as the board read took.
+  await expect(page.getByTestId("agent-open-tasks")).toHaveCount(0);
+  await expect(page.getByTestId("agent-open-task-t1")).toHaveCount(0);
+  await expect(page.getByTestId("agent-open-task-t2")).toHaveCount(0);
+  await expect(page.getByTestId("agent-tasks")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- Move desk membership and lead status into the teammate identity block, linked to each desk's established chart address.
- Show every open task assigned directly to the teammate beneath their workload count, linked to its card detail.
- Cover desk and task links in the detail-page browser tests.

Closes #1433

## Validation
- npm run typecheck
- npm run typecheck:e2e
- npm run build
- cargo build --locked --bin opencompany
- PW_BASE_URL=http://127.0.0.1:8081 npm run e2e -- company-cards.spec.ts (12 passed)

npm test ran 2,275 passing tests but exits nonzero for an unrelated delayed unhandled error in workflow-editor-unsaved-work.test.ts: its mocked client lacks post when WorkflowCreateDialog validates a graph.

## Interpretation
I chose the issue's short-list option rather than adding a new board assignee-filter route. The page lists all currently open cards assigned directly to the teammate; cards assigned to a desk remain desk work and are not attributed to its members.