### PR TITLE
fix(finances): render an honest zero state

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1545,7 +1545,11 @@ export interface TransactionDto {
  */
 export interface FinancesDto {
   balanceUsd: number;
-  budgetUsd: number;
+  /**
+   * The monthly budget cap. `null` when the manifest sets no `[budget]`;
+   * `0` when it is explicitly capped at zero — a hard cap, not an absence.
+   */
+  budgetUsd: number | null;
   spentUsd: number;
   revenueUsd: number;
   netUsd: number;

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -98,7 +98,9 @@ export function FinancesView({ client, company }: Props) {
     );
   }
 
-  const budgetPct = data.budgetUsd > 0 ? Math.min(100, Math.round((data.spentUsd / data.budgetUsd) * 100)) : 0;
+  const budgetUsd = data.budgetUsd;
+  const hasBudget = budgetUsd !== null && budgetUsd > 0;
+  const budgetPct = hasBudget ? Math.min(100, Math.round((data.spentUsd / budgetUsd) * 100)) : 0;
   const netSign = data.netUsd > 0 ? "+" : data.netUsd < 0 ? "−" : "";
 
   return (

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -178,31 +178,31 @@ export function FinancesView({ client, company }: Props) {
                 <EmptyCard icon={ArrowDownLeft} message="No transactions have been recorded yet." />
               ) : (
                 <ul className="divide-y">
-                {data.transactions.map((t) => {
-                  const inflow = t.direction === "in";
-                  return (
-                    <li key={t.id} className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
-                      <span
-                        className={cn(
-                          "flex size-8 shrink-0 items-center justify-center rounded-full",
-                          inflow ? "bg-status-done-soft text-status-done-text" : "bg-muted text-muted-foreground",
-                        )}
-                      >
-                        {inflow ? <ArrowDownLeft className="size-4" /> : <ArrowUpRight className="size-4" />}
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium">{t.description}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {new Date(t.date).toLocaleDateString(undefined, { month: "short", day: "numeric" })} · {t.category}
-                        </p>
-                      </div>
-                      <span className={cn("shrink-0 text-sm font-medium tabular-nums", inflow ? "text-status-done-text" : "text-foreground")}>
-                        {inflow ? "+" : "−"}
-                        {usd(t.amountUsd)}
-                      </span>
-                    </li>
-                  );
-                })}
+                  {data.transactions.map((t) => {
+                    const inflow = t.direction === "in";
+                    return (
+                      <li key={t.id} className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
+                        <span
+                          className={cn(
+                            "flex size-8 shrink-0 items-center justify-center rounded-full",
+                            inflow ? "bg-status-done-soft text-status-done-text" : "bg-muted text-muted-foreground",
+                          )}
+                        >
+                          {inflow ? <ArrowDownLeft className="size-4" /> : <ArrowUpRight className="size-4" />}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium">{t.description}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(t.date).toLocaleDateString(undefined, { month: "short", day: "numeric" })} · {t.category}
+                          </p>
+                        </div>
+                        <span className={cn("shrink-0 text-sm font-medium tabular-nums", inflow ? "text-status-done-text" : "text-foreground")}>
+                          {inflow ? "+" : "−"}
+                          {usd(t.amountUsd)}
+                        </span>
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </CardContent>

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -63,7 +63,13 @@ export function FinancesView({ client, company }: Props) {
       .catch((error: unknown) => {
         if (alive) {
           setData(null);
-          setLoad(error instanceof ApiError && error.status === 404 ? "unavailable" : "error");
+          // A bare 404 (no host error envelope) is the signature of a host that
+          // never wired the finances route — the "unavailable" surface. A 404
+          // the host answered itself (e.g. `company_not_found`) is a real
+          // failure and must go through the normal error state instead.
+          const unwired =
+            error instanceof ApiError && error.status === 404 && error.code === "http_404";
+          setLoad(unwired ? "unavailable" : "error");
         }
       });
     return () => {

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -117,7 +117,7 @@ export function FinancesView({ client, company }: Props) {
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Kpi icon={Wallet} label="Wallet balance" value={usd(data.balanceUsd)} hint="Ledger balance" />
           <Kpi icon={TrendingUp} label="Revenue" value={usd(data.revenueUsd, 0)} hint="This month" />
-          <Kpi icon={Coins} label="Spend" value={usd(data.spentUsd, 0)} hint={`of ${usd(data.budgetUsd, 0)} budget`} />
+          <Kpi icon={Coins} label="Spend" value={usd(data.spentUsd, 0)} hint={budgetUsd === null ? "This month" : `of ${usd(budgetUsd, 0)} budget`} />
           <Kpi
             icon={PiggyBank}
             label="Net"

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -132,12 +132,14 @@ export function FinancesView({ client, company }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Monthly budget</CardTitle>
             <CardDescription>
-              {data.budgetUsd > 0
-                ? `${usd(data.spentUsd, 0)} of ${usd(data.budgetUsd, 0)} used · ${usd(data.budgetUsd - data.spentUsd, 0)} left`
-                : "No monthly budget is set."}
+              {budgetUsd === null
+                ? "No monthly budget is set."
+                : budgetUsd === 0
+                  ? "Spending is capped at $0.00 this month."
+                  : `${usd(data.spentUsd, 0)} of ${usd(budgetUsd, 0)} used · ${usd(budgetUsd - data.spentUsd, 0)} left`}
             </CardDescription>
           </CardHeader>
-          {data.budgetUsd > 0 && (
+          {hasBudget && (
             <CardContent className="space-y-2">
               <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
                 <div

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -4,10 +4,10 @@
 // brings this surface back. Do not delete it as dead code.
 import { useEffect, useState } from "react";
 import { Bar, BarChart, LabelList, XAxis, YAxis } from "recharts";
-import { ArrowDownLeft, ArrowUpRight, Coins, PiggyBank, TrendingUp, Wallet } from "lucide-react";
+import { ArrowDownLeft, ArrowUpRight, CircleAlert, Coins, PiggyBank, TrendingUp, Wallet } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
-import type { FinancesDto } from "@/api/types";
+import { ApiError, type FinancesDto } from "@/api/types";
 import {
   Card,
   CardContent,
@@ -24,7 +24,11 @@ import {
 import { cn } from "@/lib/utils";
 
 function usd(n: number, maxFrac = 2): string {
-  return n.toLocaleString(undefined, { style: "currency", currency: "USD", maximumFractionDigits: maxFrac });
+  return (n === 0 ? 0 : n).toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: maxFrac,
+  });
 }
 
 /* The brand leads slot 1, and the token already themes itself — see the note
@@ -38,40 +42,58 @@ interface Props {
   company: string | null;
 }
 
-// The empty finances read — shown before the first fetch resolves and as the
-// fallback when a host doesn't expose the surface yet (404). Real-or-zero: no
-// fabricated balance, budget, or transactions.
-const EMPTY_FINANCE: FinancesDto = {
-  balanceUsd: 0,
-  budgetUsd: 0,
-  spentUsd: 0,
-  revenueUsd: 0,
-  netUsd: 0,
-  byCategory: [],
-  transactions: [],
-};
+type FinanceLoad = "loading" | "ready" | "unavailable" | "error";
 
 /** Company finances: balance, budget, revenue, spend by category, transactions. */
 export function FinancesView({ client, company }: Props) {
-  const [data, setData] = useState<FinancesDto>(EMPTY_FINANCE);
+  const [data, setData] = useState<FinancesDto | null>(null);
+  const [load, setLoad] = useState<FinanceLoad>("loading");
+
   useEffect(() => {
     let alive = true;
+    setLoad("loading");
     client
       .finances(company)
       .then((finances) => {
-        if (alive) setData(finances);
+        if (alive) {
+          setData(finances);
+          setLoad("ready");
+        }
       })
-      // Hosts without the surface (older builds) 404 — show the empty state.
-      .catch(() => {
-        if (alive) setData(EMPTY_FINANCE);
+      .catch((error: unknown) => {
+        if (alive) {
+          setData(null);
+          setLoad(error instanceof ApiError && error.status === 404 ? "unavailable" : "error");
+        }
       });
     return () => {
       alive = false;
     };
   }, [client, company]);
-  // Guard against an uncapped budget (0) so the bar reads 0%, not NaN.
-  const budgetPct =
-    data.budgetUsd > 0 ? Math.min(100, Math.round((data.spentUsd / data.budgetUsd) * 100)) : 0;
+  if (load === "loading") {
+    return <FinanceNotice title="Loading finances…" description="Reading the company ledger." />;
+  }
+
+  if (load === "unavailable") {
+    return (
+      <FinanceNotice
+        title="Finances unavailable"
+        description="This host doesn't expose finances, so there is no ledger data to show."
+      />
+    );
+  }
+
+  if (load === "error" || !data) {
+    return (
+      <FinanceNotice
+        title="Could not load finances"
+        description="The company ledger could not be read. Try refreshing the page."
+      />
+    );
+  }
+
+  const budgetPct = data.budgetUsd > 0 ? Math.min(100, Math.round((data.spentUsd / data.budgetUsd) * 100)) : 0;
+  const netSign = data.netUsd > 0 ? "+" : data.netUsd < 0 ? "−" : "";
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -85,15 +107,15 @@ export function FinancesView({ client, company }: Props) {
 
         {/* KPIs */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <Kpi icon={Wallet} label="Wallet balance" value={usd(data.balanceUsd)} hint="Available USDC" />
+          <Kpi icon={Wallet} label="Wallet balance" value={usd(data.balanceUsd)} hint="Ledger balance" />
           <Kpi icon={TrendingUp} label="Revenue" value={usd(data.revenueUsd, 0)} hint="This month" />
           <Kpi icon={Coins} label="Spend" value={usd(data.spentUsd, 0)} hint={`of ${usd(data.budgetUsd, 0)} budget`} />
           <Kpi
             icon={PiggyBank}
             label="Net"
-            value={`${data.netUsd >= 0 ? "+" : "−"}${usd(Math.abs(data.netUsd), 0)}`}
+            value={`${netSign}${usd(Math.abs(data.netUsd), 0)}`}
             hint="Revenue − spend"
-            valueClass={data.netUsd >= 0 ? "text-status-done-text" : "text-status-failed-text"}
+            valueClass={data.netUsd > 0 ? "text-status-done-text" : data.netUsd < 0 ? "text-status-failed-text" : undefined}
           />
         </div>
 
@@ -102,18 +124,22 @@ export function FinancesView({ client, company }: Props) {
           <CardHeader>
             <CardTitle className="text-base">Monthly budget</CardTitle>
             <CardDescription>
-              {usd(data.spentUsd, 0)} of {usd(data.budgetUsd, 0)} used · {usd(data.budgetUsd - data.spentUsd, 0)} left
+              {data.budgetUsd > 0
+                ? `${usd(data.spentUsd, 0)} of ${usd(data.budgetUsd, 0)} used · ${usd(data.budgetUsd - data.spentUsd, 0)} left`
+                : "No monthly budget is set."}
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-2">
-            <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className={cn("h-full rounded-full", budgetPct >= 90 ? "bg-status-failed" : budgetPct >= 70 ? "bg-status-blocked" : "bg-status-done")}
-                style={{ width: `${budgetPct}%` }}
-              />
-            </div>
-            <p className="text-xs text-muted-foreground">{budgetPct}% of budget used</p>
-          </CardContent>
+          {data.budgetUsd > 0 && (
+            <CardContent className="space-y-2">
+              <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className={cn("h-full rounded-full", budgetPct >= 90 ? "bg-status-failed" : budgetPct >= 70 ? "bg-status-blocked" : "bg-status-done")}
+                  style={{ width: `${budgetPct}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">{budgetPct}% of budget used</p>
+            </CardContent>
+          )}
         </Card>
 
         <div className="grid gap-4 lg:grid-cols-2">
@@ -124,16 +150,20 @@ export function FinancesView({ client, company }: Props) {
               <CardDescription>Where the money goes.</CardDescription>
             </CardHeader>
             <CardContent>
-              <ChartContainer config={chartConfig} className="h-64 w-full">
-                <BarChart data={data.byCategory} layout="vertical" margin={{ left: 8, right: 48 }}>
-                  <XAxis type="number" dataKey="amount" hide />
-                  <YAxis type="category" dataKey="category" tickLine={false} axisLine={false} width={110} />
-                  <ChartTooltip content={<ChartTooltipContent formatter={(v) => usd(Number(v), 0)} />} />
-                  <Bar dataKey="amount" fill="var(--color-amount)" radius={4}>
-                    <LabelList dataKey="amount" position="right" className="fill-muted-foreground" formatter={(v) => usd(Number(v ?? 0), 0)} />
-                  </Bar>
-                </BarChart>
-              </ChartContainer>
+              {data.byCategory.length === 0 ? (
+                <EmptyCard icon={Coins} message="No spending has been recorded yet." />
+              ) : (
+                <ChartContainer config={chartConfig} className="h-64 w-full">
+                  <BarChart data={data.byCategory} layout="vertical" margin={{ left: 8, right: 48 }}>
+                    <XAxis type="number" dataKey="amount" hide />
+                    <YAxis type="category" dataKey="category" tickLine={false} axisLine={false} width={110} />
+                    <ChartTooltip content={<ChartTooltipContent formatter={(v) => usd(Number(v), 0)} />} />
+                    <Bar dataKey="amount" fill="var(--color-amount)" radius={4}>
+                      <LabelList dataKey="amount" position="right" className="fill-muted-foreground" formatter={(v) => usd(Number(v ?? 0), 0)} />
+                    </Bar>
+                  </BarChart>
+                </ChartContainer>
+              )}
             </CardContent>
           </Card>
 
@@ -144,7 +174,10 @@ export function FinancesView({ client, company }: Props) {
               <CardDescription>Latest inflows and outflows.</CardDescription>
             </CardHeader>
             <CardContent>
-              <ul className="divide-y">
+              {data.transactions.length === 0 ? (
+                <EmptyCard icon={ArrowDownLeft} message="No transactions have been recorded yet." />
+              ) : (
+                <ul className="divide-y">
                 {data.transactions.map((t) => {
                   const inflow = t.direction === "in";
                   return (
@@ -170,11 +203,33 @@ export function FinancesView({ client, company }: Props) {
                     </li>
                   );
                 })}
-              </ul>
+                </ul>
+              )}
             </CardContent>
           </Card>
         </div>
       </div>
+    </div>
+  );
+}
+
+function FinanceNotice({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex flex-1 overflow-y-auto">
+      <div className="m-auto w-full max-w-md px-4 text-center">
+        <CircleAlert className="mx-auto size-8 text-muted-foreground" />
+        <h2 className="mt-3 text-lg font-semibold">{title}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function EmptyCard({ icon: Icon, message }: { icon: React.ComponentType<{ className?: string }>; message: string }) {
+  return (
+    <div className="flex h-64 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+      <Icon className="size-6" />
+      <p>{message}</p>
     </div>
   );
 }

--- a/frontend/test/unit/finances-view-empty-state.test.ts
+++ b/frontend/test/unit/finances-view-empty-state.test.ts
@@ -9,7 +9,8 @@ import { ApiError, type FinancesDto } from "@/api/types";
 import { FinancesView } from "@/views/FinancesView";
 
 /**
- * The finance overview must tell an empty ledger apart from an absent route.
+ * The finance overview must tell an empty ledger apart from an absent route,
+ * and an absent budget apart from a zero-dollar cap.
  *
  * A zero-filled response is a real accounting result; a 404 means this host
  * cannot make that claim. These checks also keep zero from inheriting either a
@@ -18,7 +19,7 @@ import { FinancesView } from "@/views/FinancesView";
 
 const EMPTY_LEDGER: FinancesDto = {
   balanceUsd: -0,
-  budgetUsd: 0,
+  budgetUsd: null,
   spentUsd: 0,
   revenueUsd: 0,
   netUsd: -0,

--- a/frontend/test/unit/finances-view-empty-state.test.ts
+++ b/frontend/test/unit/finances-view-empty-state.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError, type FinancesDto } from "@/api/types";
+import { FinancesView } from "@/views/FinancesView";
+
+/**
+ * The finance overview must tell an empty ledger apart from an absent route.
+ *
+ * A zero-filled response is a real accounting result; a 404 means this host
+ * cannot make that claim. These checks also keep zero from inheriting either a
+ * negative currency sign or the positive net treatment.
+ */
+
+const EMPTY_LEDGER: FinancesDto = {
+  balanceUsd: -0,
+  budgetUsd: 0,
+  spentUsd: 0,
+  revenueUsd: 0,
+  netUsd: -0,
+  byCategory: [],
+  transactions: [],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(finances: Promise<FinancesDto>): Promise<void> {
+  const client = { finances: vi.fn(() => finances) } as unknown as OpenCompanyClient;
+  await act(async () => {
+    root.render(createElement(FinancesView, { client, company: "acme" }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("FinancesView empty data", () => {
+  it("renders a genuine empty ledger without a negative zero, budget bar, or positive net state", async () => {
+    await render(Promise.resolve(EMPTY_LEDGER));
+
+    expect(container.textContent).toContain("$0.00");
+    expect(container.textContent).not.toContain("-$0.00");
+    expect(container.textContent).toContain("No monthly budget is set.");
+    expect(container.textContent).not.toContain("0% of budget used");
+    expect(container.textContent).toContain("No spending has been recorded yet.");
+    expect(container.textContent).toContain("No transactions have been recorded yet.");
+    expect(container.textContent).not.toContain("Available USDC");
+
+    const net = container.querySelectorAll<HTMLElement>(".text-2xl")[3];
+    expect(net?.textContent).toBe("$0");
+    expect(net?.className).not.toContain("text-status-done-text");
+  });
+
+  it("says when the host does not expose finances instead of rendering a zero ledger", async () => {
+    await render(Promise.reject(new ApiError(404, "not_found", "no finances route", true)));
+
+    expect(container.textContent).toContain("Finances unavailable");
+    expect(container.textContent).toContain("This host doesn't expose finances");
+    expect(container.textContent).not.toContain("Wallet balance");
+  });
+});

--- a/frontend/test/unit/finances-view-empty-state.test.ts
+++ b/frontend/test/unit/finances-view-empty-state.test.ts
@@ -69,10 +69,25 @@ describe("FinancesView empty data", () => {
   });
 
   it("says when the host does not expose finances instead of rendering a zero ledger", async () => {
-    await render(Promise.reject(new ApiError(404, "not_found", "no finances route", true)));
+    await render(Promise.reject(new ApiError(404, "http_404", "no finances route", false)));
 
     expect(container.textContent).toContain("Finances unavailable");
     expect(container.textContent).toContain("This host doesn't expose finances");
     expect(container.textContent).not.toContain("Wallet balance");
+  });
+
+  it("distinguishes a deleted company from an unwired route", async () => {
+    await render(Promise.reject(new ApiError(404, "company_not_found", "acme", true)));
+
+    expect(container.textContent).toContain("Could not load finances");
+    expect(container.textContent).not.toContain("This host doesn't expose finances");
+  });
+
+  it("labels an explicit zero-dollar cap rather than claiming no budget is set", async () => {
+    await render(Promise.resolve({ ...EMPTY_LEDGER, budgetUsd: 0 }));
+
+    expect(container.textContent).toContain("Spending is capped at $0.00 this month.");
+    expect(container.textContent).not.toContain("No monthly budget is set.");
+    expect(container.textContent).not.toContain("0% of budget used");
   });
 });

--- a/src/metering/finances.rs
+++ b/src/metering/finances.rs
@@ -176,7 +176,7 @@ mod tests {
         assert!((f.spent_usd - 20.0).abs() < 1e-9);
         assert!((f.revenue_usd - 30.0).abs() < 1e-9);
         assert!((f.net_usd - 10.0).abs() < 1e-9);
-        assert_eq!(f.budget_usd, 2000.0);
+        assert_eq!(f.budget_usd, Some(2000.0));
         // Bookkeeping net across all time: 30 - 12 - 8 - 100 = -90.
         assert!((f.balance_usd - (-90.0)).abs() < 1e-9);
     }

--- a/src/metering/finances.rs
+++ b/src/metering/finances.rs
@@ -94,7 +94,7 @@ pub fn finances_from(
 
     Finances {
         balance_usd,
-        budget_usd: budget.monthly_usd.unwrap_or(0.0),
+        budget_usd: budget.monthly_usd,
         spent_usd,
         revenue_usd,
         net_usd: revenue_usd - spent_usd,

--- a/src/metering/finances.rs
+++ b/src/metering/finances.rs
@@ -163,6 +163,18 @@ mod tests {
     }
 
     #[test]
+    fn zero_cap_is_distinct_from_no_cap() {
+        let now = at(2026, 7, 16);
+        // A manifest that sets `monthly_usd = 0` is a hard cap, not an absent
+        // budget: it survives as `Some(0.0)` so the console can say "capped at
+        // zero" rather than "no budget is set".
+        let capped = finances_from(&[], &budget(Some(0.0)), None, now);
+        assert_eq!(capped.budget_usd, Some(0.0));
+        let uncapped = finances_from(&[], &budget(None), None, now);
+        assert_eq!(uncapped.budget_usd, None);
+    }
+
+    #[test]
     fn current_month_spend_and_revenue() {
         let now = at(2026, 7, 16);
         let ledger = vec![

--- a/src/metering/finances.rs
+++ b/src/metering/finances.rs
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(f.revenue_usd, 0.0);
         assert_eq!(f.net_usd, 0.0);
         assert_eq!(f.balance_usd, 0.0);
-        assert_eq!(f.budget_usd, 0.0);
+        assert_eq!(f.budget_usd, None);
         assert!(f.by_category.is_empty());
         assert!(f.transactions.is_empty());
     }

--- a/src/metering/types.rs
+++ b/src/metering/types.rs
@@ -150,8 +150,9 @@ pub struct Transaction {
 pub struct Finances {
     /// The wallet balance (economy wallet when present, else bookkeeping net).
     pub balance_usd: f64,
-    /// The monthly budget cap from `[budget].monthly_usd` (0 when uncapped).
-    pub budget_usd: f64,
+    /// The monthly budget cap from `[budget].monthly_usd`; `None` when the
+    /// manifest sets no cap, `Some(0.0)` when it is capped at zero.
+    pub budget_usd: Option<f64>,
     /// Current-month outgoing spend (positive magnitude).
     pub spent_usd: f64,
     /// Current-month incoming revenue (positive magnitude).

--- a/src/server/graphql/finances.rs
+++ b/src/server/graphql/finances.rs
@@ -78,8 +78,8 @@ impl FinancesGql {
         self.inner.balance_usd
     }
 
-    /// The monthly budget, USD.
-    async fn budget_usd(&self) -> f64 {
+    /// The monthly budget, USD; `null` when no cap is set.
+    async fn budget_usd(&self) -> Option<f64> {
         self.inner.budget_usd
     }
 

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -356,9 +356,9 @@ type Finances {
 	"""
 	balanceUsd: Float!
 	"""
-	The monthly budget, USD.
+	The monthly budget, USD; `null` when no cap is set.
 	"""
-	budgetUsd: Float!
+	budgetUsd: Float
 	"""
 	Total spend this period, USD.
 	"""

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -169,6 +169,24 @@ mod tests {
         assert!(dto["transactions"].as_array().unwrap().is_empty(), "{dto}");
     }
 
+    /// A manifest with no `[budget]` answers `budgetUsd: null` — "no cap set" —
+    /// so the console can tell it apart from an explicit zero-dollar cap.
+    #[tokio::test]
+    async fn no_budget_projects_null_budget_usd() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_ledger(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+            Vec::new(),
+        )
+        .await;
+
+        let (status, dto) = get_finances(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["budgetUsd"], Value::Null, "{dto}");
+    }
+
     /// A ledger with a spend and a revenue entry this month projects the
     /// expected budget / spend / revenue / net, by-category, and journal.
     #[tokio::test]


### PR DESCRIPTION
## Summary
- normalize negative-zero currency values, render zero net neutrally, and remove the unconditional USDC claim
- distinguish loading, missing-finances-route (404), and other ledger read failures from a real empty ledger
- replace zero-budget and empty lower-card voids with explicit operator-facing states

Closes #1329

## Validation
- `npm run typecheck`
- `npm run typecheck:unit`
- `npm test -- --run test/unit/finances-view-empty-state.test.ts`
- `npm run build`

`npm test` was also run in full: the new finance test passed, but the existing suite finished with unrelated failures in `mock-brain`, `workflow-create-problems`, `workspace-move-dialog`, and `workspace-repair-reveal-no-write` (plus delayed workflow-editor mock-client errors). No finance-view failure was reported.

## Scope
A 404 is treated as an unwired finances surface; other request failures render a load-error notice rather than fabricated financial data. Provider-specific wallet behavior remains in the separate Wallet page.