### PR TITLE
fix(console): link inbox empty state to company

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1070,7 +1070,7 @@ export interface InboxDto {
   name: string;
   /** The full address (`{key}@{domain}` when a domain is configured). */
   address: string;
-  /** Whether the inbox is enabled on the Team page. */
+  /** Whether the inbox is enabled on this teammate's detail page. */
   enabled: boolean;
   /** The number of unread received (inbound) messages. */
   unread: number;

--- a/frontend/src/setup/SetupDialog.tsx
+++ b/frontend/src/setup/SetupDialog.tsx
@@ -327,8 +327,8 @@ function BuildOut({
         <DialogDescription>
           {finished
             ? fallback
-              ? "A general starting team for your industry — we couldn't reach a model to tailor it to your answers. Rename, retire, or add anyone from the Team page."
-              : "Built from your answers. A starting point — rename, retire, or add anyone from the Team page."
+              ? "A general starting team for your industry — we couldn't reach a model to tailor it to your answers. Rename, retire, or add anyone from the Company page."
+              : "Built from your answers. A starting point — rename, retire, or add anyone from the Company page."
             : buildOutLabel(created, agents.length)}
         </DialogDescription>
       </DialogHeader>

--- a/frontend/src/views/InboxView.tsx
+++ b/frontend/src/views/InboxView.tsx
@@ -177,9 +177,12 @@ export function InboxView({ client, company }: Props) {
         <div className="space-y-1">
           <p className="font-medium text-foreground">No inboxes yet</p>
           <p className="max-w-sm text-sm">
-            Give a teammate its own inbox from the <span className="font-medium">Team</span> page —
-            flip on the inbox toggle for anyone who needs to receive email. Mail sent to that
-            address shows up here.
+            Give a teammate its own inbox from the{" "}
+            <a className="font-medium text-foreground underline-offset-4 hover:underline" href="#/company">
+              Company page
+            </a>{" "}
+            — open a teammate to flip on the inbox toggle for anyone who needs to receive email.
+            Mail sent to that address shows up here.
           </p>
         </div>
       </div>

--- a/frontend/src/views/setup/SetupWizard.tsx
+++ b/frontend/src/views/setup/SetupWizard.tsx
@@ -1528,7 +1528,7 @@ function ReviewStep({
               </ul>
               <p className="mt-2 text-sm leading-snug text-muted-foreground">
                 You can still continue — add someone for it here, or later from
-                the team page.
+                the Company page.
               </p>
             </>
           )}

--- a/frontend/test/unit/inbox-empty-state.test.ts
+++ b/frontend/test/unit/inbox-empty-state.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { InboxView } from "@/views/InboxView";
+
+/**
+ * The inbox's empty state has no teammate id to deep-link to. Its action must
+ * therefore reach the Company roster, which can open each teammate's detail
+ * page and its inbox switch (issue #1331).
+ */
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function client(): OpenCompanyClient {
+  return {
+    listInboxes: vi.fn().mockResolvedValue([]),
+  } as unknown as OpenCompanyClient;
+}
+
+describe("the empty inbox state", () => {
+  it("links operators to the Company roster instead of the retired Team page", async () => {
+    await act(async () => {
+      root.render(createElement(InboxView, { client: client(), company: "acme" }));
+    });
+    await act(async () => {});
+
+    const link = [...container.querySelectorAll<HTMLAnchorElement>("a")].find(
+      (anchor) => anchor.textContent === "Company page",
+    );
+    expect(link?.getAttribute("href")).toBe("#/company");
+    expect(container.textContent).toContain("open a teammate to flip on the inbox toggle");
+    expect(container.textContent).not.toContain("Team page");
+  });
+});


### PR DESCRIPTION
## Summary
- replace the retired, inert Team page instruction in Inbox with a real Company page hash link
- explain that operators open a teammate from Company to enable its inbox, and add a DOM regression test for that anchor
- sweep and update the remaining active setup copy that named the retired Team page

## Validation
- npm run typecheck:unit
- npm test -- --run test/unit/inbox-empty-state.test.ts
- npm run typecheck
- npm run build
- npm test (2265 tests passed; the suite still fails on an unrelated mock-brain.test.ts helper-process startup timeout in this environment)

## Scope
The empty state has no teammate id, so it links to #/company rather than attempting an invalid teammate detail deep link. The active-copy sweep was limited to retired-destination wording; historical implementation comments were left intact.

Closes #1331