### PR TITLE
ci: use measured stack floor in gated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,11 +785,6 @@ jobs:
     name: Rust (openhuman, tinymemory)
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    env:
-      # OpenHuman's agent loop requires the same stack its production runtimes
-      # allocate. Apply it to every test invocation in this multi-feature job;
-      # Rust's test harness otherwise creates 2 MiB threads.
-      RUST_MIN_STACK: 16777216
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1044,6 +1044,13 @@ jobs:
             unshare --net -- sh -c "ip link set lo up && exec '$binary' --test-threads=1 --nocapture"
         env:
           OPENCOMPANY_OFFLINE_LANE: "1"
+          # This step runs the test binary DIRECTLY (bypassing cargo), so the
+          # tracked floor in `.cargo/config.toml` (issue #895) never reaches it:
+          # cargo applies `[env]` only to processes it launches. Without this,
+          # the OpenHuman agent-turn chain runs on libtest's 2 MiB default and
+          # can SIGABRT the whole binary before the offline lane is exercised
+          # (issue #579).
+          RUST_MIN_STACK: "8388608"
 
       # Catches the combination traps no single feature set can: most often a
       # mandatory struct field constructed differently across feature arms.


### PR DESCRIPTION
## Summary

- Remove the gated Rust job's unmeasured 16 MiB `RUST_MIN_STACK` export.
- Let its Cargo commands inherit the tracked 8 MiB setting, whose 3 MiB suite floor and cross-platform headroom are documented in `.cargo/config.toml`.
- Keep the tracked 8 MiB floor on the one step that launches a test binary directly: the `Run it with no network at all` step executes the discovered `offline_e2e` binary inside a network namespace, bypassing cargo, so `.cargo/config.toml`'s `[env]` would otherwise never reach it and the OpenHuman agent-turn chain would run on libtest's 2 MiB default.

Closes #968

## Validation

- `cargo fmt --all -- --check`
- `scripts/ci/assert-toolchain-pin.sh`
- `git diff upstream/main...HEAD --check`
- Workflow YAML parsed cleanly
- `timeout 180 cargo test --locked --features openhuman --tests` (attempted twice; both cold OpenHuman compilations exceeded the required three-minute cap before tests began, with no test failure or stack overflow)

## Scope

I interpreted the issue's suggested resolution as consolidating CI and local test stack configuration on the documented 8 MiB setting. This change does not claim a new measurement or alter the upstream OpenHuman async-depth root cause.
