### PR TITLE
fix(sidebar): close mobile drawer on navigation

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -38,6 +38,7 @@ import {
   SidebarProvider,
   SidebarRail,
   SidebarTrigger,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { ContentSurface } from "@/components/content-surface";
 import { FeedbackDialog } from "@/components/feedback-dialog";
@@ -130,6 +131,62 @@ interface NavItem {
   view: View;
   label: string;
   icon: LucideIcon;
+}
+
+function SidebarNavigation({
+  view,
+  pending,
+  onNavigate,
+}: {
+  view: View;
+  pending: number;
+  onNavigate: (view: View) => void;
+}) {
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  const navigate = useCallback(
+    (next: View) => {
+      onNavigate(next);
+      if (isMobile) setOpenMobile(false);
+    },
+    [isMobile, onNavigate, setOpenMobile],
+  );
+
+  return (
+    <SidebarGroup>
+      <SidebarMenu>
+        {NAV.map((item) => (
+          <SidebarMenuItem key={item.view} data-tour={`nav-${item.view}`}>
+            <SidebarMenuButton
+              isActive={view === item.view}
+              tooltip={item.label}
+              onClick={() => navigate(item.view)}
+              className={RESTING_ROW}
+            >
+              <item.icon />
+              <span>{item.label}</span>
+            </SidebarMenuButton>
+            {item.view === "approvals" && pending > 0 && (
+              <>
+                <SidebarMenuBadge>{pending}</SidebarMenuBadge>
+                {/* Issue #1018: the badge is the sidebar's only attention
+                    signal and `SidebarMenuBadge` hides itself on the
+                    collapsed rail, so a collapsed sidebar said nothing was
+                    waiting. The dot is the same `pending` value rendered
+                    so it survives 32px — not a second source, so it cannot
+                    disagree with the badge or fork the count contract
+                    #932 pins. Exactly one of the two is visible at a
+                    time. */}
+                <SidebarMenuDot
+                  label={`${pending} ${pending === 1 ? "approval needs" : "approvals need"} you`}
+                />
+              </>
+            )}
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  );
 }
 
 // One flat list. The nav was grouped under "Operate" and "Configure" when the
@@ -1801,39 +1858,7 @@ export function AppShell({
           </div>
         </SidebarHeader>
         <SidebarContent data-tour="sidebar">
-          <SidebarGroup>
-            <SidebarMenu>
-              {NAV.map((item) => (
-                <SidebarMenuItem key={item.view} data-tour={`nav-${item.view}`}>
-                  <SidebarMenuButton
-                    isActive={view === item.view}
-                    tooltip={item.label}
-                    onClick={() => setView(item.view)}
-                    className={RESTING_ROW}
-                  >
-                    <item.icon />
-                    <span>{item.label}</span>
-                  </SidebarMenuButton>
-                  {item.view === "approvals" && pending > 0 && (
-                    <>
-                      <SidebarMenuBadge>{pending}</SidebarMenuBadge>
-                      {/* Issue #1018: the badge is the sidebar's only attention
-                          signal and `SidebarMenuBadge` hides itself on the
-                          collapsed rail, so a collapsed sidebar said nothing was
-                          waiting. The dot is the same `pending` value rendered
-                          so it survives 32px — not a second source, so it cannot
-                          disagree with the badge or fork the count contract
-                          #932 pins. Exactly one of the two is visible at a
-                          time. */}
-                      <SidebarMenuDot
-                        label={`${pending} ${pending === 1 ? "approval needs" : "approvals need"} you`}
-                      />
-                    </>
-                  )}
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroup>
+          <SidebarNavigation view={view} pending={pending} onNavigate={setView} />
         </SidebarContent>
         <SidebarFooter>
           <SidebarControls

--- a/frontend/src/components/sidebar-controls.tsx
+++ b/frontend/src/components/sidebar-controls.tsx
@@ -99,6 +99,12 @@ export function SidebarControls({
   onNavigate,
 }: Props) {
   const { label, tone } = lifecycle(lifecycleState, emergencyPaused);
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  const navigate = (next: View) => {
+    onNavigate(next);
+    if (isMobile) setOpenMobile(false);
+  };
 
   return (
     <SidebarMenu>
@@ -128,7 +134,7 @@ export function SidebarControls({
         <SidebarMenuButton
           tooltip="Feedback"
           isActive={view === "feedback"}
-          onClick={() => onNavigate("feedback")}
+          onClick={() => navigate("feedback")}
           className={RESTING_ROW}
         >
           <MessageSquareWarning />
@@ -316,4 +322,3 @@ export function SidebarCollapseButton() {
     </Tooltip>
   );
 }
-

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -197,6 +197,12 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
+          aria-modal="true"
+          onKeyDownCapture={(event) => {
+            if (event.key === "Escape") {
+              setOpenMobile(false)
+            }
+          }}
           className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
           style={
             {

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -62,6 +62,36 @@ test.describe("sidebar toggle reachability", () => {
     await expect(page.getByText("Workflows", { exact: true })).toBeVisible();
   });
 
+  test("the mobile sheet closes after selecting a destination", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/#/overview");
+    await dismissTour(page);
+
+    await page.getByRole("button", { name: "Toggle sidebar" }).click();
+    const sheet = page.getByRole("dialog", { name: "Sidebar" });
+    await expect(sheet).toBeVisible();
+    await expect(sheet).toHaveAttribute("aria-modal", "true");
+
+    await sheet.getByRole("button", { name: "Work", exact: true }).click();
+    await expect(page).toHaveURL(/#\/ledgers\/tasks$/);
+    await expect(sheet).toBeHidden();
+  });
+
+  test("Escape closes the mobile sheet after focus moves inside it", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/#/overview");
+    await dismissTour(page);
+
+    await page.getByRole("button", { name: "Toggle sidebar" }).click();
+    const sheet = page.getByRole("dialog", { name: "Sidebar" });
+    const destination = sheet.getByRole("button", { name: "Overview", exact: true });
+    await destination.focus();
+    await expect(destination).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await expect(sheet).toBeHidden();
+  });
+
   test("the mobile trigger does not overlap scrollable page content", async ({ page }) => {
     // The issue's own repro viewport (iPhone 12-class).
     await page.setViewportSize({ width: 390, height: 844 });


### PR DESCRIPTION
## Summary
- close the mobile sidebar sheet when an operator selects any main navigation destination or Feedback
- restore Escape dismissal after focus moves within the sheet, and mark the dialog as modal
- add real-host mobile regressions for destination selection, moved-focus Escape, and modal semantics

Closes #1388

## Validation
- npm run typecheck
- npm run typecheck:e2e
- npm run typecheck:unit
- npm test
- npm run build
- cargo build --locked --bin opencompany
- focused Playwright sidebar-toggle-reachable.spec.ts against an isolated host (5 passed)

## Scope
This addresses the drawer interaction and modal-semantics defects. It deliberately leaves the mobile trigger's DOM/tab order unchanged because the issue identifies that as a separate/sibling accessibility concern.