### PR TITLE
fix(ui): restore focus after controlled dialog closes

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -52,6 +52,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
+        aria-modal="true"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid max-h-[90vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -43,18 +43,31 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
-  finalFocus = true,
+  finalFocus,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
 }) {
+  // Most console dialogs are controlled and have no `DialogTrigger`. Their
+  // owner unmounts the popup as soon as it closes, so retain the control that
+  // was active while the popup first mounted as an explicit return target.
+  const defaultFinalFocus = React.useRef<HTMLElement | null>(null)
+  if (
+    defaultFinalFocus.current === null &&
+    typeof document !== "undefined" &&
+    document.activeElement instanceof HTMLElement &&
+    document.activeElement !== document.body
+  ) {
+    defaultFinalFocus.current = document.activeElement
+  }
+
   return (
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         aria-modal="true"
-        finalFocus={finalFocus}
+        finalFocus={finalFocus ?? defaultFinalFocus}
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid max-h-[90vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -43,6 +43,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  finalFocus = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
@@ -53,6 +54,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         aria-modal="true"
+        finalFocus={finalFocus}
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid max-h-[90vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -5,10 +5,21 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { ReturnFocusContext, useReturnFocus } from "@/components/ui/return-focus"
 import { XIcon } from "lucide-react"
 
-function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog({ open, onOpenChange, ...props }: DialogPrimitive.Root.Props) {
+  const { target, handleOpenChange } = useReturnFocus(open, onOpenChange)
+  return (
+    <ReturnFocusContext.Provider value={target}>
+      <DialogPrimitive.Root
+        data-slot="dialog"
+        open={open}
+        onOpenChange={handleOpenChange}
+        {...props}
+      />
+    </ReturnFocusContext.Provider>
+  )
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
@@ -48,18 +59,10 @@ function DialogContent({
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
 }) {
-  // Most console dialogs are controlled and have no `DialogTrigger`. Their
-  // owner unmounts the popup as soon as it closes, so retain the control that
-  // was active while the popup first mounted as an explicit return target.
-  const defaultFinalFocus = React.useRef<HTMLElement | null>(null)
-  if (
-    defaultFinalFocus.current === null &&
-    typeof document !== "undefined" &&
-    document.activeElement instanceof HTMLElement &&
-    document.activeElement !== document.body
-  ) {
-    defaultFinalFocus.current = document.activeElement
-  }
+  // Most console dialogs are controlled and have no `DialogTrigger`, so Base UI
+  // has nothing to return focus to. `Dialog` captures the control that was
+  // active when this dialog opened; use it as the explicit return target.
+  const defaultFinalFocus = React.useContext(ReturnFocusContext)
 
   return (
     <DialogPortal>
@@ -67,7 +70,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         aria-modal="true"
-        finalFocus={finalFocus ?? defaultFinalFocus}
+        finalFocus={finalFocus ?? defaultFinalFocus ?? undefined}
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid max-h-[90vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className

--- a/frontend/src/components/ui/return-focus.ts
+++ b/frontend/src/components/ui/return-focus.ts
@@ -42,6 +42,13 @@ function useReturnFocus(
   const wasOpen = React.useRef(false)
 
   const capture = () => {
+    // Cleared first, every time. The target belongs to *this* opening: if
+    // nothing is focused now — a dialog opened from code after its opener was
+    // removed, say — the previous opening's target is not a sensible answer,
+    // and it may not even be in the document any more. A `null` ref makes Base
+    // UI fall back to its own return-focus handling, which is what should
+    // happen when the console has nothing better to offer.
+    target.current = null
     if (typeof document === "undefined") return
     const active = document.activeElement
     if (active instanceof HTMLElement && active !== document.body) {

--- a/frontend/src/components/ui/return-focus.ts
+++ b/frontend/src/components/ui/return-focus.ts
@@ -49,14 +49,23 @@ function useReturnFocus(
     }
   }
 
+  // Controlled: the `open` prop is the only authority. A consumer is free to
+  // refuse a requested dismissal — `SetupDialog` hands Base UI a no-op handler,
+  // `DeskCreateDialog` swallows it while submitting — so believing the callback
+  // here would record a close that never happened and make the next render look
+  // like a fresh opening, capturing an element *inside* the still-open popup.
   if (open !== undefined) {
     if (open && !wasOpen.current) capture()
     wasOpen.current = open
   }
 
   const handleOpenChange: OpenChange = (nextOpen, ...rest) => {
-    if (nextOpen && !wasOpen.current) capture()
-    wasOpen.current = nextOpen
+    // Uncontrolled: Base UI owns the state and the callback is the only report
+    // of it, so it is authoritative here for exactly the same reason.
+    if (open === undefined) {
+      if (nextOpen && !wasOpen.current) capture()
+      wasOpen.current = nextOpen
+    }
     onOpenChange?.(nextOpen, ...rest)
   }
 

--- a/frontend/src/components/ui/return-focus.ts
+++ b/frontend/src/components/ui/return-focus.ts
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import type { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+type OpenChange = NonNullable<DialogPrimitive.Root.Props["onOpenChange"]>
+
+/**
+ * The element a popup should hand focus back to when it closes.
+ *
+ * `null` outside a `Dialog`/`Sheet` root, in which case the popup falls back to
+ * Base UI's own return-focus handling.
+ */
+const ReturnFocusContext =
+  React.createContext<React.RefObject<HTMLElement | null> | null>(null)
+
+/**
+ * Remembers what was focused when a popup opened, so it can be refocused on
+ * close.
+ *
+ * Most console dialogs and sheets are controlled and have no trigger, so Base
+ * UI has no element to restore focus to and leaves it on `<body>` — keyboard
+ * users lose their place (issue #1387). Capturing `document.activeElement` is
+ * the fix, but it has to happen on the **closed → open transition**: these
+ * popups stay mounted while closed, so capturing once on first render would
+ * pin whatever happened to be focused during an unrelated ancestor rerender
+ * (typing in the ledger's search box, say) and return focus there instead of
+ * to the control that opened the popup.
+ *
+ * A controlled root flips `open` without ever calling `onOpenChange`, so that
+ * transition is only visible during render; an uncontrolled root only reports
+ * it through `onOpenChange`. Both are watched.
+ */
+function useReturnFocus(
+  open: boolean | undefined,
+  onOpenChange: OpenChange | undefined
+) {
+  const target = React.useRef<HTMLElement | null>(null)
+  // Seeded closed even when the first render is already open: a popup whose
+  // owner returns `null` while closed (`CreateTaskDialog`) mounts open, and
+  // that mount *is* its opening transition.
+  const wasOpen = React.useRef(false)
+
+  const capture = () => {
+    if (typeof document === "undefined") return
+    const active = document.activeElement
+    if (active instanceof HTMLElement && active !== document.body) {
+      target.current = active
+    }
+  }
+
+  if (open !== undefined) {
+    if (open && !wasOpen.current) capture()
+    wasOpen.current = open
+  }
+
+  const handleOpenChange: OpenChange = (nextOpen, ...rest) => {
+    if (nextOpen && !wasOpen.current) capture()
+    wasOpen.current = nextOpen
+    onOpenChange?.(nextOpen, ...rest)
+  }
+
+  return { target, handleOpenChange }
+}
+
+export { ReturnFocusContext, useReturnFocus }

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -3,10 +3,21 @@ import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { ReturnFocusContext, useReturnFocus } from "@/components/ui/return-focus"
 import { XIcon } from "lucide-react"
 
-function Sheet({ ...props }: SheetPrimitive.Root.Props) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+function Sheet({ open, onOpenChange, ...props }: SheetPrimitive.Root.Props) {
+  const { target, handleOpenChange } = useReturnFocus(open, onOpenChange)
+  return (
+    <ReturnFocusContext.Provider value={target}>
+      <SheetPrimitive.Root
+        data-slot="sheet"
+        open={open}
+        onOpenChange={handleOpenChange}
+        {...props}
+      />
+    </ReturnFocusContext.Provider>
+  )
 }
 
 function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
@@ -46,16 +57,9 @@ function SheetContent({
   showCloseButton?: boolean
 }) {
   // Sheets are controlled by the same sidebar state as dialogs are by their
-  // views. Keep the opener so closing a trigger-less sheet restores focus.
-  const defaultFinalFocus = React.useRef<HTMLElement | null>(null)
-  if (
-    defaultFinalFocus.current === null &&
-    typeof document !== "undefined" &&
-    document.activeElement instanceof HTMLElement &&
-    document.activeElement !== document.body
-  ) {
-    defaultFinalFocus.current = document.activeElement
-  }
+  // views. `Sheet` captures the opener at the moment the sheet opens, so
+  // closing a trigger-less sheet restores focus to it.
+  const defaultFinalFocus = React.useContext(ReturnFocusContext)
 
   return (
     <SheetPortal>
@@ -64,7 +68,7 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         aria-modal="true"
-        finalFocus={finalFocus ?? defaultFinalFocus}
+        finalFocus={finalFocus ?? defaultFinalFocus ?? undefined}
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
           className

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -39,12 +39,24 @@ function SheetContent({
   children,
   side = "right",
   showCloseButton = true,
-  finalFocus = true,
+  finalFocus,
   ...props
 }: SheetPrimitive.Popup.Props & {
   side?: "top" | "right" | "bottom" | "left"
   showCloseButton?: boolean
 }) {
+  // Sheets are controlled by the same sidebar state as dialogs are by their
+  // views. Keep the opener so closing a trigger-less sheet restores focus.
+  const defaultFinalFocus = React.useRef<HTMLElement | null>(null)
+  if (
+    defaultFinalFocus.current === null &&
+    typeof document !== "undefined" &&
+    document.activeElement instanceof HTMLElement &&
+    document.activeElement !== document.body
+  ) {
+    defaultFinalFocus.current = document.activeElement
+  }
+
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -52,7 +64,7 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         aria-modal="true"
-        finalFocus={finalFocus}
+        finalFocus={finalFocus ?? defaultFinalFocus}
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
           className

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -39,6 +39,7 @@ function SheetContent({
   children,
   side = "right",
   showCloseButton = true,
+  finalFocus = true,
   ...props
 }: SheetPrimitive.Popup.Props & {
   side?: "top" | "right" | "bottom" | "left"
@@ -51,6 +52,7 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         aria-modal="true"
+        finalFocus={finalFocus}
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
           className

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -50,6 +50,7 @@ function SheetContent({
       <SheetPrimitive.Popup
         data-slot="sheet-content"
         data-side={side}
+        aria-modal="true"
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
           className

--- a/frontend/test/e2e/dialog-accessibility.spec.ts
+++ b/frontend/test/e2e/dialog-accessibility.spec.ts
@@ -78,3 +78,24 @@ test("the mobile sidebar sheet is modal", async ({ page }) => {
   await expect(sheet).toBeVisible();
   await expectModal(sheet, page.getByRole("main"));
 });
+
+test("the mobile sidebar sheet returns focus to its toggle, not to an earlier control", async ({
+  page,
+}) => {
+  // The sidebar's `Sheet` stays mounted while closed, so a return target
+  // captured on first render would be whatever happened to be focused during
+  // an earlier rerender — the tour's dismiss button, which by then no longer
+  // exists — rather than the toggle the operator actually pressed.
+  await page.setViewportSize({ width: 700, height: 800 });
+  await page.goto("/#/overview");
+  await dismissTour(page);
+
+  const toggle = page.getByRole("button", { name: "Toggle sidebar" });
+  await toggle.click();
+
+  const sheet = page.getByRole("dialog", { name: "Sidebar" });
+  await expect(sheet).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(sheet).toHaveCount(0);
+  await expect(toggle).toBeFocused();
+});

--- a/frontend/test/e2e/dialog-accessibility.spec.ts
+++ b/frontend/test/e2e/dialog-accessibility.spec.ts
@@ -76,5 +76,5 @@ test("the mobile sidebar sheet is modal", async ({ page }) => {
 
   const sheet = page.getByRole("dialog", { name: "Sidebar" });
   await expect(sheet).toBeVisible();
-  await expectModal(sheet, page.getByRole("button", { name: "Toggle sidebar" }));
+  await expectModal(sheet, page.getByRole("main"));
 });

--- a/frontend/test/e2e/dialog-accessibility.spec.ts
+++ b/frontend/test/e2e/dialog-accessibility.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Regression coverage for #1387.
+ *
+ * Base UI owns the mechanics of a modal: it hides the application behind the
+ * portal and restores focus to the element that was active before opening.
+ * The console's wrappers must expose that modality to assistive technology too.
+ * This is a browser test because both the portal and the active element only
+ * exist in a real document.
+ */
+
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(page.locator('[data-slot="dialog-overlay"]')).toHaveCount(0);
+}
+
+async function openTaskDialog(page: Page): Promise<Locator> {
+  const addTask = page.getByRole("button", { name: "Add task" });
+  await addTask.focus();
+  await page.keyboard.press("Enter");
+
+  const dialog = page.locator('[data-slot="dialog-content"]');
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function expectModal(dialog: Locator, page: Page) {
+  await expect(dialog).toHaveAttribute("role", "dialog");
+  await expect(dialog).toHaveAttribute("aria-modal", "true");
+  await expect(page.locator("#root")).toHaveAttribute("aria-hidden", "true");
+}
+
+test("the task dialog is modal and restores keyboard focus for every close path", async ({
+  page,
+}) => {
+  await page.goto("/#/ledgers/tasks");
+  await dismissTour(page);
+
+  const addTask = page.getByRole("button", { name: "Add task" });
+
+  let dialog = await openTaskDialog(page);
+  await expectModal(dialog, page);
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await expect(addTask).toBeFocused();
+
+  dialog = await openTaskDialog(page);
+  await expectModal(dialog, page);
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(addTask).toBeFocused();
+
+  dialog = await openTaskDialog(page);
+  await expectModal(dialog, page);
+  await dialog.getByRole("button", { name: "Close" }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(addTask).toBeFocused();
+});
+
+test("the mobile sidebar sheet is modal", async ({ page }) => {
+  await page.setViewportSize({ width: 700, height: 800 });
+  await page.goto("/#/overview");
+  await dismissTour(page);
+
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const sheet = page.locator('[data-slot="sheet-content"]');
+  await expect(sheet).toBeVisible();
+  await expect(sheet).toHaveAttribute("role", "dialog");
+  await expect(sheet).toHaveAttribute("aria-modal", "true");
+  await expect(page.locator("#root")).toHaveAttribute("aria-hidden", "true");
+});

--- a/frontend/test/e2e/dialog-accessibility.spec.ts
+++ b/frontend/test/e2e/dialog-accessibility.spec.ts
@@ -31,10 +31,13 @@ async function openTaskDialog(page: Page): Promise<Locator> {
   return dialog;
 }
 
-async function expectModal(dialog: Locator, page: Page) {
+async function expectModal(dialog: Locator, backgroundControl: Locator) {
   await expect(dialog).toHaveAttribute("role", "dialog");
   await expect(dialog).toHaveAttribute("aria-modal", "true");
-  await expect(page.locator("#root")).toHaveAttribute("aria-hidden", "true");
+  // Base UI applies `aria-hidden` to the smallest outside subtree that can
+  // hide the page without hiding the dialog's trigger. Assert the resulting
+  // accessibility tree, not its private marker attribute or a fixed DOM shape.
+  await expect(backgroundControl).toHaveCount(0);
 }
 
 test("the task dialog is modal and restores keyboard focus for every close path", async ({
@@ -46,19 +49,19 @@ test("the task dialog is modal and restores keyboard focus for every close path"
   const addTask = page.getByRole("button", { name: "Add task" });
 
   let dialog = await openTaskDialog(page);
-  await expectModal(dialog, page);
+  await expectModal(dialog, addTask);
   await page.keyboard.press("Escape");
   await expect(dialog).toHaveCount(0);
   await expect(addTask).toBeFocused();
 
   dialog = await openTaskDialog(page);
-  await expectModal(dialog, page);
+  await expectModal(dialog, addTask);
   await dialog.getByRole("button", { name: "Cancel" }).click();
   await expect(dialog).toHaveCount(0);
   await expect(addTask).toBeFocused();
 
   dialog = await openTaskDialog(page);
-  await expectModal(dialog, page);
+  await expectModal(dialog, addTask);
   await dialog.getByRole("button", { name: "Close" }).click();
   await expect(dialog).toHaveCount(0);
   await expect(addTask).toBeFocused();
@@ -71,9 +74,7 @@ test("the mobile sidebar sheet is modal", async ({ page }) => {
 
   await page.getByRole("button", { name: "Toggle sidebar" }).click();
 
-  const sheet = page.locator('[data-slot="sheet-content"]');
+  const sheet = page.getByRole("dialog", { name: "Sidebar" });
   await expect(sheet).toBeVisible();
-  await expect(sheet).toHaveAttribute("role", "dialog");
-  await expect(sheet).toHaveAttribute("aria-modal", "true");
-  await expect(page.locator("#root")).toHaveAttribute("aria-hidden", "true");
+  await expectModal(sheet, page.getByRole("button", { name: "Toggle sidebar" }));
 });

--- a/frontend/test/unit/dialog-return-focus.test.ts
+++ b/frontend/test/unit/dialog-return-focus.test.ts
@@ -129,6 +129,27 @@ describe("useReturnFocus", () => {
     expect(harness.target.current).toBe(opener);
   });
 
+  it("drops a stale target when the next opening has nothing focused", () => {
+    const opener = button("opener");
+    render(createElement(Probe, { open: false }));
+
+    opener.focus();
+    render(createElement(Probe, { open: true }));
+    expect(harness.target.current).toBe(opener);
+
+    // The dialog closes and its opener leaves the document — a row that was
+    // deleted, a toolbar that rerendered — so focus falls back to `<body>` and
+    // the next opening comes from code rather than from a control.
+    render(createElement(Probe, { open: false }));
+    opener.remove();
+    expect(document.activeElement).toBe(document.body);
+    render(createElement(Probe, { open: true }));
+
+    // Null, not the detached opener: Base UI's own fallback is a better answer
+    // than focusing something that is no longer on the page.
+    expect(harness.target.current).toBeNull();
+  });
+
   it("recaptures for an uncontrolled root, which only reports through the callback", () => {
     const opener = button("opener");
     render(createElement(Probe, {}));

--- a/frontend/test/unit/dialog-return-focus.test.ts
+++ b/frontend/test/unit/dialog-return-focus.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useReturnFocus } from "@/components/ui/return-focus";
+
+/**
+ * Regression coverage for #1387's return-focus capture.
+ *
+ * `useReturnFocus` remembers what to refocus when a trigger-less dialog or
+ * sheet closes. Two properties are load-bearing and neither is visible from the
+ * rendered output, so they are pinned here rather than in the browser suite:
+ *
+ * 1. The capture happens on the **closed → open transition**. A popup that
+ *    stays mounted while closed (the sidebar's `Sheet`) would otherwise pin
+ *    whatever was focused during an unrelated ancestor rerender.
+ * 2. For a controlled root the `open` prop is authoritative. Base UI reports a
+ *    dismissal through `onOpenChange` before the consumer has agreed to it, and
+ *    consumers do refuse — `SetupDialog` passes a no-op handler and
+ *    `DeskCreateDialog` swallows it mid-submit. Believing the callback would
+ *    make the next render look like a fresh opening and capture an element
+ *    inside the still-open popup, so the eventual real close would restore
+ *    focus to something that no longer exists.
+ */
+
+type Harness = {
+  target: React.RefObject<HTMLElement | null>;
+  handleOpenChange: ReturnType<typeof useReturnFocus>["handleOpenChange"];
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let harness: Harness;
+
+function Probe({
+  open,
+  onOpenChange,
+}: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  harness = useReturnFocus(open, onOpenChange as never) as Harness;
+  return null;
+}
+
+function render(element: ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+function button(id: string) {
+  const el = document.createElement("button");
+  el.id = id;
+  document.body.append(el);
+  return el;
+}
+
+describe("useReturnFocus", () => {
+  it("captures the control that was focused when a controlled popup opened", () => {
+    const opener = button("opener");
+    render(createElement(Probe, { open: false }));
+
+    opener.focus();
+    render(createElement(Probe, { open: true }));
+
+    expect(harness.target.current).toBe(opener);
+  });
+
+  it("ignores what was focused during a rerender while the popup is closed", () => {
+    const search = button("search");
+    const opener = button("opener");
+    render(createElement(Probe, { open: false }));
+
+    // The always-mounted case: typing in an unrelated field rerenders the
+    // popup's owner long before anyone opens it.
+    search.focus();
+    render(createElement(Probe, { open: false }));
+    expect(harness.target.current).toBeNull();
+
+    opener.focus();
+    render(createElement(Probe, { open: true }));
+    expect(harness.target.current).toBe(opener);
+  });
+
+  it("treats a mount that is already open as that popup's opening", () => {
+    // `CreateTaskDialog` returns `null` while closed, so its root never renders
+    // in the closed state at all.
+    const opener = button("opener");
+    opener.focus();
+    render(createElement(Probe, { open: true }));
+
+    expect(harness.target.current).toBe(opener);
+  });
+
+  it("keeps the opener when a controlled consumer refuses the dismissal", () => {
+    const opener = button("opener");
+    render(createElement(Probe, { open: false }));
+
+    opener.focus();
+    render(createElement(Probe, { open: true, onOpenChange: () => {} }));
+    expect(harness.target.current).toBe(opener);
+
+    // Escape asks to close; the consumer declines, so `open` stays true.
+    const insideThePopup = button("inside");
+    act(() => {
+      harness.handleOpenChange(false, undefined as never);
+    });
+    insideThePopup.focus();
+    render(createElement(Probe, { open: true, onOpenChange: () => {} }));
+
+    expect(harness.target.current).toBe(opener);
+  });
+
+  it("recaptures for an uncontrolled root, which only reports through the callback", () => {
+    const opener = button("opener");
+    render(createElement(Probe, {}));
+
+    opener.focus();
+    act(() => {
+      harness.handleOpenChange(true, undefined as never);
+    });
+    expect(harness.target.current).toBe(opener);
+
+    // Closing and reopening from a different control moves the target.
+    act(() => {
+      harness.handleOpenChange(false, undefined as never);
+    });
+    const other = button("other");
+    other.focus();
+    act(() => {
+      harness.handleOpenChange(true, undefined as never);
+    });
+    expect(harness.target.current).toBe(other);
+  });
+
+  it("forwards every change to the consumer's own handler", () => {
+    const seen: boolean[] = [];
+    render(
+      createElement(Probe, {
+        open: false,
+        onOpenChange: (next: boolean) => seen.push(next),
+      })
+    );
+
+    act(() => {
+      harness.handleOpenChange(true, undefined as never);
+      harness.handleOpenChange(false, undefined as never);
+    });
+
+    expect(seen).toEqual([true, false]);
+  });
+});


### PR DESCRIPTION
## Summary
- restore focus to the control active before a controlled, trigger-less dialog or sheet opens
- expose modal semantics with aria-modal on the shared dialog and sheet popups
- add browser coverage for Escape, Cancel, Close, background accessibility-tree exclusion, and the mobile sidebar sheet

Closes #1387

## Validation
- npm run typecheck
- npm run typecheck:e2e
- npm run typecheck:unit
- npm run e2e -- dialog-accessibility.spec.ts
- npm test -- test/unit/mock-brain.test.ts
- cargo build --locked --bin opencompany
- cargo fmt --all -- --check

The full npm test run completed 2,264 tests but one unrelated mock-brain fixture startup hook timed out; rerunning that file directly passed all 16 tests. The reported background behavior is already enforced by Base UI through aria-hidden subtrees; this change adds the missing aria-modal contract and verifies the resulting accessibility tree.