### PR TITLE
fix(accessibility): name filter and composer controls

### DIFF
--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -836,6 +836,7 @@ export function LedgersView({
                   <Search className="pointer-events-none absolute left-2 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     className="pl-8"
+                    aria-label="Search ledger entries"
                     placeholder="Search every field"
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
@@ -853,7 +854,7 @@ export function LedgersView({
                       this read `all` while the list under it read "Every
                       status", and a chosen board column read `in_progress`
                       beside columns headed "In progress". */}
-                  <SelectTrigger className="w-[12rem]">
+                  <SelectTrigger className="w-[12rem]" aria-label="Filter by status">
                     <SelectValue>
                       {statusFilterLabel(ledger, statusFilter)}
                     </SelectValue>

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -311,12 +311,13 @@ export function MemoryView({ client, company }: Props) {
             <Input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search memory"
               placeholder="Search memory…"
               className="pl-8"
             />
           </div>
           <Select value={kind} onValueChange={(v) => v && setKind(v)} items={TYPE_FILTER_LABELS}>
-            <SelectTrigger className="w-40">
+            <SelectTrigger className="w-40" aria-label="Filter by memory type">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -146,7 +146,7 @@ export function UsageView({ client, company }: Props) {
             </p>
           </div>
           <Select value={range} onValueChange={(v) => v && setRange(v)} items={RANGE_LABELS}>
-            <SelectTrigger className="w-40">
+            <SelectTrigger className="w-40" aria-label="Usage date range">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -164,6 +164,7 @@ export function MessageComposer({
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={onKeyDown}
+          aria-label={placeholder}
           placeholder={placeholder}
           rows={1}
           className="field-sizing-content max-h-48 min-h-10 w-full resize-none bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground"

--- a/frontend/test/unit/accessibility-control-names.test.ts
+++ b/frontend/test/unit/accessibility-control-names.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+describe("operator control names (issue #1395)", () => {
+  it("names the ledger search and status filter independently of their values", () => {
+    const ledgers = read("views/LedgersView.tsx");
+
+    expect(ledgers).toContain('aria-label="Search ledger entries"');
+    expect(ledgers).toContain('aria-label="Filter by status"');
+  });
+
+  it("names the memory search and type filter independently of their placeholders", () => {
+    const memory = read("views/MemoryView.tsx");
+
+    expect(memory).toContain('aria-label="Search memory"');
+    expect(memory).toContain('aria-label="Filter by memory type"');
+  });
+
+  it("names the usage range filter", () => {
+    expect(read("views/UsageView.tsx")).toContain('aria-label="Usage date range"');
+  });
+
+  it("keeps the composer named after its placeholder disappears", () => {
+    const composer = read("views/chat/MessageComposer.tsx");
+
+    expect(composer).toContain("aria-label={placeholder}");
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit accessible names to the ledger and memory search fields and their filter triggers
- name the usage date-range trigger and preserve the chat composer’s contextual name after text is entered
- add a focused source-contract regression test for every corrected control

Closes #1395

## Validation
- `pnpm exec vitest run test/unit/accessibility-control-names.test.ts`
- `pnpm typecheck`

I also started `pnpm test` and `pnpm build`; the host command boundary ended each before its final summary, although the unit run reached and passed this regression test with no active runner left afterward.

## Scope
The issue’s SMTP host field already has a visible associated label, and the workspace file input is hidden behind the exposed upload control, so neither was changed.