### PR TITLE
fix(ledgers): default declared ledgers to list

### DIFF
--- a/docs/spec/runtime/ledgers-console-rendering.md
+++ b/docs/spec/runtime/ledgers-console-rendering.md
@@ -30,20 +30,31 @@ The compose form reads `needsReason` off the declaration and asks for the reason
 
 ### One board component, one screen
 
-Any ledger with statuses renders as columns — one per status, in declaration
-order, labelled by the host. That falls out rather than being designed: a status
-list *is* a lifecycle, and the only thing that differs between the board and a
-hiring pipeline is which call a drop makes. A native ledger's drop goes through
-`patchTask`, because entering a column fires work; every other ledger's is an
-ordinary `record_entry` merge. A drop into a status that demands a reason opens
-the compose form instead of writing, since the host refuses a silent close.
+The board is a *view*, not the screen. A ledger with statuses can render as
+columns — one per status, in declaration order, labelled by the host — but only
+the native `tasks` ledger opens that way by default (`defaultLedgerMode` in
+`views/LedgersView.tsx`). Every declared ledger opens as rows, because rows are
+where a row's whole contents get read: the closing reason a declared ledger
+records, and any long prose it carries, would be one truncated card among
+several. A "Board" toggle next to the filters switches any status-bearing ledger
+to its columns, and the choice belongs to the ledger, not the screen —
+navigating from Tasks to Goals restores Goals to rows, and coming back restores
+the dispatch board (`setMode` re-runs `defaultLedgerMode` whenever the selected
+ledger changes).
+
+The status list is still a lifecycle, and the only thing that differs between
+the board and a hiring pipeline is which call a drop makes. A native ledger's
+drop goes through `patchTask`, because entering a column fires work; every other
+ledger's is an ordinary `record_entry` merge. A drop into a status that demands
+a reason opens the compose form instead of writing, since the host refuses a
+silent close.
 
 `views/LedgerBoard.tsx` is that board, and it is the **only** one. It owns the
 columns, the counts and the drag mechanics; the card is a `renderCard` slot.
 
 There was a standalone Tasks page beside Ledgers until issue #1140, rendering
 the same records through this same component, and an operator who met their work
-twice had to learn which of the two was the real one. Now one screen uses the
+twice had to learn which of the two was the real one. Now one screen hosts the
 board, and it chooses its card by what is behind the row:
 
 | rows | card |

--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -241,6 +241,15 @@ export const RESERVED_SEGMENTS: readonly string[] = [
  */
 const EMPTY_APPROVALS: readonly ApprovalSummary[] = [];
 
+/** The task ledger is operated as a board; declared ledgers are read as rows. */
+export function defaultLedgerMode(
+  ledger: LedgerSummary | null,
+): "board" | "list" {
+  return ledger?.source === "native" && ledger.slug === BOARD_LEDGER
+    ? "board"
+    : "list";
+}
+
 /** A row is either being opened fresh or amended; the form differs only in id. */
 interface Composing {
   /** The row this edits, or empty for a new one. */
@@ -280,15 +289,8 @@ export function LedgersView({
   const [saving, setSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<LedgerEntry | null>(null);
   const [rendered, setRendered] = useState<string | null>(null);
-  /**
-   * Columns or rows.
-   *
-   * Board by default for anything with a status, because that is what a
-   * ledger's statuses *are* — a lifecycle, read left to right. The list is for
-   * reading a row's whole contents, which is what a ledger with long prose
-   * fields is actually for; the board truncates by construction.
-   */
-  const [mode, setMode] = useState<"board" | "list">("board");
+  /** Columns for dispatched tasks; rows for every agent-written ledger. */
+  const [mode, setMode] = useState<"board" | "list">("list");
   /**
    * The board's own create dialog, for the native `tasks` ledger only.
    *
@@ -330,6 +332,13 @@ export function LedgersView({
 
   /** The task board, as opposed to a ledger a company declared. */
   const isBoard = ledger?.source === "native" && ledger.slug === BOARD_LEDGER;
+
+  // A view choice belongs to the ledger it describes. Returning to Tasks
+  // restores its dispatch board; opening Goals or Decisions makes the closing
+  // reason readable without first finding and changing this toggle.
+  useEffect(() => {
+    setMode(defaultLedgerMode(ledger));
+  }, [ledger?.slug, ledger?.source]);
 
   const taskById = useMemo(
     () => new Map(tasks.map((task) => [task.id, task])),
@@ -1232,6 +1241,11 @@ function BoardMode({
             >
               {ownerOf(entry, ledger) || entry.id}
             </span>
+            {entry.closed && entry.fields.reason?.trim() && (
+              <span className="mt-2 block line-clamp-3 text-xs leading-relaxed text-muted-foreground">
+                {entry.fields.reason}
+              </span>
+            )}
           </button>
         );
       }}

--- a/frontend/test/unit/ledger-default-view.test.ts
+++ b/frontend/test/unit/ledger-default-view.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { LedgerSummary } from "@/api/ledgers";
+import { defaultLedgerMode } from "@/views/LedgersView";
+
+/** The native task ledger dispatches from its board; declared ledgers are read. */
+const TASKS = {
+  slug: "tasks",
+  source: "native",
+} as unknown as LedgerSummary;
+
+const GOALS = {
+  slug: "goals",
+  source: "events",
+} as unknown as LedgerSummary;
+
+describe("a ledger's initial view", () => {
+  it("keeps the native Tasks ledger on its dispatch board", () => {
+    expect(defaultLedgerMode(TASKS)).toBe("board");
+  });
+
+  it("opens agent-written ledgers as readable rows", () => {
+    expect(defaultLedgerMode(GOALS)).toBe("list");
+  });
+
+  it("does not give other native ledgers the Tasks board", () => {
+    expect(defaultLedgerMode({ ...TASKS, slug: "inbox" })).toBe("list");
+  });
+
+  it("does not choose a board before the selected ledger is known", () => {
+    expect(defaultLedgerMode(null)).toBe("list");
+  });
+});


### PR DESCRIPTION
## Summary
- Default declared, agent-written ledgers to List while preserving Board as an available view.
- Keep the native Tasks ledger on its dispatch board and show a closed row's reason when a declared ledger is viewed as a board.
- Add focused coverage for the Tasks-only board default.

Closes #1351

## Validation
- `npm run typecheck:unit`
- `npm test -- --run test/unit/ledger-default-view.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test` (started successfully with no failures observed, but this environment terminates foreground commands at 30 seconds before the suite summary.)

## Scope
I interpreted "non-native ledger" as every ledger other than the reserved native `tasks` ledger. Board remains available for declared ledgers; no lifecycle or status definitions were changed.