### PR TITLE
fix(approvals): link generic requests to their conversation

### DIFF
--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -38,7 +38,7 @@ import {
 
 import type { OpenCompanyClient } from "@/api/client";
 import { GRANT_DURATIONS, type ApprovalSummary, type GrantScope } from "@/api/types";
-import type { Desk } from "@/lib/desks";
+import { defaultDesks, type Desk } from "@/lib/desks";
 import {
   approvalAction,
   approvalDeadline,

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -404,7 +404,11 @@ export function useApprovalThreadLinks(
     ]).then(([deskDtos, roster]) => {
       if (!live) return;
       setTopology({
-        desks: deskDtos.map(deskFromDto),
+        // Same empty-response fallback as ChatView and AppShell: a company with
+        // no declared `[[group_chat]]` entries still has the default desks, and
+        // an approval raised in one of those (e.g. the `main` thread) must be
+        // resolvable even though `/desks` came back empty.
+        desks: deskDtos.length ? deskDtos.map(deskFromDto) : defaultDesks(),
         members: roster.map(fromDto),
       });
     });

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -378,7 +378,10 @@ export function useApprovalThreadLinks(
     setLinks(new Map());
     if (!threadKey) return;
     let live = true;
-    void Promise.all([client.listDesks(company), client.listTeam(company)])
+    void Promise.all([
+      client.listDesks(company).catch(() => []),
+      client.listTeam(company).catch(() => []),
+    ])
       .then(([deskDtos, roster]) => {
         if (!live) return;
         const desks = deskDtos.map(deskFromDto);
@@ -392,9 +395,6 @@ export function useApprovalThreadLinks(
           ),
         );
       })
-      .catch(() => {
-        if (live) setLinks(new Map());
-      });
     return () => {
       live = false;
     };

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -395,8 +395,10 @@ export function useApprovalThreadLinks(
   );
 
   useEffect(() => {
-    setTopology(null);
-    if (!threadKey) return;
+    if (!threadKey) {
+      setTopology(null);
+      return;
+    }
     let live = true;
     void Promise.all([
       // Same empty-response fallback as ChatView and AppShell: a company with

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -366,13 +366,18 @@ export function approvalThreadLink(
  * Read the small amount of chat topology the Approvals page needs to link a
  * parked request back to its conversation. An unreadable or older route simply
  * leaves the existing card intact: an unresolved thread must not be guessed.
+ *
+ * The desks and roster are the slow-moving half of the join; the approvals
+ * themselves arrive on every poll. Keeping the two apart is what lets a
+ * freshly arrived card on an already-known thread get its "Asked in" link:
+ * an effect that rebuilt the map only when the *set of thread ids* changed
+ * would skip a new approval that shares its thread with one already pending.
  */
 export function useApprovalThreadLinks(
   client: OpenCompanyClient,
   company: string | null,
   approvals: ApprovalSummary[],
 ): Map<string, ApprovalThreadLink> {
-  const [links, setLinks] = useState<Map<string, ApprovalThreadLink>>(() => new Map());
   const threadKey = useMemo(
     () =>
       Array.from(new Set(approvals.map((approval) => approval.thread).filter(Boolean)))
@@ -380,34 +385,38 @@ export function useApprovalThreadLinks(
         .join(","),
     [approvals],
   );
+  const [topology, setTopology] = useState<{ desks: Desk[]; members: TeamMember[] } | null>(
+    null,
+  );
 
   useEffect(() => {
-    setLinks(new Map());
+    setTopology(null);
     if (!threadKey) return;
     let live = true;
     void Promise.all([
       client.listDesks(company).catch(() => []),
       client.listTeam(company).catch(() => []),
-    ])
-      .then(([deskDtos, roster]) => {
-        if (!live) return;
-        const desks = deskDtos.map(deskFromDto);
-        const members = roster.map(fromDto);
-        setLinks(
-          new Map(
-            approvals.flatMap((approval) => {
-              const link = approvalThreadLink(approval, desks, members);
-              return link ? [[approval.id, link] as const] : [];
-            }),
-          ),
-        );
-      })
+    ]).then(([deskDtos, roster]) => {
+      if (!live) return;
+      setTopology({
+        desks: deskDtos.map(deskFromDto),
+        members: roster.map(fromDto),
+      });
+    });
     return () => {
       live = false;
     };
   }, [client, company, threadKey]);
 
-  return links;
+  return useMemo(() => {
+    if (!topology) return new Map();
+    return new Map(
+      approvals.flatMap((approval) => {
+        const link = approvalThreadLink(approval, topology.desks, topology.members);
+        return link ? [[approval.id, link] as const] : [];
+      }),
+    );
+  }, [approvals, topology]);
 }
 
 /**

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -38,6 +38,7 @@ import {
 
 import type { OpenCompanyClient } from "@/api/client";
 import { GRANT_DURATIONS, type ApprovalSummary, type GrantScope } from "@/api/types";
+import type { Desk } from "@/lib/desks";
 import {
   approvalAction,
   approvalDeadline,
@@ -46,7 +47,10 @@ import {
   payloadAge,
   payloadLines,
 } from "@/lib/language";
+import type { TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
+import { channelIdForThread, deskFromDto, dmChannelId } from "@/views/chat/model";
+import { fromDto } from "@/lib/team";
 
 const KIND_ICONS: Record<string, LucideIcon> = {
   "payment.send": CreditCard,
@@ -121,11 +125,14 @@ export function ApprovalMeta({
   approval: a,
   now,
   askerNames,
+  thread,
   status,
 }: {
   approval: ApprovalSummary;
   now: number;
   askerNames: Map<string, string>;
+  /** The chat channel that raised this request, when the host named one. */
+  thread?: ApprovalThreadLink | null;
   /** Trailing status text ("Waiting for the teammate…", "Approved"), if any. */
   status?: React.ReactNode;
 }) {
@@ -146,6 +153,20 @@ export function ApprovalMeta({
         <>
           <span>
             Asked by <span className="font-medium text-foreground">{asker}</span>
+          </span>
+          <span aria-hidden>·</span>
+        </>
+      )}
+      {thread && (
+        <>
+          <span>
+            Asked in{" "}
+            <a
+              href={`#/chat/${encodeURIComponent(thread.channelId)}`}
+              className="font-medium text-foreground underline-offset-2 hover:underline"
+            >
+              {thread.label}
+            </a>
           </span>
           <span aria-hidden>·</span>
         </>
@@ -258,7 +279,13 @@ export function ApprovalPayload({ approval }: { approval: ApprovalSummary }) {
     );
   }
 
-  if (lines.length === 0) return null;
+  if (lines.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No further details were supplied.
+      </p>
+    );
+  }
 
   const clampable =
     lines.length > PREVIEW_LINES || lines.some((l) => l.value.length > PREVIEW_VALUE_CHARS);
@@ -291,6 +318,85 @@ export function ApprovalPayload({ approval }: { approval: ApprovalSummary }) {
       )}
     </div>
   );
+}
+
+/** A resolved chat destination for an approval's host-side thread id. */
+export interface ApprovalThreadLink {
+  channelId: string;
+  /** A channel is written with `#`; a direct message is written as a name. */
+  label: string;
+}
+
+/**
+ * Resolve an approval's host thread id into the human-facing chat destination.
+ *
+ * The host calls desk channels by their desk id, while direct messages use an
+ * agent id. `channelIdForThread` is the one place that bridges those two id
+ * schemes; keeping this join here prevents the Approvals page from linking a
+ * DM to a URL no chat channel owns.
+ */
+export function approvalThreadLink(
+  approval: ApprovalSummary,
+  desks: Desk[],
+  members: TeamMember[],
+): ApprovalThreadLink | null {
+  if (!approval.thread) return null;
+  const channelId = channelIdForThread(approval.thread, desks, members);
+  if (!channelId) return null;
+
+  const desk = desks.find((candidate) => candidate.id === approval.thread);
+  if (desk) return { channelId, label: `#${desk.channel}` };
+
+  const member = members.find((candidate) => candidate.id === approval.thread);
+  return member ? { channelId: dmChannelId(member), label: member.name } : null;
+}
+
+/**
+ * Read the small amount of chat topology the Approvals page needs to link a
+ * parked request back to its conversation. An unreadable or older route simply
+ * leaves the existing card intact: an unresolved thread must not be guessed.
+ */
+export function useApprovalThreadLinks(
+  client: OpenCompanyClient,
+  company: string | null,
+  approvals: ApprovalSummary[],
+): Map<string, ApprovalThreadLink> {
+  const [links, setLinks] = useState<Map<string, ApprovalThreadLink>>(() => new Map());
+  const threadKey = useMemo(
+    () =>
+      Array.from(new Set(approvals.map((approval) => approval.thread).filter(Boolean)))
+        .sort()
+        .join(","),
+    [approvals],
+  );
+
+  useEffect(() => {
+    setLinks(new Map());
+    if (!threadKey) return;
+    let live = true;
+    void Promise.all([client.listDesks(company), client.listTeam(company)])
+      .then(([deskDtos, roster]) => {
+        if (!live) return;
+        const desks = deskDtos.map(deskFromDto);
+        const members = roster.map(fromDto);
+        setLinks(
+          new Map(
+            approvals.flatMap((approval) => {
+              const link = approvalThreadLink(approval, desks, members);
+              return link ? [[approval.id, link] as const] : [];
+            }),
+          ),
+        );
+      })
+      .catch(() => {
+        if (live) setLinks(new Map());
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company, threadKey]);
+
+  return links;
 }
 
 /**

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -47,10 +47,9 @@ import {
   payloadAge,
   payloadLines,
 } from "@/lib/language";
-import type { TeamMember } from "@/lib/team";
+import { fromDto, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import { channelIdForThread, deskFromDto, dmChannelId } from "@/views/chat/model";
-import { fromDto } from "@/lib/team";
 
 const KIND_ICONS: Record<string, LucideIcon> = {
   "payment.send": CreditCard,

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -168,7 +168,12 @@ export function ApprovalMeta({
           <span>
             Asked in{" "}
             <a
-              href={`#/chat/${encodeURIComponent(thread.channelId)}`}
+              // Written raw, not `encodeURIComponent`-ed: a DM's channel id is
+              // `dm:<agent-id>`, and the hash router splits `#/chat/…` on "/"
+              // without decoding, so an encoded `:` would look up a channel
+              // that does not exist. Every channel id is a slug or `dm:<uuid>`,
+              // which the hash already allows unescaped.
+              href={`#/chat/${thread.channelId}`}
               className="font-medium text-foreground underline-offset-2 hover:underline"
             >
               {thread.label}

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -278,13 +278,18 @@ export function ApprovalPayload({ approval }: { approval: ApprovalSummary }) {
     );
   }
 
-  if (lines.length === 0) {
+  // A named action can still be decided from its headline. The generic
+  // fallback cannot: without a payload it otherwise leaves the operator with
+  // no fact at all about what is being approved (#1419).
+  if (lines.length === 0 && approvalAction(approval) === "Do something that needs your sign-off") {
     return (
       <p className="text-xs text-muted-foreground">
         No further details were supplied.
       </p>
     );
   }
+
+  if (lines.length === 0) return null;
 
   const clampable =
     lines.length > PREVIEW_LINES || lines.some((l) => l.value.length > PREVIEW_VALUE_CHARS);

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -399,18 +399,19 @@ export function useApprovalThreadLinks(
     if (!threadKey) return;
     let live = true;
     void Promise.all([
-      client.listDesks(company).catch(() => []),
+      // Same empty-response fallback as ChatView and AppShell: a company with
+      // no declared `[[group_chat]]` entries still has the default desks, and
+      // an approval raised in one of those (e.g. the `main` thread) must be
+      // resolvable even though `/desks` came back empty. The fallback lives in
+      // the success handler on purpose — a failed read must not be guessed at.
+      client
+        .listDesks(company)
+        .then((dtos) => (dtos.length ? dtos.map(deskFromDto) : defaultDesks()))
+        .catch(() => []),
       client.listTeam(company).catch(() => []),
-    ]).then(([deskDtos, roster]) => {
+    ]).then(([desks, roster]) => {
       if (!live) return;
-      setTopology({
-        // Same empty-response fallback as ChatView and AppShell: a company with
-        // no declared `[[group_chat]]` entries still has the default desks, and
-        // an approval raised in one of those (e.g. the `main` thread) must be
-        // resolvable even though `/desks` came back empty.
-        desks: deskDtos.length ? deskDtos.map(deskFromDto) : defaultDesks(),
-        members: roster.map(fromDto),
-      });
+      setTopology({ desks, members: roster.map(fromDto) });
     });
     return () => {
       live = false;

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -170,7 +170,7 @@ export function ApprovalsView({
    */
   const { items: rows, containerProps: queueHold } = useStableList(visible);
   const askerNames = useAskerNames(client, company, approvals);
-  const threadLinks = useApprovalThreadLinks(client, company, approvals);
+  const threadLinks = useApprovalThreadLinks(client, company, rows);
   const { grants, granterNames, refreshGrants } = useStandingGrants(client, company);
   /**
    * How many rows each turn's batch still has waiting (#842).

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -604,8 +604,10 @@ function granterLabel(g: StandingGrant, granterNames: Map<string, string>): stri
  *
  * **An old host degrades to the pre-#372 card by construction.** It omits
  * `payload` and `agent` from the wire, so the payload block and the "Asked by"
- * line simply do not render and what is left is the headline, the amount and
- * the relative time — exactly what shipped before.
+ * line simply do not render when the action is named. An unlabelled native
+ * action instead says that no further details were supplied (#1419), because
+ * leaving its generic headline alone would not distinguish one request from
+ * another.
  */
 export function ApprovalCard({
   approval: a,

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -611,6 +611,7 @@ export function ApprovalCard({
   approval: a,
   now,
   askerNames,
+  thread,
   deciding,
   batchIndex,
   batchTotal,
@@ -619,6 +620,7 @@ export function ApprovalCard({
   approval: ApprovalSummary;
   now: number;
   askerNames: Map<string, string>;
+  thread?: import("@/components/approval-card").ApprovalThreadLink | null;
   /** The verdict this card is waiting on, or `null` when it is idle (#373). */
   deciding: Verdict | null;
   /**

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -505,14 +505,12 @@ function StandingPermissions({
   grants,
   now,
   askerNames,
-  thread,
   granterNames,
   onRevoke,
 }: {
   grants: StandingGrant[];
   now: number;
   askerNames: Map<string, string>;
-  thread?: import("@/components/approval-card").ApprovalThreadLink | null;
   /** Actor id → display name; empty when the roster read was not permitted. */
   granterNames: Map<string, string>;
   onRevoke: (id: string) => Promise<void>;

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -18,6 +18,7 @@ import {
   ApprovalPayload,
   ApprovalScopeControl,
   useAskerNames,
+  useApprovalThreadLinks,
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -169,6 +170,7 @@ export function ApprovalsView({
    */
   const { items: rows, containerProps: queueHold } = useStableList(visible);
   const askerNames = useAskerNames(client, company, approvals);
+  const threadLinks = useApprovalThreadLinks(client, company, approvals);
   const { grants, granterNames, refreshGrants } = useStandingGrants(client, company);
   /**
    * How many rows each turn's batch still has waiting (#842).
@@ -378,6 +380,7 @@ export function ApprovalsView({
                   approval={a}
                   now={now}
                   askerNames={askerNames}
+                  thread={threadLinks.get(a.id)}
                   deciding={inFlight.get(a.id) ?? null}
                   batchIndex={batchPos.get(a.id)?.index ?? 1}
                   batchTotal={batchPos.get(a.id)?.total ?? 1}
@@ -502,12 +505,14 @@ function StandingPermissions({
   grants,
   now,
   askerNames,
+  thread,
   granterNames,
   onRevoke,
 }: {
   grants: StandingGrant[];
   now: number;
   askerNames: Map<string, string>;
+  thread?: import("@/components/approval-card").ApprovalThreadLink | null;
   /** Actor id → display name; empty when the roster read was not permitted. */
   granterNames: Map<string, string>;
   onRevoke: (id: string) => Promise<void>;
@@ -671,6 +676,7 @@ export function ApprovalCard({
           approval={a}
           now={now}
           askerNames={askerNames}
+          thread={thread}
           /* Honest copy for a request that spans an agent turn (#373): an
              approve is not done when the button stops spinning, it is handed
              to the agent. A decline IS terminal, so it only has to record. */

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -304,6 +304,7 @@ export function ApprovalRow({
         approvals={pending}
         now={now}
         askerNames={askerNames}
+        thread={thread}
         actions={actions}
         busy={busy}
         status={

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -456,7 +456,13 @@ function CompactApprovalRow({
         <div className="min-w-0 flex-1">
           <CompactLabel approvals={approvals} />
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <ApprovalMeta approval={lead} now={now} askerNames={askerNames} status={status} />
+            <ApprovalMeta
+              approval={lead}
+              now={now}
+              askerNames={askerNames}
+              thread={thread}
+              status={status}
+            />
             {!busy && (
               <a
                 href="#/approvals"

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -416,6 +416,7 @@ function CompactApprovalRow({
   approvals,
   now,
   askerNames,
+  thread,
   actions,
   busy,
   status,
@@ -428,6 +429,8 @@ function CompactApprovalRow({
   approvals: ApprovalSummary[];
   now: number;
   askerNames: Map<string, string>;
+  /** The channel this inline row is already rendered inside (#1419). */
+  thread?: ApprovalThreadLink | null;
   actions: React.ReactNode;
   busy: boolean;
   status?: React.ReactNode;

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -49,6 +49,7 @@ import {
   ApprovalPayload,
   ApprovalScopeControl,
   approvalIcon,
+  type ApprovalThreadLink,
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { approvedLine } from "@/lib/approval-wording";
@@ -145,6 +146,7 @@ export function ApprovalRow({
   approvals,
   now,
   askerNames,
+  thread,
   deciding,
   decided,
   failed,
@@ -154,6 +156,8 @@ export function ApprovalRow({
   approvals: ApprovalSummary[];
   now: number;
   askerNames: Map<string, string>;
+  /** The channel this inline row is already rendered inside. */
+  thread?: ApprovalThreadLink | null;
   /** The verdict an item is waiting on, keyed by approval id; empty when idle. */
   deciding: ReadonlyMap<string, Verdict>;
   /** Verdicts already witnessed — from this console or from the page. */
@@ -306,6 +310,7 @@ export function ApprovalRow({
             approval={lead}
             now={now}
             askerNames={askerNames}
+            thread={thread}
             status={
               busy
                   ? awaiting("approve")

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -12,7 +12,6 @@ import { WorkingIndicator } from "./WorkingIndicator";
 import {
   channelIntroSentence,
   channelTitle,
-  channelTitle,
   dmFace,
   type Channel,
   type TimelineItem,

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -12,6 +12,7 @@ import { WorkingIndicator } from "./WorkingIndicator";
 import {
   channelIntroSentence,
   channelTitle,
+  channelTitle,
   dmFace,
   type Channel,
   type TimelineItem,
@@ -286,6 +287,11 @@ export function MessageTimeline({
               approvals={item.approvals}
               now={now ?? Date.now()}
               askerNames={askerNames ?? EMPTY_NAMES}
+              thread={
+                item.approvals[0]?.thread
+                  ? { channelId: channel.id, label: channelTitle(channel) }
+                  : null
+              }
               /* Narrowed to this card's own items (#842): a decision in flight
                  on another turn's batch is not this card's business, which is
                  the same rule #373 established one level down. */

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import type { ApprovalThreadLink } from "@/components/approval-card";
 import { money } from "@/lib/language";
 import { ApprovalRow } from "@/views/chat/ApprovalRow";
 

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -425,6 +425,26 @@ describe("the consolidated approval card", () => {
     expect(approve.className.split(" ")).not.toContain("bg-primary");
   });
 
+  it("links the compact chat row back to its conversation when the thread resolves", async () => {
+    // The compact branch used to return before the `ApprovalMeta` call that
+    // receives `thread`, so the value MessageTimeline constructs for it was
+    // discarded and an inline card never said where the request was asked
+    // (#1419). Forwarding it keeps the compact row linked too.
+    await render(
+      [ESPN],
+      {},
+      {},
+      new Map(),
+      true,
+      { channelId: "marketing", label: "#marketing" },
+    );
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain("Asked in");
+    const link = row?.querySelector<HTMLAnchorElement>('a[href="#/chat/marketing"]');
+    expect(link?.textContent).toBe("#marketing");
+  });
+
   it("shows the amount beside a monetary approval in the compact chat row", async () => {
     const PAYMENT: ApprovalSummary = {
       id: "a4",

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -104,6 +104,7 @@ async function render(
   failed: Record<string, string> = {},
   deciding: ReadonlyMap<string, Verdict> = new Map(),
   compact = false,
+  thread?: ApprovalThreadLink | null,
 ) {
   await act(async () => {
     root.render(
@@ -112,6 +113,7 @@ async function render(
         now: T0 + 60_000,
         askerNames: new Map([["seo", "SEO Specialist"]]),
         compact,
+        thread,
         deciding,
         decided,
         failed,

--- a/frontend/test/unit/approval-card-context.test.ts
+++ b/frontend/test/unit/approval-card-context.test.ts
@@ -88,8 +88,8 @@ describe("an unlabelled approval without details (#1419)", () => {
     // the ":" into `%3A` would produce a segment no channel matches.
     await render(nativeApproval(), { channelId: "dm:ada-1f3k", label: "Ada" });
 
-    const thread = [...container.querySelectorAll("a")].find((link) =>
-      link.textContent?.includes("#dm:ada-1f3k"),
+    const thread = [...container.querySelectorAll("a")].find(
+      (link) => link.getAttribute("href") === "#/chat/dm:ada-1f3k",
     );
     expect(thread?.getAttribute("href")).toBe("#/chat/dm:ada-1f3k");
   });

--- a/frontend/test/unit/approval-card-context.test.ts
+++ b/frontend/test/unit/approval-card-context.test.ts
@@ -81,4 +81,16 @@ describe("an unlabelled approval without details (#1419)", () => {
     await render(nativeApproval({ thread: "someone-else" }));
     expect(container.textContent).not.toContain("Asked in");
   });
+
+  it("writes a DM channel id unescaped, so the hash router can resolve it", async () => {
+    // A DM's channel id is `dm:<agent-id>`. The hash router splits
+    // `#/chat/…` on "/" without decoding, so `encodeURIComponent` turning
+    // the ":" into `%3A` would produce a segment no channel matches.
+    await render(nativeApproval(), { channelId: "dm:ada-1f3k", label: "Ada" });
+
+    const thread = [...container.querySelectorAll("a")].find((link) =>
+      link.textContent?.includes("#dm:ada-1f3k"),
+    );
+    expect(thread?.getAttribute("href")).toBe("#/chat/dm:ada-1f3k");
+  });
 });

--- a/frontend/test/unit/approval-card-context.test.ts
+++ b/frontend/test/unit/approval-card-context.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
-import { approvalThreadLink } from "@/components/approval-card";
+import { approvalThreadLink, type ApprovalThreadLink } from "@/components/approval-card";
 import type { Desk } from "@/lib/desks";
 import type { TeamMember } from "@/lib/team";
 import { ApprovalCard } from "@/views/ApprovalsView";
@@ -30,14 +30,14 @@ function nativeApproval(over: Partial<ApprovalSummary> = {}): ApprovalSummary {
 let container: HTMLDivElement;
 let root: Root;
 
-async function render(approval: ApprovalSummary) {
+async function render(approval: ApprovalSummary, thread?: ApprovalThreadLink | null) {
   await act(async () => {
     root.render(
       createElement(ApprovalCard, {
         approval,
         now: T0 + 60_000,
         askerNames: new Map(),
-        thread: approvalThreadLink(approval, ENGINEERING, NO_MEMBERS),
+        thread: thread === undefined ? approvalThreadLink(approval, ENGINEERING, NO_MEMBERS) : thread,
         deciding: null,
         batchIndex: 1,
         batchTotal: 1,

--- a/frontend/test/unit/approval-card-context.test.ts
+++ b/frontend/test/unit/approval-card-context.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { approvalThreadLink } from "@/components/approval-card";
+import type { Desk } from "@/lib/desks";
+import type { TeamMember } from "@/lib/team";
+import { ApprovalCard } from "@/views/ApprovalsView";
+
+const T0 = new Date("2026-08-20T20:00:00Z").getTime();
+const ENGINEERING: Desk[] = [
+  { id: "engineering", channel: "engineering", name: "Engineering", blurb: "" },
+];
+const NO_MEMBERS: TeamMember[] = [];
+
+function nativeApproval(over: Partial<ApprovalSummary> = {}): ApprovalSummary {
+  return {
+    id: "a1",
+    kind: "runtime.unlabelled_effect",
+    amount_usd: null,
+    at_millis: T0,
+    agent: null,
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(approval: ApprovalSummary) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalCard, {
+        approval,
+        now: T0 + 60_000,
+        askerNames: new Map(),
+        thread: approvalThreadLink(approval, ENGINEERING, NO_MEMBERS),
+        deciding: null,
+        batchIndex: 1,
+        batchTotal: 1,
+        onDecide: (_verdict: Verdict, _scope: GrantScope) => {},
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("an unlabelled approval without details (#1419)", () => {
+  it("links back to its conversation and says that the host supplied no details", async () => {
+    const approval = nativeApproval({ thread: "engineering" });
+    await render(approval);
+
+    expect(container.textContent).toContain("Do something that needs your sign-off");
+    expect(container.textContent).toContain("No further details were supplied.");
+    const thread = [...container.querySelectorAll("a")].find((link) =>
+      link.textContent?.includes("#engineering"),
+    );
+    expect(thread?.getAttribute("href")).toBe("#/chat/engineering");
+  });
+
+  it("does not invent a conversation for an absent or unresolvable thread", async () => {
+    expect(approvalThreadLink(nativeApproval(), ENGINEERING, NO_MEMBERS)).toBeNull();
+    expect(
+      approvalThreadLink(nativeApproval({ thread: "someone-else" }), ENGINEERING, NO_MEMBERS),
+    ).toBeNull();
+
+    await render(nativeApproval({ thread: "someone-else" }));
+    expect(container.textContent).not.toContain("Asked in");
+  });
+});

--- a/frontend/test/unit/use-approval-thread-links.test.ts
+++ b/frontend/test/unit/use-approval-thread-links.test.ts
@@ -111,4 +111,19 @@ describe("useApprovalThreadLinks", () => {
 
     expect(lastLinks?.get("a1")).toEqual({ channelId: "main", label: "#general" });
   });
+
+  it("does not guess desks when the desks read fails", async () => {
+    // A failed read is not an empty response: ChatView surfaces the error rather
+    // than inventing desks, and the hook's contract is that an unresolved thread
+    // must not be guessed. The `main` thread stays unlinked.
+    const client = {
+      listDesks: vi.fn(async () => {
+        throw new Error("offline");
+      }),
+      listTeam: vi.fn(async () => []),
+    } as unknown as OpenCompanyClient;
+    await render(client, [approval("a1", "main")]);
+
+    expect(lastLinks?.has("a1")).toBe(false);
+  });
 });

--- a/frontend/test/unit/use-approval-thread-links.test.ts
+++ b/frontend/test/unit/use-approval-thread-links.test.ts
@@ -97,4 +97,18 @@ describe("useApprovalThreadLinks", () => {
 
     expect(lastLinks?.has("a1")).toBe(false);
   });
+
+  it("falls back to the default desks when /desks comes back empty", async () => {
+    // A company with no declared `[[group_chat]]` entries gets `[]` from
+    // /desks, yet ChatView and AppShell still show the default desks. An
+    // approval raised in one of those (the `main` thread) must resolve too,
+    // or its "Asked in" link would silently disappear.
+    const client = {
+      listDesks: vi.fn(async () => []),
+      listTeam: vi.fn(async () => []),
+    } as unknown as OpenCompanyClient;
+    await render(client, [approval("a1", "main")]);
+
+    expect(lastLinks?.get("a1")).toEqual({ channelId: "main", label: "#general" });
+  });
 });

--- a/frontend/test/unit/use-approval-thread-links.test.ts
+++ b/frontend/test/unit/use-approval-thread-links.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ApprovalSummary } from "@/api/types";
+import { useApprovalThreadLinks, type ApprovalThreadLink } from "@/components/approval-card";
+
+const T0 = new Date("2026-08-20T20:00:00Z").getTime();
+
+function fakeClient(): OpenCompanyClient {
+  return {
+    listDesks: vi.fn(async () => [{ id: "engineering", name: "Engineering", members: [] }]),
+    listTeam: vi.fn(async () => []),
+  } as unknown as OpenCompanyClient;
+}
+
+function approval(id: string, thread?: string): ApprovalSummary {
+  return {
+    id,
+    kind: "runtime.unlabelled_effect",
+    amount_usd: null,
+    at_millis: T0,
+    agent: null,
+    ...(thread ? { thread } : {}),
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let lastLinks: Map<string, ApprovalThreadLink> | null;
+
+function Probe({
+  client,
+  approvals,
+}: {
+  client: OpenCompanyClient;
+  approvals: ApprovalSummary[];
+}) {
+  lastLinks = useApprovalThreadLinks(client, "acme", approvals);
+  return null;
+}
+
+async function render(client: OpenCompanyClient, approvals: ApprovalSummary[]) {
+  await act(async () => {
+    root.render(createElement(Probe, { client, approvals }));
+  });
+  // The effect resolves `listDesks`/`listTeam` in a microtask; let the
+  // topology land before asserting on the derived links.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  lastLinks = null;
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useApprovalThreadLinks", () => {
+  it("links a pending request whose thread resolves to a desk", async () => {
+    const client = fakeClient();
+    await render(client, [approval("a1", "engineering")]);
+
+    expect(lastLinks?.get("a1")).toEqual({ channelId: "engineering", label: "#engineering" });
+  });
+
+  it("derives links for a newly arrived approval on an already-known thread", async () => {
+    const client = fakeClient();
+    await render(client, [approval("a1", "engineering")]);
+    expect(lastLinks?.get("a1")).toEqual({ channelId: "engineering", label: "#engineering" });
+
+    // The second request shares a1's thread, so the set of distinct thread ids
+    // — the key the topology fetch is keyed on — does not change. The link map
+    // must still pick up a2, or its card would omit the "Asked in" line until
+    // some later thread change rebuilt the map.
+    await render(client, [approval("a1", "engineering"), approval("a2", "engineering")]);
+
+    expect(lastLinks?.get("a1")).toEqual({ channelId: "engineering", label: "#engineering" });
+    expect(lastLinks?.get("a2")).toEqual({ channelId: "engineering", label: "#engineering" });
+  });
+
+  it("leaves an unresolvable thread unlinked", async () => {
+    const client = fakeClient();
+    await render(client, [approval("a1", "someone-else")]);
+
+    expect(lastLinks?.has("a1")).toBe(false);
+  });
+});

--- a/frontend/test/unit/workflow-editor-unsaved-work.test.ts
+++ b/frontend/test/unit/workflow-editor-unsaved-work.test.ts
@@ -60,6 +60,11 @@ function stubClient(): OpenCompanyClient & { puts: unknown[] } {
     listTeam: async () => [],
     get: async (path: string) =>
       path.endsWith("/wired-channels") ? { channels: [] } : [],
+    // The dialog's 700ms preflight debounce calls `validateWorkflow`, which
+    // POSTs the graph. A stub without this throws synchronously out of the
+    // timer when the test runs long enough for it to fire — an unhandled
+    // error that fails the whole `vitest run` despite every test passing.
+    post: async () => ({ valid: true }),
     put: async (_path: string, body: unknown) => {
       puts.push(body);
       return savedGraph();


### PR DESCRIPTION
## Summary

- link approval cards with a known host thread back to their resolved chat channel or DM
- state when an otherwise unlabelled native approval has no additional details
- cover the generic, thread-bearing card plus absent and unresolvable threads

This takes the issue's narrow interpretation: known effect labels and named tool calls retain their existing empty-payload presentation; only the generic fallback gains the explicit no-details sentence.

Review-driven hardening (all covered by regression tests in `frontend/test/unit/`):
- thread links are derived from a cached chat topology, so a freshly arrived card on an already-known thread gets its "Asked in" link immediately
- DM channel ids are written unescaped (`#/chat/dm:<agent-id>`), matching what the hash router's `readSegments()` expects
- an empty `/desks` response falls back to `defaultDesks()`, matching `ChatView`/`AppShell`, so fallback channels like the `main` thread still resolve

Closes #1419

## Validation

- `pnpm --dir frontend run typecheck`
- `pnpm --dir frontend run typecheck:unit`
- `pnpm --dir frontend run typecheck:e2e`
- `pnpm --dir frontend exec vitest run` — 274 files / 2430 tests passing
- `pnpm --dir frontend run build`
- `pnpm --dir frontend run build:pages-sdk`

Branch merged `upstream/main` (compact inline approval rows, #1330) and kept both sides' props.