### PR TITLE
fix(harness): scope workflow publish refusals

### DIFF
--- a/src/harness/built_in/publish.rs
+++ b/src/harness/built_in/publish.rs
@@ -310,7 +310,7 @@ pub struct PendingPublishQueue {
     /// the load-bearing part: a refused file is by definition **not** staged,
     /// so it must not be visible to [`sources`](Self::sources). See that
     /// method's note.
-    refusals: Arc<Mutex<Vec<String>>>,
+    refusals: Arc<Mutex<BTreeMap<PublishRefusalScope, Vec<String>>>>,
     destination: Arc<Mutex<PublishDestination>>,
 }
 
@@ -331,7 +331,12 @@ impl PendingPublishQueue {
     /// agent-facing copy and will be reworded, and the day it is, the operator's
     /// notice silently stops appearing with every test still green.
     pub fn push_refusal(&self, source: String) {
-        self.refusals.lock().expect("publish refusals").push(source);
+        self.refusals
+            .lock()
+            .expect("publish refusals")
+            .entry(Self::current_refusal_scope())
+            .or_default()
+            .push(source);
     }
 
     /// Takes every refusal recorded so far (FIFO), emptying the bucket.
@@ -343,7 +348,24 @@ impl PendingPublishQueue {
     /// conversation to say it in.
     pub fn drain_refusals(&self) -> Vec<String> {
         let mut guard = self.refusals.lock().expect("publish refusals");
-        std::mem::take(&mut *guard)
+        guard
+            .remove(&Self::current_refusal_scope())
+            .unwrap_or_default()
+    }
+
+    /// Claims one workflow run's refusal bucket.
+    ///
+    /// `PublishArtifactTool` is constructed once for a cached roster agent, so
+    /// it cannot carry a run id. The task-local scope lets its live refusal
+    /// write and this run's drain meet on the same shared queue handle.
+    #[must_use = "the claim discards its run's refused publishes on drop"]
+    pub fn claim_refusals_for_run(&self, run_id: impl Into<String>) -> PublishRefusalClaim {
+        let scope = PublishRefusalScope::Run(run_id.into());
+        self.clear_refusals_in(&scope);
+        PublishRefusalClaim {
+            queue: self.clone(),
+            scope,
+        }
     }
 
     /// Where staged publishes are currently headed.
@@ -380,7 +402,7 @@ impl PendingPublishQueue {
     /// re-run would report a refusal against a turn that never asked.
     pub fn clear(&self) {
         self.inner.lock().expect("publish queue").clear();
-        self.refusals.lock().expect("publish refusals").clear();
+        self.clear_refusals_in(&Self::current_refusal_scope());
     }
 
     /// Drains every staged publish (FIFO), emptying the queue.
@@ -412,6 +434,57 @@ impl PendingPublishQueue {
     /// How many publishes are staged.
     pub fn queued(&self) -> usize {
         self.inner.lock().expect("publish queue").len()
+    }
+
+    fn current_refusal_scope() -> PublishRefusalScope {
+        CURRENT_REFUSAL_SCOPE
+            .try_with(Clone::clone)
+            .unwrap_or(PublishRefusalScope::Unscoped)
+    }
+
+    fn clear_refusals_in(&self, scope: &PublishRefusalScope) {
+        self.refusals.lock().expect("publish refusals").remove(scope);
+    }
+}
+
+/// Which turn owns a refused publish.
+///
+/// The queue handle is shared by cached roster tools, so workflow runs are
+/// separated by an ambient key rather than by replacing that handle per run.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+enum PublishRefusalScope {
+    /// Chat and task turns retain the historical company-wide bucket.
+    #[default]
+    Unscoped,
+    /// One workflow run, keyed by its unique run id.
+    Run(String),
+}
+
+tokio::task_local! {
+    /// The workflow run whose refusal bucket the current task uses.
+    static CURRENT_REFUSAL_SCOPE: PublishRefusalScope;
+}
+
+/// A workflow run's claim on its own refused-publish bucket.
+pub struct PublishRefusalClaim {
+    queue: PendingPublishQueue,
+    scope: PublishRefusalScope,
+}
+
+impl PublishRefusalClaim {
+    /// Runs `fut` in this claim's scope, routing refusal writes and drains to
+    /// this run's bucket even though the tool itself belongs to a cached agent.
+    pub async fn scoped<F, T>(&self, fut: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        CURRENT_REFUSAL_SCOPE.scope(self.scope.clone(), fut).await
+    }
+}
+
+impl Drop for PublishRefusalClaim {
+    fn drop(&mut self) {
+        self.queue.clear_refusals_in(&self.scope);
     }
 }
 

--- a/src/harness/built_in/publish.rs
+++ b/src/harness/built_in/publish.rs
@@ -443,7 +443,10 @@ impl PendingPublishQueue {
     }
 
     fn clear_refusals_in(&self, scope: &PublishRefusalScope) {
-        self.refusals.lock().expect("publish refusals").remove(scope);
+        self.refusals
+            .lock()
+            .expect("publish refusals")
+            .remove(scope);
     }
 }
 

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -726,6 +726,7 @@ impl HarnessAgentRunner {
         blocks: RunBlocks,
         approvals: RunApprovals,
         board_claim: Arc<crate::harness::orchestrator::DelegationClaim>,
+        publish_refusal_claim: Arc<crate::harness::publish::PublishRefusalClaim>,
     ) -> Self {
         Self {
             turn,
@@ -740,6 +741,7 @@ impl HarnessAgentRunner {
             blocks,
             approvals,
             board_claim,
+            publish_refusal_claim,
         }
     }
 
@@ -1812,6 +1814,8 @@ mod tests {
         let queue = deps.approval_requests.clone();
         let notices = RunNotices::default();
         let board_claim = Arc::new(deps.delegations.claim_board("run-1"));
+        let publish_refusal_claim =
+            Arc::new(deps.pending_publishes.claim_refusals_for_run("run-1"));
         let runner = HarnessAgentRunner::new(
             single_turn(&deps),
             deps,
@@ -1825,6 +1829,7 @@ mod tests {
             RunBlocks::default(),
             RunApprovals::default(),
             board_claim,
+            publish_refusal_claim,
         );
 
         // Pushed inside the run's own scope, exactly as its turn would.

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -342,6 +342,14 @@ pub async fn build_capabilities(
         // hard-abort path is when the engine future is dropped: staged-but-undrained
         // writes die with the run, exactly as `ApprovalClaim` treats gated calls.
         let board_claim = Arc::new(deps.delegations.claim_board(run_id.to_string()));
+        // The publish tool is captured by the fingerprint-cached roster agent,
+        // so a workflow run cannot replace its queue handle. Scope only refused
+        // publishes: staged publishes remain unavailable to runs because they
+        // still have no destination to claim.
+        let publish_refusal_claim = Arc::new(
+            deps.pending_publishes
+                .claim_refusals_for_run(run_id.to_string()),
+        );
 
         // `deps` moves in last — the borrows above (`deps.capabilities`,
         // `deps.search`, `deps.meter`, `deps.secrets`, `deps.workspace_root`,
@@ -359,6 +367,7 @@ pub async fn build_capabilities(
             blocks,
             approvals,
             board_claim,
+            publish_refusal_claim,
         ));
         (Arc::new(tools), Arc::new(http), state, Some(agent))
     };
@@ -530,6 +539,10 @@ pub struct HarnessAgentRunner {
     /// claim would let one node destroy a sibling's staged writes. See the
     /// acquisition site for the full reasoning.
     board_claim: Arc<crate::harness::orchestrator::DelegationClaim>,
+    /// The run's refusal bucket on the shared publish queue. The cached
+    /// `PublishArtifactTool` reads this task-local scope when it refuses a
+    /// publish, so sibling runs cannot drain each other's notices.
+    publish_refusal_claim: Arc<crate::harness::publish::PublishRefusalClaim>,
 }
 
 /// Where an agent node leaves a notice for the operator (issue #638).
@@ -1307,7 +1320,8 @@ impl AgentRunner for HarnessAgentRunner {
             self.drain_publish_refusals();
             (outcome, parked)
         });
-        let (outcome, parked) = self.board_claim.scoped(turn).await;
+        let turn = Box::pin(self.board_claim.scoped(turn));
+        let (outcome, parked) = self.publish_refusal_claim.scoped(turn).await;
         // Issue #849: a provider context-window refusal reaches the operator as
         // the run's error text, and the vendor's own wording ("Please start a
         // new chat") is unfollowable in a workflow — there is no chat and no

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -866,32 +866,14 @@ impl HarnessAgentRunner {
     /// three times should name it once, for the reason
     /// [`push_tool`] gives.
     ///
-    /// # Known limitation: the bucket is unscoped
+    /// # Scope
     ///
-    /// The queue handle is shared across every path in the company, and the
-    /// chat cycle's `clear()` at the top of each turn empties it. So a chat
-    /// cycle starting between a node's refusal and this drain can discard the
-    /// notice. That is the **safe** direction and the reason it is left as is:
-    /// the loss is a notice that does not appear, never one attributed to a run
-    /// that did not earn it — a claimed destination records no refusal at all
-    /// (pinned by `a_claimed_destination_records_no_refusal`), so nothing a chat
-    /// or task turn does can *add* to this bucket.
-    ///
-    /// A *different* workflow run can add to it, though: two overlapping runs
-    /// of the same company share this same bucket, and whichever run's
-    /// `drain_publish_refusals` executes first takes every refusal queued so
-    /// far, including one a sibling run just raised — a misattribution, not a
-    /// loss (tracked as issue #1243). Closing it properly is **not** as simple
-    /// as handing each run a private queue at `build_capabilities` time: the
-    /// `agent` node type dispatches through `HarnessPool::run_background` to a
-    /// roster agent built **once** by `HarnessPool::ensure` and cached behind
-    /// fingerprints, so the `PublishArtifactTool` a model's turn actually calls
-    /// captures its `pending_publishes` handle at that cache-build time, not at
-    /// per-run dispatch time — a fork made here never reaches it. The fix needs
-    /// the same *task-local* run scope issue #771 gave the delegation queue
-    /// (`ApprovalScope` / `DelegationScope` / `board_claim.scoped(..)` above),
-    /// read by `push_refusal` at call time rather than baked in at tool
-    /// construction, which is a wider change than this fix.
+    /// The queue handle is shared across every path in the company because the
+    /// cached roster tool captures it at construction time. A run therefore
+    /// claims a task-local refusal scope around its node turn and this drain;
+    /// `push_refusal` reads that scope at call time. Concurrent runs write to
+    /// and drain distinct buckets while chat and task turns retain the default
+    /// bucket and their existing behavior.
     fn drain_publish_refusals(&self) {
         let refusals = self.deps.pending_publishes.drain_refusals();
         let mut seen: Vec<String> = Vec::new();

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -226,13 +226,7 @@ async fn spawn_interleaved_publish_script() -> String {
                             "function": { "name": "publish_artifact", "arguments": json!({ "path": source }).to_string() }
                         }]
                     }),
-                    2 => {
-                        // At this point both tool calls have executed and placed
-                        // their refusals in the queue; releasing either run before
-                        // the other would not reproduce the old cross-run drain.
-                        barrier.wait().await;
-                        json!({ "role": "assistant", "content": "could not publish" })
-                    }
+                    2 => json!({ "role": "assistant", "content": "could not publish" }),
                     _ => json!({ "role": "assistant", "content": "done" }),
                 };
                 Json(json!({

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -180,9 +180,9 @@ async fn run_publishing(dir: &std::path::Path) -> crate::ports::WorkflowRun {
 /// received a refused-publish result, before either can complete and drain.
 ///
 /// The lane comes from the run request, which stays in every provider request.
-/// This deliberately shares one endpoint, one deps handle, and one cached
-/// roster agent: separate pools would evade the construction-time queue handle
-/// that made the production bug possible.
+/// Both agents share one deps handle and therefore one publish queue, while
+/// using distinct roster entries so one agent's serialized turn lock cannot
+/// prevent the other run from reaching the barrier.
 async fn spawn_interleaved_publish_script() -> String {
     let steps = Arc::new(Mutex::new(BTreeMap::<String, usize>::new()));
     let barrier = Arc::new(tokio::sync::Barrier::new(2));

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -32,8 +32,11 @@
 //! credential: the model's *choices*, via the scripted endpoint
 //! [`gated_tool_turn_test`](crate::workflows::gated_tool_turn_test) established.
 
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 
+use axum::Json;
+use axum::routing::post;
 use serde_json::json;
 
 use crate::company::{CompanyManifest, parse_workflow};
@@ -173,6 +176,82 @@ async fn run_publishing(dir: &std::path::Path) -> crate::ports::WorkflowRun {
     .expect("the run settles — a refused publish is not a failed run")
 }
 
+/// A two-lane scripted endpoint that holds both runs after they have each
+/// received a refused-publish result, before either can complete and drain.
+///
+/// The lane comes from the run request, which stays in every provider request.
+/// This deliberately shares one endpoint, one deps handle, and one cached
+/// roster agent: separate pools would evade the construction-time queue handle
+/// that made the production bug possible.
+async fn spawn_interleaved_publish_script() -> String {
+    let steps = Arc::new(Mutex::new(BTreeMap::<String, usize>::new()));
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<serde_json::Value>| {
+            let steps = Arc::clone(&steps);
+            let barrier = Arc::clone(&barrier);
+            async move {
+                let rendered = body.to_string();
+                let (lane, source) = if rendered.contains("run-a") {
+                    ("run-a", "run-a.md")
+                } else if rendered.contains("run-b") {
+                    ("run-b", "run-b.md")
+                } else {
+                    panic!("scripted workflow request did not name a lane: {rendered}");
+                };
+                let step = {
+                    let mut guard = steps.lock().expect("script steps");
+                    let step = guard.entry(lane.to_string()).or_default();
+                    let current = *step;
+                    *step += 1;
+                    current
+                };
+                let message = match step {
+                    0 => json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": format!("write-{lane}"),
+                            "type": "function",
+                            "function": { "name": "file_write", "arguments": json!({ "path": source, "content": "draft" }).to_string() }
+                        }]
+                    }),
+                    1 => json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": format!("publish-{lane}"),
+                            "type": "function",
+                            "function": { "name": "publish_artifact", "arguments": json!({ "path": source }).to_string() }
+                        }]
+                    }),
+                    2 => {
+                        // At this point both tool calls have executed and placed
+                        // their refusals in the queue; releasing either run before
+                        // the other would not reproduce the old cross-run drain.
+                        barrier.wait().await;
+                        json!({ "role": "assistant", "content": "could not publish" })
+                    }
+                    _ => json!({ "role": "assistant", "content": "done" }),
+                };
+                Json(json!({
+                    "choices": [{ "index": 0, "message": message }],
+                    "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind scripted provider");
+    let addr = listener.local_addr().expect("scripted provider address");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://{addr}")
+}
+
 /// **The headline.** A refused publish reaches the operator as a run notice that
 /// names the file.
 ///
@@ -235,6 +314,61 @@ async fn a_workflow_node_whose_publish_was_refused_says_so_on_the_run() {
         "the apology is still the node's text — this test asserts the notice is ADDITIONAL, \
          not that the prose was suppressed: {output}"
     );
+}
+
+/// Concurrent runs keep their refused-publish notices separate even though both
+/// dispatch through one cached roster agent and its one queue handle.
+#[tokio::test]
+async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let base_url = spawn_interleaved_publish_script().await;
+    let (mut deps, _journal) = deps(base_url, dir.path());
+    deps.artifacts = Some(Arc::new(FsOps::new(dir.path())));
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps)
+        .await
+        .expect("roster builds once");
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let a = WorkflowRunContext::new(false);
+    let b = WorkflowRunContext::new(false);
+
+    let (run_a, run_b) = tokio::join!(
+        super::runner::run_workflow(
+            Arc::clone(&pool),
+            deps.clone(),
+            &record,
+            &file,
+            json!({ "request": "run-a" }),
+            &a,
+        ),
+        super::runner::run_workflow(
+            Arc::clone(&pool),
+            deps.clone(),
+            &record,
+            &file,
+            json!({ "request": "run-b" }),
+            &b,
+        ),
+    );
+    let run_a = run_a.expect("run A settles");
+    let run_b = run_b.expect("run B settles");
+
+    for (run, own, sibling) in [
+        (run_a, "run-a.md", "run-b.md"),
+        (run_b, "run-b.md", "run-a.md"),
+    ] {
+        assert!(
+            run.notices.iter().any(|notice| notice.contains(own)),
+            "the run must report its own refused publish: {:?}",
+            run.notices
+        );
+        assert!(
+            !run.notices.iter().any(|notice| notice.contains(sibling)),
+            "the run must not report its sibling's refused publish: {:?}",
+            run.notices
+        );
+    }
 }
 
 /// The run's notice does not come at the cost of the #244 unpublished-work scan:

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -228,7 +228,10 @@ async fn spawn_interleaved_publish_script() -> String {
                             "function": { "name": "publish_artifact", "arguments": json!({ "path": source }).to_string() }
                         }]
                     }),
-                    2 => json!({ "role": "assistant", "content": "could not publish" }),
+                    2 => {
+                        barrier.wait().await;
+                        json!({ "role": "assistant", "content": "could not publish" })
+                    }
                     _ => json!({ "role": "assistant", "content": "done" }),
                 };
                 Json(json!({

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -181,13 +181,10 @@ async fn run_publishing(dir: &std::path::Path) -> crate::ports::WorkflowRun {
     .expect("the run settles — a refused publish is not a failed run")
 }
 
-/// A two-lane scripted endpoint that holds both runs after they have each
-/// received a refused-publish result, before either can complete and drain.
-///
-/// The lane comes from the run request, which stays in every provider request.
-/// Both agents share one deps handle and therefore one publish queue, while
-/// using distinct roster entries so one agent's serialized turn lock cannot
-/// prevent the other run from reaching the barrier.
+/// A scripted endpoint whose per-lane responses let two runs overlap while
+/// they share one publish queue. Each run receives a refused publish before it
+/// completes, so the concurrent join still exercises cross-run isolation
+/// without requiring the provider calls to rendezvous.
 async fn spawn_interleaved_publish_script() -> String {
     let steps = Arc::new(Mutex::new(BTreeMap::<String, usize>::new()));
     let barrier = Arc::new(tokio::sync::Barrier::new(2));

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -183,8 +183,10 @@ async fn run_publishing(dir: &std::path::Path) -> crate::ports::WorkflowRun {
 
 /// A scripted endpoint whose per-lane responses let two runs overlap while
 /// they share one publish queue. Each run receives a refused publish before it
-/// completes, so the concurrent join still exercises cross-run isolation
-/// without requiring the provider calls to rendezvous.
+/// completes; a two-lane barrier holds each run's final response until both
+/// have executed their `publish_artifact`, so either drain is guaranteed to
+/// meet both refusals — the exact cross-run schedule the shared bucket got
+/// wrong.
 async fn spawn_interleaved_publish_script() -> String {
     let steps = Arc::new(Mutex::new(BTreeMap::<String, usize>::new()));
     let barrier = Arc::new(tokio::sync::Barrier::new(2));

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -322,7 +322,7 @@ async fn a_workflow_node_whose_publish_was_refused_says_so_on_the_run() {
 }
 
 /// Concurrent runs keep their refused-publish notices separate even though both
-/// dispatch through one cached roster agent and its one queue handle.
+/// dispatch through one cached roster and its one queue handle.
 #[tokio::test]
 async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -97,8 +97,13 @@ mode = "full"
 allow = ["files"]
 
 [[agent]]
-id = "ceo"
-role = "Chief Executive"
+id = "ceo-a"
+role = "Chief Executive A"
+tier = "orchestrator"
+
+[[agent]]
+id = "ceo-b"
+role = "Chief Executive B"
 tier = "orchestrator"
 "#,
     )

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -345,7 +345,7 @@ async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
             Arc::clone(&pool),
             deps.clone(),
             &record,
-            &file,
+            &file_a,
             json!({ "request": "run-a" }),
             &a,
         ),

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -353,7 +353,7 @@ async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
             Arc::clone(&pool),
             deps.clone(),
             &record,
-            &file,
+            &file_b,
             json!({ "request": "run-b" }),
             &b,
         ),

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -64,8 +64,6 @@ kind = "agent"
 name = "Work"
 summary = "Draft the launch spec."
 agent = "ceo"
-[[node]]
-id = "done"
 kind = "output"
 name = "Done"
 [[edge]]

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -63,7 +63,7 @@ id = "work"
 kind = "agent"
 name = "Work"
 summary = "Draft the launch spec."
-agent = "ceo"
+agent = "ceo-a"
 [[node]]
 id = "done"
 kind = "output"

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -64,6 +64,8 @@ kind = "agent"
 name = "Work"
 summary = "Draft the launch spec."
 agent = "ceo"
+[[node]]
+id = "done"
 kind = "output"
 name = "Done"
 [[edge]]

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -187,10 +187,12 @@ async fn run_publishing(dir: &std::path::Path) -> crate::ports::WorkflowRun {
 /// without requiring the provider calls to rendezvous.
 async fn spawn_interleaved_publish_script() -> String {
     let steps = Arc::new(Mutex::new(BTreeMap::<String, usize>::new()));
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let app = axum::Router::new().route(
         "/chat/completions",
         post(move |Json(body): Json<serde_json::Value>| {
             let steps = Arc::clone(&steps);
+            let barrier = Arc::clone(&barrier);
             async move {
                 let rendered = body.to_string();
                 let (lane, source) = if rendered.contains("run-a") {

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -187,12 +187,10 @@ async fn run_publishing(dir: &std::path::Path) -> crate::ports::WorkflowRun {
 /// without requiring the provider calls to rendezvous.
 async fn spawn_interleaved_publish_script() -> String {
     let steps = Arc::new(Mutex::new(BTreeMap::<String, usize>::new()));
-    let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let app = axum::Router::new().route(
         "/chat/completions",
         post(move |Json(body): Json<serde_json::Value>| {
             let steps = Arc::clone(&steps);
-            let barrier = Arc::clone(&barrier);
             async move {
                 let rendered = body.to_string();
                 let (lane, source) = if rendered.contains("run-a") {

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -324,7 +324,7 @@ async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
         .await
         .expect("roster builds once");
     let file_a = parse_workflow(AGENT_GRAPH).expect("graph parses");
-    let graph_b = AGENT_GRAPH.replace("agent = \\\"ceo-a\\\"", "agent = \\\"ceo-b\\\"");
+    let graph_b = AGENT_GRAPH.replace("agent = \"ceo-a\"", "agent = \"ceo-b\"");
     let file_b = parse_workflow(&graph_b).expect("graph parses");
     let a = WorkflowRunContext::new(false);
     let b = WorkflowRunContext::new(false);

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -334,8 +334,9 @@ async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
     pool.ensure(&record, &deps)
         .await
         .expect("roster builds once");
-    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
-    let a = WorkflowRunContext::new(false);
+    let file_a = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let mut graph_b = AGENT_GRAPH.replace("agent = \\\"ceo-a\\\"", "agent = \\\"ceo-b\\\"");
+    let file_b = parse_workflow(&graph_b).expect("graph parses");
     let b = WorkflowRunContext::new(false);
 
     let (run_a, run_b) = tokio::join!(

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -231,6 +231,10 @@ async fn spawn_interleaved_publish_script() -> String {
                         }]
                     }),
                     2 => {
+                        // Both tool calls have executed and their refusals are
+                        // queued; releasing one run before the other would let
+                        // the first drain a bucket that had only one entry, and
+                        // a reverted shared-bucket implementation would pass.
                         barrier.wait().await;
                         json!({ "role": "assistant", "content": "could not publish" })
                     }

--- a/src/workflows/publish_refusal_notice_test.rs
+++ b/src/workflows/publish_refusal_notice_test.rs
@@ -335,8 +335,9 @@ async fn concurrent_workflow_runs_do_not_take_each_others_publish_refusals() {
         .await
         .expect("roster builds once");
     let file_a = parse_workflow(AGENT_GRAPH).expect("graph parses");
-    let mut graph_b = AGENT_GRAPH.replace("agent = \\\"ceo-a\\\"", "agent = \\\"ceo-b\\\"");
+    let graph_b = AGENT_GRAPH.replace("agent = \\\"ceo-a\\\"", "agent = \\\"ceo-b\\\"");
     let file_b = parse_workflow(&graph_b).expect("graph parses");
+    let a = WorkflowRunContext::new(false);
     let b = WorkflowRunContext::new(false);
 
     let (run_a, run_b) = tokio::join!(


### PR DESCRIPTION
## Summary

- route refused `publish_artifact` calls through a run-keyed task-local bucket on the shared cached-agent queue
- scope workflow node turns and their refusal drains to that bucket
- add an end-to-end concurrent-run regression that synchronizes both refusals before either run drains

Closes #1243

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --features openhuman workflows::publish_refusal_notice_test -- --nocapture` *(attempted repeatedly; blocked waiting for another process's Cargo package/build lock in the shared target cache)*

## Scope

This keeps workflow publishes unclaimed: runs still cannot publish deliverables because they have no card destination. It scopes only the refusal notices so concurrent runs cannot attribute each other's failures.