### PR TITLE
fix(overview): use full task labels

### DIFF
--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -46,12 +46,13 @@ except the node under the pointer. Every node keeps a `<title>`, so a native
 tooltip is the floor wherever a drawn label is suppressed. Tasks, workflow stages and tools are the numerous tiers, which is
 why they are bare until you point at one.
 
-Whatever that leaves is then decluttered: candidates are placed highest
-priority first and any label whose box overlaps one already placed is dropped
-rather than nudged. The pass measures in **screen px**, not graph units —
-labels hold one on-screen size at every camera depth (`fixedLabel` counter
-scales through `--kg-cam-k`), so zooming changes how far apart nodes are and
-never how wide a name is. `kg/label-plan.ts` holds both steps, pure.
+Whatever that leaves is then decluttered: candidates retain their full titles,
+are placed highest priority first, and any label whose box overlaps one already
+placed is dropped rather than nudged. The pass measures in **screen px**, not
+graph units — labels hold one on-screen size at every camera depth
+(`fixedLabel` counter-scales through `--kg-cam-k`), so zooming changes how far
+apart nodes are and never how wide a name is. `kg/label-plan.ts` holds both
+steps, pure.
 
 ## What is derived — read this before trusting the org chart
 

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -1879,7 +1879,7 @@ export function KnowledgeGraph({
     const degree = (adjacency.get(n.id)?.size ?? 1) - 1;
     labelCandidates.push({
       id: n.id,
-      text: n.label,
+      text: n.kind === 'task' && n.label.length > 20 ? `${n.label.slice(0, 18).trimEnd()}…` : n.label,
       x: n.x,
       y: n.y,
       dy: v.r + 11 + (labelDy.get(n.id) ?? 0),
@@ -2313,7 +2313,7 @@ export function KnowledgeGraph({
                   fill={hoverId === n.id ? 'var(--text)' : n.kind === 'team' ? color : 'var(--text-2)'}
                   style={fixedLabel(labelFontPx(n.kind))}
                 >
-                  {n.label}
+                  {n.kind === 'task' && n.label.length > 20 ? `${n.label.slice(0, 18).trimEnd()}…` : n.label}
                 </text>
               )}
             </g>

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -1879,7 +1879,7 @@ export function KnowledgeGraph({
     const degree = (adjacency.get(n.id)?.size ?? 1) - 1;
     labelCandidates.push({
       id: n.id,
-      text: n.kind === 'task' && n.label.length > 20 ? `${n.label.slice(0, 18).trimEnd()}…` : n.label,
+      text: n.label,
       x: n.x,
       y: n.y,
       dy: v.r + 11 + (labelDy.get(n.id) ?? 0),
@@ -2313,7 +2313,7 @@ export function KnowledgeGraph({
                   fill={hoverId === n.id ? 'var(--text)' : n.kind === 'team' ? color : 'var(--text-2)'}
                   style={fixedLabel(labelFontPx(n.kind))}
                 >
-                  {n.kind === 'task' && n.label.length > 20 ? `${n.label.slice(0, 18).trimEnd()}…` : n.label}
+                  {n.label}
                 </text>
               )}
             </g>

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -85,11 +85,6 @@ const EDGE_COLOR: Record<string, string> = {
   reports: 'var(--accent)',
 };
 
-// Task titles are whole jobs ("Broadcast directives across the fleet") — trim
-// for the on-canvas label; the full title lives in the hover tooltip + card.
-const shortLabel = (n: KGNode) =>
-  n.kind === 'task' && n.label.length > 20 ? `${n.label.slice(0, 18).trimEnd()}…` : n.label;
-
 // On-screen label size per tier, in px. Quoted at rest and held there at every
 // camera depth by `fixedLabel`, which is why the declutter can measure in px.
 const labelFontPx = (kind: KGNodeKind): number =>
@@ -1884,7 +1879,7 @@ export function KnowledgeGraph({
     const degree = (adjacency.get(n.id)?.size ?? 1) - 1;
     labelCandidates.push({
       id: n.id,
-      text: shortLabel(n),
+      text: n.label,
       x: n.x,
       y: n.y,
       dy: v.r + 11 + (labelDy.get(n.id) ?? 0),
@@ -2318,7 +2313,7 @@ export function KnowledgeGraph({
                   fill={hoverId === n.id ? 'var(--text)' : n.kind === 'team' ? color : 'var(--text-2)'}
                   style={fixedLabel(labelFontPx(n.kind))}
                 >
-                  {shortLabel(n)}
+                  {n.label}
                 </text>
               )}
             </g>

--- a/frontend/src/views/overview/kg/label-plan.ts
+++ b/frontend/src/views/overview/kg/label-plan.ts
@@ -51,7 +51,7 @@ export type LabelCamera = { x: number; y: number; w: number };
 
 export type LabelCandidate = {
   id: string;
-  /** the text as rendered (already shortened, if the caller shortens it) */
+  /** the complete text the component renders */
   text: string;
   /** the node's centre, in graph units */
   x: number;

--- a/frontend/test/unit/overview-graph-labels.test.ts
+++ b/frontend/test/unit/overview-graph-labels.test.ts
@@ -111,10 +111,13 @@ describe("planLabels", () => {
     );
   });
 
-  it("collides on the rendered width, so a long name costs its neighbour", () => {
-    const neighbour = cand({ id: "neighbour", x: 100, priority: LABEL_PRIORITY.worker });
+  it("costs task labels at their full rendered width", () => {
+    const neighbour = cand({ id: "neighbour", x: 80, priority: LABEL_PRIORITY.worker });
     const short = cand({ id: "named", x: 0, text: "A", priority: LABEL_PRIORITY.hovered });
-    const long = { ...short, text: "A".repeat(40) };
+    const long = {
+      ...short,
+      text: "Draft Q3 pricing experiment",
+    };
     expect(idSet(planLabels([short, neighbour], { x: 0, y: 0, w: W }, W))).toEqual(
       new Set(["named", "neighbour"]),
     );

--- a/frontend/test/unit/overview-task-labels.test.ts
+++ b/frontend/test/unit/overview-task-labels.test.ts
@@ -46,18 +46,31 @@ afterEach(() => {
   host.remove();
 });
 
+/**
+ * The d3 layout starts after mounting and its tick handler is raf-throttled,
+ * so the first nodes need at least two animation frames to reach the DOM. A
+ * fixed delay races that, so poll until the node appears instead.
+ */
+async function waitForTaskTitle(timeoutMs = 2_000): Promise<SVGTitleElement> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const found = [...host.querySelectorAll("title")].find((el) => el.textContent === TASK_TITLE);
+    if (found) return found as unknown as SVGTitleElement;
+    if (Date.now() > deadline) {
+      throw new Error(`the task node was not rendered within ${timeoutMs}ms`);
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 16));
+    });
+  }
+}
+
 describe("task labels", () => {
   it("renders the complete title when the task is named", async () => {
-    // The graph starts its d3 layout after mounting, so wait for its first
-    // tick to populate the SVG nodes.
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    });
-    const title = [...host.querySelectorAll("title")].find((el) => el.textContent === TASK_TITLE);
-    expect(title, "the task node must be rendered").toBeDefined();
+    const title = await waitForTaskTitle();
 
     act(() => {
-      title!.parentElement!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      title.parentElement!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
     });
 
     const labels = [...host.querySelectorAll("text")].map((el) => el.textContent);

--- a/frontend/test/unit/overview-task-labels.test.ts
+++ b/frontend/test/unit/overview-task-labels.test.ts
@@ -47,7 +47,12 @@ afterEach(() => {
 });
 
 describe("task labels", () => {
-  it("renders the complete title when the task is named", () => {
+  it("renders the complete title when the task is named", async () => {
+    // The graph starts its d3 layout after mounting, so wait for its first
+    // tick to populate the SVG nodes.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
     const title = [...host.querySelectorAll("title")].find((el) => el.textContent === TASK_TITLE);
     expect(title, "the task node must be rendered").toBeDefined();
 

--- a/frontend/test/unit/overview-task-labels.test.ts
+++ b/frontend/test/unit/overview-task-labels.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { KnowledgeGraph } from "@/views/overview/kg/KnowledgeGraph";
+import type { KnowledgeGraph as Graph } from "@/views/overview/kg/model";
+
+/**
+ * Issue #1312: a task title was shortened to 18 characters before the label
+ * planner could measure it. Hover makes a task a top-priority candidate, so
+ * this renders the smallest graph that exposes the on-canvas label and guards
+ * both the planner input and the text node it ultimately produces.
+ */
+
+const TASK_TITLE = "Draft Q3 pricing experiment";
+
+const graph: Graph = {
+  nodes: [
+    { id: "self", kind: "self", label: "Acme", ring: 0 },
+    { id: "team:pricing", kind: "team", label: "Pricing", ring: 1, color: "var(--accent)", order: 0 },
+    { id: "task:pricing", kind: "task", label: TASK_TITLE, ring: 2 },
+    { id: "emp:operator", kind: "employee", label: "Operator", ring: 3 },
+  ],
+  edges: [
+    { source: "self", target: "team:pricing", kind: "pillar" },
+    { source: "team:pricing", target: "task:pricing", kind: "sop" },
+    { source: "task:pricing", target: "emp:operator", kind: "does" },
+  ],
+};
+
+let host: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => root.render(createElement(KnowledgeGraph, { graph })));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+});
+
+describe("task labels", () => {
+  it("renders the complete title when the task is named", () => {
+    const title = [...host.querySelectorAll("title")].find((el) => el.textContent === TASK_TITLE);
+    expect(title, "the task node must be rendered").toBeDefined();
+
+    act(() => {
+      title!.parentElement!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    const labels = [...host.querySelectorAll("text")].map((el) => el.textContent);
+    expect(labels).toContain(TASK_TITLE);
+    expect(labels).not.toContain("Draft Q3 pricing e…");
+  });
+});


### PR DESCRIPTION
## Summary
- Pass complete task titles to the knowledge graph label planner and SVG renderer.
- Let the existing screen-space declutter pass suppress labels only when they do not fit.
- Add component and planner coverage for the full task title path.

Closes #1312

## Validation
- pnpm run typecheck
- pnpm run typecheck:unit
- pnpm exec vitest run test/unit/overview-task-labels.test.ts test/unit/overview-graph-labels.test.ts
- pnpm run build

## Scope
Interprets the issue as removing unconditional task-label truncation. It leaves the existing collision and icon-obstacle declutter behavior unchanged.