### PR TITLE
fix(console): rewrite retired Settings routes

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -239,8 +239,42 @@ const REWRITE_RETIRED = (
   // detail sub-page (issue #264), it is what the org chart's rows and the chat
   // pane's chips link to, and it is deliberately a page so it can be linked.
   if (head === "team" && !sub) return ["company", null];
+  if (head === "connections") return ["settings", "connections"];
+  if (head === "mcp") return ["settings", "mcp"];
+  if (head === "people") return ["settings", "people"];
   return null;
 };
+
+const LEGACY_CONNECT_QUERY_KEYS = ["connected", "connect_error", "provider"] as const;
+
+/**
+ * Reads a former native OAuth callback's query whether it was appended to the
+ * path or, in a bookmarked hash address, to the hash itself.
+ *
+ * `useHashView` canonicalizes a retired hash before the shell's effects run,
+ * so this must happen during the initial render while the fragment query is
+ * still present. Path-query values take precedence if an address has both.
+ */
+function legacyConnectParams(): URLSearchParams {
+  const params = new URLSearchParams(window.location.search);
+  const [, hashQuery = ""] = window.location.hash.split("?");
+  const hashParams = new URLSearchParams(hashQuery);
+  for (const key of LEGACY_CONNECT_QUERY_KEYS) {
+    if (!params.has(key) && hashParams.has(key)) params.set(key, hashParams.get(key)!);
+  }
+  return params;
+}
+
+/** Removes consumed legacy OAuth callback values without disturbing hash flags. */
+function stripLegacyConnectParams(hash: string): string {
+  const separator = hash.indexOf("?");
+  if (separator === -1) return hash;
+  const path = hash.slice(0, separator);
+  const params = new URLSearchParams(hash.slice(separator + 1));
+  for (const key of LEGACY_CONNECT_QUERY_KEYS) params.delete(key);
+  const query = params.toString().replace(/=(?=&|$)/g, "");
+  return query ? `${path}?${query}` : path;
+}
 
 /** How many workflow run-progress frames (issue #371) the shell keeps for the
  * Workflows canvas. A run emits roughly one per node, so this holds many runs'
@@ -331,6 +365,7 @@ export function AppShell({
     "overview",
     REWRITE_RETIRED,
   );
+  const legacyConnectParamsRef = useRef(legacyConnectParams());
   // Track the latest non-default segment per view so returning to a tab with
   // sub-pages restores operator context (for example `#/workflows/<id>`), instead
   // of always dropping it to the parent view.
@@ -669,7 +704,7 @@ export function AppShell({
   // back into the console. Preserve the readable landing for legacy URLs even
   // though #838 no longer redirects new native OAuth callbacks here.
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
+    const params = legacyConnectParamsRef.current;
     const connected = params.get("connected");
     const failed = params.get("connect_error");
     if (!connected && !failed) return;
@@ -683,7 +718,7 @@ export function AppShell({
     window.history.replaceState(
       {},
       "",
-      window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
+      window.location.pathname + (query ? `?${query}` : "") + stripLegacyConnectParams(window.location.hash),
     );
     setView("settings", "connections");
     // The callback param carries the raw provider id (e.g. "slack"); show the

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -45,11 +45,11 @@ async function tourKey(page: Page): Promise<string> {
   return key!;
 }
 
-test("a legacy cancelled-handshake query lands in the console, not on a dead page", async ({ page }) => {
+test("a legacy hash callback lands on Connections with its cancellation message", async ({ page }) => {
   // This is the query the former callback used after an operator cancelled at
   // the provider consent screen. Before the original fix it answered with
   // `{"error":"provider returned: access_denied"}` as the document body.
-  await page.goto("/connections?connect_error=denied&provider=slack");
+  await page.goto("/#/connections?connect_error=denied&provider=slack");
 
   // Assert the message first — the toast auto-dismisses, so anything that
   // blocks for a timeout before this would race it away.
@@ -59,10 +59,10 @@ test("a legacy cancelled-handshake query lands in the console, not on a dead pag
   await dismissWelcome(page);
   await expect(page.getByRole("heading", { name: "Connections", level: 1 })).toBeVisible();
 
-  // The param is stripped, so a refresh doesn't re-fire the toast.
+  // The fragment query is stripped, so a refresh doesn't re-fire the toast.
   await expect
-    .poll(() => new URL(page.url()).searchParams.get("connect_error"))
-    .toBeNull();
+    .poll(() => new URL(page.url()).hash.includes("connect_error"))
+    .toBe(false);
 
   // The grid is rendered and usable — the failure was a bounce-back, not a
   // terminal state.

--- a/frontend/test/unit/task-route.test.ts
+++ b/frontend/test/unit/task-route.test.ts
@@ -43,15 +43,20 @@ describe("taskIdFromSegment", () => {
  * The shell's own rewrite, verbatim (`app-shell.tsx`). Duplicated rather than
  * exported because exporting it would make the shell's route table part of its
  * public surface for one test's benefit; what matters here is the rule, and the
- * rule is two lines.
+ * rule is short.
  */
 const REWRITE = (
   head: string,
   sub: string | null,
-): [string, string | null] | null =>
-  head === "tasks" && taskIdFromSegment(sub) === null ? ["ledgers", "tasks"] : null;
+): [string, string | null] | null => {
+  if (head === "tasks" && taskIdFromSegment(sub) === null) return ["ledgers", "tasks"];
+  if (head === "connections") return ["settings", "connections"];
+  if (head === "mcp") return ["settings", "mcp"];
+  if (head === "people") return ["settings", "people"];
+  return null;
+};
 
-const VIEWS = ["overview", "ledgers", "tasks"] as const;
+const VIEWS = ["overview", "ledgers", "tasks", "settings"] as const;
 
 describe("the retired #/tasks address", () => {
   let container: HTMLDivElement;
@@ -120,5 +125,15 @@ describe("the retired #/tasks address", () => {
     await visit("#/ledgers/goals");
     expect(seen).toEqual(["ledgers", "goals"]);
     expect(window.location.hash).toBe("#/ledgers/goals");
+  });
+
+  it.each([
+    ["connections", "connections"],
+    ["mcp", "mcp"],
+    ["people", "people"],
+  ])("sends retired #/%s to its Settings page", async (retired, settingsPage) => {
+    await visit(`#/${retired}`);
+    expect(seen).toEqual(["settings", settingsPage]);
+    expect(window.location.hash).toBe(`#/settings/${settingsPage}`);
   });
 });


### PR DESCRIPTION
## Summary

- rewrite retired `#/connections`, `#/mcp`, and `#/people` addresses to their Settings pages
- preserve legacy OAuth callback fields supplied in a hash query long enough to show the existing Connections result toast, then remove them
- add route and browser-spec coverage for these legacy addresses

Closes #1338

## Validation

- `npm run typecheck:unit`
- `npm run typecheck:e2e`
- `npm run typecheck`
- `npm test -- --run test/unit/task-route.test.ts`
- `npm run build`
- `npm test` (2,267 passed, 16 skipped; the unrelated `test/unit/mock-brain.test.ts` before hook timed out starting its helper server)

## Scope

The fragment-query OAuth bounce-back required retaining the callback values at first render because hash-route canonicalization runs before the shell effect that displays the message. No broader router refactor was made.