### PR TITLE
fix(workflows): clarify copilot availability

### DIFF
--- a/frontend/src/views/workflows/CopilotPanel.tsx
+++ b/frontend/src/views/workflows/CopilotPanel.tsx
@@ -572,8 +572,9 @@ export function CopilotPanel({
             <AlertDescription>{historyError}</AlertDescription>
           </Alert>
         )}
-        {/* What it can see and what it cannot do, stated before the first
-            question rather than discovered after it.
+        {/* Lead with the work this copilot can help with. Its boundaries still
+            need to be easy to find, but they answer a question that usually
+            comes later than the operator's first one.
 
             This block is a claim about the host, so it changes only when the
             host does. #405 had to *withdraw* a confinement claim: the thread
@@ -584,43 +585,56 @@ export function CopilotPanel({
             and a turn that says which part of a question it could not answer
             rather than reaching for the rest of the company. See the header of
             `@/api/workflow-copilot`, and `harness::confine` host-side. */}
-        <div className="rounded-lg border bg-muted/30 p-2 text-2xs leading-snug text-muted-foreground">
+        <div
+          className="rounded-lg border bg-muted/30 p-2 text-2xs leading-snug text-muted-foreground"
+          data-testid="workflow-copilot-introduction"
+        >
           <p>
-            Answers are grounded in{" "}
-            <span className="font-medium text-foreground">{graph.name}</span>: its steps and
-            its recorded runs are what gets sent with your question.
+            Ask what <span className="font-medium text-foreground">{graph.name}</span> does,
+            why a run failed, or what to change.
           </p>
-          <p className="mt-1.5">
-            That is also all the answer is drawn from. This turn runs{" "}
-            <span className="font-medium text-foreground">confined to this workflow</span>: no
-            tools, no company memory, and no reach into the board, your teammates or another
-            workflow. Ask something that needs the wider company and it will say so rather
-            than guess.
-          </p>
-          <p className="mt-1.5">
-            The conversation stays here too: it isn&apos;t in the company chat, and another
-            workflow&apos;s copilot can&apos;t see it.
-          </p>
-          <p className="mt-1.5">
-            {sourceDefined ? (
-              <>
-                It can explain and suggest, but{" "}
-                <span className="font-medium text-foreground">
-                  it can&apos;t change the workflow
-                </span>
-                . This one is defined by a file in the company source tree, so changes belong in
-                the company repository.
-              </>
-            ) : (
-              <>
-                Ask for a change and it{" "}
-                <span className="font-medium text-foreground">proposes one you review</span>: you
-                see the diff and decide. Nothing is written until you press Apply, and it goes
-                through the same save the editor uses, which refuses a workflow that moved while
-                you were reading.
-              </>
-            )}
-          </p>
+          <details className="mt-1.5">
+            <summary className="cursor-pointer font-medium text-foreground">
+              How this copilot works
+            </summary>
+            <div className="mt-1.5">
+              <p>
+                Answers are grounded in <span className="font-medium text-foreground">{graph.name}</span>
+                : its steps and its recorded runs are what gets sent with your question.
+              </p>
+              <p className="mt-1.5">
+                That is also all the answer is drawn from. This turn runs{" "}
+                <span className="font-medium text-foreground">confined to this workflow</span>:
+                no tools, no company memory, and no reach into the board, your teammates or
+                another workflow. Ask something that needs the wider company and it will say so
+                rather than guess.
+              </p>
+              <p className="mt-1.5">
+                The conversation stays here too: it isn&apos;t in the company chat, and another
+                workflow&apos;s copilot can&apos;t see it.
+              </p>
+              <p className="mt-1.5">
+                {sourceDefined ? (
+                  <>
+                    It can explain and suggest, but{" "}
+                    <span className="font-medium text-foreground">
+                      it can&apos;t change the workflow
+                    </span>
+                    . This one is defined by a file in the company source tree, so changes belong
+                    in the company repository.
+                  </>
+                ) : (
+                  <>
+                    Ask for a change and it{" "}
+                    <span className="font-medium text-foreground">proposes one you review</span>:
+                    you see the diff and decide. Nothing is written until you press Apply, and it
+                    goes through the same save the editor uses, which refuses a workflow that
+                    moved while you were reading.
+                  </>
+                )}
+              </p>
+            </div>
+          </details>
         </div>
 
         {echoing && (
@@ -735,7 +749,7 @@ export function CopilotPanel({
         />
         <Button
           size="sm"
-          className="w-full"
+          className="w-full disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
           onClick={() => void send()}
           disabled={sending || echoing || !ready || !draft.trim()}
           data-testid="workflow-copilot-send"

--- a/frontend/test/e2e/workflow-canvas-escape.spec.ts
+++ b/frontend/test/e2e/workflow-canvas-escape.spec.ts
@@ -87,3 +87,26 @@ test("Escape closes the copilot and does nothing once canvas overlays are gone",
   await expect(workflowDetailName(page)).toHaveText(FIXTURE);
   await expect(page.getByTestId("workflow-node-detail")).toBeHidden();
 });
+
+test("the copilot leads with its purpose and mutes the unavailable composer", async ({ page }) => {
+  await openCanvas(page);
+
+  await page.getByTestId("workflow-copilot-toggle").click();
+  const copilot = page.getByTestId("workflow-copilot");
+  await expect(copilot).toBeVisible();
+  await expect(page.getByTestId("workflow-copilot-introduction")).toContainText(
+    "Ask what Committed flow does, why a run failed, or what to change.",
+  );
+
+  const boundaries = copilot.getByText("How this copilot works", { exact: true });
+  await expect(copilot.getByText("Answers are grounded in", { exact: false })).toBeHidden();
+  await boundaries.click();
+  await expect(copilot.getByText("Answers are grounded in", { exact: false })).toBeVisible();
+
+  // The default e2e host runs the echo brain. The unavailable affordances must
+  // be disabled, and the Ask button must opt out of primary-button paint.
+  const send = page.getByTestId("workflow-copilot-send");
+  await expect(send).toBeDisabled();
+  await expect(send).toHaveClass(/disabled:bg-muted/);
+  await expect(send).toHaveClass(/disabled:opacity-100/);
+});


### PR DESCRIPTION
## Summary
- Lead the workflow copilot with the questions it can answer and place its existing scope and change boundaries behind an accessible disclosure.
- Give the disabled Ask action a muted non-primary treatment when inference or context readiness prevents sending.
- Cover the purpose-first disclosure and echo-host disabled composer in the workflow browser suite.

Closes #1370

## Validation
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm run typecheck:unit`
- `npm test`
- `npm run build`
- `cargo build --locked --bin opencompany`
- `npm run e2e -- workflow-canvas-escape.spec.ts`

## Scope
I addressed the two remaining findings from the issue discussion (copilot onboarding and disabled Ask treatment). Earlier canvas, run-control, and index findings were already present on `main`, so this PR deliberately leaves them unchanged.