### PR TITLE
fix(views): replace whole-card click targets with focused title buttons

### DIFF
--- a/frontend/src/views/TaskCard.tsx
+++ b/frontend/src/views/TaskCard.tsx
@@ -147,6 +147,7 @@ export function TaskItem({
           type="button"
           onClick={onOpen}
           className="-m-1 min-w-0 rounded-sm p-1 text-left text-sm font-medium leading-snug hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="task-card-open"
         >
           {task.title}
         </button>

--- a/frontend/src/views/TaskCard.tsx
+++ b/frontend/src/views/TaskCard.tsx
@@ -134,16 +134,6 @@ export function TaskItem({
 }) {
   return (
     <div
-      onClick={onOpen}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.target !== e.currentTarget) return;
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
       className={cn(
         "cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-[transform,box-shadow] hover:shadow active:cursor-grabbing",
         // A card being carried needs to read as being in the operator's hand,
@@ -153,7 +143,13 @@ export function TaskItem({
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <p className="text-sm font-medium leading-snug">{task.title}</p>
+        <button
+          type="button"
+          onClick={onOpen}
+          className="-m-1 min-w-0 rounded-sm p-1 text-left text-sm font-medium leading-snug hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {task.title}
+        </button>
         {/* Only when something is being asked. `low` is what a card takes when
             nobody chose a priority, so a badge for it is a pill on a third of a
             real board announcing the default — noise competing with the title
@@ -392,15 +388,14 @@ function LinkIcon({ kind }: { kind: TaskLink["kind"] }) {
  * `card` kind there, a link back to the card itself, and the card is already
  * that click. See the guard below.
  *
- * The anchor stops its own click from bubbling: the whole card is a button that
- * opens the detail screen, and without this a click on the link would both
- * follow the href and fire the card's `onOpen`, racing two navigations.
+ * It is independent of the title button that opens the task detail screen, so
+ * following an output never also opens the task itself.
  */
 function OutputLinkRow({ task }: { task: Task }) {
   const link = primaryLink(task);
   const extra = extraOutputCount(task);
   // A card that produced nothing links to itself, labelled "Open this task" —
-  // which is what the whole card already is (`role="button"`, `onOpen`). A
+  // which is what the title button already does (`onOpen`). A
   // second copy of the card's own action, given a divider and a row of its own,
   // is most of why two cards for the same kind of object came out different
   // heights and different shapes depending only on which column they sat in.
@@ -411,7 +406,6 @@ function OutputLinkRow({ task }: { task: Task }) {
       <a
         href={link.href}
         title={link.hint}
-        onClick={(e) => e.stopPropagation()}
         className="flex min-w-0 items-center gap-1.5 text-muted-foreground hover:text-foreground hover:underline"
       >
         <LinkIcon kind={link.kind} />
@@ -421,7 +415,6 @@ function OutputLinkRow({ task }: { task: Task }) {
         <a
           href={`#/tasks/${encodeURIComponent(task.id)}`}
           title="Open the task to see everything it produced."
-          onClick={(e) => e.stopPropagation()}
           className="shrink-0 text-muted-foreground hover:text-foreground hover:underline"
         >
           +{extra} more

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -558,9 +558,9 @@ function MemberCard({
               className="-m-1 min-w-0 flex-1 rounded-sm p-1 text-left hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               data-testid="team-card-open"
             >
-              <p className="truncate font-medium">{member.name}</p>
+              <span className="block truncate font-medium">{member.name}</span>
               {subtitle && (
-                <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+                <span className="block truncate text-xs text-muted-foreground">{subtitle}</span>
               )}
             </button>
           ) : (
@@ -595,8 +595,8 @@ function MemberCard({
 
                   That leaves exactly one item. It stays a menu rather than a
                   bare button: Remove is destructive, and a deliberate extra
-                  click before it is worth keeping now that the rest of the
-                  card is one big click target. Unlike "View teammate" it does
+                  click before it is worth keeping beside the title action.
+                  Unlike "View teammate" it does
                   not duplicate the card's own action, and unlike Budget it is
                   not per-teammate configuration that reads better on a
                   detail page — it is the one roster-level action an operator

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -537,32 +537,7 @@ function MemberCard({
   return (
     <Card
       data-testid="team-card"
-      // Issue #1206: the whole card is the way in, not just the name. Both the
-      // Inbox switch (#1190) and the menu's "View teammate"/budget items are
-      // gone now, so there is nothing left inside the card that a whole-card
-      // click would swallow — the earlier "deliberately this block rather than
-      // the card" tradeoff no longer applies. Cursor and hover say so before
-      // the click does; `role`/`tabIndex`/`onKeyDown` keep it reachable and
-      // activatable from the keyboard, the same pattern `TaskItem` already uses
-      // for a whole-card click target.
-      onClick={onOpen}
-      role={onOpen ? "button" : undefined}
-      tabIndex={onOpen ? 0 : undefined}
-      onKeyDown={
-        onOpen
-          ? (e) => {
-              if (e.target !== e.currentTarget) return;
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onOpen();
-              }
-            }
-          : undefined
-      }
-      className={cn(
-        onOpen &&
-          "cursor-pointer transition-colors hover:border-primary/40 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-      )}
+      className="transition-colors"
     >
       <CardContent className="flex h-full flex-col gap-3 py-4">
         <div className="flex items-start gap-3">
@@ -576,28 +551,27 @@ function MemberCard({
             smudge and the bare tone tile is the honest fallback.
           */}
           <TeammateAvatar name={member.name} tone={member.tone} avatar={member.avatar} className="size-11 rounded-xl text-sm" />
-          {/*
-            Plain text, not its own button (issue #1206): the whole card above
-            is now the single click/keyboard target, so a second nested
-            interactive element here would just be a second tab stop for the
-            same action. `data-testid` stays for the e2e specs that click this
-            block by name — a click here still reaches the host, it just
-            bubbles to the card's own handler rather than firing one of its own.
-          */}
-          <div className="min-w-0 flex-1" data-testid="team-card-open">
-            <p className="truncate font-medium">{member.name}</p>
-            {subtitle && (
-              <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
-            )}
-          </div>
-          {/*
-            Stops every click inside — the trigger and, since Base UI portals
-            the menu content elsewhere in the DOM but React still bubbles
-            synthetic events along the *component* tree, every item inside it
-            too — from reaching the card's own onClick above. Without this,
-            opening the menu (or clicking Remove) would also navigate.
-          */}
-          <div onClick={(e) => e.stopPropagation()}>
+          {onOpen ? (
+            <button
+              type="button"
+              onClick={onOpen}
+              className="-m-1 min-w-0 flex-1 rounded-sm p-1 text-left hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-testid="team-card-open"
+            >
+              <p className="truncate font-medium">{member.name}</p>
+              {subtitle && (
+                <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+              )}
+            </button>
+          ) : (
+            <div className="min-w-0 flex-1" data-testid="team-card-open">
+              <p className="truncate font-medium">{member.name}</p>
+              {subtitle && (
+                <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+              )}
+            </div>
+          )}
+          <div>
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={<Button variant="ghost" size="icon" className="-mr-1 -mt-1 size-7" aria-label="Teammate actions" />}
@@ -666,10 +640,7 @@ function MemberCard({
                 data-testid={`team-card-desk-${desk.id}`}
                 onClick={
                   onNavigateToDesk
-                    ? (e) => {
-                        e.stopPropagation();
-                        onNavigateToDesk(desk.id);
-                      }
+                    ? () => onNavigateToDesk(desk.id)
                     : undefined
                 }
               >

--- a/frontend/test/e2e/alert-dialog-confirm.spec.ts
+++ b/frontend/test/e2e/alert-dialog-confirm.spec.ts
@@ -111,7 +111,11 @@ test("confirming a task delete dismisses the dialog before the request lands", a
   await expect(card).toBeVisible({ timeout: 30_000 });
 
   // Open the card's detail screen, then its edit dialog, then ask to delete.
-  await card.click();
+  // The open action lives on the title button, not the whole card (issue #1391):
+  // the wrapper is a drag surface, and the centre of a freshly created card
+  // happens to sit on the title today but would drift below it as soon as the
+  // card grew a note or an assignee.
+  await card.getByTestId("task-card-open").click();
   await page.getByRole("button", { name: "Edit", exact: true }).click();
   await page.getByRole("button", { name: "Delete", exact: true }).click();
   await expect(dialog(page)).toContainText("Delete");

--- a/frontend/test/e2e/orchestration.ts
+++ b/frontend/test/e2e/orchestration.ts
@@ -255,7 +255,11 @@ export async function dispatch(page: Page, title: string) {
  */
 export async function openCard(page: Page, title: string): Promise<string> {
   await openBoard(page);
-  await card(page, title).click();
+  // The card's open action lives on the title button (issue #1391), not the
+  // whole card: the draggable wrapper is a drag surface only, and the centre of
+  // a card with a note and an assignee falls below the button, so a click there
+  // opens nothing and the URL assertion below would time out.
+  await card(page, title).getByTestId("task-card-open").click();
   await expect(page).toHaveURL(/#\/tasks\/[^/]+$/, { timeout: 30_000 });
   const id = page.url().split("#/tasks/")[1];
   await expect(page.getByText(title).first()).toBeVisible({ timeout: 30_000 });

--- a/frontend/test/e2e/team-desks.spec.ts
+++ b/frontend/test/e2e/team-desks.spec.ts
@@ -156,3 +156,23 @@ test("#1440 clicking a desk chip navigates to its own address", async ({ page })
   // The org chart landed at that desk's address (issue #485).
   await expect.poll(() => page.url()).toContain("#/company/research");
 });
+
+test("#1391 the teammate action is a focused title button, not an interactive card", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  const maya = card(page, "Maya");
+  await expect(maya).toBeVisible({ timeout: 30_000 });
+
+  // The card remains a grouping surface while its real controls — the title,
+  // desk chip, and overflow menu — are siblings. This avoids a button owning
+  // other interactive descendants and leaves the title's native Enter/Space
+  // activation and focus indicator intact.
+  await expect(maya).not.toHaveAttribute("role", "button");
+  const open = maya.getByTestId("team-card-open");
+  await expect(open).toHaveJSProperty("tagName", "BUTTON");
+  await open.focus();
+  await expect(open).toBeFocused();
+  await open.press("Enter");
+  await expect(page).toHaveURL(/#\/team\/maya$/);
+});

--- a/frontend/test/unit/task-blocked-card.test.ts
+++ b/frontend/test/unit/task-blocked-card.test.ts
@@ -61,9 +61,11 @@ function parked(id: string, kind: string, at = T0): ApprovalSummary {
 let container: HTMLDivElement;
 let root: Root;
 let resumes: number;
+let opens: number;
 
 async function render(approvals: ApprovalSummary[], dragging = false) {
   resumes = 0;
+  opens = 0;
   await act(async () => {
     root.render(
       createElement(TaskItem, {
@@ -71,7 +73,9 @@ async function render(approvals: ApprovalSummary[], dragging = false) {
         dragging,
         block: taskApprovalBlock(approvals, "task-1"),
         now: NOW,
-        onOpen: () => {},
+        onOpen: () => {
+          opens += 1;
+        },
         onResume: () => {
           resumes += 1;
         },
@@ -102,6 +106,24 @@ afterEach(async () => {
 });
 
 describe("a paused card with approvals outstanding", () => {
+  it("uses its title button as the task action, leaving its controls independent", async () => {
+    await render([]);
+
+    const card = container.firstElementChild as HTMLDivElement;
+    const title = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Triage the release blockers"),
+    );
+    if (!title) throw new Error(`no task title button in:\n${container.innerHTML}`);
+
+    expect(card.getAttribute("role")).toBeNull();
+    expect(card.hasAttribute("tabindex")).toBe(false);
+    expect(title.querySelectorAll("button, a")).toHaveLength(0);
+    await act(async () => {
+      title.click();
+    });
+    expect(opens).toBe(1);
+  });
+
   it("looks lifted while the board is carrying it", async () => {
     await render([], true);
 


### PR DESCRIPTION
## Summary

- replace interactive task-card and teammate-card containers with real title buttons, leaving output links, task controls, desk chips, and the overflow menu as independent controls
- add visible `focus-visible:ring-2` indicators to both primary actions
- cover task-card semantics in a focused unit test and teammate-card semantics/keyboard activation in the roster Playwright spec

Closes #1391

## Validation

- `pnpm exec vitest run test/unit/task-blocked-card.test.ts`
- `pnpm typecheck`

The focused roster Playwright spec was not run locally: its harness requires `target/debug/opencompany`, which is absent in this fresh worktree. A capped default-feature Cargo build was attempted but did not complete in the allotted command window.

## Scope

Interpreted the issue narrowly: primary navigation now lives on each card title, preserving native Enter/Space activation and a visible focus ring. No unrelated card or roster behavior was changed.