### PR TITLE
fix(chat): compact inline approval interruptions

### DIFF
--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -619,14 +619,16 @@ const PAYLOAD_LEAD_EXTRA: Readonly<Record<string, string[]>> = {
  */
 export function payloadLeadLabel(a: ApprovalSummary): string | null {
   const lines = payloadLines(a);
-  const first = lines[0]?.value;
+  const first = lines[0];
   if (first == null) return null;
   const extras = PAYLOAD_LEAD_EXTRA[a.kind] ?? [];
-  if (extras.length === 0) return first;
+  if (extras.length === 0) return first.value;
+  // The extra keys are past the lead by definition, so a line whose label IS
+  // the lead's label is the lead itself and must not be repeated before it.
   const extraValues = lines
-    .filter((line) => extras.includes(line.label))
+    .filter((line) => line.label !== first.label && extras.includes(line.label))
     .map((line) => line.value);
-  return extraValues.length > 0 ? `${extraValues.join(" ")} ${first}` : first;
+  return extraValues.length > 0 ? `${extraValues.join(" ")} ${first.value}` : first.value;
 }
 
 function renderValue(value: unknown): string {

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -645,6 +645,34 @@ export function payloadLeadLabel(a: ApprovalSummary): string | null {
   return extraValues.length > 0 ? `${extraValues.join(" ")} ${first.value}` : first.value;
 }
 
+/**
+ * Whether {@link payloadLeadLabel} had to cut a promoted extra to fit the
+ * compact lead.
+ *
+ * The compact row's job is to distinguish two requests, not to carry the file,
+ * so a long body is previewed — but a preview is not something an operator may
+ * authorize. `true` means the lead shows **less than the complete value**, so a
+ * caller with a one-click Approve must not offer it on that label: the operator
+ * has to see the full payload (the detailed view) before deciding.
+ *
+ * Mirrors {@link preview}'s bound exactly — same code-unit measure, same
+ * `EXTRA_PREVIEW_MAX` — so "would this label be cut?" can never drift from "was
+ * this label cut?".
+ */
+export function payloadLeadTruncated(a: ApprovalSummary): boolean {
+  const lines = payloadLines(a);
+  const first = lines[0];
+  if (first == null) return false;
+  const extras = PAYLOAD_LEAD_EXTRA[a.kind] ?? [];
+  if (extras.length === 0) return false;
+  return lines.some(
+    (line) =>
+      line.label !== first.label &&
+      extras.includes(line.label) &&
+      line.value.length > EXTRA_PREVIEW_MAX,
+  );
+}
+
 function renderValue(value: unknown): string {
   if (typeof value === "string") return value;
   return JSON.stringify(value) ?? String(value);

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -593,6 +593,42 @@ const PAYLOAD_KEY_ORDER: Readonly<Record<string, string[]>> = {
   git_operations: ["operation"],
 };
 
+/**
+ * Payload keys, past the lead, that change what approving the call does.
+ *
+ * `PAYLOAD_KEY_ORDER` promotes the argument an operator is consenting to, and
+ * for most tools the first alone is the whole decision — the shell command, the
+ * glob pattern, the fetch URL. One tool carries a second key that re-describes
+ * the first: `http_request`'s method is the difference between a read and a
+ * delete on the same URL, so a row that shows only the URL cannot tell them
+ * apart. This is that list, and {@link payloadLeadLabel} appends these values
+ * ahead of the first line.
+ */
+const PAYLOAD_LEAD_EXTRA: Readonly<Record<string, string[]>> = {
+  http_request: ["method"],
+};
+
+/**
+ * The payload's lead line, with any consequential later keys in front — the
+ * per-item label for a batch row.
+ *
+ * `null` when the host sent no payload (an old host) or withheld it, so callers
+ * fall back to the action's own words rather than rendering blank. Unlisted
+ * arguments still follow the lead, exactly as in {@link payloadLines}: this
+ * promotes, it never hides.
+ */
+export function payloadLeadLabel(a: ApprovalSummary): string | null {
+  const lines = payloadLines(a);
+  const first = lines[0]?.value;
+  if (first == null) return null;
+  const extras = PAYLOAD_LEAD_EXTRA[a.kind] ?? [];
+  if (extras.length === 0) return first;
+  const extraValues = lines
+    .filter((line) => extras.includes(line.label))
+    .map((line) => line.value);
+  return extraValues.length > 0 ? `${extraValues.join(" ")} ${first}` : first;
+}
+
 function renderValue(value: unknown): string {
   if (typeof value === "string") return value;
   return JSON.stringify(value) ?? String(value);

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -598,15 +598,25 @@ const PAYLOAD_KEY_ORDER: Readonly<Record<string, string[]>> = {
  *
  * `PAYLOAD_KEY_ORDER` promotes the argument an operator is consenting to, and
  * for most tools the first alone is the whole decision — the shell command, the
- * glob pattern, the fetch URL. One tool carries a second key that re-describes
- * the first: `http_request`'s method is the difference between a read and a
- * delete on the same URL, so a row that shows only the URL cannot tell them
- * apart. This is that list, and {@link payloadLeadLabel} appends these values
- * ahead of the first line.
+ * glob pattern, the fetch URL. `http_request` carries two consequential keys
+ * past the lead: its method is the difference between a read and a delete on
+ * the same URL, and its body is what a write *sends* — two POSTs to the same
+ * address are only the same decision if the payload is the same, so a row that
+ * shows only the URL cannot tell them apart. This is that list, and
+ * {@link payloadLeadLabel} appends these values ahead of the first line.
  */
 const PAYLOAD_LEAD_EXTRA: Readonly<Record<string, string[]>> = {
-  http_request: ["method"],
+  http_request: ["method", "body"],
 };
+
+/** A promoted extra's longest render in the compact lead; past it, a preview. */
+const EXTRA_PREVIEW_MAX = 60;
+
+function preview(value: string): string {
+  return value.length > EXTRA_PREVIEW_MAX
+    ? `${value.slice(0, EXTRA_PREVIEW_MAX)}…`
+    : value;
+}
 
 /**
  * The payload's lead line, with any consequential later keys in front — the
@@ -616,6 +626,10 @@ const PAYLOAD_LEAD_EXTRA: Readonly<Record<string, string[]>> = {
  * fall back to the action's own words rather than rendering blank. Unlisted
  * arguments still follow the lead, exactly as in {@link payloadLines}: this
  * promotes, it never hides.
+ *
+ * A promoted extra is previewed, not printed whole: `http_request`'s body can
+ * be a large document, and the row's job is to distinguish two requests, not
+ * to carry the file. The detailed view still shows the full payload.
  */
 export function payloadLeadLabel(a: ApprovalSummary): string | null {
   const lines = payloadLines(a);
@@ -627,7 +641,7 @@ export function payloadLeadLabel(a: ApprovalSummary): string | null {
   // the lead's label is the lead itself and must not be repeated before it.
   const extraValues = lines
     .filter((line) => line.label !== first.label && extras.includes(line.label))
-    .map((line) => line.value);
+    .map((line) => preview(line.value));
   return extraValues.length > 0 ? `${extraValues.join(" ")} ${first.value}` : first.value;
 }
 

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -433,7 +433,8 @@ function CompactApprovalRow({
 }
 
 /**
- * The compact row's one-line summary, split so the amounts survive truncation.
+ * The compact row's summary, split so nothing an Approve covers is ever
+ * ellipsized away.
  *
  * A batch's line has to name what the one Approve covers, never just the first
  * call. When every call is the same action, each call's own detail is named —
@@ -442,10 +443,13 @@ function CompactApprovalRow({
  * When the batch mixes actions, that phrasing would hide a payment behind a
  * fetch, so the line names every distinct action and states the count plainly,
  * the way `BatchHeadline` does — and names every call's own detail too, so a
- * URL or recipient is never hidden behind a count. Either way, every amount is
+ * URL or recipient is never hidden behind a count, and a role-hidden call
+ * keeps its warning. Either way, every amount is
  * returned separately from the text so the row can keep it outside the
  * truncating region: an operator approving money must see its value whether
- * the payment is first in the batch or not.
+ * the payment is first in the batch or not, and on a narrow pane the text
+ * wraps rather than ellipsizing, so a later call's detail survives to the next
+ * line instead of vanishing behind "…".
  */
 function compactLabel(approvals: ApprovalSummary[]): { text: string; amounts: string } {
   const lead = approvals[0];

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -232,20 +232,36 @@ export function ApprovalRow({
         )}{" "}
         Decline
       </Button>
-      <Button
-        variant={compact ? "ghost" : "default"}
-        size="sm"
-        className={compact ? COMPACT_ACTION_CLASS : undefined}
-        disabled={busy}
-        onClick={() => decideAll("approve")}
-      >
-        {awaiting("approve") ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : (
-          <Check className="size-4" />
-        )}{" "}
-        Approve
-      </Button>
+      {needsFullReview ? (
+        // The row's label is a preview, not the payload: a body cut to fit the
+        // compact lead is not something the operator may authorize on. Decline
+        // is always safe and stays inline; Approve is replaced by a path to the
+        // detailed view, where the complete host-bounded payload is on the card
+        // (#1330 review).
+        <Button
+          variant={compact ? "ghost" : "default"}
+          size="sm"
+          className={compact ? COMPACT_ACTION_CLASS : undefined}
+          render={<a href="#/approvals" />}
+        >
+          Review in Approvals
+        </Button>
+      ) : (
+        <Button
+          variant={compact ? "ghost" : "default"}
+          size="sm"
+          className={compact ? COMPACT_ACTION_CLASS : undefined}
+          disabled={busy}
+          onClick={() => decideAll("approve")}
+        >
+          {awaiting("approve") ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Check className="size-4" />
+          )}{" "}
+          Approve
+        </Button>
+      )}
     </>
   );
 

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -398,7 +398,7 @@ function CompactApprovalRow({
           <Icon className="size-3.5" aria-hidden />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium">{compactLabel(approvals)}</p>
+          <CompactLabel approvals={approvals} />
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <ApprovalMeta approval={lead} now={now} askerNames={askerNames} status={status} />
             {!busy && (

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -418,18 +418,20 @@ function CompactApprovalRow({
 }
 
 /**
- * A differentiating, one-line summary rather than a second full approval card.
+ * The compact row's one-line summary, split so the amounts survive truncation.
  *
  * A batch's line has to name what the one Approve covers, never just the first
- * call. When every call is the same action, the lead's words plus the count
- * still tell the truth — "Fetch a web page … + 2 more" is three of the same
- * thing. The moment the batch mixes actions, that phrasing would hide a payment
- * behind a fetch, so the line names every distinct action and states the count
- * plainly, the way `BatchHeadline` does. Either way, every amount in the batch
- * is named: an operator approving money must see its value whether the payment
- * is first in the batch or not.
+ * call. When every call is the same action, each call's own detail is named —
+ * "Fetch a web page — espn.com, bbc.com, theguardian.com" is three things, and
+ * "+ 2 more" would let a harmless first call conceal a consequential second.
+ * When the batch mixes actions, that phrasing would hide a payment behind a
+ * fetch, so the line names every distinct action and states the count plainly,
+ * the way `BatchHeadline` does. Either way, every amount is returned separately
+ * from the text so the row can keep it outside the truncating region: an
+ * operator approving money must see its value whether the payment is first in
+ * the batch or not.
  */
-function compactLabel(approvals: ApprovalSummary[]): string {
+function compactLabel(approvals: ApprovalSummary[]): { text: string; amounts: string } {
   const lead = approvals[0];
   const action = approvalAction(lead);
   const detail = itemLabel(lead);
@@ -440,22 +442,22 @@ function compactLabel(approvals: ApprovalSummary[]): string {
   // A monetary effect shows its value beside whatever else it is doing — an
   // operator approving a payment must see its amount, whether or not the host
   // also sent a payload line to describe it.
-  const amount = lead.amount_usd != null ? ` · ${money(lead.amount_usd)}` : "";
-  const label = `${prefix}${amount}`;
+  const amounts = approvals
+    .filter((a) => a.amount_usd != null)
+    .map((a) => money(a.amount_usd as number));
+  const amountText = amounts.length > 0 ? ` · ${amounts.join(" · ")}` : "";
 
-  if (approvals.length === 1) return label;
+  if (approvals.length === 1) return { text: prefix, amounts: amountText };
 
   const rest = approvals.slice(1);
 
-  // One action, many calls. The lead's words and the count stay — the rest are
-  // the same action — but any further amounts are appended so a second payment
-  // in the batch is seen before the one Approve is pressed.
+  // One action, many calls. Every call is named, not just the lead's — a
+  // second command or recipient can be the consequential one, and "+ N more"
+  // would hide it behind the first. A hidden call's `itemLabel` already names
+  // its own action, so the comma-joined tail reads the same way.
   if (rest.every((a) => a.kind === lead.kind)) {
-    const otherAmounts = rest
-      .filter((a) => a.amount_usd != null)
-      .map((a) => money(a.amount_usd as number));
-    const amounts = otherAmounts.length > 0 ? ` · ${otherAmounts.join(" · ")}` : "";
-    return `${label}${amounts} + ${rest.length} more`;
+    const details = rest.map((a) => itemLabel(a)).join(", ");
+    return { text: `${prefix}, ${details}`, amounts: amountText };
   }
 
   // Mixed actions: "Fetch a web page + 1 more" over a card that also sends a
@@ -467,11 +469,21 @@ function compactLabel(approvals: ApprovalSummary[]): string {
     kinds.length === 2
       ? `${kinds[0]} and ${kinds[1]}`
       : `${kinds.slice(0, -1).join(", ")}, and ${kinds[kinds.length - 1]}`;
-  const amounts = approvals
-    .filter((a) => a.amount_usd != null)
-    .map((a) => money(a.amount_usd as number));
-  const amountText = amounts.length > 0 ? ` · ${amounts.join(" · ")}` : "";
-  return `${approvals.length} actions need your sign-off — ${named}${amountText}`;
+  return {
+    text: `${approvals.length} actions need your sign-off — ${named}`,
+    amounts: amountText,
+  };
+}
+
+/** The compact row's first line: text may ellipsize, amounts never do. */
+function CompactLabel({ approvals }: { approvals: ApprovalSummary[] }) {
+  const { text, amounts } = compactLabel(approvals);
+  return (
+    <p className="flex min-w-0 items-baseline text-sm font-medium">
+      <span className="min-w-0 truncate">{text}</span>
+      {amounts !== "" && <span className="shrink-0">{amounts}</span>}
+    </p>
+  );
 }
 
 /** Quiet until an operator targets a decision; the composer keeps the emphasis. */

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { approvedLine } from "@/lib/approval-wording";
-import { approvalAction, money, payloadLeadLabel } from "@/lib/language";
+import { approvalAction, money, payloadLeadLabel, payloadLeadTruncated } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
 /** One count written with the noun it qualifies. */

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -417,7 +417,18 @@ function CompactApprovalRow({
   );
 }
 
-/** A differentiating, one-line summary rather than a second full approval card. */
+/**
+ * A differentiating, one-line summary rather than a second full approval card.
+ *
+ * A batch's line has to name what the one Approve covers, never just the first
+ * call. When every call is the same action, the lead's words plus the count
+ * still tell the truth — "Fetch a web page … + 2 more" is three of the same
+ * thing. The moment the batch mixes actions, that phrasing would hide a payment
+ * behind a fetch, so the line names every distinct action and states the count
+ * plainly, the way `BatchHeadline` does. Either way, every amount in the batch
+ * is named: an operator approving money must see its value whether the payment
+ * is first in the batch or not.
+ */
 function compactLabel(approvals: ApprovalSummary[]): string {
   const lead = approvals[0];
   const action = approvalAction(lead);
@@ -431,7 +442,36 @@ function compactLabel(approvals: ApprovalSummary[]): string {
   // also sent a payload line to describe it.
   const amount = lead.amount_usd != null ? ` · ${money(lead.amount_usd)}` : "";
   const label = `${prefix}${amount}`;
-  return approvals.length > 1 ? `${label} + ${approvals.length - 1} more` : label;
+
+  if (approvals.length === 1) return label;
+
+  const rest = approvals.slice(1);
+
+  // One action, many calls. The lead's words and the count stay — the rest are
+  // the same action — but any further amounts are appended so a second payment
+  // in the batch is seen before the one Approve is pressed.
+  if (rest.every((a) => a.kind === lead.kind)) {
+    const otherAmounts = rest
+      .filter((a) => a.amount_usd != null)
+      .map((a) => money(a.amount_usd as number));
+    const amounts = otherAmounts.length > 0 ? ` · ${otherAmounts.join(" · ")}` : "";
+    return `${label}${amounts} + ${rest.length} more`;
+  }
+
+  // Mixed actions: "Fetch a web page + 1 more" over a card that also sends a
+  // payment would hide it, so the line says how many actions and names each
+  // distinct one — never letting the lead speak for the rest. Amounts are
+  // named for the whole batch, wherever the money is.
+  const kinds = [...new Set(approvals.map(approvalAction))];
+  const named =
+    kinds.length === 2
+      ? `${kinds[0]} and ${kinds[1]}`
+      : `${kinds.slice(0, -1).join(", ")}, and ${kinds[kinds.length - 1]}`;
+  const amounts = approvals
+    .filter((a) => a.amount_usd != null)
+    .map((a) => money(a.amount_usd as number));
+  const amountText = amounts.length > 0 ? ` · ${amounts.join(" · ")}` : "";
+  return `${approvals.length} actions need your sign-off — ${named}${amountText}`;
 }
 
 /** Quiet until an operator targets a decision; the composer keeps the emphasis. */

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -135,10 +135,15 @@ function failureLabel(failedCount: number, total: number): string {
  * action's own words when the host sent no payload (an old host) or withheld it
  * (#618), so a row never renders blank and never invents a value it does not
  * have.
+ *
+ * A small set of tools carry a second argument that changes what the first
+ * does — `http_request`'s method is the difference between a read and a delete
+ * on the same URL — and {@link payloadLeadLabel} puts those ahead of the lead,
+ * so a row never lets the leading argument speak for an effect it does not have.
  */
 function itemLabel(a: ApprovalSummary): string {
   if (a.contents_hidden) return `${approvalAction(a)} — details hidden by your role`;
-  return payloadLines(a)[0]?.value ?? approvalAction(a);
+  return payloadLeadLabel(a) ?? approvalAction(a);
 }
 
 export function ApprovalRow({

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -1,11 +1,11 @@
 // The gated calls one turn parked, raised inside the conversation that produced
 // them (#379, consolidated by #842).
 //
-// The same content the Approvals page shows — headline, payload, asker, waiting
-// time, and the grant-scope choice (#431), all from `@/components/approval-card`
-// — laid out as a channel row so it reads as part of the thread rather than as a
-// panel bolted beside it. Sharing the scope control rather than restating it is
-// what keeps the two surfaces from offering different things for one approval.
+// Chat is where an approval interrupts the work, not where an operator studies
+// it. The transcript therefore carries a compact summary and one-off controls;
+// the Approvals page remains the full decision surface, with the payload and
+// grant-scope choice (#431). Other callers can still use this component's full
+// card, because a workflow inspector is not a chat transcript.
 //
 // ## One card, however many calls (#842)
 //
@@ -145,6 +145,7 @@ export function ApprovalRow({
   approvals,
   now,
   askerNames,
+  compact = false,
   deciding,
   decided,
   failed,
@@ -154,6 +155,8 @@ export function ApprovalRow({
   approvals: ApprovalSummary[];
   now: number;
   askerNames: Map<string, string>;
+  /** Render as a quiet interruption inside a chat transcript (#1330). */
+  compact?: boolean;
   /** The verdict an item is waiting on, keyed by approval id; empty when idle. */
   deciding: ReadonlyMap<string, Verdict>;
   /** Verdicts already witnessed — from this console or from the page. */
@@ -210,7 +213,13 @@ export function ApprovalRow({
 
   const actions = done ? undefined : (
     <>
-      <Button variant="outline" size="sm" disabled={busy} onClick={() => decideAll("deny")}>
+      <Button
+        variant={compact ? "ghost" : "outline"}
+        size="sm"
+        className={compact ? COMPACT_ACTION_CLASS : undefined}
+        disabled={busy}
+        onClick={() => decideAll("deny")}
+      >
         {awaiting("deny") ? (
           <Loader2 className="size-4 animate-spin" />
         ) : (
@@ -218,7 +227,13 @@ export function ApprovalRow({
         )}{" "}
         Decline
       </Button>
-      <Button size="sm" disabled={busy} onClick={() => decideAll("approve")}>
+      <Button
+        variant={compact ? "ghost" : "default"}
+        size="sm"
+        className={compact ? COMPACT_ACTION_CLASS : undefined}
+        disabled={busy}
+        onClick={() => decideAll("approve")}
+      >
         {awaiting("approve") ? (
           <Loader2 className="size-4 animate-spin" />
         ) : (
@@ -236,6 +251,29 @@ export function ApprovalRow({
   if (done) {
     return (
       <SettledApprovalReceipt approvals={approvals} decided={decided} />
+    );
+  }
+
+  if (compact) {
+    return (
+      <CompactApprovalRow
+        approvals={approvals}
+        now={now}
+        askerNames={askerNames}
+        actions={actions}
+        busy={busy}
+        status={
+          busy
+            ? awaiting("approve")
+              ? "Waiting for the teammate…"
+              : "Recording…"
+            : failedCount > 0
+              ? failureLabel(failedCount, approvals.length)
+              : settledCount > 0
+                ? partialLabel(settledCount, approvals.length)
+                : undefined
+        }
+      />
     );
   }
 
@@ -327,6 +365,70 @@ export function ApprovalRow({
     </div>
   );
 }
+
+/** The deliberately quiet pending-approval interruption used in chat (#1330). */
+function CompactApprovalRow({
+  approvals,
+  now,
+  askerNames,
+  actions,
+  busy,
+  status,
+}: {
+  approvals: ApprovalSummary[];
+  now: number;
+  askerNames: Map<string, string>;
+  actions: React.ReactNode;
+  busy: boolean;
+  status?: React.ReactNode;
+}) {
+  const lead = approvals[0];
+  const Icon = approvalIcon(lead.kind);
+
+  return (
+    <div className="px-4 py-1.5">
+      <section
+        aria-label={approvals.length > 1 ? "Approval request for several actions" : "Approval request"}
+        data-approval-id={lead.id}
+        data-approval-count={approvals.length}
+        data-approval-inline="compact"
+        className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-muted/50"
+      >
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <Icon className="size-3.5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{compactLabel(approvals)}</p>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <ApprovalMeta approval={lead} now={now} askerNames={askerNames} status={status} />
+            {!busy && (
+              <a
+                href="#/approvals"
+                className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline"
+              >
+                View details
+              </a>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">{actions}</div>
+      </section>
+    </div>
+  );
+}
+
+/** A differentiating, one-line summary rather than a second full approval card. */
+function compactLabel(approvals: ApprovalSummary[]): string {
+  const lead = approvals[0];
+  const detail = itemLabel(lead);
+  const action = approvalAction(lead);
+  const prefix = detail === action ? action : `${action} — ${detail}`;
+  return approvals.length > 1 ? `${prefix} + ${approvals.length - 1} more` : prefix;
+}
+
+/** Quiet until an operator targets a decision; the composer keeps the emphasis. */
+const COMPACT_ACTION_CLASS =
+  "text-muted-foreground hover:bg-primary hover:text-primary-foreground focus-visible:bg-primary focus-visible:text-primary-foreground";
 
 /** The compact, inspectable receipt a settled turn leaves in chat (#970). */
 function SettledApprovalReceipt({

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { approvedLine } from "@/lib/approval-wording";
-import { approvalAction, payloadLines } from "@/lib/language";
+import { approvalAction, money, payloadLines } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
 /** One count written with the noun it qualifies. */

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -262,7 +262,12 @@ export function ApprovalRow({
   if (compact) {
     return (
       <CompactApprovalRow
-        approvals={approvals}
+        // The row speaks for what its buttons still decide, not for the whole
+        // original batch: an item settled on the Approvals page or in another
+        // tab is no longer something this Approve/Decline will touch, and a
+        // summary that still named it would leave the operator guessing which
+        // action the remaining buttons authorize (#842 review).
+        approvals={pending}
         now={now}
         askerNames={askerNames}
         actions={actions}

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -426,10 +426,11 @@ function CompactApprovalRow({
  * "+ 2 more" would let a harmless first call conceal a consequential second.
  * When the batch mixes actions, that phrasing would hide a payment behind a
  * fetch, so the line names every distinct action and states the count plainly,
- * the way `BatchHeadline` does. Either way, every amount is returned separately
- * from the text so the row can keep it outside the truncating region: an
- * operator approving money must see its value whether the payment is first in
- * the batch or not.
+ * the way `BatchHeadline` does — and names every call's own detail too, so a
+ * URL or recipient is never hidden behind a count. Either way, every amount is
+ * returned separately from the text so the row can keep it outside the
+ * truncating region: an operator approving money must see its value whether
+ * the payment is first in the batch or not.
  */
 function compactLabel(approvals: ApprovalSummary[]): { text: string; amounts: string } {
   const lead = approvals[0];

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -385,6 +385,11 @@ function CompactApprovalRow({
   busy,
   status,
 }: {
+  /**
+   * The still-undecided items the row's buttons will decide. The caller passes
+   * `pending`, not the whole original batch, so a line naming them never
+   * overstates what Approve/Decline covers once an item has settled elsewhere.
+   */
   approvals: ApprovalSummary[];
   now: number;
   askerNames: Map<string, string>;

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -398,7 +398,10 @@ function CompactApprovalRow({
   status?: React.ReactNode;
 }) {
   const lead = approvals[0];
-  const Icon = approvalIcon(lead.kind);
+  const sameKind = approvals.every((a) => a.kind === lead.kind);
+  // A mixed batch has no one glyph that is true of it, so it wears the neutral
+  // one rather than the first item's, just as `BatchHeadline` does.
+  const Icon = sameKind ? approvalIcon(lead.kind) : ShieldCheck;
 
   return (
     <div className="px-4 py-1.5">

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -251,14 +251,15 @@ export function ApprovalRow({
         // is always safe and stays inline; Approve is replaced by a path to the
         // detailed view, where the complete host-bounded payload is on the card
         // (#1330 review).
-        <Button
-          variant={compact ? "ghost" : "default"}
-          size="sm"
-          className={compact ? COMPACT_ACTION_CLASS : undefined}
-          render={<a href="#/approvals" />}
+        <a
+          href="#/approvals"
+          className={cn(
+            buttonVariants({ variant: compact ? "ghost" : "default", size: "sm" }),
+            compact ? COMPACT_ACTION_CLASS : undefined,
+          )}
         >
           Review in Approvals
-        </Button>
+        </a>
       ) : (
         <Button
           variant={compact ? "ghost" : "default"}

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -462,15 +462,19 @@ function compactLabel(approvals: ApprovalSummary[]): { text: string; amounts: st
 
   // Mixed actions: "Fetch a web page + 1 more" over a card that also sends a
   // payment would hide it, so the line says how many actions and names each
-  // distinct one — never letting the lead speak for the rest. Amounts are
-  // named for the whole batch, wherever the money is.
+  // distinct one — never letting the lead speak for the rest — and then names
+  // every call's own detail the way the same-kind path does, so a fetch's URL
+  // or a payment's recipient is never hidden behind a count, and a role-hidden
+  // call keeps its warning. Amounts are named for the whole batch, wherever
+  // the money is.
   const kinds = [...new Set(approvals.map(approvalAction))];
   const named =
     kinds.length === 2
       ? `${kinds[0]} and ${kinds[1]}`
       : `${kinds.slice(0, -1).join(", ")}, and ${kinds[kinds.length - 1]}`;
+  const details = approvals.map(itemLabel).join(", ");
   return {
-    text: `${approvals.length} actions need your sign-off — ${named}`,
+    text: `${approvals.length} actions need your sign-off — ${named} — ${details}`,
     amounts: amountText,
   };
 }

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -420,10 +420,18 @@ function CompactApprovalRow({
 /** A differentiating, one-line summary rather than a second full approval card. */
 function compactLabel(approvals: ApprovalSummary[]): string {
   const lead = approvals[0];
-  const detail = itemLabel(lead);
   const action = approvalAction(lead);
-  const prefix = detail === action ? action : `${action} — ${detail}`;
-  return approvals.length > 1 ? `${prefix} + ${approvals.length - 1} more` : prefix;
+  const detail = itemLabel(lead);
+  // `itemLabel` already names the action for a role-hidden payload (#618);
+  // restating it here would print the action twice.
+  const prefix =
+    lead.contents_hidden || detail === action ? detail : `${action} — ${detail}`;
+  // A monetary effect shows its value beside whatever else it is doing — an
+  // operator approving a payment must see its amount, whether or not the host
+  // also sent a payload line to describe it.
+  const amount = lead.amount_usd != null ? ` · ${money(lead.amount_usd)}` : "";
+  const label = `${prefix}${amount}`;
+  return approvals.length > 1 ? `${label} + ${approvals.length - 1} more` : label;
 }
 
 /** Quiet until an operator targets a decision; the composer keeps the emphasis. */

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -50,7 +50,7 @@ import {
   ApprovalScopeControl,
   approvalIcon,
 } from "@/components/approval-card";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { approvedLine } from "@/lib/approval-wording";
 import { approvalAction, money, payloadLeadLabel, payloadLeadTruncated } from "@/lib/language";
 import { cn } from "@/lib/utils";

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -499,12 +499,12 @@ function compactLabel(approvals: ApprovalSummary[]): { text: string; amounts: st
   };
 }
 
-/** The compact row's first line: text may ellipsize, amounts never do. */
+/** The compact row's first line: text wraps rather than ellipsizing; amounts never wrap. */
 function CompactLabel({ approvals }: { approvals: ApprovalSummary[] }) {
   const { text, amounts } = compactLabel(approvals);
   return (
     <p className="flex min-w-0 items-baseline text-sm font-medium">
-      <span className="min-w-0 truncate">{text}</span>
+      <span className="min-w-0">{text}</span>
       {amounts !== "" && <span className="shrink-0">{amounts}</span>}
     </p>
   );

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -193,6 +193,19 @@ export function ApprovalRow({
   const done = pending.length === 0;
   /** Whether any item in this card is waiting on `verdict` right now. */
   const awaiting = (verdict: Verdict) => [...deciding.values()].includes(verdict);
+  /**
+   * Whether the compact row is asked to one-click Approve something its label
+   * does not fully say.
+   *
+   * A body cut to fit the lead is a preview, not the payload — two POSTs to the
+   * same URL whose bodies share the first 60 code units render identically even
+   * when the cut-off suffix changes what the request does. The operator must
+   * see the complete host-bounded payload before approving, so the inline
+   * Approve is gated behind the detailed view. Scoped to `pending` because
+   * that is what the button would decide; an item already settled elsewhere is
+   * not part of the one-click authorisation.
+   */
+  const needsFullReview = compact && pending.some((a) => payloadLeadTruncated(a));
 
   /**
    * The decision, applied to every item the card is still asking about.

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { approvedLine } from "@/lib/approval-wording";
-import { approvalAction, money, payloadLines } from "@/lib/language";
+import { approvalAction, money, payloadLeadLabel } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
 /** One count written with the noun it qualifies. */

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -286,6 +286,7 @@ export function MessageTimeline({
               approvals={item.approvals}
               now={now ?? Date.now()}
               askerNames={askerNames ?? EMPTY_NAMES}
+              compact
               /* Narrowed to this card's own items (#842): a decision in flight
                  on another turn's batch is not this card's business, which is
                  the same rule #373 established one level down. */

--- a/frontend/test/e2e/chat-inline-approval.spec.ts
+++ b/frontend/test/e2e/chat-inline-approval.spec.ts
@@ -97,8 +97,11 @@ test("a request raised in a channel appears in that channel, and only there", as
   await openChannel(page, ENGINEERING.id);
   await expect(card(page, IN_ENGINEERING.id)).toBeVisible({ timeout: 30_000 });
   // The chat row names the decision distinctly without repeating the full
-  // approval form; the detailed card remains on the Approvals page.
+  // approval form; the detailed card remains on the Approvals page. A monetary
+  // approval also shows its amount — an operator approves the payment, not the
+  // address the payload happens to lead with.
   await expect(card(page, IN_ENGINEERING.id)).toContainText("vendor@example.test");
+  await expect(card(page, IN_ENGINEERING.id)).toContainText("$42.50");
   await expect(card(page, IN_ENGINEERING.id)).toHaveAttribute("data-approval-inline", "compact");
   await expect(card(page, IN_ENGINEERING.id).getByRole("link", { name: "View details" })).toHaveAttribute(
     "href",

--- a/frontend/test/e2e/chat-inline-approval.spec.ts
+++ b/frontend/test/e2e/chat-inline-approval.spec.ts
@@ -96,9 +96,14 @@ test("a request raised in a channel appears in that channel, and only there", as
 
   await openChannel(page, ENGINEERING.id);
   await expect(card(page, IN_ENGINEERING.id)).toBeVisible({ timeout: 30_000 });
-  // Told in full, the same as on the page — the payload is the thing being
-  // consented to, so a card without it asks for a blind signature.
+  // The chat row names the decision distinctly without repeating the full
+  // approval form; the detailed card remains on the Approvals page.
   await expect(card(page, IN_ENGINEERING.id)).toContainText("vendor@example.test");
+  await expect(card(page, IN_ENGINEERING.id)).toHaveAttribute("data-approval-inline", "compact");
+  await expect(card(page, IN_ENGINEERING.id).getByRole("link", { name: "View details" })).toHaveAttribute(
+    "href",
+    "#/approvals",
+  );
 
   // The trap, in both directions. A card belongs to the conversation that
   // raised it; a desk channel and a DM to its lead resolve to the same agent,

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -364,4 +364,46 @@ describe("the consolidated approval card", () => {
     expect(approve.className).toContain("hover:bg-primary");
     expect(approve.className.split(" ")).not.toContain("bg-primary");
   });
+
+  it("shows the amount beside a monetary approval in the compact chat row", async () => {
+    const PAYMENT: ApprovalSummary = {
+      id: "a4",
+      kind: "payment.send",
+      amount_usd: 42.5,
+      at_millis: T0,
+      agent: "seo",
+      thread: "desk-marketing",
+      batch: "turn-1",
+      broadly_grantable: true,
+      payload: { to: "vendor@example.test", amount_usd: 42.5 },
+    };
+    await render([PAYMENT], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    // An operator approving a payment must see its value beside the Approve
+    // button, not just the recipient the first payload line happens to name.
+    expect(row?.textContent).toContain(`Send a payment — vendor@example.test · ${money(42.5)}`);
+  });
+
+  it("names a hidden approval once in the compact chat row", async () => {
+    const HIDDEN: ApprovalSummary = {
+      id: "a5",
+      kind: "payment.send",
+      amount_usd: null,
+      at_millis: T0,
+      agent: "seo",
+      thread: "desk-marketing",
+      batch: "turn-1",
+      broadly_grantable: true,
+      payload: null,
+      contents_hidden: true,
+    };
+    await render([HIDDEN], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    // #618's flag reads as "not shown to you", never as an empty card — and the
+    // action must not be printed twice.
+    expect(row?.textContent).toContain("Send a payment — details hidden by your role");
+    expect(row?.textContent ?? "").not.toContain("Send a payment — Send a payment");
+  });
 });

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -374,7 +374,9 @@ describe("the consolidated approval card", () => {
       agent: "seo",
       thread: "desk-marketing",
       batch: "turn-1",
-      broadly_grantable: true,
+      // A spend stays a per-call decision, so the full card offers no standing
+      // scope — and the compact row must render the same way.
+      broadly_grantable: false,
       payload: { to: "vendor@example.test", amount_usd: 42.5 },
     };
     await render([PAYMENT], {}, {}, new Map(), true);
@@ -394,7 +396,7 @@ describe("the consolidated approval card", () => {
       agent: "seo",
       thread: "desk-marketing",
       batch: "turn-1",
-      broadly_grantable: true,
+      broadly_grantable: false,
       payload: null,
       contents_hidden: true,
     };

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -520,4 +520,51 @@ describe("the consolidated approval card", () => {
     expect(row?.textContent).toContain("Send a payment — details hidden by your role");
     expect(row?.textContent ?? "").not.toContain("Send a payment — Send a payment");
   });
+
+  it("summarizes only what the compact row's buttons still decide", async () => {
+    // The drift case in the compact row: one of three already approved on the
+    // page, and the row must not go on claiming all three are on the table.
+    // The Approve button left here authorizes only the two still open, so the
+    // line names them and lets the status say what was already decided.
+    await render([ESPN, BBC, GUARDIAN], { a1: "approve" }, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    const text = row?.textContent ?? "";
+    expect(text).toContain(
+      "Fetch a web page — https://bbc.com/sport, https://theguardian.com/uk",
+    );
+    // The status still tells the operator one has been settled elsewhere.
+    expect(text).toContain("1 of 3 decided — 2 still waiting on you");
+    // The settled item is not named as something the buttons here will touch.
+    expect(text).not.toContain("https://espn.com/nba");
+
+    await click(button("Approve"));
+    // And an approve here covers only what the label named — re-resolving a1
+    // would be a second decision on an approval the host has already dropped.
+    expect(decisions.map((d) => d.id)).toEqual(["a2", "a3"]);
+  });
+
+  it("names the HTTP method beside a request URL in the compact chat row", async () => {
+    // The method is the difference between a read and a delete on the same URL:
+    // a row that showed only the address would render GET and DELETE
+    // identically even though approving them has very different effects.
+    await render([DELETE_ITEMS], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      "Make a request to a web address — DELETE https://example.com/items",
+    );
+  });
+
+  it("names each request's method in a compact batch, not just the lead's", async () => {
+    // Same URL, opposite effects: the second item's method is the consequential
+    // half of the one Approve, so it has to be on the line, not hidden behind
+    // a count or a shared address.
+    await render([GET_ITEMS, DELETE_ITEMS], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      "Make a request to a web address — GET https://example.com/items, DELETE https://example.com/items",
+    );
+  });
 });

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -71,6 +71,23 @@ function payment(id: string, to: string, amountUsd: number): ApprovalSummary {
 const VENDOR = payment("p1", "vendor@example.test", 42.5);
 const SUPPLIER = payment("p2", "supplier@example.test", 12);
 
+function request(id: string, url: string, method: string): ApprovalSummary {
+  return {
+    id,
+    kind: "http_request",
+    amount_usd: null,
+    at_millis: T0,
+    agent: "seo",
+    thread: "desk-marketing",
+    batch: "turn-1",
+    broadly_grantable: true,
+    payload: { url, method },
+  };
+}
+
+const GET_ITEMS = request("h1", "https://example.com/items", "GET");
+const DELETE_ITEMS = request("h2", "https://example.com/items", "DELETE");
+
 interface Decision {
   id: string;
   verdict: Verdict;

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -361,6 +361,6 @@ describe("the consolidated approval card", () => {
 
     const approve = button("Approve");
     expect(approve.className).toContain("hover:bg-primary");
-    expect(approve.className).not.toContain("bg-primary ");
+    expect(approve.className.split(" ")).not.toContain("bg-primary");
   });
 });

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -430,29 +430,56 @@ describe("the consolidated approval card", () => {
     expect(row?.textContent).not.toContain("+ 2 more");
   });
 
-  it("names every action and amount in a mixed compact batch", async () => {
+  it("names every action, call and amount in a mixed compact batch", async () => {
     // A fetch and a payment in one turn: "Fetch a web page + 1 more" would
     // hide the payment (and its amount) behind the lead. The line must say
-    // what the one Approve actually covers.
+    // what the one Approve actually covers — the distinct actions, and each
+    // call's own detail, so the operator sees which page and which recipient
+    // before clicking Approve.
     await render([ESPN, VENDOR], {}, {}, new Map(), true);
 
     const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
     expect(row?.textContent).toContain(
-      `2 actions need your sign-off — Fetch a web page and Send a payment · ${money(42.5)}`,
+      `2 actions need your sign-off — Fetch a web page and Send a payment — https://espn.com/nba, vendor@example.test · ${money(42.5)}`,
     );
   });
 
   it("counts a mixed compact batch with duplicate actions honestly", async () => {
-    // Two fetches and a payment: the distinct actions are named once each, and
-    // the count says there are three of them — the one Approve covers all.
+    // Two fetches and a payment: the distinct actions are named once each, the
+    // count says there are three of them, and every call's own URL or
+    // recipient is named — the one Approve covers all of it.
     await render([ESPN, BBC, VENDOR], {}, {}, new Map(), true);
 
     const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
     expect(row?.textContent).toContain(
-      `3 actions need your sign-off — Fetch a web page and Send a payment · ${money(42.5)}`,
+      `3 actions need your sign-off — Fetch a web page and Send a payment — https://espn.com/nba, https://bbc.com/sport, vendor@example.test · ${money(42.5)}`,
     );
-    // The duplicate fetch is not repeated on the line.
+    // The duplicate fetch is not repeated as a bare action on the line.
     expect(row?.textContent).not.toContain("Fetch a web page, Fetch a web page");
+  });
+
+  it("keeps a role-hidden call's warning in a mixed compact batch", async () => {
+    // A hidden payment beside a fetch: #618's flag must survive the mixed
+    // summary, or the operator would approve a call whose payload says nothing
+    // about what it does.
+    const HIDDEN: ApprovalSummary = {
+      id: "a6",
+      kind: "payment.send",
+      amount_usd: null,
+      at_millis: T0,
+      agent: "seo",
+      thread: "desk-marketing",
+      batch: "turn-1",
+      broadly_grantable: false,
+      payload: null,
+      contents_hidden: true,
+    };
+    await render([ESPN, HIDDEN], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      `2 actions need your sign-off — Fetch a web page and Send a payment — https://espn.com/nba, Send a payment — details hidden by your role`,
+    );
   });
 
   it("names a hidden approval once in the compact chat row", async () => {

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -71,7 +71,7 @@ function payment(id: string, to: string, amountUsd: number): ApprovalSummary {
 const VENDOR = payment("p1", "vendor@example.test", 42.5);
 const SUPPLIER = payment("p2", "supplier@example.test", 12);
 
-function request(id: string, url: string, method: string): ApprovalSummary {
+function request(id: string, url: string, method: string, body?: unknown): ApprovalSummary {
   return {
     id,
     kind: "http_request",
@@ -81,7 +81,7 @@ function request(id: string, url: string, method: string): ApprovalSummary {
     thread: "desk-marketing",
     batch: "turn-1",
     broadly_grantable: true,
-    payload: { url, method },
+    payload: body === undefined ? { url, method } : { url, method, body },
   };
 }
 

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -66,6 +66,7 @@ async function render(
   decided: Record<string, Verdict> = {},
   failed: Record<string, string> = {},
   deciding: ReadonlyMap<string, Verdict> = new Map(),
+  compact = false,
 ) {
   await act(async () => {
     root.render(
@@ -73,6 +74,7 @@ async function render(
         approvals,
         now: T0 + 60_000,
         askerNames: new Map([["seo", "SEO Specialist"]]),
+        compact,
         deciding,
         decided,
         failed,
@@ -342,5 +344,23 @@ describe("the consolidated approval card", () => {
     expect(container.textContent ?? "").not.toContain("sign-offs");
     await click(button("Approve"));
     expect(decisions).toEqual([{ id: "a1", verdict: "approve", scope: { kind: "once" } }]);
+  });
+
+  it("keeps a chat approval to a quiet, differentiating two-line interruption", async () => {
+    await render([ESPN], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain("Fetch web page — https://espn.com/nba");
+    expect(row?.textContent).toContain("Asked by SEO Specialist");
+    expect(row?.querySelector('a[href="#/approvals"]')?.textContent).toBe("View details");
+    // Payload and grant scope are detailed decisions, so they stay on the
+    // Approvals page instead of making every interruption a full card.
+    expect(row?.querySelectorAll('input[type="radio"]')).toHaveLength(0);
+    expect(row?.className).not.toContain("border");
+
+    const approve = button("Approve");
+    expect(approve.className).toContain("hover:bg-primary");
+    expect(approve.className).not.toContain("bg-primary ");
   });
 });

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -567,4 +567,38 @@ describe("the consolidated approval card", () => {
       "Make a request to a web address — GET https://example.com/items, DELETE https://example.com/items",
     );
   });
+
+  it("shows what a write sends, not just where it goes, in the compact row", async () => {
+    // Two POSTs to the same address are only the same decision if the payload
+    // is the same: the body is what the one Approve authorizes. A row that
+    // showed only "POST https://example.com/items" would render a write that
+    // ships a document and a body-less read identically.
+    const WRITE = request("h3", "https://example.com/items", "POST", {
+      message: "ship it",
+    });
+    await render([WRITE], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      'Make a request to a web address — POST {"message":"ship it"} https://example.com/items',
+    );
+  });
+
+  it("previews a long request body rather than flooding the compact row", async () => {
+    // The row's job is to distinguish two requests, not to carry the file; a
+    // giant body is previewed with an ellipsis, and the detailed view still
+    // shows the full payload.
+    const body = { message: "x".repeat(120) };
+    const bodyJson = JSON.stringify(body);
+    expect(bodyJson.length).toBeGreaterThan(60);
+    const WRITE = request("h4", "https://example.com/items", "POST", body);
+    await render([WRITE], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      `Make a request to a web address — POST ${bodyJson.slice(0, 60)}… https://example.com/items`,
+    );
+    // And the preview is not the whole body.
+    expect(row?.textContent).not.toContain(bodyJson);
+  });
 });

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -406,6 +406,42 @@ describe("the consolidated approval card", () => {
     expect(row?.textContent).toContain(`Send a payment — vendor@example.test · ${money(42.5)}`);
   });
 
+  it("names every amount in a same-kind compact batch, not just the lead's", async () => {
+    // Two payments from one turn: the lead's line already shows its own value,
+    // and the second's has to appear too — one Approve authorizes both.
+    await render([VENDOR, SUPPLIER], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      `Send a payment — vendor@example.test · ${money(42.5)} · ${money(12)} + 1 more`,
+    );
+  });
+
+  it("names every action and amount in a mixed compact batch", async () => {
+    // A fetch and a payment in one turn: "Fetch a web page + 1 more" would
+    // hide the payment (and its amount) behind the lead. The line must say
+    // what the one Approve actually covers.
+    await render([ESPN, VENDOR], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      `2 actions need your sign-off — Fetch a web page and Send a payment · ${money(42.5)}`,
+    );
+  });
+
+  it("counts a mixed compact batch with duplicate actions honestly", async () => {
+    // Two fetches and a payment: the distinct actions are named once each, and
+    // the count says there are three of them — the one Approve covers all.
+    await render([ESPN, BBC, VENDOR], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      `3 actions need your sign-off — Fetch a web page and Send a payment · ${money(42.5)}`,
+    );
+    // The duplicate fetch is not repeated on the line.
+    expect(row?.textContent).not.toContain("Fetch a web page, Fetch a web page");
+  });
+
   it("names a hidden approval once in the compact chat row", async () => {
     const HIDDEN: ApprovalSummary = {
       id: "a5",

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -406,15 +406,28 @@ describe("the consolidated approval card", () => {
     expect(row?.textContent).toContain(`Send a payment — vendor@example.test · ${money(42.5)}`);
   });
 
-  it("names every amount in a same-kind compact batch, not just the lead's", async () => {
+  it("names every call and amount in a same-kind compact batch, not just the lead's", async () => {
     // Two payments from one turn: the lead's line already shows its own value,
     // and the second's has to appear too — one Approve authorizes both.
     await render([VENDOR, SUPPLIER], {}, {}, new Map(), true);
 
     const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
     expect(row?.textContent).toContain(
-      `Send a payment — vendor@example.test · ${money(42.5)} · ${money(12)} + 1 more`,
+      `Send a payment — vendor@example.test, supplier@example.test · ${money(42.5)} · ${money(12)}`,
     );
+  });
+
+  it("names every same-kind call in a compact batch, not just the lead's", async () => {
+    // Three fetches from one turn: the second and third URLs are the
+    // consequential ones — one Approve authorizes all three. "+ 2 more" would
+    // hide a sketchy destination behind a harmless first fetch.
+    await render([ESPN, BBC, GUARDIAN], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    expect(row?.textContent).toContain(
+      `Fetch a web page — https://espn.com/nba, https://bbc.com/sport, https://theguardian.com/uk`,
+    );
+    expect(row?.textContent).not.toContain("+ 2 more");
   });
 
   it("names every action and amount in a mixed compact batch", async () => {

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -52,6 +52,25 @@ const ESPN = approval("a1", "https://espn.com/nba");
 const BBC = approval("a2", "https://bbc.com/sport");
 const GUARDIAN = approval("a3", "https://theguardian.com/uk");
 
+function payment(id: string, to: string, amountUsd: number): ApprovalSummary {
+  return {
+    id,
+    kind: "payment.send",
+    amount_usd: amountUsd,
+    at_millis: T0,
+    agent: "seo",
+    thread: "desk-marketing",
+    batch: "turn-1",
+    // A spend stays a per-call decision, so the full card offers no standing
+    // scope — and the compact row must render the same way.
+    broadly_grantable: false,
+    payload: { to, amount_usd: amountUsd },
+  };
+}
+
+const VENDOR = payment("p1", "vendor@example.test", 42.5);
+const SUPPLIER = payment("p2", "supplier@example.test", 12);
+
 interface Decision {
   id: string;
   verdict: Verdict;

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -622,4 +622,29 @@ describe("the consolidated approval card", () => {
     // And the preview is not the whole body.
     expect(row?.textContent).not.toContain(bodyJson);
   });
+
+  it("gates the inline Approve when a body preview was cut (#1330 review)", async () => {
+    // A preview is not the payload: two POSTs to the same URL whose bodies share
+    // the first 60 code units render identically even when the cut-off suffix
+    // changes an amount or recipient. The compact row must not one-click
+    // Approve on that — the operator has to see the complete host-bounded
+    // payload (the detailed view) first, so the inline Approve is replaced by a
+    // path there. Decline is always safe and stays inline.
+    const body = { recipient: "vendor@example.test", message: "x".repeat(120) };
+    const bodyJson = JSON.stringify(body);
+    expect(bodyJson.length).toBeGreaterThan(60);
+    const WRITE = request("h5", "https://example.com/items", "POST", body);
+    await render([WRITE], {}, {}, new Map(), true);
+
+    const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
+    // The cut label names the row and admits it is cut…
+    expect(row?.textContent).toContain("…");
+    expect(row?.textContent).toContain("Review in Approvals");
+    // …but there is no live inline Approve button on the truncated preview, and
+    // a decline is still one press.
+    expect(() => button("Approve")).toThrow();
+    expect(() => button("Decline")).not.toThrow();
+    // Nothing was decided: the row only offered the detailed view.
+    expect(decisions).toEqual([]);
+  });
 });

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { money } from "@/lib/language";
 import { ApprovalRow } from "@/views/chat/ApprovalRow";
 
 /**

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -351,7 +351,7 @@ describe("the consolidated approval card", () => {
 
     const row = container.querySelector<HTMLElement>('[data-approval-inline="compact"]');
     expect(row).not.toBeNull();
-    expect(row?.textContent).toContain("Fetch web page — https://espn.com/nba");
+    expect(row?.textContent).toContain("Fetch a web page — https://espn.com/nba");
     expect(row?.textContent).toContain("Asked by SEO Specialist");
     expect(row?.querySelector('a[href="#/approvals"]')?.textContent).toBe("View details");
     // Payload and grant scope are detailed decisions, so they stay on the

--- a/frontend/test/unit/language.test.ts
+++ b/frontend/test/unit/language.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { approvalAction, grantHeadline, payloadLines, toolAction } from "@/lib/language";
+import { approvalAction, grantHeadline, payloadLeadTruncated, payloadLines, toolAction } from "@/lib/language";
 import type { ApprovalSummary, StandingGrant } from "@/api/types";
 
 /**

--- a/frontend/test/unit/language.test.ts
+++ b/frontend/test/unit/language.test.ts
@@ -111,6 +111,37 @@ describe("the payload block underneath the label", () => {
   });
 });
 
+describe("whether a payload lead was cut to fit the compact row", () => {
+  const request = (body: string) =>
+    approval({ kind: "http_request", payload: { url: "https://x.test", method: "POST", body } });
+
+  it("is false when no promoted extra is previewed", () => {
+    expect(payloadLeadTruncated(request("small"))).toBe(false);
+  });
+
+  it("is false at exactly the preview bound", () => {
+    // `preview` cuts strictly past `EXTRA_PREVIEW_MAX`, so the boundary itself
+    // is the full value — nothing was hidden, and nothing may be gated.
+    expect(payloadLeadTruncated(request("x".repeat(60)))).toBe(false);
+  });
+
+  it("is true when a promoted extra is cut", () => {
+    // A body longer than the bound is shown as a preview, and a preview is not
+    // something an operator may one-click Approve.
+    expect(payloadLeadTruncated(request("x".repeat(61)))).toBe(true);
+  });
+
+  it("is false for a kind that promotes nothing past the lead", () => {
+    expect(
+      payloadLeadTruncated(approval({ kind: "web_fetch", payload: { url: "x".repeat(500) } })),
+    ).toBe(false);
+  });
+
+  it("is false when there is no payload to show", () => {
+    expect(payloadLeadTruncated(approval({ kind: "http_request" }))).toBe(false);
+  });
+});
+
 describe("a kind nobody has named", () => {
   it("says a teammate wants a tool rather than inventing one", () => {
     expect(approvalAction(approval({ kind: "some_tool_nobody_declared" }))).toBe(


### PR DESCRIPTION
## Summary
- render pending chat approvals as compact transcript rows with a distinct action summary, requester/timing metadata, and a link to the detailed Approvals queue
- keep approval/decline controls neutral until hover or focus, so the composer remains the primary brand-filled action
- retain the full approval form for non-chat callers, including workflow/run contexts

Closes #1330

## Validation
- `pnpm exec vitest run test/unit/approval-batch-card.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`

## Scope
I interpreted the issue as a chat-transcript-only hierarchy change. The Approvals page and other detailed decision contexts intentionally retain their full payload and grant-scope UI; chat links operators to `#/approvals` for that detail. The updated targeted Playwright spec was not run locally because its required Rust host binary was cold-building beyond the safe foreground window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact approval presentation for chat transcripts.
  * Compact approvals show a concise summary, relevant metadata, payment amounts, and a link to view full details.
  * Approve and decline actions remain available in the compact view.
  * Batch approvals now provide clearer summaries for multiple, mixed, or hidden actions.

* **Tests**
  * Expanded coverage for compact approvals, payment formatting, batch summaries, detail links, and action styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->