### PR TITLE
feat(chat): structured @-mentions — data model, resolution, and read surfaces

### DIFF
--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -183,6 +183,7 @@ mod test {
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "hi".into(),
                     by: None,

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -108,6 +108,7 @@ fn operator_request() -> CycleRequest {
         cycle_id: "unused".into(),
         company_id: CompanyId::new("acme"),
         events: vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: None,
@@ -530,6 +531,7 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "how are we doing".into(),
             by: None,
@@ -583,6 +585,7 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "file it".into(),
             by: None,
@@ -650,6 +653,7 @@ async fn e2e_reported_usage_lands_on_the_usage_meter() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        mentions: Vec::new(),
         parent: None,
         text: "how are we doing".into(),
         by: None,
@@ -737,6 +741,7 @@ async fn e2e_hosted_catalog_advertises_delegation_tools() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        mentions: Vec::new(),
         parent: None,
         text: "hi".into(),
         by: None,
@@ -785,6 +790,7 @@ async fn e2e_spawn_task_tool_call_opens_a_board_card() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        mentions: Vec::new(),
         parent: None,
         text: "open a task to ship invoicing".into(),
         by: None,
@@ -840,6 +846,7 @@ async fn e2e_delegate_to_desk_tool_call_writes_a_handoff_card() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        mentions: Vec::new(),
         parent: None,
         text: "have engineering build invoicing".into(),
         by: None,
@@ -893,6 +900,7 @@ async fn e2e_a_cycle_without_usage_frames_meters_nothing() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        mentions: Vec::new(),
         parent: None,
         text: "hello".into(),
         by: None,

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -107,6 +107,7 @@ fn operator_request() -> CycleRequest {
         cycle_id: "unused".into(),
         company_id: CompanyId::new("acme"),
         events: vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: None,
@@ -507,6 +508,7 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "how are we doing".into(),
             by: None,
@@ -563,6 +565,7 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "file it".into(),
             by: None,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2750,7 +2750,7 @@ impl CompanyRuntime {
                 return Vec::new();
             }
         };
-        let users = self.users().list_users(&self.id).await.unwrap_or_else(|err| {
+        let mut users = self.users().list_users(&self.id).await.unwrap_or_else(|err| {
             tracing::warn!(
                 company = %self.id,
                 error = %err,
@@ -2758,6 +2758,16 @@ impl CompanyRuntime {
             );
             Vec::new()
         });
+        // Suspended users are retained only for attribution and are refused on
+        // every request — they must not be a live mention target here either.
+        users.retain(|u| u.status == crate::ports::users::UserStatus::Active);
+        // Sorted by the same stable key `GET .../chat/mentionables` uses before
+        // it mints slugs (`user_slugs`), so a collision between two same-named
+        // users gets the same `-2`/`-3` suffix here that the picker advertised —
+        // an unsorted `UserStore` order (most-recently-created first) could
+        // otherwise resolve `@sam-2` to a different person than the one the
+        // picker showed under that label.
+        users.sort_by(|a, b| a.id.cmp(&b.id));
         crate::runtime::mentions::resolve(text, supplied, sender, &record, &users)
     }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2738,7 +2738,16 @@ impl CompanyRuntime {
         supplied: Option<Vec<Mention>>,
         sender: Option<&Actor>,
     ) -> Vec<Mention> {
-        let record = match self.store.load(&self.id).await {
+        // Issue: on the operator-message path this runs BEFORE the journal
+        // append (`mention_responder` reads the resolved mentions off the
+        // journaled event, so the append cannot go first), which puts these
+        // two store reads in front of every chat POST's accept latency. Run
+        // together rather than sequentially — they read different stores and
+        // neither depends on the other's result — to keep that addition close
+        // to the cost of the slower read alone rather than the sum of both.
+        let (record, user_list) =
+            tokio::join!(self.store.load(&self.id), self.users().list_users(&self.id));
+        let record = match record {
             Ok(Some(record)) => record,
             Ok(None) => return Vec::new(),
             Err(err) => {
@@ -2751,7 +2760,7 @@ impl CompanyRuntime {
                 return Vec::new();
             }
         };
-        let mut users = self.users().list_users(&self.id).await.unwrap_or_else(|err| {
+        let mut users = user_list.unwrap_or_else(|err| {
             tracing::warn!(
                 company = %self.id,
                 error = %err,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -30,7 +30,7 @@ use crate::feedback::types::{FeedbackInput, FeedbackItem, FeedbackSummary};
 use crate::policy::ManifestApprovalGate;
 use crate::ports::now_millis;
 use crate::ports::types::{
-    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, EventSeq, Verdict,
+    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, EventSeq, Mention, Verdict,
 };
 use crate::ports::{
     AgentEconomy, ApprovalGate, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore,
@@ -411,6 +411,11 @@ fn continuation_failure_notice(thread: String, parent: Option<EventSeq>) -> Comp
             .to_string(),
         steps: Vec::new(),
         task_id: None,
+        // A runtime notice addressed to whoever is reading it. It names no
+        // teammate and no person, so there is nothing to chip and nobody to
+        // ping.
+        mentions: Vec::new(),
+        mention_depth: 0,
     }
 }
 
@@ -2015,6 +2020,22 @@ impl CompanyRuntime {
             // goes to the run or card the work belongs to, and a root belonging
             // to some other channel must not follow it there.
             let parent = self.resolvable_parent(conversation.parent, &chat_id).await;
+            // Scanned host-side from the reply text. The author is passed so a
+            // teammate naming itself in its own answer does not chip itself.
+            let reply_mentions = self
+                .resolve_mentions(
+                    &response.text,
+                    None,
+                    response
+                        .agent
+                        .as_deref()
+                        .map(|id| Actor {
+                            kind: ActorKind::Agent,
+                            id: id.to_string(),
+                        })
+                        .as_ref(),
+                )
+                .await;
             match self
                 .events
                 .append(
@@ -2032,6 +2053,10 @@ impl CompanyRuntime {
                         text: response.text.clone(),
                         steps: response.steps.clone(),
                         task_id: response.task_id.clone(),
+                        mentions: reply_mentions,
+                        // Zero, and stays zero: no reply's mentions reach
+                        // dispatch, so no reply is ever a mention hop.
+                        mention_depth: 0,
                     },
                 )
                 .await
@@ -2694,6 +2719,48 @@ impl CompanyRuntime {
         }
     }
 
+    /// Resolve the mentions in one chat message body.
+    ///
+    /// The single seam both journal sites go through, so an operator message
+    /// and an agent reply cannot end up obeying different rules about who
+    /// `@ada` is. Loads the record and the user directory and hands them to
+    /// [`crate::runtime::mentions::resolve`], which does the rest without
+    /// touching IO.
+    ///
+    /// **Never fails a send.** A store that cannot answer means mentions cannot
+    /// be resolved, not that the message cannot be delivered — so a read error
+    /// yields an empty list and is logged. The message still lands; it simply
+    /// draws no chips and pings nobody, which is the same state every message
+    /// journaled before this feature existed is in.
+    pub async fn resolve_mentions(
+        &self,
+        text: &str,
+        supplied: Option<Vec<Mention>>,
+        sender: Option<&Actor>,
+    ) -> Vec<Mention> {
+        let record = match self.store.load(&self.id).await {
+            Ok(Some(record)) => record,
+            Ok(None) => return Vec::new(),
+            Err(err) => {
+                tracing::warn!(
+                    company = %self.id,
+                    error = %err,
+                    "[mentions] the company record could not be read; this message                      is journaled with no mentions"
+                );
+                return Vec::new();
+            }
+        };
+        let users = self.users().list_users(&self.id).await.unwrap_or_else(|err| {
+            tracing::warn!(
+                company = %self.id,
+                error = %err,
+                "[mentions] the user directory could not be read; only teammates and                  desks are resolvable on this message"
+            );
+            Vec::new()
+        });
+        crate::runtime::mentions::resolve(text, supplied, sender, &record, &users)
+    }
+
     /// A status snapshot, loading the company record for name and lifecycle.
     pub async fn status(&self) -> Result<CompanyStatus> {
         let record = self.store.load(&self.id).await?;
@@ -3106,6 +3173,8 @@ mod tests {
         use crate::server::chat_history::owns;
 
         let reply = |chat_id: String| CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id,
             agent_id: "copywriter".to_string(),
@@ -3895,6 +3964,7 @@ mod tests {
             .append(
                 &rt.id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     text: "pay the invoice".into(),
                     by: None,
                     chat: Some("desk-finance".into()),
@@ -3909,6 +3979,7 @@ mod tests {
             .append(
                 &rt.id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     text: "unrelated".into(),
                     by: None,
                     chat: Some("desk-ops".into()),
@@ -3968,6 +4039,7 @@ mod tests {
             .append(
                 &rt.id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     text: "and another thing".into(),
                     by: None,
                     chat: Some("desk-finance".into()),
@@ -4062,6 +4134,7 @@ mod tests {
                     .append(
                         &rt.id,
                         CompanyEvent::OperatorMessage {
+                            mentions: Vec::new(),
                             text: "ship it".into(),
                             by: None,
                             chat: chat.map(str::to_string),
@@ -4093,6 +4166,7 @@ mod tests {
             .append(
                 &rt.id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     text: "unrelated".into(),
                     by: None,
                     chat: Some("desk-ops".into()),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2745,7 +2745,8 @@ impl CompanyRuntime {
                 tracing::warn!(
                     company = %self.id,
                     error = %err,
-                    "[mentions] the company record could not be read; this message                      is journaled with no mentions"
+                    "[mentions] the company record could not be read; this message is \
+                     journaled with no mentions"
                 );
                 return Vec::new();
             }
@@ -2754,7 +2755,8 @@ impl CompanyRuntime {
             tracing::warn!(
                 company = %self.id,
                 error = %err,
-                "[mentions] the user directory could not be read; only teammates and                  desks are resolvable on this message"
+                "[mentions] the user directory could not be read; only teammates and \
+                 desks are resolvable on this message"
             );
             Vec::new()
         });

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1752,6 +1752,8 @@ impl HarnessBrain {
             .append(
                 &self.record().id,
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     chat_id: card.id.clone(),
                     agent_id: responder.to_string(),
@@ -3428,6 +3430,7 @@ description = "Runs Acme."
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "status?".into(),
                     by: None,
@@ -6173,6 +6176,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "we should announce this".into(),
                     by: None,
@@ -6232,6 +6236,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "two things".into(),
                     by: None,
@@ -6277,6 +6282,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "status?".into(),
                     by: None,
@@ -8480,6 +8486,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "why is the site down?".into(),
                     by: None,
@@ -8546,6 +8553,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "handle it".into(),
                     by: None,
@@ -8586,6 +8594,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "status?".into(),
                     by: None,

--- a/src/harness/built_in/publish_turn_test.rs
+++ b/src/harness/built_in/publish_turn_test.rs
@@ -1184,6 +1184,7 @@ fn chat(text: &str) -> CycleRequest {
         cycle_id: "cycle-1".to_string(),
         company_id: company(),
         events: vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: text.to_string(),
             by: None,
             chat: None,

--- a/src/harness/cap_publish_test.rs
+++ b/src/harness/cap_publish_test.rs
@@ -358,6 +358,7 @@ fn chat(text: &str) -> CycleRequest {
         cycle_id: "cycle-1".to_string(),
         company_id: company(),
         events: vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: text.to_string(),
             by: None,
             chat: None,

--- a/src/harness/cap_turn_test.rs
+++ b/src/harness/cap_turn_test.rs
@@ -360,6 +360,7 @@ fn chat(text: &str) -> CycleRequest {
         cycle_id: "cycle-1".to_string(),
         company_id: company(),
         events: vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: text.to_string(),
             by: None,
             chat: None,

--- a/src/harness/spend_halt_turn_test.rs
+++ b/src/harness/spend_halt_turn_test.rs
@@ -373,6 +373,7 @@ fn chat(text: &str) -> CycleRequest {
         cycle_id: "cycle-1".to_string(),
         company_id: company(),
         events: vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: text.to_string(),
             by: None,
             chat: None,

--- a/src/ports/events.rs
+++ b/src/ports/events.rs
@@ -496,6 +496,7 @@ mod test {
         // tombstone. Pruning any of them dangles a stored pointer.
         for event in [
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 text: "hi".into(),
                 by: None,
                 chat: None,
@@ -503,6 +504,8 @@ mod test {
                 deliverable: None,
             },
             CompanyEvent::AgentReply {
+                mentions: Vec::new(),
+                mention_depth: 0,
                 chat_id: "desk".into(),
                 agent_id: "ceo".into(),
                 text: "hello".into(),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -190,6 +190,136 @@ pub struct Actor {
     pub id: String,
 }
 
+// ---------------------------------------------------------------------------
+// Mentions
+// ---------------------------------------------------------------------------
+
+/// Who a mention points at.
+///
+/// Deliberately **not** [`Actor`]: `@everyone` is a *scope*, not an actor, and
+/// `Actor` is a closed `{kind, id}` pair with no room for one. Modelling the
+/// broadcast token as a first-class variant is what keeps it readable on
+/// reload and in export — expanding it into N literal `@name`s at compose time
+/// (the shape `block/buzz` uses for its team mentions) loses the fact that the
+/// message was addressed to the *room* the moment it is journaled.
+///
+/// Internally tagged under `kind`, matching [`CompanyEvent`]'s own discipline,
+/// so every stored mention is self-describing.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum MentionTarget {
+    /// A roster teammate, by its `[[agent]].id`. The only variant that can
+    /// change who answers a message — see `crate::runtime::mentions`.
+    Agent {
+        /// The teammate's roster id.
+        id: String,
+    },
+    /// A human collaborator, by [`UserRecord::id`](crate::ports::users::UserRecord).
+    ///
+    /// Carried as an **id**, never as the typed label: a human has no handle in
+    /// this system (only a display name that can change and is not unique), so
+    /// resolving a mention by re-parsing text later would silently re-point it
+    /// after a rename. The literal the author typed lives in [`Mention::text`].
+    User {
+        /// The collaborator's user id.
+        id: String,
+    },
+    /// A desk, by its `[[group_chat]].id` — `@#engineering`.
+    Desk {
+        /// The desk's id.
+        id: String,
+    },
+    /// `@everyone` / `@channel`. Notifies every human in the company and puts
+    /// every roster agent on the addressed desk into the answering turn's
+    /// context.
+    ///
+    /// **Not a fan-out.** One operator message still spawns exactly one turn;
+    /// the mentioned agents are named *to* that turn, which spreads the work
+    /// through the existing gated delegation seam if it judges that it should.
+    Everyone,
+}
+
+impl MentionTarget {
+    /// The roster teammate this mention names, or `None` for every other
+    /// variant. The single accessor dispatch routing is allowed to consult.
+    pub fn agent_id(&self) -> Option<&str> {
+        match self {
+            Self::Agent { id } => Some(id.as_str()),
+            _ => None,
+        }
+    }
+
+    /// The human collaborator this mention names, or `None` for every other
+    /// variant.
+    pub fn user_id(&self) -> Option<&str> {
+        match self {
+            Self::User { id } => Some(id.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// One mention inside one chat message.
+///
+/// **Structured and authoritative.** The message body keeps the literal text
+/// the author typed, byte for byte, and this list says who that text actually
+/// resolved to at the moment it was sent. Two properties follow, and both are
+/// the reason it is stored this way rather than re-derived from the body:
+///
+/// * A rename never rewrites history. `@Jane` stays `@Jane` in the transcript
+///   and still resolves to the same person after they become `Jane Doe`.
+/// * Quoting a message cannot re-ping anybody, because a quote carries text
+///   and no mention rows.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Mention {
+    /// Who is mentioned.
+    pub target: MentionTarget,
+    /// The literal span the author typed — `@alice`, `@Jane Doe`, `@everyone`.
+    ///
+    /// What the renderer highlights, and **never** re-derived from the target's
+    /// current name. A chip that disagreed with the surrounding prose would be
+    /// a worse lie than no chip at all.
+    pub text: String,
+    /// Byte offset of [`Self::text`] within the message body.
+    ///
+    /// Carrying the span is what lets a multi-word human label (`@Jane Doe`)
+    /// work with no handle and no slug: the renderer highlights a known range
+    /// instead of regexing the body for something it hopes is a name.
+    pub offset: usize,
+    /// Render-only: draw the chip, but do not notify and do not route.
+    ///
+    /// Inverted (`quiet` rather than `notify`) so the `false` default means
+    /// "this pings", and the key is therefore omitted from the wire on every
+    /// ordinary mention. This is `block/buzz`'s two-tag split — `["p", id]`
+    /// notifies, `["mention", id]` only renders — collapsed into one field,
+    /// because a single list with a flag round-trips additively where two
+    /// parallel lists would not.
+    ///
+    /// Set by the server, never by the client: it is how a mention whose target
+    /// has since left the roster is demoted rather than dropped. The chip
+    /// disappears, the text stays, nobody is pinged.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub quiet: bool,
+}
+
+/// How many mentions one message may carry as *pings*.
+///
+/// The blast-radius limit, and the reason `@everyone` needs no separate cap.
+/// Past this the tail is demoted to [`Mention::quiet`] rather than deleted —
+/// the spans survive, so what a reader sees still matches what the author
+/// wrote, and only the notifying stops. Same value `block/buzz` settled on.
+pub const MENTION_CAP: usize = 50;
+
+/// `skip_serializing_if` for [`CompanyEvent::AgentReply::mention_depth`].
+///
+/// A free function rather than `u8::eq(&0)` because `skip_serializing_if` takes
+/// a path, and this is the one place the "omitted means zero" contract for that
+/// field is written down.
+fn is_zero_depth(depth: &u8) -> bool {
+    *depth == 0
+}
+
 /// An operator's resolution of a parked approval.
 ///
 /// The HTTP body uses the lowercase strings `"approve"` / `"deny"`. The
@@ -355,6 +485,22 @@ pub enum CompanyEvent {
         /// words are unchanged, so no stored record migrates.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         deliverable: Option<MessageIntent>,
+        /// Who this message names, resolved at send time.
+        ///
+        /// The body keeps the literal `@text`; this says who it pointed at, so
+        /// the transcript renders the same chips a reload does and routing has
+        /// something to consult that is not a regex over prose. Populated from
+        /// the console's picker when it sends one, and otherwise extracted
+        /// host-side from the text — either way re-validated against the live
+        /// roster before it is journaled, so a stale client cannot ping a
+        /// teammate that no longer exists.
+        ///
+        /// Additive on exactly the `by` / `chat` / `parent` / `deliverable`
+        /// terms above: an empty list is skipped, so every already-persisted
+        /// message serializes byte-for-byte as it did before this field, and no
+        /// stored record migrates.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        mentions: Vec<Mention>,
     },
     /// A turn was **accepted** for an operator message (issue #983) — the
     /// transcript line that says the company took the work on.
@@ -621,6 +767,29 @@ pub enum CompanyEvent {
         /// `task_id` above.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent: Option<EventSeq>,
+        /// Who this reply names, extracted host-side from its text.
+        ///
+        /// Rendered as chips exactly like an operator message's, and — unlike
+        /// an operator message's — **never consulted by dispatch**. That
+        /// asymmetry is the mention-loop fuse: there is no code path from a
+        /// reply's mentions to a turn, so an agent naming another agent draws a
+        /// chip and files nothing to run. The edge does not exist, which is a
+        /// stronger guarantee than an edge that is disabled.
+        ///
+        /// Additive on the same terms as `task_id` and `parent` above.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        mentions: Vec<Mention>,
+        /// How many mention hops produced this reply.
+        ///
+        /// **Reserved, and zero on every reply today.** The agent-to-agent
+        /// dispatch edge described above is off, so nothing increments this.
+        /// It ships now because it is the gate that would bound the edge if it
+        /// were ever turned on (`depth >= 2` refuses), and shipping the field
+        /// with the feature costs one omitted-when-zero key — where adding it
+        /// later would be a wire change made under pressure, at exactly the
+        /// moment a loop was being chased.
+        #[serde(default, skip_serializing_if = "is_zero_depth")]
+        mention_depth: u8,
     },
     /// A reaction was set or cleared on one chat message (issue #364).
     ///
@@ -4253,6 +4422,92 @@ mod test {
         serde_json::from_str(&json).expect("deserialize")
     }
 
+    /// The additive proof this repo asks of every new journal field: a message
+    /// carrying no mentions must serialize **byte-for-byte** as it did before
+    /// the field existed, so no stored record migrates and the cross-backend
+    /// round-trip needs no special case.
+    #[test]
+    fn a_message_with_no_mentions_serializes_as_it_did_before_the_field() {
+        let event = CompanyEvent::OperatorMessage {
+            text: "hello".to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+            mentions: Vec::new(),
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert_eq!(json, r#"{"kind":"OperatorMessage","text":"hello"}"#);
+    }
+
+    /// The same for a reply, whose `mention_depth` is a `u8` and would
+    /// otherwise serialize as a literal `0` on every reply ever written.
+    #[test]
+    fn a_reply_with_no_mentions_serializes_as_it_did_before_the_fields() {
+        let event = CompanyEvent::AgentReply {
+            chat_id: "general".to_string(),
+            agent_id: "ceo".to_string(),
+            text: "hi".to_string(),
+            steps: Vec::new(),
+            task_id: None,
+            parent: None,
+            mentions: Vec::new(),
+            mention_depth: 0,
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"kind":"AgentReply","chat_id":"general","agent_id":"ceo","text":"hi"}"#
+        );
+    }
+
+    /// And the other direction: a record written before either field existed
+    /// still loads, which is what `#[serde(default)]` is there for.
+    #[test]
+    fn a_message_journaled_before_mentions_existed_still_loads() {
+        let stored = r#"{"kind":"OperatorMessage","text":"hello"}"#;
+        let event: CompanyEvent = serde_json::from_str(stored).expect("deserialize");
+        match event {
+            CompanyEvent::OperatorMessage { mentions, .. } => assert!(mentions.is_empty()),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_mention_round_trips_with_its_target_and_span() {
+        let mention = Mention {
+            target: MentionTarget::Agent {
+                id: "engineer".to_string(),
+            },
+            text: "@engineer".to_string(),
+            offset: 4,
+            quiet: false,
+        };
+        assert_eq!(round_trip(&mention), mention);
+        // `quiet` is omitted when false, so an ordinary mention stays small on
+        // the wire and in the journal.
+        let json = serde_json::to_string(&mention).expect("serialize");
+        assert!(!json.contains("quiet"), "{json}");
+    }
+
+    #[test]
+    fn every_mention_target_round_trips() {
+        for target in [
+            MentionTarget::Agent {
+                id: "engineer".to_string(),
+            },
+            MentionTarget::User {
+                id: "u1".to_string(),
+            },
+            MentionTarget::Desk {
+                id: "engineering".to_string(),
+            },
+            MentionTarget::Everyone,
+        ] {
+            assert_eq!(round_trip(&target), target);
+        }
+    }
+
     // ── Issue #174: cycle usage carries cost, and folds ─────────────────────
 
     /// A cycle with nothing to report writes nothing, and any single non-zero
@@ -4484,6 +4739,8 @@ mod test {
 
         // A tool-less reply serializes without the `steps` key.
         let tool_less = CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: None,
             chat_id: "main".to_string(),
@@ -4496,6 +4753,8 @@ mod test {
 
         // A reply with a timeline round-trips it.
         let with_steps = CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: None,
             chat_id: "main".to_string(),
@@ -4535,6 +4794,8 @@ mod test {
 
         // An untagged reply keeps the legacy wire shape exactly.
         let untagged = CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id: "main".to_string(),
             agent_id: "ceo".to_string(),
@@ -4549,6 +4810,8 @@ mod test {
 
         // A dispatch-produced reply carries the key and round-trips.
         let tagged = CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id: "t-1".to_string(),
             agent_id: "ceo".to_string(),
@@ -4719,6 +4982,7 @@ mod test {
         }
 
         let threaded = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: Some(EventSeq::new(41)),
             text: "a follow-up".into(),
             by: None,
@@ -4733,6 +4997,8 @@ mod test {
         );
 
         let answered = CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: Some(EventSeq::new(41)),
             task_id: None,
             chat_id: "studio".into(),
@@ -4887,6 +5153,7 @@ mod test {
     #[test]
     fn a_chat_intent_journals_under_the_same_key_and_absence_stays_absent() {
         let chatting = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: "morning all".into(),
             by: None,
             chat: None,
@@ -4906,6 +5173,7 @@ mod test {
         );
 
         let unmarked = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: "morning all".into(),
             by: None,
             chat: None,
@@ -4928,6 +5196,7 @@ mod test {
         assert_eq!(
             event,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,
@@ -4943,6 +5212,7 @@ mod test {
         // export/import and the fs/sqlite/mongo round-trip stay green without
         // touching a single stored record.
         let event = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: None,
@@ -4958,6 +5228,7 @@ mod test {
     #[test]
     fn an_attributed_message_round_trips_with_its_actor() {
         let event = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: Some(Actor {
@@ -4988,6 +5259,7 @@ mod test {
     fn company_event_variants_round_trip_tagged() {
         let events = vec![
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -6687,6 +6687,7 @@ needs_reason = true
             .unwrap();
 
         let desk_turn = |text: &'static str| CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: text.to_string(),
             by: None,
@@ -6835,6 +6836,7 @@ needs_reason = true
 
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hello design".to_string(),
                 by: None,
@@ -6953,6 +6955,7 @@ needs_reason = true
         // lead `eng2`, not the blueprint lead `eng1`.
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "who leads?".to_string(),
                 by: None,

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -101,6 +101,13 @@ impl ChannelAdapter for DeskChannel {
                         .reply_to
                         .and_then(|reply| reply.chat_id.parse::<u64>().ok())
                         .map(EventSeq::new),
+                    // Workflow node output. This adapter holds no company
+                    // record, so it has nothing to resolve an `@name` against
+                    // — and a workflow bubble addresses the channel it posts
+                    // into, not a person in it. Left empty rather than
+                    // half-resolved.
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                 },
             )
             .await?;

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2885,6 +2885,7 @@ mod test {
     #[test]
     fn only_a_workflow_message_gets_the_builder_briefing() {
         let msg = |deliverable| CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: "set up a weekly AEO audit".to_string(),
             by: None,
             chat: None,
@@ -2968,6 +2969,7 @@ mod test {
         );
 
         let ask = |deliverable| CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: "set up a weekly AEO audit".into(),
             by: None,
             chat: None,
@@ -3271,6 +3273,7 @@ mod test {
             .unwrap();
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hand it off".into(),
             by: None,
@@ -3809,6 +3812,7 @@ mod test {
         context.lists.store(0, Ordering::SeqCst);
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: None,
@@ -3845,6 +3849,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,
@@ -3877,6 +3882,7 @@ mod test {
         assert_eq!(
             operator[0].event,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,
@@ -3955,6 +3961,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "file it".into(),
                 by: None,
@@ -4016,6 +4023,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "do it".into(),
                 by: None,
@@ -4081,6 +4089,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "do it".into(),
                 by: None,
@@ -4393,6 +4402,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "do it".into(),
                 by: None,
@@ -4438,6 +4448,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "do it".into(),
                 by: None,
@@ -4770,6 +4781,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "file it".into(),
                 by: None,
@@ -4850,6 +4862,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "send that email".into(),
                 by: None,
@@ -4907,6 +4920,7 @@ mod test {
                 .unwrap();
             let report = rt
                 .run_cycle(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "file it".into(),
                     by: None,
@@ -4968,6 +4982,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "file it".into(),
                 by: None,
@@ -5039,6 +5054,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "file it".into(),
                 by: None,
@@ -5129,6 +5145,7 @@ mod test {
             .unwrap();
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "how are we doing".into(),
             by: None,
@@ -5414,6 +5431,7 @@ mod test {
         );
         assert_eq!(
             cycle_trigger(&[CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hello".into(),
                 by: None,
@@ -5441,6 +5459,7 @@ mod test {
 
         let (ra, rb) = tokio::join!(
             one.run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "a".into(),
                 by: None,
@@ -5448,6 +5467,7 @@ mod test {
                 deliverable: None,
             }]),
             two.run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "b".into(),
                 by: None,
@@ -5499,6 +5519,7 @@ mod test {
             .unwrap();
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "send it".into(),
             by: None,
@@ -5823,6 +5844,7 @@ mod test {
             body: serde_json::json!({"text": "raw payload"}),
         };
         let operator = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: "please do the thing".into(),
             by: Option::<Actor>::None,
             chat: None,
@@ -5853,6 +5875,7 @@ mod test {
             task: serde_json::json!({"text": "do the thing"}),
         };
         let operator = || CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: "hi".into(),
             by: Option::<Actor>::None,
             chat: None,
@@ -6490,6 +6513,7 @@ mod test {
         };
 
         let chat = || CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: None,
@@ -6696,6 +6720,7 @@ mod test {
             _ => None,
         };
         let addressed = |chat: &str| CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "pay the invoice".into(),
             by: None,
@@ -6703,6 +6728,7 @@ mod test {
             deliverable: None,
         };
         let unaddressed = || CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".into(),
             by: None,
@@ -6848,6 +6874,8 @@ mod test {
                 origin_chat_id: None,
             },
             CompanyEvent::AgentReply {
+                mentions: Vec::new(),
+                mention_depth: 0,
                 parent: None,
                 chat_id: "desk-ops".into(),
                 agent_id: "ops".into(),
@@ -6910,6 +6938,7 @@ mod test {
             _ => None,
         };
         let in_thread = |chat: &str, parent: Option<u64>| CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: parent.map(EventSeq::new),
             text: "pay the invoice".into(),
             by: None,
@@ -7372,6 +7401,7 @@ mod test {
 
         // Asking the desk directly (by name) surfaces the handed task...
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "what are you working on?".into(),
             by: None,
@@ -7384,6 +7414,7 @@ mod test {
         // ...and asking with no address (the orchestrator) does NOT get the
         // desk's briefing folded into it.
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "status?".into(),
             by: None,
@@ -7445,6 +7476,7 @@ mod test {
             .await
             .unwrap();
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "what's up?".into(),
             by: None,
@@ -7524,6 +7556,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "do it".into(),
                 by: None,
@@ -7722,6 +7755,7 @@ mod test {
         for _ in 0..5 {
             let report = rt
                 .run_cycle(vec![CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "do it".into(),
                     by: None,
@@ -7949,6 +7983,7 @@ mod test {
             .unwrap();
 
         let ask = |text: &str| CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: text.to_string(),
             by: None,
             chat: None,
@@ -8041,6 +8076,7 @@ mod test {
             .append(
                 rt.id(),
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     text: "hello".into(),
                     by: None,
                     chat: None,
@@ -8054,6 +8090,7 @@ mod test {
             vec![(
                 seq,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     text: "hello".into(),
                     by: None,
                     chat: None,

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -1,0 +1,1388 @@
+//! Turning `@text` into somebody: the pure half of chat mentions.
+//!
+//! Everything here is IO-free. The caller does the one roster read and the one
+//! user read and hands the results in, which is what lets the same code answer
+//! for the console, for the API, and for a turn — and what keeps it in
+//! `runtime/` rather than in the harness.
+//!
+//! # Why this is not in `harness/built_in/`
+//!
+//! `src/harness/built_in/` compiles only under the `openhuman` feature, and
+//! mention resolution has to work on the hosted (default) build too — the chat
+//! POST validates mentions there whether or not a brain is compiled in. This is
+//! the same reason [`desk_lead`](crate::runtime::delegation_tools::desk_lead)
+//! was lifted out of the harness: routing helpers that a non-harness path needs
+//! do not live behind a harness feature.
+//!
+//! # The shape of the problem
+//!
+//! ```text
+//! body text ──► strip_code_regions ──► extract_with_known ──┐
+//!                                                            ├─► normalize ─► Vec<Mention>
+//! client-supplied mentions (the picker's answer) ────────────┘
+//!                            │
+//!                            └─► revalidate (drops nothing, demotes to `quiet`)
+//! ```
+//!
+//! Two entry points, deliberately:
+//!
+//! * The **picker** knows the caret, the query, and the row a human clicked.
+//!   That is the only place ambiguity can be resolved *correctly*, by asking.
+//!   Its answer arrives as structured mentions and is re-validated, never
+//!   re-derived.
+//! * **Extraction** is the fallback for everything that has no picker — `curl`,
+//!   the API, an older console, and every agent-authored reply. It resolves
+//!   what it can and leaves the rest as literal text.
+//!
+//! # Two rules that are load-bearing
+//!
+//! **Never guess a ping.** An `@name` matching two people resolves to nobody
+//! and stays literal text. Silently picking the first match is how a message
+//! meant for one colleague reaches another, and there is no way for either of
+//! them to notice.
+//!
+//! **Never render a chip that does not resolve.** The renderer highlights the
+//! spans this module returned and nothing else, so an `@word` that matched no
+//! one is drawn as the plain text it is. A chip is a claim that somebody was
+//! notified; drawing one where nobody was is worse than drawing nothing.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ports::types::{Actor, ActorKind, CompanyRecord, MENTION_CAP, Mention, MentionTarget};
+use crate::ports::users::UserRecord;
+
+/// The typed aliases that stand in for `@everyone`.
+///
+/// Three spellings because three products taught people three habits, and a
+/// person who types the one their last tool used should not silently address
+/// nobody. They are equivalent: all three resolve to
+/// [`MentionTarget::Everyone`].
+pub const EVERYONE_ALIASES: [&str; 3] = ["everyone", "channel", "here"];
+
+/// One mentionable thing and every spelling that reaches it.
+///
+/// Built once per resolution by [`directory`] and used for **both** the
+/// name-to-target map and the render spans, so a chip and the person it points
+/// at cannot drift apart — the failure `block/buzz` calls out, where a display
+/// name that renders but never resolves leaves a chip pointing at nobody.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MentionAlias {
+    /// What this alias resolves to.
+    pub target: MentionTarget,
+    /// Every spelling that reaches [`Self::target`], lowercased. May contain
+    /// spaces — a human's display name is a legitimate alias and is often two
+    /// words.
+    pub aliases: Vec<String>,
+}
+
+/// Every mentionable thing in a company, with all its spellings.
+///
+/// The union is agent id ∪ agent display name ∪ desk id ∪ desk name ∪ user
+/// label ∪ user slug ∪ the [`EVERYONE_ALIASES`].
+///
+/// # Ambiguity is preserved, not resolved
+///
+/// An alias shared by two targets appears on both, and
+/// [`extract_with_known`] then refuses it. Deduplicating here — keeping the
+/// first target for a repeated name — would bury the collision at the one point
+/// where it is still cheap to notice.
+pub fn directory(record: &CompanyRecord, users: &[UserRecord]) -> Vec<MentionAlias> {
+    let mut out = Vec::new();
+
+    // Teammates. The id is the authored, typable handle (`engineer`); the
+    // display name is what an operator who never read the manifest will type.
+    for agent in &record.manifest.agents {
+        if record.is_retired(&agent.id) {
+            continue;
+        }
+        out.push(MentionAlias {
+            target: MentionTarget::Agent {
+                id: agent.id.clone(),
+            },
+            aliases: vec![agent.id.to_lowercase()],
+        });
+    }
+    for overlay in &record.overlay_agents {
+        if record.is_retired(&overlay.id) {
+            continue;
+        }
+        // An operator-added teammate carries both: a slug id since #686, and a
+        // display name which is the only handle a teammate added before that
+        // has. Both spellings reach the same roster id.
+        let mut aliases = vec![overlay.id.to_lowercase()];
+        let name = overlay.name.to_lowercase();
+        if !aliases.contains(&name) {
+            aliases.push(name);
+        }
+        out.push(MentionAlias {
+            target: MentionTarget::Agent {
+                id: overlay.id.clone(),
+            },
+            aliases,
+        });
+    }
+
+    // Desks, by id and by name — the two spellings `resolve_desk_id` already
+    // accepts, so `@#engineering` and `@#Engineering` behave the way
+    // `delegate_to_desk` does.
+    for chat in &record.manifest.group_chats {
+        let mut aliases = vec![chat.id.to_lowercase()];
+        let name = chat.name.to_lowercase();
+        if !aliases.contains(&name) {
+            aliases.push(name);
+        }
+        out.push(MentionAlias {
+            target: MentionTarget::Desk {
+                id: chat.id.clone(),
+            },
+            aliases,
+        });
+    }
+    for desk in &record.overlay_desks {
+        let mut aliases = vec![desk.id.to_lowercase()];
+        let name = desk.name.to_lowercase();
+        if !aliases.contains(&name) {
+            aliases.push(name);
+        }
+        out.push(MentionAlias {
+            target: MentionTarget::Desk {
+                id: desk.id.clone(),
+            },
+            aliases,
+        });
+    }
+
+    // People. Both their label and a typable slug of it, because a label is
+    // frequently two words and `@Jane Doe` is only reachable by the
+    // longest-first matcher, while `@jane-doe` is what somebody typing fast
+    // will produce.
+    for (user, slug) in users.iter().zip(user_slugs(users)) {
+        let label = user_label(user).to_lowercase();
+        let mut aliases = vec![label.clone()];
+        if slug != label {
+            aliases.push(slug);
+        }
+        out.push(MentionAlias {
+            target: MentionTarget::User {
+                id: user.id.clone(),
+            },
+            aliases,
+        });
+    }
+
+    out.push(MentionAlias {
+        target: MentionTarget::Everyone,
+        aliases: EVERYONE_ALIASES.iter().map(|a| a.to_string()).collect(),
+    });
+
+    out
+}
+
+/// How a person is named to other members of their company.
+///
+/// Display name, else the local part of their login identity, else `"someone"`
+/// — the same ladder [`author_labels`](crate::server::chat_history) walks, and
+/// deliberately the same one: a mention chip that read differently from the
+/// author line above it on the very same message would look like two people.
+///
+/// Never the full identity. An email address is not a handle, and handing one
+/// to every member of a company so they can @ each other would leak it.
+pub fn user_label(user: &UserRecord) -> String {
+    if let Some(name) = user.display_name.as_deref() {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let local = user
+        .email
+        .split('@')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if local.is_empty() {
+        "someone".to_string()
+    } else {
+        local
+    }
+}
+
+/// A typable alias for each user, in the order given, disambiguated so no two
+/// are equal.
+///
+/// # This is not a handle, and is never stored
+///
+/// A human in this system has no handle — only a display name, which can change
+/// and is not unique. Minting one and persisting it would create a second
+/// identity to keep in sync, and a rename would orphan it. So a mention is
+/// carried by **user id plus byte span**, and this exists only to give the
+/// picker something short to type and the extraction path a second spelling to
+/// match. It is recomputed on every read, which is precisely why a rename can
+/// never strand anything.
+///
+/// Collisions get `-2`, `-3`, … in the order the users are passed. Callers
+/// therefore pass the list in a stable order — id order — so the suffix a
+/// person gets does not move under them between two reads.
+pub fn user_slugs(users: &[UserRecord]) -> Vec<String> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut out = Vec::with_capacity(users.len());
+    for user in users {
+        let base = mention_slug(&user_label(user));
+        let count = seen.entry(base.clone()).or_insert(0);
+        *count += 1;
+        out.push(if *count == 1 {
+            base
+        } else {
+            format!("{base}-{count}")
+        });
+    }
+    out
+}
+
+/// Lowercase, non-alphanumeric runs collapsed to a single `-`, trimmed.
+///
+/// `"Jane Doe"` becomes `jane-doe`; `"Ana  M. Ruiz"` becomes `ana-m-ruiz`. A
+/// label with nothing alphanumeric in it yields an empty string, which
+/// [`directory`] then never offers as an alias, because an empty alias would
+/// match every `@`.
+pub fn mention_slug(label: &str) -> String {
+    let mut out = String::with_capacity(label.len());
+    let mut pending_dash = false;
+    for ch in label.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            pending_dash = true;
+        }
+    }
+    out
+}
+
+/// Blanks fenced and inline code spans, **preserving byte offsets**.
+///
+/// Every byte of a code region is replaced with a space, so the result is the
+/// same length as the input and an offset computed against it indexes the
+/// original correctly. Stripping the regions instead would shift every
+/// subsequent match and silently mis-place the chips.
+///
+/// Handles ``` fences (and `~~~`), and backtick spans of any run length, per
+/// CommonMark's rule that a span closes on a backtick run of equal length.
+pub fn strip_code_regions(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out: Vec<u8> = bytes.to_vec();
+    let mut i = 0usize;
+    let mut at_line_start = true;
+
+    while i < bytes.len() {
+        let ch = bytes[i];
+
+        if at_line_start {
+            // A fence: three or more backticks or tildes at the start of a
+            // line, closed by a run of the same character at least as long.
+            if ch == b'`' || ch == b'~' {
+                let run = run_len(bytes, i, ch);
+                if run >= 3 {
+                    let mut j = line_end(bytes, i);
+                    let close = loop {
+                        if j >= bytes.len() {
+                            break bytes.len();
+                        }
+                        let line_start = j + 1;
+                        if line_start >= bytes.len() {
+                            break bytes.len();
+                        }
+                        let indent = line_start + leading_spaces(bytes, line_start);
+                        if indent < bytes.len()
+                            && bytes[indent] == ch
+                            && run_len(bytes, indent, ch) >= run
+                        {
+                            break line_end(bytes, indent);
+                        }
+                        j = line_end(bytes, line_start);
+                    };
+                    blank(&mut out, i, close.min(bytes.len()));
+                    i = close.min(bytes.len());
+                    at_line_start = true;
+                    continue;
+                }
+            }
+        }
+
+        if ch == b'`' {
+            let run = run_len(bytes, i, b'`');
+            // Scan for a closing run of exactly this length.
+            let mut j = i + run;
+            let mut close = None;
+            while j < bytes.len() {
+                if bytes[j] == b'`' {
+                    let r = run_len(bytes, j, b'`');
+                    if r == run {
+                        close = Some(j + r);
+                        break;
+                    }
+                    j += r;
+                } else {
+                    j += 1;
+                }
+            }
+            if let Some(end) = close {
+                blank(&mut out, i, end);
+                i = end;
+                at_line_start = false;
+                continue;
+            }
+            // Unclosed: not a code span at all, so leave it be. An unbalanced
+            // backtick must not swallow the rest of the message.
+        }
+
+        at_line_start = ch == b'\n';
+        i += 1;
+    }
+
+    // Only ASCII bytes were replaced, and only with ASCII spaces, so every
+    // multi-byte sequence outside a code region is untouched and the result is
+    // still valid UTF-8.
+    String::from_utf8(out).unwrap_or_else(|_| text.to_string())
+}
+
+fn blank(out: &mut [u8], from: usize, to: usize) {
+    let to = to.min(out.len());
+    for b in &mut out[from..to] {
+        if *b != b'\n' {
+            *b = b' ';
+        }
+    }
+}
+
+fn run_len(bytes: &[u8], from: usize, ch: u8) -> usize {
+    let mut n = 0;
+    while from + n < bytes.len() && bytes[from + n] == ch {
+        n += 1;
+    }
+    n
+}
+
+fn line_end(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i < bytes.len() && bytes[i] != b'\n' {
+        i += 1;
+    }
+    i
+}
+
+fn leading_spaces(bytes: &[u8], from: usize) -> usize {
+    let mut n = 0;
+    while from + n < bytes.len() && bytes[from + n] == b' ' {
+        n += 1;
+    }
+    n
+}
+
+/// Whether an `@` at `idx` opens a mention.
+///
+/// The condition that keeps `jane@acme.com` from reading as a mention of
+/// `acme`: an `@` counts only at the start of the text or after whitespace or
+/// an opening bracket, and only when something word-like follows it.
+fn opens_mention(bytes: &[u8], idx: usize) -> bool {
+    if bytes[idx] != b'@' {
+        return false;
+    }
+    let before_ok = match idx.checked_sub(1) {
+        None => true,
+        Some(prev) => matches!(
+            bytes[prev],
+            b' ' | b'\t' | b'\n' | b'\r' | b'(' | b'[' | b'{'
+        ),
+    };
+    let after_ok = bytes
+        .get(idx + 1)
+        .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
+    before_ok && after_ok
+}
+
+/// Whether the byte at `idx` closes a mention cleanly.
+///
+/// End of text, whitespace, or ordinary trailing punctuation — so
+/// `@engineer,` and `@engineer.` resolve, and `@engineerish` does not resolve
+/// to `engineer`.
+fn closes_mention(bytes: &[u8], idx: usize) -> bool {
+    match bytes.get(idx) {
+        None => true,
+        Some(b) => matches!(
+            b,
+            b' ' | b'\t'
+                | b'\n'
+                | b'\r'
+                | b','
+                | b';'
+                | b'.'
+                | b'!'
+                | b'?'
+                | b':'
+                | b')'
+                | b']'
+                | b'}'
+                | b'\''
+                | b'"'
+        ),
+    }
+}
+
+/// Every `@name` candidate in `text`, as `(byte offset of the '@', the name)`.
+///
+/// The single-word pass: the name charset is `[A-Za-z0-9._-]`, which is what a
+/// slug or a roster id looks like. Multi-word display names are the business of
+/// [`extract_with_known`], which needs the directory to know where a name ends.
+///
+/// Does **not** strip code regions — pass [`strip_code_regions`]'s output if
+/// that is wanted, which every caller here does.
+pub fn extract_at_names(text: &str) -> Vec<(usize, String)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if opens_mention(bytes, i) {
+            let mut j = i + 1;
+            while j < bytes.len()
+                && (bytes[j].is_ascii_alphanumeric() || matches!(bytes[j], b'_' | b'-' | b'.'))
+            {
+                j += 1;
+            }
+            // Trailing `.` is sentence punctuation far more often than part of
+            // a name, so it is not eaten.
+            let mut end = j;
+            while end > i + 1 && bytes[end - 1] == b'.' {
+                end -= 1;
+            }
+            if end > i + 1 {
+                out.push((i, text[i + 1..end].to_string()));
+            }
+            i = j.max(i + 1);
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Resolve `text` against `dir`, returning one [`Mention`] per `@` that names
+/// exactly one thing.
+///
+/// # Longest alias wins
+///
+/// Aliases are tried longest-first, so a company with both `Ann` and `Ann Lee`
+/// resolves `@Ann Lee` to Ann Lee rather than to Ann with a stray `Lee` after
+/// it. Without this the shorter name always wins, because it matches first.
+///
+/// # An ambiguous name resolves to nothing
+///
+/// When one alias reaches two targets — two people called "Sam", a desk and a
+/// teammate sharing a name — the span is skipped entirely and stays literal
+/// text. See the module docs: never guess a ping.
+///
+/// Offsets in the returned mentions index `text`, so pass the **original**
+/// body, not a stripped copy, when the offsets have to line up with what a
+/// reader sees. Callers that want code regions ignored should mask with
+/// [`strip_code_regions`] first, which preserves offsets exactly so both hold.
+pub fn extract_with_known(text: &str, dir: &[MentionAlias]) -> Vec<Mention> {
+    // Longest first so a name that prefixes another cannot claim it.
+    let mut by_alias: Vec<(&str, &MentionTarget)> = Vec::new();
+    for entry in dir {
+        for alias in &entry.aliases {
+            if !alias.is_empty() {
+                by_alias.push((alias.as_str(), &entry.target));
+            }
+        }
+    }
+    by_alias.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then(a.0.cmp(b.0)));
+
+    let bytes = text.as_bytes();
+    let lowered = text.to_lowercase();
+    // `to_lowercase` can change byte length for non-ASCII, which would
+    // invalidate every offset. Fall back to a byte-wise ASCII fold, which
+    // cannot, and which is all the aliases need.
+    let lowered = if lowered.len() == text.len() {
+        lowered
+    } else {
+        text.chars()
+            .map(|c| {
+                if c.is_ascii() {
+                    c.to_ascii_lowercase()
+                } else {
+                    c
+                }
+            })
+            .collect()
+    };
+
+    let mut out: Vec<Mention> = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if !opens_mention(bytes, i) {
+            i += 1;
+            continue;
+        }
+        let after = i + 1;
+        let mut matched: Option<(usize, &MentionTarget)> = None;
+        let mut ambiguous = false;
+        for (alias, target) in &by_alias {
+            let end = after + alias.len();
+            if end > lowered.len() {
+                continue;
+            }
+            if &&lowered[after..end] != alias || !closes_mention(bytes, end) {
+                continue;
+            }
+            match matched {
+                None => matched = Some((end, target)),
+                // A second target claiming a span of the same length is a real
+                // collision. A shorter one is not — longest already won.
+                Some((prev_end, prev)) if prev_end == end && prev != *target => {
+                    ambiguous = true;
+                    break;
+                }
+                Some(_) => break,
+            }
+        }
+
+        if let (Some((end, target)), false) = (matched, ambiguous) {
+            out.push(Mention {
+                target: (*target).clone(),
+                text: text[i..end].to_string(),
+                offset: i,
+                quiet: false,
+            });
+            i = end;
+            continue;
+        }
+        // Unresolved or ambiguous: leave it as text, and skip past this `@` so
+        // a longer alias starting mid-word cannot re-match inside it.
+        i = after;
+    }
+    out
+}
+
+/// Dedupe, drop self-mentions, and cap.
+///
+/// * **Deduped by target**, keeping the first span, so `@ada … @ada` pings once
+///   and chips twice.
+/// * **The sender is dropped.** You do not mention yourself, and a message that
+///   notified its own author would badge every channel the moment you posted in
+///   it.
+/// * **Capped at [`MENTION_CAP`] pings.** Past the cap the tail is demoted to
+///   [`Mention::quiet`] rather than removed — the spans survive, so what a
+///   reader sees still matches what the author wrote, and only the notifying
+///   stops.
+///
+/// Sorted by offset on the way out, so the order is the order a reader
+/// encounters them rather than the order the matcher happened to find them.
+pub fn normalize(mut mentions: Vec<Mention>, sender: Option<&Actor>) -> Vec<Mention> {
+    mentions.sort_by_key(|m| m.offset);
+
+    let mut seen: HashSet<MentionTarget> = HashSet::new();
+    let mut pings = 0usize;
+    let mut out = Vec::with_capacity(mentions.len());
+
+    for mut mention in mentions {
+        if is_sender(&mention.target, sender) {
+            continue;
+        }
+        let duplicate = !seen.insert(mention.target.clone());
+        if duplicate || pings >= MENTION_CAP {
+            mention.quiet = true;
+        } else if !mention.quiet {
+            pings += 1;
+        }
+        out.push(mention);
+    }
+    out
+}
+
+fn is_sender(target: &MentionTarget, sender: Option<&Actor>) -> bool {
+    let Some(sender) = sender else {
+        return false;
+    };
+    match (target, sender.kind) {
+        (MentionTarget::User { id }, ActorKind::User) => id == &sender.id,
+        (MentionTarget::Agent { id }, ActorKind::Agent) => id == &sender.id,
+        _ => false,
+    }
+}
+
+/// Re-check client-supplied mentions against the live company, demoting any
+/// that no longer resolve.
+///
+/// The console's picker resolved these against whatever it had loaded, which
+/// may be minutes old and may predate a teammate being retired or a person
+/// being removed. Rather than trust it or reject the message, a target that no
+/// longer exists is demoted to [`Mention::quiet`]: the chip goes, the text the
+/// author typed stays exactly as they typed it, and nobody is pinged.
+///
+/// Failing closed like this matters most for agents, where a mention *routes*:
+/// a stale picker must not be able to address a turn to a teammate the company
+/// no longer has.
+///
+/// Spans that do not actually appear at their claimed offset are dropped
+/// outright — that is a malformed body rather than a stale one, and honouring
+/// it would let a caller draw a chip over text that says something else.
+pub fn revalidate(
+    text: &str,
+    mentions: Vec<Mention>,
+    record: &CompanyRecord,
+    users: &[UserRecord],
+) -> Vec<Mention> {
+    let user_ids: HashSet<&str> = users.iter().map(|u| u.id.as_str()).collect();
+    mentions
+        .into_iter()
+        .filter(|m| text.get(m.offset..m.offset + m.text.len()) == Some(m.text.as_str()))
+        .map(|mut m| {
+            let live = match &m.target {
+                MentionTarget::Agent { id } => record.is_roster_agent(id),
+                MentionTarget::User { id } => user_ids.contains(id.as_str()),
+                MentionTarget::Desk { id } => record.resolve_desk_id(id).is_some(),
+                MentionTarget::Everyone => true,
+            };
+            if !live {
+                m.quiet = true;
+            }
+            m
+        })
+        .collect()
+}
+
+/// The whole server-side pipeline for one message body.
+///
+/// Uses `supplied` when the caller had a picker, and falls back to extracting
+/// from the text when it did not. Either way the result is normalized, so both
+/// paths obey the cap, the dedupe, and the no-self-mention rule identically.
+pub fn resolve(
+    text: &str,
+    supplied: Option<Vec<Mention>>,
+    sender: Option<&Actor>,
+    record: &CompanyRecord,
+    users: &[UserRecord],
+) -> Vec<Mention> {
+    let found = match supplied {
+        Some(supplied) if !supplied.is_empty() => revalidate(text, supplied, record, users),
+        // An explicitly empty list is still an answer — a console that ran its
+        // picker and found nothing must not have the host guess on its behalf.
+        Some(_) => Vec::new(),
+        None => {
+            let masked = strip_code_regions(text);
+            extract_with_known(&masked, &directory(record, users))
+                .into_iter()
+                .map(|mut m| {
+                    // Offsets are preserved by the mask, so re-read the span
+                    // from the real body — the masked copy has spaces where a
+                    // code region was.
+                    if let Some(real) = text.get(m.offset..m.offset + m.text.len()) {
+                        m.text = real.to_string();
+                    }
+                    m
+                })
+                .collect()
+        }
+    };
+    normalize(found, sender)
+}
+
+/// The teammate an operator message addresses by name, or `None` to fall
+/// through to the desk's own routing.
+///
+/// Returns the **first** non-quiet agent mention that is still on the roster.
+/// First rather than last because that is the one the sentence is about:
+/// "@ada can you check with @ben" is a question for Ada.
+///
+/// # Why this outranks the desk lead
+///
+/// Naming somebody in a room is a stronger address than the room's default
+/// answerer. This is the same explicit-beats-implicit ordering the existing
+/// resolver already applies between an addressed desk and the orchestrator —
+/// mentions extend the ladder by one rung at the top rather than introducing a
+/// second, competing notion of "who is this for".
+///
+/// Resolving nothing returns `None`, which leaves dispatch exactly as it was.
+pub fn mention_responder(record: &CompanyRecord, mentions: &[Mention]) -> Option<String> {
+    mentions
+        .iter()
+        .filter(|m| !m.quiet)
+        .filter_map(|m| m.target.agent_id())
+        .find(|id| record.is_roster_agent(id))
+        .map(str::to_string)
+}
+
+/// Every teammate this message names, for the answering turn's context.
+///
+/// Expands [`MentionTarget::Desk`] and [`MentionTarget::Everyone`] against the
+/// desk's effective membership, so `@everyone` in `#engineering` names the
+/// engineering desk rather than the whole company.
+///
+/// # This is a list, not a fan-out
+///
+/// One operator message spawns exactly one turn — the invariant the chat POST
+/// has always had — and nothing here changes that. These ids are *named to*
+/// the responding teammate so it knows who else was addressed, and it spreads
+/// the work, if it should, through the existing gated delegation seam. A
+/// mention must not become a way to start N turns without an approval in sight.
+///
+/// Deduplicated, in first-mention order, and the responder itself is excluded:
+/// telling a teammate it was mentioned in the message it is answering is noise.
+pub fn mentioned_agents(
+    record: &CompanyRecord,
+    desk: &str,
+    mentions: &[Mention],
+    responder: Option<&str>,
+) -> Vec<String> {
+    fn push(out: &mut Vec<String>, record: &CompanyRecord, responder: Option<&str>, id: String) {
+        if Some(id.as_str()) != responder && !out.contains(&id) && record.is_roster_agent(&id) {
+            out.push(id);
+        }
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for mention in mentions.iter().filter(|m| !m.quiet) {
+        match &mention.target {
+            MentionTarget::Agent { id } => push(&mut out, record, responder, id.clone()),
+            MentionTarget::Desk { id } => {
+                if let Some(desk_id) = record.resolve_desk_id(id) {
+                    for member in record.effective_desk_members(&desk_id) {
+                        push(&mut out, record, responder, member);
+                    }
+                }
+            }
+            MentionTarget::Everyone => {
+                if let Some(desk_id) = record.resolve_desk_id(desk) {
+                    for member in record.effective_desk_members(&desk_id) {
+                        push(&mut out, record, responder, member);
+                    }
+                }
+            }
+            MentionTarget::User { .. } => {}
+        }
+    }
+    out
+}
+
+/// Every person this message should notify.
+///
+/// Expands [`MentionTarget::Everyone`] to the whole user list — a broadcast
+/// addresses the company's people, not the addressed desk's, because desk
+/// membership is a teammate concept and every signed-in person can already see
+/// every desk.
+///
+/// Quiet mentions notify nobody, which is what makes them quiet. Deduplicated,
+/// in first-mention order.
+pub fn mentioned_users(users: &[UserRecord], mentions: &[Mention]) -> Vec<String> {
+    let known: HashSet<&str> = users.iter().map(|u| u.id.as_str()).collect();
+    let mut out: Vec<String> = Vec::new();
+    for mention in mentions.iter().filter(|m| !m.quiet) {
+        match &mention.target {
+            MentionTarget::User { id } => {
+                if known.contains(id.as_str()) && !out.contains(id) {
+                    out.push(id.clone());
+                }
+            }
+            MentionTarget::Everyone => {
+                for user in users {
+                    if !out.contains(&user.id) {
+                        out.push(user.id.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::ports::users::{UserRole, UserStatus};
+
+    const MANIFEST: &str = r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "engineer"
+role = "Backend Engineer"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering"
+members = ["engineer", "ceo"]
+"#;
+
+    fn record(toml_src: &str) -> CompanyRecord {
+        CompanyRecord {
+            overlay_retired_agents: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            id: CompanyId::new("acme"),
+            manifest: toml::from_str(toml_src).expect("parse manifest"),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+            setup: None,
+        }
+    }
+
+    fn acme() -> CompanyRecord {
+        record(MANIFEST)
+    }
+
+    fn user(id: &str, email: &str, display: Option<&str>) -> UserRecord {
+        UserRecord {
+            id: id.to_string(),
+            email: email.to_string(),
+            display_name: display.map(str::to_string),
+            role: UserRole::Member,
+            status: UserStatus::Active,
+            password_hash: None,
+            must_change_password: false,
+            created_at_millis: 0,
+            last_seen_at_millis: None,
+            updated_at_millis: 0,
+        }
+    }
+
+    fn people() -> Vec<UserRecord> {
+        vec![
+            user("u1", "jane@acme.test", Some("Jane Doe")),
+            user("u2", "sam@acme.test", None),
+        ]
+    }
+
+    fn resolve_text(text: &str) -> Vec<Mention> {
+        let record = acme();
+        let users = people();
+        resolve(text, None, None, &record, &users)
+    }
+
+    fn targets(mentions: &[Mention]) -> Vec<&MentionTarget> {
+        mentions.iter().map(|m| &m.target).collect()
+    }
+
+    fn agent(id: &str) -> MentionTarget {
+        MentionTarget::Agent { id: id.to_string() }
+    }
+
+    // -----------------------------------------------------------------------
+    // What is, and is not, a mention
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_roster_id_after_whitespace_is_a_mention() {
+        let found = resolve_text("hey @engineer can you look?");
+        assert_eq!(targets(&found), vec![&agent("engineer")]);
+        assert_eq!(found[0].text, "@engineer");
+        assert_eq!(found[0].offset, 4);
+        assert!(!found[0].quiet);
+    }
+
+    #[test]
+    fn a_mention_at_the_very_start_resolves() {
+        let found = resolve_text("@engineer ping");
+        assert_eq!(targets(&found), vec![&agent("engineer")]);
+        assert_eq!(found[0].offset, 0);
+    }
+
+    /// The single most important negative case: an email address contains an
+    /// `@` followed by something that can look exactly like a roster id.
+    #[test]
+    fn an_email_address_is_not_a_mention() {
+        assert!(resolve_text("write to jane@engineer.com about it").is_empty());
+        assert!(resolve_text("engineer@acme.test").is_empty());
+    }
+
+    #[test]
+    fn trailing_punctuation_does_not_break_a_mention() {
+        for text in ["@engineer, thoughts?", "ask @engineer.", "(@engineer)"] {
+            let found = resolve_text(text);
+            assert_eq!(targets(&found), vec![&agent("engineer")], "text: {text}");
+            assert_eq!(found[0].text, "@engineer", "text: {text}");
+        }
+    }
+
+    /// `@engineering` must not resolve to the `engineer` teammate — a mention
+    /// has to end on a boundary, or every longer name becomes a misroute.
+    #[test]
+    fn a_longer_word_does_not_resolve_to_a_shorter_id() {
+        let found = resolve_text("the @engineerish thing");
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn an_unknown_name_resolves_to_nothing() {
+        assert!(resolve_text("@nobody are you there").is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Code regions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_mention_inside_an_inline_code_span_is_not_a_mention() {
+        assert!(resolve_text("run `@engineer --help` first").is_empty());
+    }
+
+    #[test]
+    fn a_mention_inside_a_fenced_block_is_not_a_mention() {
+        let text = "before\n```\n@engineer\n```\nafter";
+        assert!(resolve_text(text).is_empty());
+    }
+
+    /// The reason [`strip_code_regions`] blanks rather than removes: a mention
+    /// *after* a code span must still land on its real byte offset.
+    #[test]
+    fn offsets_survive_a_masked_code_span() {
+        let text = "`@ceo` but really @engineer";
+        let found = resolve_text(text);
+        assert_eq!(targets(&found), vec![&agent("engineer")]);
+        let m = &found[0];
+        assert_eq!(&text[m.offset..m.offset + m.text.len()], "@engineer");
+    }
+
+    #[test]
+    fn masking_preserves_length_and_newlines() {
+        let text = "a\n```\nxx\n```\nb `y` c";
+        let masked = strip_code_regions(text);
+        assert_eq!(masked.len(), text.len());
+        assert_eq!(
+            masked.matches('\n').count(),
+            text.matches('\n').count(),
+            "newlines are kept so line structure survives"
+        );
+        assert!(!masked.contains("xx"));
+        assert!(masked.starts_with("a\n"));
+    }
+
+    /// An unbalanced backtick is not a code span, and must not swallow the rest
+    /// of the message.
+    #[test]
+    fn an_unclosed_backtick_does_not_mask_the_rest() {
+        let found = resolve_text("weird ` tick then @engineer");
+        assert_eq!(targets(&found), vec![&agent("engineer")]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Longest-alias-wins, and ambiguity
+    // -----------------------------------------------------------------------
+
+    /// `@Jane Doe` has a space in it and is only reachable because the matcher
+    /// tries the whole display name, longest first.
+    #[test]
+    fn a_two_word_display_name_resolves() {
+        let found = resolve_text("thanks @Jane Doe!");
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::User {
+                id: "u1".to_string()
+            }]
+        );
+        assert_eq!(found[0].text, "@Jane Doe");
+    }
+
+    #[test]
+    fn a_slug_also_reaches_a_person() {
+        let found = resolve_text("thanks @jane-doe");
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::User {
+                id: "u1".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn a_person_with_no_display_name_is_reachable_by_their_local_part() {
+        let found = resolve_text("@sam what do you think");
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::User {
+                id: "u2".to_string()
+            }]
+        );
+    }
+
+    /// One member's name prefixing another's is the case that silently
+    /// misroutes if the matcher takes the first match rather than the longest.
+    #[test]
+    fn the_longest_alias_wins() {
+        let users = vec![
+            user("u1", "ann@acme.test", Some("Ann")),
+            user("u2", "annlee@acme.test", Some("Ann Lee")),
+        ];
+        let found = resolve("ping @Ann Lee now", None, None, &acme(), &users);
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::User {
+                id: "u2".to_string()
+            }],
+            "the longer name must win, or Ann Lee can never be mentioned"
+        );
+    }
+
+    /// Never guess a ping.
+    #[test]
+    fn an_ambiguous_name_resolves_to_nobody() {
+        let users = vec![
+            user("u1", "sam.a@acme.test", Some("Sam")),
+            user("u2", "sam.b@acme.test", Some("Sam")),
+        ];
+        let found = resolve("hey @Sam", None, None, &acme(), &users);
+        assert!(
+            found.is_empty(),
+            "two people share this name, so it must stay literal text: {found:?}"
+        );
+    }
+
+    #[test]
+    fn colliding_slugs_are_disambiguated_in_order() {
+        let users = vec![
+            user("u1", "a@acme.test", Some("Sam")),
+            user("u2", "b@acme.test", Some("Sam")),
+            user("u3", "c@acme.test", Some("Sam")),
+        ];
+        assert_eq!(user_slugs(&users), vec!["sam", "sam-2", "sam-3"]);
+    }
+
+    #[test]
+    fn a_label_with_nothing_typable_yields_an_empty_slug() {
+        assert_eq!(mention_slug("!!!"), "");
+        assert_eq!(mention_slug("Ana  M. Ruiz"), "ana-m-ruiz");
+    }
+
+    // -----------------------------------------------------------------------
+    // Desks and everyone
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_desk_resolves_by_id_and_by_name() {
+        for text in ["@engineering please", "@Engineering please"] {
+            let found = resolve_text(text);
+            assert_eq!(
+                targets(&found),
+                vec![&MentionTarget::Desk {
+                    id: "engineering".to_string()
+                }],
+                "text: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_everyone_alias_reaches_the_same_target() {
+        for alias in EVERYONE_ALIASES {
+            let found = resolve_text(&format!("@{alias} heads up"));
+            assert_eq!(
+                targets(&found),
+                vec![&MentionTarget::Everyone],
+                "alias: {alias}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // normalize: self, duplicates, the cap
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn the_sender_is_not_mentioned_in_their_own_message() {
+        let sender = Actor {
+            kind: ActorKind::User,
+            id: "u1".to_string(),
+        };
+        let found = resolve(
+            "@Jane Doe and @sam",
+            None,
+            Some(&sender),
+            &acme(),
+            &people(),
+        );
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::User {
+                id: "u2".to_string()
+            }],
+            "a message must not notify its own author"
+        );
+    }
+
+    #[test]
+    fn an_agent_does_not_mention_itself_in_its_own_reply() {
+        let sender = Actor {
+            kind: ActorKind::Agent,
+            id: "engineer".to_string(),
+        };
+        let found = resolve(
+            "@engineer and @ceo",
+            None,
+            Some(&sender),
+            &acme(),
+            &people(),
+        );
+        assert_eq!(targets(&found), vec![&agent("ceo")]);
+    }
+
+    #[test]
+    fn a_repeated_mention_chips_twice_and_pings_once() {
+        let found = resolve_text("@engineer ... @engineer again");
+        assert_eq!(found.len(), 2, "both spans render");
+        assert!(!found[0].quiet);
+        assert!(found[1].quiet, "the second is render-only");
+    }
+
+    /// Past the cap the tail is demoted, never deleted — what a reader sees
+    /// still has to match what the author wrote.
+    #[test]
+    fn the_cap_demotes_the_tail_and_keeps_every_span() {
+        let mentions: Vec<Mention> = (0..MENTION_CAP + 5)
+            .map(|i| Mention {
+                target: MentionTarget::User {
+                    id: format!("u{i}"),
+                },
+                text: format!("@u{i}"),
+                offset: i * 8,
+                quiet: false,
+            })
+            .collect();
+        let out = normalize(mentions, None);
+        assert_eq!(out.len(), MENTION_CAP + 5, "no span is dropped");
+        assert_eq!(
+            out.iter().filter(|m| !m.quiet).count(),
+            MENTION_CAP,
+            "exactly the cap pings"
+        );
+        assert!(out.last().expect("a tail mention").quiet);
+    }
+
+    #[test]
+    fn mentions_come_back_in_reading_order() {
+        let found = resolve_text("@ceo then @engineer");
+        let offsets: Vec<usize> = found.iter().map(|m| m.offset).collect();
+        let mut sorted = offsets.clone();
+        sorted.sort_unstable();
+        assert_eq!(offsets, sorted);
+    }
+
+    // -----------------------------------------------------------------------
+    // revalidate: the client's answer is checked, not trusted
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_supplied_mention_for_a_missing_teammate_is_demoted_not_dropped() {
+        let supplied = vec![Mention {
+            target: agent("ghost"),
+            text: "@ghost".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        let out = resolve("@ghost hello", Some(supplied), None, &acme(), &people());
+        assert_eq!(out.len(), 1, "the span survives so the text still matches");
+        assert!(out[0].quiet, "but it pings nobody");
+    }
+
+    #[test]
+    fn a_supplied_span_that_is_not_in_the_text_is_dropped() {
+        let supplied = vec![Mention {
+            target: agent("engineer"),
+            text: "@engineer".to_string(),
+            offset: 40,
+            quiet: false,
+        }];
+        let out = resolve("short message", Some(supplied), None, &acme(), &people());
+        assert!(
+            out.is_empty(),
+            "a chip must never be drawn over text that says something else"
+        );
+    }
+
+    /// A console that ran its picker and found nothing has given an answer; the
+    /// host must not then extract on its behalf.
+    #[test]
+    fn an_explicitly_empty_list_suppresses_extraction() {
+        let out = resolve(
+            "@engineer hello",
+            Some(Vec::new()),
+            None,
+            &acme(),
+            &people(),
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn an_absent_list_falls_back_to_extraction() {
+        let out = resolve("@engineer hello", None, None, &acme(), &people());
+        assert_eq!(targets(&out), vec![&agent("engineer")]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Routing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_mentioned_teammate_becomes_the_responder() {
+        let found = resolve_text("@engineer what is the build status");
+        assert_eq!(
+            mention_responder(&acme(), &found),
+            Some("engineer".to_string())
+        );
+    }
+
+    #[test]
+    fn the_first_mentioned_teammate_answers() {
+        let found = resolve_text("@ceo can you check with @engineer");
+        assert_eq!(mention_responder(&acme(), &found), Some("ceo".to_string()));
+    }
+
+    #[test]
+    fn a_quiet_mention_never_routes() {
+        let mentions = vec![Mention {
+            target: agent("engineer"),
+            text: "@engineer".to_string(),
+            offset: 0,
+            quiet: true,
+        }];
+        assert_eq!(mention_responder(&acme(), &mentions), None);
+    }
+
+    #[test]
+    fn an_off_roster_mention_falls_through_to_desk_routing() {
+        let mentions = vec![Mention {
+            target: agent("ghost"),
+            text: "@ghost".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        assert_eq!(
+            mention_responder(&acme(), &mentions),
+            None,
+            "so the caller uses the desk lead, exactly as before"
+        );
+    }
+
+    #[test]
+    fn mentioning_only_people_does_not_change_the_responder() {
+        let found = resolve_text("@Jane Doe thoughts?");
+        assert_eq!(mention_responder(&acme(), &found), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Expansion — a list for the turn's context, never a fan-out
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn everyone_expands_to_the_addressed_desks_members() {
+        let found = resolve_text("@everyone standup in five");
+        let named = mentioned_agents(&acme(), "engineering", &found, None);
+        assert_eq!(named, vec!["engineer".to_string(), "ceo".to_string()]);
+    }
+
+    #[test]
+    fn everyone_notifies_every_person_in_the_company() {
+        let found = resolve_text("@everyone standup in five");
+        assert_eq!(
+            mentioned_users(&people(), &found),
+            vec!["u1".to_string(), "u2".to_string()],
+            "a broadcast addresses the company's people, not a desk's teammates"
+        );
+    }
+
+    #[test]
+    fn a_desk_mention_expands_to_that_desk_not_the_addressed_one() {
+        let found = resolve_text("@engineering can you take this");
+        let named = mentioned_agents(&acme(), "general", &found, None);
+        assert_eq!(named, vec!["engineer".to_string(), "ceo".to_string()]);
+    }
+
+    #[test]
+    fn the_responder_is_not_told_it_was_mentioned() {
+        let found = resolve_text("@engineer and @ceo");
+        let named = mentioned_agents(&acme(), "engineering", &found, Some("engineer"));
+        assert_eq!(named, vec!["ceo".to_string()]);
+    }
+
+    #[test]
+    fn expansion_deduplicates() {
+        let found = resolve_text("@engineer and @engineering");
+        let named = mentioned_agents(&acme(), "engineering", &found, None);
+        assert_eq!(named, vec!["engineer".to_string(), "ceo".to_string()]);
+    }
+
+    #[test]
+    fn a_quiet_mention_expands_to_nothing() {
+        let mentions = vec![Mention {
+            target: MentionTarget::Everyone,
+            text: "@everyone".to_string(),
+            offset: 0,
+            quiet: true,
+        }];
+        assert!(mentioned_agents(&acme(), "engineering", &mentions, None).is_empty());
+        assert!(mentioned_users(&people(), &mentions).is_empty());
+    }
+
+    #[test]
+    fn a_person_who_has_left_is_not_notified() {
+        let mentions = vec![Mention {
+            target: MentionTarget::User {
+                id: "gone".to_string(),
+            },
+            text: "@gone".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        assert!(mentioned_users(&people(), &mentions).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Labels
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_label_falls_back_from_display_name_to_local_part() {
+        assert_eq!(user_label(&user("u", "jane@x.test", Some("Jane"))), "Jane");
+        assert_eq!(user_label(&user("u", "jane@x.test", None)), "jane");
+        assert_eq!(user_label(&user("u", "jane@x.test", Some("  "))), "jane");
+        assert_eq!(user_label(&user("u", "@x.test", None)), "someone");
+    }
+
+    #[test]
+    fn a_label_never_leaks_the_full_identity() {
+        let label = user_label(&user("u", "jane@acme.test", None));
+        assert!(!label.contains('@'), "{label}");
+        assert!(!label.contains("acme.test"), "{label}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Retired teammates
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_retired_teammate_is_not_mentionable() {
+        let mut record = acme();
+        record.overlay_retired_agents.push("engineer".to_string());
+        let found = resolve("@engineer hello", None, None, &record, &people());
+        assert!(found.is_empty(), "{found:?}");
+    }
+}

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -231,16 +231,30 @@ pub fn user_label(user: &UserRecord) -> String {
 /// person gets does not move under them between two reads.
 pub fn user_slugs(users: &[UserRecord]) -> Vec<String> {
     let mut seen: HashMap<String, usize> = HashMap::new();
+    // Every slug actually handed out so far, natural or generated. A natural
+    // label can already carry a `-2`-shaped suffix (`"Sam-2"` is a real
+    // display name, not a disambiguation this function made up), so counting
+    // per base alone can mint the same slug twice — `"Sam"`, `"Sam"`,
+    // `"Sam-2"` would otherwise emit `sam`, `sam-2`, `sam-2`. Checking against
+    // every emitted slug, not just this base's own counter, is what catches
+    // that collision.
+    let mut emitted: HashSet<String> = HashSet::new();
     let mut out = Vec::with_capacity(users.len());
     for user in users {
         let base = mention_slug(&user_label(user));
-        let count = seen.entry(base.clone()).or_insert(0);
-        *count += 1;
-        out.push(if *count == 1 {
-            base
-        } else {
-            format!("{base}-{count}")
-        });
+        loop {
+            let count = seen.entry(base.clone()).or_insert(0);
+            *count += 1;
+            let candidate = if *count == 1 {
+                base.clone()
+            } else {
+                format!("{base}-{count}")
+            };
+            if emitted.insert(candidate.clone()) {
+                out.push(candidate);
+                break;
+            }
+        }
     }
     out
 }
@@ -404,9 +418,18 @@ fn opens_mention(bytes: &[u8], idx: usize) -> bool {
             b' ' | b'\t' | b'\n' | b'\r' | b'(' | b'[' | b'{'
         ),
     };
-    let after_ok = bytes
-        .get(idx + 1)
-        .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
+    // `@#engineering` is the documented desk spelling (`MentionTarget::Desk`'s
+    // own doc comment). The `#` is not itself word-like, so it needs its own
+    // branch: either the byte right after `@` is word-like, or it is `#` and
+    // the byte after THAT is — an `@#` with nothing nameable following it
+    // opens nothing.
+    let after_ok = match bytes.get(idx + 1) {
+        Some(b'#') => bytes
+            .get(idx + 2)
+            .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_'),
+        Some(b) => b.is_ascii_alphanumeric() || *b == b'_',
+        None => false,
+    };
     before_ok && after_ok
 }
 
@@ -532,10 +555,21 @@ pub fn extract_with_known(text: &str, dir: &[MentionAlias]) -> Vec<Mention> {
             i += 1;
             continue;
         }
-        let after = i + 1;
+        // `@#engineering` is the desk-only spelling `opens_mention` also
+        // accepts (see its doc comment): the `#` is not part of any alias in
+        // `dir`, so it is consumed here and the match is narrowed to desk
+        // targets only, rather than asking every alias to carry a `#` twin.
+        let (after, desk_only) = if bytes.get(i + 1) == Some(&b'#') {
+            (i + 2, true)
+        } else {
+            (i + 1, false)
+        };
         let mut matched: Option<(usize, &MentionTarget)> = None;
         let mut ambiguous = false;
         for (alias, target) in &by_alias {
+            if desk_only && !matches!(target, MentionTarget::Desk { .. }) {
+                continue;
+            }
             let end = after + alias.len();
             if end > lowered.len() {
                 continue;
@@ -618,10 +652,13 @@ pub fn normalize(mut mentions: Vec<Mention>, sender: Option<&Actor>) -> Vec<Ment
 /// here. `Everyone` and `Desk` targets are covered the same way, since a
 /// caller can misclaim those exactly as easily as an agent or a user.
 fn is_valid_alias_for(mention: &Mention, dir: &[MentionAlias]) -> bool {
-    let body = mention
-        .text
-        .strip_prefix(['@', '#'])
-        .unwrap_or(&mention.text);
+    // Strips `@` and, for the desk spelling `opens_mention`/`extract_with_known`
+    // both accept, the `#` right after it too — `@#engineering` must compare
+    // against the same `"engineering"` alias `@engineering` does, not against
+    // `"#engineering"`, which is nobody's alias and would fail every desk
+    // mention the console's own picker can produce for that spelling.
+    let body = mention.text.strip_prefix('@').unwrap_or(&mention.text);
+    let body = body.strip_prefix('#').unwrap_or(body);
     let body = body.to_lowercase();
     dir.iter()
         .any(|entry| entry.target == mention.target && entry.aliases.iter().any(|a| a == &body))
@@ -1106,6 +1143,25 @@ members = ["engineer", "ceo"]
         assert_eq!(user_slugs(&users), vec!["sam", "sam-2", "sam-3"]);
     }
 
+    /// A natural display name can already look like a generated
+    /// disambiguation (`"Sam-2"` is a real name someone can type at signup),
+    /// and the counter must still notice it collided with the second `Sam`
+    /// rather than handing both people the same slug.
+    #[test]
+    fn a_natural_label_matching_a_generated_suffix_does_not_collide() {
+        let users = vec![
+            user("u1", "a@acme.test", Some("Sam")),
+            user("u2", "b@acme.test", Some("Sam")),
+            user("u3", "c@acme.test", Some("Sam-2")),
+        ];
+        let slugs = user_slugs(&users);
+        assert_eq!(
+            slugs.len(),
+            slugs.iter().collect::<std::collections::HashSet<_>>().len(),
+            "every emitted slug must be unique: {slugs:?}"
+        );
+    }
+
     #[test]
     fn a_label_with_nothing_typable_yields_an_empty_slug() {
         assert_eq!(mention_slug("!!!"), "");
@@ -1128,6 +1184,49 @@ members = ["engineer", "ceo"]
                 "text: {text}"
             );
         }
+    }
+
+    /// `MentionTarget::Desk`'s own doc comment advertises `@#engineering` as
+    /// the desk spelling; extraction must actually accept it, and a
+    /// client-supplied mention using it must revalidate as live rather than
+    /// being demoted for a text/target mismatch.
+    #[test]
+    fn a_hash_prefixed_desk_mention_resolves() {
+        let found = resolve_text("@#engineering please");
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::Desk {
+                id: "engineering".to_string()
+            }]
+        );
+        assert_eq!(found[0].text, "@#engineering");
+
+        let supplied = vec![Mention {
+            target: MentionTarget::Desk {
+                id: "engineering".to_string(),
+            },
+            text: "@#engineering".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        let out = resolve(
+            "@#engineering please",
+            Some(supplied),
+            None,
+            &acme(),
+            &people(),
+        );
+        assert_eq!(out.len(), 1);
+        assert!(!out[0].quiet, "{out:?}");
+    }
+
+    /// `@#` naming a non-desk alias must not resolve — the `#` is desk-only,
+    /// so `@#engineer` (an agent id) must stay literal text rather than
+    /// silently falling back to the unprefixed match.
+    #[test]
+    fn a_hash_prefixed_non_desk_alias_does_not_resolve() {
+        let found = resolve_text("@#engineer please");
+        assert!(found.is_empty(), "{found:?}");
     }
 
     #[test]

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -1609,9 +1609,31 @@ members = ["engineer", "ceo"]
 
     /// A caller cannot pair arbitrary text with a live target's id and have it
     /// persisted as a real, notifying mention — the span must actually be a
-    /// spelling of that target.
+    /// spelling of that target. `@hello` is syntactically a mention (starts
+    /// with `@`, closes at the space), so this isolates the alias-mismatch
+    /// path from the syntax check covered separately below.
     #[test]
     fn a_supplied_mention_whose_text_does_not_name_its_target_is_demoted() {
+        let supplied = vec![Mention {
+            target: agent("engineer"),
+            text: "@hello".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        let out = resolve("@hello there", Some(supplied), None, &acme(), &people());
+        assert_eq!(out.len(), 1, "the span survives so the text still matches");
+        assert!(
+            out[0].quiet,
+            "text that never named the target must not ping it: {out:?}"
+        );
+    }
+
+    /// Text that never had `@`-shape at all (no `@`, nowhere) is dropped
+    /// outright rather than kept and demoted — the same treatment a
+    /// mid-word or in-code-span match gets, and consistent with fallback
+    /// extraction, which would never have produced a mention here either.
+    #[test]
+    fn a_supplied_mention_with_no_at_sign_at_all_is_dropped() {
         let supplied = vec![Mention {
             target: agent("engineer"),
             text: "hello".to_string(),
@@ -1619,11 +1641,7 @@ members = ["engineer", "ceo"]
             quiet: false,
         }];
         let out = resolve("hello there", Some(supplied), None, &acme(), &people());
-        assert_eq!(out.len(), 1, "the span survives so the text still matches");
-        assert!(
-            out[0].quiet,
-            "text that never named the target must not ping it: {out:?}"
-        );
+        assert!(out.is_empty(), "{out:?}");
     }
 
     /// The picker is still trusted to disambiguate — a genuinely valid alias

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -583,7 +583,19 @@ pub fn extract_with_known(text: &str, dir: &[MentionAlias]) -> Vec<Mention> {
             if end > lowered.len() {
                 continue;
             }
-            if &&lowered[after..end] != alias || !closes_mention(bytes, end) {
+            // Byte comparison, not a `&lowered[after..end]` str slice: `end`
+            // is an arbitrary byte offset (`after` plus some alias's byte
+            // length), and nothing has proven it lands on a UTF-8 character
+            // boundary in `lowered`. A message that puts a multi-byte
+            // character where a shorter alias's end would fall — `@é` against
+            // a one-character alias `j`, for instance — slices mid-character
+            // and panics. Comparing `&[u8]` cannot panic on a partial
+            // character: two byte spans are equal or they are not, and
+            // `lowered`/`bytes` share `text`'s length either way (the fold
+            // above guarantees it), so the offsets still line up.
+            if &lowered.as_bytes()[after..end] != alias.as_bytes()
+                || !closes_mention(bytes, end)
+            {
                 continue;
             }
             match matched {

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -91,15 +91,20 @@ pub fn directory(record: &CompanyRecord, users: &[UserRecord]) -> Vec<MentionAli
 
     // Teammates. The id is the authored, typable handle (`engineer`); the
     // display name is what an operator who never read the manifest will type.
-    for agent in &record.manifest.agents {
-        if record.is_retired(&agent.id) {
-            continue;
+    // Read through `effective_agents()` rather than the raw manifest so an
+    // operator-renamed teammate is addressable by the name actually shown —
+    // `id = "ceo", name = "Ada"` must resolve `@Ada`, not just `@ceo`.
+    for agent in record.effective_agents() {
+        let mut aliases = vec![agent.id.to_lowercase()];
+        if let Some(name) = agent.name.as_deref() {
+            let name = name.to_lowercase();
+            if !aliases.contains(&name) {
+                aliases.push(name);
+            }
         }
         out.push(MentionAlias {
-            target: MentionTarget::Agent {
-                id: agent.id.clone(),
-            },
-            aliases: vec![agent.id.to_lowercase()],
+            target: MentionTarget::Agent { id: agent.id },
+            aliases,
         });
     }
     for overlay in &record.overlay_agents {
@@ -603,6 +608,25 @@ pub fn normalize(mut mentions: Vec<Mention>, sender: Option<&Actor>) -> Vec<Ment
     out
 }
 
+/// Whether a client-supplied mention's typed text is a real spelling of its
+/// claimed target, per the same [`directory`] the extraction path matches
+/// against.
+///
+/// The comparison strips the leading `@` (or `#` — [`directory`] aliases carry
+/// neither) and folds ASCII case, mirroring [`extract_with_known`]'s own
+/// matching rule so a span the extractor would have accepted is never rejected
+/// here. `Everyone` and `Desk` targets are covered the same way, since a
+/// caller can misclaim those exactly as easily as an agent or a user.
+fn is_valid_alias_for(mention: &Mention, dir: &[MentionAlias]) -> bool {
+    let body = mention
+        .text
+        .strip_prefix(['@', '#'])
+        .unwrap_or(&mention.text);
+    let body = body.to_lowercase();
+    dir.iter()
+        .any(|entry| entry.target == mention.target && entry.aliases.iter().any(|a| a == &body))
+}
+
 fn is_sender(target: &MentionTarget, sender: Option<&Actor>) -> bool {
     let Some(sender) = sender else {
         return false;
@@ -630,6 +654,20 @@ fn is_sender(target: &MentionTarget, sender: Option<&Actor>) -> bool {
 /// Spans that do not actually appear at their claimed offset are dropped
 /// outright — that is a malformed body rather than a stale one, and honouring
 /// it would let a caller draw a chip over text that says something else.
+///
+/// A span whose text is not actually a spelling of the claimed target is
+/// demoted the same way a stale target is. Matching the byte span alone only
+/// proves the caller copied real text out of the message; it does not prove
+/// that text names the target it claims — a caller could otherwise pair
+/// arbitrary text (`"hello"`, no `@` and no alias at all) with any live agent
+/// id and have it persisted as a non-quiet mention, drawing a chip and a
+/// routing decision over prose that never named anyone. The picker is still
+/// trusted to pick *which* of several genuinely ambiguous aliases a click
+/// meant — this only checks that the typed span is *a* valid spelling of the
+/// target it was paired with. Checked only when the target is otherwise live:
+/// a target that is already being demoted for having left the roster is not
+/// in `dir` at all (it is built from the same live company and user list),
+/// so it would fail this check for the wrong reason.
 pub fn revalidate(
     text: &str,
     mentions: Vec<Mention>,
@@ -637,6 +675,7 @@ pub fn revalidate(
     users: &[UserRecord],
 ) -> Vec<Mention> {
     let user_ids: HashSet<&str> = users.iter().map(|u| u.id.as_str()).collect();
+    let dir = directory(record, users);
     mentions
         .into_iter()
         .filter(|m| text.get(m.offset..m.offset + m.text.len()) == Some(m.text.as_str()))
@@ -647,6 +686,7 @@ pub fn revalidate(
                 MentionTarget::Desk { id } => record.resolve_desk_id(id).is_some(),
                 MentionTarget::Everyone => true,
             };
+            let live = live && is_valid_alias_for(&m, &dir);
             if !live {
                 m.quiet = true;
             }
@@ -803,7 +843,7 @@ pub fn mentioned_users(users: &[UserRecord], mentions: &[Mention]) -> Vec<String
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::ports::types::{AgentOverride, CompanyId, CompanyRecord};
     use crate::ports::users::{UserRole, UserStatus};
 
     const MANIFEST: &str = r#"
@@ -1384,5 +1424,65 @@ members = ["engineer", "ceo"]
         record.overlay_retired_agents.push("engineer".to_string());
         let found = resolve("@engineer hello", None, None, &record, &people());
         assert!(found.is_empty(), "{found:?}");
+    }
+
+    /// Issue: a manifest teammate's operator-set display name (an
+    /// `AgentOverride`, applied through `effective_agents()`) must be a real
+    /// alias, not just its authored roster id — an operator who renamed
+    /// `ceo` to "Ada" expects `@Ada` to reach them.
+    #[test]
+    fn an_operator_renamed_manifest_agent_is_mentionable_by_the_new_name() {
+        let mut record = acme();
+        record.overlay_agent_edits.push(AgentOverride {
+            agent_id: "ceo".to_string(),
+            name: Some("Ada".to_string()),
+            role: None,
+            description: None,
+            tools: None,
+            instructions: None,
+        });
+        let found = resolve("hey @Ada, got a sec?", None, None, &record, &people());
+        assert_eq!(targets(&found), vec![&agent("ceo")], "{found:?}");
+        // The authored id must keep working too — a rename is additive.
+        let found = resolve("hey @ceo, got a sec?", None, None, &record, &people());
+        assert_eq!(targets(&found), vec![&agent("ceo")], "{found:?}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Client-supplied mentions must actually name their claimed target
+    // -----------------------------------------------------------------------
+
+    /// A caller cannot pair arbitrary text with a live target's id and have it
+    /// persisted as a real, notifying mention — the span must actually be a
+    /// spelling of that target.
+    #[test]
+    fn a_supplied_mention_whose_text_does_not_name_its_target_is_demoted() {
+        let supplied = vec![Mention {
+            target: agent("engineer"),
+            text: "hello".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        let out = resolve("hello there", Some(supplied), None, &acme(), &people());
+        assert_eq!(out.len(), 1, "the span survives so the text still matches");
+        assert!(
+            out[0].quiet,
+            "text that never named the target must not ping it: {out:?}"
+        );
+    }
+
+    /// The picker is still trusted to disambiguate — a genuinely valid alias
+    /// for the claimed target stays a real, notifying mention.
+    #[test]
+    fn a_supplied_mention_whose_text_does_name_its_target_still_notifies() {
+        let supplied = vec![Mention {
+            target: agent("engineer"),
+            text: "@engineer".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        let out = resolve("@engineer hello", Some(supplied), None, &acme(), &people());
+        assert_eq!(out.len(), 1);
+        assert!(!out[0].quiet, "{out:?}");
     }
 }

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -483,7 +483,7 @@ pub fn extract_at_names(text: &str) -> Vec<(usize, String)> {
     let mut out = Vec::new();
     let mut i = 0usize;
     while i < bytes.len() {
-        if opens_mention(bytes, i) {
+        if opens_mention(text, bytes, i) {
             let mut j = i + 1;
             while j < bytes.len()
                 && (bytes[j].is_ascii_alphanumeric() || matches!(bytes[j], b'_' | b'-' | b'.'))
@@ -560,7 +560,7 @@ pub fn extract_with_known(text: &str, dir: &[MentionAlias]) -> Vec<Mention> {
     let mut out: Vec<Mention> = Vec::new();
     let mut i = 0usize;
     while i < bytes.len() {
-        if !opens_mention(bytes, i) {
+        if !opens_mention(text, bytes, i) {
             i += 1;
             continue;
         }

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -407,7 +407,7 @@ fn leading_spaces(bytes: &[u8], from: usize) -> usize {
 /// The condition that keeps `jane@acme.com` from reading as a mention of
 /// `acme`: an `@` counts only at the start of the text or after whitespace or
 /// an opening bracket, and only when something word-like follows it.
-fn opens_mention(bytes: &[u8], idx: usize) -> bool {
+fn opens_mention(text: &str, bytes: &[u8], idx: usize) -> bool {
     if bytes[idx] != b'@' {
         return false;
     }
@@ -420,14 +420,23 @@ fn opens_mention(bytes: &[u8], idx: usize) -> bool {
     };
     // `@#engineering` is the documented desk spelling (`MentionTarget::Desk`'s
     // own doc comment). The `#` is not itself word-like, so it needs its own
-    // branch: either the byte right after `@` is word-like, or it is `#` and
-    // the byte after THAT is — an `@#` with nothing nameable following it
+    // branch: either the char right after `@` is word-like, or it is `#` and
+    // the char after THAT is — an `@#` with nothing nameable following it
     // opens nothing.
-    let after_ok = match bytes.get(idx + 1) {
-        Some(b'#') => bytes
-            .get(idx + 2)
-            .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_'),
-        Some(b) => b.is_ascii_alphanumeric() || *b == b'_',
+    //
+    // Unicode-aware (`char::is_alphanumeric`), not the ASCII-only byte
+    // predicate this used to be: a label like "Élodie" is a real alias
+    // `directory` offers verbatim (see its people loop), and `@Élodie` must
+    // open a mention exactly as `@engineer` does. `idx` is `@`'s byte offset
+    // and `@` is one byte, so `idx + 1` is always a char boundary to slice
+    // from; that only fails if `idx + 1` also needs a second character (the
+    // `@#` arm), which re-slices from `idx + 1` rather than assuming `#` is
+    // one byte at some other fixed offset — it is, but the slice makes that
+    // true by construction instead of by charset assumption.
+    let mut after_chars = text[idx + 1..].chars();
+    let after_ok = match after_chars.next() {
+        Some('#') => after_chars.next().is_some_and(|c| c.is_alphanumeric() || c == '_'),
+        Some(c) => c.is_alphanumeric() || c == '_',
         None => false,
     };
     before_ok && after_ok

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -1640,4 +1640,113 @@ members = ["engineer", "ceo"]
         assert_eq!(out.len(), 1);
         assert!(!out[0].quiet, "{out:?}");
     }
+
+    /// A live alias sitting somewhere `opens_mention`/`closes_mention` would
+    /// refuse — mid-word, here — must be demoted the same way a mismatched
+    /// span is, not trusted just because the text happens to spell a real
+    /// alias.
+    #[test]
+    fn a_supplied_mention_mid_word_is_dropped() {
+        let supplied = vec![Mention {
+            target: agent("engineer"),
+            text: "@engineer".to_string(),
+            offset: 4,
+            quiet: false,
+        }];
+        let out = resolve("jane@engineer", Some(supplied), None, &acme(), &people());
+        assert!(
+            out.is_empty(),
+            "a span with no whitespace/bracket before it is not a mention: {out:?}"
+        );
+    }
+
+    /// The same alias-shaped-but-not-a-mention rule applies inside a fenced or
+    /// inline code span — fallback extraction already masks these, and a
+    /// structured caller must not be able to route around that mask.
+    #[test]
+    fn a_supplied_mention_inside_a_code_span_is_dropped() {
+        let text = "see `@engineer` for the review";
+        let offset = text.find("@engineer").expect("span present");
+        let supplied = vec![Mention {
+            target: agent("engineer"),
+            text: "@engineer".to_string(),
+            offset,
+            quiet: false,
+        }];
+        let out = resolve(text, Some(supplied), None, &acme(), &people());
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    /// Two live targets can share an alias (two "Sam"s, say); a structured
+    /// caller submitting the identical span for both must not double-ping —
+    /// only the first-supplied target for that exact span survives.
+    #[test]
+    fn only_the_first_target_for_one_span_survives() {
+        let users = vec![
+            user("u1", "sam.one@acme.test", Some("Sam")),
+            user("u2", "sam.two@acme.test", Some("Sam")),
+        ];
+        let supplied = vec![
+            Mention {
+                target: MentionTarget::User {
+                    id: "u1".to_string(),
+                },
+                text: "@Sam".to_string(),
+                offset: 0,
+                quiet: false,
+            },
+            Mention {
+                target: MentionTarget::User {
+                    id: "u2".to_string(),
+                },
+                text: "@Sam".to_string(),
+                offset: 0,
+                quiet: false,
+            },
+        ];
+        let out = resolve("@Sam please review", Some(supplied), None, &acme(), &users);
+        assert_eq!(
+            out.len(),
+            1,
+            "one run of text cannot name two different people: {out:?}"
+        );
+        assert_eq!(
+            out[0].target,
+            MentionTarget::User {
+                id: "u1".to_string()
+            },
+            "the picker's own ordering decides which of the pair is honoured: {out:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Unicode
+    // -----------------------------------------------------------------------
+
+    /// A display name that starts with a non-ASCII letter is still a real
+    /// alias `directory` offers verbatim — extraction must open a mention on
+    /// it exactly as it does on an ASCII one.
+    #[test]
+    fn a_non_ascii_display_name_opens_a_mention() {
+        let users = vec![user("u1", "elodie@acme.test", Some("Élodie"))];
+        let found = resolve("hey @Élodie, can you look?", None, None, &acme(), &users);
+        assert_eq!(
+            targets(&found),
+            vec![&MentionTarget::User {
+                id: "u1".to_string()
+            }],
+            "{found:?}"
+        );
+    }
+
+    /// A multi-byte character landing where a short alias's span would end
+    /// must not panic — it simply does not match, the same as any other
+    /// non-matching text.
+    #[test]
+    fn a_multibyte_character_at_a_short_aliass_boundary_does_not_panic() {
+        let users = vec![user("u1", "j@acme.test", Some("J"))];
+        // "é" is two UTF-8 bytes; a one-character alias ("j") ends inside it.
+        let found = resolve("@é hello", None, None, &acme(), &users);
+        assert!(found.is_empty(), "{found:?}");
+    }
 }

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -639,17 +639,32 @@ pub fn extract_with_known(text: &str, dir: &[MentionAlias]) -> Vec<Mention> {
 ///   reader sees still matches what the author wrote, and only the notifying
 ///   stops.
 ///
+/// * **At most one target per span.** A structured caller can otherwise
+///   submit the same `(offset, text)` twice with two different live targets —
+///   two people who share an alias, say — and both would survive dedupe-by-
+///   target (which only catches the SAME target repeated) as separate,
+///   non-quiet mentions. One run of text cannot literally name two different
+///   people at once, so only the first target claiming a span is honoured;
+///   sorting by offset first (below) and Rust's stable sort is what makes
+///   "first" mean "first as the caller supplied it" for two entries at the
+///   same offset — the picker's own ordering, so it still decides which of an
+///   ambiguous pair a click meant.
+///
 /// Sorted by offset on the way out, so the order is the order a reader
 /// encounters them rather than the order the matcher happened to find them.
 pub fn normalize(mut mentions: Vec<Mention>, sender: Option<&Actor>) -> Vec<Mention> {
     mentions.sort_by_key(|m| m.offset);
 
     let mut seen: HashSet<MentionTarget> = HashSet::new();
+    let mut seen_spans: HashSet<usize> = HashSet::new();
     let mut pings = 0usize;
     let mut out = Vec::with_capacity(mentions.len());
 
     for mut mention in mentions {
         if is_sender(&mention.target, sender) {
+            continue;
+        }
+        if !seen_spans.insert(mention.offset) {
             continue;
         }
         let duplicate = !seen.insert(mention.target.clone());

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -726,6 +726,18 @@ fn is_sender(target: &MentionTarget, sender: Option<&Actor>) -> bool {
 /// a target that is already being demoted for having left the roster is not
 /// in `dir` at all (it is built from the same live company and user list),
 /// so it would fail this check for the wrong reason.
+///
+/// A span whose text is a real alias but sits somewhere `opens_mention`/
+/// `closes_mention` would refuse — mid-word (`jane@engineer`), or inside a
+/// fenced or inline code span — is dropped outright too, same as a span that
+/// does not match its claimed text at all. Matching alias text is not enough
+/// on its own: fallback extraction deliberately never treats either shape as
+/// a mention, and a structured caller must not be able to manufacture a chip,
+/// and — once mention routing is wired — a routing decision, from text that
+/// reads as something else to every other path through this module. Checked
+/// against a **masked** copy (`strip_code_regions`), which preserves every
+/// offset, so a span the mask blanked out (inside a code region) fails the
+/// open check exactly as one that was never `@`-shaped at all.
 pub fn revalidate(
     text: &str,
     mentions: Vec<Mention>,
@@ -734,9 +746,17 @@ pub fn revalidate(
 ) -> Vec<Mention> {
     let user_ids: HashSet<&str> = users.iter().map(|u| u.id.as_str()).collect();
     let dir = directory(record, users);
+    let masked = strip_code_regions(text);
+    let masked_bytes = masked.as_bytes();
     mentions
         .into_iter()
         .filter(|m| text.get(m.offset..m.offset + m.text.len()) == Some(m.text.as_str()))
+        .filter(|m| {
+            let end = m.offset + m.text.len();
+            end <= masked_bytes.len()
+                && opens_mention(&masked, masked_bytes, m.offset)
+                && closes_mention(masked_bytes, end)
+        })
         .map(|mut m| {
             let live = match &m.target {
                 MentionTarget::Agent { id } => record.is_roster_agent(id),

--- a/src/runtime/mentions.rs
+++ b/src/runtime/mentions.rs
@@ -435,7 +435,9 @@ fn opens_mention(text: &str, bytes: &[u8], idx: usize) -> bool {
     // true by construction instead of by charset assumption.
     let mut after_chars = text[idx + 1..].chars();
     let after_ok = match after_chars.next() {
-        Some('#') => after_chars.next().is_some_and(|c| c.is_alphanumeric() || c == '_'),
+        Some('#') => after_chars
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_'),
         Some(c) => c.is_alphanumeric() || c == '_',
         None => false,
     };
@@ -593,9 +595,7 @@ pub fn extract_with_known(text: &str, dir: &[MentionAlias]) -> Vec<Mention> {
             // character: two byte spans are equal or they are not, and
             // `lowered`/`bytes` share `text`'s length either way (the fold
             // above guarantees it), so the offsets still line up.
-            if &lowered.as_bytes()[after..end] != alias.as_bytes()
-                || !closes_mention(bytes, end)
-            {
+            if &lowered.as_bytes()[after..end] != alias.as_bytes() || !closes_mention(bytes, end) {
                 continue;
             }
             match matched {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -84,6 +84,10 @@ pub mod mailbox_poller;
 /// expired approvals, expired grants and stale fire claims for EVERY registered
 /// company, not only those with a manifest `[[schedule]]`. See [`maintenance`].
 pub mod maintenance;
+/// Resolving `@name` in chat to a teammate, a person, a desk, or the whole
+/// room — and deciding what that addresses. Pure and brain-agnostic, for the
+/// same reason [`delegation_tools`] is. See [`mentions`].
+pub mod mentions;
 /// Issue #290: replacing a registered company's runtime in place, so first-time
 /// BYOK setup takes effect without a process restart. See [`rebuild`].
 pub mod rebuild;

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -13,7 +13,8 @@ use std::collections::{HashMap, HashSet};
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::{
-    Actor, ActorKind, CompanyEvent, CompanyRecord, EventSeq, StoredEvent, TurnStep,
+    Actor, ActorKind, CompanyEvent, CompanyRecord, EventSeq, Mention, MentionTarget, StoredEvent,
+    TurnStep,
 };
 use crate::server::ops::language::DEFAULT_DESK as GENERAL_DESK;
 
@@ -230,6 +231,40 @@ pub struct MessageView {
     /// ever-increasing counter. Grouping rows into a count is the renderer's
     /// job; deriving names from a count is impossible.
     pub reactions: Vec<ReactionView>,
+    /// Who this message names, in reading order.
+    ///
+    /// Spans plus a **label**, never a target id: this is the surface a member
+    /// reads other members' messages through, and handing every reader the raw
+    /// user id of everyone ever mentioned would widen who-sees-what for no gain
+    /// the renderer can use. Same discipline as [`ReactionView::by_label`], and
+    /// the same reason.
+    ///
+    /// Empty for a message that mentions nobody, which is every message
+    /// journaled before mentions existed.
+    pub mentions: Vec<MentionView>,
+}
+
+/// One mention inside one message, as a reader sees it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MentionView {
+    /// The literal span the author typed, so the renderer highlights what is
+    /// actually in the text rather than what the target is called now.
+    pub text: String,
+    /// Byte offset of [`Self::text`] in the message body.
+    pub offset: usize,
+    /// Who was named, as a display label — a teammate's id, a person's label, a
+    /// desk's name, or `everyone`. Never a raw user id.
+    pub label: String,
+    /// Whether this mention is the viewer's own — what the console renders as a
+    /// highlighted chip and counts as "this message is for me". Relative to the
+    /// [`Viewer`], on the same terms [`MessageView::mine`] is.
+    ///
+    /// True for a direct mention of the viewer **and** for `@everyone`, because
+    /// a broadcast is addressed to them too.
+    pub mine: bool,
+    /// Whether this mention renders but does not ping — a duplicate, a mention
+    /// past the cap, or a target that has since left the company.
+    pub quiet: bool,
 }
 
 /// One person's reaction to one message, as a reader sees it.
@@ -369,6 +404,7 @@ impl MessageView {
                 steps,
                 task_id,
                 parent,
+                mentions,
                 ..
             } => MessageView {
                 id,
@@ -381,9 +417,14 @@ impl MessageView {
                 task_id,
                 parent_id: parent.map(|seq| seq.value().to_string()),
                 reactions: Vec::new(),
+                mentions: project_mentions(&mentions, authors, viewer),
             },
             CompanyEvent::OperatorMessage {
-                text, by, parent, ..
+                text,
+                by,
+                parent,
+                mentions,
+                ..
             } => {
                 let (author, mine) = match &by {
                     // Sent by a signed-in human.
@@ -410,6 +451,7 @@ impl MessageView {
                     task_id: None,
                     parent_id: parent.map(|seq| seq.value().to_string()),
                     reactions: Vec::new(),
+                    mentions: project_mentions(&mentions, authors, viewer),
                 }
             }
             // The dispatch terminal (issue #377), as the channel marker a
@@ -445,6 +487,7 @@ impl MessageView {
                 task_id: Some(task_id),
                 parent_id: None,
                 reactions: Vec::new(),
+                mentions: Vec::new(),
             },
             // `owns` never admits other variants into a history.
             other => MessageView {
@@ -458,9 +501,54 @@ impl MessageView {
                 task_id: None,
                 parent_id: None,
                 reactions: Vec::new(),
+                mentions: Vec::new(),
             },
         }
     }
+}
+
+/// Turns stored mentions into what a particular reader should see.
+///
+/// Two things happen here and nowhere else:
+///
+/// * **Ids become labels.** A [`MentionTarget::User`] carries a user id, which
+///   no member-facing surface hands out; it is resolved through the same
+///   `authors` map the byline above the message uses, so a chip and the author
+///   line can never disagree about what somebody is called. A target that
+///   resolves to nothing falls back to the literal text the author typed, minus
+///   its `@` — which is exactly what a reader would have seen anyway.
+/// * **`mine` is decided.** Per viewer, and `true` for `@everyone` as well as
+///   for a direct mention, because a broadcast is addressed to this reader too.
+fn project_mentions(
+    mentions: &[Mention],
+    authors: &HashMap<String, String>,
+    viewer: &Viewer,
+) -> Vec<MentionView> {
+    mentions
+        .iter()
+        .map(|mention| {
+            let fallback = || mention.text.trim_start_matches('@').to_string();
+            let (label, mine) = match &mention.target {
+                MentionTarget::Agent { id } => (id.clone(), false),
+                MentionTarget::Desk { id } => (id.clone(), false),
+                MentionTarget::User { id } => (
+                    authors.get(id).cloned().unwrap_or_else(fallback),
+                    *viewer == Viewer::User(id.clone()),
+                ),
+                // Addressed to the room, so it is addressed to whoever is
+                // reading — including the operator credential, which is a
+                // reader even though it is not a person.
+                MentionTarget::Everyone => ("everyone".to_string(), true),
+            };
+            MentionView {
+                text: mention.text.clone(),
+                offset: mention.offset,
+                label,
+                mine,
+                quiet: mention.quiet,
+            }
+        })
+        .collect()
 }
 
 /// The blast radius of issue #885, for one company.
@@ -844,6 +932,8 @@ mod test {
 
     fn agent_reply(chat_id: &str) -> CompanyEvent {
         CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: None,
             chat_id: chat_id.to_string(),
@@ -856,6 +946,7 @@ mod test {
     /// `None` is the shape the chat route stores for an unaddressed post.
     fn operator_message(chat: Option<&str>) -> CompanyEvent {
         CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".to_string(),
             by: None,
@@ -940,6 +1031,7 @@ mod test {
     #[test]
     fn general_desk_owns_every_operator_message() {
         let event = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".to_string(),
             by: Some(Actor {
@@ -958,6 +1050,7 @@ mod test {
     #[test]
     fn main_thread_owns_operator_messages_it_stored() {
         let event = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".to_string(),
             by: None,
@@ -975,6 +1068,7 @@ mod test {
     #[test]
     fn desk_addressed_operator_message_belongs_to_that_desk() {
         let event = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".to_string(),
             by: None,
@@ -1086,6 +1180,181 @@ mod test {
         assert!(!folded["4"][0].mine);
     }
 
+    fn mention(target: MentionTarget, text: &str, offset: usize) -> Mention {
+        Mention {
+            target,
+            text: text.to_string(),
+            offset,
+            quiet: false,
+        }
+    }
+
+    fn message_mentioning(mentions: Vec<Mention>) -> CompanyEvent {
+        CompanyEvent::OperatorMessage {
+            mentions,
+            parent: None,
+            text: "ping".to_string(),
+            by: None,
+            chat: Some("studio".to_string()),
+            deliverable: None,
+        }
+    }
+
+    /// A person's mention reaches a reader as a **label**, never as the user id
+    /// it is stored under — the same rule `by_label` follows for reactions.
+    #[test]
+    fn project_resolves_a_person_to_a_label_and_never_to_an_id() {
+        let view = MessageView::project(
+            at(
+                7,
+                message_mentioning(vec![mention(
+                    MentionTarget::User {
+                        id: "u1".to_string(),
+                    },
+                    "@Ada",
+                    0,
+                )]),
+            ),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert_eq!(view.mentions.len(), 1);
+        assert_eq!(view.mentions[0].label, "Ada");
+        assert_eq!(view.mentions[0].text, "@Ada");
+        assert_eq!(view.mentions[0].offset, 0);
+        assert!(
+            !view.mentions[0].label.contains("u1"),
+            "the stored id must not reach a reader"
+        );
+    }
+
+    /// `mine` is per viewer: the same stored row is the reader's own mention
+    /// for one person and somebody else's for everyone else.
+    #[test]
+    fn project_decides_mine_per_viewer() {
+        let event = at(
+            8,
+            message_mentioning(vec![mention(
+                MentionTarget::User {
+                    id: "u1".to_string(),
+                },
+                "@Ada",
+                0,
+            )]),
+        );
+        let ada = MessageView::project(event.clone(), &Viewer::User("u1".to_string()), &labels());
+        assert!(ada.mentions[0].mine);
+
+        let grace = MessageView::project(event, &Viewer::User("u2".to_string()), &labels());
+        assert!(!grace.mentions[0].mine);
+    }
+
+    /// A broadcast is addressed to whoever is reading, so it is everybody's own
+    /// mention — that is what makes it badge every recipient.
+    #[test]
+    fn everyone_is_mine_for_every_reader() {
+        let event = at(
+            9,
+            message_mentioning(vec![mention(MentionTarget::Everyone, "@everyone", 0)]),
+        );
+        for viewer in [
+            Viewer::Operator,
+            Viewer::User("u1".to_string()),
+            Viewer::User("u2".to_string()),
+        ] {
+            let view = MessageView::project(event.clone(), &viewer, &labels());
+            assert!(view.mentions[0].mine, "viewer: {viewer:?}");
+            assert_eq!(view.mentions[0].label, "everyone");
+        }
+    }
+
+    /// A person who has since been removed has no label to resolve to. The
+    /// literal text the author typed is the honest fallback — it is what a
+    /// reader would have seen anyway — and it must not be the raw id.
+    #[test]
+    fn a_mention_of_a_departed_person_falls_back_to_the_typed_text() {
+        let view = MessageView::project(
+            at(
+                10,
+                message_mentioning(vec![mention(
+                    MentionTarget::User {
+                        id: "gone".to_string(),
+                    },
+                    "@Bob",
+                    0,
+                )]),
+            ),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert_eq!(view.mentions[0].label, "Bob");
+    }
+
+    #[test]
+    fn a_teammate_and_a_desk_project_their_ids_as_labels() {
+        let view = MessageView::project(
+            at(
+                11,
+                message_mentioning(vec![
+                    mention(
+                        MentionTarget::Agent {
+                            id: "engineer".to_string(),
+                        },
+                        "@engineer",
+                        0,
+                    ),
+                    mention(
+                        MentionTarget::Desk {
+                            id: "engineering".to_string(),
+                        },
+                        "@engineering",
+                        10,
+                    ),
+                ]),
+            ),
+            &Viewer::Operator,
+            &labels(),
+        );
+        let labels: Vec<&str> = view.mentions.iter().map(|m| m.label.as_str()).collect();
+        assert_eq!(labels, vec!["engineer", "engineering"]);
+        assert!(
+            view.mentions.iter().all(|m| !m.mine),
+            "a teammate or a desk is never the human reader"
+        );
+    }
+
+    #[test]
+    fn a_quiet_mention_projects_as_quiet() {
+        let view = MessageView::project(
+            at(
+                12,
+                message_mentioning(vec![Mention {
+                    quiet: true,
+                    ..mention(
+                        MentionTarget::User {
+                            id: "u1".to_string(),
+                        },
+                        "@Ada",
+                        0,
+                    )
+                }]),
+            ),
+            &Viewer::User("u1".to_string()),
+            &labels(),
+        );
+        assert!(view.mentions[0].quiet);
+    }
+
+    #[test]
+    fn a_message_that_mentions_nobody_projects_an_empty_list() {
+        let view = MessageView::project(
+            at(13, message_mentioning(Vec::new())),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert!(view.mentions.is_empty());
+    }
+
     /// A thread parent survives projection on both halves of an exchange, as
     /// the message id a reader can resolve rather than a raw sequence number.
     #[test]
@@ -1094,6 +1363,7 @@ mod test {
             at(
                 12,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: Some(EventSeq::new(4)),
                     text: "a follow-up".to_string(),
                     by: None,
@@ -1110,6 +1380,8 @@ mod test {
             at(
                 13,
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: Some(EventSeq::new(4)),
                     task_id: None,
                     chat_id: "studio".to_string(),
@@ -1133,6 +1405,7 @@ mod test {
     #[test]
     fn legacy_operator_message_without_chat_stays_on_general() {
         let event = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: "hi".to_string(),
             by: None,
@@ -1308,6 +1581,8 @@ mod test {
             at(
                 seq,
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     chat_id: "engineering".to_string(),
                     agent_id: agent_id.to_string(),
                     text: "…".to_string(),
@@ -1506,6 +1781,7 @@ mod test {
                     at(
                         1,
                         CompanyEvent::OperatorMessage {
+                            mentions: Vec::new(),
                             text: "hello".to_string(),
                             by: None,
                             chat: None,
@@ -1561,6 +1837,8 @@ mod dead_card_test {
     /// A reply that opened a card, exactly as the dispatch path journals it.
     fn reply_naming(task_id: &str) -> CompanyEvent {
         CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: Some(task_id.to_string()),
             chat_id: MAIN_THREAD_ID.to_string(),
@@ -1691,6 +1969,8 @@ mod dead_card_test {
             .append(
                 &id,
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id: None,
                     chat_id: MAIN_THREAD_ID.to_string(),

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::CompanyId;
 use crate::ports::types::TurnStep;
-use crate::server::chat_history::{self, MessageView, ReactionView, Viewer};
+use crate::server::chat_history::{self, MentionView, MessageView, ReactionView, Viewer};
 
 /// The aggregation-root handle over one company. See the module docs.
 pub struct CompanyGql {
@@ -556,6 +556,45 @@ pub struct MessageGql {
     /// Who reacted to this message with what (issue #364), one row per person
     /// per emoji. Empty when nobody has.
     pub reactions: Vec<MessageReactionGql>,
+    /// Who this message names, in reading order. Empty when it names nobody.
+    /// Same [`MessageView`] field the REST route reads, so the two surfaces
+    /// cannot disagree about who was mentioned.
+    pub mentions: Vec<MessageMentionGql>,
+}
+
+/// One mention on a history message. GraphQL mirror of the REST `mentions`
+/// array, so the two surfaces carry the same rows.
+#[derive(SimpleObject)]
+#[graphql(name = "MessageMention")]
+pub struct MessageMentionGql {
+    /// The literal span the author typed.
+    pub text: String,
+    /// Byte offset of `text` in the message body.
+    pub offset: u32,
+    /// Who was named, as a display label — never a raw user id.
+    pub label: String,
+    /// Whether the reading viewer is the one named (or was named by
+    /// `@everyone`).
+    pub mine: bool,
+    /// Whether this mention renders but pings nobody.
+    pub quiet: bool,
+}
+
+impl From<MentionView> for MessageMentionGql {
+    fn from(view: MentionView) -> Self {
+        MessageMentionGql {
+            text: view.text,
+            // Saturating rather than `as`: GraphQL has no 64-bit integer, and a
+            // silent wrap would put a chip at the wrong place in the text. An
+            // offset this large cannot occur in a chat message, so the clamp is
+            // unreachable — it is here so that if it ever is reached, the chip
+            // lands at the end rather than at a wrapped-around position.
+            offset: u32::try_from(view.offset).unwrap_or(u32::MAX),
+            label: view.label,
+            mine: view.mine,
+            quiet: view.quiet,
+        }
+    }
 }
 
 /// One person's reaction on a history message (issue #364). GraphQL mirror of
@@ -631,6 +670,11 @@ impl From<MessageView> for MessageGql {
                 .reactions
                 .into_iter()
                 .map(MessageReactionGql::from)
+                .collect(),
+            mentions: view
+                .mentions
+                .into_iter()
+                .map(MessageMentionGql::from)
                 .collect(),
         }
     }

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -589,7 +589,14 @@ impl From<MentionView> for MessageMentionGql {
             // offset this large cannot occur in a chat message, so the clamp is
             // unreachable — it is here so that if it ever is reached, the chip
             // lands at the end rather than at a wrapped-around position.
-            offset: u32::try_from(view.offset).unwrap_or(u32::MAX),
+            //
+            // `i32::MAX`, not `u32::MAX`: the GraphQL spec defines `Int` as a
+            // signed 32-bit integer, so a `u32` value above `i32::MAX` is
+            // already out of range for the scalar this field is declared as
+            // and can fail serialization on the way out — the clamp exists
+            // for exactly this unreachable-in-practice case, so it needs to
+            // clamp to a value the wire type can actually carry.
+            offset: i32::try_from(view.offset).unwrap_or(i32::MAX) as u32,
             label: view.label,
             mine: view.mine,
             quiet: view.quiet,

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -598,6 +598,40 @@ type Message {
 	per emoji. Empty when nobody has.
 	"""
 	reactions: [MessageReaction!]!
+	"""
+	Who this message names, in reading order. Empty when it names nobody.
+	Same [`MessageView`] field the REST route reads, so the two surfaces
+	cannot disagree about who was mentioned.
+	"""
+	mentions: [MessageMention!]!
+}
+
+"""
+One mention on a history message. GraphQL mirror of the REST `mentions`
+array, so the two surfaces carry the same rows.
+"""
+type MessageMention {
+	"""
+	The literal span the author typed.
+	"""
+	text: String!
+	"""
+	Byte offset of `text` in the message body.
+	"""
+	offset: Int!
+	"""
+	Who was named, as a display label — never a raw user id.
+	"""
+	label: String!
+	"""
+	Whether the reading viewer is the one named (or was named by
+	`@everyone`).
+	"""
+	mine: Boolean!
+	"""
+	Whether this mention renders but pings nobody.
+	"""
+	quiet: Boolean!
 }
 
 """

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -746,6 +746,8 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .append(
             runtime.id(),
             crate::ports::types::CompanyEvent::AgentReply {
+                mentions: Vec::new(),
+                mention_depth: 0,
                 parent: None,
                 task_id: None,
                 chat_id: "General".to_string(),
@@ -761,6 +763,8 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .append(
             runtime.id(),
             crate::ports::types::CompanyEvent::AgentReply {
+                mentions: Vec::new(),
+                mention_depth: 0,
                 parent: None,
                 task_id: None,
                 chat_id: "main".to_string(),
@@ -809,6 +813,8 @@ async fn chat_history_clamps_an_oversized_page_request() {
             .append(
                 runtime.id(),
                 crate::ports::types::CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id: None,
                     chat_id: "General".to_string(),
@@ -884,6 +890,8 @@ async fn chat_history_projects_the_card_a_reply_opened() {
             .append(
                 runtime.id(),
                 crate::ports::types::CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id,
                     chat_id: "General".to_string(),
@@ -939,6 +947,8 @@ async fn chat_history_projects_threads_and_reactions() {
         .append(
             runtime.id(),
             CompanyEvent::AgentReply {
+                mentions: Vec::new(),
+                mention_depth: 0,
                 parent: None,
                 task_id: None,
                 chat_id: "General".to_string(),
@@ -954,6 +964,8 @@ async fn chat_history_projects_threads_and_reactions() {
         .append(
             runtime.id(),
             CompanyEvent::AgentReply {
+                mentions: Vec::new(),
+                mention_depth: 0,
                 parent: Some(root),
                 task_id: None,
                 chat_id: "General".to_string(),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -38,8 +38,8 @@ use crate::ports::types::{
 use crate::runtime::grants::{GrantId, GrantScope, MAX_STANDING_GRANT_MILLIS};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::chat_history::{
-    CHAT_HISTORY_PAGE_LIMIT, MessageView, ReactionView, Viewer, channel_attributed_replies,
-    history_for_desk,
+    CHAT_HISTORY_PAGE_LIMIT, MentionView, MessageView, ReactionView, Viewer,
+    channel_attributed_replies, history_for_desk,
 };
 use crate::server::error::ApiError;
 use crate::server::graphql::auth::GqlAuth;
@@ -685,6 +685,8 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             steps,
             task_id,
             parent,
+            mentions,
+            ..
         } => {
             let mut o = envelope("agent_reply");
             o["chatId"] = json!(chat_id);
@@ -706,6 +708,29 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             // an ordinary chat reply so the legacy wire shape is unchanged.
             if let Some(task_id) = task_id {
                 o["taskId"] = json!(task_id);
+            }
+            // Mention spans, so a console watching live draws the same chips a
+            // reload would rather than rendering the reply flat and then
+            // re-rendering it on refresh.
+            //
+            // **Spans only — deliberately no targets.** A `Mention` carries an
+            // agent id or a *user* id, and this stream has no per-viewer
+            // projection to resolve either into a label; that is the same
+            // reason `ReactionToggled` is dropped here entirely (issue #364).
+            // A chip needs the range and whether it pings, and nothing else, so
+            // that is all this projects. `chat/history` remains the one surface
+            // that answers *who*, per viewer, with labels rather than ids.
+            if !mentions.is_empty() {
+                o["mentions"] = json!(
+                    mentions
+                        .iter()
+                        .map(|m| json!({
+                            "text": m.text,
+                            "offset": m.offset,
+                            "quiet": m.quiet,
+                        }))
+                        .collect::<Vec<_>>()
+                );
             }
             o
         }
@@ -1288,6 +1313,27 @@ struct ChatMessage {
     /// hands back a 202, which needs this turn record to exist first.
     #[serde(default)]
     detach: bool,
+    /// Who this message names, as the console's picker resolved them.
+    ///
+    /// Three states, and they are three different instructions:
+    ///
+    /// * **Absent** — the caller has no picker (`curl`, the API, a console
+    ///   predating this field). The host extracts mentions from the text
+    ///   itself, so `@engineer` still works from the command line.
+    /// * **Present and non-empty** — the caller resolved these against a roster
+    ///   it had loaded. Re-validated here against the live one and demoted, not
+    ///   trusted; a stale picker must not be able to address a turn to a
+    ///   teammate the company no longer has.
+    /// * **Present and empty** — the caller ran its picker and found nothing.
+    ///   Honoured as the answer it is: the host does not then guess on its
+    ///   behalf and chip an `@word` the author deliberately left unresolved.
+    ///
+    /// Additive in both directions, on exactly the terms `detach` documents
+    /// above: this struct has no `deny_unknown_fields`, so a newer console
+    /// against an older host degrades to host-side extraction, and an older
+    /// console against a newer host gets extraction too.
+    #[serde(default)]
+    mentions: Option<Vec<crate::ports::types::Mention>>,
 }
 
 /// A chat or approval-resolution response: the company's channel replies.
@@ -1756,6 +1802,13 @@ async fn accept_chat_turn(
         // that was being exercised on the very same message — see the field
         // docs on `CompanyEvent::OperatorMessage`.
         deliverable: message.deliverable,
+        // Resolved before the journal write, so the durable record and the
+        // routing decision that follows read the same list. The picker's answer
+        // when it sent one, extraction from the text when it did not — and
+        // either way re-validated against the live roster.
+        mentions: runtime
+            .resolve_mentions(&message.text, message.mentions.clone(), by)
+            .await,
     };
     let message_seq = runtime
         .events()
@@ -2081,11 +2134,34 @@ async fn journal_chat_replies(
     // made against a bubble the operator can still see names something every
     // other reader can resolve.
     for response in &mut report.responses {
+        // Scanned host-side from the reply text — the console's picker never
+        // touched this message. The author is passed so a teammate naming
+        // itself in its own answer does not chip itself.
+        let reply_mentions = runtime
+            .resolve_mentions(
+                &response.text,
+                None,
+                response
+                    .agent
+                    .as_deref()
+                    .map(|agent| Actor {
+                        kind: ActorKind::Agent,
+                        id: agent.to_string(),
+                    })
+                    .as_ref(),
+            )
+            .await;
         let journaled = runtime
             .events()
             .append(
                 id,
                 CompanyEvent::AgentReply {
+                    // Who this reply names. Rendered as chips and — unlike an
+                    // operator message's — never consulted by dispatch, which
+                    // is the mention-loop fuse.
+                    mentions: reply_mentions,
+                    // Zero, and stays zero while that edge does not exist.
+                    mention_depth: 0,
                     // The answer joins the thread its question was asked in,
                     // rather than opening one under the question (issue #364).
                     parent,
@@ -2275,6 +2351,43 @@ struct ChatHistoryMessageDto {
     /// per emoji. Omitted when nobody has, keeping the legacy shape.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     reactions: Vec<ChatReactionDto>,
+    /// Who this message names, in reading order. Omitted when it names nobody
+    /// — which is every message journaled before mentions existed — so the
+    /// legacy shape is unchanged.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    mentions: Vec<ChatMentionDto>,
+}
+
+/// One mention on a history message. Mirrors `Mention` in
+/// `frontend/src/lib/chat.ts`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChatMentionDto {
+    /// The literal span the author typed, so the renderer highlights the text
+    /// as written rather than the target's current name.
+    text: String,
+    /// Byte offset of `text` in the message body.
+    offset: usize,
+    /// Who was named, as a display label — never a raw user id.
+    label: String,
+    /// Whether the reading viewer is the one named (or was named by
+    /// `@everyone`).
+    mine: bool,
+    /// Whether this mention renders but pings nobody.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    quiet: bool,
+}
+
+impl From<MentionView> for ChatMentionDto {
+    fn from(view: MentionView) -> Self {
+        Self {
+            text: view.text,
+            offset: view.offset,
+            label: view.label,
+            mine: view.mine,
+            quiet: view.quiet,
+        }
+    }
 }
 
 /// One person's reaction on a history message. Mirrors `Reaction` in
@@ -2316,6 +2429,11 @@ impl From<MessageView> for ChatHistoryMessageDto {
                 .reactions
                 .into_iter()
                 .map(ChatReactionDto::from)
+                .collect(),
+            mentions: view
+                .mentions
+                .into_iter()
+                .map(ChatMentionDto::from)
                 .collect(),
         }
     }
@@ -3865,6 +3983,7 @@ mode = "full"
             let runtime = state.registry().get(&id).unwrap();
 
             let message = ChatMessage {
+                mentions: None,
                 text: ask.to_string(),
                 chat: None,
                 parent: None,
@@ -4811,6 +4930,8 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id: None,
                     chat_id: "General".to_string(),
@@ -4826,6 +4947,8 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id: None,
                     chat_id: "main".to_string(),
@@ -4882,6 +5005,8 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id: None,
                     chat_id: "main".to_string(),
@@ -4978,6 +5103,8 @@ mode = "full"
                 .append(
                     runtime.id(),
                     CompanyEvent::AgentReply {
+                        mentions: Vec::new(),
+                        mention_depth: 0,
                         parent: None,
                         task_id,
                         chat_id: "main".to_string(),
@@ -5071,6 +5198,8 @@ mode = "full"
                     .append(
                         runtime.id(),
                         CompanyEvent::AgentReply {
+                            mentions: Vec::new(),
+                            mention_depth: 0,
                             parent: None,
                             task_id: None,
                             chat_id: "workflow-copilot:weekly_report".to_string(),
@@ -5120,6 +5249,8 @@ mode = "full"
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    mentions: Vec::new(),
+                    mention_depth: 0,
                     parent: None,
                     task_id: None,
                     chat_id: "General".to_string(),
@@ -7344,6 +7475,8 @@ mode = "full"
     fn projects_agent_reply_with_chat_fields_and_steps() {
         use crate::ports::types::{TurnStep, TurnStepKind, TurnStepStatus};
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: None,
             chat_id: "General".into(),
@@ -7379,6 +7512,8 @@ mode = "full"
     #[test]
     fn projects_agent_reply_with_its_thread_parent() {
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: Some(EventSeq::new(4)),
             task_id: None,
             chat_id: "General".into(),
@@ -7467,6 +7602,7 @@ mode = "full"
     fn projects_nothing_for_the_operators_own_message() {
         assert!(
             super::project_event(&stored(CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 text: "the operator's own words".into(),
                 by: None,
                 chat: Some("General".into()),
@@ -7554,6 +7690,8 @@ mode = "full"
     #[test]
     fn projects_agent_reply_omits_empty_steps() {
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: None,
             chat_id: "General".into(),
@@ -7576,6 +7714,8 @@ mode = "full"
     #[test]
     fn projects_task_id_only_when_the_event_is_correlated() {
         let reply = super::project_event(&stored(CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             task_id: Some("t-1".into()),
             chat_id: "t-1".into(),
@@ -8225,6 +8365,7 @@ mode = "full"
         // still drops everything it dropped before.
         let dropped = [
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,

--- a/src/server/ops/mentions.rs
+++ b/src/server/ops/mentions.rs
@@ -134,17 +134,19 @@ async fn list_mentionables(company: ScopedCompany) -> Result<Json<MentionablesDt
                 .into_response()
         })?;
 
+    // `effective_agents()` rather than the raw manifest: an operator-renamed
+    // manifest teammate's stored name lives in an override, and reading the
+    // manifest directly would ignore it and advertise the authored id forever.
     let mut agents: Vec<MentionableAgentDto> = record
-        .manifest
-        .agents
-        .iter()
-        .filter(|a| !record.is_retired(&a.id))
+        .effective_agents()
+        .into_iter()
         .map(|a| MentionableAgentDto {
             id: a.id.clone(),
             // A manifest teammate's id is human-authored (`engineer`, `ceo`),
-            // so it is already the best label there is for one.
-            name: a.name.clone().unwrap_or_else(|| a.id.clone()),
-            role: a.role.clone(),
+            // so it is already the best label there is for one absent an
+            // override.
+            name: a.name.clone().unwrap_or(a.id),
+            role: a.role,
         })
         .collect();
     agents.extend(
@@ -185,6 +187,13 @@ async fn list_mentionables(company: ScopedCompany) -> Result<Json<MentionablesDt
         .list_users(company.id())
         .await
         .map_err(|e| ApiError(e).into_response())?;
+    // `Suspended` is retained only for attribution and is refused on every
+    // request (see `UserStatus::Suspended`) — advertising a suspended user
+    // here would offer a mention target that can never sign back in to see
+    // it, and the same list feeds mention resolution's "live" check below, so
+    // an unfiltered list would also let a removed collaborator keep accepting
+    // non-quiet direct mentions and `@everyone`.
+    users.retain(|u| u.status == crate::ports::users::UserStatus::Active);
     users.sort_by(|a, b| a.id.cmp(&b.id));
     let slugs = user_slugs(&users);
     let people = users
@@ -380,5 +389,85 @@ mod tests {
         let (status, body) = call(&state, false).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(body["code"], "unauthorized");
+    }
+
+    /// A suspended user is retained only for attribution and is refused on
+    /// every request (`UserStatus::Suspended`) — advertising one here would
+    /// offer a mention target that can never sign back in, and the same list
+    /// backs live mention resolution, so a stale collaborator must not keep
+    /// accepting non-quiet direct mentions or `@everyone` either.
+    #[tokio::test]
+    async fn a_suspended_user_is_not_offered_as_a_mention_target() {
+        use crate::ports::CompanyId;
+        use crate::ports::users::{UserRecord, UserRole, UserStatus};
+
+        let home = home();
+        let state = state(home.path()).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).expect("registered");
+        runtime
+            .users()
+            .upsert_user(
+                &id,
+                &UserRecord {
+                    id: "gone".to_string(),
+                    email: "gone@acme.test".to_string(),
+                    display_name: Some("Gone Guy".to_string()),
+                    role: UserRole::Member,
+                    status: UserStatus::Suspended,
+                    password_hash: None,
+                    must_change_password: false,
+                    created_at_millis: 0,
+                    last_seen_at_millis: None,
+                    updated_at_millis: 0,
+                },
+            )
+            .await
+            .expect("upsert suspended user");
+
+        let (status, body) = call(&state, true).await;
+        assert_eq!(status, StatusCode::OK);
+        let people = body["people"].as_array().expect("people");
+        assert_eq!(
+            people.len(),
+            1,
+            "only the seeded active admin is offered: {people:?}"
+        );
+        assert!(
+            people.iter().all(|p| p["id"] != "gone"),
+            "a suspended user must not be a mention target: {people:?}"
+        );
+    }
+
+    /// A manifest teammate's operator-set display name is a stored override,
+    /// applied through `effective_agents()` — the picker must show it, not the
+    /// authored roster id, and future edits must not be silently ignored.
+    #[tokio::test]
+    async fn a_renamed_manifest_agent_is_offered_by_its_effective_name() {
+        use crate::ports::types::AgentOverride;
+
+        let home = home();
+        let state = state(home.path()).await;
+        let id = CompanyId::new("acme");
+        let store = FsCompanyStore::new(home.path().to_path_buf());
+        let mut record = store.load(&id).await.unwrap().expect("record");
+        record.overlay_agent_edits.push(AgentOverride {
+            agent_id: "ceo".to_string(),
+            name: Some("Ada".to_string()),
+            role: None,
+            description: None,
+            tools: None,
+            instructions: None,
+        });
+        store.save(&record).await.expect("save");
+
+        let (status, body) = call(&state, true).await;
+        assert_eq!(status, StatusCode::OK);
+        let agents = body["agents"].as_array().expect("agents");
+        let ceo = agents
+            .iter()
+            .find(|a| a["id"] == "ceo")
+            .expect("ceo present");
+        assert_eq!(ceo["name"], "Ada", "{agents:?}");
     }
 }

--- a/src/server/ops/mentions.rs
+++ b/src/server/ops/mentions.rs
@@ -1,0 +1,384 @@
+//! The mention directory: `GET {scope}/chat/mentionables`.
+//!
+//! Everything a composer needs to offer an `@` picker — the teammates, the
+//! people, the desks, and the broadcast token — in one read, resolved the same
+//! way the host resolves a mention it receives.
+//!
+//! # Why this is not `GET {scope}/users`
+//!
+//! The user directory is **admin-gated**
+//! ([`require_admin`](crate::server::users::admin::require_admin)), and
+//! correctly so: it carries login identities, roles, statuses, and invite
+//! state, which is administration, not collaboration. But every member has to
+//! be able to mention every other member, so mentioning a colleague cannot
+//! require being an admin.
+//!
+//! The answer is a second, much narrower read rather than a relaxation of the
+//! first. This route hands out **an id and a label**, and nothing else — no
+//! email, no role, no status, no last-seen. That is the same discipline
+//! [`author_labels`](crate::server::chat_history) already enforces on every
+//! message a member reads, so this widens nothing: a person who has ever posted
+//! is already named to their colleagues by exactly this label.
+//!
+//! # Signed-in humans only
+//!
+//! A machine credential names no person and has no composer, so both the
+//! privacy argument and the use case are absent. Same `401` as
+//! [`read_state`](super::read_state), and for the same reason.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Serialize;
+use serde_json::json;
+
+use crate::AppState;
+use crate::runtime::mentions::{EVERYONE_ALIASES, user_label, user_slugs};
+use crate::server::error::ApiError;
+use crate::server::ops::scope::{ScopedCompany, scoped};
+
+pub fn router() -> Router<AppState> {
+    scoped("/chat/mentionables", get(list_mentionables))
+}
+
+/// One teammate the composer can offer.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MentionableAgentDto {
+    /// The roster id — the authored, typable handle, and what a resolved
+    /// mention is stored under.
+    id: String,
+    /// What to show in the picker. The display name for an operator-added
+    /// teammate, the id for a manifest one, which is already human-authored.
+    name: String,
+    /// The teammate's job title, so two similarly-named teammates are
+    /// distinguishable in the list.
+    role: String,
+}
+
+/// One person the composer can offer.
+///
+/// **Id and label only.** See the module note: this is deliberately not the
+/// admin user record, and must not grow toward it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MentionablePersonDto {
+    /// The user id a resolved mention is stored under.
+    id: String,
+    /// How this person is named to their colleagues — the same label their
+    /// messages are attributed with.
+    label: String,
+    /// A short typable alias, disambiguated across the company.
+    ///
+    /// **Not a handle and not stored.** Recomputed on every read, so a rename
+    /// can never strand it; it exists so somebody typing fast has something
+    /// shorter than a two-word display name to hit.
+    slug: String,
+}
+
+/// One desk the composer can offer.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MentionableDeskDto {
+    /// The desk id a resolved mention is stored under.
+    id: String,
+    /// The desk's display name.
+    name: String,
+    /// The teammates a mention of this desk expands to, so the composer can
+    /// warn about the blast radius before the message is sent rather than
+    /// after.
+    member_ids: Vec<String>,
+}
+
+/// The broadcast token, described rather than assumed.
+///
+/// Sent as data so the composer does not hard-code the spellings — the host
+/// decides what `@everyone` is called, and a console that disagreed would offer
+/// a row that resolves to nothing.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MentionableEveryoneDto {
+    /// The canonical spelling to insert.
+    label: String,
+    /// Every spelling the host accepts, so the picker can match on any of them.
+    aliases: Vec<String>,
+}
+
+/// `GET {scope}/chat/mentionables` — everything an `@` can name.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MentionablesDto {
+    agents: Vec<MentionableAgentDto>,
+    people: Vec<MentionablePersonDto>,
+    desks: Vec<MentionableDeskDto>,
+    everyone: MentionableEveryoneDto,
+}
+
+async fn list_mentionables(company: ScopedCompany) -> Result<Json<MentionablesDto>, Response> {
+    if company.actor.is_none() {
+        return Err(unauthorized());
+    }
+
+    let record = company
+        .runtime
+        .store()
+        .load(company.id())
+        .await
+        .map_err(|e| ApiError(e).into_response())?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "no such company", "code": "not_found" })),
+            )
+                .into_response()
+        })?;
+
+    let mut agents: Vec<MentionableAgentDto> = record
+        .manifest
+        .agents
+        .iter()
+        .filter(|a| !record.is_retired(&a.id))
+        .map(|a| MentionableAgentDto {
+            id: a.id.clone(),
+            // A manifest teammate's id is human-authored (`engineer`, `ceo`),
+            // so it is already the best label there is for one.
+            name: a.name.clone().unwrap_or_else(|| a.id.clone()),
+            role: a.role.clone(),
+        })
+        .collect();
+    agents.extend(
+        record
+            .overlay_agents
+            .iter()
+            .filter(|a| !record.is_retired(&a.id))
+            .map(|a| MentionableAgentDto {
+                id: a.id.clone(),
+                name: a.name.clone(),
+                role: a.role.clone(),
+            }),
+    );
+
+    let mut desks: Vec<MentionableDeskDto> = record
+        .manifest
+        .group_chats
+        .iter()
+        .map(|c| MentionableDeskDto {
+            id: c.id.clone(),
+            name: c.name.clone(),
+            member_ids: record.effective_desk_members(&c.id),
+        })
+        .collect();
+    desks.extend(record.overlay_desks.iter().map(|d| MentionableDeskDto {
+        id: d.id.clone(),
+        name: d.name.clone(),
+        member_ids: record.effective_desk_members(&d.id),
+    }));
+
+    // Sorted by id before the slugs are minted, so the `-2`/`-3` suffix a
+    // colliding label gets is stable between two reads. An unsorted list would
+    // let two people swap suffixes because a store returned them in a different
+    // order, which would move a picker entry under somebody mid-type.
+    let mut users = company
+        .runtime
+        .users()
+        .list_users(company.id())
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    users.sort_by(|a, b| a.id.cmp(&b.id));
+    let slugs = user_slugs(&users);
+    let people = users
+        .iter()
+        .zip(slugs)
+        .map(|(u, slug)| MentionablePersonDto {
+            id: u.id.clone(),
+            label: user_label(u),
+            slug,
+        })
+        .collect();
+
+    Ok(Json(MentionablesDto {
+        agents,
+        people,
+        desks,
+        everyone: MentionableEveryoneDto {
+            label: EVERYONE_ALIASES[0].to_string(),
+            aliases: EVERYONE_ALIASES.iter().map(|a| a.to_string()).collect(),
+        },
+    }))
+}
+
+/// The `401` for a caller with no person behind it.
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "the mention directory is for signed-in people, and this credential names none",
+            "code": "unauthorized",
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::CompanyStore;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    const MANIFEST: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief Executive\"\n\
+         [[agent]]\nid = \"engineer\"\nrole = \"Backend Engineer\"\n\
+         [[group_chat]]\nid = \"engineering\"\nname = \"Engineering\"\n\
+         members = [\"engineer\", \"ceo\"]\n";
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-mentionables-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn call(state: &AppState, signed_in: bool) -> (StatusCode, Value) {
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("/api/v1/company/chat/mentionables");
+        if signed_in {
+            request = request.header("cookie", crate::server::test_support::fixed_cookie("acme"));
+        }
+        let response = router(state.clone())
+            .oneshot(request.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (
+            status,
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_signed_in_member_gets_every_kind_of_target() {
+        let home = home();
+        let state = state(home.path()).await;
+        let (status, body) = call(&state, true).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let agents: Vec<&str> = body["agents"]
+            .as_array()
+            .expect("agents")
+            .iter()
+            .map(|a| a["id"].as_str().expect("id"))
+            .collect();
+        // Containment, not equality: the global baseline roster
+        // (`docs/spec/runtime/globals.md`) is appended to every company, and
+        // those teammates are real teammates — so they are mentionable too.
+        // Pinning the exact list here would fail every time the baseline grows.
+        assert!(agents.contains(&"ceo"), "{agents:?}");
+        assert!(agents.contains(&"engineer"), "{agents:?}");
+        assert_eq!(
+            body["agents"][0]["role"], "Chief Executive",
+            "a row carries the job title, so two similar names stay apart"
+        );
+
+        let desks = body["desks"].as_array().expect("desks");
+        assert_eq!(desks[0]["id"], "engineering");
+        assert_eq!(desks[0]["name"], "Engineering");
+        // The blast radius, so a composer can warn before the send rather than
+        // after it.
+        assert_eq!(
+            desks[0]["memberIds"].as_array().expect("memberIds").len(),
+            2
+        );
+
+        // The seeded admin is a person, and is offered with a label and a slug.
+        let people = body["people"].as_array().expect("people");
+        assert_eq!(people.len(), 1);
+        assert!(people[0]["label"].as_str().is_some_and(|l| !l.is_empty()));
+        assert!(people[0]["slug"].as_str().is_some_and(|s| !s.is_empty()));
+
+        assert_eq!(body["everyone"]["label"], "everyone");
+        let aliases = body["everyone"]["aliases"].as_array().expect("aliases");
+        assert!(aliases.iter().any(|a| a == "channel"));
+        assert!(aliases.iter().any(|a| a == "here"));
+    }
+
+    /// The whole reason this route exists rather than a relaxation of
+    /// `GET {scope}/users`: a person is offered by **label and id only**.
+    #[tokio::test]
+    async fn a_person_row_carries_no_email_role_or_status() {
+        let home = home();
+        let state = state(home.path()).await;
+        let (_, body) = call(&state, true).await;
+
+        let person = &body["people"][0];
+        let keys: Vec<&String> = person.as_object().expect("object").keys().collect();
+        assert_eq!(
+            keys,
+            vec!["id", "label", "slug"],
+            "a mentionable person must carry nothing else: {person}"
+        );
+        assert!(
+            !person.to_string().contains("example.test"),
+            "the login identity must never reach a member: {person}"
+        );
+    }
+
+    /// A machine credential has no composer and no person to be. Same `401`
+    /// the read-state routes answer, for the same reason.
+    #[tokio::test]
+    async fn a_caller_with_no_person_behind_it_is_refused() {
+        let home = home();
+        let state = state(home.path()).await;
+        let (status, body) = call(&state, false).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["code"], "unauthorized");
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -42,6 +42,9 @@ pub mod mcp_registry;
 pub mod memory;
 pub mod memory_engine;
 pub mod memory_ingest;
+/// The `@` picker's directory: every teammate, person, desk and broadcast token
+/// a mention can name, in one member-safe read. See [`mentions`].
+pub mod mentions;
 pub mod pages;
 pub mod policy;
 pub mod read_state;
@@ -220,6 +223,7 @@ pub fn router() -> Router<AppState> {
         .merge(mcp::router())
         .merge(mcp_registry::router())
         .merge(read_state::router())
+        .merge(mentions::router())
         .merge(repos::router())
         .merge(inference::router())
         .merge(team::router())

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -4760,6 +4760,8 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // Tagged to this task — admitted.
         CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id: "t-1".into(),
             agent_id: "ceo".into(),
@@ -4769,6 +4771,8 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // An ordinary chat reply — excluded.
         CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id: "General".into(),
             agent_id: "ceo".into(),
@@ -4778,6 +4782,8 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // Tagged to a different task — excluded.
         CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id: "t-other".into(),
             agent_id: "ceo".into(),
@@ -5615,6 +5621,8 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
             run_id: None,
         },
         CompanyEvent::AgentReply {
+            mentions: Vec::new(),
+            mention_depth: 0,
             parent: None,
             chat_id: "t-1".into(),
             agent_id: "writer".into(),

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -312,6 +312,7 @@ mod tests {
 
     fn operator_message(text: &str) -> CompanyEvent {
         CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             text: text.into(),
             by: Some(Actor {
                 kind: ActorKind::Operator,

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -318,6 +318,7 @@ pub async fn assert_isolation_by_company(
         .append(
             &alpha,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "a".into(),
                 by: None,
@@ -552,6 +553,7 @@ pub async fn assert_append_only_event_and_ledger(
         .append(
             &id,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "e0".into(),
                 by: None,
@@ -565,6 +567,7 @@ pub async fn assert_append_only_event_and_ledger(
         .append(
             &id,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "e1".into(),
                 by: None,
@@ -584,6 +587,7 @@ pub async fn assert_append_only_event_and_ledger(
         .append(
             &id,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "e2".into(),
                 by: None,
@@ -619,6 +623,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
             .append(
                 &alpha,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: format!("a{expected}"),
                     by: None,
@@ -636,6 +641,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
         .append(
             &beta,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "b0".into(),
                 by: None,
@@ -680,6 +686,7 @@ pub async fn assert_event_subscription_surfaces_gap(events: Arc<dyn EventLog>) {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: format!("event {seq}"),
                     by: None,
@@ -714,6 +721,7 @@ pub async fn assert_event_read_before(events: Arc<dyn EventLog>) {
                 .append(
                     &id,
                     CompanyEvent::OperatorMessage {
+                        mentions: Vec::new(),
                         parent: None,
                         text: text.to_string(),
                         by: None,
@@ -985,6 +993,7 @@ pub async fn assert_export_totality(
     let mut appended = Vec::new();
     for i in 0..4 {
         let ev = CompanyEvent::OperatorMessage {
+            mentions: Vec::new(),
             parent: None,
             text: format!("event {i}"),
             by: None,

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -926,6 +926,7 @@ mod test {
         let id = runtime.id().clone();
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "kick off".into(),
                 by: None,
@@ -2041,6 +2042,7 @@ mod test {
         let id = runtime.id().clone();
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -2520,6 +2520,7 @@ mod test {
                 log.append(
                     &id,
                     CompanyEvent::OperatorMessage {
+                        mentions: Vec::new(),
                         parent: None,
                         text: format!("event {i}"),
                         by: None,
@@ -2848,6 +2849,7 @@ mod test {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "a".into(),
                     by: None,
@@ -2861,6 +2863,7 @@ mod test {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "b".into(),
                     by: None,
@@ -2891,6 +2894,7 @@ mod test {
         log.append(
             &id,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,
@@ -2907,6 +2911,7 @@ mod test {
         assert_eq!(
             received.event,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -4469,6 +4469,7 @@ mod test {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "hi".into(),
                     by: None,
@@ -4522,6 +4523,7 @@ mod test {
         s.append(
             &id,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,
@@ -4538,6 +4540,7 @@ mod test {
         assert_eq!(
             received.event,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "hi".into(),
                 by: None,
@@ -4625,6 +4628,7 @@ mod test {
             s.append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    mentions: Vec::new(),
                     parent: None,
                     text: "persist".into(),
                     by: None,
@@ -4642,6 +4646,7 @@ mod test {
         assert_eq!(
             events[0].event,
             CompanyEvent::OperatorMessage {
+                mentions: Vec::new(),
                 parent: None,
                 text: "persist".into(),
                 by: None,


### PR DESCRIPTION
## What

The data model, resolution and read surfaces for Slack-style `@`-mentions in chat.
**Nothing routes, notifies or renders yet** — this is a tested no-op, and the
foundation the next four slices sit on.

Design drawn from [block/buzz](https://github.com/block/buzz) (structured mention
list beside verbatim text, alias union, longest-name-wins, the cap) and
[vercel/chat](https://github.com/vercel/chat) (the bare-mention accept condition,
ambiguity-degrades-to-literal).

## What you can mention

`@teammate`, `@person`, `@#desk`, and `@everyone` / `@channel` / `@here`.

## The shape

`Mention { target, text, offset, quiet }` rides both `OperatorMessage` and
`AgentReply`. The body keeps the literal text the author typed; the mention list
says who it resolved to. Two properties follow, and they are why it is stored
this way rather than re-derived from the body on read:

- **A rename never rewrites history.** `@Jane` stays `@Jane` in the transcript and
  still resolves to the same person after they become `Jane Doe`.
- **Quoting cannot re-ping.** A quote carries text and no mention rows.

`quiet` is buzz's two-tag split (`["p", id]` notifies, `["mention", id]` only
renders) collapsed into one field, because a single list with a flag round-trips
additively where two parallel lists would not.

### Humans have no handle, and this does not mint one

A person here has only a display name — mutable, and not unique. So a mention is
carried by **user id plus byte span**, never by a stored handle, which is also
what makes `@Jane Doe` work with a space in it and no slug at all. `mention_slug`
exists purely as a typing convenience in the picker and a fallback alias for
extraction; it is recomputed on every read and never persisted, so a rename
cannot strand it.

## Two rules the resolver exists to keep

**Never guess a ping.** An `@name` matching two people resolves to nobody and
stays literal text. Silently taking the first match is how a message meant for
one colleague reaches another, and neither of them can tell.

**Never render a chip that does not resolve.** The renderer will highlight the
spans this returns and nothing else, so an `@word` that matched no one draws as
the plain text it is. A chip is a claim that somebody was notified.

## Resolution

Client and server, with the server authoritative and failing closed:

- The **picker** knows the caret and the row a human clicked — the only place
  ambiguity is resolved correctly, by asking. Its answer is re-validated, never
  re-derived.
- **Extraction** is the fallback for everything with no picker: `curl`, the API,
  an older console, and every agent-authored reply.

A supplied target that no longer resolves is **demoted to `quiet`, not dropped**:
the chip goes, the text stays exactly as typed, nobody is pinged. An explicitly
empty list is honoured as an answer — the host does not then guess on the
caller's behalf.

## Additive, in both directions

Every new field is `skip_serializing_if`-omitted when empty, pinned by tests that
assert the exact legacy bytes:

```
{"kind":"OperatorMessage","text":"hello"}
{"kind":"AgentReply","chat_id":"general","agent_id":"ceo","text":"hi"}
```

No stored record migrates. `ChatMessage` has no `deny_unknown_fields`, so a newer
console against an older host degrades to host-side extraction, and an older
console against a newer host gets extraction too.

## `GET {scope}/chat/mentionables`

The picker's directory: teammates, people, desks, and the broadcast token's
spellings (sent as data, so the console does not hard-code them).

Deliberately **not** a relaxation of the admin-gated `GET {scope}/users`. A person
is offered by **id and label only** — no email, no role, no status. That is the
same label `author_labels` already attributes their messages with, so this widens
nothing: anyone who has ever posted is already named to their colleagues exactly
this way. A test asserts the row has precisely the keys `id`, `label`, `slug`.

Signed-in humans only, same `401` as the read-state routes: a machine credential
has no composer and no person to be.

## Not in this PR

Routing (`@engineer` answering instead of the desk lead), notifications, the
badge, the composer picker, chip rendering, presence and typing. `mention_depth`
ships now as the reserved fuse for a future agent-to-agent edge — zero on every
reply, omitted from the wire — so turning that edge on later is not a schema
change made under pressure while chasing a loop.

## Mention loops

Worth stating even though nothing routes yet, because the shape is set here:
`AgentReply.mentions` is populated only by host-side extraction over the reply
text, and `normalize` drops self-mentions. When routing lands it will read
`OperatorMessage.mentions` only — there is no code path from a reply's mentions
to dispatch. The edge does not exist, which is stronger than an edge that is
disabled. buzz's agent prompt has to *ask* agents not to post bare
acknowledgements because their protocol has no dedupe; this has one.

## Commands run

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test                                    # 3497 passed, 0 failed
cargo check --features openhuman --all-targets
cargo check --all-features --all-targets
cargo test -- --ignored regenerate_sdl_snapshot
```

Both gated lanes were checked, not assumed — the `openhuman` and `--all-features`
lanes each turned up event-construction sites the default lane does not compile.

**No new cargo feature**, so `scripts/ci/feature-lanes.txt` needs no row and
`assert-feature-lanes.sh` stays green (issue #770's trap — checked, not assumed).
All new code is in `src/runtime/`, `src/server/`, `src/ports/`, which the default
lane builds and runs.

## Tests

- `src/runtime/mentions.rs` — 44 tests: `user@host.com` is not a mention; a
  mention inside a fenced block or inline code is not, **and the surrounding
  offsets still land correctly**; longest-alias-wins; ambiguity resolves to
  nobody; the sender is dropped; the cap demotes the tail and keeps every span;
  a retired teammate is unmentionable; a stale supplied target is demoted; a
  span not present in the text is dropped.
- `src/ports/types.rs` — the byte-exact additive proofs above, both directions.
- `src/server/chat_history.rs` — a person projects to a label and never an id;
  `mine` is per viewer; `@everyone` is mine for every reader; a departed person
  falls back to the typed text.
- `src/server/ops/mentions.rs` — the directory answers every kind of target, a
  person row carries nothing but id/label/slug, and a machine credential gets 401.

## Untested edge

`MessageMentionGql::offset` saturates at `u32::MAX` (GraphQL has no 64-bit int).
Unreachable — a chat message cannot be 4GB — and asserted only by construction;
the clamp exists so that if it ever were reached the chip lands at the end rather
than at a wrapped-around position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat mention support for agents, people, desks, and broadcast aliases.
  * Added mention suggestions for chat composers.
  * Chat messages now display mention labels, positions, ownership, and quiet status.
  * Added mention data to GraphQL chat responses.
  * Added validation, routing, duplicate prevention, and a 50-mention limit.

* **Bug Fixes**
  * Prevented self-mentions from creating response loops.
  * Improved handling of renamed, inactive, ambiguous, or unavailable mention targets.
  * Preserved compatibility with existing chat history and event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->