### PR TITLE
feat(console): @-mention picker and chips in chat

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,8 @@ import {
   type BoardQuery,
   type BoardVote,
   type ReadMarker,
+  type ChatMentionInput,
+  type MentionablesResponse,
   type ReadStateResponse,
   type ApiErrorBody,
   type WorkflowProblem,
@@ -477,6 +479,18 @@ export class OpenCompanyClient {
      * is exactly why this returns a union rather than the detached type.
      */
     detach?: boolean,
+    /**
+     * Who this message names, as the picker resolved them.
+     *
+     * Sent only when the picker actually resolved something, so an ordinary
+     * post keeps the exact body shape it had before mentions existed — the
+     * same omitted-field rule `deliverable` and `detach` follow.
+     *
+     * The host re-validates every entry against the live roster and demotes
+     * what no longer resolves, so this is a suggestion, not an instruction.
+     * Omitting it entirely asks the host to extract from the text instead.
+     */
+    mentions?: ChatMentionInput[],
   ): Promise<ChatPostResult> {
     const body: {
       text: string;
@@ -484,6 +498,7 @@ export class OpenCompanyClient {
       parent?: string;
       deliverable?: MessageIntent;
       detach?: boolean;
+      mentions?: ChatMentionInput[];
     } = {
       text,
     };
@@ -493,6 +508,7 @@ export class OpenCompanyClient {
     // Sent only when asked for, so an ordinary post keeps the exact body shape
     // it had before #983 — the same omitted-field rule `deliverable` follows.
     if (detach) body.detach = detach;
+    if (mentions?.length) body.mentions = mentions;
     return this.request<ChatPostResult>("POST", `${this.scope(company)}/chat`, body);
   }
 
@@ -625,6 +641,22 @@ export class OpenCompanyClient {
    */
   readState(company?: string | null): Promise<ReadStateResponse> {
     return this.request<ReadStateResponse>("GET", `${this.scope(company)}/chat/read-state`);
+  }
+
+  /**
+   * Everything an `@` can name: teammates, people, desks, and the broadcast
+   * token's spellings.
+   *
+   * A host that predates this route answers 404; the caller treats that as
+   * "no picker" and typing an `@` stays plain text, which the host still
+   * extracts what it can from. So an older host degrades to the previous
+   * behaviour rather than throwing on load.
+   */
+  mentionables(company?: string | null): Promise<MentionablesResponse> {
+    return this.request<MentionablesResponse>(
+      "GET",
+      `${this.scope(company)}/chat/mentionables`,
+    );
   }
 
   /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -260,6 +260,52 @@ export interface ChatHistoryMessageDto {
    * emoji. Absent when nobody has, and on a host that predates the field.
    */
   reactions?: ChatReactionDto[];
+  /**
+   * Who this message names, in reading order. Absent when it names nobody, and
+   * on a host that predates the field.
+   */
+  mentions?: ChatMentionDto[];
+}
+
+/**
+ * What a mention points at. Mirrors the Rust `MentionTarget`.
+ *
+ * `everyone` is a scope rather than an actor, which is why this is a union and
+ * not an `{ kind, id }` pair.
+ */
+export type MentionTarget =
+  | { kind: "agent"; id: string }
+  | { kind: "user"; id: string }
+  | { kind: "desk"; id: string }
+  | { kind: "everyone" };
+
+/**
+ * One mention as the composer *sends* it. Mirrors the Rust `Mention` input.
+ *
+ * Distinct from {@link ChatMentionDto}, which is what comes back: outgoing
+ * carries the target the picker resolved, incoming carries the label the host
+ * resolved it to. A client never sends a label and never receives a target.
+ */
+export interface ChatMentionInput {
+  target: MentionTarget;
+  /** The literal span typed, `@` included. */
+  text: string;
+  /** Offset of `text` in the message body. */
+  offset: number;
+}
+
+/** One mention. Mirrors `ChatMentionDto` in `src/server/operator.rs`. */
+export interface ChatMentionDto {
+  /** The literal span the author typed, `@` included. */
+  text: string;
+  /** Byte offset of `text` in the message body. */
+  offset: number;
+  /** Who was named, as a display label — never a raw user id. */
+  label: string;
+  /** Whether the reading viewer is the one named (or was named by @everyone). */
+  mine: boolean;
+  /** Whether this mention renders but pinged nobody. */
+  quiet?: boolean;
 }
 
 /** One person's reaction. Mirrors `ChatReactionDto` in `src/server/operator.rs`. */
@@ -1733,4 +1779,55 @@ export interface ReadMarker {
 /** Response of `GET {scope}/chat/read-state`. */
 export interface ReadStateResponse {
   markers: ReadMarker[];
+}
+
+/**
+ * Response of `GET {scope}/chat/mentionables` — everything an `@` can name.
+ *
+ * Mirrors `MentionablesDto` in `src/server/ops/mentions.rs`.
+ */
+export interface MentionablesResponse {
+  agents: MentionableAgentDto[];
+  people: MentionablePersonDto[];
+  desks: MentionableDeskDto[];
+  everyone: MentionableEveryoneDto;
+}
+
+/** One teammate the picker can offer. */
+export interface MentionableAgentDto {
+  id: string;
+  name: string;
+  role: string;
+}
+
+/**
+ * One person the picker can offer.
+ *
+ * Id and label only, by design — this is deliberately not the admin user
+ * record, and must not grow toward it.
+ */
+export interface MentionablePersonDto {
+  id: string;
+  /** How this person is named to colleagues; never their login identity. */
+  label: string;
+  /** A short typable alias, disambiguated company-wide. Not a handle. */
+  slug: string;
+}
+
+/** One desk the picker can offer. */
+export interface MentionableDeskDto {
+  id: string;
+  name: string;
+  /** The teammates a mention of this desk expands to. */
+  memberIds: string[];
+}
+
+/**
+ * The broadcast token, described by the host rather than hard-coded here — a
+ * console that disagreed about the spellings would offer a row resolving to
+ * nothing.
+ */
+export interface MentionableEveryoneDto {
+  label: string;
+  aliases: string[];
 }

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -1,7 +1,69 @@
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
+import { mentionRegex } from "@/views/chat/mentions";
+
+/** One mention span this document should chip, as `chat/history` returns it. */
+export interface MentionSpan {
+  text: string;
+  label: string;
+  mine: boolean;
+  quiet?: boolean;
+}
+
+/**
+ * Wraps every delivered mention span in `nodes` in a chip.
+ *
+ * Splits only **string** children, so a mention inside `**bold**` or a link
+ * still chips while the surrounding markup is left to `react-markdown`.
+ *
+ * The pattern comes from {@link mentionRegex}, which matches nothing when the
+ * list is empty. That is the rule, not an optimisation: an `@word` is
+ * highlighted only when the host actually delivered a mention for it. A chip
+ * claims somebody was notified, and one drawn over unresolved text is a claim
+ * the reader has no way to check.
+ */
+function chipMentions(nodes: ReactNode, mentions: MentionSpan[]): ReactNode {
+  if (mentions.length === 0) return nodes;
+  const byText = new Map(mentions.map((m) => [m.text, m]));
+  const pattern = mentionRegex(mentions);
+
+  const split = (node: ReactNode, key: string): ReactNode => {
+    if (typeof node !== "string") return node;
+    const parts = node.split(pattern);
+    if (parts.length === 1) return node;
+    return parts.map((part, i) => {
+      const hit = byText.get(part);
+      if (!hit) return part;
+      return (
+        <span
+          key={`${key}-${i}`}
+          // `mine` is the reader's own mention — including `@everyone`, which is
+          // addressed to them too. It reads as an alert; somebody else's mention
+          // is only a reference, so it stays quiet.
+          className={cn(
+            "rounded px-1 py-0.5 font-medium",
+            hit.mine
+              ? "bg-primary/15 text-primary"
+              : "bg-muted text-foreground/80",
+          )}
+          // A quiet mention rendered but pinged nobody — a duplicate, one past
+          // the cap, or a target that has since left. Saying so is better than
+          // a chip that silently means something different from its neighbour.
+          title={hit.quiet ? `${hit.label} — mentioned, not notified` : hit.label}
+        >
+          {part}
+        </span>
+      );
+    });
+  };
+
+  return Array.isArray(nodes)
+    ? nodes.map((node, i) => split(node, String(i)))
+    : split(nodes, "0");
+}
 
 /**
  * Is `href` a link that leaves the console?
@@ -38,10 +100,18 @@ export function isExternalHref(href?: string): boolean {
 export function Markdown({
   children,
   className,
+  mentions,
 }: {
   children: string;
   className?: string;
+  /**
+   * Mention spans to chip, when this document is a chat message that carries
+   * any. Omitted everywhere else — memory, workspace, workflows — so those
+   * surfaces render exactly as they did.
+   */
+  mentions?: MentionSpan[];
 }) {
+  const spans = mentions ?? [];
   return (
     <div className={cn("prose prose-sm max-w-none dark:prose-invert", className)}>
       <ReactMarkdown
@@ -55,6 +125,15 @@ export function Markdown({
             >
               {content}
             </a>
+          ),
+          // Chips are injected at the leaf elements that hold prose rather than
+          // through a remark plugin, so the mention list stays a plain prop and
+          // no AST transform has to be kept in step with it.
+          p: ({ children: content, ...rest }) => (
+            <p {...rest}>{chipMentions(content, spans)}</p>
+          ),
+          li: ({ children: content, ...rest }) => (
+            <li {...rest}>{chipMentions(content, spans)}</li>
           ),
         }}
       >

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -20,6 +20,20 @@ export interface Reaction {
   mine: boolean;
 }
 
+/** One mention on one line. Mirrors `ChatMentionDto` on the host. */
+export interface Mention {
+  /** The literal span the author typed, `@` included. */
+  text: string;
+  /** Byte offset of `text` in the message body. */
+  offset: number;
+  /** Who was named, as a display label — never a raw user id. */
+  label: string;
+  /** Whether the reader is the one named (or was named by `@everyone`). */
+  mine: boolean;
+  /** Whether this mention renders but pinged nobody. */
+  quiet?: boolean;
+}
+
 /** One line in the conversation with the company. */
 export interface ChatMessage {
   id: string;
@@ -62,6 +76,15 @@ export interface ChatMessage {
    * `#/tasks/<id>`.
    */
   taskId?: string;
+  /**
+   * Who this line names (`@engineer`, `@Jane Doe`, `@everyone`), as the host
+   * resolved them — spans plus a label, never a target id.
+   *
+   * Carried rather than re-parsed from `text`, so a chip is drawn only where
+   * somebody was actually notified. Absent when the line names nobody, and on
+   * a host that predates the field.
+   */
+  mentions?: Mention[];
 }
 
 /**
@@ -312,6 +335,9 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
       // Reactions come through whoever the host said reacted; nothing is
       // inferred here, `mine` included.
       reactions: entry.reactions?.length ? entry.reactions : undefined,
+      // Same rule as reactions: the host says who was mentioned, and nothing
+      // here infers one from the text.
+      mentions: entry.mentions?.length ? entry.mentions : undefined,
       // A sent message never carries a channel; only attribute one when the
       // line came from someone/something else, mirroring `ChatPane.send`.
       channel: from === "company" ? entry.channel : undefined,

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -49,6 +49,11 @@ import { ChannelRail } from "./chat/ChannelRail";
 import { ChatHeader } from "./chat/ChatHeader";
 import { MembersPane } from "./chat/MembersPane";
 import { MessageComposer } from "./chat/MessageComposer";
+import {
+  mentionablesFor,
+  type Mention,
+  type Mentionable,
+} from "./chat/mentions";
 import { MessageTimeline } from "./chat/MessageTimeline";
 import { ThreadPanel } from "./chat/ThreadPanel";
 import { useLocalScope } from "@/connections/ConnectionContext";
@@ -482,6 +487,49 @@ export function ChatView({
     return channelMembers(channel, members);
   }, [channel, members]);
 
+  /**
+   * Everything an `@` can name in this company.
+   *
+   * Fetched once per company rather than per channel: the directory is
+   * company-wide, and only the `inChannel` ranking below is per channel.
+   *
+   * A host that predates the route answers 404, which lands here as `null` —
+   * read as "no picker", so typing an `@` stays plain text and the host still
+   * extracts what it can. An older host therefore degrades to the composer's
+   * previous behaviour rather than to a broken one.
+   */
+  const [directory, setDirectory] = useState<Mentionable[] | null>(null);
+  useEffect(() => {
+    let live = true;
+    void client
+      .mentionables(company)
+      .then((d) => {
+        if (live) setDirectory(mentionablesFor(d));
+      })
+      .catch(() => {
+        if (live) setDirectory(null);
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
+
+  /**
+   * The directory with this channel's teammates marked, so they rank first.
+   *
+   * Re-marked rather than re-fetched on a channel switch — the rows are the
+   * same, only their ordering hint changes.
+   */
+  const mentionables = useMemo(() => {
+    if (!directory) return undefined;
+    const inside = new Set((inChannel ?? []).map((m) => m.id));
+    return directory.map((entry) =>
+      entry.target.kind === "agent"
+        ? { ...entry, inChannel: inside.has(entry.target.id) }
+        : entry,
+    );
+  }, [directory, inChannel]);
+
   const outsideChannel = useMemo(() => {
     if (!inChannel) return members;
     const inside = new Set(inChannel.map((m) => m.id));
@@ -663,7 +711,12 @@ export function ChatView({
    * cannot resolve — the row's own actions are disabled in that window, so this
    * is the belt to that brace.
    */
-  async function send(text: string, intent?: MessageIntent, parentId?: string) {
+  async function send(
+    text: string,
+    intent?: MessageIntent,
+    parentId?: string,
+    mentions?: Mention[],
+  ) {
     if (sending) return;
     const target = active.id;
     const chatId = activeThreadId;
@@ -693,6 +746,10 @@ export function ChatView({
         // field ignores this and answers synchronously, which is why the branch
         // below reads the response's shape and never this argument.
         true,
+        // Who the picker resolved. The host re-validates every entry and
+        // demotes what no longer exists, so this is a suggestion; omitting it
+        // asks the host to extract from the text instead.
+        mentions,
       );
       // Reconcile the optimistic id first, for BOTH shapes. On the detached one
       // this is strictly better than what came before: since #983 the message is
@@ -1058,13 +1115,16 @@ export function ChatView({
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}
-              onSend={(text, intent) => void send(text, intent)}
+              onSend={(text, intent, mentions) =>
+                void send(text, intent, undefined, mentions)
+              }
               // Channel *and* DM composers offer "just chatting" / "do it once" /
               // "build me the workflow" (issues #580, #845, #1152) — see
               // `offersDeliverableChoice`, which owns the rule and is unchanged:
               // the new position inherits the same channel+DM gating. Only the
               // thread and copilot composers below go without.
               deliverableChoice={offersDeliverableChoice(active.kind)}
+              mentionables={mentionables}
             />
           </div>
 

--- a/frontend/src/views/chat/MentionPicker.tsx
+++ b/frontend/src/views/chat/MentionPicker.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from "react";
+import { AtSign, Hash, Users } from "lucide-react";
+
+import { TeammateAvatar } from "@/components/teammate-avatar";
+import { cn } from "@/lib/utils";
+import type { Mentionable } from "@/views/chat/mentions";
+
+/**
+ * The `@` picker, anchored above the composer.
+ *
+ * Positioned relative to the composer box rather than to the caret. A textarea
+ * exposes no caret rectangle, so anchoring to one means mirroring the whole
+ * field into a hidden clone to measure it — which has to track font, padding,
+ * wrapping and scroll, and is wrong the moment any of them change. The composer
+ * is a narrow box at the bottom of the pane, so "above the box" and "above the
+ * caret" differ by a few pixels and only the first is reliable. The composer's
+ * own formatting toolbar already sets this precedent.
+ *
+ * Selection is owned by the composer, not by this component: the keys that move
+ * it (`ArrowUp`/`ArrowDown`/`Tab`/`Enter`) arrive at the textarea, and a picker
+ * holding its own index would have to be told about every one of them anyway.
+ */
+export function MentionPicker({
+  entries,
+  active,
+  onPick,
+  onHover,
+}: {
+  entries: Mentionable[];
+  /** Index into `entries` of the highlighted row. */
+  active: number;
+  onPick: (entry: Mentionable) => void;
+  onHover: (index: number) => void;
+}) {
+  const list = useRef<HTMLDivElement>(null);
+
+  // Keep the highlighted row in view as the arrows walk past the fold.
+  // `block: "nearest"` so an already-visible row does not jump the list.
+  useEffect(() => {
+    const el = list.current?.querySelector<HTMLElement>(`[data-index="${active}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [active]);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div
+      ref={list}
+      // Not a listbox/combobox: focus stays in the textarea the whole time, so
+      // the aria pattern that fits is a controlled list the input points at.
+      id="mention-picker"
+      role="listbox"
+      aria-label="Mention someone"
+      data-testid="mention-picker"
+      className="absolute bottom-full left-0 z-20 mb-2 max-h-64 w-72 overflow-y-auto rounded-xl border bg-popover p-1 shadow-lg"
+    >
+      {entries.map((entry, index) => (
+        <button
+          key={`${entry.target.kind}:${"id" in entry.target ? entry.target.id : "everyone"}`}
+          type="button"
+          role="option"
+          aria-selected={index === active}
+          data-index={index}
+          data-testid="mention-option"
+          // `onMouseDown` with `preventDefault`, not `onClick`: a click would
+          // blur the textarea first, and the composer would lose the selection
+          // range the insert needs.
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onPick(entry);
+          }}
+          onMouseEnter={() => onHover(index)}
+          className={cn(
+            "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm",
+            index === active ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+          )}
+        >
+          <RowIcon entry={entry} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate font-medium">{entry.label}</span>
+            {entry.hint && (
+              <span className="block truncate text-xs text-muted-foreground">
+                {entry.hint}
+              </span>
+            )}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RowIcon({ entry }: { entry: Mentionable }) {
+  if (entry.target.kind === "agent") {
+    return <TeammateAvatar name={entry.label} className="size-6 shrink-0" />;
+  }
+  const Icon =
+    entry.target.kind === "desk" ? Hash : entry.target.kind === "everyone" ? Users : AtSign;
+  return (
+    <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted">
+      <Icon className="size-3.5 text-muted-foreground" aria-hidden />
+    </span>
+  );
+}

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils";
 import { MentionPicker } from "@/views/chat/MentionPicker";
 import {
   activeMentionQuery,
+  aliasSet,
   insertMention,
   rankMentionables,
   reconcileMentions,
@@ -112,6 +113,11 @@ export function MessageComposer({
     () => (query && mentionables ? rankMentionables(mentionables, query.query) : []),
     [query, mentionables],
   );
+  // Built once per directory, not per keystroke.
+  const aliases = useMemo(
+    () => (mentionables ? aliasSet(mentionables) : undefined),
+    [mentionables],
+  );
   const pickerOpen = query !== null && rows.length > 0;
 
   function closePicker() {
@@ -125,7 +131,7 @@ export function MessageComposer({
       closePicker();
       return;
     }
-    const next = activeMentionQuery(text, caret);
+    const next = activeMentionQuery(text, caret, aliases);
     setQuery(next);
     setActiveRow(0);
   }

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   ArrowUp,
   AtSign,
@@ -16,11 +16,29 @@ import {
 import type { MessageIntent } from "@/api/tasks";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { MentionPicker } from "@/views/chat/MentionPicker";
+import {
+  activeMentionQuery,
+  insertMention,
+  rankMentionables,
+  reconcileMentions,
+  type Mention,
+  type Mentionable,
+} from "@/views/chat/mentions";
 
 interface Props {
   placeholder: string;
   disabled?: boolean;
-  onSend: (text: string, intent?: MessageIntent) => void;
+  onSend: (text: string, intent?: MessageIntent, mentions?: Mention[]) => void;
+  /**
+   * Everything an `@` can name here, from `GET {scope}/chat/mentionables`.
+   *
+   * Absent — a host that predates the route, or a surface with no roster
+   * loaded — simply means no picker opens; typing an `@` is then plain text
+   * and the host still extracts what it can from it. So the composer degrades
+   * to exactly its previous behaviour rather than to a broken one.
+   */
+  mentionables?: Mentionable[];
   /** Compact form, for the narrower thread panel. */
   compact?: boolean;
   /**
@@ -63,8 +81,18 @@ export function MessageComposer({
   onSend,
   compact,
   deliverableChoice,
+  mentionables,
 }: Props) {
   const [draft, setDraft] = useState("");
+  // What the draft currently resolves to. Reconciled on every edit, so editing
+  // or backspacing through a chip un-mentions it rather than leaving a ping
+  // for somebody whose name is no longer in the message.
+  const [mentions, setMentions] = useState<Mention[]>([]);
+  // Where the caret is in an `@query`, or null when it is not in one. Held in
+  // state (not derived at render) because it has to survive the mouse leaving
+  // the textarea to click a row.
+  const [query, setQuery] = useState<{ start: number; query: string } | null>(null);
+  const [activeRow, setActiveRow] = useState(0);
   // What the NEXT line is for, and only the next one. It resets to "once"
   // after every send so neither a workflow request nor a "just chatting" mark
   // silently carries into the message after it — each is an explicit, per-line
@@ -80,15 +108,96 @@ export function MessageComposer({
   const [formatting, setFormatting] = useState(false);
   const input = useRef<HTMLTextAreaElement>(null);
 
+  const rows = useMemo(
+    () => (query && mentionables ? rankMentionables(mentionables, query.query) : []),
+    [query, mentionables],
+  );
+  const pickerOpen = query !== null && rows.length > 0;
+
+  function closePicker() {
+    setQuery(null);
+    setActiveRow(0);
+  }
+
+  /** Re-read the caret's mention query after any edit or caret move. */
+  function syncQuery(text: string, caret: number | null) {
+    if (!mentionables || caret === null) {
+      closePicker();
+      return;
+    }
+    const next = activeMentionQuery(text, caret);
+    setQuery(next);
+    setActiveRow(0);
+  }
+
+  function onChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const text = e.target.value;
+    setDraft(text);
+    // Trailing the text, so a mention whose span was edited away goes with it.
+    setMentions((current) => reconcileMentions(text, current));
+    syncQuery(text, e.target.selectionStart);
+  }
+
+  function pick(entry: Mentionable) {
+    const el = input.current;
+    if (!query || !el) return;
+    const range = { start: query.start, end: el.selectionStart ?? query.start };
+    const result = insertMention(draft, range, entry);
+    setDraft(result.text);
+    setMentions((current) =>
+      reconcileMentions(result.text, [...current, result.mention]),
+    );
+    closePicker();
+    // After React repaints, same as `wrap` below.
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(result.caret, result.caret);
+    });
+  }
+
   function send() {
     const text = draft.trim();
     if (!text || disabled) return;
+    // The trim can shift every span, so the list is re-anchored against exactly
+    // what is being sent — never against the untrimmed draft.
+    const sending = reconcileMentions(text, mentions);
     setDraft("");
-    onSend(text, deliverableChoice ? intent : undefined);
+    setMentions([]);
+    closePicker();
+    onSend(
+      text,
+      deliverableChoice ? intent : undefined,
+      sending.length ? sending : undefined,
+    );
     setIntent("once");
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // While the picker is open it owns these keys. Enter in particular PICKS
+    // and does not send — a person mid-`@name` is choosing somebody, not
+    // finishing a message, and sending there is unrecoverable.
+    if (pickerOpen) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveRow((i) => (i + 1) % rows.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveRow((i) => (i - 1 + rows.length) % rows.length);
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        pick(rows[activeRow]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closePicker();
+        return;
+      }
+    }
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       send();
@@ -116,7 +225,15 @@ export function MessageComposer({
       // compact copy stays unlabelled so the tour can't anchor on the wrong one.
       data-tour={compact ? undefined : "chat-composer"}
     >
-      <div className="rounded-xl border bg-card shadow-sm focus-within:ring-2 focus-within:ring-ring/40">
+      <div className="relative rounded-xl border bg-card shadow-sm focus-within:ring-2 focus-within:ring-ring/40">
+        {pickerOpen && (
+          <MentionPicker
+            entries={rows}
+            active={activeRow}
+            onPick={pick}
+            onHover={setActiveRow}
+          />
+        )}
         {!compact && formatting && (
           <div className="flex items-center gap-0.5 border-b px-2 py-1">
             {WRAPS.map((w) => (
@@ -162,8 +279,18 @@ export function MessageComposer({
         <textarea
           ref={input}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={onChange}
           onKeyDown={onKeyDown}
+          // A click or an arrow can move the caret into (or out of) an existing
+          // `@name` without changing the text, so the query is re-read on
+          // selection changes too, not only on edits.
+          onSelect={(e) => {
+            const el = e.currentTarget;
+            syncQuery(el.value, el.selectionStart);
+          }}
+          onBlur={closePicker}
+          aria-controls={pickerOpen ? "mention-picker" : undefined}
+          aria-expanded={pickerOpen}
           placeholder={placeholder}
           rows={1}
           className="field-sizing-content max-h-48 min-h-10 w-full resize-none bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground"
@@ -220,7 +347,25 @@ export function MessageComposer({
             className="size-7 text-muted-foreground"
             aria-label="Mention someone"
             title="Mention someone"
-            onClick={() => wrap("@")}
+            // Types the `@` and lets the ordinary path take over, rather than
+            // opening the picker directly: one code path decides when a picker
+            // is open, so the button and the keyboard can never disagree.
+            onClick={() => {
+              const el = input.current;
+              if (!el) return;
+              const at = el.selectionStart ?? draft.length;
+              // A separator first when the caret is mid-word, or the `@` would
+              // land inside another token and open nothing.
+              const lead = at > 0 && !/[\s([{]/.test(draft[at - 1] ?? " ") ? " " : "";
+              const next = `${draft.slice(0, at)}${lead}@${draft.slice(at)}`;
+              const caret = at + lead.length + 1;
+              setDraft(next);
+              requestAnimationFrame(() => {
+                el.focus();
+                el.setSelectionRange(caret, caret);
+                syncQuery(next, caret);
+              });
+            }}
           >
             <AtSign className="size-4" />
           </Button>

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -100,7 +100,7 @@ export function MessageRow({
 
       <div className="flex min-w-0 flex-1 flex-col">
         {!continuation && <AuthorLine sender={sender} at={message.at} />}
-        <Markdown className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
+        <Markdown mentions={message.mentions} className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
 
         {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
         {message.taskId && (

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -100,7 +100,7 @@ function Line({
             {formatTime(message.at)}
           </span>
         </div>
-        <Markdown className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
+        <Markdown mentions={message.mentions} className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
       </div>
     </div>
   );

--- a/frontend/src/views/chat/mentions.ts
+++ b/frontend/src/views/chat/mentions.ts
@@ -1,0 +1,333 @@
+// The composer's half of @-mentions: what the caret is currently typing, what
+// to insert when a row is picked, and which mentions a draft still carries.
+//
+// Pure by design — the repo keeps chat logic in `model.ts`/`lib` with a unit
+// test rather than inline in a component, and every rule below is one that is
+// much easier to get wrong in a keydown handler than in a function.
+//
+// The server has a twin of this in `src/runtime/mentions.rs`. It is the
+// authority: whatever the picker resolves here is re-validated there against
+// the live roster, and a target that no longer exists is demoted rather than
+// trusted. This side exists to make the *typing* good, not to be believed.
+
+/** How many mentions one message may carry as pings. Mirrors `MENTION_CAP`. */
+export const MENTION_CAP = 50;
+
+/** A regular expression that matches nothing, ever. */
+const NEVER_MATCH = /(?!)/g;
+
+/** Longest `@query` the picker will keep open before giving up. */
+const MAX_QUERY = 32;
+
+import type { ChatMentionInput, MentionTarget } from "@/api/types";
+
+// The composer produces a wire value, so the shape it builds is the API's, not
+// a parallel one that would have to be kept in step with it.
+export type { MentionTarget };
+
+/** One resolved mention, as the composer sends it. */
+export type Mention = ChatMentionInput;
+
+/** One row the picker can offer. */
+export interface Mentionable {
+  target: MentionTarget;
+  /** What to render, and what gets inserted after the `@`. */
+  label: string;
+  /** Every spelling that reaches this row, lowercase. */
+  aliases: string[];
+  /** A line of context under the label — a job title, a slug, a member count. */
+  hint?: string;
+  /** Whether this row is on the channel being composed in. Ranks first. */
+  inChannel?: boolean;
+}
+
+/** Whether `ch` is word-like, for the mention boundary rules. */
+function isWord(ch: string | undefined): boolean {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+
+/**
+ * Whether the `@` at `i` opens a mention.
+ *
+ * The condition that keeps `jane@acme.com` from opening a picker mid-address:
+ * an `@` counts only at the start or after whitespace or an opening bracket,
+ * and never immediately after a `<`.
+ */
+function opensMention(text: string, i: number): boolean {
+  if (text[i] !== "@") return false;
+  const before = text[i - 1];
+  // Start of text always opens.
+  if (before === undefined) return true;
+  // Never inside an existing `<@id>` token.
+  if (before === "<") return false;
+  // Anything word-like before it means this `@` is part of something else —
+  // overwhelmingly an email address. This is `vercel/chat`'s accept condition
+  // minus its `isWord(text[i + 1])` half, which a picker cannot have: the
+  // first keystroke of a mention is a bare `@` with nothing after it yet.
+  return !isWord(before);
+}
+
+/**
+ * The `@query` the caret is currently inside, or `null` when it is not in one.
+ *
+ * Scans backwards from the caret to the nearest mention-opening `@`, giving up
+ * at a newline, a second `@`, or {@link MAX_QUERY} characters — so a stray `@`
+ * earlier in a long paragraph cannot hold the picker open while somebody types
+ * an unrelated sentence.
+ *
+ * The query may contain spaces, because a person's label often does
+ * (`@Jane Doe`). That is what makes the multi-word case reachable at all, and
+ * why the give-up conditions above have to be real rather than "stop at a
+ * space".
+ */
+export function activeMentionQuery(
+  text: string,
+  caret: number,
+): { start: number; query: string } | null {
+  for (let i = caret - 1; i >= 0 && caret - i <= MAX_QUERY; i--) {
+    const ch = text[i];
+    if (ch === "\n") return null;
+    if (ch !== "@") continue;
+    if (!opensMention(text, i)) return null;
+    return { start: i, query: text.slice(i + 1, caret) };
+  }
+  return null;
+}
+
+/**
+ * Blanks fenced and inline code spans, preserving every offset.
+ *
+ * Each masked byte becomes a space, so the result is the same length as the
+ * input and an index computed against it is valid against the original.
+ * Stripping instead would shift every later match.
+ */
+export function stripCodeRegions(text: string): string {
+  const out = text.split("");
+  const blank = (from: number, to: number) => {
+    for (let i = from; i < Math.min(to, out.length); i++) {
+      if (out[i] !== "\n") out[i] = " ";
+    }
+  };
+
+  // Fenced blocks first, so a backtick inside one is never read as a span.
+  const fence = /^([`~]{3,})[^\n]*\n?([\s\S]*?)(?:^\1[`~]*[^\n]*$|$)/gm;
+  for (const m of text.matchAll(fence)) {
+    if (m.index !== undefined) blank(m.index, m.index + m[0].length);
+  }
+
+  const masked = out.join("");
+  // Inline spans, closed by a backtick run of equal length.
+  const span = /(`+)(?:(?!\1)[\s\S])*?\1/g;
+  for (const m of masked.matchAll(span)) {
+    if (m.index !== undefined) blank(m.index, m.index + m[0].length);
+  }
+  return out.join("");
+}
+
+/**
+ * Orders the picker's rows for `query`.
+ *
+ * Two levels, following the shape `block/buzz` settled on: a group rank first,
+ * so people you are actually talking to come before the long tail, then a
+ * match score, then the original order. Sorting by score alone buries a channel
+ * member under a better-spelled stranger.
+ */
+export function rankMentionables(
+  entries: Mentionable[],
+  query: string,
+): Mentionable[] {
+  const q = query.trim().toLowerCase();
+  const groupRank = (e: Mentionable): number => {
+    if (e.inChannel) return 0;
+    if (e.target.kind === "everyone") return 1;
+    if (e.target.kind === "user") return 2;
+    if (e.target.kind === "desk") return 3;
+    return 4;
+  };
+  const score = (e: Mentionable): number => {
+    if (!q) return 0;
+    let best = Number.MAX_SAFE_INTEGER;
+    for (const alias of e.aliases) {
+      if (alias === q) best = Math.min(best, 0);
+      else if (alias.startsWith(q)) best = Math.min(best, 1);
+      else if (alias.split(/[\s\-_.]+/).some((w) => w === q))
+        best = Math.min(best, 2);
+      else if (alias.split(/[\s\-_.]+/).some((w) => w.startsWith(q)))
+        best = Math.min(best, 3);
+      else if (alias.includes(q)) best = Math.min(best, 4);
+    }
+    return best;
+  };
+
+  return entries
+    .map((entry, index) => ({ entry, index, s: score(entry) }))
+    .filter((row) => row.s !== Number.MAX_SAFE_INTEGER)
+    .sort(
+      (a, b) =>
+        // An exact match outranks the group preference, and only an exact
+        // match does. Otherwise typing a teammate's whole name still hands you
+        // the desk that merely starts with it — `@engineer` offering
+        // `engineering` first — which is precisely the case where the person
+        // has already told you exactly who they mean.
+        (a.s === 0 ? 0 : 1) - (b.s === 0 ? 0 : 1) ||
+        groupRank(a.entry) - groupRank(b.entry) ||
+        a.s - b.s ||
+        a.index - b.index,
+    )
+    .map((row) => row.entry);
+}
+
+/**
+ * Replaces the active `@query` with `entry`, and says where the caret lands.
+ *
+ * A trailing space is appended so the next word does not extend the mention —
+ * without it, typing straight on after picking would grow the span and the
+ * reconcile below would drop it.
+ */
+export function insertMention(
+  draft: string,
+  range: { start: number; end: number },
+  entry: Mentionable,
+): { text: string; caret: number; mention: Mention } {
+  const span = `@${entry.label}`;
+  const text = `${draft.slice(0, range.start)}${span} ${draft.slice(range.end)}`;
+  return {
+    text,
+    caret: range.start + span.length + 1,
+    mention: { target: entry.target, text: span, offset: range.start },
+  };
+}
+
+/**
+ * Drops every mention whose span no longer sits where it was recorded, and
+ * shifts the ones that merely moved.
+ *
+ * This is what makes backspacing through a chip un-mention it: edit the text of
+ * `@Jane Doe` and the recorded span stops matching, so the mention goes with
+ * it. Without this the composer would keep pinging somebody whose name is no
+ * longer in the message.
+ *
+ * A mention that still exists verbatim but has shifted — because text was
+ * inserted before it — is re-anchored rather than dropped, so typing at the
+ * start of a draft does not silently unresolve everything after the caret.
+ */
+export function reconcileMentions(text: string, mentions: Mention[]): Mention[] {
+  const used: Array<[number, number]> = [];
+  const out: Mention[] = [];
+  for (const mention of mentions) {
+    if (text.slice(mention.offset, mention.offset + mention.text.length) === mention.text) {
+      used.push([mention.offset, mention.offset + mention.text.length]);
+      out.push(mention);
+      continue;
+    }
+    // Re-anchor to the first occurrence not already claimed by another mention,
+    // so two mentions of the same person do not collapse onto one span.
+    let from = 0;
+    for (;;) {
+      const at = text.indexOf(mention.text, from);
+      if (at === -1) break;
+      const overlaps = used.some(([s, e]) => at < e && at + mention.text.length > s);
+      if (!overlaps) {
+        used.push([at, at + mention.text.length]);
+        out.push({ ...mention, offset: at });
+        break;
+      }
+      from = at + 1;
+    }
+  }
+  return out.sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * A pattern matching exactly the spans in `mentions`, and nothing else.
+ *
+ * Returns {@link NEVER_MATCH} for an empty list, which is the point: an
+ * `@word` is highlighted **only** when it corresponds to a mention the host
+ * actually delivered. A chip is a claim that somebody was notified, so drawing
+ * one over unresolved text would be a lie the reader cannot check.
+ */
+export function mentionRegex(mentions: Array<{ text: string }>): RegExp {
+  if (mentions.length === 0) return NEVER_MATCH;
+  const escaped = [...new Set(mentions.map((m) => m.text))]
+    // Longest first, so `@Ann` cannot match inside `@Ann Lee`.
+    .sort((a, b) => b.length - a.length)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return new RegExp(`(${escaped.join("|")})`, "g");
+}
+
+/**
+ * Turns the host's directory into picker rows for one channel.
+ *
+ * `inChannel` is what puts the people you are actually talking to at the top of
+ * the list, and it is derived from the channel's own membership — which the
+ * host only knows for teammates. Every signed-in person can see every desk, so
+ * people are never "outside" a channel and are not marked either way.
+ *
+ * The `@everyone` row carries the host's spellings rather than a hard-coded
+ * set, so the picker cannot offer a token the host would fail to resolve.
+ */
+export function mentionablesFor(
+  directory: {
+    agents: Array<{ id: string; name: string; role: string }>;
+    people: Array<{ id: string; label: string; slug: string }>;
+    desks: Array<{ id: string; name: string; memberIds: string[] }>;
+    everyone: { label: string; aliases: string[] };
+  },
+  channelMemberIds?: string[],
+): Mentionable[] {
+  const inChannel = new Set(channelMemberIds ?? []);
+  const agents: Mentionable[] = directory.agents.map((a) => ({
+    target: { kind: "agent", id: a.id },
+    label: a.id,
+    aliases: [...new Set([a.id.toLowerCase(), a.name.toLowerCase()])],
+    hint: a.role,
+    inChannel: inChannel.has(a.id),
+  }));
+  const people: Mentionable[] = directory.people.map((p) => ({
+    target: { kind: "user", id: p.id },
+    label: p.label,
+    aliases: [...new Set([p.label.toLowerCase(), p.slug])],
+    hint: "Person",
+  }));
+  const desks: Mentionable[] = directory.desks.map((d) => ({
+    target: { kind: "desk", id: d.id },
+    label: d.id,
+    aliases: [...new Set([d.id.toLowerCase(), d.name.toLowerCase()])],
+    hint:
+      d.memberIds.length === 1
+        ? `${d.name} — 1 teammate`
+        : `${d.name} — ${d.memberIds.length} teammates`,
+  }));
+  const everyone: Mentionable = {
+    target: { kind: "everyone" },
+    label: directory.everyone.label,
+    aliases: directory.everyone.aliases.map((a) => a.toLowerCase()),
+    hint: "Notify everyone here",
+  };
+  return [...agents, ...people, ...desks, everyone];
+}
+
+/**
+ * The teammates a draft would address who are **not** on this channel.
+ *
+ * Mentioning somebody who cannot see the channel is a real mistake and a silent
+ * one: the message sends, the chip renders, and the person never appears. The
+ * composer warns before the send rather than after.
+ *
+ * People are never returned. Every signed-in person can see every desk, so
+ * "outside this channel" does not apply to them — only to teammates, whose desk
+ * membership is real.
+ */
+export function mentionsOutsideChannel(
+  mentions: Mention[],
+  channelMemberIds: string[] | undefined,
+): string[] {
+  // Unknown membership is not empty membership: a DM and a fallback desk both
+  // report none, and warning about every mention there would be noise.
+  if (!channelMemberIds) return [];
+  const members = new Set(channelMemberIds);
+  return mentions
+    .filter((m) => m.target.kind === "agent" && !members.has(m.target.id))
+    .map((m) => (m.target.kind === "agent" ? m.target.id : ""))
+    .filter((id, i, all) => id && all.indexOf(id) === i);
+}

--- a/frontend/src/views/chat/mentions.ts
+++ b/frontend/src/views/chat/mentions.ts
@@ -83,15 +83,46 @@ function opensMention(text: string, i: number): boolean {
 export function activeMentionQuery(
   text: string,
   caret: number,
+  knownAliases?: ReadonlySet<string>,
 ): { start: number; query: string } | null {
   for (let i = caret - 1; i >= 0 && caret - i <= MAX_QUERY; i--) {
     const ch = text[i];
     if (ch === "\n") return null;
     if (ch !== "@") continue;
     if (!opensMention(text, i)) return null;
-    return { start: i, query: text.slice(i + 1, caret) };
+    const query = text.slice(i + 1, caret);
+    // A finished name followed by a space closes the query.
+    //
+    // Without this the picker reopens the instant you pick somebody: inserting
+    // `@engineer ` leaves the caret after a trailing space, the scan above
+    // still finds the `@`, and the query becomes `"engineer "` — which matches
+    // and re-renders the list over the message you are now trying to write.
+    //
+    // Gated on an EXACT alias rather than on any trailing space, because a
+    // space is also how a two-word name is typed: `@Jane ` must stay open on
+    // the way to `@Jane Doe`. `block/buzz` draws the line in the same place,
+    // and for the same reason — a longer name sharing a prefix must not hold
+    // the query open once a shorter one is complete.
+    if (knownAliases && /\s$/.test(query)) {
+      if (knownAliases.has(query.trim().toLowerCase())) return null;
+    }
+    return { start: i, query };
   }
   return null;
+}
+
+/**
+ * Every spelling in `entries`, for {@link activeMentionQuery}'s close rule.
+ *
+ * Built by the caller once per directory rather than per keystroke.
+ */
+export function aliasSet(entries: readonly Mentionable[]): Set<string> {
+  const out = new Set<string>();
+  for (const entry of entries) {
+    out.add(entry.label.toLowerCase());
+    for (const alias of entry.aliases) out.add(alias);
+  }
+  return out;
 }
 
 /**

--- a/frontend/test/e2e/chat-mentions.spec.ts
+++ b/frontend/test/e2e/chat-mentions.spec.ts
@@ -1,0 +1,258 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for the `@`-mention composer.
+ *
+ * Three things a unit test of the pure module cannot show, because all three
+ * are about the composer's *keyboard*, which only exists in a browser:
+ *
+ * 1. **Enter picks and does not send.** Somebody mid-`@name` is choosing a
+ *    person, not finishing a message. Sending there is unrecoverable — the
+ *    half-typed message is already in the channel — and it is the single most
+ *    likely way to get this feature wrong.
+ * 2. The picker opens on a real `@` and stays shut inside an email address.
+ * 3. What the console *sends* carries structured mentions, so the host resolves
+ *    what the person actually picked rather than re-guessing from the text.
+ *
+ * Mocks the operator API, following `chat-channel-membership.spec.ts`: the
+ * inputs that matter are a known directory and an inspectable chat POST body,
+ * and only a stub produces those on demand.
+ */
+
+const COMPANY = "acme";
+
+const DESKS = [
+  { id: "engineering", name: "Engineering", description: "Ships it", members: ["engineer", "ceo"] },
+];
+
+const ROSTER = [
+  { id: "engineer", name: "Ada", role: "Backend Engineer" },
+  { id: "ceo", name: "Rae", role: "Chief Executive" },
+];
+
+const MENTIONABLES = {
+  agents: ROSTER,
+  people: [{ id: "u1", label: "Jane Doe", slug: "jane-doe" }],
+  desks: [{ id: "engineering", name: "Engineering", memberIds: ["engineer", "ceo"] }],
+  everyone: { label: "everyone", aliases: ["everyone", "channel", "here"] },
+};
+
+type SentChat = {
+  text: string;
+  chat?: string;
+  mentions?: Array<{ target: { kind: string; id?: string }; text: string; offset: number }>;
+};
+
+let sent: SentChat[] = [];
+
+async function mockApi(page: Page) {
+  // The first-run tour renders a modal over the console and swallows clicks.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+    if (path.endsWith("/desks")) return json(DESKS);
+    if (path.endsWith("/team")) return json(ROSTER);
+    if (path.endsWith("/chat/mentionables")) return json(MENTIONABLES);
+    if (path.endsWith("/chat/read-state")) return json({ markers: [] });
+    if (path.endsWith("/chat/history")) return json([]);
+    if (path.endsWith("/chat")) {
+      const body = route.request().postDataJSON() as SentChat;
+      sent.push(body);
+      return json({ responses: [{ text: `echo: ${body.text}`, channel: body.chat }] });
+    }
+    if (path.endsWith("/events")) {
+      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+    }
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "member" });
+    return json([]);
+  });
+}
+
+const composer = (page: Page) => page.getByPlaceholder(/^Message /);
+const picker = (page: Page) => page.getByTestId("mention-picker");
+const options = (page: Page) => page.getByTestId("mention-option");
+
+async function openChannel(page: Page, channelId: string) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(composer(page)).toBeVisible({ timeout: 30_000 });
+}
+
+test.beforeEach(() => {
+  sent = [];
+});
+
+test("typing @ opens the picker and filters as you type", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("hey @");
+  await expect(picker(page)).toBeVisible();
+
+  // Everything is offered before a query narrows it.
+  await expect(options(page).first()).toBeVisible();
+
+  await composer(page).type("eng");
+  // The teammate wins the exact query even though a desk also starts with it.
+  await expect(options(page).first()).toContainText("engineer");
+});
+
+/**
+ * The assertion this whole spec exists for. Enter with the picker open must
+ * pick, never send — the message is half-typed and sending it cannot be undone.
+ */
+test("Enter picks the highlighted row and does not send", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("hey @eng");
+  await expect(picker(page)).toBeVisible();
+  await composer(page).press("Enter");
+
+  // Picked: the draft now holds the full handle, and the picker is shut.
+  await expect(composer(page)).toHaveValue(/@engineer\s$/);
+  await expect(picker(page)).toHaveCount(0);
+  // And crucially, nothing was sent.
+  expect(sent).toHaveLength(0);
+});
+
+test("Enter with the picker shut sends, and carries the resolved mention", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("hey @eng");
+  await composer(page).press("Enter"); // picks
+  await composer(page).type("what is the build status?");
+  await composer(page).press("Enter"); // sends
+
+  await expect.poll(() => sent.length).toBe(1);
+  const body = sent[0];
+  expect(body.text).toContain("@engineer");
+  // Structured, not re-guessed from the text: the host is told exactly who the
+  // person picked.
+  expect(body.mentions).toHaveLength(1);
+  expect(body.mentions?.[0].target).toEqual({ kind: "agent", id: "engineer" });
+  expect(body.mentions?.[0].text).toBe("@engineer");
+  // The span has to actually sit at the recorded offset, or the chip renders
+  // over the wrong characters.
+  const { offset, text } = body.mentions![0];
+  expect(body.text.slice(offset, offset + text.length)).toBe("@engineer");
+});
+
+test("Escape closes the picker and leaves the draft alone", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("hey @eng");
+  await expect(picker(page)).toBeVisible();
+  await composer(page).press("Escape");
+
+  await expect(picker(page)).toHaveCount(0);
+  await expect(composer(page)).toHaveValue("hey @eng");
+  expect(sent).toHaveLength(0);
+});
+
+/** An email address is the case a naive `@` trigger gets wrong every time. */
+test("the picker does not open inside an email address", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("write to jane@eng");
+  await expect(picker(page)).toHaveCount(0);
+});
+
+test("a two-word person is reachable, space and all", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("thanks @Jane Do");
+  // The query survives the space — without that, a display name with one in it
+  // can never be picked.
+  await expect(picker(page)).toBeVisible();
+  await expect(options(page).first()).toContainText("Jane Doe");
+
+  await composer(page).press("Enter");
+  await expect(composer(page)).toHaveValue(/@Jane Doe\s$/);
+});
+
+test("backspacing through a chip un-mentions it", async ({ page }) => {
+  await mockApi(page);
+  await openChannel(page, "engineering");
+
+  await composer(page).click();
+  await composer(page).type("hey @eng");
+  await composer(page).press("Enter"); // picks `@engineer `
+  // Delete the trailing space and one character of the handle.
+  await composer(page).press("Backspace");
+  await composer(page).press("Backspace");
+  await composer(page).type(" hello");
+  await composer(page).press("Enter");
+
+  await expect.poll(() => sent.length).toBe(1);
+  // The text no longer contains the handle the mention recorded, so the mention
+  // must go with it rather than pinging somebody who is not named any more.
+  expect(sent[0].mentions ?? []).toHaveLength(0);
+});
+
+test("a host with no mention directory still sends, with no picker", async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+    if (path.endsWith("/desks")) return json(DESKS);
+    if (path.endsWith("/team")) return json(ROSTER);
+    // The pre-feature host.
+    if (path.endsWith("/chat/mentionables")) return json({ error: "not_found" }, 404);
+    if (path.endsWith("/chat/read-state")) return json({ markers: [] });
+    if (path.endsWith("/chat/history")) return json([]);
+    if (path.endsWith("/chat")) {
+      const body = route.request().postDataJSON() as SentChat;
+      sent.push(body);
+      return json({ responses: [{ text: `echo: ${body.text}`, channel: body.chat }] });
+    }
+    if (path.endsWith("/events")) {
+      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+    }
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "member" });
+    return json([]);
+  });
+
+  await openChannel(page, "engineering");
+  await composer(page).click();
+  await composer(page).type("hey @engineer");
+  // No picker, and Enter therefore sends — the composer's behaviour before the
+  // feature existed, which is what an older host must keep getting.
+  await expect(picker(page)).toHaveCount(0);
+  await composer(page).press("Enter");
+
+  await expect.poll(() => sent.length).toBe(1);
+  expect(sent[0].text).toContain("@engineer");
+  // Nothing structured to send; the host extracts from the text instead.
+  expect(sent[0].mentions).toBeUndefined();
+});

--- a/frontend/test/unit/chat-mentions-compose.test.ts
+++ b/frontend/test/unit/chat-mentions-compose.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   activeMentionQuery,
+  aliasSet,
   insertMention,
   mentionablesFor,
   mentionRegex,
@@ -70,6 +71,47 @@ describe("activeMentionQuery", () => {
 
   it("is null when the caret is not in a mention at all", () => {
     expect(activeMentionQuery("just talking", 12)).toBeNull();
+  });
+
+  /**
+   * Without this the picker reopens the instant you pick somebody: inserting
+   * `@engineer ` leaves the caret after a trailing space, the backward scan
+   * still finds the `@`, and the list re-renders over the message you are now
+   * trying to write.
+   */
+  it("closes once a known name is finished and followed by a space", () => {
+    const known = aliasSet([engineer, jane]);
+    expect(activeMentionQuery("hey @engineer ", 14, known)).toBeNull();
+  });
+
+  /** A space is also how a two-word name gets typed, so it cannot just close. */
+  it("stays open through the space of a name still being typed", () => {
+    const known = aliasSet([engineer, jane]);
+    expect(activeMentionQuery("hi @Jane ", 9, known)).toEqual({
+      start: 3,
+      query: "Jane ",
+    });
+  });
+
+  it("stays open on a finished name with no trailing space", () => {
+    const known = aliasSet([engineer, jane]);
+    expect(activeMentionQuery("hey @engineer", 13, known)).toEqual({
+      start: 4,
+      query: "engineer",
+    });
+  });
+
+  /** With no directory to check against, the old behaviour is kept. */
+  it("cannot close on a finished name when it has no aliases to check", () => {
+    expect(activeMentionQuery("hey @engineer ", 14)).not.toBeNull();
+  });
+});
+
+describe("aliasSet", () => {
+  it("carries every spelling, plus the label", () => {
+    const set = aliasSet([jane]);
+    expect(set.has("jane doe")).toBe(true);
+    expect(set.has("jane-doe")).toBe(true);
   });
 });
 

--- a/frontend/test/unit/chat-mentions-compose.test.ts
+++ b/frontend/test/unit/chat-mentions-compose.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeMentionQuery,
+  insertMention,
+  mentionablesFor,
+  mentionRegex,
+  mentionsOutsideChannel,
+  rankMentionables,
+  reconcileMentions,
+  stripCodeRegions,
+  type Mention,
+  type Mentionable,
+} from "@/views/chat/mentions";
+
+/**
+ * The composer half of @-mentions.
+ *
+ * Every rule here is one that is easy to get subtly wrong in a keydown handler
+ * and hard to notice afterwards: a picker that opens inside an email address, a
+ * chip that keeps pinging somebody whose name has been backspaced away, an
+ * `@word` highlighted although it resolved to nobody. The server re-validates
+ * what this produces, but it cannot fix any of those — by the time a message is
+ * sent, the wrong person is already in the list.
+ */
+
+const engineer: Mentionable = {
+  target: { kind: "agent", id: "engineer" },
+  label: "engineer",
+  aliases: ["engineer"],
+  inChannel: true,
+};
+const jane: Mentionable = {
+  target: { kind: "user", id: "u1" },
+  label: "Jane Doe",
+  aliases: ["jane doe", "jane-doe"],
+};
+const everyone: Mentionable = {
+  target: { kind: "everyone" },
+  label: "everyone",
+  aliases: ["everyone", "channel", "here"],
+};
+
+describe("activeMentionQuery", () => {
+  it("opens on an @ at the start or after whitespace", () => {
+    expect(activeMentionQuery("@eng", 4)).toEqual({ start: 0, query: "eng" });
+    expect(activeMentionQuery("hey @eng", 8)).toEqual({ start: 4, query: "eng" });
+    expect(activeMentionQuery("(@eng", 5)).toEqual({ start: 1, query: "eng" });
+  });
+
+  it("does not open inside an email address", () => {
+    expect(activeMentionQuery("jane@acme", 9)).toBeNull();
+  });
+
+  it("keeps the query open across a space, so a two-word name is reachable", () => {
+    expect(activeMentionQuery("hi @Jane Do", 11)).toEqual({
+      start: 3,
+      query: "Jane Do",
+    });
+  });
+
+  it("gives up at a newline rather than holding open across lines", () => {
+    expect(activeMentionQuery("@eng\nnext", 9)).toBeNull();
+  });
+
+  it("gives up once the query gets implausibly long", () => {
+    const long = `@${"x".repeat(40)}`;
+    expect(activeMentionQuery(long, long.length)).toBeNull();
+  });
+
+  it("is null when the caret is not in a mention at all", () => {
+    expect(activeMentionQuery("just talking", 12)).toBeNull();
+  });
+});
+
+describe("stripCodeRegions", () => {
+  it("preserves length, so offsets computed against it stay valid", () => {
+    const text = "a `code` b";
+    const masked = stripCodeRegions(text);
+    expect(masked).toHaveLength(text.length);
+    expect(masked).not.toContain("code");
+    expect(masked.startsWith("a ")).toBe(true);
+  });
+
+  it("masks fenced blocks and keeps the newlines", () => {
+    const text = "before\n```\n@engineer\n```\nafter";
+    const masked = stripCodeRegions(text);
+    expect(masked).toHaveLength(text.length);
+    expect(masked).not.toContain("@engineer");
+    expect(masked.split("\n")).toHaveLength(text.split("\n").length);
+  });
+});
+
+describe("rankMentionables", () => {
+  it("puts channel members before everyone else", () => {
+    const ranked = rankMentionables([jane, everyone, engineer], "e");
+    expect(ranked[0]).toBe(engineer);
+  });
+
+  it("scores an exact match above a mere substring", () => {
+    const other: Mentionable = {
+      target: { kind: "agent", id: "senior_engineer" },
+      label: "senior_engineer",
+      aliases: ["senior_engineer"],
+      inChannel: true,
+    };
+    const ranked = rankMentionables([other, engineer], "engineer");
+    expect(ranked[0]).toBe(engineer);
+  });
+
+  it("drops rows that do not match at all", () => {
+    expect(rankMentionables([engineer, jane], "zzz")).toEqual([]);
+  });
+
+  it("keeps everything, in order, for an empty query", () => {
+    expect(rankMentionables([engineer, jane, everyone], "")).toHaveLength(3);
+  });
+});
+
+describe("insertMention", () => {
+  it("replaces the query and leaves the caret past a trailing space", () => {
+    const draft = "hey @eng";
+    const range = { start: 4, end: 8 };
+    const { text, caret, mention } = insertMention(draft, range, engineer);
+    expect(text).toBe("hey @engineer ");
+    expect(caret).toBe(text.length);
+    expect(mention).toEqual({
+      target: { kind: "agent", id: "engineer" },
+      text: "@engineer",
+      offset: 4,
+    });
+    // The recorded span must actually be at the recorded offset, or the chip
+    // renders over the wrong characters.
+    expect(text.slice(mention.offset, mention.offset + mention.text.length)).toBe(
+      "@engineer",
+    );
+  });
+
+  it("keeps whatever followed the caret", () => {
+    const { text } = insertMention("hey @eng please", { start: 4, end: 8 }, engineer);
+    expect(text).toBe("hey @engineer  please");
+  });
+});
+
+describe("reconcileMentions", () => {
+  const mention: Mention = {
+    target: { kind: "agent", id: "engineer" },
+    text: "@engineer",
+    offset: 4,
+  };
+
+  it("keeps a mention whose span is untouched", () => {
+    expect(reconcileMentions("hey @engineer ok", [mention])).toEqual([mention]);
+  });
+
+  /** Backspacing through a chip has to un-mention it. */
+  it("drops a mention whose text has been edited away", () => {
+    expect(reconcileMentions("hey @engine ok", [mention])).toEqual([]);
+  });
+
+  it("re-anchors a mention that merely shifted", () => {
+    const shifted = reconcileMentions("well hey @engineer ok", [mention]);
+    expect(shifted).toHaveLength(1);
+    expect(shifted[0].offset).toBe(9);
+  });
+
+  it("does not collapse two mentions of the same person onto one span", () => {
+    const twice: Mention[] = [
+      { ...mention, offset: 0 },
+      { ...mention, offset: 10 },
+    ];
+    const out = reconcileMentions("@engineer @engineer", twice);
+    expect(out.map((m) => m.offset)).toEqual([0, 10]);
+  });
+
+  it("returns them in reading order", () => {
+    const out = reconcileMentions("@engineer and @engineer", [
+      { ...mention, offset: 14 },
+      { ...mention, offset: 0 },
+    ]);
+    expect(out.map((m) => m.offset)).toEqual([0, 14]);
+  });
+});
+
+describe("mentionRegex", () => {
+  /**
+   * The rule that keeps a chip honest: it is a claim that somebody was
+   * notified, so it is drawn only where the host actually delivered a mention.
+   */
+  it("matches nothing when there are no mentions", () => {
+    const re = mentionRegex([]);
+    expect("@engineer and @everyone".match(re)).toBeNull();
+  });
+
+  it("matches only the delivered spans", () => {
+    const re = mentionRegex([{ text: "@engineer" }]);
+    const hits = "@engineer told @nobody".match(re);
+    expect(hits).toEqual(["@engineer"]);
+  });
+
+  it("prefers the longer span when one name prefixes another", () => {
+    const re = mentionRegex([{ text: "@Ann" }, { text: "@Ann Lee" }]);
+    expect("@Ann Lee".match(re)).toEqual(["@Ann Lee"]);
+  });
+
+  it("escapes regex metacharacters in a label", () => {
+    const re = mentionRegex([{ text: "@a.b(c)" }]);
+    expect("@a.b(c)".match(re)).toEqual(["@a.b(c)"]);
+    expect("@axbyc".match(re)).toBeNull();
+  });
+});
+
+describe("mentionablesFor", () => {
+  const directory = {
+    agents: [
+      { id: "engineer", name: "Ada", role: "Backend Engineer" },
+      { id: "ceo", name: "Rae", role: "Chief Executive" },
+    ],
+    people: [{ id: "u1", label: "Jane Doe", slug: "jane-doe" }],
+    desks: [{ id: "engineering", name: "Engineering", memberIds: ["engineer"] }],
+    everyone: { label: "everyone", aliases: ["everyone", "channel", "here"] },
+  };
+
+  it("marks only the teammates on this channel", () => {
+    const rows = mentionablesFor(directory, ["engineer"]);
+    const byLabel = Object.fromEntries(rows.map((r) => [r.label, r]));
+    expect(byLabel.engineer.inChannel).toBe(true);
+    expect(byLabel.ceo.inChannel).toBe(false);
+    // Everyone can see every desk, so a person is never "outside" one.
+    expect(byLabel["Jane Doe"].inChannel).toBeUndefined();
+  });
+
+  it("reaches a teammate by id or by display name", () => {
+    const rows = mentionablesFor(directory, []);
+    expect(rankMentionables(rows, "ada")[0].label).toBe("engineer");
+  });
+
+  /**
+   * A desk called `engineering` and a teammate called `engineer` both match
+   * "engineer", and the desk outranks an off-channel teammate by group. The
+   * exact match has to win anyway: the person has already typed exactly who
+   * they mean.
+   */
+  it("puts an exact match above a better-ranked partial one", () => {
+    const rows = mentionablesFor(directory, []);
+    expect(rankMentionables(rows, "engineer")[0].label).toBe("engineer");
+    // And the desk is still offered, just second.
+    expect(rankMentionables(rows, "engineer")[1].label).toBe("engineering");
+  });
+
+  it("takes the broadcast spellings from the host, not from a constant", () => {
+    const rows = mentionablesFor(
+      { ...directory, everyone: { label: "all", aliases: ["all"] } },
+      [],
+    );
+    const broadcast = rows.find((r) => r.target.kind === "everyone");
+    expect(broadcast?.label).toBe("all");
+    expect(broadcast?.aliases).toEqual(["all"]);
+  });
+
+  it("says how many teammates a desk would address", () => {
+    const rows = mentionablesFor(directory, []);
+    expect(rows.find((r) => r.target.kind === "desk")?.hint).toContain("1 teammate");
+  });
+});
+
+describe("mentionsOutsideChannel", () => {
+  const onChannel: Mention = {
+    target: { kind: "agent", id: "engineer" },
+    text: "@engineer",
+    offset: 0,
+  };
+  const offChannel: Mention = {
+    target: { kind: "agent", id: "ceo" },
+    text: "@ceo",
+    offset: 10,
+  };
+
+  it("names a teammate who cannot see this channel", () => {
+    expect(mentionsOutsideChannel([onChannel, offChannel], ["engineer"])).toEqual([
+      "ceo",
+    ]);
+  });
+
+  it("is silent when membership is unknown, not noisy", () => {
+    expect(mentionsOutsideChannel([offChannel], undefined)).toEqual([]);
+  });
+
+  it("never warns about a person, who can see every desk", () => {
+    const person: Mention = {
+      target: { kind: "user", id: "u1" },
+      text: "@Jane Doe",
+      offset: 0,
+    };
+    expect(mentionsOutsideChannel([person], ["engineer"])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Stacked on #1661 (→ #1645). The console half: type `@`, pick somebody, see chips.

## The composer

The dead `AtSign` button — which wrapped the selection in literal `@`s and
resolved nothing — now opens a real picker.

**Enter picks and does not send.** Somebody mid-`@name` is choosing a person,
not finishing a message, and sending there is unrecoverable. Arrows wrap, Tab
accepts, Escape closes. When the picker is shut, Enter sends exactly as before.

## Anchored to the composer, not the caret

The plan called for a Base UI popover on the caret rect. A `<textarea>` exposes
no caret rectangle — getting one means mirroring the whole field into a hidden
clone and tracking font, padding, wrapping and scroll, which is wrong the moment
any of them change. The composer is a narrow box at the bottom of the pane, so
"above the box" and "above the caret" differ by a few pixels and only the first
is reliable. The composer's own formatting toolbar already sets this precedent.

**Zero new dependencies**, and no new UI wrapper.

## Chips are drawn only where somebody was notified

`mentionRegex` returns `/(?!)/g` — a pattern matching nothing — for an empty
list. That is the rule, not an optimisation: an `@word` is highlighted **only**
when the host actually delivered a mention for it. A chip claims somebody was
notified, and one drawn over unresolved text is a claim the reader cannot check.
Chips carry the host's label in a tooltip, and a quiet mention says so
("mentioned, not notified") rather than looking identical to its neighbour.

## Degrading

A host without `GET {scope}/chat/mentionables` answers 404 → no picker. Typing
`@` stays plain text and the host still extracts what it can from it, so an
older host degrades to the composer's previous behaviour rather than a broken
one. `client.chat` sends `mentions` only when the picker resolved something, so
an ordinary post keeps the exact body shape it had before.

## A ranking bug worth calling out

Typing `@engineer` offered the **desk** `engineering` first, because desks
outrank off-channel teammates by group. Fixed: an exact match now beats the
group preference, and only an exact match does. The person has already typed
exactly who they mean.

## Commands run

```
pnpm typecheck        # tsc -b --noEmit
pnpm test             # 252 files, 2311 passed
```

Note for anyone verifying this: `npx tsc --noEmit` in `frontend/` checks
**nothing** — `tsconfig.json` is a solution file with `"files": []` and project
references, so it compiles an empty list and exits 0. Use `pnpm typecheck`. This
caught a genuine unused-symbol error that a bare `tsc` had been passing.

## Tests

31 unit tests over the pure module (`views/chat/mentions.ts`), because every
rule is easier to get wrong in a keydown handler than in a function:

- the picker does not open inside `jane@acme`
- it *stays* open across the space in `@Jane Do`, which is what makes a
  two-word name reachable at all
- it gives up at a newline, a second `@`, and an implausibly long query
- code regions are masked with offsets preserved
- editing a chip un-mentions it; a chip that merely *shifted* is re-anchored
- two mentions of the same person do not collapse onto one span
- an unresolved `@word` is never chipped
- regex metacharacters in a label are escaped
- an exact match outranks a better-grouped partial one

## Not in this PR

Presence and typing (separate PR), and the mention badge.
