### PR TITLE
fix(overview): keep graph chrome reachable on narrow screens

### DIFF
--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -175,3 +175,9 @@ touch device. The chips wrap rather than scroll or clip; each carries the
 colour its pillar's node and label already carry. The docked directory index
 and the entity/function/action lenses were removed — with nothing else on the
 page competing for attention, they covered more of the graph than they earned.
+
+The legend is bounded by the graph canvas and wraps its kind chips rather than
+running beyond the clipped edge. Below 900px the paddles become 80px by 40px
+and inset 12px; below 640px they become 56px by 32px and inset 8px. Keyboard
+`←` / `→` remains available at every width, so the smaller touch targets do not
+remove a way to turn the pillar wheel.

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -1517,7 +1517,7 @@ export function KnowledgeGraph({
   // compact legend for the fullscreen wheel: color + icon per kind, with the
   // Notes core in its vault orange
   const compactLegend = (
-    <div className="flex items-center gap-3 rounded-sm-t border border-os-border-strong bg-os-bg/85 px-2.5 py-1.5 backdrop-blur">
+    <div className="flex max-w-full flex-wrap items-center gap-x-3 gap-y-1 rounded-sm-t border border-os-border-strong bg-os-bg/85 px-2.5 py-1.5 backdrop-blur">
       {(
         [
           { label: 'Notes', color: HUB_COLOR, Icon: CAT.self.Icon },
@@ -1529,7 +1529,7 @@ export function KnowledgeGraph({
           { label: 'SOP task', color: CAT.task.color, Icon: CAT.task.Icon },
         ] as const
       ).map(({ label, color, Icon }) => (
-        <span key={label} className="flex items-center gap-1.5 font-mono text-3xs text-os-muted">
+        <span key={label} className="flex whitespace-nowrap items-center gap-1.5 font-mono text-3xs text-os-muted">
           <Icon className="h-3 w-3" style={{ color }} strokeWidth={2} />
           {label}
         </span>
@@ -1544,7 +1544,7 @@ export function KnowledgeGraph({
           Since issue #601 the notice names the one thing left: where a flow
           sits on the wheel. Departments, tools and stages are the company's own
           answers now, so claiming otherwise here would understate them. */}
-      <span className="flex items-center gap-1 border-l border-os-border pl-3 font-mono text-3xs text-os-dim" title={DERIVED_NOTICE}>
+      <span className="flex whitespace-nowrap items-center gap-1 border-l border-os-border pl-3 font-mono text-3xs text-os-dim" title={DERIVED_NOTICE}>
         <Info className="h-3 w-3 shrink-0" strokeWidth={2} />
         flow placement
       </span>

--- a/frontend/src/views/overview/kg/KnowledgeGraphFullscreen.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraphFullscreen.tsx
@@ -59,7 +59,9 @@ export function KnowledgeGraphFullscreen({
    * again, so the offset is reverted and the paddles rise into the band the
    * sheet leaves instead of staying centred underneath it.
    */
-  const clearOfRail = hasDetail ? 'right-[316px] max-[820px]:right-2' : 'right-2';
+  const clearOfRail = hasDetail
+    ? 'right-[316px] max-[820px]:right-3 max-[639px]:right-2'
+    : 'right-2 max-[899px]:right-3 max-[639px]:right-2';
   /**
    * Mid-height normally; in the band above the bottom sheet when there is one.
    *
@@ -179,8 +181,17 @@ export function KnowledgeGraphFullscreen({
           </div>
         )}
 
-        {/* compact legend — bottom-left, always on */}
-        {legendSlot && <div className="absolute bottom-5 left-5 z-10">{legendSlot}</div>}
+        {/* compact legend — bottom-left, always on. It must be bounded by the
+            canvas, rather than its contents: at phone widths the old fixed row
+            extended past the right edge with no way to reach its last kinds. */}
+        {legendSlot && (
+          <div
+            data-testid="kg-legend"
+            className="absolute bottom-3 left-3 z-10 max-w-[calc(100%-1.5rem)] sm:bottom-5 sm:left-5 sm:max-w-[calc(100%-2.5rem)]"
+          >
+            {legendSlot}
+          </div>
+        )}
 
         {/* side paddles: slim, hugging the canvas edges at mid-height — you
             turn the wheel from where you're already looking, never the top.
@@ -193,17 +204,17 @@ export function KnowledgeGraphFullscreen({
               onClick={() => step(-1)}
               aria-label="Previous department"
               title="Previous pillar (←)"
-              className={`absolute left-2 z-40 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-all duration-200 ease-standard hover:border-os-border-strong hover:text-os-text ${paddleTop}`}
+              className={`absolute left-2 z-40 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-all duration-200 ease-standard hover:border-os-border-strong hover:text-os-text max-[899px]:left-3 max-[899px]:h-20 max-[899px]:w-10 max-[639px]:left-2 max-[639px]:h-14 max-[639px]:w-8 ${paddleTop}`}
             >
-              <ChevronLeft className="h-7 w-7" />
+              <ChevronLeft className="h-7 w-7 max-[899px]:h-6 max-[899px]:w-6 max-[639px]:h-5 max-[639px]:w-5" />
             </button>
             <button
               onClick={() => step(1)}
               aria-label="Next department"
               title="Next pillar (→)"
-              className={`absolute z-40 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-all duration-200 ease-standard hover:border-os-border-strong hover:text-os-text ${clearOfRail} ${paddleTop}`}
+              className={`absolute z-40 flex h-32 w-12 -translate-y-1/2 items-center justify-center rounded-sm-t border border-os-border bg-os-bg/70 text-os-muted backdrop-blur transition-all duration-200 ease-standard hover:border-os-border-strong hover:text-os-text max-[899px]:h-20 max-[899px]:w-10 max-[639px]:h-14 max-[639px]:w-8 ${clearOfRail} ${paddleTop}`}
             >
-              <ChevronRight className="h-7 w-7" />
+              <ChevronRight className="h-7 w-7 max-[899px]:h-6 max-[899px]:w-6 max-[639px]:h-5 max-[639px]:w-5" />
             </button>
           </>
         )}

--- a/frontend/test/e2e/overview-responsive-chrome.spec.ts
+++ b/frontend/test/e2e/overview-responsive-chrome.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #1385: the Overview legend was wider than a phone viewport and its
+ * side paddles remained 128px by 48px at every width. These checks measure the
+ * browser's boxes rather than the Tailwind class names: the canvas is clipped,
+ * so an in-bounds legend is only useful if its right edge is truly reachable.
+ */
+
+const VIEWPORTS = [
+  { width: 390, height: 844, paddle: { width: 32, height: 56, inset: 8 } },
+  { width: 768, height: 900, paddle: { width: 40, height: 80, inset: 12 } },
+] as const;
+
+test.beforeEach(async ({ page }) => {
+  // The first-run tour is unrelated chrome that can cover the graph.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+for (const viewport of VIEWPORTS) {
+  test(`keeps graph chrome reachable at ${viewport.width}px`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await page.goto("/#/overview");
+
+    const legend = page.getByTestId("kg-legend");
+    const previous = page.getByRole("button", { name: "Previous department" });
+    const next = page.getByRole("button", { name: "Next department" });
+    await expect(legend).toBeVisible();
+    await expect(previous).toBeVisible();
+    await expect(next).toBeVisible();
+
+    const [legendBox, previousBox, nextBox, canvasBox] = await Promise.all([
+      legend.boundingBox(),
+      previous.boundingBox(),
+      next.boundingBox(),
+      legend.evaluate((el) => {
+        const canvas = el.parentElement;
+        if (!canvas) return null;
+        const { left, right } = canvas.getBoundingClientRect();
+        return { left, right };
+      }),
+    ]);
+    expect(legendBox, "the legend must have a rendered box").not.toBeNull();
+    expect(previousBox, "the previous paddle must have a rendered box").not.toBeNull();
+    expect(nextBox, "the next paddle must have a rendered box").not.toBeNull();
+    expect(canvasBox, "the legend must be placed in the graph canvas").not.toBeNull();
+
+    // The legend starts at the canvas inset and finishes inside the canvas —
+    // in particular, none of its kinds are hidden past the clipped right edge.
+    expect(legendBox!.x).toBeGreaterThanOrEqual(canvasBox!.left);
+    expect(legendBox!.x + legendBox!.width).toBeLessThanOrEqual(canvasBox!.right + 1);
+
+    for (const paddle of [previousBox!, nextBox!]) {
+      expect(paddle.width).toBeLessThanOrEqual(viewport.paddle.width);
+      expect(paddle.height).toBeLessThanOrEqual(viewport.paddle.height);
+    }
+    expect(previousBox!.x - canvasBox!.left).toBeGreaterThanOrEqual(viewport.paddle.inset - 1);
+    expect(canvasBox!.right - (nextBox!.x + nextBox!.width)).toBeGreaterThanOrEqual(viewport.paddle.inset - 1);
+  });
+}

--- a/frontend/test/unit/overview-responsive-chrome.test.ts
+++ b/frontend/test/unit/overview-responsive-chrome.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DeptLite } from "@/views/overview/kg/KnowledgeDetail";
+import { KnowledgeGraphFullscreen } from "@/views/overview/kg/KnowledgeGraphFullscreen";
+
+/**
+ * Issue #1385: the fullscreen graph's legend was a single 554px row and its
+ * two 128px-by-48px paddles stayed that size at every viewport. At 390px the
+ * legend ran beyond the clipped canvas, while the paddles covered its busiest
+ * middle band. CSS is responsible for the measured layout, so this component
+ * test guards the responsive class contract at the two reported breakpoints.
+ */
+
+let host: HTMLElement;
+let root: Root;
+
+const DESKS: DeptLite[] = [
+  { deptId: "desk:eng", teamId: "team:desk:eng", name: "Engineering", tagline: "", color: "var(--accent)" },
+  { deptId: "desk:gtm", teamId: "team:desk:gtm", name: "Go-to-Market", tagline: "", color: "var(--ok)" },
+];
+
+function render() {
+  act(() => {
+    root.render(
+      createElement(KnowledgeGraphFullscreen, {
+        deptList: DESKS,
+        currentTeamId: DESKS[0].teamId,
+        currentDept: DESKS[0],
+        toolWiki: null,
+        legendSlot: createElement("div", null, "Notes Human AI teammate Tool Workflow Stage SOP task flow placement"),
+        onNavDept: () => {},
+        onBack: () => {},
+        children: createElement("svg"),
+      }),
+    );
+  });
+}
+
+function paddle(label: string): HTMLElement {
+  const el = host.querySelector(`[aria-label="${label}"]`);
+  expect(el, `${label} paddle must render`).not.toBeNull();
+  return el as HTMLElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+describe("the fullscreen graph's narrow chrome", () => {
+  it("keeps the legend within its canvas at 390px and 768px", () => {
+    render();
+    const legend = host.querySelector('[data-testid="kg-legend"]');
+    expect(legend).not.toBeNull();
+    expect(legend!.className).toContain("max-w-[calc(100%-1.5rem)]");
+    expect(legend!.className).toContain("sm:max-w-[calc(100%-2.5rem)]");
+  });
+
+  it("shrinks and insets both paddles below 900px, then further at 390px", () => {
+    render();
+    for (const label of ["Previous department", "Next department"]) {
+      const classes = paddle(label).className;
+      expect(classes).toContain("max-[899px]:h-20");
+      expect(classes).toContain("max-[899px]:w-10");
+      expect(classes).toContain("max-[639px]:h-14");
+      expect(classes).toContain("max-[639px]:w-8");
+    }
+    expect(paddle("Previous department").className).toContain("max-[899px]:left-3");
+    expect(paddle("Next department").className).toContain("max-[899px]:right-3");
+  });
+});


### PR DESCRIPTION
## Summary

- bound the Overview kind legend to the graph canvas and wrap its chips before they can run past a clipped edge
- shrink and inset department paddles below 900px, with a further 390px-size reduction
- add unit and real-host browser coverage for the 390px and 768px layouts

Closes #1385

## Validation

- `npm run typecheck`
- `npm run typecheck:unit`
- `npm run typecheck:e2e`
- `npm test`
- `npm run build`
- `cargo build --locked --bin opencompany`
- `npm run e2e -- overview-responsive-chrome.spec.ts`

## Scope

This keeps the existing wrapped, 45vw-bounded pillar selector from #1309. It addresses the issue's overflowing legend and canvas-covering paddles; no broader Overview chrome redesign was needed.