### PR TITLE
fix(approvals): wrap chat approval actions

### DIFF
--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -93,9 +93,9 @@ export function ApprovalHeadline({
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
         <Icon className="size-5" />
       </div>
-      {/* 12rem floor, capped at the card's own width (#1617 review): a chat
-          column can be narrower than the icon plus a 12rem title, and a hard
-          floor would overflow the card there instead of wrapping. */}
+      {/* 12rem floor, capped at the card's own width: a chat column can be
+          narrower than the icon plus a 12rem title, and a hard floor would
+          overflow the card there instead of wrapping. */}
       <div className="min-w-[min(12rem,100%)] flex-1">
         <p className="font-medium">{approvalAction(a)}</p>
         {a.amount_usd != null && (

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -89,11 +89,11 @@ export function ApprovalHeadline({
 }) {
   const Icon = approvalIcon(a.kind);
   return (
-    <div className="flex items-start gap-4">
+    <div className="flex flex-wrap items-start gap-4">
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
         <Icon className="size-5" />
       </div>
-      <div className="min-w-0 flex-1">
+      <div className="min-w-48 flex-1">
         <p className="font-medium">{approvalAction(a)}</p>
         {a.amount_usd != null && (
           <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>
@@ -108,7 +108,11 @@ export function ApprovalHeadline({
           <p className="text-xs font-medium text-muted-foreground italic">Amount hidden</p>
         )}
       </div>
-      {actions && <div className="flex shrink-0 gap-2">{actions}</div>}
+      {actions && (
+        <div data-approval-actions className="flex shrink-0 gap-2">
+          {actions}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -93,7 +93,10 @@ export function ApprovalHeadline({
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
         <Icon className="size-5" />
       </div>
-      <div className="min-w-48 flex-1">
+      {/* 12rem floor, capped at the card's own width (#1617 review): a chat
+          column can be narrower than the icon plus a 12rem title, and a hard
+          floor would overflow the card there instead of wrapping. */}
+      <div className="min-w-[min(12rem,100%)] flex-1">
         <p className="font-medium">{approvalAction(a)}</p>
         {a.amount_usd != null && (
           <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -399,18 +399,22 @@ function BatchHeadline({
   const title = sameKind ? approvalAction(lead) : `${approvals.length} actions need your sign-off`;
 
   return (
-    <div className="flex items-start gap-4">
+    <div className="flex flex-wrap items-start gap-4">
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
         <Icon className="size-5" />
       </div>
-      <div className="min-w-0 flex-1">
+      <div className="min-w-48 flex-1">
         <p className="font-medium">{title}</p>
         <p className="text-xs text-muted-foreground">
           {asker ? `${asker} needs` : "This turn needs"} {approvals.length} sign-offs before it
           can carry on
         </p>
       </div>
-      {actions && <div className="flex shrink-0 gap-2">{actions}</div>}
+      {actions && (
+        <div data-approval-actions className="flex shrink-0 gap-2">
+          {actions}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -403,7 +403,7 @@ function BatchHeadline({
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
         <Icon className="size-5" />
       </div>
-      {/* Same container-capped 12rem floor as `ApprovalHeadline` (#1617 review). */}
+      {/* Same container-capped 12rem floor as `ApprovalHeadline`. */}
       <div className="min-w-[min(12rem,100%)] flex-1">
         <p className="font-medium">{title}</p>
         <p className="text-xs text-muted-foreground">

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -403,7 +403,8 @@ function BatchHeadline({
       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
         <Icon className="size-5" />
       </div>
-      <div className="min-w-48 flex-1">
+      {/* Same container-capped 12rem floor as `ApprovalHeadline` (#1617 review). */}
+      <div className="min-w-[min(12rem,100%)] flex-1">
         <p className="font-medium">{title}</p>
         <p className="text-xs text-muted-foreground">
           {asker ? `${asker} needs` : "This turn needs"} {approvals.length} sign-offs before it

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -142,8 +142,8 @@ describe("the consolidated approval card", () => {
     // a viewport breakpoint. A 12rem title plus the icon and action pair cannot
     // fit in the narrow transcript, moving the pair to its own line instead of
     // reducing the title to one word per line. The floor is capped at the
-    // card's own width (#1617 review) so a column narrower than the icon plus
-    // a 12rem title wraps rather than overflowing the card.
+    // card's own width so a column narrower than the icon plus a 12rem title
+    // wraps rather than overflowing the card.
     await render([ESPN]);
     const singleActions = container.querySelector<HTMLElement>("[data-approval-actions]");
     expect(singleActions).not.toBeNull();

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -141,18 +141,20 @@ describe("the consolidated approval card", () => {
     // this has to be a width floor and wrapping contract on each headline — not
     // a viewport breakpoint. A 12rem title plus the icon and action pair cannot
     // fit in the narrow transcript, moving the pair to its own line instead of
-    // reducing the title to one word per line.
+    // reducing the title to one word per line. The floor is capped at the
+    // card's own width (#1617 review) so a column narrower than the icon plus
+    // a 12rem title wraps rather than overflowing the card.
     await render([ESPN]);
     const singleActions = container.querySelector<HTMLElement>("[data-approval-actions]");
     expect(singleActions).not.toBeNull();
     expect(singleActions!.parentElement?.className).toContain("flex-wrap");
-    expect(singleActions!.previousElementSibling?.className).toContain("min-w-48");
+    expect(singleActions!.previousElementSibling?.className).toContain("min-w-[min(12rem,100%)]");
 
     await render([ESPN, BBC]);
     const batchActions = container.querySelector<HTMLElement>("[data-approval-actions]");
     expect(batchActions).not.toBeNull();
     expect(batchActions!.parentElement?.className).toContain("flex-wrap");
-    expect(batchActions!.previousElementSibling?.className).toContain("min-w-48");
+    expect(batchActions!.previousElementSibling?.className).toContain("min-w-[min(12rem,100%)]");
   });
 
   it("asks once for a turn's three gated calls, naming each of them", async () => {

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -136,6 +136,25 @@ afterEach(() => {
 });
 
 describe("the consolidated approval card", () => {
+  it("lets actions wrap below a readable headline in single and batch cards (#1384)", async () => {
+    // The chat column is narrower than the viewport in both reported cases, so
+    // this has to be a width floor and wrapping contract on each headline — not
+    // a viewport breakpoint. A 12rem title plus the icon and action pair cannot
+    // fit in the narrow transcript, moving the pair to its own line instead of
+    // reducing the title to one word per line.
+    await render([ESPN]);
+    const singleActions = container.querySelector<HTMLElement>("[data-approval-actions]");
+    expect(singleActions).not.toBeNull();
+    expect(singleActions!.parentElement?.className).toContain("flex-wrap");
+    expect(singleActions!.previousElementSibling?.className).toContain("min-w-48");
+
+    await render([ESPN, BBC]);
+    const batchActions = container.querySelector<HTMLElement>("[data-approval-actions]");
+    expect(batchActions).not.toBeNull();
+    expect(batchActions!.parentElement?.className).toContain("flex-wrap");
+    expect(batchActions!.previousElementSibling?.className).toContain("min-w-48");
+  });
+
   it("asks once for a turn's three gated calls, naming each of them", async () => {
     await render([ESPN, BBC, GUARDIAN]);
 


### PR DESCRIPTION
## Summary
- let inline chat approval headlines wrap while keeping their title at a readable minimum width
- apply the same narrow-transcript behavior to single and batched approval cards
- cover both headline variants with a focused render test

Closes #1384

## Validation
- `npm test -- test/unit/approval-batch-card.test.ts`
- `npm run typecheck:unit`
- `npm test`
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm run build`

## Scope
This fixes the inline `#/chat` card. The Approvals-page card already places its actions in a wrapping footer, so it was deliberately left unchanged.