### PR TITLE
feat(chat): a mentioned teammate answers, instead of the desk lead

### DIFF
--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -2847,6 +2847,7 @@ impl HarnessBrain {
                     text,
                     chat,
                     deliverable,
+                    mentions,
                     ..
                 } => {
                     // Issue #416: a workflow copilot thread is answered by a
@@ -2879,8 +2880,38 @@ impl HarnessBrain {
                         channel_responses.push(confined_bubble(outcome));
                         continue;
                     }
-                    // Route to the addressed desk's lead, else the orchestrator.
-                    let responder = self.responder_for(chat.as_deref());
+                    // Route to the teammate the message named, else to the
+                    // addressed desk's lead, else the orchestrator.
+                    //
+                    // Naming somebody in a room is a stronger address than the
+                    // room's default answerer, so a mention outranks the desk
+                    // lead. That is the same explicit-beats-implicit ordering
+                    // `responder_for` already applies between an addressed desk
+                    // and the orchestrator (issue #884) — one more rung at the
+                    // top of the existing ladder, not a second competing notion
+                    // of who a message is for.
+                    //
+                    // Resolves nothing on a message that mentions no teammate,
+                    // which is every message journaled before mentions existed,
+                    // so routing is unchanged byte-for-byte for them.
+                    let responder = crate::runtime::mentions::mention_responder(
+                        &self.record(),
+                        mentions,
+                    )
+                    .unwrap_or_else(|| self.responder_for(chat.as_deref()));
+                    // Everyone else the message named, for the answering turn's
+                    // context. A list, not a fan-out: one operator message still
+                    // spawns exactly one turn, and this teammate spreads the
+                    // work — if it should — through the existing gated
+                    // delegation seam rather than through a new uncontrolled
+                    // one. `@everyone` expands here, against the addressed
+                    // desk's membership.
+                    let also_mentioned = crate::runtime::mentions::mentioned_agents(
+                        &self.record(),
+                        chat.as_deref().unwrap_or(crate::server::ops::language::DEFAULT_DESK),
+                        mentions,
+                        Some(&responder),
+                    );
                     // The chat/desk thread this turn answers — the same id the
                     // reply is journaled under (`AgentReply.chat_id`). Passed into
                     // the pool so the live turn-stream frames carry it and the
@@ -2957,6 +2988,9 @@ impl HarnessBrain {
                         // "this is not work", which the runtime has to honour or
                         // the console's promise holds on one surface only.
                         .requested(*deliverable)
+                        // Who else this message named (issue: mentions). Context
+                        // for the turn, never a second dispatch.
+                        .also_mentioned(also_mentioned)
                         .handle_operator_message(&responder, text, chat_id)
                         .await?;
                     let mut operator_steps = turn.steps;
@@ -5728,6 +5762,93 @@ members = ["engineer"]
             cycle.is_err(),
             "a cycle must fail when the record cannot be read, rather than \
              quietly routing on a stale one"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Mention routing: naming somebody outranks the desk lead
+    // -----------------------------------------------------------------------
+
+    fn mention_of(id: &str) -> crate::ports::types::Mention {
+        crate::ports::types::Mention {
+            target: crate::ports::types::MentionTarget::Agent { id: id.to_string() },
+            text: format!("@{id}"),
+            offset: 0,
+            quiet: false,
+        }
+    }
+
+    /// The whole point of the feature: `@engineer` in the main line is answered
+    /// by the engineer, not by the orchestrator that would otherwise take it.
+    #[test]
+    fn a_mentioned_teammate_answers_instead_of_the_default_responder() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        // Without a mention, the orchestrator answers an unaddressed message.
+        assert_eq!(brain.responder_for(None), "chief");
+        // With one, the named teammate does.
+        assert_eq!(
+            crate::runtime::mentions::mention_responder(&brain.record(), &[mention_of("engineer")]),
+            Some("engineer".to_string()),
+        );
+    }
+
+    /// And it outranks the *desk lead*, which is the stronger claim: a message
+    /// addressed to a desk still goes to the teammate it names.
+    #[test]
+    fn a_mention_outranks_the_addressed_desks_lead() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        assert_eq!(brain.responder_for(Some("eng_desk")), "engineer");
+        assert_eq!(
+            crate::runtime::mentions::mention_responder(&brain.record(), &[mention_of("ceo")]),
+            Some("ceo".to_string()),
+            "the named teammate answers even on a desk with its own lead",
+        );
+    }
+
+    /// A message that mentions nobody routes exactly as it did before mentions
+    /// existed — which is every message already in every journal.
+    #[test]
+    fn a_message_with_no_mentions_routes_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        assert_eq!(
+            crate::runtime::mentions::mention_responder(&brain.record(), &[]),
+            None,
+            "so the caller falls through to responder_for",
+        );
+        assert_eq!(brain.responder_for(Some("eng_desk")), "engineer");
+        assert_eq!(brain.responder_for(None), "chief");
+    }
+
+    /// `@everyone` names the addressed desk's teammates for the turn's context
+    /// — and still leaves exactly one responder, because it is a list and not a
+    /// fan-out.
+    #[test]
+    fn everyone_names_the_desk_without_choosing_a_responder() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        let mentions = [crate::ports::types::Mention {
+            target: crate::ports::types::MentionTarget::Everyone,
+            text: "@everyone".to_string(),
+            offset: 0,
+            quiet: false,
+        }];
+        assert_eq!(
+            crate::runtime::mentions::mention_responder(&brain.record(), &mentions),
+            None,
+            "a broadcast names no single teammate, so the desk lead still answers",
+        );
+        assert_eq!(
+            crate::runtime::mentions::mentioned_agents(
+                &brain.record(),
+                "eng_desk",
+                &mentions,
+                Some("engineer"),
+            ),
+            Vec::<String>::new(),
+            "the only member is the responder, and it is not told it was mentioned",
         );
     }
 

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -2894,11 +2894,9 @@ impl HarnessBrain {
                     // Resolves nothing on a message that mentions no teammate,
                     // which is every message journaled before mentions existed,
                     // so routing is unchanged byte-for-byte for them.
-                    let responder = crate::runtime::mentions::mention_responder(
-                        &self.record(),
-                        mentions,
-                    )
-                    .unwrap_or_else(|| self.responder_for(chat.as_deref()));
+                    let responder =
+                        crate::runtime::mentions::mention_responder(&self.record(), mentions)
+                            .unwrap_or_else(|| self.responder_for(chat.as_deref()));
                     // Everyone else the message named, for the answering turn's
                     // context. A list, not a fan-out: one operator message still
                     // spawns exactly one turn, and this teammate spreads the
@@ -2908,7 +2906,8 @@ impl HarnessBrain {
                     // desk's membership.
                     let also_mentioned = crate::runtime::mentions::mentioned_agents(
                         &self.record(),
-                        chat.as_deref().unwrap_or(crate::server::ops::language::DEFAULT_DESK),
+                        chat.as_deref()
+                            .unwrap_or(crate::server::ops::language::DEFAULT_DESK),
                         mentions,
                         Some(&responder),
                     );

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1138,10 +1138,27 @@ impl<'a> DelegationRunner<'a> {
         // delegation tools it already has. Nothing here dispatches.
         let with_mentions;
         let message = if operator_turn && !self.also_mentioned.is_empty() {
-            with_mentions = format!(
-                "{message}\n\n[Also mentioned in this message: {}. They have not been asked to answer — you have. Hand work to them only if it genuinely needs them.]",
-                self.also_mentioned.join(", ")
-            );
+            // A responder with no hand-off tool at all (an overlay teammate,
+            // or a manifest member with an empty `delegates_to`) cannot act on
+            // "hand work to them" — see `responder_can_delegate`. Telling it
+            // to anyway is not a harmless nudge: it is an instruction the
+            // model has no tool to follow, for a name it now believes should
+            // be receiving work it never will.
+            with_mentions = if self.responder_can_delegate(responder) {
+                format!(
+                    "{message}
+
+[Also mentioned in this message: {}. They have not been asked to answer — you have. Hand work to them only if it genuinely needs them.]",
+                    self.also_mentioned.join(", ")
+                )
+            } else {
+                format!(
+                    "{message}
+
+[Also mentioned in this message: {}. They have not been asked to answer — you have. You have no way to hand this off to them, so answer it yourself, or say so if it genuinely needs them.]",
+                    self.also_mentioned.join(", ")
+                )
+            };
             with_mentions.as_str()
         } else {
             message
@@ -2720,6 +2737,25 @@ impl<'a> DelegationRunner<'a> {
         orchestrator::orchestrator_id(&self.record.effective_agents()).unwrap_or_default()
     }
 
+    /// Whether `responder` has any way to hand work to somebody else — the
+    /// orchestrator always does, and an ordinary teammate does only when its
+    /// manifest row names a `delegates_to` allowlist (`build.rs` wires
+    /// `spawn_task`/`delegate_to_desk`/`delegate_to_teammate` on exactly that
+    /// condition; an overlay teammate has no `delegates_to` field at all and
+    /// so never qualifies here either).
+    ///
+    /// Read before the "also mentioned" turn context is worded (see
+    /// [`Self::run`]): telling a responder with no hand-off tool at all to
+    /// "hand work to them" is an instruction it cannot follow, and the honest
+    /// phrasing differs.
+    fn responder_can_delegate(&self, responder: &str) -> bool {
+        responder == self.orchestrator_id()
+            || self
+                .record
+                .effective_agent(responder)
+                .is_some_and(|agent| !agent.delegates_to.is_empty())
+    }
+
     /// The voice a note this drain appends is recorded under.
     ///
     /// The orchestrator on every chat and task path, unchanged. On a **workflow
@@ -3856,6 +3892,56 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     /// promised really executed. A test with only the second half would pass on
     /// a path that drains but never claims — which is not the invariant, because
     /// the next such path written would inherit nothing.
+    /// A responder who cannot delegate (an ordinary manifest member with no
+    /// `delegates_to`) must not be told to "hand work to them" — it has no
+    /// tool to do that with. The orchestrator, who always can, keeps the
+    /// original phrasing.
+    #[tokio::test]
+    async fn also_mentioned_wording_matches_the_responders_own_delegation_reach() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+
+        fx.runner(&turns)
+            .also_mentioned(vec!["chief".to_string()])
+            .handle_operator_message("engineer", "look into this", Some("eng_desk"))
+            .await
+            .expect("operator message handled");
+
+        let calls = turns.calls();
+        assert_eq!(calls.len(), 1);
+        let (agent, message) = &calls[0];
+        assert_eq!(agent, "engineer");
+        assert!(
+            message.contains("You have no way to hand this off"),
+            "a non-delegating responder must be told plainly, not asked to do the impossible: {message}"
+        );
+        assert!(!message.contains("Hand work to them only if it genuinely needs them"));
+    }
+
+    /// The orchestrator always carries the hand-off tools, so it gets the
+    /// original "hand work to them" phrasing.
+    #[tokio::test]
+    async fn also_mentioned_wording_trusts_the_orchestrator_to_delegate() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+
+        fx.runner(&turns)
+            .also_mentioned(vec!["engineer".to_string()])
+            .handle_operator_message("chief", "look into this", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let calls = turns.calls();
+        assert_eq!(calls.len(), 1);
+        let (agent, message) = &calls[0];
+        assert_eq!(agent, "chief");
+        assert!(
+            message.contains("Hand work to them only if it genuinely needs them"),
+            "the orchestrator can always delegate: {message}"
+        );
+        assert!(!message.contains("You have no way to hand this off"));
+    }
+
     #[tokio::test]
     async fn an_operator_turn_approval_actually_lands_the_card() {
         let fx = Fixture::new();

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -550,6 +550,18 @@ pub(crate) struct DelegationRunner<'a> {
     /// (issues #1035, #1152). `None` for every path that is not an operator chat
     /// turn, and for a message whose sender expressed no preference.
     requested_intent: Option<crate::ports::types::MessageIntent>,
+    /// The other teammates this message named, when it named any.
+    ///
+    /// Context for the turn, **never a second dispatch**: one operator message
+    /// spawns exactly one turn, and this is how the teammate answering it
+    /// learns who else was addressed. It decides whether the work should
+    /// actually spread, and spreads it through the delegation tools it already
+    /// has — so a mention cannot become a way to start N turns with no approval
+    /// in sight.
+    ///
+    /// Empty on every path that is not a person typing into the composer, and
+    /// on every message that names nobody.
+    also_mentioned: Vec<String>,
     /// The cycle's approval queue, read (never written) to tell whether a turn
     /// this runner drove parked an approval (issue #465).
     ///
@@ -606,6 +618,7 @@ impl<'a> DelegationRunner<'a> {
             task: None,
             run_sink: None,
             requested_intent: None,
+            also_mentioned: Vec::new(),
             approvals: None,
             workflow_run: None,
             workflow_refs: None,
@@ -655,6 +668,7 @@ impl<'a> DelegationRunner<'a> {
             // A workflow run has no operator message and therefore no composer
             // choice; `None` is the only honest value here.
             requested_intent: None,
+            also_mentioned: Vec::new(),
             approvals: None,
             workflow_run: Some(run),
             workflow_refs: None,
@@ -858,6 +872,17 @@ impl<'a> DelegationRunner<'a> {
     /// make a dozen test call sites restate `None` to say nothing.
     pub(crate) fn requested(mut self, intent: Option<crate::ports::types::MessageIntent>) -> Self {
         self.requested_intent = intent;
+        self
+    }
+
+    /// Carries the other teammates this message named.
+    ///
+    /// A builder for the same reason [`requested`](Self::requested) is: optional
+    /// context about the turn, absent on every path that is not an operator
+    /// message, and threading it as an argument would make a dozen test call
+    /// sites restate an empty vector to say nothing.
+    pub(crate) fn also_mentioned(mut self, agents: Vec<String>) -> Self {
+        self.also_mentioned = agents;
         self
     }
 
@@ -1100,6 +1125,27 @@ impl<'a> DelegationRunner<'a> {
         // what *this* turn parked, not what the cycle was already holding from
         // an earlier one.
         let approvals_before = self.approvals_queued();
+        // Who else the message named, told to the teammate answering it.
+        //
+        // Appended to the turn input only — **not** to the journaled message,
+        // which is already stored verbatim with its own mention rows. A reader
+        // sees exactly what the author typed; the model additionally sees who
+        // that resolved to, which it otherwise could not know, because a mention
+        // is a structured fact about the message rather than a word in it.
+        //
+        // Deliberately phrased as context rather than an instruction: the turn
+        // decides whether the work needs to spread, and spreads it through the
+        // delegation tools it already has. Nothing here dispatches.
+        let with_mentions;
+        let message = if operator_turn && !self.also_mentioned.is_empty() {
+            with_mentions = format!(
+                "{message}\n\n[Also mentioned in this message: {}. They have not been asked to answer — you have. Hand work to them only if it genuinely needs them.]",
+                self.also_mentioned.join(", ")
+            );
+            with_mentions.as_str()
+        } else {
+            message
+        };
         let outcome = self
             .run_turn
             .run(self.company, responder, message, chat_id)


### PR DESCRIPTION
Stacked on #1645 — review that first. This PR is the one that makes mentions *do*
something.

## What changes

`@engineer what's the build status?` in `#general` is now answered by the
engineer, instead of by whichever teammate the desk routes to by default.

One line at the seam:

```rust
let responder = mentions::mention_responder(&self.record(), mentions)
    .unwrap_or_else(|| self.responder_for(chat.as_deref()));
```

## Why a mention outranks the desk lead

Naming somebody in a room is a stronger address than the room's default
answerer. This is the same explicit-beats-implicit ordering `responder_for`
(`brain.rs:2487`) already applies between an addressed desk and the orchestrator
— one more rung at the top of an existing ladder, not a second competing notion
of who a message is for.

A message that names no teammate resolves to `None` and routes **exactly** as
before, including the issue-#884 warning. That is every message already in every
journal.

## `@everyone` and `@#desk`: a list, not a fan-out

**One operator message still spawns exactly one turn.** That is today's
invariant (`spawn_chat_turn` spawns one) and this must not break it — a mention
becoming a way to start N turns with no approval in sight is the obvious hazard,
and the reason `block/buzz` has no `@everyone` at all.

Instead, `mentioned_agents` expands `@everyone`/`@#desk` against the addressed
desk's effective membership and the result is **named to the answering turn**:

```
[Also mentioned in this message: cto, engineer. They have not been asked to
answer — you have. Hand work to them only if it genuinely needs them.]
```

The responder decides whether the work should spread, and spreads it through the
existing gated, card-producing `delegate_to_desk` seam. `MENTION_CAP` bounds the
list.

Appended to the **turn input only** — never to the journaled message, which is
already stored verbatim with its own mention rows. A reader sees exactly what the
author typed.

## Mention loops, prevented structurally

`mention_responder` reads `OperatorMessage.mentions` and nothing else. There is
no code path from an `AgentReply`'s mentions to dispatch, so an agent naming
another agent draws a chip, files a notification, and starts nothing. **The
agent-to-agent edge does not exist**, which is stronger than an edge that is
disabled — there is nothing to accidentally re-enable.

If it is ever wanted, `AgentReply.mention_depth` shipped in #1645 as the gate
(`depth >= 2` refuses). buzz's agent prompt has to *ask* agents not to post bare
acknowledgements because their protocol has no dedupe; this has one.

## Commands run

```
cargo test --features openhuman --lib harness::built_in::brain   # 107 passed
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
```

The changed file compiles only under the `openhuman` feature, which is why the
gated lane is the one that matters here. All mention logic itself lives in
brain-agnostic `src/runtime/` (shipped in #1645) for the same reason `desk_lead`
was lifted there.

## Tests

Four, in `brain.rs`:

- `a_mentioned_teammate_answers_instead_of_the_default_responder` — the feature.
- `a_mention_outranks_the_addressed_desks_lead` — the stronger claim.
- `a_message_with_no_mentions_routes_unchanged` — the regression guard.
- `everyone_names_the_desk_without_choosing_a_responder` — a broadcast names no
  single teammate, so the desk lead still answers.
