### PR TITLE
fix(setup): open roster after build

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -390,7 +390,15 @@ function Console() {
   // Now that any credential is captured in state, take it out of the URL.
   useEffect(() => {
     if (magicLink) clearMagicLinkFromUrl();
-    if (hubToken || hubFailed) clearHubResultFromUrl();
+    if (hubToken || hubFailed) {
+      clearHubResultFromUrl();
+      // A hub sign-in that was asked to land on setup's destination carries it
+      // as a query parameter (`?from=setup`) — the host put it there so the
+      // OAuth round trip could carry it. Translate it into the hash marker the
+      // shell consumes, so the sign-in lands on the roster setup just built
+      // with the welcome suppressed, exactly as a setup link would have.
+      absorbHubSetupHandoff();
+    }
   }, [magicLink, hubToken, hubFailed]);
 
   /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import { HostsProvider, useHosts, type HostsValue } from "@/connections/HostsCon
 import { firstHostCopy } from "@/connections/first-host";
 import type { ConnectionId } from "@/connections/types";
 import { useHostAddress, useHostRoute } from "@/hooks/use-host-route";
+import { absorbHubSetupHandoff } from "@/setup/state";
 import { ConnectionConsole } from "@/views/ConnectionConsole";
 import { AddHostPage } from "@/views/setup/AddHostPage";
 import { cn } from "@/lib/utils";

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -182,13 +182,19 @@ export interface HubProvider {
  * An empty list is the normal answer on a self-hosted host and is not an
  * error — it means "no ecosystem here, show the magic-link form alone". So this
  * never throws for that case; callers only need to handle the network failing.
+ *
+ * `from`, when present, is the destination the host should put on the sign-in's
+ * return URI — the console's own fragment cannot cross the OAuth round trip, so
+ * the host carries it as a query parameter the landing reads back. Only setup's
+ * dead-link recovery asks for one today (`from=setup`).
  */
 export async function fetchHubProviders(
   client: OpenCompanyClient,
   company: string | null,
+  from?: string,
 ): Promise<HubProvider[]> {
   const result = await client.get<{ providers: HubProvider[] }>(
-    `${client.scopeFor(company)}/auth/hub`,
+    `${client.scopeFor(company)}/auth/hub${from ? `?from=${encodeURIComponent(from)}` : ""}`,
   );
   return result.providers ?? [];
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -141,8 +141,16 @@ export async function requestCode(
   client: OpenCompanyClient,
   company: string | null,
   email: string,
+  redirect?: string,
 ): Promise<RequestCodeResult> {
-  return client.post<RequestCodeResult>(`${client.scopeFor(company)}/auth/request`, { email });
+  return client.post<RequestCodeResult>(`${client.scopeFor(company)}/auth/request`, {
+    email,
+    // The landing fragment a *mailed* link should carry (setup's hand-off
+    // passes `#/company?from=setup`). Absent for a normal sign-in, which lands
+    // wherever it always did. `undefined` is dropped by JSON.stringify, so the
+    // body is unchanged unless a redirect was actually asked for.
+    redirect,
+  });
 }
 
 /** Redeems a magic link for a session. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -48,6 +48,7 @@ import {
   SidebarControls,
 } from "@/components/sidebar-controls";
 import { SetupController } from "@/setup/SetupController";
+import { arrivedViaSetupHandoff, clearSetupHandoff } from "@/setup/state";
 import { TourController } from "@/tour/TourController";
 import { useCompany } from "@/hooks/use-company";
 import { getRun, listRuns } from "@/api/runs";
@@ -428,6 +429,16 @@ export function AppShell({
    * not immediately cover the roster it leads to with the tour welcome.
    */
   const [setupCompleted, setSetupCompleted] = useState(false);
+  // A setup that had to sign in hands off with a full-page navigation
+  // (`window.location.href`), so `onCompleted` never fires in this mount. The
+  // link carries a one-shot marker (`#/company?from=setup`); consume it here so
+  // this fresh mount applies the same welcome suppression a same-mount
+  // completion gets, and so a reload cannot re-apply it.
+  useEffect(() => {
+    if (!arrivedViaSetupHandoff()) return;
+    setSetupCompleted(true);
+    clearSetupHandoff();
+  }, []);
   // The shell owns every channel's transcript, not `ChatView` — the shell
   // mounts and unmounts `ChatView` per route, so component-local state there
   // would be discarded on every trip away from Chat and back.

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -434,11 +434,12 @@ export function AppShell({
   // link carries a one-shot marker (`#/company?from=setup`); consume it here so
   // this fresh mount applies the same welcome suppression a same-mount
   // completion gets, and so a reload cannot re-apply it.
+  const setupScope = { connection: scope.connection, company };
   useEffect(() => {
-    if (!arrivedViaSetupHandoff()) return;
+    if (!arrivedViaSetupHandoff(setupScope)) return;
     setSetupCompleted(true);
     clearSetupHandoff();
-  }, []);
+  }, [scope.connection, company]);
   // The shell owns every channel's transcript, not `ChatView` — the shell
   // mounts and unmounts `ChatView` per route, so component-local state there
   // would be discarded on every trip away from Chat and back.

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -423,6 +423,11 @@ export function AppShell({
    * the read, and a flag that was already `true` would not.
    */
   const [teamBuilt, setTeamBuilt] = useState(0);
+  /**
+   * Setup has already introduced the console while it builds the team, so do
+   * not immediately cover the roster it leads to with the tour welcome.
+   */
+  const [setupCompleted, setSetupCompleted] = useState(false);
   // The shell owns every channel's transcript, not `ChatView` — the shell
   // mounts and unmounts `ChatView` per route, so component-local state there
   // would be discarded on every trip away from Chat and back.
@@ -2223,10 +2228,21 @@ export function AppShell({
         deepLinked={deepLinked}
         onForceHandled={() => setSetupForced(false)}
         onOpenChange={setSetupOpen}
-        onCompleted={() => setTeamBuilt((n) => n + 1)}
+        onCompleted={() => {
+          // Keep these together: Company mounts with the new refresh key, and
+          // setup's payoff is the roster rather than the Overview graph.
+          setTeamBuilt((n) => n + 1);
+          setSetupCompleted(true);
+          setView("company");
+        }}
       />
 
-      <TourController company={company} setView={setView} hold={setupOpen} />
+      <TourController
+        company={company}
+        setView={setView}
+        hold={setupOpen}
+        suppressWelcome={setupCompleted}
+      />
     </SidebarProvider>
   );
 }

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -97,6 +97,12 @@ export function setupHandoffFragment(scope: SetupHandoffScope): string {
   return `#/company?${SETUP_HANDOFF_FLAG}=setup&connection=${encodeURIComponent(scope.connection)}&company=${encodeURIComponent(company)}`;
 }
 
+/** A fragment marker scoped to one connection and company. */
+export function setupHandoffFragment(scope: SetupHandoffScope): string {
+  const company = scope.company ?? "single";
+  return `#/company?${SETUP_HANDOFF_FLAG}=setup&connection=${encodeURIComponent(scope.connection)}&company=${encodeURIComponent(company)}`;
+}
+
 export interface SetupHandoffScope {
   connection: string;
   company: string | null;

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -98,6 +98,44 @@ export function arrivedViaSetupHandoff(): boolean {
 }
 
 /**
+ * Whether the current address rode in on a hub sign-in that was asked to land
+ * on setup's destination.
+ *
+ * The host puts the destination on the hub's return URI as a *query* parameter
+ * (`?company=…&from=setup`), because a fragment cannot cross the OAuth round
+ * trip — the hub appends its own `token=` to whatever it was given, and
+ * anything after a `#` there would swallow it.
+ */
+export function arrivedViaHubSetupHandoff(): boolean {
+  return new URLSearchParams(window.location.search).get(SETUP_HANDOFF_FLAG) === "setup";
+}
+
+/**
+ * Consumes a hub-carried setup destination, translating it into the same
+ * one-shot hash marker a setup hand-off link carries.
+ *
+ * An ecosystem sign-in returns to `/?company=…&from=setup`; the token
+ * redemption strips the hub's own params but leaves `from`. This reads it,
+ * takes it out of the query, and writes `#/company?from=setup` — the exact
+ * landing a setup link would have produced — so the shell applies the same
+ * welcome suppression and route, then clears the marker like any other
+ * hand-off. A reload after the conversion has neither the query flag nor the
+ * hash marker, so it cannot re-apply either.
+ */
+export function absorbHubSetupHandoff(): void {
+  if (!arrivedViaHubSetupHandoff()) return;
+  const params = new URLSearchParams(window.location.search);
+  params.delete(SETUP_HANDOFF_FLAG);
+  const qs = params.toString();
+  window.history.replaceState(
+    {},
+    "",
+    window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash,
+  );
+  window.location.hash = SETUP_HANDOFF_FRAGMENT;
+}
+
+/**
  * Removes the hand-off flag from the address.
  *
  * One-shot: the suppression it enables belongs to the arrival it rode in on,

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -91,10 +91,21 @@ export const SETUP_HANDOFF_FLAG = "from";
  */
 export const SETUP_HANDOFF_FRAGMENT = `#/company?${SETUP_HANDOFF_FLAG}=setup`;
 
+export interface SetupHandoffScope {
+  connection: string;
+  company: string | null;
+}
+
 /** Whether the current address arrived from setup's sign-in hand-off. */
-export function arrivedViaSetupHandoff(): boolean {
+export function arrivedViaSetupHandoff(scope?: SetupHandoffScope): boolean {
   const [, query = ""] = window.location.hash.split("?");
-  return new URLSearchParams(query).get(SETUP_HANDOFF_FLAG) === "setup";
+  const params = new URLSearchParams(query);
+  if (params.get(SETUP_HANDOFF_FLAG) !== "setup") return false;
+  if (!scope) return true;
+  return (
+    params.get("connection") === scope.connection &&
+    params.get("company") === (scope.company ?? "single")
+  );
 }
 
 /**

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -91,10 +91,27 @@ export const SETUP_HANDOFF_FLAG = "from";
  */
 export const SETUP_HANDOFF_FRAGMENT = `#/company?${SETUP_HANDOFF_FLAG}=setup`;
 
+/** A fragment marker scoped to one connection and company. */
+export function setupHandoffFragment(scope: SetupHandoffScope): string {
+  const company = scope.company ?? "single";
+  return `#/company?${SETUP_HANDOFF_FLAG}=setup&connection=${encodeURIComponent(scope.connection)}&company=${encodeURIComponent(company)}`;
+}
+
+export interface SetupHandoffScope {
+  connection: string;
+  company: string | null;
+}
+
 /** Whether the current address arrived from setup's sign-in hand-off. */
-export function arrivedViaSetupHandoff(): boolean {
+export function arrivedViaSetupHandoff(scope?: SetupHandoffScope): boolean {
   const [, query = ""] = window.location.hash.split("?");
-  return new URLSearchParams(query).get(SETUP_HANDOFF_FLAG) === "setup";
+  const params = new URLSearchParams(query);
+  if (params.get(SETUP_HANDOFF_FLAG) !== "setup") return false;
+  if (!scope) return true;
+  return (
+    params.get("connection") === scope.connection &&
+    params.get("company") === (scope.company ?? "single")
+  );
 }
 
 /**
@@ -106,8 +123,14 @@ export function arrivedViaSetupHandoff(): boolean {
  * trip — the hub appends its own `token=` to whatever it was given, and
  * anything after a `#` there would swallow it.
  */
-export function arrivedViaHubSetupHandoff(): boolean {
-  return new URLSearchParams(window.location.search).get(SETUP_HANDOFF_FLAG) === "setup";
+export function arrivedViaHubSetupHandoff(scope?: SetupHandoffScope): boolean {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get(SETUP_HANDOFF_FLAG) !== "setup") return false;
+  if (!scope) return true;
+  return (
+    params.get("connection") === scope.connection &&
+    params.get("company") === (scope.company ?? "single")
+  );
 }
 
 /**
@@ -122,8 +145,8 @@ export function arrivedViaHubSetupHandoff(): boolean {
  * hand-off. A reload after the conversion has neither the query flag nor the
  * hash marker, so it cannot re-apply either.
  */
-export function absorbHubSetupHandoff(): void {
-  if (!arrivedViaHubSetupHandoff()) return;
+export function absorbHubSetupHandoff(scope?: SetupHandoffScope): void {
+  if (!arrivedViaHubSetupHandoff(scope)) return;
   const params = new URLSearchParams(window.location.search);
   params.delete(SETUP_HANDOFF_FLAG);
   const qs = params.toString();
@@ -132,7 +155,7 @@ export function absorbHubSetupHandoff(): void {
     "",
     window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash,
   );
-  window.location.hash = SETUP_HANDOFF_FRAGMENT;
+  window.location.hash = scope ? setupHandoffFragment(scope) : SETUP_HANDOFF_FRAGMENT;
 }
 
 /**

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -91,6 +91,12 @@ export const SETUP_HANDOFF_FLAG = "from";
  */
 export const SETUP_HANDOFF_FRAGMENT = `#/company?${SETUP_HANDOFF_FLAG}=setup`;
 
+/** A fragment marker scoped to one connection and company. */
+export function setupHandoffFragment(scope: SetupHandoffScope): string {
+  const company = scope.company ?? "single";
+  return `#/company?${SETUP_HANDOFF_FLAG}=setup&connection=${encodeURIComponent(scope.connection)}&company=${encodeURIComponent(company)}`;
+}
+
 export interface SetupHandoffScope {
   connection: string;
   company: string | null;

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -145,8 +145,8 @@ export function arrivedViaHubSetupHandoff(scope?: SetupHandoffScope): boolean {
  * hand-off. A reload after the conversion has neither the query flag nor the
  * hash marker, so it cannot re-apply either.
  */
-export function absorbHubSetupHandoff(): void {
-  if (!arrivedViaHubSetupHandoff()) return;
+export function absorbHubSetupHandoff(scope?: SetupHandoffScope): void {
+  if (!arrivedViaHubSetupHandoff(scope)) return;
   const params = new URLSearchParams(window.location.search);
   params.delete(SETUP_HANDOFF_FLAG);
   const qs = params.toString();
@@ -155,7 +155,7 @@ export function absorbHubSetupHandoff(): void {
     "",
     window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash,
   );
-  window.location.hash = SETUP_HANDOFF_FRAGMENT;
+  window.location.hash = scope ? setupHandoffFragment(scope) : SETUP_HANDOFF_FRAGMENT;
 }
 
 /**

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -68,3 +68,48 @@ export function clearSetupSkipped(scope: LocalScope): void {
     /* nothing to clear */
   }
 }
+
+// ---------------------------------------------------------------------------
+// The sign-in hand-off marker
+// ---------------------------------------------------------------------------
+
+/**
+ * The hash-query key a setup hand-off link carries, so a sign-in that
+ * navigates the whole document away (setup's button sets `window.location.href`)
+ * still lands knowing setup just finished: `…code=…#/company?from=setup`.
+ *
+ * `useHashView`'s segment parsing strips everything from `?` onward, so the
+ * flag never reaches the router; AppShell consumes it on the landing mount to
+ * apply the same welcome suppression a same-mount completion gets, then removes
+ * it so a reload or a copied link cannot re-apply it.
+ */
+export const SETUP_HANDOFF_FLAG = "from";
+
+/**
+ * The landing fragment a setup hand-off link carries. The wizard hands this to
+ * the host so a *mailed* link lands the same way the loopback link does.
+ */
+export const SETUP_HANDOFF_FRAGMENT = `#/company?${SETUP_HANDOFF_FLAG}=setup`;
+
+/** Whether the current address arrived from setup's sign-in hand-off. */
+export function arrivedViaSetupHandoff(): boolean {
+  const [, query = ""] = window.location.hash.split("?");
+  return new URLSearchParams(query).get(SETUP_HANDOFF_FLAG) === "setup";
+}
+
+/**
+ * Removes the hand-off flag from the address.
+ *
+ * One-shot: the suppression it enables belongs to the arrival it rode in on,
+ * not to a later reload. Other hash-query keys (`?host=`, for instance) are
+ * preserved.
+ */
+export function clearSetupHandoff(): void {
+  const [path, query = ""] = window.location.hash.replace(/^#/, "").split("?");
+  const params = new URLSearchParams(query);
+  if (!params.has(SETUP_HANDOFF_FLAG)) return;
+  params.delete(SETUP_HANDOFF_FLAG);
+  const qs = params.toString().replace(/=(?=&|$)/g, "");
+  const next = `#${path}${qs ? `?${qs}` : ""}`;
+  if (next !== window.location.hash) window.history.replaceState(null, "", next);
+}

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -97,12 +97,6 @@ export function setupHandoffFragment(scope: SetupHandoffScope): string {
   return `#/company?${SETUP_HANDOFF_FLAG}=setup&connection=${encodeURIComponent(scope.connection)}&company=${encodeURIComponent(company)}`;
 }
 
-/** A fragment marker scoped to one connection and company. */
-export function setupHandoffFragment(scope: SetupHandoffScope): string {
-  const company = scope.company ?? "single";
-  return `#/company?${SETUP_HANDOFF_FLAG}=setup&connection=${encodeURIComponent(scope.connection)}&company=${encodeURIComponent(company)}`;
-}
-
 export interface SetupHandoffScope {
   connection: string;
   company: string | null;

--- a/frontend/src/setup/state.ts
+++ b/frontend/src/setup/state.ts
@@ -123,8 +123,14 @@ export function arrivedViaSetupHandoff(scope?: SetupHandoffScope): boolean {
  * trip — the hub appends its own `token=` to whatever it was given, and
  * anything after a `#` there would swallow it.
  */
-export function arrivedViaHubSetupHandoff(): boolean {
-  return new URLSearchParams(window.location.search).get(SETUP_HANDOFF_FLAG) === "setup";
+export function arrivedViaHubSetupHandoff(scope?: SetupHandoffScope): boolean {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get(SETUP_HANDOFF_FLAG) !== "setup") return false;
+  if (!scope) return true;
+  return (
+    params.get("connection") === scope.connection &&
+    params.get("company") === (scope.company ?? "single")
+  );
 }
 
 /**

--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -78,6 +78,7 @@ export function TourController({
   company,
   setView,
   hold,
+  suppressWelcome,
 }: {
   company: string | null;
   /** `sub` names a section's sub-page, e.g. `#/settings/connections`. */
@@ -97,6 +98,12 @@ export function TourController({
    * tour's own stops are what would have been empty.
    */
   hold?: boolean;
+  /**
+   * Setup has just finished and navigated to the new roster. Its build-out
+   * already introduced the product, so leave that arrival unobscured for this
+   * console mount rather than opening a second welcome dialog over it.
+   */
+  suppressWelcome?: boolean;
 }) {
   // Which (connection, company) this subtree's browser-local state belongs to.
   const scope = useLocalScope();
@@ -222,7 +229,7 @@ export function TourController({
         // nobody on it (`docs/spec/runtime/company-setup.md`). A render-time gate
         // rather than a state one: the effect above has side effects that must
         // fire exactly once, and this only decides what is on screen.
-        open={welcomeOpen && !hold}
+        open={welcomeOpen && !hold && !suppressWelcome}
         onOpenChange={setWelcomeOpen}
         onStart={start}
         onSkip={handleSkip}

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -237,7 +237,7 @@ export function ConnectionConsole({
     case "setup":
       return (
         <ConsoleChrome>
-          <SetupWizard client={client} onDone={reBoot} />
+          <SetupWizard client={client} onDone={reBoot} expectsShellRemount />
         </ConsoleChrome>
       );
 

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -497,7 +497,11 @@ export function Login({ client, company, notice, onSignedIn }: Props) {
               {hubProviders.map((provider) => (
                 <a
                   key={provider.id}
-                  href={provider.startUrl}
+                  href={
+                    arrivedViaSetupHandoff()
+                      ? `${provider.startUrl}${provider.startUrl.includes("?") ? "&" : "?"}from=setup`
+                      : provider.startUrl
+                  }
                   className={cn(buttonVariants({ variant: "outline", size: "lg" }), "w-full")}
                 >
                   Continue with {provider.label}

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/api/auth";
 import { connectWallet, hasWallet, NoWalletError, signMessage } from "@/lib/wallet";
 import { resendLabel, secondsUntilResend } from "@/views/login/resend";
-import { arrivedViaSetupHandoff, SETUP_HANDOFF_FRAGMENT, setupHandoffFragment } from "@/setup/state";
+import { arrivedViaSetupHandoff, SETUP_HANDOFF_FRAGMENT } from "@/setup/state";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -254,7 +254,18 @@ export function Login({ client, company, notice, onSignedIn }: Props) {
     setBusy(true);
     setError(null);
     try {
-      const result = await requestCode(client, company, email);
+      const result = await requestCode(
+        client,
+        company,
+        email,
+        // A dead setup hand-off link keeps the address while it falls back to
+        // this form (`#/company?from=setup` survives in the hash), so a link
+        // asked for from here must carry the same destination the original did
+        // — otherwise following the replacement lands on Overview and can show
+        // the tour welcome instead of the roster setup just built. Absent for
+        // any other sign-in, which lands wherever it always did.
+        arrivedViaSetupHandoff() ? SETUP_HANDOFF_FRAGMENT : undefined,
+      );
       // Always the same acknowledgement, whoever they are.
       setSent(true);
       setDevCode(result.dev_code ?? null);

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -192,7 +192,13 @@ export function Login({ client, company, notice, onSignedIn }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    fetchHubProviders(client, company)
+    // A dead setup hand-off link keeps its marker in the hash while it falls
+    // back to this form, so an ecosystem button asked for from here must land on
+    // the same destination the link promised — the host carries it on the
+    // sign-in's return URI (`from=setup`), which survives the OAuth round trip
+    // the way a fragment cannot. Absent for any other sign-in, which lands
+    // wherever it always did.
+    fetchHubProviders(client, company, arrivedViaSetupHandoff() ? "setup" : undefined)
       .then((providers) => {
         if (!cancelled) setHubProviders(providers);
       })

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/api/auth";
 import { connectWallet, hasWallet, NoWalletError, signMessage } from "@/lib/wallet";
 import { resendLabel, secondsUntilResend } from "@/views/login/resend";
+import { arrivedViaSetupHandoff, SETUP_HANDOFF_FRAGMENT } from "@/setup/state";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/api/auth";
 import { connectWallet, hasWallet, NoWalletError, signMessage } from "@/lib/wallet";
 import { resendLabel, secondsUntilResend } from "@/views/login/resend";
-import { arrivedViaSetupHandoff, SETUP_HANDOFF_FRAGMENT } from "@/setup/state";
+import { arrivedViaSetupHandoff, SETUP_HANDOFF_FRAGMENT, setupHandoffFragment } from "@/setup/state";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -636,14 +636,21 @@ export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: P
             <Button
               onClick={() => {
                 // The link branch above carries the landing fragment inside its
-                // URL. This branch hands off by remounting the shell in place
-                // (`onDone` re-probes and boots a fresh `AppShell`), so write
-                // the same fragment first: the fresh shell reads it, routes to
-                // the roster setup just built, suppresses the tour welcome, and
+                // URL. This branch hands off through `onDone`, and
+                // `expectsShellRemount` says that hands off to a fresh
+                // `AppShell` (the connection console's re-probe), so write the
+                // same fragment first: the fresh shell reads it, routes to the
+                // roster setup just built, suppresses the tour welcome, and
                 // clears the one-shot marker. Without it a no-sign-in host —
                 // and the "anyway" escapes for a mailed sign-in — lands on
                 // Overview with the tour free to open over that roster.
-                if (window.location.hash !== SETUP_HANDOFF_FRAGMENT) {
+                //
+                // The in-shell dialog must NOT write it: `onDone` there closes
+                // the dialog in place and the running shell already suppresses
+                // the welcome via `onCompleted`, so the marker would have no
+                // consuming mount and would be read as a fresh hand-off on the
+                // next reload.
+                if (expectsShellRemount && window.location.hash !== SETUP_HANDOFF_FRAGMENT) {
                   window.location.hash = SETUP_HANDOFF_FRAGMENT;
                 }
                 onDone();

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -624,7 +624,23 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
               Sign in and open my company
             </Button>
           ) : (
-            <Button onClick={onDone} data-testid="setup-open-console">
+            <Button
+              onClick={() => {
+                // The link branch above carries the landing fragment inside its
+                // URL. This branch hands off by remounting the shell in place
+                // (`onDone` re-probes and boots a fresh `AppShell`), so write
+                // the same fragment first: the fresh shell reads it, routes to
+                // the roster setup just built, suppresses the tour welcome, and
+                // clears the one-shot marker. Without it a no-sign-in host —
+                // and the "anyway" escapes for a mailed sign-in — lands on
+                // Overview with the tour free to open over that roster.
+                if (window.location.hash !== SETUP_HANDOFF_FRAGMENT) {
+                  window.location.hash = SETUP_HANDOFF_FRAGMENT;
+                }
+                onDone();
+              }}
+              data-testid="setup-open-console"
+            >
               {/* "Anyway" wherever something is genuinely outstanding — a
                   staged setting, or a sign-in we could not arrange. That word is
                   the only thing saying this button does not finish the job. */}

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -28,6 +28,7 @@ import { AlertTriangle, Check, Loader2, Lock, RotateCw } from "lucide-react";
 
 import { requestCode } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import { SETUP_HANDOFF_FRAGMENT } from "@/setup/state";
 import {
   changedFields,
   fieldsFor,
@@ -356,17 +357,18 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
     }
 
     setHandoff({ kind: "arranging" });
-    requestCode(client, company, address)
+    requestCode(client, company, address, SETUP_HANDOFF_FRAGMENT)
       .then((result) => {
         if (result.dev_code) {
           // The only branch holding the code, and so the only one that can hand
-          // over a link rather than describe one.
+          // over a link rather than describe one. The same fragment is passed to
+          // the host above, so a *mailed* link (this host never echoes) carries
+          // the same destination; the magic-link landing preserves the router
+          // hash while it strips the single-use code, so sign-in reaches the
+          // roster setup just created rather than the stale Overview graph.
           setHandoff({
             kind: "link",
-            // The magic-link landing preserves this router hash while it
-            // strips the single-use code, so sign-in reaches the roster setup
-            // just created rather than the stale Overview graph.
-            url: `/login?company=${encodeURIComponent(company)}&code=${encodeURIComponent(result.dev_code)}#/company`,
+            url: `/login?company=${encodeURIComponent(company)}&code=${encodeURIComponent(result.dev_code)}${SETUP_HANDOFF_FRAGMENT}`,
           });
         } else {
           setHandoff(status.mail.wired ? { kind: "mailed" } : { kind: "unmailable" });

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -165,9 +165,18 @@ interface Props {
    * run, where there is no console to go back to.
    */
   onCancel?: () => void;
+  /**
+   * Whether `onDone` hands off to a **fresh** shell mount. The connection
+   * console's re-probe does (it boots a new `AppShell`), so its completion
+   * button writes the one-shot hand-off marker for that shell to consume. The
+   * in-shell dialog does not — it closes in place and the running shell
+   * suppresses the welcome through `onCompleted` — and a marker with no
+   * consuming mount would be read as a fresh hand-off on the next reload.
+   */
+  expectsShellRemount?: boolean;
 }
 
-export function SetupWizard({ client, onDone, onCancel }: Props) {
+export function SetupWizard({ client, onDone, onCancel, expectsShellRemount }: Props) {
   const [status, setStatus] = useState<SetupStatus | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   /**

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -363,7 +363,10 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
           // over a link rather than describe one.
           setHandoff({
             kind: "link",
-            url: `/login?company=${encodeURIComponent(company)}&code=${encodeURIComponent(result.dev_code)}`,
+            // The magic-link landing preserves this router hash while it
+            // strips the single-use code, so sign-in reaches the roster setup
+            // just created rather than the stale Overview graph.
+            url: `/login?company=${encodeURIComponent(company)}&code=${encodeURIComponent(result.dev_code)}#/company`,
           });
         } else {
           setHandoff(status.mail.wired ? { kind: "mailed" } : { kind: "unmailable" });
@@ -611,6 +614,7 @@ export function SetupWizard({ client, onDone, onCancel }: Props) {
           {handoff?.kind === "link" ? (
             <Button
               data-testid="setup-signin"
+              data-handoff-url={handoff.url}
               onClick={() => {
                 window.location.href = handoff.url;
               }}

--- a/frontend/test/e2e/company-setup.spec.ts
+++ b/frontend/test/e2e/company-setup.spec.ts
@@ -202,6 +202,11 @@ test("first-run setup builds a real team from three answers", async ({ page, req
 
   await page.getByTestId("setup-finish").click();
   await expect(dialog).toBeHidden();
+  await expect(page).toHaveURL(/#\/company$/);
+
+  // Setup's payoff is the roster, and its own build-out is the introduction;
+  // the first-run welcome must not immediately cover either one.
+  await expect(page.getByRole("button", { name: "Take the tour" })).toBeHidden();
 
   // 5. The host really holds them — not the console's fabricated starter team,
   //    and not the global baseline every company already had.
@@ -211,8 +216,7 @@ test("first-run setup builds a real team from three answers", async ({ page, req
     "the teammates setup created, over and above the baseline every company gets",
   ).toBeGreaterThanOrEqual(4);
 
-  // 6. And the Team page shows that roster, refreshed without a reload.
-  await page.goto("/#/company");
+  // 6. The arrival page shows that roster, refreshed without a reload.
   for (const member of designed.slice(0, 3)) {
     await expect(page.getByText(member.role, { exact: false }).first()).toBeVisible();
   }

--- a/frontend/test/unit/login-dead-link-destination.test.ts
+++ b/frontend/test/unit/login-dead-link-destination.test.ts
@@ -34,20 +34,20 @@ afterEach(() => {
   container.remove();
 });
 
-/** A host answering `/auth/config` and `/auth/hub`, recording every `post`. */
+/** A host answering `/auth/config` and `/auth/hub`, recording every `get`/`post`. */
 function hostReporting(
   config: Record<string, unknown>,
   post: ReturnType<typeof vi.fn>,
-): OpenCompanyClient {
-  return {
-    scopeFor: () => "/api/v1/company",
-    get: vi.fn().mockImplementation(async (path: string) => {
-      if (path.endsWith("/auth/config")) return config;
-      if (path.endsWith("/auth/hub")) return { providers: [] };
-      throw new Error(`unexpected GET ${path}`);
-    }),
-    post,
-  } as unknown as OpenCompanyClient;
+): OpenCompanyClient & { get: ReturnType<typeof vi.fn> } {
+  const get = vi.fn().mockImplementation(async (path: string) => {
+    const base = path.split("?")[0];
+    if (base.endsWith("/auth/config")) return config;
+    if (base.endsWith("/auth/hub")) return { providers: [] };
+    throw new Error(`unexpected GET ${path}`);
+  });
+  return { scopeFor: () => "/api/v1/company", get, post } as unknown as OpenCompanyClient & {
+    get: ReturnType<typeof vi.fn>;
+  };
 }
 
 async function render(client: OpenCompanyClient) {

--- a/frontend/test/unit/login-dead-link-destination.test.ts
+++ b/frontend/test/unit/login-dead-link-destination.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Login } from "@/views/Login";
+import type { OpenCompanyClient } from "@/api/client";
+
+/**
+ * The dead-link recovery path keeps the destination a dead link was carrying.
+ *
+ * A setup hand-off link (`…/login?code=…#/company?from=setup`) that has
+ * expired or been consumed lands here with the fragment still in the address:
+ * `App` strips the single-use code, preserves the hash, and falls back to this
+ * form. A replacement link asked for from here must carry the same fragment,
+ * or following it lands on Overview and can show the tour welcome instead of
+ * the roster setup just built. `askForLink` forwards the marker when — and only
+ * when — the current address carries it.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** A host answering `/auth/config` and `/auth/hub`, recording every `post`. */
+function hostReporting(
+  config: Record<string, unknown>,
+  post: ReturnType<typeof vi.fn>,
+): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company",
+    get: vi.fn().mockImplementation(async (path: string) => {
+      if (path.endsWith("/auth/config")) return config;
+      if (path.endsWith("/auth/hub")) return { providers: [] };
+      throw new Error(`unexpected GET ${path}`);
+    }),
+    post,
+  } as unknown as OpenCompanyClient;
+}
+
+async function render(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(Login, { client, company: "acme", onSignedIn: () => {} }));
+    await Promise.resolve();
+  });
+}
+
+/** Fills the form and sends it, the recovery path after a refused link. */
+async function sendLinkRequest() {
+  const input = container.querySelector("#email") as HTMLInputElement | null;
+  expect(input, "no email field").toBeTruthy();
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    setter.call(input!, "ada@example.com");
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  const submit = Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Email me a link"),
+  );
+  expect(submit, "no send button").toBeTruthy();
+  await act(async () => {
+    submit!.click();
+    await Promise.resolve();
+  });
+}
+
+describe("the dead-link recovery path", () => {
+  it("forwards the setup destination when the address carries it", async () => {
+    window.location.hash = "#/company?from=setup";
+    const post = vi.fn().mockResolvedValue({ sent: true });
+    await render(hostReporting({ mode: "email", passwords: true, magicLink: true }, post));
+
+    await sendLinkRequest();
+
+    const [path, body] = post.mock.calls[0];
+    expect(path).toBe("/api/v1/company/auth/request");
+    expect(body).toEqual({ email: "ada@example.com", redirect: "#/company?from=setup" });
+  });
+
+  it("asks for nothing extra when the address carries no destination", async () => {
+    window.location.hash = "#/overview";
+    const post = vi.fn().mockResolvedValue({ sent: true });
+    await render(hostReporting({ mode: "email", passwords: true, magicLink: true }, post));
+
+    await sendLinkRequest();
+
+    const [, body] = post.mock.calls[0];
+    // `undefined` is dropped by JSON.stringify on the wire; the body is
+    // unchanged from an ordinary sign-in request.
+    expect(body).toEqual({ email: "ada@example.com" });
+  });
+});

--- a/frontend/test/unit/login-dead-link-destination.test.ts
+++ b/frontend/test/unit/login-dead-link-destination.test.ts
@@ -83,7 +83,14 @@ describe("the dead-link recovery path", () => {
   it("forwards the setup destination when the address carries it", async () => {
     window.location.hash = "#/company?from=setup";
     const post = vi.fn().mockResolvedValue({ sent: true });
-    await render(hostReporting({ mode: "email", passwords: true, magicLink: true }, post));
+    const client = hostReporting({ mode: "email", passwords: true, magicLink: true }, post);
+    await render(client);
+
+    // The ecosystem buttons are asked for with the same destination, so a
+    // "Continue with …" click from this form lands on the roster the link
+    // promised rather than on Overview with the welcome free to open.
+    const hubFetch = client.get.mock.calls.find(([path]) => path.startsWith("/api/v1/company/auth/hub"));
+    expect(hubFetch?.[0]).toBe("/api/v1/company/auth/hub?from=setup");
 
     await sendLinkRequest();
 

--- a/frontend/test/unit/setup-handoff.test.ts
+++ b/frontend/test/unit/setup-handoff.test.ts
@@ -97,4 +97,12 @@ describe("a hub-carried setup destination", () => {
     expect(window.location.search).toBe("?company=acme");
     expect(hash()).toBe("");
   });
+
+  it("recognizes the marker only for its originating connection and company", () => {
+    land("/", "?company=acme&from=setup&connection=conn-a");
+
+    expect(arrivedViaHubSetupHandoff({ connection: "conn-a", company: "acme" })).toBe(true);
+    expect(arrivedViaHubSetupHandoff({ connection: "conn-b", company: "acme" })).toBe(false);
+    expect(arrivedViaHubSetupHandoff({ connection: "conn-a", company: "other" })).toBe(false);
+  });
 });

--- a/frontend/test/unit/setup-handoff.test.ts
+++ b/frontend/test/unit/setup-handoff.test.ts
@@ -3,6 +3,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  absorbHubSetupHandoff,
+  arrivedViaHubSetupHandoff,
   arrivedViaSetupHandoff,
   clearSetupHandoff,
   SETUP_HANDOFF_FRAGMENT,

--- a/frontend/test/unit/setup-handoff.test.ts
+++ b/frontend/test/unit/setup-handoff.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import {
+  arrivedViaSetupHandoff,
+  clearSetupHandoff,
+  SETUP_HANDOFF_FRAGMENT,
+} from "@/setup/state";
+
+/**
+ * The one-shot marker a setup hand-off link carries, and how the landing
+ * mount consumes it.
+ *
+ * The marker is a hash-query flag (`#/company?from=setup`) rather than a state
+ * write, because it has to survive a full-page navigation: setup's sign-in
+ * button sets `window.location.href`, so component state dies at the boundary.
+ * What survives is the URL — and `useHashView`'s segment parsing strips the
+ * query from the route, so the flag is visible to the shell without ever
+ * reaching the router.
+ */
+
+const hash = () => window.location.hash;
+
+describe("the setup hand-off marker", () => {
+  it("is a fragment whose route the router ignores", () => {
+    expect(SETUP_HANDOFF_FRAGMENT).toBe("#/company?from=setup");
+    // The view segment is still `company` — the query is the marker, not the
+    // route, so `#/company?from=setup` resolves to the same view as `#/company`.
+    const [path] = SETUP_HANDOFF_FRAGMENT.replace(/^#/, "").split("?");
+    expect(path).toBe("/company");
+  });
+
+  it("reads true only when the address carries the marker", () => {
+    window.location.hash = "#/company";
+    expect(arrivedViaSetupHandoff()).toBe(false);
+
+    window.location.hash = SETUP_HANDOFF_FRAGMENT;
+    expect(arrivedViaSetupHandoff()).toBe(true);
+
+    // A different origin value for the same key is not this marker.
+    window.location.hash = "#/company?from=elsewhere";
+    expect(arrivedViaSetupHandoff()).toBe(false);
+  });
+
+  it("consumes the marker without touching the route or other keys", () => {
+    window.location.hash = "#/company?from=setup&host=conn-a";
+    clearSetupHandoff();
+    expect(hash()).toBe("#/company?host=conn-a");
+    expect(arrivedViaSetupHandoff()).toBe(false);
+  });
+
+  it("leaves an address without the marker alone", () => {
+    window.location.hash = "#/overview";
+    clearSetupHandoff();
+    expect(hash()).toBe("#/overview");
+  });
+});

--- a/frontend/test/unit/setup-handoff.test.ts
+++ b/frontend/test/unit/setup-handoff.test.ts
@@ -62,3 +62,39 @@ describe("the setup hand-off marker", () => {
     expect(hash()).toBe("#/overview");
   });
 });
+
+describe("a hub-carried setup destination", () => {
+  it("reads true only when the *query* carries it", () => {
+    land("/", "?company=acme");
+    expect(arrivedViaHubSetupHandoff()).toBe(false);
+
+    land("/", "?company=acme&from=setup");
+    expect(arrivedViaHubSetupHandoff()).toBe(true);
+
+    // A different value for the same key is not this marker.
+    land("/", "?company=acme&from=elsewhere");
+    expect(arrivedViaHubSetupHandoff()).toBe(false);
+  });
+
+  it("translates into the hash marker and takes the flag out of the query", () => {
+    land("/", "?company=acme&from=setup");
+
+    absorbHubSetupHandoff();
+
+    // The query flag is gone — the shell's own one-shot marker took its place,
+    // and a reload has neither to re-apply.
+    expect(window.location.search).toBe("?company=acme");
+    expect(hash()).toBe(SETUP_HANDOFF_FRAGMENT);
+    expect(arrivedViaHubSetupHandoff()).toBe(false);
+    expect(arrivedViaSetupHandoff()).toBe(true);
+  });
+
+  it("leaves an address without the marker alone", () => {
+    land("/", "?company=acme");
+
+    absorbHubSetupHandoff();
+
+    expect(window.location.search).toBe("?company=acme");
+    expect(hash()).toBe("");
+  });
+});

--- a/frontend/test/unit/setup-handoff.test.ts
+++ b/frontend/test/unit/setup-handoff.test.ts
@@ -24,6 +24,10 @@ import {
 
 const hash = () => window.location.hash;
 
+/** A landing, as the console's own routing sees it (pathname + search + hash). */
+const land = (pathname: string, search: string, hash = "") =>
+  window.history.replaceState({}, "", `${pathname}${search}${hash}`);
+
 describe("the setup hand-off marker", () => {
   it("is a fragment whose route the router ignores", () => {
     expect(SETUP_HANDOFF_FRAGMENT).toBe("#/company?from=setup");

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -94,9 +94,12 @@ afterEach(() => {
   delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
 });
 
-async function show(client: OpenCompanyClient) {
+async function show(
+  client: OpenCompanyClient,
+  props: { expectsShellRemount?: boolean } = {},
+) {
   await act(async () => {
-    root.render(createElement(SetupWizard, { client, onDone: done }));
+    root.render(createElement(SetupWizard, { client, onDone: done, ...props }));
   });
 }
 

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { SetupStatus } from "@/api/setup";
+import { SETUP_HANDOFF_FRAGMENT } from "@/setup/state";
+import { SetupWizard } from "@/views/setup/SetupWizard";
+
+/**
+ * The console button's destination on completions that do not hand over a link.
+ *
+ * The sign-in hand-off navigates the whole document to a URL that already
+ * carries the landing fragment (`#/company?from=setup`). The other three
+ * outcomes — a host that asks nobody to sign in, a mailed link the operator
+ * skips, and a link that could not be sent — all finish through the same
+ * `setup-open-console` button, which remounts the shell in place (`onDone`
+ * re-probes and boots a fresh `AppShell`). That remount must carry the same
+ * fragment, or it lands on Overview with the tour free to open over the roster
+ * setup just built — the exact miss the link path was fixed to avoid.
+ */
+
+function status(over: Partial<SetupStatus> = {}): SetupStatus {
+  return {
+    complete: false,
+    config_path: "/data/config.toml",
+    fields: [],
+    templates: [],
+    auth_modes: ["email", "wallet", "none"],
+    build: {
+      acp_in_build: false,
+      acp_transport_mounted: false,
+      mcp_in_build: false,
+      harness_in_build: false,
+      oauth_in_build: false,
+    },
+    companies: [],
+    inference: { ready: false, provider: null, base_url: null },
+    mail: { wired: false, echoes_code: true },
+    ...over,
+  };
+}
+
+/**
+ * Routed by path: the wizard makes different calls through `post` (the roster
+ * design, the sign-in request, and the apply), so a blanket override would
+ * silently change what the other two see.
+ */
+function clientWith(s: SetupStatus): OpenCompanyClient {
+  return {
+    scopeFor: (company: string | null) => `/api/v1/companies/${company}`,
+    get: async () => s,
+    post: async (path: string) => {
+      if (path.endsWith("/setup/roster")) {
+        return {
+          agents: [{ name: "Ada", role: "Operations", description: "Runs the desk." }],
+          template: "ecommerce",
+          source: "fallback",
+        };
+      }
+      if (path.endsWith("/auth/request")) return { sent: true };
+      return {
+        complete: true,
+        config_path: s.config_path,
+        restart_required: [],
+        seeded_company: "acme",
+      };
+    },
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let done: () => void;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  done = () => {};
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
+});
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(SetupWizard, { client, onDone: done }));
+  });
+}
+
+const find = (testId: string) => container.querySelector(`[data-testid="${testId}"]`);
+
+async function click(testId: string) {
+  const el = find(testId) as HTMLElement | null;
+  expect(el, `no element ${testId}`).toBeTruthy();
+  await act(async () => {
+    el!.click();
+  });
+}
+
+const next = async () =>
+  act(async () => {
+    const match = Array.from(container.querySelectorAll("button")).find((b) =>
+      ["Next", "Looks good"].includes(b.textContent?.trim() ?? ""),
+    );
+    expect(match, "no advance button").toBeTruthy();
+    match!.click();
+  });
+
+async function fill(testId: string, value: string) {
+  const field = find(testId) as HTMLInputElement | HTMLTextAreaElement | null;
+  expect(field, `no field ${testId}`).toBeTruthy();
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      field instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    setter.call(field!, value);
+    field!.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/** Lets the design, apply and sign-in requests settle. */
+const settle = async () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+/**
+ * The desktop install: a host that asks nobody to sign in, so the wizard
+ * preselects `none` and the address step is absent.
+ */
+async function finishNoSignIn() {
+  (window as unknown as { __TAURI__: unknown }).__TAURI__ = { core: {} };
+  await click("setup-skip-model");
+  await next(); // -> business
+  await fill("setup-field-industry", "E-commerce — homeware");
+  await next(); // -> sign-in (none preselected)
+  await next(); // -> advanced
+  await next(); // -> review
+  await settle();
+  await click("setup-finish");
+  await settle();
+}
+
+/** An email-sign-in host that cannot send mail: the "anyway" escape. */
+async function finishUnmailable() {
+  await click("setup-skip-model");
+  await next(); // -> business
+  await fill("setup-field-industry", "E-commerce — homeware");
+  await next(); // -> sign-in
+  await next(); // -> account
+  await fill("setup-field-email", "ada@example.com");
+  await next(); // -> advanced
+  await next(); // -> review
+  await settle();
+  await click("setup-finish");
+  await settle();
+}
+
+describe("the console button after setup applies without a hand-off link", () => {
+  it("carries the roster destination out of a no-sign-in setup", async () => {
+    let calls = 0;
+    done = () => {
+      calls += 1;
+    };
+    await show(clientWith(status()));
+    await finishNoSignIn();
+
+    // Nobody to invite, so there is no link to hand over — only the console.
+    expect(find("setup-handoff-link")).toBeNull();
+    expect(find("setup-open-console")).toBeTruthy();
+
+    await click("setup-open-console");
+
+    // The fresh `AppShell` this hands off to reads the fragment: it routes to
+    // `#/company`, suppresses the tour welcome, and clears the marker.
+    expect(window.location.hash).toBe(SETUP_HANDOFF_FRAGMENT);
+    expect(calls).toBe(1);
+  });
+
+  it("carries the same destination out of the unmailable escape", async () => {
+    await show(clientWith(status({ mail: { wired: false, echoes_code: false } })));
+    await finishUnmailable();
+
+    expect(find("setup-handoff-unmailable")).toBeTruthy();
+    expect(find("setup-open-console")?.textContent).toContain("anyway");
+
+    await click("setup-open-console");
+
+    expect(window.location.hash).toBe(SETUP_HANDOFF_FRAGMENT);
+  });
+});

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -16,10 +16,14 @@ import { SetupWizard } from "@/views/setup/SetupWizard";
  * carries the landing fragment (`#/company?from=setup`). The other three
  * outcomes — a host that asks nobody to sign in, a mailed link the operator
  * skips, and a link that could not be sent — all finish through the same
- * `setup-open-console` button, which remounts the shell in place (`onDone`
- * re-probes and boots a fresh `AppShell`). That remount must carry the same
- * fragment, or it lands on Overview with the tour free to open over the roster
- * setup just built — the exact miss the link path was fixed to avoid.
+ * `setup-open-console` button. When that button's `onDone` hands off to a
+ * fresh `AppShell` (the connection console's re-probe), it must write the same
+ * fragment first, or the fresh shell lands on Overview with the tour free to
+ * open over the roster setup just built — the exact miss the link path was
+ * fixed to avoid. When it instead completes in place (the in-shell dialog,
+ * whose running shell suppresses the welcome through `onCompleted`), the
+ * button must NOT write the marker: no mount is waiting to consume it, so it
+ * would be read as a fresh hand-off on the next reload.
  */
 
 function status(over: Partial<SetupStatus> = {}): SetupStatus {

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -141,7 +141,6 @@ const settle = async () =>
  * preselects `none` and the address step is absent.
  */
 async function finishNoSignIn() {
-  (window as unknown as { __TAURI__: unknown }).__TAURI__ = { core: {} };
   await click("setup-skip-model");
   await next(); // -> business
   await fill("setup-field-industry", "E-commerce — homeware");

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -169,6 +169,9 @@ async function finishUnmailable() {
 
 describe("the console button after setup applies without a hand-off link", () => {
   it("carries the roster destination out of a no-sign-in setup", async () => {
+    // The desktop runtime is what makes the wizard preselect `none`; it must
+    // be in place before the wizard mounts (`isDesktopRuntime` is read once).
+    (window as unknown as { __TAURI__: unknown }).__TAURI__ = { core: {} };
     let calls = 0;
     done = () => {
       calls += 1;

--- a/frontend/test/unit/setup-wizard-console-destination.test.ts
+++ b/frontend/test/unit/setup-wizard-console-destination.test.ts
@@ -183,7 +183,9 @@ describe("the console button after setup applies without a hand-off link", () =>
     done = () => {
       calls += 1;
     };
-    await show(clientWith(status()));
+    // The connection console's `onDone` re-probes and boots a fresh `AppShell`,
+    // so this completion writes the marker for that shell to read.
+    await show(clientWith(status()), { expectsShellRemount: true });
     await finishNoSignIn();
 
     // Nobody to invite, so there is no link to hand over — only the console.
@@ -199,7 +201,9 @@ describe("the console button after setup applies without a hand-off link", () =>
   });
 
   it("carries the same destination out of the unmailable escape", async () => {
-    await show(clientWith(status({ mail: { wired: false, echoes_code: false } })));
+    await show(clientWith(status({ mail: { wired: false, echoes_code: false } })), {
+      expectsShellRemount: true,
+    });
     await finishUnmailable();
 
     expect(find("setup-handoff-unmailable")).toBeTruthy();
@@ -208,5 +212,25 @@ describe("the console button after setup applies without a hand-off link", () =>
     await click("setup-open-console");
 
     expect(window.location.hash).toBe(SETUP_HANDOFF_FRAGMENT);
+  });
+
+  it("leaves the URL alone when completion happens in place", async () => {
+    // The in-shell dialog's `onDone` closes in place — the running shell
+    // suppresses the welcome through `onCompleted`, so no mount follows to
+    // consume a marker. Writing one here would be read as a fresh hand-off on
+    // the next reload, so the button must leave the address untouched.
+    (window as unknown as { __TAURI__: unknown }).__TAURI__ = { core: {} };
+    let calls = 0;
+    done = () => {
+      calls += 1;
+    };
+    window.location.hash = "#/overview";
+    await show(clientWith(status()));
+    await finishNoSignIn();
+
+    await click("setup-open-console");
+
+    expect(window.location.hash).toBe("#/overview");
+    expect(calls).toBe(1);
   });
 });

--- a/frontend/test/unit/setup-wizard-mail-honesty.test.ts
+++ b/frontend/test/unit/setup-wizard-mail-honesty.test.ts
@@ -205,8 +205,7 @@ describe("the hand-off after setup applies", () => {
     await finish();
 
     expect(find("setup-handoff-link")).toBeTruthy();
-    expect(find("setup-signin")).toHaveAttribute(
-      "data-handoff-url",
+    expect(find("setup-signin")?.getAttribute("data-handoff-url")).toBe(
       "/login?company=acme&code=abc123#/company",
     );
   });

--- a/frontend/test/unit/setup-wizard-mail-honesty.test.ts
+++ b/frontend/test/unit/setup-wizard-mail-honesty.test.ts
@@ -206,7 +206,7 @@ describe("the hand-off after setup applies", () => {
 
     expect(find("setup-handoff-link")).toBeTruthy();
     expect(find("setup-signin")?.getAttribute("data-handoff-url")).toBe(
-      "/login?company=acme&code=abc123#/company",
+      "/login?company=acme&code=abc123#/company?from=setup",
     );
   });
 

--- a/frontend/test/unit/setup-wizard-mail-honesty.test.ts
+++ b/frontend/test/unit/setup-wizard-mail-honesty.test.ts
@@ -205,7 +205,10 @@ describe("the hand-off after setup applies", () => {
     await finish();
 
     expect(find("setup-handoff-link")).toBeTruthy();
-    expect(find("setup-signin")).toBeTruthy();
+    expect(find("setup-signin")).toHaveAttribute(
+      "data-handoff-url",
+      "/login?company=acme&code=abc123#/company",
+    );
   });
 
   it("points at the inbox only when the host can actually send", async () => {

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -220,6 +220,44 @@ async fn the_start_url_points_at_the_hub_and_returns_to_this_console() {
 }
 
 #[tokio::test]
+async fn a_setup_handoff_asks_the_hub_to_return_to_the_setup_destination() {
+    // A dead setup link that falls back to the form and continues through an
+    // ecosystem button has to arrive on the same roster the link promised. The
+    // destination rides in the return URI as a query parameter (`&from=setup`):
+    // the console's own fragment cannot cross the OAuth round trip — the hub
+    // appends `token=…&key=auth` to whatever it was given, and anything after a
+    // `#` there would swallow them.
+    let home = home();
+    let state = state_with(home.path(), Some(Arc::new(MockHubIdentityExchange::new()))).await;
+
+    let body = providers_from(&state, "from=setup").await;
+    let start = body["providers"][0]["startUrl"].as_str().unwrap();
+
+    assert!(
+        start.ends_with("redirectUri=http%3A%2F%2F127.0.0.1%3A8080%2F%3Fcompany%3Dacme%26from%3Dsetup"),
+        "the redirect must carry the setup destination: {start}"
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_from_is_dropped_not_obeyed() {
+    // `from` rides the return URI through an external service and back into the
+    // address bar, so a value that could escape it — a fragment that would
+    // capture the hub's token, say — must be ignored, and the buttons must
+    // still come back.
+    let home = home();
+    let state = state_with(home.path(), Some(Arc::new(MockHubIdentityExchange::new()))).await;
+
+    let body = providers_from(&state, "from=https%3A%2F%2Fevil.example%0A").await;
+    let start = body["providers"][0]["startUrl"].as_str().unwrap();
+
+    assert!(
+        start.ends_with("redirectUri=http%3A%2F%2F127.0.0.1%3A8080%2F%3Fcompany%3Dacme"),
+        "the malformed destination must be dropped: {start}"
+    );
+}
+
+#[tokio::test]
 async fn a_hosted_console_offers_no_providers_while_the_hub_refuses_its_origin() {
     let home = home();
     let state = state_with_public_url(

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -234,7 +234,9 @@ async fn a_setup_handoff_asks_the_hub_to_return_to_the_setup_destination() {
     let start = body["providers"][0]["startUrl"].as_str().unwrap();
 
     assert!(
-        start.ends_with("redirectUri=http%3A%2F%2F127.0.0.1%3A8080%2F%3Fcompany%3Dacme%26from%3Dsetup"),
+        start.ends_with(
+            "redirectUri=http%3A%2F%2F127.0.0.1%3A8080%2F%3Fcompany%3Dacme%26from%3Dsetup"
+        ),
         "the redirect must carry the setup destination: {start}"
     );
 }

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -156,6 +156,21 @@ async fn providers(state: &AppState) -> serde_json::Value {
     body_json(response).await
 }
 
+/// `providers`, with the console's own `?…` query appended to the request.
+async fn providers_from(state: &AppState, query: &str) -> serde_json::Value {
+    let response = router(state.clone())
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/companies/acme/auth/hub?{query}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    body_json(response).await
+}
+
 // ---------------------------------------------------------------------------
 // The buttons
 // ---------------------------------------------------------------------------

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -763,6 +763,20 @@ fn redirect_fragment(redirect: &str) -> Option<String> {
     safe.then(|| redirect.to_string())
 }
 
+/// The safe subset of a hub sign-in destination hint.
+///
+/// `from` is carried in the hub's return URI as a query parameter — a fragment
+/// would swallow the hub's own `token=` on the way back, which is why this is
+/// not a [`redirect_fragment`]. It is round-tripped through an external service
+/// and back into the console's address bar, so it is validated to a slug
+/// subset (`setup`, today): a value that cannot be honoured is dropped rather
+/// than refused, exactly like [`redirect_fragment`].
+fn redirect_from(from: &str) -> Option<&str> {
+    let safe = from.len() <= 32
+        && from.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'));
+    safe.then_some(from)
+}
+
 /// Mails the magic link. Returns whether it was actually sent.
 ///
 /// `redirect`, when present, is appended to the link so the console lands on

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -898,9 +898,17 @@ fn hub_refused(code: &'static str, message: &'static str) -> Response {
 ///
 /// Carries `?company=` so the console lands scoped to the company it left from.
 /// The hub appends its own `token=…&key=auth` with `&`, so the two coexist.
-fn console_redirect_uri(state: &AppState, company: &CompanyId) -> String {
+///
+/// `from`, when the console asked for one, names the destination the sign-in
+/// should land on. It rides here as a query parameter (a fragment would capture
+/// the hub's `token=` on the way back) and is validated by [`redirect_from`].
+fn console_redirect_uri(state: &AppState, company: &CompanyId, from: Option<&str>) -> String {
     let origin = state.config().host_base_url();
-    format!("{}/?company={}", origin.trim_end_matches('/'), company)
+    let mut uri = format!("{}/?company={}", origin.trim_end_matches('/'), company);
+    if let Some(from) = from.and_then(redirect_from) {
+        uri.push_str(&format!("&from={from}"));
+    }
+    uri
 }
 
 /// `GET …/auth/hub` — the ecosystem sign-in buttons, ready to render.

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -920,6 +920,7 @@ fn console_redirect_uri(state: &AppState, company: &CompanyId, from: Option<&str
 async fn hub_providers(
     company: PublicCompany,
     State(state): State<AppState>,
+    Query(query): Query<HubProvidersQuery>,
 ) -> Json<HubProvidersResult> {
     // No exchange means no way to check a token that came back, so there is no
     // honest button to offer. Refusing here — rather than at redemption — is

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -936,7 +936,7 @@ async fn hub_providers(
             providers: Vec::new(),
         });
     }
-    let redirect_uri = console_redirect_uri(&state, company.runtime.id());
+    let redirect_uri = console_redirect_uri(&state, company.runtime.id(), query.from.as_deref());
     // The same judgement one step earlier in the flow. A hosted console's
     // `https` origin is refused by the hub's redirect gate with a `400` raised
     // before the provider handshake begins (issue #512), so the button is not

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -773,7 +773,9 @@ fn redirect_fragment(redirect: &str) -> Option<String> {
 /// than refused, exactly like [`redirect_fragment`].
 fn redirect_from(from: &str) -> Option<&str> {
     let safe = from.len() <= 32
-        && from.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'));
+        && from
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'));
     safe.then_some(from)
 }
 

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -153,6 +153,19 @@ struct HubProvidersResult {
     providers: Vec<HubProviderOption>,
 }
 
+/// What the console may ask a hub sign-in to return to, beyond its company.
+#[derive(Debug, Deserialize)]
+struct HubProvidersQuery {
+    /// The console destination the hub sign-in should land on, asked as a
+    /// *query* parameter because the console's fragment cannot survive the
+    /// OAuth round trip — the hub appends `token=…&key=auth` to the return URI
+    /// it was given, and anything after a `#` there would swallow them. Only
+    /// setup's dead-link recovery forwards a destination today (`from=setup`);
+    /// every other sign-in omits it and lands wherever it always did.
+    #[serde(default)]
+    from: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct LoginPassword {
     email: String,

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -99,6 +99,13 @@ pub fn router() -> Router<AppState> {
 #[derive(Debug, Deserialize)]
 struct RequestCode {
     email: String,
+    /// Where the console should land after this magic-link sign-in, carried as
+    /// a URL fragment (`#/company`). Only setup's hand-off asks for one today;
+    /// a normal sign-in omits it and lands wherever it always did. The value is
+    /// mailed inside the login link, so it is validated to a conservative
+    /// fragment subset — see [`redirect_fragment`].
+    #[serde(default)]
+    redirect: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -659,7 +666,14 @@ async fn request_code(
 
     // Deliver. A send failure must not change the response — it would report
     // that the address exists.
-    let delivered = deliver_code(&state, &runtime, &email, &plaintext).await;
+    let delivered = deliver_code(
+        &state,
+        &runtime,
+        &email,
+        &plaintext,
+        body.redirect.as_deref(),
+    )
+    .await;
 
     // Echoing the code makes local development work with no mail server. It is
     // also, literally, returning a credential in an HTTP response — so it is
@@ -718,8 +732,37 @@ pub(crate) fn echoes_code_in_response(state: &AppState) -> bool {
     state.config().is_local_only() && !mail_transport_wired(state)
 }
 
+/// The safe subset of a URL fragment a mailed login link may carry.
+///
+/// Only the fragment part of a link is ever client-supplied, and a value that
+/// cannot be honoured is dropped rather than refused — a malformed redirect
+/// must not block sign-in. The set is deliberately small: fragment characters
+/// that route the console (`#/company`), with nothing that could break the
+/// link out of a mail client's linkification (`@`, whitespace, control
+/// characters).
+fn redirect_fragment(redirect: &str) -> Option<String> {
+    let safe = redirect.starts_with('#')
+        && redirect.len() <= 128
+        && redirect.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(b, b'#' | b'/' | b'?' | b'&' | b'=' | b'-' | b'_' | b'.')
+        });
+    safe.then(|| redirect.to_string())
+}
+
 /// Mails the magic link. Returns whether it was actually sent.
-async fn deliver_code(state: &AppState, runtime: &CompanyRuntime, email: &str, code: &str) -> bool {
+///
+/// `redirect`, when present, is appended to the link so the console lands on
+/// the fragment the requester asked for (setup's `#/company`, for example)
+/// rather than its default view. Sanitized by [`redirect_fragment`]: an
+/// invalid value means the link is mailed without it, never refused.
+async fn deliver_code(
+    state: &AppState,
+    runtime: &CompanyRuntime,
+    email: &str,
+    code: &str,
+    redirect: Option<&str>,
+) -> bool {
     // Asked through the shared predicate so "can this host mail at all" has one
     // answer: the throttle and the dev echo both branch on it, and a second
     // spelling here is how those three drift apart.
@@ -731,7 +774,10 @@ async fn deliver_code(state: &AppState, runtime: &CompanyRuntime, email: &str, c
         return false;
     };
     let base = state.config().host_base_url();
-    let link = format!("{base}/login?company={}&code={code}", runtime.id().as_ref());
+    let mut link = format!("{base}/login?company={}&code={code}", runtime.id().as_ref());
+    if let Some(fragment) = redirect.and_then(redirect_fragment) {
+        link.push_str(&fragment);
+    }
     let company_name = load_manifest(runtime)
         .await
         .ok()

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -25,7 +25,7 @@
 //! kind of grant, not a second one: eligibility only, minted on redemption,
 //! revoked by unsetting the source.
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -374,6 +374,59 @@ async fn a_login_that_asks_for_nothing_is_unchanged() {
 }
 
 #[tokio::test]
+async fn a_setup_link_carries_the_requested_landing_fragment() {
+    // Setup's hand-off asks the mailed link to land on the roster, so a
+    // production operator who finishes setup and follows the email reaches the
+    // company the wizard just built rather than the Overview graph. The
+    // fragment is appended after the code so the magic-link landing strips the
+    // credential and keeps the destination.
+    let home = home();
+    let (state, sender) = state_with_mail(home.path()).await;
+    let app = router(state.clone());
+    app.oneshot(post(
+        "/api/v1/companies/acme/auth/request",
+        serde_json::json!({
+            "email": "ada@example.com",
+            "redirect": "#/company?from=setup",
+        }),
+    ))
+    .await
+    .unwrap();
+    let sent = sender.sent();
+    let body = &sent.last().expect("no mail was sent").1.body;
+    assert!(
+        body.contains("/login?company=acme&code=") && body.contains("#/company?from=setup"),
+        "the mailed link must carry the setup destination: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_redirect_is_dropped_not_obeyed() {
+    // The fragment is mailed, so a value that could break the link out of the
+    // body — or name something that is not a console route — must be ignored,
+    // and it must not stop the sign-in mail from going out at all.
+    let home = home();
+    let (state, sender) = state_with_mail(home.path()).await;
+    let app = router(state.clone());
+    app.oneshot(post(
+        "/api/v1/companies/acme/auth/request",
+        serde_json::json!({
+            "email": "ada@example.com",
+            "redirect": "https://evil.example\n#/company",
+        }),
+    ))
+    .await
+    .unwrap();
+    let sent = sender.sent();
+    let body = &sent.last().expect("no mail was sent").1.body;
+    assert!(!body.contains("evil.example"), "{body}");
+    assert!(
+        body.contains("/login?company=acme&code="),
+        "the sign-in link itself must survive: {body}"
+    );
+}
+
+#[tokio::test]
 async fn a_header_carried_session_can_be_logged_out() {
     // Revocation has to reach the session however it was carried, or a hub
     // console's "sign out" would clear its own storage and leave a live token


### PR DESCRIPTION
## Summary

- route completed console setup directly to the refreshed `#/company` roster and keep the first-run tour welcome from covering that arrival
- carry `#/company` through the host wizard's local magic-link handoff
- cover the completion destination, hidden tour, roster refresh, and magic-link destination

Closes #1409

## Validation

- `npm --prefix frontend run typecheck:unit`
- `npm --prefix frontend run test -- test/unit/setup-wizard-mail-honesty.test.ts --reporter=verbose`
- `npm --prefix frontend run typecheck`

The first-run browser lane was attempted with `npm --prefix frontend run e2e:first-run`, but this fresh worktree has no `target/debug/opencompany` binary, which the lane requires.

## Scope

I implemented the issue's three arrival-path fixes. I deliberately left the optional company-name field out: it is a separate setup-flow expansion rather than necessary to make the created roster visible.