### PR TITLE
fix(styleguide): add theme control and console navigation

### DIFF
--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -77,13 +77,19 @@ function Header() {
       className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur"
       data-testid="styleguide-header"
     >
-      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-6 px-6 py-4">
-        <div>
+      {/*
+        Wraps rather than overflows. The title block's min-content width is set
+        by an unbreakable path (`docs/design-system/`), and the controls do not
+        shrink — so on a 320px viewport a single row would push "Back to
+        console" off the right edge instead of stacking under the heading.
+      */}
+      <div className="mx-auto flex w-full max-w-5xl flex-wrap items-center justify-between gap-x-6 gap-y-4 px-6 py-4">
+        <div className="min-w-0">
           <p className="text-2xs font-medium tracking-wide text-sidebar-accent-foreground uppercase">
             OpenCompany design system
           </p>
           <h1 className="mt-1 text-2xl font-semibold tracking-tight">Styleguide</h1>
-          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+          <p className="mt-2 max-w-2xl text-sm break-words text-muted-foreground">
             Every token and component state the console ships, rendered by the
             console&apos;s own stylesheet. Switch the theme to check both. Written
             reference lives in{" "}

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -31,6 +31,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { withHostParam } from "@/hooks/use-host-route";
 import { cn } from "@/lib/utils";
 
 /**
@@ -66,6 +67,11 @@ export function StyleguideView() {
 }
 
 function Header() {
+  // The styleguide is reachable from a console scoped to one of several hosts
+  // (`#/styleguide?host=<id>`), and `App` remounts `Console` on the way back:
+  // a bare `#/overview` would drop the scope and land the operator on whichever
+  // host the bootstrap fallback picks. `withHostParam` carries it over.
+  const backHref = withHostParam("overview");
   return (
     <header
       className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur"
@@ -91,7 +97,7 @@ function Header() {
           <ThemeToggle />
           <a
             className="inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
-            href="#/overview"
+            href={backHref}
           >
             <ArrowLeft className="size-4" />
             Back to console

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -47,7 +47,7 @@ import { cn } from "@/lib/utils";
  */
 export function StyleguideView() {
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
+    <div className="min-h-svh">
       <Header />
       <div className="mx-auto w-full max-w-5xl px-6 py-10">
         <div className="space-y-14 pb-24">

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
+  ArrowLeft,
   Check,
   ChevronRight,
   CircleDashed,
@@ -29,6 +30,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
 
 /**
@@ -46,9 +48,9 @@ import { cn } from "@/lib/utils";
 export function StyleguideView() {
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
+      <Header />
       <div className="mx-auto w-full max-w-5xl px-6 py-10">
-        <Header />
-        <div className="mt-10 space-y-14 pb-24">
+        <div className="space-y-14 pb-24">
           <ColorSection />
           <StatusSection />
           <ToneSection />
@@ -65,20 +67,37 @@ export function StyleguideView() {
 
 function Header() {
   return (
-    <header>
-      <p className="text-2xs font-medium tracking-wide text-sidebar-accent-foreground uppercase">
-        OpenCompany design system
-      </p>
-      <h1 className="mt-2 text-2xl font-semibold tracking-tight">Styleguide</h1>
-      <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-        Every token and component state the console ships, rendered by the
-        console's own stylesheet. Switch the theme to check both. Written
-        reference lives in{" "}
-        <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-2xs">
-          docs/design-system/
-        </code>
-        .
-      </p>
+    <header
+      className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur"
+      data-testid="styleguide-header"
+    >
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-6 px-6 py-4">
+        <div>
+          <p className="text-2xs font-medium tracking-wide text-sidebar-accent-foreground uppercase">
+            OpenCompany design system
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight">Styleguide</h1>
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+            Every token and component state the console ships, rendered by the
+            console&apos;s own stylesheet. Switch the theme to check both. Written
+            reference lives in{" "}
+            <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-2xs">
+              docs/design-system/
+            </code>
+            .
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <ThemeToggle />
+          <a
+            className="inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+            href="#/overview"
+          >
+            <ArrowLeft className="size-4" />
+            Back to console
+          </a>
+        </div>
+      </div>
     </header>
   );
 }

--- a/frontend/test/e2e/styleguide-navigation.spec.ts
+++ b/frontend/test/e2e/styleguide-navigation.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test("the standalone styleguide keeps theme controls and console navigation available", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("theme", "light");
+  });
+  await page.goto("/#/styleguide");
+
+  const header = page.getByTestId("styleguide-header");
+  const themeToggle = page.getByRole("button", { name: "Change theme" });
+  const backToConsole = page.getByRole("link", { name: "Back to console" });
+
+  await expect(header).toBeVisible();
+  await expect(themeToggle).toBeVisible();
+  await expect(backToConsole).toHaveAttribute("href", "#/overview");
+
+  await page.locator("text=Components").scrollIntoViewIfNeeded();
+  const headerBox = await header.boundingBox();
+  expect(headerBox?.y).toBe(0);
+
+  await themeToggle.click();
+  await page.getByRole("menuitem", { name: "Dark" }).click();
+  await expect(page.locator("html")).toHaveClass(/\bdark\b/);
+
+  await backToConsole.click();
+  await expect(page).toHaveURL(/#\/overview$/);
+});

--- a/frontend/test/unit/styleguide-back-link.test.ts
+++ b/frontend/test/unit/styleguide-back-link.test.ts
@@ -6,7 +6,7 @@
 // would leave `useHostRoute` to initialize from an absent parameter and land on
 // whichever host the bootstrap fallback picks — a silent host switch.
 
-import { act } from "react";
+import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -27,8 +27,9 @@ afterEach(() => {
   window.history.replaceState(null, "", "#/");
 });
 
-function render() {
-  act(() => root.render(<StyleguideView />));
+/** Renders the styleguide and returns its header link's destination. */
+function backHref(): string | null {
+  act(() => root.render(createElement(StyleguideView)));
   const link = container.querySelector<HTMLAnchorElement>(
     '[data-testid="styleguide-header"] a',
   );
@@ -39,11 +40,11 @@ function render() {
 describe("the styleguide's back link", () => {
   it("carries the host scope the styleguide was opened with", () => {
     window.history.replaceState(null, "", "#/styleguide?host=c-2");
-    expect(render()).toBe("#/overview?host=c-2");
+    expect(backHref()).toBe("#/overview?host=c-2");
   });
 
   it("names no host when the address names none", () => {
     window.history.replaceState(null, "", "#/styleguide");
-    expect(render()).toBe("#/overview");
+    expect(backHref()).toBe("#/overview");
   });
 });

--- a/frontend/test/unit/styleguide-back-link.test.ts
+++ b/frontend/test/unit/styleguide-back-link.test.ts
@@ -12,6 +12,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { StyleguideView } from "@/views/StyleguideView";
 
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
 let container: HTMLDivElement;
 let root: Root;
 

--- a/frontend/test/unit/styleguide-back-link.test.ts
+++ b/frontend/test/unit/styleguide-back-link.test.ts
@@ -40,7 +40,17 @@ function backHref(): string | null {
   return link!.getAttribute("href");
 }
 
-describe("the styleguide's back link", () => {
+/** The styleguide header's outer row. */
+function headerRow(): HTMLElement {
+  act(() => root.render(createElement(StyleguideView)));
+  const row = container.querySelector<HTMLElement>(
+    '[data-testid="styleguide-header"] > div',
+  );
+  expect(row).not.toBeNull();
+  return row!;
+}
+
+describe("the styleguide back link", () => {
   it("carries the host scope the styleguide was opened with", () => {
     window.history.replaceState(null, "", "#/styleguide?host=c-2");
     expect(backHref()).toBe("#/overview?host=c-2");
@@ -49,5 +59,25 @@ describe("the styleguide's back link", () => {
   it("names no host when the address names none", () => {
     window.history.replaceState(null, "", "#/styleguide");
     expect(backHref()).toBe("#/overview");
+  });
+});
+
+/**
+ * jsdom lays nothing out, so this pins the properties that decide the outcome
+ * rather than the geometry: the title block sets its min-content width from an
+ * unbreakable path (`docs/design-system/`) and the controls do not shrink, so a
+ * non-wrapping row pushes "Back to console" past the right edge of a 320px
+ * viewport instead of stacking it under the heading.
+ */
+describe("the styleguide header on a narrow viewport", () => {
+  it("wraps its controls instead of overflowing", () => {
+    const row = headerRow();
+    expect(row.className).toContain("flex-wrap");
+    expect(row.className).not.toContain("flex-nowrap");
+  });
+
+  it("lets the title block shrink below its min-content width", () => {
+    const title = headerRow().firstElementChild as HTMLElement;
+    expect(title.className).toContain("min-w-0");
   });
 });

--- a/frontend/test/unit/styleguide-back-link.test.tsx
+++ b/frontend/test/unit/styleguide-back-link.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+//
+// "Back to console" has to return the operator to the console they left, and on
+// a desktop holding several hosts that is a scope, not just a page (issue
+// #1358). `App` remounts `Console` on the way back, so a bare `#/overview`
+// would leave `useHostRoute` to initialize from an absent parameter and land on
+// whichever host the bootstrap fallback picks — a silent host switch.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { StyleguideView } from "@/views/StyleguideView";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  window.history.replaceState(null, "", "#/");
+});
+
+function render() {
+  act(() => root.render(<StyleguideView />));
+  const link = container.querySelector<HTMLAnchorElement>(
+    '[data-testid="styleguide-header"] a',
+  );
+  expect(link).not.toBeNull();
+  return link!.getAttribute("href");
+}
+
+describe("the styleguide's back link", () => {
+  it("carries the host scope the styleguide was opened with", () => {
+    window.history.replaceState(null, "", "#/styleguide?host=c-2");
+    expect(render()).toBe("#/overview?host=c-2");
+  });
+
+  it("names no host when the address names none", () => {
+    window.history.replaceState(null, "", "#/styleguide");
+    expect(render()).toBe("#/overview");
+  });
+});


### PR DESCRIPTION
## Summary

- add a viewport-sticky standalone styleguide header with the existing light/dark/system control
- provide a direct return link to `#/overview`
- cover the persistent header, theme switching, and navigation in Playwright

Closes #1326

## Validation

- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm test`
- `npm run build`
- `PW_BASE_URL=http://127.0.0.1:4173 npx playwright test test/e2e/styleguide-navigation.spec.ts` (against a temporary local Vite server)

## Scope

Implemented the issue’s minimal requested sticky header, theme control, and console return link. The optional side-by-side theme mode was deliberately left out.