### PR TITLE
fix(ledgers): simplify list row presentation

### DIFF
--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -1322,7 +1322,7 @@ function EntryCard({
               return (
                 <div key={field.name} className="contents">
                   <dt className="text-muted-foreground">{field.name}</dt>
-                  <dd className="whitespace-pre-line">
+                  <dd className="whitespace-pre-wrap">
                     {compactFieldValue(value)}
                   </dd>
                 </div>
@@ -1362,7 +1362,9 @@ function EntryCard({
   );
 }
 
-/** Keep an empty paragraph from turning a compact list row into a document. */
+/** Keep an empty paragraph from turning a compact list row into a document.
+    Only the blank lines go: indentation and aligned columns inside a line are
+    part of what was recorded, so the row still renders with `pre-wrap`. */
 function compactFieldValue(value: string): string {
   return value
     .split(/\r?\n/)

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -1287,7 +1287,10 @@ function EntryCard({
               {entry.title}
             </button>
           ) : (
-            <span className="min-w-0 flex-1 font-medium" data-testid="ledger-entry-title">
+            <span
+              className="min-w-0 flex-1 font-medium"
+              data-testid="ledger-entry-title"
+            >
               {entry.title}
             </span>
           )}
@@ -1319,7 +1322,9 @@ function EntryCard({
               return (
                 <div key={field.name} className="contents">
                   <dt className="text-muted-foreground">{field.name}</dt>
-                  <dd className="whitespace-pre-line">{compactFieldValue(value)}</dd>
+                  <dd className="whitespace-pre-line">
+                    {compactFieldValue(value)}
+                  </dd>
                 </div>
               );
             })}

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -1269,40 +1269,57 @@ function EntryCard({
   onDelete: () => void;
 }) {
   const writable = isWritable(ledger);
+  const columns = columnsOf(ledger);
   return (
     <Card className={cn(entry.closed && "opacity-75")}>
-      <CardContent className="space-y-2 p-4">
+      <CardContent
+        className="space-y-2 p-4"
+        data-testid={`ledger-entry-${entry.id}`}
+      >
         <div className="flex flex-wrap items-start gap-2">
-          <code className="text-xs text-muted-foreground">{entry.id}</code>
-          {entry.status && (
-            <Badge variant={entry.closed ? "secondary" : "default"}>
-              {entry.closed && <CheckCircle2 className="mr-1 size-3" />}
-              {entry.status}
-            </Badge>
-          )}
           {onOpen ? (
             <button
               type="button"
-              className="flex-1 text-left font-medium hover:underline"
+              className="min-w-0 flex-1 text-left font-medium hover:underline"
               onClick={onOpen}
+              data-testid="ledger-entry-title"
             >
               {entry.title}
             </button>
           ) : (
-            <span className="flex-1 font-medium">{entry.title}</span>
+            <span className="min-w-0 flex-1 font-medium" data-testid="ledger-entry-title">
+              {entry.title}
+            </span>
           )}
+          {entry.status && (
+            <Badge variant="secondary" data-testid="ledger-entry-status">
+              {entry.closed && <CheckCircle2 className="mr-1 size-3" />}
+              {labelFor(columns, entry.status)}
+            </Badge>
+          )}
+          <code
+            className="text-xs text-muted-foreground"
+            data-testid="ledger-entry-id"
+          >
+            {entry.id}
+          </code>
         </div>
 
-        <dl className="grid gap-x-4 gap-y-1 text-sm sm:grid-cols-[10rem_1fr]">
+        <dl className="grid max-w-3xl gap-x-4 gap-y-1 text-sm sm:grid-cols-[8rem_minmax(0,1fr)]">
           {ledger.fields
-            .filter((field) => field.role !== "id" && field.role !== "title")
+            .filter(
+              (field) =>
+                field.role !== "id" &&
+                field.role !== "title" &&
+                field.role !== "status",
+            )
             .map((field) => {
               const value = entry.fields[field.name];
               if (!value) return null;
               return (
                 <div key={field.name} className="contents">
                   <dt className="text-muted-foreground">{field.name}</dt>
-                  <dd className="whitespace-pre-wrap">{value}</dd>
+                  <dd className="whitespace-pre-line">{compactFieldValue(value)}</dd>
                 </div>
               );
             })}
@@ -1338,6 +1355,14 @@ function EntryCard({
       </CardContent>
     </Card>
   );
+}
+
+/** Keep an empty paragraph from turning a compact list row into a document. */
+function compactFieldValue(value: string): string {
+  return value
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .join("\n");
 }
 
 function ComposeDialog({

--- a/frontend/test/e2e/ledger-list-row.spec.ts
+++ b/frontend/test/e2e/ledger-list-row.spec.ts
@@ -47,7 +47,7 @@ test("a list row leads with its title and shows one readable status", async ({
     expect(recorded.ok()).toBeTruthy();
 
     await page.goto(`/#/ledgers/${slug}`);
-    await page.getByRole("button", { name: "List" }).click();
+    await page.getByRole("button", { name: "List", exact: true }).click();
 
     const row = page.getByTestId(`ledger-entry-${id}`);
     await expect(row).toBeVisible({ timeout: 15_000 });

--- a/frontend/test/e2e/ledger-list-row.spec.ts
+++ b/frontend/test/e2e/ledger-list-row.spec.ts
@@ -63,8 +63,10 @@ test("a list row leads with its title and shows one readable status", async ({
     await expect(row.getByTestId("ledger-entry-status")).toHaveText("To-do");
     await expect(row.getByTestId("ledger-entry-id")).toHaveText(id);
     await expect(row.getByText("column", { exact: true })).toHaveCount(0);
-    // The blank paragraph goes, but the indentation inside a line is part of
-    // what was recorded — `pre-line` would have collapsed it.
+    // The blank paragraph goes — that is `compactFieldValue`, and textContent
+    // shows it. Indentation inside a line survives only because the row renders
+    // with `pre-wrap`; CSS collapsing under `pre-line` leaves textContent
+    // untouched, so the computed style is what actually guards it.
     const note = row.locator("dd");
     expect(await note.evaluate((el) => el.textContent)).toBe(
       "First line\n    indented line\nSecond line",

--- a/frontend/test/e2e/ledger-list-row.spec.ts
+++ b/frontend/test/e2e/ledger-list-row.spec.ts
@@ -5,7 +5,11 @@ const API = "/api/v1/company";
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
-    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+    for (const key of [
+      "oc-tour:single",
+      "oc-tour:e2e-harness-co",
+      "oc-tour:null",
+    ]) {
       window.localStorage.setItem(key, seen);
     }
   });
@@ -41,7 +45,11 @@ test("a list row leads with its title and shows one readable status", async ({
       data: {
         id,
         status: "todo",
-        fields: { title, column: "todo", note: "First line\n\nSecond line" },
+        fields: {
+          title,
+          column: "todo",
+          note: "First line\n\nSecond line",
+        },
       },
     });
     expect(recorded.ok()).toBeTruthy();
@@ -60,7 +68,11 @@ test("a list row leads with its title and shows one readable status", async ({
     const order = await row.locator(":scope > div").first().evaluate((header) =>
       Array.from(header.children).map((child) => child.getAttribute("data-testid")),
     );
-    expect(order).toEqual(["ledger-entry-title", "ledger-entry-status", "ledger-entry-id"]);
+    expect(order).toEqual([
+      "ledger-entry-title",
+      "ledger-entry-status",
+      "ledger-entry-id",
+    ]);
   } finally {
     await request.delete(`${API}/ledgers/${slug}?purge=true`);
   }

--- a/frontend/test/e2e/ledger-list-row.spec.ts
+++ b/frontend/test/e2e/ledger-list-row.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+const API = "/api/v1/company";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+test("a list row leads with its title and shows one readable status", async ({
+  page,
+  request,
+}) => {
+  const marker = Date.now();
+  const slug = `e2e-list-row-${marker}`;
+  const title = `E2E list row ${marker}`;
+  const id = `entry-${marker}`;
+  const declared = await request.post(`${API}/ledgers`, {
+    data: {
+      slug,
+      title: `E2E list ${marker}`,
+      purpose: "A list used to check its row presentation.",
+      fields: [
+        { name: "id", role: "id" },
+        { name: "title", role: "title", required: true },
+        { name: "column", role: "status", required: true },
+        { name: "note", role: "prose" },
+      ],
+      statuses: [{ name: "todo", label: "To-do" }],
+      checks: ["required-field", "known-status"],
+    },
+  });
+  expect(declared.ok()).toBeTruthy();
+
+  try {
+    const recorded = await request.post(`${API}/ledgers/${slug}/entries`, {
+      data: {
+        id,
+        status: "todo",
+        fields: { title, column: "todo", note: "First line\n\nSecond line" },
+      },
+    });
+    expect(recorded.ok()).toBeTruthy();
+
+    await page.goto(`/#/ledgers/${slug}`);
+    await page.getByRole("button", { name: "List" }).click();
+
+    const row = page.getByTestId(`ledger-entry-${id}`);
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await expect(row.getByTestId("ledger-entry-title")).toHaveText(title);
+    await expect(row.getByTestId("ledger-entry-status")).toHaveText("To-do");
+    await expect(row.getByTestId("ledger-entry-id")).toHaveText(id);
+    await expect(row.getByText("column", { exact: true })).toHaveCount(0);
+    await expect(row.locator("dd")).toHaveText("First line\nSecond line");
+
+    const order = await row.locator(":scope > div > div").first().evaluate((header) =>
+      Array.from(header.children).map((child) => child.getAttribute("data-testid")),
+    );
+    expect(order).toEqual(["ledger-entry-title", "ledger-entry-status", "ledger-entry-id"]);
+  } finally {
+    await request.delete(`${API}/ledgers/${slug}?purge=true`);
+  }
+});

--- a/frontend/test/e2e/ledger-list-row.spec.ts
+++ b/frontend/test/e2e/ledger-list-row.spec.ts
@@ -48,7 +48,7 @@ test("a list row leads with its title and shows one readable status", async ({
         fields: {
           title,
           column: "todo",
-          note: "First line\n\nSecond line",
+          note: "First line\n\n    indented line\nSecond line",
         },
       },
     });
@@ -63,7 +63,15 @@ test("a list row leads with its title and shows one readable status", async ({
     await expect(row.getByTestId("ledger-entry-status")).toHaveText("To-do");
     await expect(row.getByTestId("ledger-entry-id")).toHaveText(id);
     await expect(row.getByText("column", { exact: true })).toHaveCount(0);
-    await expect(row.locator("dd")).toHaveText("First line\nSecond line");
+    // The blank paragraph goes, but the indentation inside a line is part of
+    // what was recorded — `pre-line` would have collapsed it.
+    const note = row.locator("dd");
+    expect(await note.evaluate((el) => el.textContent)).toBe(
+      "First line\n    indented line\nSecond line",
+    );
+    expect(await note.evaluate((el) => getComputedStyle(el).whiteSpace)).toBe(
+      "pre-wrap",
+    );
 
     const order = await row.locator(":scope > div").first().evaluate((header) =>
       Array.from(header.children).map((child) => child.getAttribute("data-testid")),

--- a/frontend/test/e2e/ledger-list-row.spec.ts
+++ b/frontend/test/e2e/ledger-list-row.spec.ts
@@ -57,7 +57,7 @@ test("a list row leads with its title and shows one readable status", async ({
     await expect(row.getByText("column", { exact: true })).toHaveCount(0);
     await expect(row.locator("dd")).toHaveText("First line\nSecond line");
 
-    const order = await row.locator(":scope > div > div").first().evaluate((header) =>
+    const order = await row.locator(":scope > div").first().evaluate((header) =>
       Array.from(header.children).map((child) => child.getAttribute("data-testid")),
     );
     expect(order).toEqual(["ledger-entry-title", "ledger-entry-status", "ledger-entry-id"]);


### PR DESCRIPTION
## Summary
- lead list rows with their title, show one neutral human-readable status, and demote the internal id
- omit status fields from the detail grid, bound its reading measure, and collapse empty prose paragraphs
- add a browser spec covering title/status/id order, status deduplication, and compact note rendering

Closes #1355

## Validation
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm test`
- `npm run build`
- `npm run e2e -- ledger-list-row.spec.ts`

## Interpretation
The status chip uses the ledger-provided board label where available and the existing readable fallback otherwise. Blank prose paragraphs are intentionally collapsed in list mode; field content and line breaks remain.