### PR TITLE
fix(chat): remove unavailable chat controls

### DIFF
--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { ChevronRight, CircleDot, Hash, Lock } from "lucide-react";
 
 import { TeammateAvatar } from "@/components/teammate-avatar";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { channelSubtitle, dmFace, type Channel, type ChannelSection } from "./model";
 

--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronRight, CircleDot, Hash, Lock, SquarePen } from "lucide-react";
+import { ChevronRight, CircleDot, Hash, Lock } from "lucide-react";
 
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
@@ -43,18 +43,8 @@ export function ChannelRail({ sections, activeId, unread, onSelect, className }:
         className,
       )}
     >
-      <div className="flex items-center justify-between gap-2 px-3 py-3">
+      <div className="px-3 py-3">
         <h2 className="truncate text-sm font-semibold tracking-tight">Chat</h2>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7 text-muted-foreground"
-          aria-label="New message"
-          disabled
-          title="New message — coming soon"
-        >
-          <SquarePen className="size-4" />
-        </Button>
       </div>
 
       {sections.map((section) => (

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -6,10 +6,6 @@ import {
   CaseSensitive,
   Code,
   Italic,
-  Link2,
-  List,
-  Paperclip,
-  Smile,
   Strikethrough,
 } from "lucide-react";
 
@@ -132,27 +128,6 @@ export function MessageComposer({
                 <w.icon className="size-3.5" />
               </Button>
             ))}
-            <span className="mx-1 h-4 w-px bg-border" aria-hidden />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 text-muted-foreground"
-              aria-label="Bulleted list"
-              title="Bulleted list"
-              disabled
-            >
-              <List className="size-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 text-muted-foreground"
-              aria-label="Link"
-              title="Link"
-              disabled
-            >
-              <Link2 className="size-3.5" />
-            </Button>
           </div>
         )}
 
@@ -223,26 +198,6 @@ export function MessageComposer({
             onClick={() => wrap("@")}
           >
             <AtSign className="size-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground"
-            aria-label="Attach a file"
-            title="Attach a file"
-            disabled
-          >
-            <Paperclip className="size-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground"
-            aria-label="Add an emoji"
-            title="Add an emoji"
-            disabled
-          >
-            <Smile className="size-4" />
           </Button>
           {!compact && (
             <Button

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -144,7 +144,7 @@ test("an empty board leaves its column affordances to explain the empty state", 
     // A declared ledger defaults to list mode since issue #1336. Switch to
     // board mode so the columns render and the empty-state affordances are
     // visible where this test asserts them.
-    await page.getByRole("button", { name: "Board" }).click();
+    await page.getByTitle("Group rows by status").click();
     await expect(page.getByTestId("ledger-board")).toBeVisible({ timeout: 15_000 });
 
     // Board columns already say what an empty board is for. A second status

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -140,6 +140,11 @@ test("an empty board leaves its column affordances to explain the empty state", 
   try {
     await page.goto(`/#/ledgers/${slug}`);
     await dismissTour(page);
+
+    // A declared ledger defaults to list mode since issue #1336. Switch to
+    // board mode so the columns render and the empty-state affordances are
+    // visible where this test asserts them.
+    await page.getByRole("button", { name: "Board" }).click();
     await expect(page.getByTestId("ledger-board")).toBeVisible({ timeout: 15_000 });
 
     // Board columns already say what an empty board is for. A second status

--- a/frontend/test/unit/chat-unavailable-controls.test.ts
+++ b/frontend/test/unit/chat-unavailable-controls.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ChannelRail } from "@/views/chat/ChannelRail";
+import { MessageComposer } from "@/views/chat/MessageComposer";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(element: ReturnType<typeof createElement>) {
+  act(() => root.render(element));
+}
+
+function action(label: string) {
+  return container.querySelector(`[aria-label="${label}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("chat only renders controls it can perform (issue #1336)", () => {
+  it("does not offer a new-message action in the channel rail", () => {
+    render(
+      createElement(ChannelRail, {
+        sections: [],
+        activeId: null,
+        unread: {},
+        onSelect: () => {},
+      }),
+    );
+
+    expect(action("New message")).toBeNull();
+  });
+
+  it("keeps working composer controls and holds unavailable ones back", () => {
+    render(
+      createElement(MessageComposer, {
+        placeholder: "Message",
+        onSend: () => {},
+      }),
+    );
+
+    expect(action("Mention someone")).not.toBeNull();
+    expect(action("Formatting")).not.toBeNull();
+    expect(action("Attach a file")).toBeNull();
+    expect(action("Add an emoji")).toBeNull();
+
+    act(() => (action("Formatting") as HTMLButtonElement).click());
+    expect(action("Bold")).not.toBeNull();
+    expect(action("Bulleted list")).toBeNull();
+    expect(action("Link")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- remove the permanently disabled New message action from the channel rail
- remove unavailable file, emoji, list, and link actions from the composer
- add a rendered UI regression test that keeps the working controls visible and the unavailable ones absent

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `cargo fmt --all -- --check`

## Scope
Takes issue #1336's hold-back-until-functional interpretation: unavailable controls are absent rather than shown disabled with a tooltip. Working mention, formatting, and markdown-wrap actions are unchanged.

Closes #1336