### PR TITLE
feat(task-detail): route detail tabs through the URL

### DIFF
--- a/frontend/src/lib/task-output.ts
+++ b/frontend/src/lib/task-output.ts
@@ -170,12 +170,24 @@ export function extraOutputCount(task: Task): number {
 
 /** What a `#/tasks/<id>?…` address asks the detail screen to open. */
 export interface TaskFocus {
+  /** An explicitly addressed always-visible task-detail tab. */
+  tab?: TaskTab;
   /** Open this artifact on the Artifacts tab… */
   artifactId?: string;
   /** …pinned at this revision, when the address named one. */
   version?: number;
   /** Or open this attempt's trace on the Attempts tab. */
   runId?: string;
+}
+
+/** The task-detail tabs that every card renders. */
+export const TASK_TABS = ["timeline", "attempts", "artifacts", "discussion"] as const;
+
+export type TaskTab = (typeof TASK_TABS)[number];
+
+/** Whether a query value names a task-detail tab that can always be opened. */
+export function isTaskTab(value: string): value is TaskTab {
+  return (TASK_TABS as readonly string[]).includes(value);
 }
 
 /**
@@ -195,6 +207,8 @@ export function readTaskFocus(hash: string): TaskFocus {
     return {};
   }
   const focus: TaskFocus = {};
+  const tab = params.get("tab");
+  if (tab && isTaskTab(tab)) focus.tab = tab;
   const artifactId = params.get("artifact");
   if (artifactId) {
     focus.artifactId = artifactId;
@@ -209,7 +223,18 @@ export function readTaskFocus(hash: string): TaskFocus {
   return focus;
 }
 
+/**
+ * Replaces the addressed task-detail tab without discarding another focus or
+ * the host scope carried in the same hash query.
+ */
+export function taskTabHref(hash: string, tab: TaskTab): string {
+  const [path, query = ""] = hash.split("?");
+  const params = new URLSearchParams(query);
+  params.set("tab", tab);
+  return `${path}?${params.toString()}`;
+}
+
 /** Whether a focus asks for anything at all. */
 export function hasFocus(focus: TaskFocus): boolean {
-  return Boolean(focus.artifactId || focus.runId);
+  return Boolean(focus.tab || focus.artifactId || focus.runId);
 }

--- a/frontend/src/lib/task-output.ts
+++ b/frontend/src/lib/task-output.ts
@@ -234,6 +234,20 @@ export function taskTabHref(hash: string, tab: TaskTab): string {
   return `${path}?${params.toString()}`;
 }
 
+/**
+ * Which tab an address asks the task detail to open (issue #339).
+ *
+ * `timeline` for everything else — including a focus that names nothing, which
+ * is every navigation that existed before this, and every lineage hop, whose
+ * plain `#/tasks/<id>` claims the default and must therefore land on it.
+ */
+export function tabForFocus(focus?: TaskFocus): TaskTab {
+  if (focus?.tab) return focus.tab;
+  if (focus?.artifactId) return "artifacts";
+  if (focus?.runId) return "attempts";
+  return "timeline";
+}
+
 /** Whether a focus asks for anything at all. */
 export function hasFocus(focus: TaskFocus): boolean {
   return Boolean(focus.tab || focus.artifactId || focus.runId);

--- a/frontend/src/lib/task-output.ts
+++ b/frontend/src/lib/task-output.ts
@@ -247,8 +247,3 @@ export function tabForFocus(focus?: TaskFocus): TaskTab {
   if (focus?.runId) return "attempts";
   return "timeline";
 }
-
-/** Whether a focus asks for anything at all. */
-export function hasFocus(focus: TaskFocus): boolean {
-  return Boolean(focus.tab || focus.artifactId || focus.runId);
-}

--- a/frontend/src/views/TaskDetailRoute.tsx
+++ b/frontend/src/views/TaskDetailRoute.tsx
@@ -23,7 +23,12 @@ import { useEffect, useState } from "react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { ApprovalSummary } from "@/api/types";
-import { readTaskFocus, type TaskFocus } from "@/lib/task-output";
+import {
+  readTaskFocus,
+  taskTabHref,
+  type TaskFocus,
+  type TaskTab,
+} from "@/lib/task-output";
 import { TaskDetailView } from "@/views/TaskDetailView";
 
 export function TaskDetailRoute({
@@ -65,6 +70,17 @@ export function TaskDetailRoute({
       taskId={taskId}
       attemptEventTick={attemptEventTick}
       focus={focus}
+      onTabChange={(tab: TaskTab) => {
+        // A tab is part of the task detail's current place, but a succession
+        // of clicks is not a succession of browser destinations. Replacing the
+        // current entry means Back still returns to the board and Forward
+        // returns to the tab the operator was using there.
+        const next = taskTabHref(window.location.hash, tab);
+        if (next === window.location.hash) return;
+        window.history.replaceState(null, "", next);
+        // replaceState does not emit hashchange, so follow it locally.
+        setFocus(readTaskFocus(next));
+      }}
       parked={parked}
       onBack={onLeave}
       onNavigate={(id) => {

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -82,7 +82,12 @@ import {
   type ApprovalSummary,
 } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
-import { hasFocus, isTaskTab, type TaskFocus, type TaskTab } from "@/lib/task-output";
+import {
+  isTaskTab,
+  tabForFocus,
+  type TaskFocus,
+  type TaskTab,
+} from "@/lib/task-output";
 import { pendingApprovalWait } from "@/lib/task-approvals";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import {
@@ -249,20 +254,6 @@ function timeOf(at: number): string {
 }
 
 /**
- * Which tab a card's output link asks for (issue #339).
- *
- * `timeline` for everything else — including a focus that names nothing, which
- * is every navigation that existed before this — so the screen's default is
- * untouched by the feature.
- */
-function tabForFocus(focus?: TaskFocus): string {
-  if (focus?.tab) return focus.tab;
-  if (focus?.artifactId) return "artifacts";
-  if (focus?.runId) return "attempts";
-  return "timeline";
-}
-
-/**
  * The count that rides the Plan tab's trigger, and the colour it wears (#337).
  *
  * Two different signals, never merged into one number. Red is *blocking*: only
@@ -347,18 +338,24 @@ export function TaskDetailView({
   // whenever the address asked for nothing.
   const [tab, setTab] = useState<string>(() => tabForFocus(focus));
 
-  // Follow a focus that arrives (or changes) after mount: a card link clicked
-  // while this screen is already open, or a back/forward between two links on
-  // the same card. Keyed on the focus's own identity rather than the object,
-  // because the parent rebuilds it on every hash event and an object dependency
-  // would yank the operator back to the linked tab on every re-render.
+  // Follow the address after mount: a card link clicked while this screen is
+  // already open, a back/forward between two links on the same card, or a
+  // lineage hop to a neighbouring card. Keyed on the focus's own identity
+  // rather than the object, because the parent rebuilds it on every hash event
+  // and an object dependency would yank the operator back to the linked tab on
+  // every re-render.
+  //
+  // `taskId` is a dependency because a lineage hop writes a plain
+  // `#/tasks/<id>` — no tab addressed — while this component instance survives.
+  // Without the reset the screen would keep showing the previous card's tab
+  // while its address claimed the default, so copying or reloading that URL
+  // opened a different view than the one on screen.
   const focusKey = `${focus?.tab ?? ""}|${focus?.artifactId ?? ""}|${focus?.version ?? ""}|${focus?.runId ?? ""}`;
   useEffect(() => {
-    if (!hasFocus(focus ?? {})) return;
     setTab(tabForFocus(focus));
     // `focus` is read through `focusKey`, which is what actually changed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusKey]);
+  }, [focusKey, taskId]);
 
   // `isActive` is a per-effect-run token, not a shared ref: a superseded run
   // (e.g. taskId A→B) flips its own token to false so an in-flight `load()` from

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -82,7 +82,7 @@ import {
   type ApprovalSummary,
 } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
-import { hasFocus, type TaskFocus } from "@/lib/task-output";
+import { hasFocus, isTaskTab, type TaskFocus, type TaskTab } from "@/lib/task-output";
 import { pendingApprovalWait } from "@/lib/task-approvals";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import {
@@ -256,6 +256,7 @@ function timeOf(at: number): string {
  * untouched by the feature.
  */
 function tabForFocus(focus?: TaskFocus): string {
+  if (focus?.tab) return focus.tab;
   if (focus?.artifactId) return "artifacts";
   if (focus?.runId) return "attempts";
   return "timeline";
@@ -290,6 +291,7 @@ export function TaskDetailView({
   taskId,
   attemptEventTick,
   focus,
+  onTabChange,
   parked = EMPTY_PARKED,
   onBack,
   onNavigate,
@@ -317,6 +319,8 @@ export function TaskDetailView({
    * lands on the default tab, exactly as before.
    */
   focus?: TaskFocus;
+  /** Writes an always-visible tab into the task detail's address. */
+  onTabChange?: (tab: TaskTab) => void;
   /** Return to the board. */
   onBack: () => void;
   /** Navigate the detail to a neighbouring (lineage) task. */
@@ -348,7 +352,7 @@ export function TaskDetailView({
   // the same card. Keyed on the focus's own identity rather than the object,
   // because the parent rebuilds it on every hash event and an object dependency
   // would yank the operator back to the linked tab on every re-render.
-  const focusKey = `${focus?.artifactId ?? ""}|${focus?.version ?? ""}|${focus?.runId ?? ""}`;
+  const focusKey = `${focus?.tab ?? ""}|${focus?.artifactId ?? ""}|${focus?.version ?? ""}|${focus?.runId ?? ""}`;
   useEffect(() => {
     if (!hasFocus(focus ?? {})) return;
     setTab(tabForFocus(focus));
@@ -579,7 +583,14 @@ export function TaskDetailView({
               />
             )}
 
-            <Tabs value={tab} onValueChange={(next) => setTab(String(next))}>
+            <Tabs
+              value={tab}
+              onValueChange={(next) => {
+                const selected = String(next);
+                setTab(selected);
+                if (isTaskTab(selected)) onTabChange?.(selected);
+              }}
+            >
               <TabsList>
                 <TabsTrigger value="timeline">Timeline</TabsTrigger>
                 <TabsTrigger value="attempts">

--- a/frontend/test/unit/task-detail-tab-address.test.ts
+++ b/frontend/test/unit/task-detail-tab-address.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+/**
+ * The task detail's tab is addressed (issue #1399), so the screen and its URL
+ * must never disagree about which tab is open. The tab resolution itself is
+ * covered as a pure function in `task-links.test.ts`; what this file pins is
+ * the wiring that makes the screen re-read the address.
+ */
+describe("Task detail tab address (issue #1399)", () => {
+  const view = read("views/TaskDetailView.tsx");
+
+  it("re-reads the address on a lineage hop, not only on a focus change", () => {
+    // A lineage hop keeps this component instance mounted and writes a plain
+    // `#/tasks/<id>`: the focus goes empty, so without `taskId` in the deps the
+    // effect would not run and the previous card's tab would survive a URL
+    // that claims the default.
+    expect(view).toContain("}, [focusKey, taskId]);");
+  });
+
+  it("resets rather than returning early when the address names no tab", () => {
+    expect(view).not.toContain("if (!hasFocus(");
+    expect(view).toContain("setTab(tabForFocus(focus));");
+  });
+
+  it("writes every tab selection back into the address", () => {
+    expect(view).toContain("if (isTaskTab(selected)) onTabChange?.(selected);");
+  });
+});

--- a/frontend/test/unit/task-links.test.ts
+++ b/frontend/test/unit/task-links.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { extraOutputCount, primaryLink, readTaskFocus } from "@/lib/task-output";
+import {
+  extraOutputCount,
+  primaryLink,
+  readTaskFocus,
+  taskTabHref,
+} from "@/lib/task-output";
 import type { Task, TaskOutput } from "@/api/tasks";
 
 /**
@@ -157,8 +162,34 @@ describe("readTaskFocus", () => {
     expect(readTaskFocus("#/tasks/t-1?run=run-9")).toEqual({ runId: "run-9" });
   });
 
+  it("reads an explicitly addressed detail tab before a linked focus", () => {
+    expect(readTaskFocus("#/tasks/t-1?artifact=a-1&v=3&tab=discussion")).toEqual({
+      tab: "discussion",
+      artifactId: "a-1",
+      version: 3,
+    });
+  });
+
+  it("drops a tab that this screen cannot render", () => {
+    expect(readTaskFocus("#/tasks/t-1?tab=plan")).toEqual({});
+  });
+
   it("yields an empty focus for an address that asks for nothing", () => {
     expect(readTaskFocus("#/tasks/t-1")).toEqual({});
     expect(readTaskFocus("#/tasks/t-1?")).toEqual({});
+  });
+});
+
+describe("taskTabHref", () => {
+  it("replaces the tab while retaining the task focus and host scope", () => {
+    expect(taskTabHref("#/tasks/t-1?artifact=a-1&v=3&host=local", "discussion")).toBe(
+      "#/tasks/t-1?artifact=a-1&v=3&host=local&tab=discussion",
+    );
+  });
+
+  it("replaces an earlier tab rather than emitting it twice", () => {
+    expect(taskTabHref("#/tasks/t-1?tab=timeline", "attempts")).toBe(
+      "#/tasks/t-1?tab=attempts",
+    );
   });
 });

--- a/frontend/test/unit/task-links.test.ts
+++ b/frontend/test/unit/task-links.test.ts
@@ -4,6 +4,7 @@ import {
   extraOutputCount,
   primaryLink,
   readTaskFocus,
+  tabForFocus,
   taskTabHref,
 } from "@/lib/task-output";
 import type { Task, TaskOutput } from "@/api/tasks";
@@ -191,5 +192,24 @@ describe("taskTabHref", () => {
     expect(taskTabHref("#/tasks/t-1?tab=timeline", "attempts")).toBe(
       "#/tasks/t-1?tab=attempts",
     );
+  });
+});
+
+describe("tabForFocus", () => {
+  it("opens the tab the address names, ahead of a linked focus", () => {
+    expect(tabForFocus({ tab: "discussion", artifactId: "a-1" })).toBe("discussion");
+  });
+
+  it("derives the tab from a link that names no tab of its own", () => {
+    expect(tabForFocus({ artifactId: "a-1" })).toBe("artifacts");
+    expect(tabForFocus({ runId: "run-9" })).toBe("attempts");
+  });
+
+  it("falls back to the default for an address that asks for nothing", () => {
+    // A lineage hop writes a plain `#/tasks/<id>`, which claims the default
+    // tab — so the screen must land there rather than keep the tab the
+    // operator had selected on the previous card.
+    expect(tabForFocus({})).toBe("timeline");
+    expect(tabForFocus(undefined)).toBe("timeline");
   });
 });


### PR DESCRIPTION
## Summary
- route Timeline, Attempts, Artifacts, and Discussion through the task detail hash query as `?tab=…`
- replace the current task history entry on a tab click while preserving host, artifact, revision, and run focus
- parse only always-visible tabs and cover parsing and URL rewriting with focused unit tests

Closes #1399

## Validation
- `npm run typecheck:unit`
- `npx vitest run test/unit/task-links.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Scope
Uses `history.replaceState` so Back still returns to the board and Forward returns to the tab last selected on that task. The conditional Plan tab is intentionally not addressable; this issue names the four always-visible tabs.