### PR TITLE
fix(overview): make workflow placement caveat reachable

### DIFF
--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -61,7 +61,8 @@ workflow hangs on the wheel**: the host scopes a flow to the *company*, and
 nothing links a flow to a desk, so a flow is drawn on the desk of the first
 teammate it runs through. That is a real relationship read as a placement it was
 never declared to be. `DERIVED_NOTICE` in `kg/adapter.ts` is the standing
-caveat, and the legend chip reads "flow placement".
+caveat; the legend visibly labels its placement as inferred, and its native
+disclosure opens the full explanation for pointer, keyboard, and touch users.
 
 Three rings used to be invented, and were deleted as the host grew the reads
 they were standing in for:

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -12,8 +12,7 @@ import {
   forceY,
   type Simulation,
 } from 'd3-force';
-import { ClipboardList, Info, Milestone, Sparkles, User, UserRound, Users, Workflow as WorkflowIcon, Wrench, type LucideIcon } from 'lucide-react';
-import { DERIVED_NOTICE } from './adapter';
+import { ClipboardList, Milestone, Sparkles, User, UserRound, Users, Workflow as WorkflowIcon, Wrench, type LucideIcon } from 'lucide-react';
 import { orderGraphDepartments, SELF_ID, toolSlugOf, type KGNode, type KGNodeKind, type KnowledgeGraph as KGData } from './model';
 import { branchPath, branchWidth, cyclicDeltaF, edgeArc, focusWheel, radialRestLayout, responsiveRingR, rotateAbout, shortestAngleDelta, treeLayout, wheelPoint, wheelStageGeom, wheelStageSpot, type RestLayoutResult, type TreeLayoutResult, type TreeNodePos } from './tree-layout';
 import { focusLabelIds, LABEL_PRIORITY, planLabels, type LabelCandidate, type LabelIcon } from './label-plan';
@@ -28,6 +27,7 @@ import {
 } from './KnowledgeDetail';
 import { destinationFor, MEMORY_DESTINATION } from './open-in-console';
 import { KnowledgeGraphFullscreen } from './KnowledgeGraphFullscreen';
+import { WorkflowPlacementNotice } from './WorkflowPlacementNotice';
 
 const W = 880;
 const H = 600;
@@ -1534,20 +1534,7 @@ export function KnowledgeGraph({
           {label}
         </span>
       ))}
-      {/* The standing caveat (adapter.ts's DERIVED_NOTICE): this legend is the
-          graph's persistent, low-weight chrome, so it is where an operator
-          reading the wheel is already looking to learn how to read it. The
-          full sentence lives in the title — the strip is crowded enough
-          without seven kind-labels wrapping around a whole caveat.
-
-          It used to read "derived data", covering three whole invented rings.
-          Since issue #601 the notice names the one thing left: where a flow
-          sits on the wheel. Departments, tools and stages are the company's own
-          answers now, so claiming otherwise here would understate them. */}
-      <span className="flex items-center gap-1 border-l border-os-border pl-3 font-mono text-3xs text-os-dim" title={DERIVED_NOTICE}>
-        <Info className="h-3 w-3 shrink-0" strokeWidth={2} />
-        flow placement
-      </span>
+      <WorkflowPlacementNotice />
     </div>
   );
 

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -1516,8 +1516,16 @@ export function KnowledgeGraph({
 
   // compact legend for the fullscreen wheel: color + icon per kind, with the
   // Notes core in its vault orange
+  // `flex-wrap` + `max-w-full` are load-bearing, not cosmetic: this strip is
+  // pinned bottom-left inside the field's `overflow-hidden` box, so a single
+  // non-wrapping row is silently cut off at narrow widths — on mobile, and on
+  // desktop whenever the 13.5rem sidebar is expanded. The trailing caveat is
+  // the last item, so it is the first thing to disappear, which would put the
+  // one control that explains the wheel out of reach exactly where the wheel
+  // is hardest to read. `items-end` keeps every label on the summary's line
+  // when the caveat is open and its explanation has grown the box upward.
   const compactLegend = (
-    <div className="flex items-center gap-3 rounded-sm-t border border-os-border-strong bg-os-bg/85 px-2.5 py-1.5 backdrop-blur">
+    <div className="flex max-w-full flex-wrap items-end gap-3 rounded-sm-t border border-os-border-strong bg-os-bg/85 px-2.5 py-1.5 backdrop-blur">
       {(
         [
           { label: 'Notes', color: HUB_COLOR, Icon: CAT.self.Icon },

--- a/frontend/src/views/overview/kg/WorkflowPlacementNotice.tsx
+++ b/frontend/src/views/overview/kg/WorkflowPlacementNotice.tsx
@@ -11,19 +11,31 @@ import { DERIVED_NOTICE } from "./adapter";
  * keyboard, and touch users keep its canonical explanation open while they
  * read the wheel.
  *
- * The panel opens UPWARD (`bottom-full`). Its only caller is the compact
- * legend, which the fullscreen field pins at `bottom-5` inside an
- * `overflow-hidden` container — a downward panel would be clipped after a few
- * pixels, which is exactly the unreadable caveat this component exists to fix.
+ * The explanation opens ABOVE the summary and stays IN FLOW rather than
+ * floating as an absolute popover. Both facts are forced by where this lives:
+ * its only caller is the compact legend, which the fullscreen field pins at
+ * `bottom-5 left-5` inside an `overflow-hidden` container.
+ *
+ * - Opening downward put the panel in the ~20px strip below the legend, where
+ *   it was clipped away — the caveat stayed unreadable for exactly the
+ *   pointer, keyboard, and touch users this component exists to serve.
+ * - An absolute panel then had the same problem sideways: anchored to one
+ *   edge of a summary whose position moves with the legend's wrapping, it ran
+ *   off whichever side it was not anchored to at narrow widths.
+ *
+ * In flow, the panel simply grows the legend box upward into the field, which
+ * is the one direction that always has room. `flex-col-reverse` renders it
+ * above the summary while leaving the summary first in the DOM, so the native
+ * disclosure semantics and focus order are untouched.
  */
 export function WorkflowPlacementNotice() {
   return (
-    <details className="group relative border-l border-os-border pl-3 font-mono text-3xs text-os-dim">
+    <details className="group flex flex-col-reverse border-l border-os-border pl-3 font-mono text-3xs text-os-dim">
       <summary className="flex cursor-pointer list-none items-center gap-1 rounded-sm-t px-1 py-0.5 underline decoration-dotted underline-offset-2 outline-none hover:bg-os-bg/85 hover:text-os-muted focus-visible:ring-1 focus-visible:ring-os-accent [&::-webkit-details-marker]:hidden">
         <Info className="h-3 w-3 shrink-0" aria-hidden="true" strokeWidth={2} />
         workflow placement is inferred
       </summary>
-      <p className="absolute bottom-full right-0 z-50 mb-1 hidden w-72 rounded-sm-t border border-os-border-strong bg-os-bg px-2 py-1.5 font-sans text-2xs leading-relaxed text-os-text shadow-lg group-open:block">
+      <p className="mb-1 hidden w-72 max-w-full rounded-sm-t border border-os-border-strong bg-os-bg px-2 py-1.5 font-sans text-2xs leading-relaxed text-os-text shadow-lg group-open:block">
         {DERIVED_NOTICE}
       </p>
     </details>

--- a/frontend/src/views/overview/kg/WorkflowPlacementNotice.tsx
+++ b/frontend/src/views/overview/kg/WorkflowPlacementNotice.tsx
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { Info } from "lucide-react";
+
+import { DERIVED_NOTICE } from "./adapter";
+
+/**
+ * The graph's one non-declared placement, available without a hover-only cue.
+ *
+ * A native disclosure gives the caveat a visible affordance and lets pointer,
+ * keyboard, and touch users keep its canonical explanation open while they
+ * read the wheel.
+ */
+export function WorkflowPlacementNotice() {
+  return (
+    <details className="group relative border-l border-os-border pl-3 font-mono text-3xs text-os-dim">
+      <summary className="flex cursor-pointer list-none items-center gap-1 rounded-sm-t px-1 py-0.5 underline decoration-dotted underline-offset-2 outline-none hover:bg-os-bg/85 hover:text-os-muted focus-visible:ring-1 focus-visible:ring-os-accent [&::-webkit-details-marker]:hidden">
+        <Info className="h-3 w-3 shrink-0" aria-hidden="true" strokeWidth={2} />
+        workflow placement is inferred
+      </summary>
+      <p className="absolute right-0 top-full z-50 mt-1 hidden w-72 rounded-sm-t border border-os-border-strong bg-os-bg px-2 py-1.5 font-sans text-2xs leading-relaxed text-os-text shadow-lg group-open:block">
+        {DERIVED_NOTICE}
+      </p>
+    </details>
+  );
+}

--- a/frontend/src/views/overview/kg/WorkflowPlacementNotice.tsx
+++ b/frontend/src/views/overview/kg/WorkflowPlacementNotice.tsx
@@ -10,6 +10,11 @@ import { DERIVED_NOTICE } from "./adapter";
  * A native disclosure gives the caveat a visible affordance and lets pointer,
  * keyboard, and touch users keep its canonical explanation open while they
  * read the wheel.
+ *
+ * The panel opens UPWARD (`bottom-full`). Its only caller is the compact
+ * legend, which the fullscreen field pins at `bottom-5` inside an
+ * `overflow-hidden` container — a downward panel would be clipped after a few
+ * pixels, which is exactly the unreadable caveat this component exists to fix.
  */
 export function WorkflowPlacementNotice() {
   return (
@@ -18,7 +23,7 @@ export function WorkflowPlacementNotice() {
         <Info className="h-3 w-3 shrink-0" aria-hidden="true" strokeWidth={2} />
         workflow placement is inferred
       </summary>
-      <p className="absolute right-0 top-full z-50 mt-1 hidden w-72 rounded-sm-t border border-os-border-strong bg-os-bg px-2 py-1.5 font-sans text-2xs leading-relaxed text-os-text shadow-lg group-open:block">
+      <p className="absolute bottom-full right-0 z-50 mb-1 hidden w-72 rounded-sm-t border border-os-border-strong bg-os-bg px-2 py-1.5 font-sans text-2xs leading-relaxed text-os-text shadow-lg group-open:block">
         {DERIVED_NOTICE}
       </p>
     </details>

--- a/frontend/test/unit/overview-workflow-placement-notice.test.ts
+++ b/frontend/test/unit/overview-workflow-placement-notice.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DERIVED_NOTICE } from "@/views/overview/kg/adapter";
+import { WorkflowPlacementNotice } from "@/views/overview/kg/WorkflowPlacementNotice";
+
+let host: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => root.render(createElement(WorkflowPlacementNotice)));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+describe("the workflow placement caveat", () => {
+  it("is a visible, keyboard- and touch-operable disclosure of the canonical notice", () => {
+    const disclosure = host.querySelector("details");
+    const summary = disclosure?.querySelector("summary");
+    const notice = disclosure?.querySelector("p");
+
+    expect(disclosure).not.toBeNull();
+    expect(summary?.textContent).toContain("workflow placement is inferred");
+    expect(summary?.className).toContain("cursor-pointer");
+    expect(summary?.className).toContain("focus-visible:ring-1");
+    expect(notice?.textContent).toBe(DERIVED_NOTICE);
+
+    summary?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(disclosure?.open).toBe(true);
+  });
+});

--- a/frontend/test/unit/workflow-placement-notice-direction.test.ts
+++ b/frontend/test/unit/workflow-placement-notice-direction.test.ts
@@ -25,6 +25,7 @@ let host: HTMLDivElement;
 let root: Root;
 
 beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   host = document.createElement("div");
   document.body.appendChild(host);
   root = createRoot(host);

--- a/frontend/test/unit/workflow-placement-notice-direction.test.ts
+++ b/frontend/test/unit/workflow-placement-notice-direction.test.ts
@@ -7,18 +7,26 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { WorkflowPlacementNotice } from "@/views/overview/kg/WorkflowPlacementNotice";
 
 /**
- * The caveat panel must open UPWARD.
+ * The caveat panel must open UPWARD and must not float.
  *
  * Its only caller is the compact legend, which the fullscreen field pins at
- * `bottom-5` inside an `overflow-hidden` container
- * (`KnowledgeGraphFullscreen.tsx`). A downward panel (`top-full`) therefore
- * has ~20px of field beneath it and is clipped away, which defeats the whole
- * point of giving the caveat a non-hover affordance — pointer, keyboard, and
- * touch users open the disclosure and still cannot read it.
+ * `bottom-5 left-5` inside an `overflow-hidden` container
+ * (`KnowledgeGraphFullscreen.tsx`). That box clips in both axes, and the
+ * component was caught by it twice:
+ *
+ *  - `top-full` dropped the panel into the ~20px strip below the legend, so it
+ *    was cut off vertically;
+ *  - an absolute panel anchored to one edge of the summary then ran off the
+ *    opposite edge once the legend wrapped at narrow widths.
+ *
+ * Keeping the panel in flow and stacking it above the summary removes both:
+ * the legend box just grows upward into the field, the one direction that
+ * always has room.
  *
  * jsdom has no layout engine, so the clipping itself cannot be measured here.
- * What is asserted instead is the one decision that causes it: the side of the
- * summary the panel is anchored to.
+ * What is asserted instead are the three decisions that cause it — the stacking
+ * direction, the panel staying in flow, and its width being capped — plus the
+ * DOM order the native disclosure depends on.
  */
 
 let host: HTMLDivElement;
@@ -36,31 +44,55 @@ afterEach(() => {
   host.remove();
 });
 
-function panel(): HTMLElement {
+function render(): { details: HTMLElement; panel: HTMLElement } {
   act(() => root.render(createElement(WorkflowPlacementNotice)));
-  const p = host.querySelector("details > p");
-  expect(p).not.toBeNull();
-  return p as HTMLElement;
+  const details = host.querySelector("details");
+  const panel = host.querySelector("details > p");
+  expect(details).not.toBeNull();
+  expect(panel).not.toBeNull();
+  return { details: details as HTMLElement, panel: panel as HTMLElement };
 }
 
-describe("WorkflowPlacementNotice panel direction", () => {
-  it("anchors the panel above the summary, not below it", () => {
-    const classes = panel().className.split(/\s+/);
+const classesOf = (el: HTMLElement) => el.className.split(/\s+/);
 
-    expect(classes).toContain("bottom-full");
-    // The bug: `top-full` dropped the panel into the clipped strip under a
-    // bottom-anchored legend.
-    expect(classes).not.toContain("top-full");
+describe("WorkflowPlacementNotice panel placement", () => {
+  it("stacks the panel above the summary", () => {
+    const classes = classesOf(render().details);
+
+    expect(classes).toContain("flex");
+    expect(classes).toContain("flex-col-reverse");
   });
 
-  it("offsets the gap upward too, so the margin follows the anchor", () => {
-    const classes = panel().className.split(/\s+/);
+  it("keeps the summary first in the DOM, so the disclosure stays native", () => {
+    // `flex-col-reverse` reverses only the visual order. Reversing the DOM
+    // instead would move the summary out of the position `<details>` requires
+    // and break focus order with it.
+    const { details } = render();
 
-    expect(classes).toContain("mb-1");
-    expect(classes).not.toContain("mt-1");
+    expect(details.firstElementChild?.tagName).toBe("SUMMARY");
+  });
+
+  it("leaves the panel in flow rather than floating it over the field", () => {
+    const classes = classesOf(render().panel);
+
+    // The two failed attempts: a downward popover, then an edge-anchored one.
+    expect(classes).not.toContain("absolute");
+    expect(classes).not.toContain("top-full");
+    expect(classes).not.toContain("bottom-full");
+  });
+
+  it("caps the panel width so a narrow field cannot clip it sideways", () => {
+    expect(classesOf(render().panel)).toContain("max-w-full");
+  });
+
+  it("hides the panel until the disclosure is open", () => {
+    const classes = classesOf(render().panel);
+
+    expect(classes).toContain("hidden");
+    expect(classes).toContain("group-open:block");
   });
 
   it("still renders the caveat text inside the disclosure", () => {
-    expect(panel().textContent?.trim().length).toBeGreaterThan(0);
+    expect(render().panel.textContent?.trim().length).toBeGreaterThan(0);
   });
 });

--- a/frontend/test/unit/workflow-placement-notice-direction.test.ts
+++ b/frontend/test/unit/workflow-placement-notice-direction.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { WorkflowPlacementNotice } from "@/views/overview/kg/WorkflowPlacementNotice";
+
+/**
+ * The caveat panel must open UPWARD.
+ *
+ * Its only caller is the compact legend, which the fullscreen field pins at
+ * `bottom-5` inside an `overflow-hidden` container
+ * (`KnowledgeGraphFullscreen.tsx`). A downward panel (`top-full`) therefore
+ * has ~20px of field beneath it and is clipped away, which defeats the whole
+ * point of giving the caveat a non-hover affordance — pointer, keyboard, and
+ * touch users open the disclosure and still cannot read it.
+ *
+ * jsdom has no layout engine, so the clipping itself cannot be measured here.
+ * What is asserted instead is the one decision that causes it: the side of the
+ * summary the panel is anchored to.
+ */
+
+let host: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+function panel(): HTMLElement {
+  act(() => root.render(createElement(WorkflowPlacementNotice)));
+  const p = host.querySelector("details > p");
+  expect(p).not.toBeNull();
+  return p as HTMLElement;
+}
+
+describe("WorkflowPlacementNotice panel direction", () => {
+  it("anchors the panel above the summary, not below it", () => {
+    const classes = panel().className.split(/\s+/);
+
+    expect(classes).toContain("bottom-full");
+    // The bug: `top-full` dropped the panel into the clipped strip under a
+    // bottom-anchored legend.
+    expect(classes).not.toContain("top-full");
+  });
+
+  it("offsets the gap upward too, so the margin follows the anchor", () => {
+    const classes = panel().className.split(/\s+/);
+
+    expect(classes).toContain("mb-1");
+    expect(classes).not.toContain("mt-1");
+  });
+
+  it("still renders the caveat text inside the disclosure", () => {
+    expect(panel().textContent?.trim().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the hover-only flow-placement title with a visible native disclosure in the graph legend.
- Label the caveat as inferred and expose the canonical DERIVED_NOTICE to pointer, keyboard, and touch users.
- Cover the disclosure's wording, canonical content, focus affordance, and open interaction with a focused DOM test.

Closes #1318

## Validation
- pnpm exec vitest run test/unit/overview-workflow-placement-notice.test.ts
- pnpm run typecheck:unit
- pnpm run typecheck
- pnpm run build
- timeout 120 pnpm test (251 test files passed; one pre-existing mock-brain startup timeout and an unrelated delayed workflow-editor exception caused the full suite to exit non-zero.)

## Scope
I interpreted the issue as requiring a compact persistent disclosure rather than a tooltip replacement. The native details/summary control deliberately keeps the legend compact until opened; no graph placement logic changed.