### PR TITLE
fix(ui): meet contrast targets for console tokens

### DIFF
--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -135,7 +135,7 @@ Layer 2. These are what components use.
 | `--chrome` | `#EBEBF4` | rung `2` | The window chrome |
 | `--chrome-border` | rung `4` | rung `active` | Where the content card meets it |
 | `--border` | rung `4` | rung `4` | The hairline |
-| `--input` | rung `4` | rung `active` | Field borders, stronger rules |
+| `--input` | `#85858F` | rung `active` | Field borders, stronger rules |
 | `--ring` | `brand-500` | `brand-400` | Focus |
 
 Light surfaces climb *toward* the viewer with lightness (canvas `#F7F7FC` →
@@ -202,7 +202,7 @@ the nav row you are standing on.
 | `--foreground` | 18.44:1 | 19.92:1 | Primary reading text |
 | `--muted-foreground` | 5.07:1 | 5.46:1 | Secondary, metadata, captions |
 | `--primary` | 4.58:1 | 5.98:1 | Links, emphasis |
-| `--destructive` | 3.82:1 | 6.73:1 | Error marks (see caveat below) |
+| `--destructive` | 4.67:1 | 6.73:1 | Error text and marks |
 
 `--muted-foreground` also measures 4.55:1 on `--muted`, so caption text on a
 recessed fill still passes.
@@ -221,16 +221,15 @@ both fill a 6px dot and set legible 11px text.
 | State | Light mark | Light text | Dark (both) |
 | --- | --- | --- | --- |
 | **idle** | `#8C8C9E` 3.22:1 | `#6E6E80` 4.87:1 | `#9797A8` 6.80:1 |
-| **running** | `#0EA5E9` 2.70:1 | `#0A6E9C` 5.50:1 | `#38BDF8` 9.12:1 |
-| **blocked** | `#F5A524` 1.99:1 | `#A16207` 4.80:1 | `#FFC53D` 12.38:1 |
-| **done** | `#12A150` 3.28:1 | `#0A7D3E` 5.10:1 | `#35C77F` 8.95:1 |
-| **failed** | `#E5484D` 3.82:1 | `#C62A2F` 5.43:1 | `#FF6369` 6.73:1 |
+| **running** | `#008DD0` 3.08:1 | `#0A6E9C` 5.50:1 | `#38BDF8` 9.12:1 |
+| **blocked** | `#BF7200` 3.14:1 | `#A16207` 4.80:1 | `#FFC53D` 12.38:1 |
+| **done** | `#12A150` 3.08:1 | `#0A7D3E` 5.10:1 | `#35C77F` 8.95:1 |
+| **failed** | `#E5484D` 3.29:1 | `#C62A2F` 5.43:1 | `#FF6369` 6.73:1 |
 
-**Read the two low numbers.** Amber at 1.99:1 and cyan at 2.70:1 do not meet
-even the 3:1 UI threshold on the light canvas — that is exactly why the split
-exists. They are legitimate on a badge's soft background or as a large filled
-bar, and they must never set text or paint a lone thin mark on the canvas. Use
-`-text` for anything a person reads.
+The light marks clear 3:1 against every surface where they render, including
+the muted and active fills. The light text weights remain darker, so a compact
+label keeps the 4.5:1 text target without making the corresponding dot or bar
+unnecessarily heavy.
 
 In dark mode `-mark` and `-text` intentionally collapse to the same bright
 value: on near-black it clears 4.5:1 on its own, and a separate text weight

--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -297,9 +297,9 @@ renamed — they name a slot, not a colour. A desk keyed `amber` resolves to
 | Slot | Light | Dark |
 | --- | --- | --- |
 | `--chart-1` | `#7153F0` violet | `#937BF6` |
-| `--chart-2` | `#0EA5E9` cyan | `#38BDF8` |
-| `--chart-3` | `#12A150` green | `#35C77F` |
-| `--chart-4` | `#F5A524` amber | `#FFC53D` |
+| `--chart-2` | `#008DD0` cyan | `#38BDF8` |
+| `--chart-3` | `#009A49` green | `#35C77F` |
+| `--chart-4` | `#BF7200` amber | `#FFC53D` |
 | `--chart-5` | `#E93D82` pink | `#FF6BA6` |
 
 Brand leads slot 1; the sequence then walks the hue circle so neighbouring

--- a/docs/design-system/color.md
+++ b/docs/design-system/color.md
@@ -223,7 +223,7 @@ both fill a 6px dot and set legible 11px text.
 | **idle** | `#8C8C9E` 3.22:1 | `#6E6E80` 4.87:1 | `#9797A8` 6.80:1 |
 | **running** | `#008DD0` 3.08:1 | `#0A6E9C` 5.50:1 | `#38BDF8` 9.12:1 |
 | **blocked** | `#BF7200` 3.14:1 | `#A16207` 4.80:1 | `#FFC53D` 12.38:1 |
-| **done** | `#12A150` 3.08:1 | `#0A7D3E` 5.10:1 | `#35C77F` 8.95:1 |
+| **done** | `#009A49` 3.08:1 | `#0A7D3E` 5.10:1 | `#35C77F` 8.95:1 |
 | **failed** | `#E5484D` 3.29:1 | `#C62A2F` 5.43:1 | `#FF6369` 6.73:1 |
 
 The light marks clear 3:1 against every surface where they render, including

--- a/frontend/.issue1394-frontend-checks.log
+++ b/frontend/.issue1394-frontend-checks.log
@@ -1,4 +1,0 @@
-
-> opencompany-console@0.1.0 typecheck
-> tsc -b --noEmit
-

--- a/frontend/.issue1394-frontend-checks.log
+++ b/frontend/.issue1394-frontend-checks.log
@@ -1,0 +1,4 @@
+
+> opencompany-console@0.1.0 typecheck
+> tsc -b --noEmit
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -164,7 +164,7 @@
        canvas), `-text` sets words (needs 4.5:1, so it is materially darker
        in light mode), and `-soft` is the tinted background a badge sits on.
        Every ratio is measured, not eyeballed — see docs/design-system/color.md. */
-    --green-mark: oklch(0.6221 0.1627 151.05); /* #12A150  3.28:1 */
+    --green-mark: oklch(0.60 0.1627 151.05); /* #009A49  3.08:1 on light active */
     --green-text: oklch(0.5175 0.1343 151.56); /* #0A7D3E  5.10:1 */
     --green-bright: oklch(0.7369 0.1603 156.57); /* #35C77F  dark mode */
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,15 +168,15 @@
     --green-text: oklch(0.5175 0.1343 151.56); /* #0A7D3E  5.10:1 */
     --green-bright: oklch(0.7369 0.1603 156.57); /* #35C77F  dark mode */
 
-    --amber-mark: oklch(0.7819 0.1585 72.33); /* #F5A524  1.99:1 — mark only */
+    --amber-mark: oklch(0.62 0.1585 72.33); /* #BF7200  3.14:1 on light active */
     --amber-text: oklch(0.5538 0.1207 66.44); /* #A16207  4.80:1 */
     --amber-bright: oklch(0.8537 0.1572 84.13); /* #FFC53D  dark mode */
 
-    --red-mark: oklch(0.6256 0.1933 23.03); /* #E5484D  3.82:1 */
+    --red-mark: oklch(0.6256 0.1933 23.03); /* #E5484D  3.29:1 on light active */
     --red-text: oklch(0.5409 0.1916 25.1); /* #C62A2F  5.43:1 */
     --red-bright: oklch(0.7013 0.1901 21.2); /* #FF6369  dark mode */
 
-    --cyan-mark: oklch(0.6847 0.1479 237.32); /* #0EA5E9  2.70:1 — mark only */
+    --cyan-mark: oklch(0.61 0.1479 237.32); /* #008DD0  3.08:1 on light active */
     --cyan-text: oklch(0.5103 0.1085 236.98); /* #0A6E9C  5.50:1 */
     --cyan-bright: oklch(0.7535 0.139 232.66); /* #38BDF8  dark mode */
 
@@ -231,11 +231,11 @@
     --accent: var(--surface-light-active);
     --accent-foreground: var(--ink-light-primary);
 
-    --destructive: var(--red-mark);
+    --destructive: var(--red-text);
     --destructive-foreground: var(--surface-light-1);
 
     --border: var(--surface-light-4);
-    --input: var(--surface-light-4);
+    --input: oklch(0.62 0.0149 286.09); /* #85858F  3.07:1 on light active */
 
     /* The window chrome, and the hairline where the content card meets it.
        One value, painted exactly once — on the shell root — so the sidebar

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,6 +86,7 @@
     --surface-light-2: oklch(0.9601 0.0093 286.22); /* #F1F1F8 */
     --surface-light-3: oklch(0.9339 0.0134 286.14); /* #E8E8F2 */
     --surface-light-4: oklch(0.8916 0.0149 286.09); /* #DADAE5 */
+    --surface-light-input: oklch(0.62 0.0149 286.09); /* #85858F  3.07:1 on light active */
     --surface-light-active: oklch(0.942 0.0256 293.15); /* #ECE9FC */
 
     --surface-dark-bg: oklch(0.1395 0.0048 262.8); /* #08090B */
@@ -235,7 +236,7 @@
     --destructive-foreground: var(--surface-light-1);
 
     --border: var(--surface-light-4);
-    --input: oklch(0.62 0.0149 286.09); /* #85858F  3.07:1 on light active */
+    --input: var(--surface-light-input);
 
     /* The window chrome, and the hairline where the content card meets it.
        One value, painted exactly once — on the shell root — so the sidebar

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -289,7 +289,7 @@ function ColorSection() {
               ink-muted — teammate counts, metadata. 4.5:1
             </p>
             <p className="text-sm text-primary">primary — links and emphasis. 4.7:1</p>
-            <p className="text-sm text-destructive">destructive — errors. 3.8:1 (marks)</p>
+            <p className="text-sm text-destructive">destructive — errors. 4.67:1</p>
           </CardContent>
         </Card>
         <p className="mt-2 text-2xs text-muted-foreground">

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -847,7 +847,7 @@ function DetailHeader({
           host older than #333 has no link and still falls back to the run
           window. Said plainly rather than left for a reader to discover. */}
       {showWaiting && (
-        <p className="mt-2 text-2xs text-muted-foreground/70">
+        <p className="mt-2 text-2xs text-muted-foreground">
           Waiting counts this task&rsquo;s own approvals; sign-offs parked before they carried a
           task id fall back to its run window.
         </p>
@@ -1505,7 +1505,7 @@ function StepBody({ entry }: { entry: TimelineEntry }) {
       {entry.detail && (
         <div>
           {entry.result && (
-            <div className="text-3xs font-medium uppercase tracking-wide text-muted-foreground/70">
+            <div className="text-3xs font-medium uppercase tracking-wide text-muted-foreground">
               Called with
             </div>
           )}
@@ -1517,7 +1517,7 @@ function StepBody({ entry }: { entry: TimelineEntry }) {
       {entry.result && (
         <div>
           {entry.detail && (
-            <div className="text-3xs font-medium uppercase tracking-wide text-muted-foreground/70">
+            <div className="text-3xs font-medium uppercase tracking-wide text-muted-foreground">
               Result
             </div>
           )}

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -995,12 +995,12 @@ function FieldRow({
         onChange={(e) => onChange(e.target.value)}
       />
       <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
-        <code className="font-mono text-2xs text-muted-foreground/70">{field.key}</code>
+        <code className="font-mono text-2xs text-muted-foreground">{field.key}</code>
         {/* Only where it is true *and* actionable: a locked field cannot be
             changed here at all, so telling its owner about a restart is noise
             about work they are not doing. */}
         {field.requires_restart && !locked && (
-          <span className="text-2xs text-muted-foreground/70">· needs a restart</span>
+          <span className="text-2xs text-muted-foreground">· needs a restart</span>
         )}
       </div>
       {locked && <div className="mt-1.5">{<LayerLock />}</div>}

--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -298,7 +298,7 @@ function WorkflowCard({
       {workflow.description ? (
         <p className="line-clamp-2 text-xs text-muted-foreground">{workflow.description}</p>
       ) : (
-        <p className="text-xs italic text-muted-foreground/70">No description.</p>
+        <p className="text-xs italic text-muted-foreground">No description.</p>
       )}
 
       <WorkflowFacts workflow={workflow} />
@@ -408,7 +408,7 @@ function RowHealth({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoade
         {NO_RUNS_LABEL}
       </span>
     ) : (
-      <span className="truncate text-2xs text-muted-foreground/60">{LOADING_RUNS_LABEL}</span>
+      <span className="truncate text-2xs text-muted-foreground">{LOADING_RUNS_LABEL}</span>
     );
   }
 
@@ -421,7 +421,7 @@ function RowHealth({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoade
         <span className={`size-1.5 shrink-0 rounded-full ${tone.dot}`} />
         <span className="truncate text-muted-foreground">{label}</span>
       </span>
-      <span className="truncate text-right text-2xs text-muted-foreground/70">
+      <span className="truncate text-right text-2xs text-muted-foreground">
         {relativeTime(last.atMillis)}
       </span>
     </>
@@ -439,7 +439,7 @@ function HealthLine({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoad
   if (!last) {
     // Nothing yet, and the two reasons for that are NOT the same thing.
     if (!runsLoaded) {
-      return <span className="text-2xs text-muted-foreground/60">{LOADING_RUNS_LABEL}</span>;
+      return <span className="text-2xs text-muted-foreground">{LOADING_RUNS_LABEL}</span>;
     }
     // "No recent runs", never "never run". The company-wide run page is cut by
     // a limit, so a workflow whose last run has scrolled off it is
@@ -469,7 +469,7 @@ function HealthLine({ runs, runsLoaded }: { runs: WorkflowRunOutcome[]; runsLoad
         {last.scheduled ? "Scheduled" : "Manual"} run {tone.label}
         {failedNode ? ` at “${failedNode}”` : ""}
       </span>
-      <span className="text-muted-foreground/70">· {relativeTime(last.atMillis)}</span>
+      <span className="text-muted-foreground">· {relativeTime(last.atMillis)}</span>
       {undelivered > 0 && (
         <Badge
           variant="outline"
@@ -512,7 +512,7 @@ function RunStrip({ runs }: { runs: WorkflowRunOutcome[] }) {
           />
         );
       })}
-      <span className="ml-0.5 text-3xs text-muted-foreground/70">
+      <span className="ml-0.5 text-3xs text-muted-foreground">
         last {recent.length}
       </span>
     </span>

--- a/frontend/test/unit/shell-chrome-tokens.test.ts
+++ b/frontend/test/unit/shell-chrome-tokens.test.ts
@@ -108,7 +108,8 @@ describe("light accessibility tokens", () => {
     // `--input` stroke must therefore not inherit the deliberately subtle
     // decorative `--border` value (issue #1394).
     expect(declaration(light, "input")).not.toBe(declaration(light, "border"));
-    expect(declaration(light, "input")).toBe("oklch(0.62 0.0149 286.09)");
+    expect(declaration(light, "input")).toBe("var(--surface-light-input)");
+    expect(declaration(light, "surface-light-input")).toBe("oklch(0.62 0.0149 286.09)");
   });
 
   it("uses the AA light error text weight for destructive text", () => {

--- a/frontend/test/unit/shell-chrome-tokens.test.ts
+++ b/frontend/test/unit/shell-chrome-tokens.test.ts
@@ -99,3 +99,25 @@ describe("chrome tokens", () => {
     expect(declaration(theme, "color-chrome-border")).toBe("var(--chrome-border)");
   });
 });
+
+describe("light accessibility tokens", () => {
+  const light = block(":root");
+
+  it("gives form controls a stronger boundary than decorative borders", () => {
+    // A text field has no fill difference from the card it sits on. Its
+    // `--input` stroke must therefore not inherit the deliberately subtle
+    // decorative `--border` value (issue #1394).
+    expect(declaration(light, "input")).not.toBe(declaration(light, "border"));
+    expect(declaration(light, "input")).toBe("oklch(0.62 0.0149 286.09)");
+  });
+
+  it("uses the AA light error text weight for destructive text", () => {
+    expect(declaration(light, "destructive")).toBe("var(--red-text)");
+  });
+
+  it("keeps every light status mark at its measured accessible weight", () => {
+    expect(declaration(light, "green-mark")).toBe("oklch(0.60 0.1627 151.05)");
+    expect(declaration(light, "cyan-mark")).toBe("oklch(0.61 0.1479 237.32)");
+    expect(declaration(light, "amber-mark")).toBe("oklch(0.62 0.1585 72.33)");
+  });
+});


### PR DESCRIPTION
## Summary
- Give light-theme form controls a dedicated 3:1 boundary, lift every light status mark to its 3:1 floor, and use the AA error-text weight for destructive text.
- Remove opacity reductions from muted text, including workflow relative timestamps, and document the remeasured values.
- Add a token regression test covering the semantic bindings and accessible light mark weights.

Closes #1394

## Validation
- npm run typecheck (from frontend/)
- npx vitest run test/unit/shell-chrome-tokens.test.ts (from frontend/)
- npx vitest run test/unit/workflow-run-summary-line.test.ts (from frontend/)
- Browser rasterisation of the committed tokens: input 3.07:1; running 3.08:1; blocked 3.14:1; done 3.08:1; failed 3.29:1; destructive 4.67:1 on their worst light grounds.

I treated the decorative border token as intentionally subtle and scoped the stronger stroke to the input token, the sole normal boundary for form controls. The full frontend test/build commands were started but could not complete within this environment’s 30-second foreground-command cutoff; focused tests and the application typecheck completed successfully.