### PR TITLE
fix(ui): ensure minimum touch targets on mobile views

### DIFF
--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -284,7 +284,7 @@ export function Overview({ client, company, companyName }: Props) {
           disabled={loading}
           title="This page is a snapshot, not a live view. Re-read the company."
           aria-label="Refresh the graph"
-          className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-muted disabled:opacity-50"
+          className="inline-flex min-h-6 items-center gap-1 rounded px-1 py-0.5 hover:bg-muted disabled:opacity-50 md:min-h-0"
         >
           <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} aria-hidden />
           Refresh

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2251,7 +2251,7 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
       <div
         ref={rowRef}
         className={cn(
-          "group flex items-center gap-1 rounded-md px-1.5 py-1 text-sm",
+          "group flex items-center gap-1 rounded-md px-1.5 py-0 text-sm md:py-1",
           active ? "bg-accent font-medium" : "hover:bg-accent/50",
           // Muted whether or not it is the open note: neither what writes the
           // file (#1377) nor who can read it (#1465) changes when you select
@@ -2262,7 +2262,7 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
       >
         <button
           onClick={() => (isFolder ? onToggle(node.id) : onOpen(node.id))}
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+          className="flex min-h-6 min-w-0 flex-1 items-center gap-1.5 text-left md:min-h-0"
         >
           {isFolder ? (
             <>

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -222,7 +222,7 @@ function Reactions({
           onClick={() => onReact(chip.emoji)}
           title={disabledReason ?? `${chip.by.join(", ")} reacted with ${chip.emoji}`}
           className={cn(
-            "flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors",
+            "flex min-h-6 items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors md:min-h-0",
             chip.mine
               ? "border-primary/40 bg-primary/10 hover:bg-primary/20"
               : "border-border bg-muted/60 hover:bg-muted",

--- a/frontend/test/unit/chat-reaction-touch-target.test.ts
+++ b/frontend/test/unit/chat-reaction-touch-target.test.ts
@@ -53,7 +53,9 @@ describe("reaction chips at a touch viewport", () => {
       );
     });
 
-    const chip = container.querySelector('[aria-label="👍 — Mithil"]');
+    const chip = [...container.querySelectorAll("button")].find((button) =>
+      button.className.includes("rounded-full"),
+    );
     expect(chip).not.toBeNull();
     expect(chip?.className).toContain("min-h-6");
     expect(chip?.className).toContain("md:min-h-0");

--- a/frontend/test/unit/chat-reaction-touch-target.test.ts
+++ b/frontend/test/unit/chat-reaction-touch-target.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MessageRow } from "@/views/chat/MessageRow";
+import type { TimelineEntry } from "@/views/chat/model";
+
+/** Issue #1396: adjacent reaction chips need a 24px target on touch layouts. */
+
+let container: HTMLDivElement;
+let root: Root;
+
+const ENTRY: TimelineEntry = {
+  message: {
+    id: "h1",
+    from: "you",
+    text: "A message with a reaction.",
+    at: 1_700_000_000_000,
+    reactions: [{ emoji: "👍", by: "Mithil", mine: false }],
+  },
+  sender: { key: "you", name: "You", kind: "you" },
+  continuation: false,
+  replies: [],
+  replySenders: [],
+};
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("reaction chips at a touch viewport", () => {
+  it("reserve a 24px minimum height below md while retaining desktop density", () => {
+    act(() => {
+      root.render(
+        createElement(MessageRow, {
+          entry: ENTRY,
+          threadOpen: false,
+          onOpenThread: () => {},
+          onReact: () => {},
+          onDismissCard: () => {},
+          dismissingCardId: null,
+        }),
+      );
+    });
+
+    const chip = container.querySelector('[aria-label="👍 — Mithil"]');
+    expect(chip).not.toBeNull();
+    expect(chip?.className).toContain("min-h-6");
+    expect(chip?.className).toContain("md:min-h-0");
+  });
+});

--- a/frontend/test/unit/overview-unreachable-host.test.ts
+++ b/frontend/test/unit/overview-unreachable-host.test.ts
@@ -129,6 +129,15 @@ function clickRefresh() {
 }
 
 describe("a host that cannot be reached at all", () => {
+  it("keeps Refresh at a 24px touch target below the desktop breakpoint", async () => {
+    await render(fakeClient().client);
+
+    const refresh = container.querySelector('[aria-label="Refresh the graph"]');
+    expect(refresh).not.toBeNull();
+    expect(refresh?.className).toContain("min-h-6");
+    expect(refresh?.className).toContain("md:min-h-0");
+  });
+
   it("says so, and does not draw an empty company", async () => {
     const unreachable = fakeClient();
     goUnreachable(unreachable);

--- a/frontend/test/unit/workspace-explorer-icons.test.ts
+++ b/frontend/test/unit/workspace-explorer-icons.test.ts
@@ -111,6 +111,20 @@ describe("every explorer icon says what it is (issue #1378)", () => {
   });
 });
 
+describe("the explorer tree at a touch viewport (issue #1396)", () => {
+  it("gives each row a 24px target below the desktop breakpoint", async () => {
+    await render();
+
+    const name = container.querySelector('[data-testid="workspace-tree-name"]');
+    const row = name?.closest("button");
+    expect(row, "a tree name must be inside its open/toggle button").not.toBeNull();
+    expect(row?.className).toContain("min-h-6");
+    // The denser 20px row is preserved on desktop; mobile is where a pointer
+    // is ordinarily a finger, and where adjacent rows need distinct targets.
+    expect(row?.className).toContain("md:min-h-0");
+  });
+});
+
 describe("the sweep's confirm wears the destroy weight (issue #1378)", () => {
   it("renders Remove with the solid destructive class, not the pale tint", async () => {
     await render();


### PR DESCRIPTION
## Summary
- give workspace tree open/toggle buttons, chat reaction chips, and the Overview refresh control a 24px minimum height below the `md` breakpoint
- preserve the existing compact desktop dimensions with `md:min-h-0`
- add rendered-component regression coverage for all three controls

Closes #1396

## Validation
- `pnpm exec vitest run test/unit/workspace-explorer-icons.test.ts test/unit/overview-unreachable-host.test.ts test/unit/chat-reaction-touch-target.test.ts`
- `pnpm run typecheck:unit`
- `pnpm run build`

## Scope
The issue's “Open this task” control was already removed on `main`, so this PR intentionally does not restore or resize it. The formerly reported pillar dots have already been replaced by named pillar chips; this change covers the remaining undersized controls identified in the current implementation.