### PR TITLE
fix(chat): leave message intent unselected

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -454,12 +454,12 @@ export class OpenCompanyClient {
      * `"workflow"` say what the card it opens produces, `"chat"` says it is not
      * a request for work and no card should be opened for it.
      *
-     * Everything except `"once"` reaches the wire; `"once"` and the default are
-     * sent as *nothing at all*. That is what keeps "Do it once" the default: an
-     * unmarked message posts the exact body shape it posted before any of these
-     * controls existed, so the host cannot tell one from a pre-#580 client —
-     * the same omitted-field compatibility rule the deliverable field follows
-     * everywhere (see `CreateTask.deliverable`).
+     * Everything except `"once"` reaches the wire; `"once"` and no selection
+     * are sent as *nothing at all*. That preserves the historical wire shape:
+     * an unmarked message posts exactly what it did before any of these controls
+     * existed, so the host can apply its normal triage without a browser-asserted
+     * override — the same omitted-field compatibility rule the deliverable field
+     * follows everywhere (see `CreateTask.deliverable`).
      *
      * One key, not two. `"chat"` rides `deliverable` rather than arriving as a
      * second `intent` field, so a body cannot claim "build me the workflow" and

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -65,15 +65,12 @@ export function MessageComposer({
   deliverableChoice,
 }: Props) {
   const [draft, setDraft] = useState("");
-  // What the NEXT line is for, and only the next one. It resets to "once"
-  // after every send so neither a workflow request nor a "just chatting" mark
-  // silently carries into the message after it — each is an explicit, per-line
-  // decision.
-  //
-  // "once" is the initial value, and stays it (issue #1152): "Just chatting" is
-  // a third position, not the new default, so an unmarked message is
-  // byte-identical on the wire to one sent before this control existed.
-  const [intent, setIntent] = useState<MessageIntent>("once");
+  // What the NEXT line is for, and only the next one. It starts and resets
+  // unselected: an intent is an operator assertion, so no button may claim one
+  // until the operator presses it (issue #984). An unmarked message therefore
+  // reaches the host without an override and lets triage decide whether it is
+  // work or conversation.
+  const [intent, setIntent] = useState<MessageIntent>();
   // The formatting row is opt-in, behind the `Aa` toggle in the icon row. It
   // used to sit open above every composer, which spent the widest strip of the
   // dock on four buttons most lines never use.
@@ -85,7 +82,7 @@ export function MessageComposer({
     if (!text || disabled) return;
     setDraft("");
     onSend(text, deliverableChoice ? intent : undefined);
-    setIntent("once");
+    setIntent(undefined);
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -189,8 +186,8 @@ export function MessageComposer({
                   // "Just chatting" leads, because it is the position that
                   // withholds: the operator reaches for it to stop something
                   // happening, and a control you press to prevent an action
-                  // belongs before the ones that cause it. It is NOT pre-pressed
-                  // — "Do it once" stays the default.
+                  // belongs before the ones that cause it. None is pre-pressed:
+                  // an operator has to state which outcome they want.
                   { value: "chat", label: "Just chatting" },
                   { value: "once", label: "Do it once" },
                   { value: "workflow", label: "Build me the workflow" },

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -50,7 +50,7 @@ backend, and there is no per-channel routing on the host.
 | Threads | A reply posts its `parent` — the parent message's own id — and comes back under it. Both halves of the exchange hang off the row the thread opened from. |
 | Reactions | One durable row per person per emoji, so a chip says who reacted and whether one of them was you. `POST {scope}/chat/messages/{seq}/reactions` with an explicit `on`, which makes a retry idempotent. |
 | Message ids | A sent message comes back with the id it was journaled under (`messageId`), which is what a thread reply or a reaction names. Until the id lands the row's reply/react actions are disabled and say why. |
-| Message intent | The composer's three positions — "Just chatting" / "Do it once" / "Build me the workflow" — travel as `deliverable` on the message and are journaled with it. Only a non-default value is sent, so an unmarked line is byte-identical on the wire to a pre-#580 one. `chat` withholds the card the host would otherwise open by construction; it does **not** take the orchestrator's own `spawn_task` away, so it means "not automatically carded", not "never carded". |
+| Message intent | The composer's three positions — "Just chatting" / "Do it once" / "Build me the workflow" — travel as `deliverable` on the message and are journaled with it. None starts selected: an unmarked line leaves no operator override, so the host's triage decides whether to open a card. `chat` withholds the card the host would otherwise open by construction; it does **not** take the orchestrator's own `spawn_task` away, so it means "not automatically carded", not "never carded". |
 
 **Still console-local:**
 

--- a/frontend/test/unit/chat-deliverable-choice.test.ts
+++ b/frontend/test/unit/chat-deliverable-choice.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OpenCompanyClient } from "@/api/client";
 import type { MessageIntent } from "@/api/tasks";
+import { MessageComposer } from "@/views/chat/MessageComposer";
 import type { ChannelKind } from "@/views/chat/model";
 import { offersDeliverableChoice } from "@/views/chat/model";
 
@@ -112,5 +117,77 @@ describe("client.chat — what the composer's choice puts on the wire", () => {
    */
   it("never puts a second intent field beside the deliverable", async () => {
     expect(await chatBody("chat")).not.toHaveProperty("intent");
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+let sent: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  sent = vi.fn();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function renderComposer() {
+  await act(async () => {
+    root.render(
+      createElement(MessageComposer, {
+        placeholder: "Message engineering",
+        deliverableChoice: true,
+        onSend: sent,
+      }),
+    );
+  });
+}
+
+async function send(text: string) {
+  const input = container.querySelector("textarea") as HTMLTextAreaElement;
+  const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  await act(async () => {
+    setValue?.call(input, text);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await act(async () => {
+    (container.querySelector('[aria-label="Send"]') as HTMLButtonElement).click();
+  });
+}
+
+describe("composer intent selection (issue #984)", () => {
+  it("starts unselected, sends no override, and resets to unselected after a choice", async () => {
+    await renderComposer();
+
+    for (const intent of ["chat", "once", "workflow"]) {
+      expect(
+        container.querySelector(`[data-testid="composer-deliverable-${intent}"]`)?.getAttribute(
+          "aria-pressed",
+        ),
+      ).toBe("false");
+    }
+
+    await send("ordinary message");
+    expect(sent).toHaveBeenLastCalledWith("ordinary message", undefined);
+
+    await act(async () => {
+      (container.querySelector('[data-testid="composer-deliverable-workflow"]') as HTMLButtonElement).click();
+    });
+    await send("make it reusable");
+    expect(sent).toHaveBeenLastCalledWith("make it reusable", "workflow");
+
+    for (const intent of ["chat", "once", "workflow"]) {
+      expect(
+        container.querySelector(`[data-testid="composer-deliverable-${intent}"]`)?.getAttribute(
+          "aria-pressed",
+        ),
+      ).toBe("false");
+    }
   });
 });

--- a/frontend/test/unit/chat-deliverable-choice.test.ts
+++ b/frontend/test/unit/chat-deliverable-choice.test.ts
@@ -87,11 +87,10 @@ async function chatBody(intent?: MessageIntent) {
  * `"chat"` is that control, and these pin the only thing the console decides
  * about it: which values reach the body.
  *
- * The omission half is the compatibility guarantee. "Do it once" is the default
- * *because nothing is sent for it*, so an unmarked message posts a body
- * byte-identical to one from a console that predates every one of these
- * controls — which is what lets the host treat an absent field as "no choice"
- * rather than having to tell two kinds of client apart.
+ * The omission half is the compatibility guarantee. Both "Do it once" and no
+ * selection send nothing, so an unmarked message posts a body byte-identical to
+ * one from a console that predates every one of these controls. The host can
+ * therefore apply its normal triage without having to distinguish client ages.
  */
 describe("client.chat — what the composer's choice puts on the wire", () => {
   it("sends the new chat intent explicitly, under the existing key", async () => {


### PR DESCRIPTION
## Summary

- leave all three composer intent choices unselected initially and after each send
- send no operator override for an unmarked message, allowing normal host triage to decide whether it is work or conversation
- add a DOM regression test covering the unselected state, ordinary send, explicit workflow choice, and reset

Closes #984

## Validation

- `pnpm vitest run test/unit/chat-deliverable-choice.test.ts`
- `pnpm typecheck:unit`
- `pnpm typecheck`
- `pnpm build`

## Scope

This implements the remaining composer-default requirement. The classifier, explicit Just chatting override, and dismissible card chip were already present on `main`; bulk cleanup of existing cards is deliberately left out because the issue specifies an operator-reviewed flow and no such selection/review contract is implemented here.