### PR TITLE
fix(settings): canonicalize invalid Settings sub-hashes

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -100,6 +100,7 @@ import { InboxView } from "@/views/InboxView";
 import { MemoryView } from "@/views/MemoryView";
 import { FeedbackView } from "@/views/FeedbackView";
 import { SettingsSection } from "@/views/SettingsSection";
+import { isSettingsPage } from "@/views/settings-pages";
 import { useLocalScope } from "@/connections/ConnectionContext";
 
 // React Flow is heavy and only used here — load it on demand.
@@ -231,6 +232,10 @@ const REWRITE_RETIRED = (
   sub: string | null,
 ): [View, string | null] | null => {
   if (head === "tasks" && taskIdFromSegment(sub) === null) return ["ledgers", BOARD_LEDGER];
+  // Settings owns a fixed table of sub-pages, unlike the entity ids beneath
+  // Team and Workspace. Do not render General under an address that names no
+  // page: a bookmark or shared link must say where it actually lands.
+  if (head === "settings" && sub !== null && !isSettingsPage(sub)) return ["settings", "general"];
   // Bare `#/team` is the Company page now (issue #1141). It rendered the
   // teammate card grid from a route with no nav entry, so nobody arrived at it;
   // the grid is Company's Cards half, and leaving `#/team` answering as well

--- a/frontend/src/views/DevicesView.tsx
+++ b/frontend/src/views/DevicesView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Copy, Laptop, Loader2, TriangleAlert } from "lucide-react";
+import { Copy, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -150,9 +150,7 @@ export function DevicesView({ client, company }: Props) {
     <div className="flex-1 overflow-y-auto" data-testid="devices-view">
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div>
-          <h1 className="flex items-center gap-2 text-lg font-medium">
-            <Laptop className="size-5" /> Devices
-          </h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Devices</h1>
           <p className="text-sm text-muted-foreground">
             The desktop app cannot use this browser&rsquo;s session, so it enrols
             as a device of its own. Create a code here and paste it into the app

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Globe, Loader2, TriangleAlert } from "lucide-react";
+import { Check, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -154,9 +154,7 @@ export function HostingView({ client, company }: Props) {
     <div className="flex-1 overflow-y-auto" data-testid="hosting-view">
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div>
-          <h1 className="flex items-center gap-2 text-lg font-medium">
-            <Globe className="size-5" /> Hosting
-          </h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Hosting</h1>
           <p className="text-sm text-muted-foreground">
             Connect a hosting provider so your teammates can put a site from this
             company&rsquo;s workspace on the internet — with a managed database

--- a/frontend/src/views/SearchView.tsx
+++ b/frontend/src/views/SearchView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, Loader2, Search, TriangleAlert } from "lucide-react";
+import { Check, Loader2, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import { clearSearch, getSearch, saveSearch, type SearchStatus } from "@/api/search";
@@ -191,9 +191,7 @@ export function SearchView({ client, company }: Props) {
     <div className="flex-1 overflow-y-auto" data-testid="search-view">
       <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
         <div>
-          <h1 className="flex items-center gap-2 text-lg font-medium">
-            <Search className="size-5" /> Search
-          </h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Search</h1>
           <p className="text-sm text-muted-foreground">
             Where your teammates look things up. Every teammate that can search
             gets one <code>web_search</code> tool — this decides which index

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -64,7 +64,7 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
       <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
         {/* This sub-page draws no visible title of its own — the sub-nav rail
             beside it already says "Settings" (issue #1221). */}
-        <h1 className="text-2xl font-semibold tracking-tight lg:sr-only">General settings</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">General settings</h1>
         {/* Pairing this machine. Renders nothing in a browser, where the
             session cookie already works. */}
         <DevicePairing />

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -62,8 +62,8 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
-        {/* This sub-page draws no visible title of its own — the sub-nav rail
-            beside it already says "Settings" (issue #1221). */}
+        {/* Settings pages share one visible heading treatment. The rail names
+            the section; this names the page currently open within it. */}
         <h1 className="text-2xl font-semibold tracking-tight">General settings</h1>
         {/* Pairing this machine. Renders nothing in a browser, where the
             session cookie already works. */}

--- a/frontend/src/views/settings-pages.ts
+++ b/frontend/src/views/settings-pages.ts
@@ -71,8 +71,13 @@ export const SETTINGS_PAGE_GROUPS = [
 export const DEFAULT_SETTINGS_PAGE: SettingsPage = "general";
 
 /** Whether a hash segment names a real sub-page. */
+export function isSettingsPage(sub: string | null): sub is SettingsPage {
+  return SETTINGS_PAGES.some((page) => page.id === sub);
+}
+
+/** Whether a hash segment names a real sub-page. */
 export function resolveSettingsPage(sub: string | null): SettingsPage {
-  return SETTINGS_PAGES.some((p) => p.id === sub) ? (sub as SettingsPage) : DEFAULT_SETTINGS_PAGE;
+  return isSettingsPage(sub) ? sub : DEFAULT_SETTINGS_PAGE;
 }
 
 /**

--- a/frontend/test/unit/settings-navigation.test.ts
+++ b/frontend/test/unit/settings-navigation.test.ts
@@ -4,7 +4,11 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { SETTINGS_PAGE_GROUPS, SETTINGS_PAGES } from "@/views/settings-pages";
+import {
+  isSettingsPage,
+  SETTINGS_PAGE_GROUPS,
+  SETTINGS_PAGES,
+} from "@/views/settings-pages";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
@@ -25,6 +29,12 @@ describe("Settings navigation (issue #1468)", () => {
     expect(SETTINGS_PAGES.find((page) => page.id === "general")?.hint).toContain("Approvals");
   });
 
+  it("distinguishes Settings page ids from unknown sub-hashes", () => {
+    expect(isSettingsPage("general")).toBe(true);
+    expect(isSettingsPage("nonsense")).toBe(false);
+    expect(isSettingsPage(null)).toBe(false);
+  });
+
   it("renders linkable rows and gives narrow-screen navigation its missing context", () => {
     const section = read("views/SettingsSection.tsx");
     const settings = read("views/SettingsView.tsx");
@@ -32,6 +42,6 @@ describe("Settings navigation (issue #1468)", () => {
     expect(section.match(/href=\{`#\/settings\/\$\{item\.id\}`\}/g)).toHaveLength(2);
     expect(section).toContain("title={item.hint}");
     expect(section).toContain("{activePage.hint}");
-    expect(settings).toContain('className="text-2xl font-semibold tracking-tight lg:sr-only"');
+    expect(settings).toContain('className="text-2xl font-semibold tracking-tight"');
   });
 });

--- a/frontend/test/unit/settings-navigation.test.ts
+++ b/frontend/test/unit/settings-navigation.test.ts
@@ -37,11 +37,23 @@ describe("Settings navigation (issue #1468)", () => {
 
   it("renders linkable rows and gives narrow-screen navigation its missing context", () => {
     const section = read("views/SettingsSection.tsx");
-    const settings = read("views/SettingsView.tsx");
+    const settingsPages = [
+      "SettingsView.tsx",
+      "PeopleView.tsx",
+      "DevicesView.tsx",
+      "ConnectionsView.tsx",
+      "McpServersView.tsx",
+      "HostingView.tsx",
+      "SearchView.tsx",
+      "SkillsView.tsx",
+      "UsageView.tsx",
+    ].map((page) => read(`views/${page}`));
 
     expect(section.match(/href=\{`#\/settings\/\$\{item\.id\}`\}/g)).toHaveLength(2);
     expect(section).toContain("title={item.hint}");
     expect(section).toContain("{activePage.hint}");
-    expect(settings).toContain('className="text-2xl font-semibold tracking-tight"');
+    for (const page of settingsPages) {
+      expect(page).toContain('className="text-2xl font-semibold tracking-tight"');
+    }
   });
 });

--- a/frontend/test/unit/settings-route.test.ts
+++ b/frontend/test/unit/settings-route.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useHashView } from "@/hooks/use-hash-view";
+import { isSettingsPage } from "@/views/settings-pages";
+
+const VIEWS = ["overview", "settings"] as const;
+
+// This is the Settings branch of app-shell.tsx's route rewrite. Settings has a
+// closed page table, so unlike entity-addressed views it can repair an unknown
+// segment before the section renders its default page.
+const REWRITE = (head: string, sub: string | null): [string, string | null] | null =>
+  head === "settings" && sub !== null && !isSettingsPage(sub) ? ["settings", "general"] : null;
+
+describe("Settings hash routes (issue #1422)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let seen: [string, string | null];
+
+  function Probe() {
+    const [view, sub] = useHashView<string>(VIEWS as readonly string[], "overview", REWRITE);
+    seen = [view, sub];
+    return null;
+  }
+
+  async function visit(hash: string) {
+    window.history.replaceState(null, "", hash);
+    await act(async () => {
+      root.render(createElement(Probe));
+    });
+  }
+
+  beforeEach(() => {
+    (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("replaces an unknown Settings sub-hash with General", async () => {
+    await visit("#/settings/nonsense");
+
+    expect(seen).toEqual(["settings", "general"]);
+    expect(window.location.hash).toBe("#/settings/general");
+  });
+
+  it("leaves a real Settings sub-hash alone", async () => {
+    await visit("#/settings/people");
+
+    expect(seen).toEqual(["settings", "people"]);
+    expect(window.location.hash).toBe("#/settings/people");
+  });
+});


### PR DESCRIPTION
## Summary
- Canonicalize an unknown Settings sub-hash to #/settings/general before the section renders its default page.
- Use the shared visible text-2xl heading treatment on all nine current Settings pages.
- Add route and navigation regression coverage.

Closes #1422

## Validation
- npm test -- --run test/unit/settings-navigation.test.ts test/unit/settings-route.test.ts
- npm run typecheck:unit
- npm run typecheck
- npm run build
- npm test (fails outside this change: workspace-repair-reveal-no-write.test.ts observes an unexpected write; WorkflowCreateDialog delayed timers also raise client.post is not a function.)

## Scope
Issue #1583 had already grouped the rail and addressed its responsive layout, so this PR deliberately leaves that landed work intact. The current Settings table has nine pages after Billing moved to Finance; this change applies the shared heading treatment to all nine.