### PR TITLE
fix(console): preserve raw run failure details

### DIFF
--- a/frontend/src/views/workflows/RunFailurePanel.tsx
+++ b/frontend/src/views/workflows/RunFailurePanel.tsx
@@ -107,6 +107,14 @@ export function RunFailurePanel({
             {message}
           </AlertDescription>
         </Alert>
+        <details className="mt-2">
+          <summary className="cursor-pointer text-2xs text-muted-foreground">
+            Details
+          </summary>
+          <pre className="mt-1 overflow-auto rounded border bg-muted/40 p-2 font-mono text-2xs leading-snug text-foreground">
+            {failure.message}
+          </pre>
+        </details>
         <p className="mt-2 text-2xs text-muted-foreground">
           Failed after {formatDuration(ranFor)} ·{" "}
           {new Date(failure.atMillis).toLocaleString()}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -519,8 +519,8 @@ function RunHistoryRow({
                 wrong name. */}
             <p className="text-2xs font-medium text-status-failed-text">
               {failedNode
-                ? `The “${nodeName(graph, failedNode)}” step failed.`
-                : "This run failed."}
+                ? `This run failed at “${nodeName(graph, failedNode)}”: ${errorMessage}`
+                : `This run failed: ${errorMessage}`}
             </p>
             <p className="mt-1 text-2xs text-muted-foreground">
               Review the error details, then correct the workflow and run it again.
@@ -530,7 +530,7 @@ function RunHistoryRow({
                 Details
               </summary>
               <pre className="mt-1 overflow-auto rounded border bg-muted/40 p-2 font-mono text-2xs leading-snug text-foreground">
-                {errorMessage}
+                {run.error}
               </pre>
             </details>
           </div>

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -254,7 +254,7 @@ describe("dispatching a run clears the previous run's detail", () => {
 });
 
 describe("the history row names the node the operator named", () => {
-  it("prints the node's display name on the failure line, not its raw id", async () => {
+  it("leads with the actionable failure at the node's display name and keeps raw details", async () => {
     // The engine's trail is keyed by node id, and this line printed it verbatim
     // while the run drawer's own timeline — and the canvas, and the overlay
     // banner — all said “Draft the digest”.
@@ -267,7 +267,8 @@ describe("the history row names the node the operator named", () => {
       runId: "r9",
       deliveries: [],
       pendingApprovals: [],
-      error: "the writer agent has no model",
+      error:
+        "harness error: capability error: agent: the writer agent has no model",
       nodes: [
         { nodeId: "start", status: "ok", elapsedMs: 1 },
         { nodeId: "n_3", status: "error", elapsedMs: 12_000 },
@@ -286,8 +287,15 @@ describe("the history row names the node the operator named", () => {
       );
     });
     const row = container.querySelector('[data-testid="workflow-run-row"]');
-    expect(row?.textContent).toContain("The “Draft the digest” step failed.");
-    expect(row?.textContent).not.toContain("The “n_3” step failed.");
+    expect(row?.textContent).toContain(
+      "This run failed at “Draft the digest”: the writer agent has no model",
+    );
+    expect(row?.textContent).not.toContain("This run failed at “n_3”");
+    const details = row?.querySelector("details");
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain(
+      "harness error: capability error: agent: the writer agent has no model",
+    );
     // …and says how long it took, which nothing on this surface did before.
     expect(
       container.querySelector('[data-testid="workflow-run-duration"]')?.textContent,
@@ -359,6 +367,36 @@ describe("failure panel follow-up controls", () => {
     expect(openHistory).toHaveBeenCalledOnce();
     expect(showStep).toHaveBeenCalledOnce();
     expect(fixWithCopilot).toHaveBeenCalledOnce();
+  });
+});
+
+describe("failure panel error details", () => {
+  it("shows the actionable leaf while preserving the host diagnostic verbatim", async () => {
+    const raw =
+      "harness error: capability error: http_request: Blocked local/private host: 127.0.0.1";
+    await act(async () => {
+      root.render(
+        createElement(RunFailurePanel, {
+          failure: {
+            message: raw,
+            fromHost: true,
+            sawRunStart: false,
+            startedAtMillis: 1_000,
+            atMillis: 3_400,
+            request: "",
+            dryRun: false,
+          },
+          onClose: () => {},
+        }),
+      );
+    });
+
+    expect(
+      container.querySelector('[data-testid="workflow-run-failure-message"]')?.textContent,
+    ).toBe("Blocked local/private host: 127.0.0.1");
+    const details = container.querySelector("details");
+    expect(details?.open).toBe(false);
+    expect(details?.textContent).toContain(raw);
   });
 });
 


### PR DESCRIPTION
## Summary

- lead failed-run history and failure-panel messages with the actionable error clause
- preserve the untouched host diagnostic behind a closed, monospaced Details disclosure in both surfaces
- add renderer coverage for the visible leaf and raw diagnostic

Closes #1366

## Validation

- `npm test -- workflow-run-failure.test.ts workflow-run-error-message.test.ts`
- `npm run typecheck:unit`
- `npm run typecheck`
- `npm run build`

`npm test` was also run: 250 files / 2,265 tests passed, but the unrelated `test/unit/mock-brain.test.ts` timed out starting its local server.

## Scope

No host error contract was changed; the console retains raw errors only for the Details disclosure and uses the existing known-prefix helper for display.