### PR TITLE
fix(composio): make feature coverage hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1116,57 +1116,12 @@ jobs:
       # `composio` adds no `openhuman_core/*` subfeature, so there is no vendored
       # rebuild at all.
       #
-      # TWO NARROW FILTERS RATHER THAN THE BARE WORD `composio`, which would be a
-      # substring match sweeping every composio module at once. That wider
-      # selection is what this lane should eventually be, and it cannot be yet:
-      # of the 24, two FAIL. `server::ops::composio::tests::an_admin_is_unaffected`
-      # dials `api.tinyhumans.ai` for real once the feature is on (it passes today
-      # only because the un-gated stub stands in), and the scripted two-toolkit
-      # turn reaches neither provider. Issue #801 has both diagnoses; the wider
-      # filter lands with the fix, not as a red lane (#428).
-      #
-      # These two groups are chosen because they are the ones whose silence cost
-      # the most. `isolation_tests` is per-tenant token isolation — each tenant
-      # only ever carries its own token and sees its own accounts, a rotated
-      # token is scrubbed per call, an error body reflecting the token is
-      # scrubbed. That is the property keeping one company out of another's
-      # Gmail, and it had no runner at all. `ops_helper_tests` is the allowlist
-      # refusals that must happen BEFORE any network call, plus the catalog and
-      # connection projections.
-      #
-      # Separate invocations, each with its own asserted count, for the reason
-      # the ACP step above states: the first bare argument is the filter and a
-      # second would narrow the selection to nothing.
-      - name: Test Composio tenant isolation
-        run: scripts/ci/run-scoped-suite.sh "composio isolation" openhuman,chargebee,paypal,composio harness::built_in::composio::isolation_tests
-
-      - name: Test the Composio ops helpers
-        run: scripts/ci/run-scoped-suite.sh "composio ops helpers" openhuman,chargebee,paypal,composio harness::built_in::composio::ops_helper_tests
-
-      # Issue #820 — which connected account an agent acts as. A third narrow
-      # filter for the same reason the two above are narrow, and the same reason
-      # they exist at all: these assert on the `composio_execute` REQUEST BODY —
-      # that an unpinned toolkit still carries no connection id, and a pinned one
-      # carries the operator's. Both are decidable only under `composio`, so
-      # without a lane they would be twenty-four's worth of silence again, and
-      # the negative half is the one protecting every existing single-account
-      # company from having its account resolution changed.
-      - name: Test which Composio account an execute acts as
-        run: scripts/ci/run-scoped-suite.sh "composio account choice" openhuman,chargebee,paypal,composio harness::built_in::composio::live::live_tests
-
-      # Issue #820 — a fourth narrow filter, and the first outside `harness::`.
-      # The console-plane half of the same decision: the grouping the choice is
-      # reported through, and the cleanup that drops a choice naming an account
-      # Composio no longer lists. Both are gated on `composio`, so before this
-      # step they were compiled by `Check (--all-features)` and run by nothing.
-      #
-      # `…::tests::gated_tests` and not `server::ops::composio`, which would
-      # sweep in `an_admin_is_unaffected` — the one that dials
-      # `api.tinyhumans.ai` for real once the feature is on (#801). The module
-      # exists to be nameable here: a gated ops test added later joins it and is
-      # run, rather than depending on somebody remembering this file.
-      - name: Test the Composio account choice on the console plane
-        run: scripts/ci/run-scoped-suite.sh "composio choice ops" openhuman,chargebee,paypal,composio server::ops::composio::tests::gated_tests
+      # Issue #801 makes the two formerly-red cases hermetic: the console test
+      # uses a loopback authorization endpoint and the scripted turn reaches
+      # both loopback providers. One broad filter therefore covers every
+      # Composio test, including future tests that join this surface.
+      - name: Test Composio
+        run: scripts/ci/run-scoped-suite.sh "composio" openhuman,chargebee,paypal,composio composio
 
       # Issue #914. The `tinymemory` feature binds the engine-neutral
       # `MemoryProvider` contract and adds the `remote`/`null` selection modes

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -60,7 +60,7 @@ acp            | partial      | acp,runner,tinymemory | server::acp harness::acp
 runner         | partial      | acp,runner,tinymemory | runner
 mcp            | partial      | openhuman,mcp,telegram,media    | harness::built_in::build::tests app::types
 media          | partial      | openhuman,mcp,telegram,media    | harness::built_in::build::tests harness::built_in::toolbelt
-composio       | partial      | openhuman,chargebee,paypal,composio | harness::built_in::composio::isolation_tests harness::built_in::composio::ops_helper_tests harness::built_in::composio::live::live_tests server::ops::composio::tests::gated_tests
+composio       | tested       | openhuman,chargebee,paypal,composio | composio
 export         | partial      | export                          | store::export
 imap           | partial      | imap,smtp                       | server::ops::imap
 chargebee      | partial      | openhuman,chargebee,paypal,composio | chargebee server::ops::finance

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -60,7 +60,7 @@ acp            | partial      | acp,runner,tinymemory | server::acp harness::acp
 runner         | partial      | acp,runner,tinymemory | runner
 mcp            | partial      | openhuman,mcp,telegram,media    | harness::built_in::build::tests app::types
 media          | partial      | openhuman,mcp,telegram,media    | harness::built_in::build::tests harness::built_in::toolbelt
-composio       | tested       | openhuman,chargebee,paypal,composio | composio
+composio       | partial      | openhuman,chargebee,paypal,composio | composio
 export         | partial      | export                          | store::export
 imap           | partial      | imap,smtp                       | server::ops::imap
 chargebee      | partial      | openhuman,chargebee,paypal,composio | chargebee server::ops::finance

--- a/src/harness/built_in/composio_turn_test.rs
+++ b/src/harness/built_in/composio_turn_test.rs
@@ -183,7 +183,7 @@ fn github_catalogue() -> Vec<Value> {
         .collect();
     out[97] = action(
         "github",
-        "GITHUB_LIST_ISSUES",
+        "GITHUB_LIST_REPOSITORY_ISSUES",
         "List the issues on a repository, optionally filtered by state.",
     );
     out
@@ -203,7 +203,7 @@ fn notion_catalogue() -> Vec<Value> {
         .collect();
     out[131] = action(
         "notion",
-        "NOTION_SEARCH_PAGES",
+        "NOTION_SEARCH_NOTION_PAGE",
         "Search the pages in a workspace by query text.",
     );
     out
@@ -292,8 +292,9 @@ async fn spawn_composio_backend() -> (String, Arc<ComposioStub>) {
 // ---------------------------------------------------------------------------
 
 /// A one-agent company that explicitly grants `composio` (the catch-all `*`
-/// deliberately does not) and runs in `full` mode, so `composio_execute` is not
-/// parked for operator approval mid-test.
+/// deliberately does not) and runs in `full` mode. The scripted actions use
+/// the provider's curated read slugs, so the policy can classify and run them
+/// rather than conservatively parking an unknown action mid-test.
 fn manifest() -> CompanyManifest {
     toml::from_str(
         r#"
@@ -482,7 +483,7 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
         Turn::Call {
             tool: "composio_execute",
             args: json!({
-                "tool": "GITHUB_LIST_ISSUES",
+                "tool": "GITHUB_LIST_REPOSITORY_ISSUES",
                 "arguments": { "owner": "acme", "state": "open" }
             }),
         },
@@ -494,7 +495,7 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
         Turn::Call {
             tool: "composio_execute",
             args: json!({
-                "tool": "NOTION_SEARCH_PAGES",
+                "tool": "NOTION_SEARCH_NOTION_PAGE",
                 "arguments": { "owner": "acme", "target": "roadmap" }
             }),
         },
@@ -548,7 +549,7 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
 
     // The narrowed step delivered exactly the schema needed to call it.
     assert!(
-        joined.contains("GITHUB_LIST_ISSUES"),
+        joined.contains("GITHUB_LIST_REPOSITORY_ISSUES"),
         "the needle slug never reached the model: {joined}"
     );
     assert!(
@@ -556,7 +557,7 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
         "the parameter schema never reached the model: {joined}"
     );
     assert!(
-        joined.contains("NOTION_SEARCH_PAGES"),
+        joined.contains("NOTION_SEARCH_NOTION_PAGE"),
         "the second toolkit's needle never reached the model: {joined}"
     );
 
@@ -566,8 +567,8 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
     assert_eq!(
         executed,
         vec![
-            "GITHUB_LIST_ISSUES".to_string(),
-            "NOTION_SEARCH_PAGES".to_string()
+            "GITHUB_LIST_REPOSITORY_ISSUES".to_string(),
+            "NOTION_SEARCH_NOTION_PAGE".to_string()
         ],
         "the agent did not reach both providers: {executed:?}; tool results: {results:#?}"
     );

--- a/src/harness/built_in/composio_turn_test.rs
+++ b/src/harness/built_in/composio_turn_test.rs
@@ -569,7 +569,7 @@ async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() 
             "GITHUB_LIST_ISSUES".to_string(),
             "NOTION_SEARCH_PAGES".to_string()
         ],
-        "the agent did not reach both providers: {executed:?}"
+        "the agent did not reach both providers: {executed:?}; tool results: {results:#?}"
     );
 
     // The generic fix, stated as a wire fact: the second Notion listing carried

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1783,7 +1783,7 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "{raw}");
         assert_eq!(resp["status"]["credentialSource"], "static");
 
-        let (status, body, raw) = send(
+        let (status, _body, raw) = send(
             &state,
             "POST",
             "/api/v1/company/composio/authorize",
@@ -1798,8 +1798,8 @@ mod tests {
         );
         #[cfg(feature = "composio")]
         assert_eq!(
-            body["connectUrl"], "https://composio.test/connect/gmail",
-            "the handler returns the loopback backend's authorization URL: {body}"
+            _body["connectUrl"], "https://composio.test/connect/gmail",
+            "the handler returns the loopback backend's authorization URL: {_body}"
         );
         #[cfg(not(feature = "composio"))]
         assert_eq!(

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1246,6 +1246,24 @@ mod tests {
         hundred_entries().into_iter().map(|e| e.slug).collect()
     }
 
+    /// Serialises this test against `an_admin_is_unaffected`'s env mutation.
+    ///
+    /// In composio builds that test repoints `COMPOSIO_BACKEND_URL_ENV` at a
+    /// loopback backend for its whole body. The cache-seeding tests below derive
+    /// a cache key that embeds that URL, seed the cache under it, then re-derive
+    /// the key on the request path — a process-wide override landing between the
+    /// two reads would change the key and strand the seeded entry, failing the
+    /// `catalogSource == "backend"` assertion. `EnvVarGuard` serialises guard
+    /// users against each other, so taking it here closes the race the way the
+    /// crate documents (unguarded `std::env::var` readers are otherwise fair
+    /// game). Gated to composio builds, where the mutation exists.
+    #[cfg(feature = "composio")]
+    fn composio_backend_env_guard() -> crate::test_support::EnvVarGuard {
+        crate::test_support::EnvVarGuard::capture(&[
+            crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
+        ])
+    }
+
     /// The heart of the reopened issue: in open mode the console is offered the
     /// **backend's** catalog, not a list maintained by hand in this repo.
     ///
@@ -1257,6 +1275,8 @@ mod tests {
     /// in favour of the constant.
     #[tokio::test]
     async fn open_mode_serves_the_fetched_catalog_rather_than_a_hardcoded_list() {
+        #[cfg(feature = "composio")]
+        let _env = composio_backend_env_guard();
         let home_dir = home();
         let state = state_with_manifest_id(
             home_dir.path(),
@@ -1306,6 +1326,8 @@ mod tests {
     /// ninety-nine providers it decided against.
     #[tokio::test]
     async fn an_explicit_allowlist_is_never_widened_by_the_catalog() {
+        #[cfg(feature = "composio")]
+        let _env = composio_backend_env_guard();
         let home_dir = home();
         let state = state_with_manifest_id(
             home_dir.path(),
@@ -1337,6 +1359,8 @@ mod tests {
     /// catalog is the failure this pins shut.
     #[tokio::test]
     async fn an_unfetchable_catalog_is_marked_degraded_not_passed_off_as_real() {
+        #[cfg(feature = "composio")]
+        let _env = composio_backend_env_guard();
         let home_dir = home();
         let state = state_with_manifest_id(
             home_dir.path(),
@@ -1387,6 +1411,8 @@ mod tests {
     /// different test.
     #[tokio::test]
     async fn a_credential_change_evicts_the_cached_catalog() {
+        #[cfg(feature = "composio")]
+        let _env = composio_backend_env_guard();
         let home_dir = home();
         let state = state_with_manifest_id(
             home_dir.path(),

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1797,9 +1797,9 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "an admin reaches authorization: {raw}");
         #[cfg(feature = "composio")]
         assert_eq!(
-            _body["connectUrl"],
+            body["connectUrl"],
             "https://composio.test/connect/gmail",
-            "the handler returns the loopback backend's authorization URL: {_body}"
+            "the handler returns the loopback backend's authorization URL: {body}"
         );
         #[cfg(not(feature = "composio"))]
         assert_eq!(

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1006,6 +1006,10 @@ mod tests {
 
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
+    #[cfg(feature = "composio")]
+    use axum::routing::post;
+    #[cfg(feature = "composio")]
+    use axum::{Json, Router};
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
@@ -1023,6 +1027,33 @@ mod tests {
             .prefix("oc-composio-")
             .tempdir()
             .expect("tempdir")
+    }
+
+    /// A loopback Composio authorize endpoint for the feature-enabled route
+    /// test. Keeping the HTTP boundary real proves the handler reaches the
+    /// client after the admin guard, without allowing a unit test to dial the
+    /// production backend.
+    #[cfg(feature = "composio")]
+    async fn spawn_authorize_backend() -> String {
+        let app = Router::new().route(
+            "/agent-integrations/composio/authorize",
+            post(|Json(body): Json<Value>| async move {
+                assert_eq!(body["toolkit"], "gmail");
+                Json(json!({
+                    "success": true,
+                    "data": {
+                        "connectUrl": "https://composio.test/connect/gmail",
+                        "connectionId": "gmail-connection"
+                    }
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
@@ -1724,12 +1755,24 @@ mod tests {
     }
 
     /// The other side of the boundary, and the reason this is a role check
-    /// rather than a removal: an admin still does both things. `authorize`
-    /// answering `409` here is the *build* refusing (no `composio` feature),
-    /// which is exactly the point — it got past the guard and failed later, on
-    /// a different axis than the member's `403`.
+    /// rather than a removal: an admin still does both things. Without the
+    /// feature, `authorize` answers `409` at the build boundary; with it, this
+    /// test supplies a loopback backend and proves the admin reaches the real
+    /// authorization call without dialling production (issue #801).
     #[tokio::test]
     async fn an_admin_is_unaffected() {
+        #[cfg(feature = "composio")]
+        let backend = spawn_authorize_backend().await;
+        #[cfg(feature = "composio")]
+        let env = crate::test_support::EnvVarGuard::capture(&[
+            crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
+        ]);
+        #[cfg(feature = "composio")]
+        env.set(
+            crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
+            &backend,
+        );
+
         let home_dir = home();
         let state = state_with_manifest(home_dir.path(), GRANTED).await;
 
@@ -1743,13 +1786,22 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "{raw}");
         assert_eq!(resp["status"]["credentialSource"], "static");
 
-        let (status, _, raw) = send(
+        let (status, body, raw) = send(
             &state,
             "POST",
             "/api/v1/company/composio/authorize",
             Some(json!({ "toolkit": "gmail" })),
         )
         .await;
+        #[cfg(feature = "composio")]
+        assert_eq!(status, StatusCode::OK, "an admin reaches authorization: {raw}");
+        #[cfg(feature = "composio")]
+        assert_eq!(
+            body["connectUrl"],
+            "https://composio.test/connect/gmail",
+            "the handler returns the loopback backend's authorization URL: {body}"
+        );
+        #[cfg(not(feature = "composio"))]
         assert_eq!(
             status,
             StatusCode::CONFLICT,

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1768,10 +1768,7 @@ mod tests {
             crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
         ]);
         #[cfg(feature = "composio")]
-        env.set(
-            crate::company::composio::COMPOSIO_BACKEND_URL_ENV,
-            &backend,
-        );
+        env.set(crate::company::composio::COMPOSIO_BACKEND_URL_ENV, &backend);
 
         let home_dir = home();
         let state = state_with_manifest(home_dir.path(), GRANTED).await;
@@ -1794,11 +1791,14 @@ mod tests {
         )
         .await;
         #[cfg(feature = "composio")]
-        assert_eq!(status, StatusCode::OK, "an admin reaches authorization: {raw}");
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "an admin reaches authorization: {raw}"
+        );
         #[cfg(feature = "composio")]
         assert_eq!(
-            body["connectUrl"],
-            "https://composio.test/connect/gmail",
+            body["connectUrl"], "https://composio.test/connect/gmail",
             "the handler returns the loopback backend's authorization URL: {body}"
         );
         #[cfg(not(feature = "composio"))]

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1682,7 +1682,7 @@ mod tests {
         )
         .await;
 
-        let (status, _body, raw) = send(
+        let (status, body, raw) = send(
             &state,
             "POST",
             "/api/v1/company/composio/authorize",

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1682,7 +1682,7 @@ mod tests {
         )
         .await;
 
-        let (status, body, raw) = send(
+        let (status, _body, raw) = send(
             &state,
             "POST",
             "/api/v1/company/composio/authorize",
@@ -1797,9 +1797,9 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "an admin reaches authorization: {raw}");
         #[cfg(feature = "composio")]
         assert_eq!(
-            body["connectUrl"],
+            _body["connectUrl"],
             "https://composio.test/connect/gmail",
-            "the handler returns the loopback backend's authorization URL: {body}"
+            "the handler returns the loopback backend's authorization URL: {_body}"
         );
         #[cfg(not(feature = "composio"))]
         assert_eq!(


### PR DESCRIPTION
## Summary
- route the feature-enabled admin authorization test to a loopback Composio backend, proving the real client path without contacting production
- update the scripted two-toolkit turn to use the provider's curated read-action slugs, so the approval policy permits the intended mocked execute calls
- widen the Composio CI lane and feature-lane record to cover the complete Composio test surface

Closes #801.

## Validation
- cargo fmt --all -- --check
- cargo test --locked --features openhuman,chargebee,paypal,composio --lib an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits
- cargo test --locked --features openhuman,chargebee,paypal,composio --lib an_admin_is_unaffected
- scripts/ci/run-scoped-suite.sh "composio" openhuman,chargebee,paypal,composio composio

## Scope
The scripted fixture now names the current curated read actions rather than obsolete uncurated aliases. This keeps the test focused on discovery and dispatch; unknown provider actions remain conservatively approval-gated in production.