### PR TITLE
feat(chat): presence and typing indicators in group chat

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,8 @@ import {
   type BoardQuery,
   type BoardVote,
   type ReadMarker,
+  type MentionablesResponse,
+  type PresenceListResponse,
   type ReadStateResponse,
   type ApiErrorBody,
   type WorkflowProblem,
@@ -625,6 +627,78 @@ export class OpenCompanyClient {
    */
   readState(company?: string | null): Promise<ReadStateResponse> {
     return this.request<ReadStateResponse>("GET", `${this.scope(company)}/chat/read-state`);
+  }
+
+  /**
+   * Everything an `@` can name. Presence uses only `people`, for the
+   * user-id → label map the live frames deliberately do not carry.
+   *
+   * A host that predates this route answers 404; callers treat that as an
+   * empty directory rather than throwing on load.
+   */
+  mentionables(company?: string | null): Promise<MentionablesResponse> {
+    return this.request<MentionablesResponse>(
+      "GET",
+      `${this.scope(company)}/chat/mentionables`,
+    );
+  }
+
+  /** Who is present on this replica right now. */
+  presence(company?: string | null): Promise<PresenceListResponse> {
+    return this.request<PresenceListResponse>("GET", `${this.scope(company)}/presence`);
+  }
+
+  /**
+   * A heartbeat, and what to appear as.
+   *
+   * The body deliberately carries **no user id**: the host takes the subject
+   * from the session, so no caller can move somebody else's dot.
+   */
+  announcePresence(
+    status: "online" | "away" | "offline",
+    company?: string | null,
+  ): Promise<void> {
+    return this.request<void>("PUT", `${this.scope(company)}/presence`, { status });
+  }
+
+  /**
+   * Clear this console's dot on the way out.
+   *
+   * A `keepalive` fetch rather than the ordinary request path, because a
+   * request issued from `pagehide` is otherwise cancelled along with the
+   * document. `sendBeacon` would be the usual tool but cannot issue a
+   * `DELETE`, and inventing a POST alias for one route is a worse trade than
+   * `keepalive`, which every browser this console supports honours.
+   *
+   * Best-effort by design, and allowed to fail silently: if it does not land,
+   * the host's lease expires the dot within a few minutes anyway. That is the
+   * whole reason presence is a lease — no disconnect path has to be correct.
+   */
+  disconnectPresenceBeacon(company?: string | null): void {
+    try {
+      void fetch(`${this.baseUrl}${this.scope(company)}/presence`, {
+        method: "DELETE",
+        credentials: "include",
+        keepalive: true,
+      }).catch(() => {});
+    } catch {
+      // The document is unloading. Nothing to do, and nobody to report it to.
+    }
+  }
+
+  /**
+   * Say this console is typing. Fire-and-forget: an undelivered ping is not
+   * worth a retry, and the indicator expires on its own regardless.
+   */
+  typing(
+    chatId: string,
+    parentId?: string,
+    company?: string | null,
+  ): Promise<void> {
+    return this.request<void>("POST", `${this.scope(company)}/chat/typing`, {
+      chatId,
+      ...(parentId ? { parentId } : {}),
+    });
   }
 
   /**

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -652,13 +652,20 @@ export class OpenCompanyClient {
    * A heartbeat, and what to appear as.
    *
    * The body deliberately carries **no user id**: the host takes the subject
-   * from the session, so no caller can move somebody else's dot.
+   * from the session, so no caller can move somebody else's dot. `consoleId`
+   * is not an identity either — it is this tab's opaque lease key, so closing
+   * one of several open tabs drops only that tab's lease rather than logging
+   * every tab for this person out (see `usePresence`'s `consoleId`).
    */
   announcePresence(
     status: "online" | "away" | "offline",
     company?: string | null,
+    consoleId?: string,
   ): Promise<void> {
-    return this.request<void>("PUT", `${this.scope(company)}/presence`, { status });
+    return this.request<void>("PUT", `${this.scope(company)}/presence`, {
+      status,
+      ...(consoleId ? { consoleId } : {}),
+    });
   }
 
   /**
@@ -670,16 +677,25 @@ export class OpenCompanyClient {
    * `DELETE`, and inventing a POST alias for one route is a worse trade than
    * `keepalive`, which every browser this console supports honours.
    *
+   * Carries the same session and bearer headers `request` would attach.
+   * `credentials: "include"` alone only carries a same-origin cookie; a
+   * console authenticated cross-origin (or through a desktop transport) holds
+   * its session in `x-opencompany-session`/`authorization` instead, and
+   * without them this call 401s on every tab close, leaving the lease visible
+   * until its TTL expires regardless of the beacon firing.
+   *
    * Best-effort by design, and allowed to fail silently: if it does not land,
    * the host's lease expires the dot within a few minutes anyway. That is the
    * whole reason presence is a lease — no disconnect path has to be correct.
    */
-  disconnectPresenceBeacon(company?: string | null): void {
+  disconnectPresenceBeacon(company?: string | null, consoleId?: string): void {
     try {
-      void fetch(`${this.baseUrl}${this.scope(company)}/presence`, {
+      const query = consoleId ? `?consoleId=${encodeURIComponent(consoleId)}` : "";
+      void fetch(`${this.baseUrl}${this.scope(company)}/presence${query}`, {
         method: "DELETE",
         credentials: "include",
         keepalive: true,
+        headers: this.authHeaders(),
       }).catch(() => {});
     } catch {
       // The document is unloading. Nothing to do, and nobody to report it to.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -671,35 +671,45 @@ export class OpenCompanyClient {
   /**
    * Clear this console's dot on the way out.
    *
-   * A `keepalive` fetch rather than the ordinary request path, because a
-   * request issued from `pagehide` is otherwise cancelled along with the
-   * document. `sendBeacon` would be the usual tool but cannot issue a
-   * `DELETE`, and inventing a POST alias for one route is a worse trade than
-   * `keepalive`, which every browser this console supports honours.
+   * Goes through `this.transport`, the same seam every other call on this
+   * class uses — **not** a direct `fetch`, which this used to be. A desktop
+   * console's webview cannot satisfy this route on its own even with the
+   * right headers: it is cross-origin with the host (so a direct request
+   * needs CORS the host does not grant it) and the device credential lives
+   * only in the Rust core's keychain, never in JS. `ProxyTransport` is what
+   * gets both right, and only routing through `this.transport` reaches it.
    *
-   * Carries the same session and bearer headers `request` would attach.
-   * `credentials: "include"` alone only carries a same-origin cookie; a
-   * console authenticated cross-origin (or through a desktop transport) holds
-   * its session in `x-opencompany-session`/`authorization` instead, and
-   * without them this call 401s on every tab close, leaving the lease visible
-   * until its TTL expires regardless of the beacon firing.
+   * The one thing this needs beyond an ordinary request — surviving the
+   * document going away, since this fires from `pagehide` — is
+   * `keepalive: true`, threaded through `TransportRequest` for exactly this
+   * call. `BrowserTransport` forwards it to `fetch`'s own `keepalive` option;
+   * `ProxyTransport` ignores it, because a Tauri `invoke` is core-process IPC
+   * with no equivalent teardown-survival problem. `sendBeacon` would be the
+   * usual browser-only tool here but cannot issue a `DELETE` or run through
+   * the desktop bridge at all.
+   *
+   * Carries the same session and bearer headers `request` would attach —
+   * `credentials: "include"` alone (still set unconditionally inside
+   * `BrowserTransport`) only carries a same-origin cookie, and a console
+   * authenticated cross-origin holds its session in
+   * `x-opencompany-session`/`authorization` instead.
    *
    * Best-effort by design, and allowed to fail silently: if it does not land,
    * the host's lease expires the dot within a few minutes anyway. That is the
    * whole reason presence is a lease — no disconnect path has to be correct.
    */
   disconnectPresenceBeacon(company?: string | null, consoleId?: string): void {
-    try {
-      const query = consoleId ? `?consoleId=${encodeURIComponent(consoleId)}` : "";
-      void fetch(`${this.baseUrl}${this.scope(company)}/presence${query}`, {
+    const query = consoleId ? `?consoleId=${encodeURIComponent(consoleId)}` : "";
+    void this.transport
+      .request({
         method: "DELETE",
-        credentials: "include",
-        keepalive: true,
+        url: `${this.baseUrl}${this.scope(company)}/presence${query}`,
         headers: this.authHeaders(),
-      }).catch(() => {});
-    } catch {
-      // The document is unloading. Nothing to do, and nobody to report it to.
-    }
+        keepalive: true,
+      })
+      .catch(() => {
+        // Best-effort by design; see this method's doc comment.
+      });
   }
 
   /**

--- a/frontend/src/api/transport/browser.ts
+++ b/frontend/src/api/transport/browser.ts
@@ -29,6 +29,10 @@ export class BrowserTransport implements Transport {
       // Access-Control-Allow-Credentials — use the Vite proxy so the console
       // stays same-origin.
       credentials: "include",
+      // Only ever set by a request issued from `pagehide` — see
+      // `TransportRequest.keepalive`. `undefined` for every other call, which
+      // `fetch` treats as `false`.
+      keepalive: req.keepalive,
     });
 
     // Read the body here rather than handing the caller a live `Response`: the

--- a/frontend/src/api/transport/types.ts
+++ b/frontend/src/api/transport/types.ts
@@ -29,6 +29,16 @@ export interface TransportRequest {
   headers: Record<string, string>;
   /** Already serialized. `undefined` for a bodyless request. */
   body?: string;
+  /**
+   * Ask the browser to keep this request alive past the page that issued it —
+   * for the one caller that fires a request from `pagehide` and needs it to
+   * still land after the document is gone (`disconnectPresenceBeacon`).
+   * Meaningful only to `BrowserTransport`, which threads it straight to
+   * `fetch`'s own `keepalive` option; `ProxyTransport` ignores it, because a
+   * Tauri `invoke` call is core-process IPC, not a page-scoped browser
+   * request, and has no equivalent teardown-survival problem to solve.
+   */
+  keepalive?: boolean;
 }
 
 export interface TransportResponse {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1734,3 +1734,37 @@ export interface ReadMarker {
 export interface ReadStateResponse {
   markers: ReadMarker[];
 }
+
+/** Response of `GET {scope}/presence`. */
+export interface PresenceListResponse {
+  /**
+   * Present people, most recently seen first.
+   *
+   * **This replica's view.** A second host serving the same tenant keeps its
+   * own map, so somebody connected there is simply absent here — which is why
+   * an absence reads as "no live signal" and never as a grey "offline" dot.
+   */
+  people: PresenceDto[];
+}
+
+/** One person's live presence. */
+export interface PresenceDto {
+  /** The user id, as `GET {scope}/chat/mentionables` already names them. */
+  userId: string;
+  status: "online" | "away" | "offline";
+  /** When their lease was last renewed, epoch millis. */
+  atMillis: number;
+}
+
+/**
+ * Response of `GET {scope}/chat/mentionables` — everything an `@` can name.
+ *
+ * Presence reads only `people` from it, for the user-id → label map the
+ * `presence` and `typing` frames deliberately do not carry.
+ */
+export interface MentionablesResponse {
+  agents: Array<{ id: string; name: string; role: string }>;
+  people: Array<{ id: string; label: string; slug: string }>;
+  desks: Array<{ id: string; name: string; memberIds: string[] }>;
+  everyone: { label: string; aliases: string[] };
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -55,6 +55,8 @@ import { startVisiblePolling } from "@/lib/visible-poll";
 import { mergeOpenTurns, openTurnsFromRuns, PendingSyncPosts, type OpenTurn } from "@/lib/live-reply";
 import { type AgentReplyEvent, type CompanyStreamEvent, useEvents } from "@/hooks/use-events";
 import { useLedgerNav } from "@/hooks/use-ledger-nav";
+import { usePresence } from "@/hooks/use-presence";
+import { useTyping } from "@/hooks/use-typing";
 import type { WorkspaceEvent } from "@/views/WorkspaceView";
 import { useHashView } from "@/hooks/use-hash-view";
 import { BOARD_LEDGER } from "@/lib/board-columns";
@@ -1501,6 +1503,61 @@ export function AppShell({
   // upserts a `running` row keyed by `toolCallId`; a `tool_result` flips that row
   // to `ok`/`error` in place (FIFO fallback when no id pairs), mirroring
   // OpenHuman's `toolCallReceived` / `toolResultReceived`.
+  // Who is here, and who is typing. Both are shell-level because the SSE
+  // subscription is: the frames arrive on one stream for the whole console, so
+  // the state they feed has to live where that stream is read.
+  const presence = usePresence(client, company);
+  const typing = useTyping(client, company);
+  /**
+   * The company's people, id → label.
+   *
+   * Presence and typing frames carry a user id and no label — deliberately, so
+   * the wire does not repeat a name the console already holds — which means
+   * something has to hold it. This is that. Read from the mention directory
+   * rather than the admin user route, because it is the one people-listing a
+   * *member* may read.
+   *
+   * A host without the route leaves this empty, which degrades cleanly: the
+   * People section does not render and a typing line falls back to naming
+   * nobody rather than naming a raw id.
+   */
+  const [companyPeople, setCompanyPeople] = useState<Array<{ id: string; label: string }>>(
+    [],
+  );
+  useEffect(() => {
+    let live = true;
+    void client
+      .mentionables(company)
+      .then((d) => {
+        if (live) setCompanyPeople(d.people.map((p) => ({ id: p.id, label: p.label })));
+      })
+      .catch(() => {
+        if (live) setCompanyPeople([]);
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
+
+  /**
+   * Who to name in the typing line for the channel on screen.
+   *
+   * Resolved here rather than in the view because the label map is here.
+   * Somebody the directory does not name is dropped rather than shown as a raw
+   * id — "u_01H4… is typing" is worse than saying nothing.
+   */
+  const typingNames = useMemo(() => {
+    const byId = new Map(companyPeople.map((p) => [p.id, p.label]));
+    // `sub` rather than `activeChatChannelRef`, which is a ref and so cannot
+    // drive a memo — and falling back to the first desk matches what the chat
+    // view itself opens when the hash names no channel.
+    const active = view === "chat" ? (sub ?? firstDeskChannelId) : null;
+    if (!active) return [];
+    return typing.typers
+      .filter((t) => t.chatId === active && !t.parentId)
+      .map((t) => byId.get(t.userId))
+      .filter((label): label is string => Boolean(label));
+  }, [typing.typers, companyPeople, view, sub, firstDeskChannelId]);
   const onTurnEvent = useCallback((event: CompanyStreamEvent) => {
     // Route by the frame's own thread id so concurrent turns (even from the same
     // desk member) never cross-attribute; fall back to the in-flight ref only
@@ -1703,6 +1760,20 @@ export function AppShell({
       }));
     }, []),
     onTurnEvent,
+    onPresenceEvent: useCallback(
+      (event: CompanyStreamEvent) => {
+        if (event.type !== "presence") return;
+        presence.onFrame(event);
+      },
+      [presence],
+    ),
+    onTypingEvent: useCallback(
+      (event: CompanyStreamEvent) => {
+        if (event.type !== "typing") return;
+        typing.onFrame(event);
+      },
+      [typing],
+    ),
     onWorkflowRunEvent: useCallback((event: CompanyStreamEvent) => {
       // Both halves. The tick refreshes the durable history; the frames drive
       // the live canvas. Progress frames are far more frequent than outcomes,
@@ -1903,6 +1974,10 @@ export function AppShell({
               client={client}
               company={company}
               sub={sub}
+              presence={presence.peers}
+              companyPeople={companyPeople}
+              typingNames={typingNames}
+              onTyping={typing.announce}
               onNavigate={(channelId) => navigate("chat", channelId)}
               onReply={() => void feed.refresh()}
               transcripts={transcripts}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -57,6 +57,7 @@ import { type AgentReplyEvent, type CompanyStreamEvent, useEvents } from "@/hook
 import { useLedgerNav } from "@/hooks/use-ledger-nav";
 import { usePresence } from "@/hooks/use-presence";
 import { useTyping } from "@/hooks/use-typing";
+import { typersIn } from "@/lib/awareness";
 import type { WorkspaceEvent } from "@/views/WorkspaceView";
 import { useHashView } from "@/hooks/use-hash-view";
 import { BOARD_LEDGER } from "@/lib/board-columns";
@@ -1540,24 +1541,30 @@ export function AppShell({
   }, [client, company]);
 
   /**
-   * Who to name in the typing line for the channel on screen.
+   * Who to name in the typing line for a given channel (and, when a thread
+   * is open, that thread) — a resolver rather than one precomputed array,
+   * because `ChatView` needs two independent lines: the main composer's
+   * (`parentId` unset) and the open thread panel's (`parentId` set to the
+   * parent message's id). A single array could only ever answer one of them,
+   * which is why thread typing indicators never worked before this: the wire
+   * and `useTyping` already carried `parentId`, but everything upstream threw
+   * it away.
    *
    * Resolved here rather than in the view because the label map is here.
    * Somebody the directory does not name is dropped rather than shown as a raw
-   * id — "u_01H4… is typing" is worse than saying nothing.
+   * id — "u_01H4… is typing" is worse than saying nothing. Reuses `typersIn`
+   * — the same filter+sort `TypingLine`'s stable ordering already relies on —
+   * rather than re-deriving it here.
    */
-  const typingNames = useMemo(() => {
-    const byId = new Map(companyPeople.map((p) => [p.id, p.label]));
-    // `sub` rather than `activeChatChannelRef`, which is a ref and so cannot
-    // drive a memo — and falling back to the first desk matches what the chat
-    // view itself opens when the hash names no channel.
-    const active = view === "chat" ? (sub ?? firstDeskChannelId) : null;
-    if (!active) return [];
-    return typing.typers
-      .filter((t) => t.chatId === active && !t.parentId)
-      .map((t) => byId.get(t.userId))
-      .filter((label): label is string => Boolean(label));
-  }, [typing.typers, companyPeople, view, sub, firstDeskChannelId]);
+  const resolveTypingNames = useCallback(
+    (chatId: string, parentId?: string) => {
+      const byId = new Map(companyPeople.map((p) => [p.id, p.label]));
+      return typersIn(typing.typers, chatId, parentId, Date.now())
+        .map((t) => byId.get(t.userId))
+        .filter((label): label is string => Boolean(label));
+    },
+    [typing.typers, companyPeople],
+  );
   const onTurnEvent = useCallback((event: CompanyStreamEvent) => {
     // Route by the frame's own thread id so concurrent turns (even from the same
     // desk member) never cross-attribute; fall back to the in-flight ref only
@@ -1976,7 +1983,7 @@ export function AppShell({
               sub={sub}
               presence={presence.peers}
               companyPeople={companyPeople}
-              typingNames={typingNames}
+              resolveTypingNames={resolveTypingNames}
               onTyping={typing.announce}
               onNavigate={(channelId) => navigate("chat", channelId)}
               onReply={() => void feed.refresh()}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1530,7 +1530,18 @@ export function AppShell({
     void client
       .mentionables(company)
       .then((d) => {
-        if (live) setCompanyPeople(d.people.map((p) => ({ id: p.id, label: p.label })));
+        // `d.people` is trusted by the types and not by reality: a host that
+        // answers this route with a different shape — an older one, a proxy, a
+        // stub that returns `[]` for anything it does not recognise — makes
+        // this `undefined`, and `.map` on it throws during render. That blanks
+        // the WHOLE console, not just the presence roster.
+        //
+        // Not hypothetical: it took out every test in
+        // chat-channel-membership.spec.ts, a file with nothing to do with
+        // presence, because its mock returns `[]` for unmatched routes.
+        if (!live) return;
+        const people = Array.isArray(d?.people) ? d.people : [];
+        setCompanyPeople(people.map((p) => ({ id: p.id, label: p.label })));
       })
       .catch(() => {
         if (live) setCompanyPeople([]);

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -358,7 +358,29 @@ export type CompanyStreamEvent =
   // A coalesced "Thinking" run between tool calls — streamed so the live
   // timeline shows the same rows the final folded one does (else the count
   // jumps up when the reply lands).
-  | { type: "thinking"; seq: number; agentId?: string; chatId?: string };
+  | { type: "thinking"; seq: number; agentId?: string; chatId?: string }
+  // Somebody arrived, went idle, or left. Published on a CHANGE only — a
+  // console heartbeats every minute whether or not anything moved, and
+  // republishing that would be one frame per person per minute for no visible
+  // difference. Carries no label: the console already holds the directory that
+  // names people (`GET {scope}/chat/mentionables`).
+  | {
+      type: "presence";
+      userId: string;
+      status: "online" | "away" | "offline";
+      atMillis: number;
+    }
+  // Somebody is typing. Stored nowhere, on either side: the frame carries its
+  // own moment and the console expires it. There is deliberately no "stopped
+  // typing" frame — the absence of a renewal is the stop signal, so a console
+  // that closes mid-word clears itself with no teardown to get wrong.
+  | {
+      type: "typing";
+      userId: string;
+      chatId: string;
+      parentId?: string;
+      atMillis: number;
+    };
 
 /** An `AgentReply` the hook hands back for injection into a chat transcript. */
 export interface AgentReplyEvent {
@@ -480,6 +502,15 @@ interface Options {
    */
   onTurnEvent?: (event: CompanyStreamEvent) => void;
   /**
+   * Called for each `presence` frame — somebody arrived, went idle, or left.
+   *
+   * Toast-free by construction: a dot moving is not news anybody needs
+   * interrupting for, and a company of ten would produce a stream of them.
+   */
+  onPresenceEvent?: (event: CompanyStreamEvent) => void;
+  /** Called for each `typing` frame. Toast-free for the same reason. */
+  onTypingEvent?: (event: CompanyStreamEvent) => void;
+  /**
    * Called for each `workflow_run_finished` event (issue #228) so the Workflows
    * view can refresh its run history live. Matters most for a *scheduled* run:
    * it fires with the tab already open and nothing else would tell the view a
@@ -566,6 +597,8 @@ export function useEvents(
     onDispatchTerminal,
     onWorkspaceEvent,
     onTurnEvent,
+    onPresenceEvent,
+    onTypingEvent,
     onWorkflowRunEvent,
     onWorkflowChanged,
     onApprovalEvent,
@@ -599,6 +632,14 @@ export function useEvents(
   useEffect(() => {
     onTurnEventRef.current = onTurnEvent;
   }, [onTurnEvent]);
+  const onPresenceEventRef = useRef(onPresenceEvent);
+  useEffect(() => {
+    onPresenceEventRef.current = onPresenceEvent;
+  }, [onPresenceEvent]);
+  const onTypingEventRef = useRef(onTypingEvent);
+  useEffect(() => {
+    onTypingEventRef.current = onTypingEvent;
+  }, [onTypingEvent]);
   const onWorkflowRunEventRef = useRef(onWorkflowRunEvent);
   useEffect(() => {
     onWorkflowRunEventRef.current = onWorkflowRunEvent;
@@ -702,6 +743,8 @@ export function useEvents(
             onDispatchTerminal: onDispatchTerminalRef.current,
             onWorkspaceEvent: onWorkspaceEventRef.current,
             onTurnEvent: onTurnEventRef.current,
+            onPresenceEvent: onPresenceEventRef.current,
+            onTypingEvent: onTypingEventRef.current,
             onWorkflowRunEvent: onWorkflowRunEventRef.current,
             onWorkflowChanged: onWorkflowChangedRef.current,
             onApprovalEvent: onApprovalEventRef.current,
@@ -754,6 +797,8 @@ export function handleEvent(
     onDispatchTerminal,
     onWorkspaceEvent,
     onTurnEvent,
+    onPresenceEvent,
+    onTypingEvent,
     onWorkflowRunEvent,
     onWorkflowChanged,
     onApprovalEvent,
@@ -772,6 +817,14 @@ export function handleEvent(
     case "tool_result":
     case "thinking":
       onTurnEvent?.(event);
+      break;
+    // Awareness frames, alongside the turn frames above and toast-free for the
+    // same reason: they render inline, and a dot moving is not an interruption.
+    case "presence":
+      onPresenceEvent?.(event);
+      break;
+    case "typing":
+      onTypingEvent?.(event);
       break;
     case "mcp_call_failed":
       toast.error(`MCP ${event.server} failed`, {

--- a/frontend/src/hooks/use-presence.ts
+++ b/frontend/src/hooks/use-presence.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  applyPresence,
+  livePeers,
+  presenceToAnnounce,
+  PRESENCE_HEARTBEAT_MS,
+  PRESENCE_TTL_MS,
+  type Peer,
+  type PresencePreference,
+  type PresenceStatus,
+} from "@/lib/awareness";
+
+const PREFERENCE_KEY = "oc.presence.override";
+
+/** The viewer's stored appear-as choice, defaulting to automatic. */
+function storedPreference(): PresencePreference {
+  try {
+    const raw = localStorage.getItem(PREFERENCE_KEY);
+    return raw === "away" || raw === "offline" ? raw : "auto";
+  } catch {
+    // A private window, or storage disabled. Not a reason to fail.
+    return "auto";
+  }
+}
+
+/**
+ * Who is here, and announcing that this console is.
+ *
+ * # Activity lives in a ref, never in state
+ *
+ * The idle timer needs the last time the human touched the page, which means a
+ * listener on every `keydown`, `pointermove` and `scroll` in the document. Held
+ * in state, that re-renders this hook's host on **every keystroke anywhere in
+ * the application** — and this hook's host is the app shell. `block/buzz` has a
+ * performance regression test for exactly this mistake. So the timestamp is a
+ * ref, and only a status *transition* is allowed to call `setState`.
+ *
+ * # A departure is best-effort, and does not need to work
+ *
+ * `pagehide` fires a beacon so a closed tab clears its dot at once instead of
+ * lingering for the lease. If it does not fire — a crash, a killed process, a
+ * browser that skipped it — the host's TTL collects it anyway. That is the
+ * whole reason presence is a lease: no disconnect path has to be correct.
+ */
+export function usePresence(
+  client: OpenCompanyClient,
+  company: string | null | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const enabled = options.enabled ?? true;
+  const [peers, setPeers] = useState<ReadonlyMap<string, Peer>>(new Map());
+  const [preference, setPreference] = useState<PresencePreference>(storedPreference);
+  const [supported, setSupported] = useState(true);
+
+  // The one value that must not be state. See the header.
+  const lastActivity = useRef(Date.now());
+  const preferenceRef = useRef(preference);
+  preferenceRef.current = preference;
+
+  /** Apply one live frame. */
+  const onFrame = useCallback(
+    (frame: { userId: string; status: PresenceStatus; atMillis: number }) => {
+      setPeers((current) => applyPresence(current, frame) ?? current);
+    },
+    [],
+  );
+
+  // Document-level activity. Passive and capture-phase so it sees input
+  // wherever it lands, and writes only to the ref.
+  useEffect(() => {
+    if (!enabled) return;
+    const bump = () => {
+      lastActivity.current = Date.now();
+    };
+    const events = ["keydown", "pointerdown", "pointermove", "scroll"] as const;
+    for (const name of events) {
+      document.addEventListener(name, bump, { capture: true, passive: true });
+    }
+    return () => {
+      for (const name of events) {
+        document.removeEventListener(name, bump, { capture: true });
+      }
+    };
+  }, [enabled]);
+
+  // The heartbeat, plus the initial roster read.
+  useEffect(() => {
+    if (!enabled || !supported) return;
+    let live = true;
+
+    const announce = () => {
+      const status = presenceToAnnounce(
+        preferenceRef.current,
+        Date.now() - lastActivity.current,
+      );
+      // Appearing offline means sending nothing at all rather than sending
+      // "offline" every minute — a lapsed lease says it more cheaply, and says
+      // the same thing to every reader.
+      if (status === "offline") return;
+      void client.announcePresence(status, company).catch(() => {
+        // A host without the route. Stop asking rather than retrying every
+        // minute for the life of the tab.
+        if (live) setSupported(false);
+      });
+    };
+
+    void client
+      .presence(company)
+      .then((res) => {
+        if (!live) return;
+        setPeers(
+          new Map(res.people.map((p) => [p.userId, { status: p.status, atMillis: p.atMillis }])),
+        );
+      })
+      .catch(() => {
+        if (live) setSupported(false);
+      });
+
+    announce();
+    const beat = setInterval(announce, PRESENCE_HEARTBEAT_MS);
+    return () => {
+      live = false;
+      clearInterval(beat);
+    };
+  }, [client, company, enabled, supported]);
+
+  // Expire lapsed peers. Runs on the heartbeat rather than every second: a
+  // presence dot going stale is not urgent, and a frame usually arrives first.
+  useEffect(() => {
+    if (!enabled) return;
+    const sweep = setInterval(() => {
+      setPeers((current) => {
+        const next = livePeers(current, Date.now());
+        return next.size === current.size ? current : next;
+      });
+    }, PRESENCE_TTL_MS);
+    return () => clearInterval(sweep);
+  }, [enabled]);
+
+  // Clear the dot on the way out, best-effort.
+  useEffect(() => {
+    if (!enabled || !supported) return;
+    const leave = () => {
+      client.disconnectPresenceBeacon(company);
+    };
+    window.addEventListener("pagehide", leave);
+    return () => {
+      window.removeEventListener("pagehide", leave);
+    };
+  }, [client, company, enabled, supported]);
+
+  const choose = useCallback(
+    (next: PresencePreference) => {
+      setPreference(next);
+      try {
+        localStorage.setItem(PREFERENCE_KEY, next);
+      } catch {
+        // Storage refused; the choice still holds for this tab.
+      }
+      if (next === "offline") {
+        client.disconnectPresenceBeacon(company);
+        setPeers((current) => current);
+      }
+    },
+    [client, company],
+  );
+
+  return { peers, preference, choose, onFrame, supported };
+}

--- a/frontend/src/hooks/use-presence.ts
+++ b/frontend/src/hooks/use-presence.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
 import {
   applyPresence,
   livePeers,
@@ -13,6 +14,7 @@ import {
 } from "@/lib/awareness";
 
 const PREFERENCE_KEY = "oc.presence.override";
+const CONSOLE_ID_KEY = "oc.presence.consoleId";
 
 /** The viewer's stored appear-as choice, defaulting to automatic. */
 function storedPreference(): PresencePreference {
@@ -22,6 +24,32 @@ function storedPreference(): PresencePreference {
   } catch {
     // A private window, or storage disabled. Not a reason to fail.
     return "auto";
+  }
+}
+
+/**
+ * This tab's lease key — never a second identity, just which of this
+ * person's open consoles is announcing (see the server's presence module
+ * header). `sessionStorage` rather than `localStorage`: it is already scoped
+ * per tab, so a reload keeps the same lease (no double-announce) while a
+ * second tab gets its own key (no shared lease to steal on close). A private
+ * window or storage disabled falls back to a key that lives only for this
+ * render — still correct, just unable to survive a reload without minting a
+ * new one.
+ */
+function consoleId(): string {
+  const mint = () =>
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  try {
+    const existing = sessionStorage.getItem(CONSOLE_ID_KEY);
+    if (existing) return existing;
+    const fresh = mint();
+    sessionStorage.setItem(CONSOLE_ID_KEY, fresh);
+    return fresh;
+  } catch {
+    return mint();
   }
 }
 
@@ -58,6 +86,19 @@ export function usePresence(
   const lastActivity = useRef(Date.now());
   const preferenceRef = useRef(preference);
   preferenceRef.current = preference;
+  // This tab's lease key, minted once per mount. See `consoleId`'s own doc.
+  const tabId = useRef(consoleId());
+
+  /**
+   * Whether a failed request means "this host predates the route" (permanent,
+   * disable) versus a network blip or a proxy hiccup (transient, try again on
+   * the next beat). Only a 404 is the former: everything else — a dropped
+   * connection, a 5xx, a timeout — says nothing about whether the route
+   * exists, and treating it as permanent would leave presence disabled for
+   * the rest of the tab's life over one bad request.
+   */
+  const isRouteMissing = (error: unknown): boolean =>
+    error instanceof ApiError && error.status === 404;
 
   /** Apply one live frame. */
   const onFrame = useCallback(
@@ -85,7 +126,18 @@ export function usePresence(
     };
   }, [enabled]);
 
-  // The heartbeat, plus the initial roster read.
+  // The heartbeat, plus a snapshot re-read on every beat.
+  //
+  // The re-read (not just the announce) is what keeps a *steady* peer's clock
+  // from lapsing. The host only publishes a live frame when somebody's status
+  // changes — a renewal that doesn't move anything is deliberately silent, see
+  // `PresenceRegistry::beat` — so a peer who stays `online` the whole time
+  // never gets a fresh frame, and this hook's `atMillis` for them would freeze
+  // at whatever the very first snapshot said. `livePeers`'s sweep then reads
+  // that frozen timestamp against a moving clock and prunes them once the
+  // lease looks stale, even though the host still has them live. Re-fetching
+  // the snapshot every heartbeat renews `atMillis` for everybody still
+  // present, so the local sweep never outruns the truth.
   useEffect(() => {
     if (!enabled || !supported) return;
     let live = true;
@@ -99,27 +151,35 @@ export function usePresence(
       // "offline" every minute — a lapsed lease says it more cheaply, and says
       // the same thing to every reader.
       if (status === "offline") return;
-      void client.announcePresence(status, company).catch(() => {
-        // A host without the route. Stop asking rather than retrying every
-        // minute for the life of the tab.
-        if (live) setSupported(false);
+      void client.announcePresence(status, company, tabId.current).catch((error) => {
+        if (live && isRouteMissing(error)) setSupported(false);
+        // Otherwise a transient failure: the next beat tries again rather
+        // than disabling presence for the rest of the tab's life.
       });
     };
 
-    void client
-      .presence(company)
-      .then((res) => {
-        if (!live) return;
-        setPeers(
-          new Map(res.people.map((p) => [p.userId, { status: p.status, atMillis: p.atMillis }])),
-        );
-      })
-      .catch(() => {
-        if (live) setSupported(false);
-      });
+    const refresh = () => {
+      void client
+        .presence(company)
+        .then((res) => {
+          if (!live) return;
+          setPeers(
+            new Map(
+              res.people.map((p) => [p.userId, { status: p.status, atMillis: p.atMillis }]),
+            ),
+          );
+        })
+        .catch((error) => {
+          if (live && isRouteMissing(error)) setSupported(false);
+        });
+    };
 
+    refresh();
     announce();
-    const beat = setInterval(announce, PRESENCE_HEARTBEAT_MS);
+    const beat = setInterval(() => {
+      announce();
+      refresh();
+    }, PRESENCE_HEARTBEAT_MS);
     return () => {
       live = false;
       clearInterval(beat);
@@ -143,7 +203,7 @@ export function usePresence(
   useEffect(() => {
     if (!enabled || !supported) return;
     const leave = () => {
-      client.disconnectPresenceBeacon(company);
+      client.disconnectPresenceBeacon(company, tabId.current);
     };
     window.addEventListener("pagehide", leave);
     return () => {
@@ -160,7 +220,7 @@ export function usePresence(
         // Storage refused; the choice still holds for this tab.
       }
       if (next === "offline") {
-        client.disconnectPresenceBeacon(company);
+        client.disconnectPresenceBeacon(company, tabId.current);
         setPeers((current) => current);
       }
     },

--- a/frontend/src/hooks/use-presence.ts
+++ b/frontend/src/hooks/use-presence.ts
@@ -184,7 +184,7 @@ export function usePresence(
         .then((res) => {
           if (!live) return;
           setPeers((current) =>
-            reconcilePresenceSnapshot(current, tombstones.current, res.people, requestSentAt),
+            reconcilePresenceSnapshot(current, tombstones.current, res?.people, requestSentAt),
           );
         })
         .catch((error) => {

--- a/frontend/src/hooks/use-presence.ts
+++ b/frontend/src/hooks/use-presence.ts
@@ -6,6 +6,7 @@ import {
   applyPresence,
   livePeers,
   presenceToAnnounce,
+  reconcilePresenceSnapshot,
   PRESENCE_HEARTBEAT_MS,
   PRESENCE_TTL_MS,
   type Peer,
@@ -100,9 +101,23 @@ export function usePresence(
   const isRouteMissing = (error: unknown): boolean =>
     error instanceof ApiError && error.status === 404;
 
+  // The `atMillis` of the newest known `offline` frame per user, so a
+  // snapshot reconciled later (see `reconcilePresenceSnapshot`) knows a
+  // departure happened even though the departed peer has no entry left in
+  // `peers` to compare a timestamp against.
+  const tombstones = useRef(new Map<string, number>());
+
   /** Apply one live frame. */
   const onFrame = useCallback(
     (frame: { userId: string; status: PresenceStatus; atMillis: number }) => {
+      if (frame.status === "offline") {
+        const known = tombstones.current.get(frame.userId) ?? 0;
+        if (frame.atMillis > known) tombstones.current.set(frame.userId, frame.atMillis);
+      } else {
+        // Present again — a stale tombstone must not keep suppressing a
+        // future snapshot row for them once they're genuinely back.
+        tombstones.current.delete(frame.userId);
+      }
       setPeers((current) => applyPresence(current, frame) ?? current);
     },
     [],
@@ -159,14 +174,17 @@ export function usePresence(
     };
 
     const refresh = () => {
+      // Captured before the request goes out: see `reconcilePresenceSnapshot`
+      // for why a peer this snapshot never mentions is only dropped when what
+      // we already knew about them predates this moment, rather than the
+      // moment the response happens to land.
+      const requestSentAt = Date.now();
       void client
         .presence(company)
         .then((res) => {
           if (!live) return;
-          setPeers(
-            new Map(
-              res.people.map((p) => [p.userId, { status: p.status, atMillis: p.atMillis }]),
-            ),
+          setPeers((current) =>
+            reconcilePresenceSnapshot(current, tombstones.current, res.people, requestSentAt),
           );
         })
         .catch((error) => {

--- a/frontend/src/hooks/use-typing.ts
+++ b/frontend/src/hooks/use-typing.ts
@@ -35,6 +35,16 @@ export function useTyping(
   const lastSent = useRef(new Map<string, number>());
   // Each author's most recent message per channel, for the de-flicker rules.
   const lastMessage = useRef(new Map<string, number>());
+  // The newest `atMillis` already applied per typer, so a redelivered frame —
+  // an SSE reconnect replaying its last event is the real-world case — cannot
+  // renew an indicator that a genuine new ping did not actually buy. This is
+  // the de-flicker rule `typingExpiry` used to get by capping expiry at
+  // `frame.atMillis + TTL`; that comparison read the *server's* clock against
+  // nothing of the browser's, but broke for anyone whose workstation clock ran
+  // ahead of the host (see `awareness.ts`). Comparing a frame's stamp only to
+  // the previous frame's stamp — both server-issued — keeps the guard without
+  // ever touching the browser's own clock.
+  const lastFrameAt = useRef(new Map<string, number>());
   const supported = useRef(true);
 
   /** Apply one live typing frame. */
@@ -47,15 +57,18 @@ export function useTyping(
     }) => {
       const now = Date.now();
       const seen = lastMessage.current.get(`${frame.userId}:${frame.chatId}`);
-      if (!shouldShowTyping(frame, now, seen)) return;
+      if (!shouldShowTyping(frame, seen)) return;
+      const key = typerKey(frame);
+      const previousAt = lastFrameAt.current.get(key);
+      if (previousAt !== undefined && frame.atMillis <= previousAt) return;
+      lastFrameAt.current.set(key, frame.atMillis);
       setTypers((current) => {
-        const key = typerKey(frame);
         const existing = current.find((t) => typerKey(t) === key);
         const next: Typer = {
           userId: frame.userId,
           chatId: frame.chatId,
           parentId: frame.parentId,
-          expiresAt: typingExpiry(frame, now),
+          expiresAt: typingExpiry(now),
           // Preserved across renewals so the displayed order stays put.
           firstSeenAt: existing?.firstSeenAt ?? now,
         };
@@ -103,7 +116,15 @@ export function useTyping(
     const prune = setInterval(() => {
       setTypers((current) => {
         const next = pruneTypers(current, Date.now());
-        return next.length === current.length ? current : next;
+        if (next.length === current.length) return current;
+        // Forget the dedup memory for whoever just expired, so a genuinely
+        // new burst of typing from them later is never mistaken for a
+        // replay of the one that just timed out.
+        const stillTyping = new Set(next.map((t) => typerKey(t)));
+        for (const key of lastFrameAt.current.keys()) {
+          if (!stillTyping.has(key)) lastFrameAt.current.delete(key);
+        }
+        return next;
       });
     }, TYPING_PRUNE_INTERVAL_MS);
     return () => clearInterval(prune);

--- a/frontend/src/hooks/use-typing.ts
+++ b/frontend/src/hooks/use-typing.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
 import {
   pruneTypers,
   shouldShowTyping,
@@ -101,10 +102,13 @@ export function useTyping(
       const sent = lastSent.current.get(key) ?? 0;
       if (now - sent < TYPING_SEND_THROTTLE_MS) return;
       lastSent.current.set(key, now);
-      void client.typing(chatId, parentId, company).catch(() => {
-        // A host without the route, or a transient failure. Either way this is
-        // fire-and-forget: an undelivered typing ping is not worth a retry.
-        supported.current = false;
+      void client.typing(chatId, parentId, company).catch((error) => {
+        // Only a 404 means this host predates the route — disable it, the
+        // same distinction `usePresence`'s heartbeat makes. Anything else
+        // (a network blip, a proxy hiccup, a 5xx) is fire-and-forget: this
+        // one ping is not worth retrying, but the *route* is not disabled,
+        // so the next keystroke's ping still goes out.
+        if (error instanceof ApiError && error.status === 404) supported.current = false;
       });
     },
     [client, company, connected],

--- a/frontend/src/hooks/use-typing.ts
+++ b/frontend/src/hooks/use-typing.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  pruneTypers,
+  shouldShowTyping,
+  typerKey,
+  typingExpiry,
+  TYPING_PRUNE_INTERVAL_MS,
+  TYPING_SEND_THROTTLE_MS,
+  type Typer,
+} from "@/lib/awareness";
+
+/**
+ * Who is typing, and telling the company that this console is.
+ *
+ * Sending is throttled per channel, and skipped entirely while the event
+ * stream is down: a typing ping is not worth waking a dead connection for, and
+ * an indicator nobody will receive is not worth a request.
+ *
+ * The prune interval is armed **only while somebody is typing**. An interval
+ * that runs once a second for the life of every tab, to filter an empty list,
+ * is a real cost paid by every idle console in the company.
+ */
+export function useTyping(
+  client: OpenCompanyClient,
+  company: string | null | undefined,
+  options: { connected?: boolean } = {},
+) {
+  const connected = options.connected ?? true;
+  const [typers, setTypers] = useState<Typer[]>([]);
+
+  // Last time this console announced typing, per channel. A ref: throttling is
+  // not something the UI renders.
+  const lastSent = useRef(new Map<string, number>());
+  // Each author's most recent message per channel, for the de-flicker rules.
+  const lastMessage = useRef(new Map<string, number>());
+  const supported = useRef(true);
+
+  /** Apply one live typing frame. */
+  const onFrame = useCallback(
+    (frame: {
+      userId: string;
+      chatId: string;
+      parentId?: string;
+      atMillis: number;
+    }) => {
+      const now = Date.now();
+      const seen = lastMessage.current.get(`${frame.userId}:${frame.chatId}`);
+      if (!shouldShowTyping(frame, now, seen)) return;
+      setTypers((current) => {
+        const key = typerKey(frame);
+        const existing = current.find((t) => typerKey(t) === key);
+        const next: Typer = {
+          userId: frame.userId,
+          chatId: frame.chatId,
+          parentId: frame.parentId,
+          expiresAt: typingExpiry(frame, now),
+          // Preserved across renewals so the displayed order stays put.
+          firstSeenAt: existing?.firstSeenAt ?? now,
+        };
+        return [...current.filter((t) => typerKey(t) !== key), next];
+      });
+    },
+    [],
+  );
+
+  /**
+   * Record that somebody's message landed, so their in-flight typing ping does
+   * not leave a ghost indicator behind it.
+   */
+  const onMessage = useCallback(
+    (userId: string, chatId: string, atMillis: number) => {
+      lastMessage.current.set(`${userId}:${chatId}`, atMillis);
+      setTypers((current) =>
+        current.filter((t) => !(t.userId === userId && t.chatId === chatId)),
+      );
+    },
+    [],
+  );
+
+  /** Say this console is typing in `chatId`, at most once per throttle window. */
+  const announce = useCallback(
+    (chatId: string, parentId?: string) => {
+      if (!connected || !supported.current || !chatId) return;
+      const key = `${chatId}:${parentId ?? ""}`;
+      const now = Date.now();
+      const sent = lastSent.current.get(key) ?? 0;
+      if (now - sent < TYPING_SEND_THROTTLE_MS) return;
+      lastSent.current.set(key, now);
+      void client.typing(chatId, parentId, company).catch(() => {
+        // A host without the route, or a transient failure. Either way this is
+        // fire-and-forget: an undelivered typing ping is not worth a retry.
+        supported.current = false;
+      });
+    },
+    [client, company, connected],
+  );
+
+  // Armed only while there is something to expire.
+  useEffect(() => {
+    if (typers.length === 0) return;
+    const prune = setInterval(() => {
+      setTypers((current) => {
+        const next = pruneTypers(current, Date.now());
+        return next.length === current.length ? current : next;
+      });
+    }, TYPING_PRUNE_INTERVAL_MS);
+    return () => clearInterval(prune);
+  }, [typers.length]);
+
+  return { typers, onFrame, onMessage, announce };
+}

--- a/frontend/src/lib/awareness.ts
+++ b/frontend/src/lib/awareness.ts
@@ -1,0 +1,196 @@
+// The pure rules behind presence and typing indicators.
+//
+// Kept out of the hooks on purpose: every rule here is a timing rule, and a
+// timing rule tested through a rendered component is tested by sleeping. These
+// take a clock as an argument instead, so the awkward cases — a frame that
+// arrives already stale, an indicator racing the message that should cancel it
+// — are checked directly.
+
+/** How often a live console announces itself. Mirrors the host constant. */
+export const PRESENCE_HEARTBEAT_MS = 60_000;
+
+/**
+ * How long a peer stays present without a fresh frame.
+ *
+ * Three times the heartbeat, matching the host's lease. The console has to
+ * agree with the host here or the two disagree about who is online — and the
+ * console is the one drawing the dot.
+ */
+export const PRESENCE_TTL_MS = 3 * PRESENCE_HEARTBEAT_MS;
+
+/** No document input for this long means the human has left the machine. */
+export const IDLE_AWAY_MS = 10 * 60_000;
+
+/** How often one console may say it is typing, per channel. */
+export const TYPING_SEND_THROTTLE_MS = 3_000;
+
+/** How long a typing indicator survives without a renewal. */
+export const TYPING_RECEIVE_TTL_MS = 8_000;
+
+/** How often expired typers are pruned — only while there are any. */
+export const TYPING_PRUNE_INTERVAL_MS = 1_000;
+
+/** How long after somebody's message to ignore their typing frames. */
+export const TYPING_POST_MESSAGE_SUPPRESS_MS = 2_000;
+
+export type PresenceStatus = "online" | "away" | "offline";
+
+/** What the viewer has chosen to appear as. */
+export type PresencePreference = "auto" | "away" | "offline";
+
+export interface Peer {
+  status: PresenceStatus;
+  atMillis: number;
+}
+
+/** One person typing in one place. */
+export interface Typer {
+  userId: string;
+  chatId: string;
+  parentId?: string;
+  /** When this indicator stops being true. */
+  expiresAt: number;
+  /** When this person was first seen typing here — the stable sort key. */
+  firstSeenAt: number;
+}
+
+/**
+ * What to announce, given the viewer's preference and how long they have been
+ * idle.
+ *
+ * `away` means "the human is not at the machine" — Slack and Discord's meaning.
+ * It deliberately does **not** mean "the window is unfocused": people read a
+ * channel in a background tab constantly, and marking them away for it makes
+ * the dot mean nothing. A browser has no OS-idle API, so document-level input
+ * idleness is the honest analogue.
+ */
+export function presenceToAnnounce(
+  preference: PresencePreference,
+  idleForMs: number,
+): PresenceStatus {
+  if (preference === "offline") return "offline";
+  if (preference === "away") return "away";
+  return idleForMs >= IDLE_AWAY_MS ? "away" : "online";
+}
+
+/**
+ * Applies one presence frame to the peer map, or removes the peer when they
+ * went offline.
+ *
+ * Returns a new map only when something changed, so an unchanged frame does not
+ * re-render every consumer.
+ */
+export function applyPresence(
+  peers: ReadonlyMap<string, Peer>,
+  frame: { userId: string; status: PresenceStatus; atMillis: number },
+): Map<string, Peer> | null {
+  const current = peers.get(frame.userId);
+  // Out-of-order delivery is possible on a reconnect, and an older frame must
+  // not undo a newer one.
+  if (current && current.atMillis > frame.atMillis) return null;
+  if (frame.status === "offline") {
+    if (!current) return null;
+    const next = new Map(peers);
+    next.delete(frame.userId);
+    return next;
+  }
+  if (current && current.status === frame.status) return null;
+  const next = new Map(peers);
+  next.set(frame.userId, { status: frame.status, atMillis: frame.atMillis });
+  return next;
+}
+
+/** Peers whose lease is still good. */
+export function livePeers(
+  peers: ReadonlyMap<string, Peer>,
+  now: number,
+): Map<string, Peer> {
+  const next = new Map<string, Peer>();
+  for (const [id, peer] of peers) {
+    if (now - peer.atMillis <= PRESENCE_TTL_MS) next.set(id, peer);
+  }
+  return next;
+}
+
+/** The key one typing indicator is held under. */
+export function typerKey(frame: { userId: string; chatId: string; parentId?: string }): string {
+  return `${frame.userId}:${frame.chatId}:${frame.parentId ?? ""}`;
+}
+
+/**
+ * Whether a typing frame should be shown at all.
+ *
+ * Three rules, all of which exist because a typing indicator that lies is worse
+ * than none. Every one of them was a visible flicker before it was a rule:
+ *
+ * 1. **A frame older than its own TTL is dead on arrival.** A delayed or
+ *    replayed frame must not resurrect an indicator for somebody who stopped
+ *    typing ten seconds ago.
+ * 2. **A frame at or before that author's last message here is stale.** Their
+ *    message and their final typing ping race constantly, and the ping loses:
+ *    somebody who has just spoken is not still typing.
+ * 3. **A short window after their message, ignore them entirely.** Rule 2 only
+ *    catches frames stamped before the message; one stamped a few milliseconds
+ *    after it is the same in-flight ping and reads the same way to a viewer.
+ */
+export function shouldShowTyping(
+  frame: { atMillis: number },
+  now: number,
+  lastMessageAt: number | undefined,
+): boolean {
+  if (now - frame.atMillis >= TYPING_RECEIVE_TTL_MS) return false;
+  if (lastMessageAt === undefined) return true;
+  if (frame.atMillis <= lastMessageAt) return false;
+  return frame.atMillis - lastMessageAt > TYPING_POST_MESSAGE_SUPPRESS_MS;
+}
+
+/**
+ * When a typing indicator should disappear.
+ *
+ * The earlier of "a TTL from now" and "a TTL from the frame's own timestamp",
+ * so a frame delayed in transit cannot extend the bubble past its own validity.
+ */
+export function typingExpiry(frame: { atMillis: number }, now: number): number {
+  return Math.min(now + TYPING_RECEIVE_TTL_MS, frame.atMillis + TYPING_RECEIVE_TTL_MS);
+}
+
+/** Drops every typer whose indicator has expired. */
+export function pruneTypers(typers: readonly Typer[], now: number): Typer[] {
+  return typers.filter((t) => t.expiresAt > now);
+}
+
+/**
+ * The typers to show in one channel, in a stable order.
+ *
+ * Sorted by when each was first seen rather than by their latest frame, so the
+ * list does not reshuffle every three seconds as renewals arrive — which reads
+ * as flicker even though nobody has started or stopped.
+ */
+export function typersIn(
+  typers: readonly Typer[],
+  chatId: string,
+  parentId: string | undefined,
+  now: number,
+): Typer[] {
+  return typers
+    .filter(
+      (t) =>
+        t.chatId === chatId &&
+        (t.parentId ?? undefined) === parentId &&
+        t.expiresAt > now,
+    )
+    .sort((a, b) => a.firstSeenAt - b.firstSeenAt || a.userId.localeCompare(b.userId));
+}
+
+/**
+ * "Jane is typing…", "Jane and Ada are typing…", "Several people are typing…".
+ *
+ * Names at most two. Three names is already longer than the line it sits on,
+ * and past that the count is what a reader actually takes in.
+ */
+export function typingLabel(names: string[]): string | null {
+  if (names.length === 0) return null;
+  if (names.length === 1) return `${names[0]} is typing…`;
+  if (names.length === 2) return `${names[0]} and ${names[1]} are typing…`;
+  return "Several people are typing…";
+}

--- a/frontend/src/lib/awareness.ts
+++ b/frontend/src/lib/awareness.ts
@@ -130,6 +130,12 @@ export function reconcilePresenceSnapshot(
 ): Map<string, Peer> {
   const next = new Map(peers);
   const seen = new Set<string>();
+  // The type says this is an array; a host says whatever it says. An older
+  // host, a proxy, or a stub that answers `[]` for unrecognised routes makes
+  // this `undefined`, and iterating it throws during render — which blanks the
+  // whole console, not just the presence roster. A missing snapshot means "no
+  // news", which is exactly an empty one.
+  if (!Array.isArray(snapshot)) return next;
   for (const row of snapshot) {
     seen.add(row.userId);
     const current = next.get(row.userId);

--- a/frontend/src/lib/awareness.ts
+++ b/frontend/src/lib/awareness.ts
@@ -100,6 +100,54 @@ export function applyPresence(
   return next;
 }
 
+/**
+ * Merges a `GET /presence` snapshot into the peers already held, instead of
+ * replacing the map outright.
+ *
+ * The snapshot request and the live SSE stream race: a status change or a
+ * disconnect can arrive over the stream *while the GET is in flight*, and a
+ * plain replace on the response would silently undo it — reverting a status
+ * change to what the snapshot saw a moment earlier, or resurrecting somebody
+ * whose `offline` frame already deleted them, for up to the next refresh
+ * interval. Reconciled here the same way a live frame is: per user, whichever
+ * `atMillis` is newer wins.
+ *
+ * `tombstones` (userId → the `atMillis` of the last known `offline` frame) is
+ * what makes a disconnect win even though a departed peer has no entry left in
+ * `peers` to compare against — without it, any snapshot row for them would be
+ * applied unconditionally, since there is nothing in the *map* to compare its
+ * timestamp to. `requestSentAt` (`Date.now()` when the GET was issued) plays
+ * the same role for a peer the snapshot doesn't mention at all: they are only
+ * dropped if what we already knew about them predates the request, so an
+ * arrival whose live frame raced ahead of the snapshot is not undone by the
+ * snapshot's silence about them.
+ */
+export function reconcilePresenceSnapshot(
+  peers: ReadonlyMap<string, Peer>,
+  tombstones: ReadonlyMap<string, number>,
+  snapshot: ReadonlyArray<{ userId: string; status: PresenceStatus; atMillis: number }>,
+  requestSentAt: number,
+): Map<string, Peer> {
+  const next = new Map(peers);
+  const seen = new Set<string>();
+  for (const row of snapshot) {
+    seen.add(row.userId);
+    const current = next.get(row.userId);
+    if (current && current.atMillis > row.atMillis) continue;
+    const tombstone = tombstones.get(row.userId);
+    if (tombstone !== undefined && tombstone > row.atMillis) continue;
+    next.set(row.userId, { status: row.status, atMillis: row.atMillis });
+  }
+  for (const [userId, peer] of next) {
+    if (seen.has(userId)) continue;
+    // Missing from the snapshot. Only take that as "gone" when what we
+    // already knew predates the request — otherwise a live frame arrived
+    // after the GET was issued and simply raced ahead of its response.
+    if (peer.atMillis < requestSentAt) next.delete(userId);
+  }
+  return next;
+}
+
 /** Peers whose lease is still good. */
 export function livePeers(
   peers: ReadonlyMap<string, Peer>,

--- a/frontend/src/lib/awareness.ts
+++ b/frontend/src/lib/awareness.ts
@@ -120,38 +120,46 @@ export function typerKey(frame: { userId: string; chatId: string; parentId?: str
 /**
  * Whether a typing frame should be shown at all.
  *
- * Three rules, all of which exist because a typing indicator that lies is worse
- * than none. Every one of them was a visible flicker before it was a rule:
+ * Two rules, both of which exist because a typing indicator that lies is worse
+ * than none:
  *
- * 1. **A frame older than its own TTL is dead on arrival.** A delayed or
- *    replayed frame must not resurrect an indicator for somebody who stopped
- *    typing ten seconds ago.
- * 2. **A frame at or before that author's last message here is stale.** Their
+ * 1. **A frame at or before that author's last message here is stale.** Their
  *    message and their final typing ping race constantly, and the ping loses:
  *    somebody who has just spoken is not still typing.
- * 3. **A short window after their message, ignore them entirely.** Rule 2 only
+ * 2. **A short window after their message, ignore them entirely.** Rule 1 only
  *    catches frames stamped before the message; one stamped a few milliseconds
  *    after it is the same in-flight ping and reads the same way to a viewer.
+ *
+ * There used to be a third rule here — drop a frame already older than its own
+ * TTL — but it compared `frame.atMillis` (the *server's* clock) against `now`
+ * (the *browser's*), so any viewer whose workstation clock ran more than
+ * [`TYPING_RECEIVE_TTL_MS`] ahead of the host saw every typing frame arrive
+ * "already expired" and typing broke outright for them. `atMillis` is kept
+ * for the two rules above — both compare it only to `lastMessageAt`, another
+ * server timestamp, so they never cross clock domains — and freshness is
+ * [`typingExpiry`]'s job now, anchored to local receipt time instead.
  */
 export function shouldShowTyping(
   frame: { atMillis: number },
-  now: number,
   lastMessageAt: number | undefined,
 ): boolean {
-  if (now - frame.atMillis >= TYPING_RECEIVE_TTL_MS) return false;
   if (lastMessageAt === undefined) return true;
   if (frame.atMillis <= lastMessageAt) return false;
   return frame.atMillis - lastMessageAt > TYPING_POST_MESSAGE_SUPPRESS_MS;
 }
 
 /**
- * When a typing indicator should disappear.
+ * When a typing indicator should disappear: a TTL from the moment *this*
+ * console received it.
  *
- * The earlier of "a TTL from now" and "a TTL from the frame's own timestamp",
- * so a frame delayed in transit cannot extend the bubble past its own validity.
+ * Deliberately not derived from `frame.atMillis` (the server's clock) at all
+ * — see [`shouldShowTyping`]'s header. Anchoring to local receipt time instead
+ * means a skewed workstation clock can no longer make an indicator vanish
+ * instantly or, in the other direction, linger past its host-side lease; the
+ * only clock this reads is the one the caller is already using for `now`.
  */
-export function typingExpiry(frame: { atMillis: number }, now: number): number {
-  return Math.min(now + TYPING_RECEIVE_TTL_MS, frame.atMillis + TYPING_RECEIVE_TTL_MS);
+export function typingExpiry(now: number): number {
+  return now + TYPING_RECEIVE_TTL_MS;
 }
 
 /** Drops every typer whose indicator has expired. */

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -48,6 +48,7 @@ import { BudgetDialog } from "./chat/BudgetDialog";
 import { ChannelRail } from "./chat/ChannelRail";
 import { ChatHeader } from "./chat/ChatHeader";
 import { MembersPane } from "./chat/MembersPane";
+import { TypingLine } from "./chat/TypingLine";
 import { MessageComposer } from "./chat/MessageComposer";
 import { MessageTimeline } from "./chat/MessageTimeline";
 import { ThreadPanel } from "./chat/ThreadPanel";
@@ -106,6 +107,23 @@ interface Props {
    * race the Conversation surface already brackets against.
    */
   onSendStart?: (threadId: string) => void;
+  /**
+   * Who is present right now, keyed by user id. Empty when the host has no
+   * presence route, or when nobody else is connected to this replica.
+   */
+  presence?: ReadonlyMap<string, { status: "online" | "away" | "offline" }>;
+  /**
+   * The company's people, for the members pane's People section.
+   *
+   * Separate from `members` (teammates) on purpose: desk membership is a
+   * teammate concept, and every signed-in person can already see every desk,
+   * so people are never "in" or "outside" a channel.
+   */
+  companyPeople?: Array<{ id: string; label: string }>;
+  /** Display names for the typing line, in a stable order. */
+  typingNames?: string[];
+  /** Called as the composer is typed in; the caller throttles. */
+  onTyping?: (chatId: string) => void;
   onSendEnd?: (threadId: string) => void;
   /**
    * The host accepted the turn and answered `202` instead of the reply
@@ -202,6 +220,10 @@ export function ChatView({
   setTranscripts,
   hydration = HISTORY_UNTRACKED,
   onSendStart,
+  presence,
+  companyPeople,
+  typingNames = [],
+  onTyping,
   onSendEnd,
   onSendDetached,
   onSendFailed,
@@ -1055,10 +1077,15 @@ export function ChatView({
                 </span>
               </p>
             )}
+            <TypingLine names={typingNames} />
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}
               onSend={(text, intent) => void send(text, intent)}
+              // Every keystroke asks; the hook throttles to one ping per
+              // channel per few seconds and skips entirely while the event
+              // stream is down.
+              onTyping={() => onTyping?.(active.id)}
               // Channel *and* DM composers offer "just chatting" / "do it once" /
               // "build me the workflow" (issues #580, #845, #1152) — see
               // `offersDeliverableChoice`, which owns the rule and is unchanged:
@@ -1084,6 +1111,8 @@ export function ChatView({
             <MembersPane
               channelMembers={inChannel}
               others={outsideChannel}
+              people={companyPeople}
+              presence={presence}
               leadId={active.kind === "channel" ? active.memberIds?.[0] : undefined}
               loading={loadingTeam}
               fromHost={fromHost}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -120,10 +120,16 @@ interface Props {
    * so people are never "in" or "outside" a channel.
    */
   companyPeople?: Array<{ id: string; label: string }>;
-  /** Display names for the typing line, in a stable order. */
-  typingNames?: string[];
-  /** Called as the composer is typed in; the caller throttles. */
-  onTyping?: (chatId: string) => void;
+  /**
+   * Display names for the typing line, in a stable order — resolved on
+   * demand rather than a single precomputed array, because this view needs
+   * two independent lines: the main composer's (no `parentId`) and, when a
+   * thread is open, that thread's own (`parentId` set). A single `string[]`
+   * could only ever answer one of them.
+   */
+  resolveTypingNames?: (chatId: string, parentId?: string) => string[];
+  /** Called as a composer is typed in; the caller throttles. */
+  onTyping?: (chatId: string, parentId?: string) => void;
   onSendEnd?: (threadId: string) => void;
   /**
    * The host accepted the turn and answered `202` instead of the reply
@@ -222,7 +228,7 @@ export function ChatView({
   onSendStart,
   presence,
   companyPeople,
-  typingNames = [],
+  resolveTypingNames,
   onTyping,
   onSendEnd,
   onSendDetached,
@@ -1077,7 +1083,7 @@ export function ChatView({
                 </span>
               </p>
             )}
-            <TypingLine names={typingNames} />
+            <TypingLine names={resolveTypingNames?.(active.id) ?? []} />
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}
@@ -1104,6 +1110,8 @@ export function ChatView({
               sending={sending}
               onSend={(text) => void send(text, undefined, parent.id)}
               onClose={() => setOpenThreadId(null)}
+              typingNames={resolveTypingNames?.(active.id, parent.id) ?? []}
+              onTyping={() => onTyping?.(active.id, parent.id)}
             />
           )}
 

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -12,8 +12,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { PresenceStatus } from "@/lib/awareness";
 import { roleSubtitle, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
+import { PresenceDot } from "@/views/chat/PresenceDot";
 
 interface Props {
   /**
@@ -37,6 +39,24 @@ interface Props {
    * happens to be first.
    */
   leadId?: string;
+  /**
+   * The company's people.
+   *
+   * A section of their own, and **not** part of `channelMembers` or `others`:
+   * desk membership is a teammate concept, so a person is never "in" or
+   * "outside" a channel — every signed-in human can see every desk. Folding
+   * them into either list would state a membership that does not exist.
+   *
+   * Absent on a host without the mentionables route, which simply renders no
+   * People section.
+   */
+  people?: Array<{ id: string; label: string }>;
+  /**
+   * Who is present, keyed by user id. A person missing from this map has **no
+   * live signal** — which is not the same as offline, because presence is
+   * replica-local. {@link PresenceDot} renders that distinction.
+   */
+  presence?: ReadonlyMap<string, { status: PresenceStatus }>;
   loading: boolean;
   /** True when the roster came from the host rather than the starter set. */
   fromHost: boolean;
@@ -95,6 +115,8 @@ export function MembersPane({
   channelMembers,
   others,
   leadId,
+  people,
+  presence,
   loading,
   fromHost,
   onToggleInbox,
@@ -201,6 +223,22 @@ export function MembersPane({
                   <div className="mt-2 border-t pt-2">
                     <SectionLabel className="text-muted-foreground">Everyone else</SectionLabel>
                     {rows(others)}
+                  </div>
+                )}
+
+                {people && people.length > 0 && (
+                  <div className="mt-2 border-t pt-2">
+                    <SectionLabel className="text-muted-foreground">People</SectionLabel>
+                    {people.map((person) => (
+                      <div
+                        key={person.id}
+                        data-testid="person-row"
+                        className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm"
+                      >
+                        <PresenceDot status={presence?.get(person.id)?.status} />
+                        <span className="min-w-0 flex-1 truncate">{person.label}</span>
+                      </div>
+                    ))}
                   </div>
                 )}
               </>

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -21,6 +21,16 @@ interface Props {
   placeholder: string;
   disabled?: boolean;
   onSend: (text: string, intent?: MessageIntent) => void;
+  /**
+   * Called as the box is typed in, so the company can show a typing
+   * indicator.
+   *
+   * Fired on **every** change rather than on a timer: throttling is the
+   * caller's job, because it is per channel and this component does not know
+   * which channel it is in. Absent on the composers where a typing indicator
+   * would be noise.
+   */
+  onTyping?: () => void;
   /** Compact form, for the narrower thread panel. */
   compact?: boolean;
   /**
@@ -63,6 +73,7 @@ export function MessageComposer({
   onSend,
   compact,
   deliverableChoice,
+  onTyping,
 }: Props) {
   const [draft, setDraft] = useState("");
   // What the NEXT line is for, and only the next one. It resets to "once"
@@ -162,7 +173,10 @@ export function MessageComposer({
         <textarea
           ref={input}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            onTyping?.();
+          }}
           onKeyDown={onKeyDown}
           placeholder={placeholder}
           rows={1}

--- a/frontend/src/views/chat/PresenceDot.tsx
+++ b/frontend/src/views/chat/PresenceDot.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+import type { PresenceStatus } from "@/lib/awareness";
+
+/**
+ * A person's live status.
+ *
+ * Three states and an absence, and the absence is the interesting one: no dot
+ * at all means *no live signal*, not "offline". Presence is replica-local, so
+ * somebody connected to another host of the same tenant is simply unknown here
+ * — and drawing them as offline would be a confident claim the console cannot
+ * support. A hollow ring says "not seen" honestly.
+ *
+ * Never rendered for a teammate. An agent is not "online": it has no session
+ * and no machine to be at, and its live state is already the working
+ * indicator. A dot on one would be decoration that reads as fact.
+ */
+export function PresenceDot({
+  status,
+  className,
+}: {
+  status: PresenceStatus | undefined;
+  className?: string;
+}) {
+  const label =
+    status === "online" ? "Online" : status === "away" ? "Away" : "No recent activity";
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      data-testid="presence-dot"
+      data-status={status ?? "unknown"}
+      className={cn(
+        "inline-block size-2 shrink-0 rounded-full",
+        status === "online" && "bg-status-running",
+        status === "away" && "bg-status-idle",
+        // Not seen: a ring rather than a fill, so it reads as "unknown" instead
+        // of as a third status.
+        !status && "border border-muted-foreground/40",
+        className,
+      )}
+    />
+  );
+}

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import type { ChatMessage } from "@/lib/chat";
 import type { TeamMember } from "@/lib/team";
 import { MessageComposer } from "./MessageComposer";
+import { TypingLine } from "./TypingLine";
 import { channelTitle, formatTime, senderOf, type Channel } from "./model";
 
 interface Props {
@@ -22,6 +23,16 @@ interface Props {
   sending: boolean;
   onSend: (text: string) => void;
   onClose: () => void;
+  /**
+   * Who is typing *in this thread* — scoped by the parent's own id, never the
+   * channel's. Without this the thread panel had no typing signal at all: the
+   * wire and `useTyping` already carry `parentId`, but nothing upstream of
+   * this component filtered by it or rendered a line for it.
+   */
+  typingNames?: string[];
+  /** This console is typing here. Distinct from the main composer's callback
+   * so the ping this thread sends carries the thread's own `parentId`. */
+  onTyping?: () => void;
 }
 
 /**
@@ -31,7 +42,17 @@ interface Props {
  * channel apart. The parent message sits at the top under a rule, and the
  * panel carries its own composer scoped to the thread.
  */
-export function ThreadPanel({ channel, members, parent, replies, sending, onSend, onClose }: Props) {
+export function ThreadPanel({
+  channel,
+  members,
+  parent,
+  replies,
+  sending,
+  onSend,
+  onClose,
+  typingNames = [],
+  onTyping,
+}: Props) {
   return (
     <aside className="flex w-96 shrink-0 flex-col border-l bg-background">
       <header className="flex h-13 shrink-0 items-center gap-2 border-b px-3">
@@ -57,11 +78,13 @@ export function ThreadPanel({ channel, members, parent, replies, sending, onSend
         ))}
       </div>
 
+      <TypingLine names={typingNames} />
       <MessageComposer
         compact
         placeholder="Reply…"
         disabled={sending}
         onSend={onSend}
+        onTyping={onTyping}
       />
     </aside>
   );

--- a/frontend/src/views/chat/TypingLine.tsx
+++ b/frontend/src/views/chat/TypingLine.tsx
@@ -1,0 +1,38 @@
+import { typingLabel } from "@/lib/awareness";
+import { cn } from "@/lib/utils";
+
+/**
+ * "Jane is typing…", under the composer.
+ *
+ * Deliberately a separate component from `WorkingIndicator`, which says an
+ * *agent* is running a turn. The two look similar and mean different things —
+ * one is a person at a keyboard, the other is a machine mid-task — and
+ * collapsing them would make both less informative.
+ *
+ * Renders nothing at all when nobody is typing, rather than an empty reserved
+ * row: the composer is at the bottom of a scrolling pane, and a row that
+ * appears and disappears there pushes the transcript. Reserving the space
+ * permanently costs a line of every conversation to say nothing.
+ */
+export function TypingLine({
+  names,
+  className,
+}: {
+  names: string[];
+  className?: string;
+}) {
+  const label = typingLabel(names);
+  if (!label) return null;
+  return (
+    <p
+      data-testid="typing-line"
+      aria-live="polite"
+      className={cn(
+        "px-4 pb-1 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      {label}
+    </p>
+  );
+}

--- a/frontend/test/e2e/chat-presence.spec.ts
+++ b/frontend/test/e2e/chat-presence.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for presence and typing indicators.
+ *
+ * Both features are streams of timed frames, and the parts worth proving in a
+ * browser are the ones the pure rules cannot reach:
+ *
+ * - a presence frame actually moves a dot in the members pane;
+ * - **no dot is not the same as an offline dot** — presence is replica-local,
+ *   so somebody this host has never heard from is *unknown*, and claiming they
+ *   are offline would be a confident lie;
+ * - a typing frame renders a line under the composer, and that line clears on
+ *   its own when the renewals stop.
+ *
+ * Frames are pushed through a mocked SSE response rather than by driving a
+ * second browser: the interesting inputs are a frame at a chosen instant and
+ * then deliberate silence, and a second real console can produce neither on
+ * demand.
+ */
+
+const COMPANY = "acme";
+
+const DESKS = [
+  { id: "engineering", name: "Engineering", description: "Ships it", members: ["ceo"] },
+];
+const ROSTER = [{ id: "ceo", name: "Rae", role: "Chief Executive" }];
+
+const PEOPLE = [
+  { id: "u-ada", label: "Ada Lovelace", slug: "ada-lovelace" },
+  { id: "u-grace", label: "Grace Hopper", slug: "grace-hopper" },
+];
+
+const MENTIONABLES = {
+  agents: ROSTER,
+  people: PEOPLE,
+  desks: [{ id: "engineering", name: "Engineering", memberIds: ["ceo"] }],
+  everyone: { label: "everyone", aliases: ["everyone", "channel", "here"] },
+};
+
+/** Presence rows the host reports on the initial read. */
+type Seed = Array<{ userId: string; status: string; atMillis: number }>;
+
+async function mockApi(page: Page, opts: { seed?: Seed; frames?: string[] } = {}) {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+    if (path.endsWith("/desks")) return json(DESKS);
+    if (path.endsWith("/team")) return json(ROSTER);
+    if (path.endsWith("/chat/mentionables")) return json(MENTIONABLES);
+    if (path.endsWith("/chat/read-state")) return json({ markers: [] });
+    if (path.endsWith("/chat/history")) return json([]);
+    if (path.endsWith("/presence")) {
+      if (route.request().method() === "GET") return json({ people: opts.seed ?? [] });
+      return route.fulfill({ status: 204, body: "" });
+    }
+    if (path.endsWith("/chat/typing")) return route.fulfill({ status: 204, body: "" });
+    if (path.endsWith("/events")) {
+      // One SSE response carrying the scripted frames, then held open.
+      const body = (opts.frames ?? []).map((f) => `data: ${f}\n\n`).join("");
+      return route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache" },
+        body,
+      });
+    }
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "member" });
+    return json([]);
+  });
+}
+
+async function openChannel(page: Page, channelId: string) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+/** The member pane; the channel rail is the other `complementary` on screen. */
+const pane = (page: Page) => page.getByRole("complementary").last();
+
+async function openPane(page: Page) {
+  const toggle = page.getByRole("button", { name: /teammates$/i });
+  if ((await toggle.getAttribute("aria-pressed")) !== "true") await toggle.click();
+  await expect(page.getByRole("heading", { name: "Team" })).toBeVisible();
+}
+
+/** One person's row in the People section. */
+function personRow(page: Page, label: string) {
+  return pane(page).getByTestId("person-row").filter({ hasText: label });
+}
+
+test("a present person shows an online dot; an absent one shows no status", async ({ page }) => {
+  await mockApi(page, {
+    seed: [{ userId: "u-ada", status: "online", atMillis: Date.now() }],
+  });
+  await openChannel(page, "engineering");
+  await openPane(page);
+
+  await expect(personRow(page, "Ada Lovelace")).toBeVisible();
+  await expect(personRow(page, "Ada Lovelace").getByTestId("presence-dot")).toHaveAttribute(
+    "data-status",
+    "online",
+  );
+
+  // Grace is in the directory but this replica has never heard from her.
+  // "Unknown", not "offline" — presence is replica-local, and claiming she is
+  // offline would be a confident statement the console cannot support.
+  await expect(personRow(page, "Grace Hopper").getByTestId("presence-dot")).toHaveAttribute(
+    "data-status",
+    "unknown",
+  );
+  await expect(personRow(page, "Grace Hopper").getByTestId("presence-dot")).toHaveAttribute(
+    "aria-label",
+    /no recent activity/i,
+  );
+});
+
+test("an away status renders distinctly from online", async ({ page }) => {
+  await mockApi(page, {
+    seed: [
+      { userId: "u-ada", status: "online", atMillis: Date.now() },
+      { userId: "u-grace", status: "away", atMillis: Date.now() },
+    ],
+  });
+  await openChannel(page, "engineering");
+  await openPane(page);
+
+  await expect(personRow(page, "Ada Lovelace").getByTestId("presence-dot")).toHaveAttribute(
+    "data-status",
+    "online",
+  );
+  await expect(personRow(page, "Grace Hopper").getByTestId("presence-dot")).toHaveAttribute(
+    "data-status",
+    "away",
+  );
+});
+
+/** Teammates are not people: an agent has no session and no machine to be at. */
+test("a teammate row carries no presence dot", async ({ page }) => {
+  await mockApi(page, { seed: [{ userId: "u-ada", status: "online", atMillis: Date.now() }] });
+  await openChannel(page, "engineering");
+  await openPane(page);
+
+  const teammate = pane(page).getByText("Rae", { exact: false }).first();
+  await expect(teammate).toBeVisible();
+  // Exactly as many dots as there are people rows — none of them on a teammate.
+  const dots = await pane(page).getByTestId("presence-dot").count();
+  const rows = await pane(page).getByTestId("person-row").count();
+  expect(dots).toBe(rows);
+});
+
+test("a typing frame renders a line, and it clears when the renewals stop", async ({ page }) => {
+  const now = Date.now();
+  await mockApi(page, {
+    seed: [{ userId: "u-ada", status: "online", atMillis: now }],
+    frames: [
+      JSON.stringify({
+        type: "typing",
+        userId: "u-ada",
+        chatId: "engineering",
+        atMillis: now,
+      }),
+    ],
+  });
+  await openChannel(page, "engineering");
+
+  await expect(page.getByTestId("typing-line")).toHaveText(/Ada Lovelace is typing/);
+
+  // No renewal arrives, so the indicator expires on its own. That is the whole
+  // design: there is no "stopped typing" frame, and a console that closed
+  // mid-word must clear itself with no teardown.
+  await expect(page.getByTestId("typing-line")).toHaveCount(0, { timeout: 15_000 });
+});
+
+test("a typing frame for another channel does not leak into this one", async ({ page }) => {
+  const now = Date.now();
+  await mockApi(page, {
+    seed: [{ userId: "u-ada", status: "online", atMillis: now }],
+    frames: [
+      JSON.stringify({
+        type: "typing",
+        userId: "u-ada",
+        chatId: "some-other-desk",
+        atMillis: now,
+      }),
+    ],
+  });
+  await openChannel(page, "engineering");
+
+  // Give the frame time to arrive and be (correctly) ignored.
+  await page.waitForTimeout(1_000);
+  await expect(page.getByTestId("typing-line")).toHaveCount(0);
+});
+
+test("a host with no presence route degrades to no dots at all", async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+    if (path.endsWith("/desks")) return json(DESKS);
+    if (path.endsWith("/team")) return json(ROSTER);
+    if (path.endsWith("/chat/mentionables")) return json(MENTIONABLES);
+    if (path.endsWith("/chat/read-state")) return json({ markers: [] });
+    if (path.endsWith("/chat/history")) return json([]);
+    // The pre-feature host.
+    if (path.endsWith("/presence")) return json({ error: "not_found" }, 404);
+    if (path.endsWith("/events")) {
+      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+    }
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "member" });
+    return json([]);
+  });
+
+  await openChannel(page, "engineering");
+  await openPane(page);
+
+  // People still list; they simply carry no live status, which is honest.
+  await expect(personRow(page, "Ada Lovelace")).toBeVisible();
+  await expect(personRow(page, "Ada Lovelace").getByTestId("presence-dot")).toHaveAttribute(
+    "data-status",
+    "unknown",
+  );
+  await expect(page.getByTestId("typing-line")).toHaveCount(0);
+});

--- a/frontend/test/unit/chat-awareness.test.ts
+++ b/frontend/test/unit/chat-awareness.test.ts
@@ -112,45 +112,49 @@ describe("livePeers", () => {
 
 describe("shouldShowTyping", () => {
   it("shows a fresh frame", () => {
-    expect(shouldShowTyping({ atMillis: 1_000 }, 1_100, undefined)).toBe(true);
+    expect(shouldShowTyping({ atMillis: 1_000 }, undefined)).toBe(true);
   });
 
-  /** Rule 1: a delayed or replayed frame must not resurrect an indicator. */
-  it("drops a frame that is already older than its own TTL", () => {
-    expect(
-      shouldShowTyping({ atMillis: 0 }, TYPING_RECEIVE_TTL_MS, undefined),
-    ).toBe(false);
+  /**
+   * There is deliberately no "frame older than its own TTL" case here anymore.
+   * That rule compared the frame's *server*-stamped `atMillis` against the
+   * *browser's* `now`, so a viewer whose workstation clock ran fast by more
+   * than the TTL saw every typing frame read as already-expired on arrival —
+   * typing was silently broken for them. Freshness is `typingExpiry`'s job
+   * now, anchored to local receipt time instead of a comparison across clock
+   * domains. See both functions' doc comments.
+   */
+  it("does not depend on the receiving console's own clock at all", () => {
+    // A frame nominally many minutes "old" by a naive `now - atMillis` check
+    // must still be shown: nothing here reads wall-clock time.
+    expect(shouldShowTyping({ atMillis: 0 }, undefined)).toBe(true);
   });
 
-  /** Rule 2: somebody who has just spoken is not still typing. */
+  /** Rule 1: somebody who has just spoken is not still typing. */
   it("drops a frame stamped before that author's own message", () => {
-    expect(shouldShowTyping({ atMillis: 1_000 }, 1_100, 1_500)).toBe(false);
+    expect(shouldShowTyping({ atMillis: 1_000 }, 1_500)).toBe(false);
   });
 
-  /** Rule 3: the in-flight ping that lands just after the message. */
+  /** Rule 2: the in-flight ping that lands just after the message. */
   it("suppresses a frame stamped just after that author's message", () => {
-    expect(shouldShowTyping({ atMillis: 1_600 }, 1_700, 1_500)).toBe(false);
+    expect(shouldShowTyping({ atMillis: 1_600 }, 1_500)).toBe(false);
   });
 
   it("shows them again once they genuinely start typing after it", () => {
-    expect(shouldShowTyping({ atMillis: 5_000 }, 5_100, 1_500)).toBe(true);
+    expect(shouldShowTyping({ atMillis: 5_000 }, 1_500)).toBe(true);
   });
 });
 
 describe("typingExpiry", () => {
   /**
-   * A frame delayed in transit must not extend the bubble past its own
-   * validity — otherwise a slow network makes indicators linger.
+   * Anchored purely to the receipt time the caller passes in — never to the
+   * frame's own (server-clock) timestamp, which is exactly what fixes the
+   * clock-skew bug: a workstation clock running arbitrarily far ahead of or
+   * behind the host no longer changes when the indicator disappears.
    */
-  it("never extends past the frame's own lifetime", () => {
-    const delayed = typingExpiry({ atMillis: 0 }, 5_000);
-    expect(delayed).toBe(TYPING_RECEIVE_TTL_MS);
-  });
-
-  it("uses now for a frame that arrived promptly", () => {
-    expect(typingExpiry({ atMillis: 1_000 }, 1_000)).toBe(
-      1_000 + TYPING_RECEIVE_TTL_MS,
-    );
+  it("is a TTL from the given now, regardless of any server timestamp", () => {
+    expect(typingExpiry(1_000)).toBe(1_000 + TYPING_RECEIVE_TTL_MS);
+    expect(typingExpiry(5_000)).toBe(5_000 + TYPING_RECEIVE_TTL_MS);
   });
 });
 

--- a/frontend/test/unit/chat-awareness.test.ts
+++ b/frontend/test/unit/chat-awareness.test.ts
@@ -15,6 +15,7 @@ import {
   typingLabel,
   TYPING_RECEIVE_TTL_MS,
   type Peer,
+  type PresenceStatus,
   type Typer,
 } from "@/lib/awareness";
 

--- a/frontend/test/unit/chat-awareness.test.ts
+++ b/frontend/test/unit/chat-awareness.test.ts
@@ -5,6 +5,7 @@ import {
   IDLE_AWAY_MS,
   livePeers,
   presenceToAnnounce,
+  reconcilePresenceSnapshot,
   PRESENCE_HEARTBEAT_MS,
   PRESENCE_TTL_MS,
   pruneTypers,
@@ -107,6 +108,72 @@ describe("livePeers", () => {
 
   it("drops somebody whose lease lapsed", () => {
     expect(livePeers(peers, PRESENCE_TTL_MS + 1).size).toBe(0);
+  });
+});
+
+describe("reconcilePresenceSnapshot", () => {
+  /**
+   * Regression coverage for the race `usePresence`'s periodic snapshot
+   * refresh introduced: a `GET /presence` in flight racing a newer SSE frame
+   * must never let the (now stale) response win.
+   */
+  it("keeps a newer local status over an older snapshot row for the same peer", () => {
+    const peers = new Map<string, Peer>([["u1", { status: "away", atMillis: 2_000 }]]);
+    const next = reconcilePresenceSnapshot(
+      peers,
+      new Map(),
+      [{ userId: "u1", status: "online", atMillis: 1_000 }],
+      500,
+    );
+    expect(next.get("u1")).toEqual({ status: "away", atMillis: 2_000 });
+  });
+
+  it("applies a snapshot row newer than what is locally held", () => {
+    const peers = new Map<string, Peer>([["u1", { status: "away", atMillis: 1_000 }]]);
+    const next = reconcilePresenceSnapshot(
+      peers,
+      new Map(),
+      [{ userId: "u1", status: "online", atMillis: 2_000 }],
+      500,
+    );
+    expect(next.get("u1")).toEqual({ status: "online", atMillis: 2_000 });
+  });
+
+  it("does not resurrect somebody an offline tombstone already removed", () => {
+    // No entry in `peers` for u1 — a live "offline" frame already deleted it.
+    const tombstones = new Map([["u1", 3_000]]);
+    const next = reconcilePresenceSnapshot(
+      new Map(),
+      tombstones,
+      [{ userId: "u1", status: "online", atMillis: 2_000 }],
+      500,
+    );
+    expect(next.has("u1")).toBe(false);
+  });
+
+  it("applies a snapshot row newer than a stale offline tombstone", () => {
+    const tombstones = new Map([["u1", 1_000]]);
+    const next = reconcilePresenceSnapshot(
+      new Map(),
+      tombstones,
+      [{ userId: "u1", status: "online", atMillis: 2_000 }],
+      500,
+    );
+    expect(next.get("u1")).toEqual({ status: "online", atMillis: 2_000 });
+  });
+
+  it("does not drop a peer the snapshot omits if a live frame raced ahead of the request", () => {
+    // u2 arrived (via a live frame) *after* the snapshot request was sent —
+    // the snapshot's silence about them predates that arrival.
+    const peers = new Map<string, Peer>([["u2", { status: "online", atMillis: 5_000 }]]);
+    const next = reconcilePresenceSnapshot(peers, new Map(), [], 1_000);
+    expect(next.get("u2")).toEqual({ status: "online", atMillis: 5_000 });
+  });
+
+  it("drops a peer the snapshot omits when what we knew predates the request", () => {
+    const peers = new Map<string, Peer>([["u2", { status: "online", atMillis: 500 }]]);
+    const next = reconcilePresenceSnapshot(peers, new Map(), [], 1_000);
+    expect(next.has("u2")).toBe(false);
   });
 });
 

--- a/frontend/test/unit/chat-awareness.test.ts
+++ b/frontend/test/unit/chat-awareness.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyPresence,
+  IDLE_AWAY_MS,
+  livePeers,
+  presenceToAnnounce,
+  PRESENCE_HEARTBEAT_MS,
+  PRESENCE_TTL_MS,
+  pruneTypers,
+  shouldShowTyping,
+  typersIn,
+  typingExpiry,
+  typingLabel,
+  TYPING_RECEIVE_TTL_MS,
+  type Peer,
+  type Typer,
+} from "@/lib/awareness";
+
+/**
+ * Presence and typing are the two features where being slightly wrong is worse
+ * than being absent: a dot that flickers, or a "still typing…" for somebody who
+ * finished a paragraph ago, teaches people to ignore the indicator entirely.
+ * Every rule below is a case that produced exactly that.
+ */
+
+describe("presenceToAnnounce", () => {
+  it("is online while the human is at the machine", () => {
+    expect(presenceToAnnounce("auto", 0)).toBe("online");
+    expect(presenceToAnnounce("auto", IDLE_AWAY_MS - 1)).toBe("online");
+  });
+
+  it("goes away only after a real idle stretch", () => {
+    expect(presenceToAnnounce("auto", IDLE_AWAY_MS)).toBe("away");
+  });
+
+  it("lets the viewer override in both directions", () => {
+    expect(presenceToAnnounce("away", 0)).toBe("away");
+    expect(presenceToAnnounce("offline", 0)).toBe("offline");
+    // An override wins even when they are plainly at the machine.
+    expect(presenceToAnnounce("offline", IDLE_AWAY_MS)).toBe("offline");
+  });
+});
+
+describe("applyPresence", () => {
+  const peers = (): Map<string, Peer> =>
+    new Map([["u1", { status: "online" as const, atMillis: 1_000 }]]);
+
+  it("adds somebody who arrives", () => {
+    const next = applyPresence(new Map(), {
+      userId: "u1",
+      status: "online",
+      atMillis: 1,
+    });
+    expect(next?.get("u1")?.status).toBe("online");
+  });
+
+  it("removes somebody who goes offline", () => {
+    const next = applyPresence(peers(), {
+      userId: "u1",
+      status: "offline",
+      atMillis: 2_000,
+    });
+    expect(next?.has("u1")).toBe(false);
+  });
+
+  /** No change means no new map, so nothing downstream re-renders. */
+  it("reports no change for a repeat of what it already knows", () => {
+    expect(
+      applyPresence(peers(), { userId: "u1", status: "online", atMillis: 2_000 }),
+    ).toBeNull();
+  });
+
+  /**
+   * A reconnect can replay frames out of order, and an older one must not undo
+   * a newer one — otherwise somebody who just went away flips back to online.
+   */
+  it("ignores a frame older than what it already has", () => {
+    expect(
+      applyPresence(peers(), { userId: "u1", status: "away", atMillis: 500 }),
+    ).toBeNull();
+  });
+
+  it("applies a newer status change", () => {
+    const next = applyPresence(peers(), {
+      userId: "u1",
+      status: "away",
+      atMillis: 2_000,
+    });
+    expect(next?.get("u1")?.status).toBe("away");
+  });
+
+  it("ignores an offline frame for somebody it never had", () => {
+    expect(
+      applyPresence(new Map(), { userId: "ghost", status: "offline", atMillis: 1 }),
+    ).toBeNull();
+  });
+});
+
+describe("livePeers", () => {
+  const peers = new Map<string, Peer>([["u1", { status: "online", atMillis: 0 }]]);
+
+  /** The 3x margin: a missed heartbeat must not blink somebody out. */
+  it("keeps somebody through a missed heartbeat", () => {
+    expect(livePeers(peers, PRESENCE_HEARTBEAT_MS * 2).size).toBe(1);
+  });
+
+  it("drops somebody whose lease lapsed", () => {
+    expect(livePeers(peers, PRESENCE_TTL_MS + 1).size).toBe(0);
+  });
+});
+
+describe("shouldShowTyping", () => {
+  it("shows a fresh frame", () => {
+    expect(shouldShowTyping({ atMillis: 1_000 }, 1_100, undefined)).toBe(true);
+  });
+
+  /** Rule 1: a delayed or replayed frame must not resurrect an indicator. */
+  it("drops a frame that is already older than its own TTL", () => {
+    expect(
+      shouldShowTyping({ atMillis: 0 }, TYPING_RECEIVE_TTL_MS, undefined),
+    ).toBe(false);
+  });
+
+  /** Rule 2: somebody who has just spoken is not still typing. */
+  it("drops a frame stamped before that author's own message", () => {
+    expect(shouldShowTyping({ atMillis: 1_000 }, 1_100, 1_500)).toBe(false);
+  });
+
+  /** Rule 3: the in-flight ping that lands just after the message. */
+  it("suppresses a frame stamped just after that author's message", () => {
+    expect(shouldShowTyping({ atMillis: 1_600 }, 1_700, 1_500)).toBe(false);
+  });
+
+  it("shows them again once they genuinely start typing after it", () => {
+    expect(shouldShowTyping({ atMillis: 5_000 }, 5_100, 1_500)).toBe(true);
+  });
+});
+
+describe("typingExpiry", () => {
+  /**
+   * A frame delayed in transit must not extend the bubble past its own
+   * validity — otherwise a slow network makes indicators linger.
+   */
+  it("never extends past the frame's own lifetime", () => {
+    const delayed = typingExpiry({ atMillis: 0 }, 5_000);
+    expect(delayed).toBe(TYPING_RECEIVE_TTL_MS);
+  });
+
+  it("uses now for a frame that arrived promptly", () => {
+    expect(typingExpiry({ atMillis: 1_000 }, 1_000)).toBe(
+      1_000 + TYPING_RECEIVE_TTL_MS,
+    );
+  });
+});
+
+describe("typers", () => {
+  const typer = (over: Partial<Typer> & Pick<Typer, "userId">): Typer => ({
+    chatId: "eng",
+    expiresAt: 10_000,
+    firstSeenAt: 0,
+    ...over,
+  });
+
+  it("prunes the expired", () => {
+    const kept = pruneTypers([typer({ userId: "a", expiresAt: 5 })], 10);
+    expect(kept).toEqual([]);
+  });
+
+  it("keeps each channel's typers to itself", () => {
+    const all = [typer({ userId: "a" }), typer({ userId: "b", chatId: "design" })];
+    expect(typersIn(all, "eng", undefined, 0).map((t) => t.userId)).toEqual(["a"]);
+  });
+
+  it("keeps a thread's typers out of the channel", () => {
+    const all = [typer({ userId: "a" }), typer({ userId: "b", parentId: "42" })];
+    expect(typersIn(all, "eng", undefined, 0).map((t) => t.userId)).toEqual(["a"]);
+    expect(typersIn(all, "eng", "42", 0).map((t) => t.userId)).toEqual(["b"]);
+  });
+
+  /**
+   * Sorted by first-seen, not by latest frame: renewals arrive every few
+   * seconds, and re-sorting on them reshuffles the line although nobody
+   * started or stopped.
+   */
+  it("orders by who started first, so renewals do not reshuffle it", () => {
+    const all = [
+      typer({ userId: "b", firstSeenAt: 200 }),
+      typer({ userId: "a", firstSeenAt: 100 }),
+    ];
+    expect(typersIn(all, "eng", undefined, 0).map((t) => t.userId)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+});
+
+describe("typingLabel", () => {
+  it("names one and two, and counts past that", () => {
+    expect(typingLabel([])).toBeNull();
+    expect(typingLabel(["Jane"])).toBe("Jane is typing…");
+    expect(typingLabel(["Jane", "Ada"])).toBe("Jane and Ada are typing…");
+    expect(typingLabel(["Jane", "Ada", "Rae"])).toBe("Several people are typing…");
+  });
+});

--- a/frontend/test/unit/chat-awareness.test.ts
+++ b/frontend/test/unit/chat-awareness.test.ts
@@ -98,6 +98,29 @@ describe("applyPresence", () => {
   });
 });
 
+/**
+ * Every one of these iterates something the host supplied. The types promise an
+ * array; a host promises nothing. A stub answering `[]` for unrecognised routes
+ * made `res.people` `undefined`, and iterating it threw during render — blanking
+ * the entire console and failing every test in an unrelated spec file. Presence
+ * is the least important thing on the screen and has to fail like it.
+ */
+describe("malformed host responses", () => {
+  it("reconcilePresenceSnapshot treats a missing snapshot as no news", () => {
+    const peers = new Map([["u1", { status: "online" as const, atMillis: 1 }]]);
+    for (const bad of [undefined, null, "nope", 7, {}]) {
+      const out = reconcilePresenceSnapshot(
+        peers,
+        new Map(),
+        bad as unknown as Array<{ userId: string; status: PresenceStatus; atMillis: number }>,
+        1_000,
+      );
+      // Unchanged, not emptied: absent news must not evict somebody we know of.
+      expect(out.get("u1")?.status).toBe("online");
+    }
+  });
+});
+
 describe("livePeers", () => {
   const peers = new Map<string, Peer>([["u1", { status: "online", atMillis: 0 }]]);
 

--- a/frontend/test/unit/use-presence.test.ts
+++ b/frontend/test/unit/use-presence.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import { usePresence } from "@/hooks/use-presence";
+import { PRESENCE_HEARTBEAT_MS } from "@/lib/awareness";
+
+function fakeClient(over: Partial<OpenCompanyClient> = {}): OpenCompanyClient {
+  return {
+    presence: vi.fn(async () => ({ people: [] })),
+    announcePresence: vi.fn(async () => undefined),
+    disconnectPresenceBeacon: vi.fn(),
+    ...over,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let lastState: ReturnType<typeof usePresence> | null;
+
+function Probe({ client }: { client: OpenCompanyClient }) {
+  lastState = usePresence(client, "acme");
+  return null;
+}
+
+function mount(client: OpenCompanyClient) {
+  return act(async () => {
+    root.render(createElement(Probe, { client }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  sessionStorage.clear();
+  localStorage.clear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  lastState = null;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+/**
+ * Regression coverage for the three findings fixed alongside the per-tab
+ * lease: a stable per-tab id gets attached to every request, a 404 disables
+ * the feature but nothing else does, and a steady peer's snapshot is
+ * refreshed on the heartbeat rather than only once at mount.
+ */
+describe("usePresence", () => {
+  it("attaches the same consoleId to every announce and to the disconnect beacon", async () => {
+    const client = fakeClient();
+    await mount(client);
+
+    const announce = client.announcePresence as ReturnType<typeof vi.fn>;
+    expect(announce).toHaveBeenCalled();
+    const [, , consoleId] = announce.mock.calls[0] as [string, string, string];
+    expect(typeof consoleId).toBe("string");
+    expect(consoleId.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      lastState?.choose("offline");
+    });
+    const beacon = client.disconnectPresenceBeacon as ReturnType<typeof vi.fn>;
+    expect(beacon).toHaveBeenCalledWith("acme", consoleId);
+  });
+
+  it("keeps the same consoleId across a remount of the same tab", async () => {
+    const clientA = fakeClient();
+    await mount(clientA);
+    const idA = (clientA.announcePresence as ReturnType<typeof vi.fn>).mock.calls[0][2];
+
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    const clientB = fakeClient();
+    await mount(clientB);
+    const idB = (clientB.announcePresence as ReturnType<typeof vi.fn>).mock.calls[0][2];
+
+    // Same tab, so the same `sessionStorage`: the id survives a remount,
+    // matching the server's expectation that reloading a tab renews one
+    // lease rather than doubling it onto two different keys.
+    expect(idB).toBe(idA);
+  });
+
+  it("mints a different consoleId for what a new tab's sessionStorage looks like", async () => {
+    const clientA = fakeClient();
+    await mount(clientA);
+    const idA = (clientA.announcePresence as ReturnType<typeof vi.fn>).mock.calls[0][2];
+
+    await act(async () => {
+      root.unmount();
+    });
+    // A second tab never shares the first tab's `sessionStorage` — simulated
+    // here by clearing it, since jsdom gives every test one global instance.
+    sessionStorage.clear();
+    root = createRoot(container);
+    const clientB = fakeClient();
+    await mount(clientB);
+    const idB = (clientB.announcePresence as ReturnType<typeof vi.fn>).mock.calls[0][2];
+
+    expect(idB).not.toBe(idA);
+  });
+
+  it("disables presence on a 404 (the route does not exist on this host)", async () => {
+    const client = fakeClient({
+      announcePresence: vi.fn(async () => {
+        throw new ApiError(404, "not_found", "no such route");
+      }),
+    });
+    await mount(client);
+    expect(lastState?.supported).toBe(false);
+  });
+
+  it("does not disable presence on a transient failure", async () => {
+    const client = fakeClient({
+      announcePresence: vi.fn(async () => {
+        throw new ApiError(0, "network_error", "cannot reach the company host");
+      }),
+    });
+    await mount(client);
+    expect(lastState?.supported).toBe(true);
+  });
+
+  it("does not disable presence when the initial snapshot read fails transiently", async () => {
+    const client = fakeClient({
+      presence: vi.fn(async () => {
+        throw new ApiError(503, "unavailable", "quiescing");
+      }),
+    });
+    await mount(client);
+    expect(lastState?.supported).toBe(true);
+  });
+
+  it("re-reads the snapshot on every heartbeat, not just at mount", async () => {
+    vi.useFakeTimers();
+    const client = fakeClient();
+    await act(async () => {
+      root.render(createElement(Probe, { client }));
+    });
+    const presence = client.presence as ReturnType<typeof vi.fn>;
+    const callsAtMount = presence.mock.calls.length;
+    expect(callsAtMount).toBeGreaterThan(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PRESENCE_HEARTBEAT_MS);
+    });
+    expect(presence.mock.calls.length).toBeGreaterThan(callsAtMount);
+  });
+});

--- a/frontend/test/unit/use-typing.test.ts
+++ b/frontend/test/unit/use-typing.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { useTyping } from "@/hooks/use-typing";
+import { TYPING_RECEIVE_TTL_MS } from "@/lib/awareness";
+
+function fakeClient(): OpenCompanyClient {
+  return { typing: vi.fn(async () => undefined) } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let lastState: ReturnType<typeof useTyping> | null;
+
+function Probe({ client }: { client: OpenCompanyClient }) {
+  lastState = useTyping(client, "acme");
+  return null;
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(Probe, { client }));
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  lastState = null;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+const frame = (atMillis: number) => ({
+  userId: "u-ada",
+  chatId: "engineering",
+  atMillis,
+});
+
+/**
+ * Regression coverage for the bug the e2e suite caught once `typingExpiry`
+ * stopped capping expiry at `frame.atMillis + TTL` (necessary to fix the
+ * clock-skew finding — see `awareness.ts`): a redelivered frame — an SSE
+ * reconnect replaying the last event a mocked or buffered transport still
+ * holds is the real case — must not indefinitely renew an indicator that no
+ * genuine new ping actually bought.
+ */
+describe("useTyping dedup", () => {
+  it("shows a typer on the first frame", async () => {
+    const client = fakeClient();
+    await mount(client);
+    await act(async () => {
+      lastState?.onFrame(frame(1_000));
+    });
+    expect(lastState?.typers.map((t) => t.userId)).toEqual(["u-ada"]);
+  });
+
+  it("ignores an exact replay of the same frame rather than renewing it", async () => {
+    vi.useFakeTimers();
+    const client = fakeClient();
+    await mount(client);
+
+    await act(async () => {
+      lastState?.onFrame(frame(1_000));
+    });
+    const firstExpiry = lastState?.typers[0]?.expiresAt;
+
+    // Time passes, but well inside the TTL, and the exact same frame (same
+    // `atMillis`) arrives again — the shape of a reconnect replaying its last
+    // buffered event, not a fresh keystroke.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    await act(async () => {
+      lastState?.onFrame(frame(1_000));
+    });
+    expect(lastState?.typers[0]?.expiresAt).toBe(firstExpiry);
+
+    // And the indicator still expires on the original schedule rather than
+    // lingering because of the replay.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TYPING_RECEIVE_TTL_MS);
+    });
+    expect(lastState?.typers).toEqual([]);
+  });
+
+  it("treats a frame with a newer atMillis as a genuine renewal", async () => {
+    vi.useFakeTimers();
+    const client = fakeClient();
+    await mount(client);
+
+    await act(async () => {
+      lastState?.onFrame(frame(1_000));
+    });
+    const firstExpiry = lastState?.typers[0]?.expiresAt;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    await act(async () => {
+      lastState?.onFrame(frame(3_000));
+    });
+    expect(lastState?.typers[0]?.expiresAt).not.toBe(firstExpiry);
+    expect(lastState?.typers.map((t) => t.userId)).toEqual(["u-ada"]);
+  });
+});

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -974,6 +974,13 @@ impl AppState {
         &self.presence
     }
 
+    /// A cloned handle to the same host-global registry [`Self::presence`]
+    /// borrows from, for a background task (the periodic sweep) that must
+    /// outlive any single request's borrow of `self`.
+    pub fn presence_handle(&self) -> std::sync::Arc<crate::server::presence::PresenceRegistry> {
+        self.presence.clone()
+    }
+
     /// The prebuilt GraphQL read-plane schema.
     pub fn schema(&self) -> &crate::server::graphql::OcSchema {
         &self.schema

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -444,6 +444,13 @@ pub struct AppState {
     /// the process. Lazy because it is a disk read that only `/spec` needs, and
     /// `AppState::new` is deliberately IO-free.
     instance_id: Arc<OnceLock<String>>,
+    /// Who is currently present, per company.
+    ///
+    /// Host-global and in-memory, like the live turn bus it publishes
+    /// alongside — presence is a lease, not a record, so it has no port and no
+    /// backend. See [`crate::server::presence`] for the TTL contract and for
+    /// why a second replica knowing nothing about this one is acceptable.
+    presence: Arc<crate::server::presence::PresenceRegistry>,
     /// Which storage backend is serving the durable ports. Reported by `/spec`
     /// as a kind only — never a path or a connection string.
     storage_kind: crate::store::StorageKind,
@@ -544,6 +551,7 @@ impl AppState {
             skills_root: None,
             skill_registry: Arc::new(OnceLock::new()),
             instance_id: Arc::new(OnceLock::new()),
+            presence: Arc::new(crate::server::presence::PresenceRegistry::new()),
             storage_kind: crate::store::StorageKind::default(),
             // Fails "not set up", so a host that never calls `with_setup_complete`
             // — every test fixture — presents the wizard rather than silently
@@ -959,6 +967,11 @@ impl AppState {
     /// The registry of running companies served by this host.
     pub fn registry(&self) -> &CompanyRegistry {
         &self.registry
+    }
+
+    /// Who is currently present, per company.
+    pub fn presence(&self) -> &crate::server::presence::PresenceRegistry {
+        &self.presence
     }
 
     /// The prebuilt GraphQL read-plane schema.

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -648,6 +648,16 @@ fn spawn_maintenance_ticker(
     MaintenanceTicker::new(state.registry().clone(), Arc::new(SystemClock)).spawn(shutdown.clone())
 }
 
+/// Starts the process-wide presence sweep (issue: "Bound client-supplied
+/// console leases"). See [`opencompany::server::presence::PresenceSweeper`]
+/// for why this is a separate task from the maintenance ticker above rather
+/// than folded into it: presence is host-global, not scoped to a registered
+/// company.
+fn spawn_presence_sweeper(state: &AppState, shutdown: &Arc<Notify>) -> tokio::task::JoinHandle<()> {
+    opencompany::server::presence::PresenceSweeper::new(state.presence_handle())
+        .spawn(shutdown.clone())
+}
+
 /// Starts a company's IMAP mailbox poller as a background task, if the
 /// platform injected mailbox credentials for this tenant.
 ///
@@ -2026,6 +2036,7 @@ async fn async_main() -> Result<()> {
             // and fire claims are retired, and it covers a company registered
             // after boot — which the per-company scheduler spawn above does not.
             scheduler_handles.push(spawn_maintenance_ticker(&state, &shutdown));
+            scheduler_handles.push(spawn_presence_sweeper(&state, &shutdown));
 
             // Stop the schedulers on a termination signal so background cycle
             // work halts with the process (lifecycle shutdown).

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,6 +50,9 @@ pub mod mcp_oauth;
 pub mod operator;
 pub mod ops;
 pub mod platform_auth;
+/// Who is here, and who is typing — ephemeral, leased, and never journaled.
+/// See [`presence`].
+pub mod presence;
 pub mod provision;
 mod routes;
 /// The first-run setup flow: one surface that configures an instance.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -624,16 +624,46 @@ async fn company_events(
     // These are ephemeral and never journaled; the console switches on `type`
     // just like the durable projections. On a company with no active turn this
     // stream is simply quiet.
-    let live = crate::turn_stream::subscribe(&company).map(|frame| {
-        Ok::<Event, Infallible>(
-            Event::default().data(serde_json::to_string(&frame).unwrap_or_default()),
-        )
-    });
+    //
+    // A typing frame authored by this very connection is dropped here rather
+    // than by the console: the bus fans a ping out to every subscriber of the
+    // company, including its sender, so without this a composer would echo its
+    // own "You are typing…" line back at itself for the length of the ping's
+    // TTL. Presence is left alone — a console does not render its own dot from
+    // the live feed, so there is nothing to echo.
+    let self_id = scope.actor.as_ref().map(|a| a.id.clone());
+    let live = crate::turn_stream::subscribe(&company)
+        .filter_map(move |frame| {
+            let drop = is_own_typing_frame(&frame, self_id.as_deref());
+            std::future::ready(if drop { None } else { Some(frame) })
+        })
+        .map(|frame| {
+            Ok::<Event, Infallible>(
+                Event::default().data(serde_json::to_string(&frame).unwrap_or_default()),
+            )
+        });
     let stream = futures::stream::select(durable, live);
     Sse::new(stream).keep_alive(
         KeepAlive::new()
             .interval(Duration::from_secs(15))
             .text("keep-alive"),
+    )
+}
+
+/// Whether a live frame is a typing ping authored by the very connection about
+/// to receive it.
+///
+/// The typing bus fans one ping out to every subscriber in the company,
+/// including its sender — there is no per-listener addressing beneath it — so
+/// without this check a console's own composer would echo its own "You are
+/// typing…" line back at itself for the length of the ping's TTL. Presence
+/// frames are left alone: a console never renders its own dot from the live
+/// feed, so there is nothing there to echo.
+fn is_own_typing_frame(frame: &crate::turn_stream::LiveFrame, self_id: Option<&str>) -> bool {
+    matches!(
+        frame,
+        crate::turn_stream::LiveFrame::Typing(typing)
+            if self_id == Some(typing.user_id.as_str())
     )
 }
 
@@ -8445,6 +8475,38 @@ mode = "full"
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// The composer's own typing pings must not echo back to it — the bus has
+    /// no per-listener addressing, so this filter is the only thing standing
+    /// between "you typed" and a fresh "Alice is typing…" line under your own
+    /// cursor.
+    #[test]
+    fn a_typing_frame_from_the_viewer_is_dropped_and_from_anybody_else_is_kept() {
+        let mine = crate::turn_stream::LiveFrame::Typing(crate::turn_stream::TypingFrame {
+            kind: "typing",
+            user_id: "u1".into(),
+            chat_id: "engineering".into(),
+            parent_id: None,
+            at_millis: 0,
+        });
+        assert!(super::is_own_typing_frame(&mine, Some("u1")));
+        assert!(!super::is_own_typing_frame(&mine, Some("u2")));
+        assert!(
+            !super::is_own_typing_frame(&mine, None),
+            "a machine credential with nobody behind it authors nothing to echo"
+        );
+
+        let presence = crate::turn_stream::LiveFrame::Presence(crate::turn_stream::PresenceFrame {
+            kind: "presence",
+            user_id: "u1".into(),
+            status: "online",
+            at_millis: 0,
+        });
+        assert!(
+            !super::is_own_typing_frame(&presence, Some("u1")),
+            "presence is left alone — only typing echoes"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -47,6 +47,9 @@ pub mod memory_ingest;
 pub mod mentions;
 pub mod pages;
 pub mod policy;
+/// Who is here and who is typing: heartbeat, clean disconnect, typing ping.
+/// Ephemeral, leased, never journaled. See [`presence`].
+pub mod presence;
 pub mod read_state;
 /// Issue #245 (operator half): bind a real repository to a company, list what
 /// is bound, revoke one. The whole credential path, with **no agent surface**
@@ -223,6 +226,7 @@ pub fn router() -> Router<AppState> {
         .merge(mcp::router())
         .merge(mcp_registry::router())
         .merge(read_state::router())
+        .merge(presence::router())
         .merge(mentions::router())
         .merge(repos::router())
         .merge(inference::router())

--- a/src/server/ops/presence.rs
+++ b/src/server/ops/presence.rs
@@ -28,7 +28,7 @@
 //! renewal *is* the stop signal. A console that closes mid-word therefore
 //! clears itself with no teardown to get wrong.
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -70,7 +70,31 @@ struct AnnounceBody {
     /// What to appear as. Note there is deliberately no `userId`: see the
     /// module header.
     status: PresenceStatus,
+    /// Which of this person's open tabs is announcing (issue: multi-tab
+    /// detach). An opaque value the console mints once per tab and holds for
+    /// its lifetime — never a second identity, just a second dimension of the
+    /// same authenticated one, so it carries no impersonation risk the module
+    /// header's rule would need to police.
+    ///
+    /// Missing on an older console: every tab from one falls onto
+    /// [`DEFAULT_CONSOLE`], which reproduces today's one-lease-per-user
+    /// behaviour for a client that predates this field.
+    #[serde(default)]
+    console_id: Option<String>,
 }
+
+/// `DELETE {scope}/presence` — a clean disconnect, naming which tab left.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DisconnectQuery {
+    #[serde(default)]
+    console_id: Option<String>,
+}
+
+/// The lease key an older console's requests — ones with no `consoleId` at
+/// all — collapse onto, so every tab from one that predates this field keeps
+/// sharing a single lease exactly as before.
+const DEFAULT_CONSOLE: &str = "default";
 
 /// `POST {scope}/chat/typing` — one ping.
 #[derive(Debug, Deserialize)]
@@ -103,11 +127,30 @@ async fn announce(
     let Some(user) = actor_id(&company) else {
         return Err(unauthorized());
     };
+    // An "offline" announcement is a disconnect, not a lease to store. `list`
+    // only ever reads live leases, so an `Offline` entry inserted here would
+    // still answer present to `GET /presence` — a viewer refreshing mid-TTL
+    // would see somebody the live stream just told them left. Route it through
+    // the same `detach` the DELETE takes so the registry and the wire agree.
+    let console = body.console_id.as_deref().unwrap_or(DEFAULT_CONSOLE);
+    if body.status == PresenceStatus::Offline {
+        return disconnect(
+            State(state),
+            company,
+            Query(DisconnectQuery {
+                console_id: body.console_id,
+            }),
+        )
+        .await;
+    }
     let at = now_millis();
     // Published on a *change* only. A console beats every minute whether or not
     // anything moved, so announcing every renewal would put one frame per
     // person per minute on every open console for no visible difference.
-    if state.presence().beat(company.id(), &user, body.status, at) {
+    if state
+        .presence()
+        .beat(company.id(), &user, console, body.status, at)
+    {
         crate::turn_stream::publish(
             company.id(),
             PresenceFrame {
@@ -124,14 +167,20 @@ async fn announce(
 async fn disconnect(
     State(state): State<AppState>,
     company: ScopedCompany,
+    Query(query): Query<DisconnectQuery>,
 ) -> Result<StatusCode, Response> {
     let Some(user) = actor_id(&company) else {
         return Err(unauthorized());
     };
-    // Only announce a departure that actually happened, so a duplicate teardown
-    // — `pagehide` and `visibilitychange` both firing, which they do — puts one
-    // frame on the bus rather than two.
-    if state.presence().detach(company.id(), &user) {
+    let console = query.console_id.as_deref().unwrap_or(DEFAULT_CONSOLE);
+    // Only announce a departure that actually happened — a duplicate teardown
+    // (`pagehide` and `visibilitychange` both firing, which they do) or a tab
+    // closing while another the same person has open is still live — publishes
+    // nothing.
+    if state
+        .presence()
+        .detach(company.id(), &user, console, now_millis())
+    {
         crate::turn_stream::publish(
             company.id(),
             PresenceFrame {
@@ -410,5 +459,79 @@ mod tests {
             );
             assert_eq!(body["code"], "unauthorized", "{method} {path}");
         }
+    }
+
+    /// Announcing `offline` must behave exactly like `DELETE`: the caller
+    /// disappears from `GET /presence` at once, not just after its lease
+    /// lapses. See the module header's "the wire and the registry must agree"
+    /// note on `announce`.
+    #[tokio::test]
+    async fn announcing_offline_disconnects_like_a_delete_would() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "online"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(listed["people"].as_array().unwrap().len(), 1);
+
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "offline"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(
+            listed["people"].as_array().unwrap().len(),
+            0,
+            "an offline announcement must drop the lease, not store it"
+        );
+    }
+
+    /// The multi-tab fix: two consoles for the same signed-in person, and
+    /// closing one must not disconnect the other.
+    #[tokio::test]
+    async fn closing_one_tab_leaves_the_other_open() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        for console in ["tab-1", "tab-2"] {
+            let (status, _) = call(
+                &state,
+                "PUT",
+                "/presence",
+                Some(json!({"status": "online", "consoleId": console})),
+                true,
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+        }
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(listed["people"].as_array().unwrap().len(), 1);
+
+        let (status, _) = call(&state, "DELETE", "/presence?consoleId=tab-1", None, true).await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(
+            listed["people"].as_array().unwrap().len(),
+            1,
+            "tab-2 is still open"
+        );
+
+        let (status, _) = call(&state, "DELETE", "/presence?consoleId=tab-2", None, true).await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(listed["people"].as_array().unwrap().len(), 0);
     }
 }

--- a/src/server/ops/presence.rs
+++ b/src/server/ops/presence.rs
@@ -173,11 +173,14 @@ async fn disconnect(
         return Err(unauthorized());
     };
     let console = query.console_id.as_deref().unwrap_or(DEFAULT_CONSOLE);
-    // Only announce a departure that actually happened — a duplicate teardown
-    // (`pagehide` and `visibilitychange` both firing, which they do) or a tab
-    // closing while another the same person has open is still live — publishes
-    // nothing.
-    if state
+    // Only announce a change the person's aggregate status actually made — a
+    // duplicate teardown, or a tab closing while another the same person has
+    // open already carried the same aggregate status, publishes nothing. When
+    // it does change, publish *that* status: closing the online tab while an
+    // away one is still open reports `away`, not `offline` — the person is
+    // still here, just not at their most-present console anymore. `Offline`
+    // only comes back once nobody is left.
+    if let Some(status) = state
         .presence()
         .detach(company.id(), &user, console, now_millis())
     {
@@ -186,7 +189,7 @@ async fn disconnect(
             PresenceFrame {
                 kind: "presence",
                 user_id: user,
-                status: PresenceStatus::Offline.as_str(),
+                status: status.as_str(),
                 at_millis: now_millis(),
             },
         );
@@ -533,5 +536,54 @@ mod tests {
         assert_eq!(status, StatusCode::NO_CONTENT);
         let (_, listed) = call(&state, "GET", "/presence", None, true).await;
         assert_eq!(listed["people"].as_array().unwrap().len(), 0);
+    }
+
+    /// Closing the console that was carrying the aggregate must downgrade the
+    /// person to `away`, not disappear them to `offline` — the away tab is
+    /// still open, and every viewer should see that immediately rather than
+    /// waiting out its next heartbeat.
+    #[tokio::test]
+    async fn closing_the_more_present_tab_downgrades_rather_than_disconnects() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "online", "consoleId": "tab-online"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "away", "consoleId": "tab-away"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        let people = listed["people"].as_array().expect("people");
+        assert_eq!(people.len(), 1);
+        assert_eq!(people[0]["status"], "online");
+
+        let (status, _) = call(
+            &state,
+            "DELETE",
+            "/presence?consoleId=tab-online",
+            None,
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        let people = listed["people"].as_array().expect("people");
+        assert_eq!(people.len(), 1, "the away tab keeps them present");
+        assert_eq!(people[0]["status"], "away");
     }
 }

--- a/src/server/ops/presence.rs
+++ b/src/server/ops/presence.rs
@@ -1,0 +1,414 @@
+//! Presence and typing routes.
+//!
+//! * `GET {scope}/presence` — who is here right now.
+//! * `PUT {scope}/presence` — a heartbeat, and a status.
+//! * `DELETE {scope}/presence` — a clean disconnect.
+//! * `POST {scope}/chat/typing` — one typing ping.
+//!
+//! # The subject is always the caller
+//!
+//! No body here names a user. The subject is taken from the session, every
+//! time. A body that could name somebody else would let any member mark a
+//! colleague online, offline, or typing, and nothing downstream could tell that
+//! from the real thing — the frames are identical. This is the rule `block/buzz`
+//! learned the hard way and states in its own presence code: a self-signed
+//! presence event's subject is always its author, never a field inside it.
+//!
+//! # Signed-in humans only
+//!
+//! Same `401` as [`read_state`](super::read_state), for the same reason: a
+//! machine credential names no person. Presence is *about* people, so a
+//! credential with nobody behind it has nothing to announce and no dot to own.
+//!
+//! # Typing stores nothing
+//!
+//! `POST …/chat/typing` publishes one frame and returns `204`. There is no
+//! typing registry and no "stopped typing" route: the frame carries its own
+//! moment, the console expires it after a few seconds, and the absence of a
+//! renewal *is* the stop signal. A console that closes mid-word therefore
+//! clears itself with no teardown to get wrong.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::AppState;
+use crate::ports::now_millis;
+use crate::server::ops::scope::{ScopedCompany, scoped};
+use crate::server::presence::{PresenceStatus, PresenceView};
+use crate::turn_stream::{PresenceFrame, TypingFrame};
+
+pub fn router() -> Router<AppState> {
+    scoped(
+        "/presence",
+        get(list_presence).put(announce).delete(disconnect),
+    )
+    .merge(scoped("/chat/typing", post(typing)))
+}
+
+/// `GET {scope}/presence` — everyone whose lease is still good.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PresenceListDto {
+    /// Present people, most recently seen first.
+    ///
+    /// **This replica's view.** A second host serving the same tenant keeps its
+    /// own map, so somebody connected there is absent here rather than shown as
+    /// offline — which is why the console treats an absence as "no live signal"
+    /// and falls back to the durable last-seen, instead of drawing a grey dot.
+    people: Vec<PresenceView>,
+}
+
+/// `PUT {scope}/presence` — a heartbeat.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AnnounceBody {
+    /// What to appear as. Note there is deliberately no `userId`: see the
+    /// module header.
+    status: PresenceStatus,
+}
+
+/// `POST {scope}/chat/typing` — one ping.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TypingBody {
+    /// The channel being typed in.
+    chat_id: String,
+    /// The thread inside it, when the composer is a thread's.
+    #[serde(default)]
+    parent_id: Option<String>,
+}
+
+async fn list_presence(
+    State(state): State<AppState>,
+    company: ScopedCompany,
+) -> Result<Json<PresenceListDto>, Response> {
+    let Some(_) = actor_id(&company) else {
+        return Err(unauthorized());
+    };
+    Ok(Json(PresenceListDto {
+        people: state.presence().list(company.id(), now_millis()),
+    }))
+}
+
+async fn announce(
+    State(state): State<AppState>,
+    company: ScopedCompany,
+    Json(body): Json<AnnounceBody>,
+) -> Result<StatusCode, Response> {
+    let Some(user) = actor_id(&company) else {
+        return Err(unauthorized());
+    };
+    let at = now_millis();
+    // Published on a *change* only. A console beats every minute whether or not
+    // anything moved, so announcing every renewal would put one frame per
+    // person per minute on every open console for no visible difference.
+    if state.presence().beat(company.id(), &user, body.status, at) {
+        crate::turn_stream::publish(
+            company.id(),
+            PresenceFrame {
+                kind: "presence",
+                user_id: user,
+                status: body.status.as_str(),
+                at_millis: at,
+            },
+        );
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn disconnect(
+    State(state): State<AppState>,
+    company: ScopedCompany,
+) -> Result<StatusCode, Response> {
+    let Some(user) = actor_id(&company) else {
+        return Err(unauthorized());
+    };
+    // Only announce a departure that actually happened, so a duplicate teardown
+    // — `pagehide` and `visibilitychange` both firing, which they do — puts one
+    // frame on the bus rather than two.
+    if state.presence().detach(company.id(), &user) {
+        crate::turn_stream::publish(
+            company.id(),
+            PresenceFrame {
+                kind: "presence",
+                user_id: user,
+                status: PresenceStatus::Offline.as_str(),
+                at_millis: now_millis(),
+            },
+        );
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn typing(
+    company: ScopedCompany,
+    Json(body): Json<TypingBody>,
+) -> Result<StatusCode, Response> {
+    let Some(user) = actor_id(&company) else {
+        return Err(unauthorized());
+    };
+    if body.chat_id.trim().is_empty() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": "chatId must not be empty", "code": "invalid_request" })),
+        )
+            .into_response());
+    }
+    crate::turn_stream::publish(
+        company.id(),
+        TypingFrame {
+            kind: "typing",
+            user_id: user,
+            chat_id: body.chat_id,
+            parent_id: body.parent_id,
+            at_millis: now_millis(),
+        },
+    );
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// The signed-in person behind the request, if there is one.
+fn actor_id(company: &ScopedCompany) -> Option<String> {
+    company.actor.as_ref().map(|a| a.id.clone())
+}
+
+/// The `401` for a caller with no person behind it.
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "presence is about people, and this credential names none",
+            "code": "unauthorized",
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::CompanyStore;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    const MANIFEST: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n";
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-presence-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                overlay_retired_agents: Vec::new(),
+                overlay_agent_edits: Vec::new(),
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+                setup: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn call(
+        state: &AppState,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        signed_in: bool,
+    ) -> (StatusCode, Value) {
+        let mut request = Request::builder()
+            .method(method)
+            .uri(format!("/api/v1/company{path}"))
+            .header("content-type", "application/json");
+        if signed_in {
+            request = request.header("cookie", crate::server::test_support::fixed_cookie("acme"));
+        }
+        let request = match body {
+            Some(value) => request.body(Body::from(value.to_string())).unwrap(),
+            None => request.body(Body::empty()).unwrap(),
+        };
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (
+            status,
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_heartbeat_makes_the_caller_visible_and_a_disconnect_clears_them() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        let (status, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(listed["people"].as_array().unwrap().len(), 0);
+
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "online"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        let people = listed["people"].as_array().expect("people");
+        assert_eq!(people.len(), 1);
+        assert_eq!(people[0]["status"], "online");
+
+        let (status, _) = call(&state, "DELETE", "/presence", None, true).await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(listed["people"].as_array().unwrap().len(), 0);
+    }
+
+    /// The impersonation guard, and the reason no route here takes a `userId`:
+    /// a body naming somebody else must not be able to move their dot. An
+    /// unknown key is ignored by serde, so the announcement lands under the
+    /// *caller* — which is the safe outcome, and the one asserted here.
+    #[tokio::test]
+    async fn a_body_cannot_name_somebody_else_as_the_subject() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "away", "userId": "somebody-else"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        let people = listed["people"].as_array().expect("people");
+        assert_eq!(people.len(), 1, "one dot moved, not two");
+        assert_ne!(
+            people[0]["userId"], "somebody-else",
+            "the subject is the session, never the body"
+        );
+        assert_eq!(people[0]["status"], "away");
+    }
+
+    #[tokio::test]
+    async fn an_unknown_status_is_refused_rather_than_stored() {
+        let home = home();
+        let state = state(home.path()).await;
+        let (status, _) = call(
+            &state,
+            "PUT",
+            "/presence",
+            Some(json!({"status": "invisible"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn a_typing_ping_is_accepted_and_stores_nothing() {
+        let home = home();
+        let state = state(home.path()).await;
+        let (status, _) = call(
+            &state,
+            "POST",
+            "/chat/typing",
+            Some(json!({"chatId": "engineering"})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        // Typing is not presence: a ping must not make somebody "here".
+        let (_, listed) = call(&state, "GET", "/presence", None, true).await;
+        assert_eq!(listed["people"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_typing_ping_needs_a_channel() {
+        let home = home();
+        let state = state(home.path()).await;
+        let (status, body) = call(
+            &state,
+            "POST",
+            "/chat/typing",
+            Some(json!({"chatId": "  "})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["code"], "invalid_request");
+    }
+
+    /// A machine credential has no person to be, so it has no dot to own and
+    /// nothing to say it is typing. Same rule the read-state routes apply.
+    #[tokio::test]
+    async fn a_caller_with_no_person_behind_it_is_refused_everywhere() {
+        let home = home();
+        let state = state(home.path()).await;
+        for (method, path, body) in [
+            ("GET", "/presence", None),
+            ("PUT", "/presence", Some(json!({"status": "online"}))),
+            ("DELETE", "/presence", None),
+            (
+                "POST",
+                "/chat/typing",
+                Some(json!({"chatId": "engineering"})),
+            ),
+        ] {
+            let (status, body) = call(&state, method, path, body, false).await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "{method} {path} must refuse a caller with no person"
+            );
+            assert_eq!(body["code"], "unauthorized", "{method} {path}");
+        }
+    }
+}

--- a/src/server/presence.rs
+++ b/src/server/presence.rs
@@ -95,15 +95,41 @@ struct Peer {
     last_beat_millis: u64,
 }
 
+/// The most present of two statuses — the aggregation rule for a person with
+/// more than one open console.
+///
+/// `Online` beats `Away` beats nothing at all, so a person reading in one tab
+/// while idle in another still shows as present: the honest answer to "is this
+/// person here" is "yes, in at least one of their consoles," never the
+/// gloomiest tab's guess.
+fn most_present(a: PresenceStatus, b: PresenceStatus) -> PresenceStatus {
+    use PresenceStatus::*;
+    match (a, b) {
+        (Online, _) | (_, Online) => Online,
+        (Away, _) | (_, Away) => Away,
+        _ => Offline,
+    }
+}
+
 /// Who is currently present, per company.
 ///
 /// Peer state is deliberately thin — a status and a timestamp, nothing else.
 /// No cursor, no current room, no last-read: which channel somebody is looking
 /// at is not a fact their colleagues need, and carrying it would turn a
 /// presence dot into activity tracking.
+///
+/// # A lease is per console, not per person
+///
+/// The same signed-in human commonly has more than one tab open. Keying solely
+/// on `(company, user)` made closing *any one* of them delete the lease every
+/// other tab was still renewing, so the person flapped offline until their next
+/// heartbeat healed it (up to a full [`PRESENCE_HEARTBEAT_MILLIS`]). The inner
+/// map keys on `(company, user)` as before; the value is now every console that
+/// user currently has open, so a departure only ever removes the console that
+/// actually left.
 #[derive(Debug, Default)]
 pub struct PresenceRegistry {
-    people: Mutex<HashMap<(CompanyId, String), Peer>>,
+    people: Mutex<HashMap<(CompanyId, String), HashMap<String, Peer>>>,
 }
 
 /// One person's presence, as a reader sees it.
@@ -124,14 +150,15 @@ impl PresenceRegistry {
         Self::default()
     }
 
-    /// Records a heartbeat, and says whether it changed anything a watcher
-    /// would care about.
+    /// Records one console's heartbeat, and says whether it changed anything a
+    /// watcher would care about.
     ///
     /// Returning "did this change" is what keeps the bus quiet: a console beats
     /// every minute whether or not anything moved, and republishing an
     /// unchanged `online` to every other console once a minute per person is
-    /// pure noise. A frame goes out when somebody *arrives* or *changes state*,
-    /// which is exactly when a dot would move.
+    /// pure noise. A frame goes out when the person's *aggregate* status
+    /// — [`most_present`] across every console they have open — arrives or
+    /// changes, which is exactly when a dot would move.
     ///
     /// An expired lease counts as an arrival, so somebody who was away long
     /// enough to lapse is re-announced rather than silently reappearing on the
@@ -140,37 +167,49 @@ impl PresenceRegistry {
         &self,
         company: &CompanyId,
         user: &str,
+        console: &str,
         status: PresenceStatus,
         now_millis: u64,
     ) -> bool {
         let mut people = self.people.lock().expect("presence registry poisoned");
         let key = (company.clone(), user.to_string());
-        let changed = match people.get(&key) {
-            Some(peer) => peer.status != status || expired(peer.last_beat_millis, now_millis),
-            None => true,
-        };
-        people.insert(
-            key,
+        let consoles = people.entry(key).or_default();
+        let before = aggregate(consoles, now_millis);
+        consoles.insert(
+            console.to_string(),
             Peer {
                 status,
                 last_beat_millis: now_millis,
             },
         );
-        changed
+        let after = aggregate(consoles, now_millis);
+        before != after
     }
 
-    /// Drops a lease immediately — a clean disconnect.
+    /// Drops one console's lease immediately — a clean disconnect.
     ///
     /// Worth having even though the TTL would get there eventually: a person
     /// who closes a tab should not linger as online for three minutes, and the
-    /// browser can say so on the way out. Returns whether anything was actually
-    /// removed, so a duplicate teardown publishes nothing.
-    pub fn detach(&self, company: &CompanyId, user: &str) -> bool {
-        self.people
-            .lock()
-            .expect("presence registry poisoned")
-            .remove(&(company.clone(), user.to_string()))
-            .is_some()
+    /// browser can say so on the way out. Only removes the departing console —
+    /// a colleague's other open tabs keep their own leases, so closing one does
+    /// not drop the others. Returns whether the person's aggregate status
+    /// actually changed (i.e. that was their last console), so a duplicate
+    /// teardown, or a departure that leaves another console still live,
+    /// publishes nothing.
+    pub fn detach(&self, company: &CompanyId, user: &str, console: &str, now_millis: u64) -> bool {
+        let mut people = self.people.lock().expect("presence registry poisoned");
+        let key = (company.clone(), user.to_string());
+        let Some(consoles) = people.get_mut(&key) else {
+            return false;
+        };
+        if consoles.remove(console).is_none() {
+            return false;
+        }
+        let still_present = aggregate(consoles, now_millis).is_some();
+        if consoles.is_empty() {
+            people.remove(&key);
+        }
+        !still_present
     }
 
     /// Everyone whose lease is still good, newest first.
@@ -178,16 +217,37 @@ impl PresenceRegistry {
     /// Expired entries are filtered here rather than swept on a timer: reads
     /// are the only thing that cares, so a lapsed lease costs a comparison
     /// instead of a background task. [`Self::sweep`] exists for the memory,
-    /// not for the correctness.
+    /// not for the correctness. A person with several open consoles is one row
+    /// here — [`most_present`] across them, timestamped by whichever renewed
+    /// most recently.
     pub fn list(&self, company: &CompanyId, now_millis: u64) -> Vec<PresenceView> {
         let people = self.people.lock().expect("presence registry poisoned");
         let mut out: Vec<PresenceView> = people
             .iter()
-            .filter(|((id, _), peer)| id == company && !expired(peer.last_beat_millis, now_millis))
-            .map(|((_, user), peer)| PresenceView {
-                user_id: user.clone(),
-                status: peer.status,
-                at_millis: peer.last_beat_millis,
+            .filter(|((id, _), _)| id == company)
+            .filter_map(|((_, user), consoles)| {
+                let live: Vec<&Peer> = consoles
+                    .values()
+                    .filter(|peer| !expired(peer.last_beat_millis, now_millis))
+                    .collect();
+                if live.is_empty() {
+                    return None;
+                }
+                let status = live
+                    .iter()
+                    .map(|peer| peer.status)
+                    .reduce(most_present)
+                    .expect("checked non-empty above");
+                let at_millis = live
+                    .iter()
+                    .map(|peer| peer.last_beat_millis)
+                    .max()
+                    .expect("checked non-empty above");
+                Some(PresenceView {
+                    user_id: user.clone(),
+                    status,
+                    at_millis,
+                })
             })
             .collect();
         out.sort_by(|a, b| {
@@ -202,13 +262,28 @@ impl PresenceRegistry {
     ///
     /// Purely to bound memory on a long-lived host — [`Self::list`] already
     /// ignores what this removes, so nothing observable changes. Returns how
-    /// many went, for a log line.
+    /// many console leases went, for a log line.
     pub fn sweep(&self, now_millis: u64) -> usize {
         let mut people = self.people.lock().expect("presence registry poisoned");
-        let before = people.len();
-        people.retain(|_, peer| !expired(peer.last_beat_millis, now_millis));
-        before - people.len()
+        let mut removed = 0;
+        people.retain(|_, consoles| {
+            let before = consoles.len();
+            consoles.retain(|_, peer| !expired(peer.last_beat_millis, now_millis));
+            removed += before - consoles.len();
+            !consoles.is_empty()
+        });
+        removed
     }
+}
+
+/// The aggregate status across every live console a person currently has open,
+/// or `None` when none of them are (an empty map, or every lease expired).
+fn aggregate(consoles: &HashMap<String, Peer>, now_millis: u64) -> Option<PresenceStatus> {
+    consoles
+        .values()
+        .filter(|peer| !expired(peer.last_beat_millis, now_millis))
+        .map(|peer| peer.status)
+        .reduce(most_present)
 }
 
 /// Whether a lease taken at `last_beat` has lapsed by `now`.
@@ -232,7 +307,7 @@ mod tests {
     #[test]
     fn a_beat_makes_somebody_present() {
         let reg = PresenceRegistry::new();
-        assert!(reg.beat(&acme(), "u1", PresenceStatus::Online, 0));
+        assert!(reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0));
         let live = reg.list(&acme(), 0);
         assert_eq!(live.len(), 1);
         assert_eq!(live[0].user_id, "u1");
@@ -244,7 +319,7 @@ mod tests {
     #[test]
     fn one_missed_beat_does_not_flap_somebody_offline() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
         assert_eq!(
             reg.list(&acme(), PRESENCE_HEARTBEAT_MILLIS * 2).len(),
             1,
@@ -255,7 +330,7 @@ mod tests {
     #[test]
     fn a_lapsed_lease_stops_being_present() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
         assert!(reg.list(&acme(), PRESENCE_TTL_MILLIS + 1).is_empty());
     }
 
@@ -263,7 +338,7 @@ mod tests {
     #[test]
     fn a_crashed_console_needs_no_cleanup() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
         // No detach — the tab is simply gone.
         assert!(reg.list(&acme(), PRESENCE_TTL_MILLIS + 1).is_empty());
     }
@@ -271,13 +346,51 @@ mod tests {
     #[test]
     fn a_clean_disconnect_drops_the_lease_at_once() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
-        assert!(reg.detach(&acme(), "u1"));
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
+        assert!(reg.detach(&acme(), "u1", "tab-1", 0));
         assert!(reg.list(&acme(), 0).is_empty());
         assert!(
-            !reg.detach(&acme(), "u1"),
+            !reg.detach(&acme(), "u1", "tab-1", 0),
             "a second teardown changes nothing"
         );
+    }
+
+    /// The bug this module's header now calls out by name: the same person
+    /// with two tabs open must not have one tab's departure log the other one
+    /// out. Closing tab 1 must not touch tab 2's lease, and only closing the
+    /// last open tab is a real departure worth a frame.
+    #[test]
+    fn closing_one_tab_does_not_disconnect_another() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-2", PresenceStatus::Online, 0);
+
+        assert!(
+            !reg.detach(&acme(), "u1", "tab-1", 0),
+            "tab 2 is still open, so this is not a real departure"
+        );
+        let live = reg.list(&acme(), 0);
+        assert_eq!(live.len(), 1, "still present through tab 2");
+        assert_eq!(live[0].status, PresenceStatus::Online);
+
+        assert!(
+            reg.detach(&acme(), "u1", "tab-2", 0),
+            "the last open tab leaving is a real departure"
+        );
+        assert!(reg.list(&acme(), 0).is_empty());
+    }
+
+    /// Two open tabs disagreeing about status — one idle, one active — must
+    /// read as the more present of the two: a person reading in one tab while
+    /// away in another is still here.
+    #[test]
+    fn the_most_present_tab_wins_the_aggregate_status() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Away, 0);
+        reg.beat(&acme(), "u1", "tab-2", PresenceStatus::Online, 0);
+        let live = reg.list(&acme(), 0);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].status, PresenceStatus::Online);
     }
 
     /// The bus stays quiet while nothing moves: a console beats every minute
@@ -287,13 +400,14 @@ mod tests {
     fn an_unchanged_beat_reports_no_change() {
         let reg = PresenceRegistry::new();
         assert!(
-            reg.beat(&acme(), "u1", PresenceStatus::Online, 0),
+            reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0),
             "arrival"
         );
         assert!(
             !reg.beat(
                 &acme(),
                 "u1",
+                "tab-1",
                 PresenceStatus::Online,
                 PRESENCE_HEARTBEAT_MILLIS
             ),
@@ -303,6 +417,7 @@ mod tests {
             reg.beat(
                 &acme(),
                 "u1",
+                "tab-1",
                 PresenceStatus::Away,
                 PRESENCE_HEARTBEAT_MILLIS
             ),
@@ -313,11 +428,12 @@ mod tests {
     #[test]
     fn a_beat_after_the_lease_lapsed_is_an_arrival_again() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
         assert!(
             reg.beat(
                 &acme(),
                 "u1",
+                "tab-1",
                 PresenceStatus::Online,
                 PRESENCE_TTL_MILLIS + 1
             ),
@@ -329,8 +445,14 @@ mod tests {
     #[test]
     fn presence_does_not_leak_between_companies() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
-        reg.beat(&CompanyId::new("other"), "u2", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
+        reg.beat(
+            &CompanyId::new("other"),
+            "u2",
+            "tab-1",
+            PresenceStatus::Online,
+            0,
+        );
         let live = reg.list(&acme(), 0);
         assert_eq!(live.len(), 1);
         assert_eq!(live[0].user_id, "u1");
@@ -339,8 +461,14 @@ mod tests {
     #[test]
     fn the_sweep_frees_only_what_list_already_ignores() {
         let reg = PresenceRegistry::new();
-        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
-        reg.beat(&acme(), "u2", PresenceStatus::Online, PRESENCE_TTL_MILLIS);
+        reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
+        reg.beat(
+            &acme(),
+            "u2",
+            "tab-1",
+            PresenceStatus::Online,
+            PRESENCE_TTL_MILLIS,
+        );
         let now = PRESENCE_TTL_MILLIS + 1;
         let visible_before = reg.list(&acme(), now);
         assert_eq!(reg.sweep(now), 1);

--- a/src/server/presence.rs
+++ b/src/server/presence.rs
@@ -1,0 +1,375 @@
+//! Who is here, and who is typing.
+//!
+//! Two ephemeral facts about the humans in a company, kept in memory and
+//! published on the live event bus. Neither is journaled and neither has a
+//! store: presence is a *lease* rather than a record, and typing is not even
+//! that.
+//!
+//! # Presence is a TTL, not a connection table
+//!
+//! A console heartbeats every [`PRESENCE_HEARTBEAT_MILLIS`]; an entry is live
+//! for [`PRESENCE_TTL_MILLIS`], which is **three times** the beat. The multiple
+//! is the point: one dropped request must not flap somebody offline and back,
+//! and a browser that crashes needs no cleanup at all — its lease simply
+//! expires. Tracking sockets instead would mean every disconnect path (tab
+//! close, sleep, network drop, pod restart) had to be handled correctly, and
+//! the failure mode of missing one is a person who looks online forever.
+//!
+//! This is the same shape [`RunnerRegistry`](crate::runner::registry) already
+//! uses, including its rule that a heartbeat is only meaningful for a caller
+//! the host has actually authenticated.
+//!
+//! # The subject is always the caller
+//!
+//! A presence write names no user; the subject is taken from the session. A
+//! body that could name somebody else would let any member mark any colleague
+//! online or offline, and nothing downstream could tell the difference.
+//!
+//! # Replica-local, deliberately
+//!
+//! Two hosted replicas share a tenant database but not this map, so each knows
+//! only about the consoles connected to it. That is exactly as partitioned as
+//! the live turn timeline ([`crate::turn_stream`]) already is, and for the same
+//! reason: both ride a process-local broadcast bus. A viewer sees everyone on
+//! their own replica live, and everyone else through the durable
+//! `lastSeenAtMillis` floor. Making presence cross-replica means a shared bus,
+//! which is a much larger change than the feature warrants.
+//!
+//! # This is not read receipts
+//!
+//! [`read_state`](crate::server::ops::read_state) stays what it is: a private
+//! floor for computing *your own* unread badge. Nothing here exposes what
+//! another person has read. "Who is here" and "who has read this" look adjacent
+//! and are not.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ports::types::CompanyId;
+
+/// How often a live console announces itself.
+pub const PRESENCE_HEARTBEAT_MILLIS: u64 = 60_000;
+
+/// How long an announcement stays good for.
+///
+/// Three times [`PRESENCE_HEARTBEAT_MILLIS`], so a single missed beat — a
+/// slow request, a moment of packet loss, a tab that was throttled while
+/// backgrounded — does not flap somebody offline and back.
+pub const PRESENCE_TTL_MILLIS: u64 = 3 * PRESENCE_HEARTBEAT_MILLIS;
+
+/// Exactly three states.
+///
+/// Anything a browser cannot honestly distinguish is deliberately not a state.
+/// In particular there is no "busy" and no "invisible": the first is a guess,
+/// and the second is a promise this design cannot keep, because a peer that
+/// stops beating is indistinguishable from one that closed its laptop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PresenceStatus {
+    /// At the machine.
+    Online,
+    /// Signed in, but idle — **not** "the window is unfocused". See the console
+    /// half: an unfocused window is not an absent human.
+    Away,
+    /// Explicitly appearing offline, or gone.
+    Offline,
+}
+
+impl PresenceStatus {
+    /// The wire word.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Online => "online",
+            Self::Away => "away",
+            Self::Offline => "offline",
+        }
+    }
+}
+
+/// One person's live lease.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Peer {
+    status: PresenceStatus,
+    last_beat_millis: u64,
+}
+
+/// Who is currently present, per company.
+///
+/// Peer state is deliberately thin — a status and a timestamp, nothing else.
+/// No cursor, no current room, no last-read: which channel somebody is looking
+/// at is not a fact their colleagues need, and carrying it would turn a
+/// presence dot into activity tracking.
+#[derive(Debug, Default)]
+pub struct PresenceRegistry {
+    people: Mutex<HashMap<(CompanyId, String), Peer>>,
+}
+
+/// One person's presence, as a reader sees it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceView {
+    /// The user id. Already known to every signed-in member through
+    /// `GET {scope}/chat/mentionables`, which is why this carries no label:
+    /// the console already holds the directory that names them.
+    pub user_id: String,
+    pub status: PresenceStatus,
+    /// When this lease was last renewed, epoch millis.
+    pub at_millis: u64,
+}
+
+impl PresenceRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a heartbeat, and says whether it changed anything a watcher
+    /// would care about.
+    ///
+    /// Returning "did this change" is what keeps the bus quiet: a console beats
+    /// every minute whether or not anything moved, and republishing an
+    /// unchanged `online` to every other console once a minute per person is
+    /// pure noise. A frame goes out when somebody *arrives* or *changes state*,
+    /// which is exactly when a dot would move.
+    ///
+    /// An expired lease counts as an arrival, so somebody who was away long
+    /// enough to lapse is re-announced rather than silently reappearing on the
+    /// next reader's poll.
+    pub fn beat(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        status: PresenceStatus,
+        now_millis: u64,
+    ) -> bool {
+        let mut people = self.people.lock().expect("presence registry poisoned");
+        let key = (company.clone(), user.to_string());
+        let changed = match people.get(&key) {
+            Some(peer) => peer.status != status || expired(peer.last_beat_millis, now_millis),
+            None => true,
+        };
+        people.insert(
+            key,
+            Peer {
+                status,
+                last_beat_millis: now_millis,
+            },
+        );
+        changed
+    }
+
+    /// Drops a lease immediately — a clean disconnect.
+    ///
+    /// Worth having even though the TTL would get there eventually: a person
+    /// who closes a tab should not linger as online for three minutes, and the
+    /// browser can say so on the way out. Returns whether anything was actually
+    /// removed, so a duplicate teardown publishes nothing.
+    pub fn detach(&self, company: &CompanyId, user: &str) -> bool {
+        self.people
+            .lock()
+            .expect("presence registry poisoned")
+            .remove(&(company.clone(), user.to_string()))
+            .is_some()
+    }
+
+    /// Everyone whose lease is still good, newest first.
+    ///
+    /// Expired entries are filtered here rather than swept on a timer: reads
+    /// are the only thing that cares, so a lapsed lease costs a comparison
+    /// instead of a background task. [`Self::sweep`] exists for the memory,
+    /// not for the correctness.
+    pub fn list(&self, company: &CompanyId, now_millis: u64) -> Vec<PresenceView> {
+        let people = self.people.lock().expect("presence registry poisoned");
+        let mut out: Vec<PresenceView> = people
+            .iter()
+            .filter(|((id, _), peer)| id == company && !expired(peer.last_beat_millis, now_millis))
+            .map(|((_, user), peer)| PresenceView {
+                user_id: user.clone(),
+                status: peer.status,
+                at_millis: peer.last_beat_millis,
+            })
+            .collect();
+        out.sort_by(|a, b| {
+            b.at_millis
+                .cmp(&a.at_millis)
+                .then(a.user_id.cmp(&b.user_id))
+        });
+        out
+    }
+
+    /// Forgets every lapsed lease, in every company.
+    ///
+    /// Purely to bound memory on a long-lived host — [`Self::list`] already
+    /// ignores what this removes, so nothing observable changes. Returns how
+    /// many went, for a log line.
+    pub fn sweep(&self, now_millis: u64) -> usize {
+        let mut people = self.people.lock().expect("presence registry poisoned");
+        let before = people.len();
+        people.retain(|_, peer| !expired(peer.last_beat_millis, now_millis));
+        before - people.len()
+    }
+}
+
+/// Whether a lease taken at `last_beat` has lapsed by `now`.
+///
+/// Clock-skew tolerant in the one direction that matters: a beat stamped in the
+/// future (two hosts disagreeing by a second) is not expired, because
+/// `saturating_sub` floors the age at zero rather than wrapping it to
+/// eighteen quintillion milliseconds and marking a live peer as gone.
+fn expired(last_beat: u64, now: u64) -> bool {
+    now.saturating_sub(last_beat) > PRESENCE_TTL_MILLIS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acme() -> CompanyId {
+        CompanyId::new("acme")
+    }
+
+    #[test]
+    fn a_beat_makes_somebody_present() {
+        let reg = PresenceRegistry::new();
+        assert!(reg.beat(&acme(), "u1", PresenceStatus::Online, 0));
+        let live = reg.list(&acme(), 0);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].user_id, "u1");
+        assert_eq!(live[0].status, PresenceStatus::Online);
+    }
+
+    /// The 3x margin doing its job: a beat missed entirely still leaves the
+    /// person online, so a dot does not flicker on one slow request.
+    #[test]
+    fn one_missed_beat_does_not_flap_somebody_offline() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        assert_eq!(
+            reg.list(&acme(), PRESENCE_HEARTBEAT_MILLIS * 2).len(),
+            1,
+            "two beats' worth of silence is still within the lease"
+        );
+    }
+
+    #[test]
+    fn a_lapsed_lease_stops_being_present() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        assert!(reg.list(&acme(), PRESENCE_TTL_MILLIS + 1).is_empty());
+    }
+
+    /// Crash recovery costs nothing: nobody has to notice the browser died.
+    #[test]
+    fn a_crashed_console_needs_no_cleanup() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        // No detach — the tab is simply gone.
+        assert!(reg.list(&acme(), PRESENCE_TTL_MILLIS + 1).is_empty());
+    }
+
+    #[test]
+    fn a_clean_disconnect_drops_the_lease_at_once() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        assert!(reg.detach(&acme(), "u1"));
+        assert!(reg.list(&acme(), 0).is_empty());
+        assert!(
+            !reg.detach(&acme(), "u1"),
+            "a second teardown changes nothing"
+        );
+    }
+
+    /// The bus stays quiet while nothing moves: a console beats every minute
+    /// whether or not anything changed, and republishing that to everyone would
+    /// be one frame per person per minute for no visible difference.
+    #[test]
+    fn an_unchanged_beat_reports_no_change() {
+        let reg = PresenceRegistry::new();
+        assert!(
+            reg.beat(&acme(), "u1", PresenceStatus::Online, 0),
+            "arrival"
+        );
+        assert!(
+            !reg.beat(
+                &acme(),
+                "u1",
+                PresenceStatus::Online,
+                PRESENCE_HEARTBEAT_MILLIS
+            ),
+            "a routine renewal is not news"
+        );
+        assert!(
+            reg.beat(
+                &acme(),
+                "u1",
+                PresenceStatus::Away,
+                PRESENCE_HEARTBEAT_MILLIS
+            ),
+            "a status change is"
+        );
+    }
+
+    #[test]
+    fn a_beat_after_the_lease_lapsed_is_an_arrival_again() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        assert!(
+            reg.beat(
+                &acme(),
+                "u1",
+                PresenceStatus::Online,
+                PRESENCE_TTL_MILLIS + 1
+            ),
+            "otherwise somebody who lapsed reappears with no frame announcing it"
+        );
+    }
+
+    /// One tenant must never see another's people, and the map is shared.
+    #[test]
+    fn presence_does_not_leak_between_companies() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        reg.beat(&CompanyId::new("other"), "u2", PresenceStatus::Online, 0);
+        let live = reg.list(&acme(), 0);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].user_id, "u1");
+    }
+
+    #[test]
+    fn the_sweep_frees_only_what_list_already_ignores() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u2", PresenceStatus::Online, PRESENCE_TTL_MILLIS);
+        let now = PRESENCE_TTL_MILLIS + 1;
+        let visible_before = reg.list(&acme(), now);
+        assert_eq!(reg.sweep(now), 1);
+        assert_eq!(reg.list(&acme(), now), visible_before);
+    }
+
+    /// A beat stamped slightly in the future — two hosts whose clocks disagree
+    /// — must not read as expired. Wrapping subtraction would make the age
+    /// enormous and mark a live person gone.
+    #[test]
+    fn a_beat_from_a_slightly_fast_clock_is_not_expired() {
+        assert!(!expired(1_000, 0));
+    }
+
+    #[test]
+    fn every_status_has_a_stable_wire_word() {
+        assert_eq!(PresenceStatus::Online.as_str(), "online");
+        assert_eq!(PresenceStatus::Away.as_str(), "away");
+        assert_eq!(PresenceStatus::Offline.as_str(), "offline");
+        assert_eq!(
+            serde_json::to_string(&PresenceStatus::Away).expect("serialize"),
+            "\"away\""
+        );
+    }
+
+    /// Forward-compatibility is not wanted here: an unknown status must be a
+    /// refusal, not a silently-stored string a reader cannot render.
+    #[test]
+    fn an_unknown_status_is_refused() {
+        assert!(serde_json::from_str::<PresenceStatus>("\"invisible\"").is_err());
+    }
+}

--- a/src/server/presence.rs
+++ b/src/server/presence.rs
@@ -43,9 +43,12 @@
 //! and are not.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 
 use crate::ports::types::CompanyId;
 
@@ -58,6 +61,19 @@ pub const PRESENCE_HEARTBEAT_MILLIS: u64 = 60_000;
 /// slow request, a moment of packet loss, a tab that was throttled while
 /// backgrounded — does not flap somebody offline and back.
 pub const PRESENCE_TTL_MILLIS: u64 = 3 * PRESENCE_HEARTBEAT_MILLIS;
+
+/// The most consoles one person may hold a lease on at once, per company.
+///
+/// Bounds a real memory-growth vector: a `consoleId` is client-supplied and
+/// otherwise unbounded, so a buggy console minting a fresh one on every
+/// reconnect — or a member deliberately hammering the route — would otherwise
+/// grow this map forever, since an expired lease is only ever *hidden* from
+/// reads (`list`, `aggregate`) rather than removed until [`PresenceRegistry::sweep`]
+/// next runs. `beat` enforces this cap directly rather than relying on the
+/// sweep's cadence, which bounds the *worst case* between sweeps rather than
+/// the sweep interval itself. Comfortably above any real browser's tab count
+/// (issue: "Bound client-supplied console leases").
+const MAX_CONSOLES_PER_PERSON: usize = 16;
 
 /// Exactly three states.
 ///
@@ -175,6 +191,20 @@ impl PresenceRegistry {
         let key = (company.clone(), user.to_string());
         let consoles = people.entry(key).or_default();
         let before = aggregate(consoles, now_millis);
+        // A genuinely new console (not a renewal of one already tracked) past
+        // the cap evicts the stalest entry first — expired ones before live
+        // ones, then oldest `last_beat_millis` — so an unbounded stream of
+        // fresh `consoleId`s cannot grow this map without limit. See
+        // `MAX_CONSOLES_PER_PERSON`.
+        if !consoles.contains_key(console)
+            && consoles.len() >= MAX_CONSOLES_PER_PERSON
+            && let Some(stalest) = consoles
+                .iter()
+                .min_by_key(|(_, peer)| peer.last_beat_millis)
+                .map(|(id, _)| id.clone())
+        {
+            consoles.remove(&stalest);
+        }
         consoles.insert(
             console.to_string(),
             Peer {
@@ -192,24 +222,39 @@ impl PresenceRegistry {
     /// who closes a tab should not linger as online for three minutes, and the
     /// browser can say so on the way out. Only removes the departing console —
     /// a colleague's other open tabs keep their own leases, so closing one does
-    /// not drop the others. Returns whether the person's aggregate status
-    /// actually changed (i.e. that was their last console), so a duplicate
-    /// teardown, or a departure that leaves another console still live,
-    /// publishes nothing.
-    pub fn detach(&self, company: &CompanyId, user: &str, console: &str, now_millis: u64) -> bool {
+    /// not drop the others.
+    ///
+    /// Returns the person's **new aggregate status**, and only when it
+    /// actually changed: `None` for a duplicate teardown, or for a departure
+    /// that leaves another console whose status already matched the
+    /// aggregate (an away tab closing while an online one is still live
+    /// changes nothing an observer could see). When the departing console was
+    /// carrying the aggregate up — an online tab closing while only an away
+    /// one remains — this reports the *downgraded* status (`Away`), not
+    /// `Offline`, so the caller publishes what the person now looks like
+    /// rather than a false "gone" a moment before their away tab's next
+    /// heartbeat corrects it. `Offline` is reported only when nobody is left.
+    pub fn detach(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        console: &str,
+        now_millis: u64,
+    ) -> Option<PresenceStatus> {
         let mut people = self.people.lock().expect("presence registry poisoned");
         let key = (company.clone(), user.to_string());
-        let Some(consoles) = people.get_mut(&key) else {
-            return false;
-        };
-        if consoles.remove(console).is_none() {
-            return false;
-        }
-        let still_present = aggregate(consoles, now_millis).is_some();
+        let consoles = people.get_mut(&key)?;
+        let before = aggregate(consoles, now_millis);
+        consoles.remove(console)?;
+        let after = aggregate(consoles, now_millis);
         if consoles.is_empty() {
             people.remove(&key);
         }
-        !still_present
+        if after == before {
+            None
+        } else {
+            Some(after.unwrap_or(PresenceStatus::Offline))
+        }
     }
 
     /// Everyone whose lease is still good, newest first.
@@ -296,6 +341,53 @@ fn expired(last_beat: u64, now: u64) -> bool {
     now.saturating_sub(last_beat) > PRESENCE_TTL_MILLIS
 }
 
+/// Periodically forgets lapsed leases across the whole process (issue: "Bound
+/// client-supplied console leases").
+///
+/// [`PresenceRegistry::sweep`] existed from the start but had no production
+/// caller — its only caller was a unit test. That was not silently unsafe
+/// (`list` already filters an expired lease out of every read, so nothing
+/// downstream ever saw a stale one), but the backing map itself only ever
+/// grew: a crashed tab that never sent `DELETE`, or a client minting fresh
+/// `consoleId`s, both left dead entries nothing ever removed. Deliberately not
+/// folded into [`crate::runtime::maintenance::MaintenanceTicker`] — that ticker
+/// is scoped to registered *companies* and drives per-company retirement
+/// through [`crate::CompanyRuntime`]; this registry is host-global and keyed by
+/// neither, so it gets its own always-on task, spawned once at boot the same
+/// way. [`MAX_CONSOLES_PER_PERSON`] bounds the worst case *per person* between
+/// sweeps; this is what reclaims the memory for everyone once a lease expires.
+pub struct PresenceSweeper {
+    registry: Arc<PresenceRegistry>,
+}
+
+impl PresenceSweeper {
+    pub fn new(registry: Arc<PresenceRegistry>) -> Self {
+        Self { registry }
+    }
+
+    /// Runs until `shutdown` is notified, sweeping once per [`PRESENCE_TTL_MILLIS`]
+    /// — lapsed-but-unswept memory is bounded by one TTL's worth of leases, not
+    /// by how long the process has been up.
+    pub fn spawn(self, shutdown: Arc<Notify>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            // Built once and pinned, not rebuilt inside the loop — see
+            // `MaintenanceTicker::spawn`'s identical comment for why a
+            // freshly-built `Notified` each iteration can miss a shutdown that
+            // arrives mid-sweep.
+            let notified = shutdown.notified();
+            tokio::pin!(notified);
+            loop {
+                tokio::select! {
+                    _ = &mut notified => break,
+                    _ = tokio::time::sleep(Duration::from_millis(PRESENCE_TTL_MILLIS)) => {
+                        self.registry.sweep(crate::ports::now_millis());
+                    }
+                }
+            }
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,10 +439,14 @@ mod tests {
     fn a_clean_disconnect_drops_the_lease_at_once() {
         let reg = PresenceRegistry::new();
         reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
-        assert!(reg.detach(&acme(), "u1", "tab-1", 0));
+        assert_eq!(
+            reg.detach(&acme(), "u1", "tab-1", 0),
+            Some(PresenceStatus::Offline)
+        );
         assert!(reg.list(&acme(), 0).is_empty());
-        assert!(
-            !reg.detach(&acme(), "u1", "tab-1", 0),
+        assert_eq!(
+            reg.detach(&acme(), "u1", "tab-1", 0),
+            None,
             "a second teardown changes nothing"
         );
     }
@@ -365,16 +461,18 @@ mod tests {
         reg.beat(&acme(), "u1", "tab-1", PresenceStatus::Online, 0);
         reg.beat(&acme(), "u1", "tab-2", PresenceStatus::Online, 0);
 
-        assert!(
-            !reg.detach(&acme(), "u1", "tab-1", 0),
-            "tab 2 is still open, so this is not a real departure"
+        assert_eq!(
+            reg.detach(&acme(), "u1", "tab-1", 0),
+            None,
+            "tab 2 is still open at the same status, so this is not a real departure"
         );
         let live = reg.list(&acme(), 0);
         assert_eq!(live.len(), 1, "still present through tab 2");
         assert_eq!(live[0].status, PresenceStatus::Online);
 
-        assert!(
+        assert_eq!(
             reg.detach(&acme(), "u1", "tab-2", 0),
+            Some(PresenceStatus::Offline),
             "the last open tab leaving is a real departure"
         );
         assert!(reg.list(&acme(), 0).is_empty());
@@ -391,6 +489,90 @@ mod tests {
         let live = reg.list(&acme(), 0);
         assert_eq!(live.len(), 1);
         assert_eq!(live[0].status, PresenceStatus::Online);
+    }
+
+    /// The downgrade case: closing the console that was carrying the
+    /// aggregate must report the *new* aggregate (`Away`), not `Offline` —
+    /// the person is still here, just not at their most-present console
+    /// anymore, and every other viewer's dot should say so at once rather
+    /// than waiting for the away tab's next heartbeat to correct a false
+    /// "gone".
+    #[test]
+    fn closing_the_more_present_tab_reports_the_downgraded_status() {
+        let reg = PresenceRegistry::new();
+        reg.beat(&acme(), "u1", "tab-online", PresenceStatus::Online, 0);
+        reg.beat(&acme(), "u1", "tab-away", PresenceStatus::Away, 0);
+
+        assert_eq!(
+            reg.detach(&acme(), "u1", "tab-online", 0),
+            Some(PresenceStatus::Away),
+            "the away tab is still open — the aggregate degrades, it does not vanish"
+        );
+        let live = reg.list(&acme(), 0);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].status, PresenceStatus::Away);
+    }
+
+    /// The memory-growth finding: a client that keeps minting fresh
+    /// `consoleId`s (a bug in some other console, or a member hammering the
+    /// route) must not grow one person's lease set without bound. Past the
+    /// cap, a new console evicts the stalest one rather than being appended.
+    #[test]
+    fn a_flood_of_new_consoles_is_capped_rather_than_grown_forever() {
+        let reg = PresenceRegistry::new();
+        for i in 0..(MAX_CONSOLES_PER_PERSON * 3) {
+            reg.beat(
+                &acme(),
+                "u1",
+                &format!("console-{i}"),
+                PresenceStatus::Online,
+                i as u64,
+            );
+        }
+        let count = reg
+            .people
+            .lock()
+            .unwrap()
+            .get(&(acme(), "u1".to_string()))
+            .map(|consoles| consoles.len())
+            .unwrap_or(0);
+        assert!(
+            count <= MAX_CONSOLES_PER_PERSON,
+            "expected at most {MAX_CONSOLES_PER_PERSON} tracked consoles, found {count}"
+        );
+        // And the person is still (correctly) present — capping evicts the
+        // stalest lease, it does not stop tracking the person altogether.
+        assert_eq!(
+            reg.list(&acme(), (MAX_CONSOLES_PER_PERSON * 3) as u64)
+                .len(),
+            1
+        );
+    }
+
+    /// A console renewing its own existing lease must never be evicted by its
+    /// own renewal, even sitting exactly at the cap — the cap only ever makes
+    /// room for a *new* console id.
+    #[test]
+    fn renewing_an_existing_console_at_the_cap_never_evicts_itself() {
+        let reg = PresenceRegistry::new();
+        for i in 0..MAX_CONSOLES_PER_PERSON {
+            reg.beat(
+                &acme(),
+                "u1",
+                &format!("console-{i}"),
+                PresenceStatus::Online,
+                0,
+            );
+        }
+        // Renew the very first console many times — it must still be present
+        // afterward, not evicted as "stalest" by its own renewals.
+        for tick in 1..10 {
+            reg.beat(&acme(), "u1", "console-0", PresenceStatus::Online, tick);
+        }
+        let people = reg.people.lock().unwrap();
+        let consoles = people.get(&(acme(), "u1".to_string())).unwrap();
+        assert!(consoles.contains_key("console-0"));
+        assert_eq!(consoles.len(), MAX_CONSOLES_PER_PERSON);
     }
 
     /// The bus stays quiet while nothing moves: a console beats every minute

--- a/src/turn_stream.rs
+++ b/src/turn_stream.rs
@@ -44,7 +44,7 @@ use crate::ports::types::{CompanyId, TurnStepFailure};
 /// Per-company broadcast senders. Created lazily on first publish/subscribe for
 /// a company and kept for the process lifetime (companies are few and long
 /// lived, matching the durable event log's own `senders` map in `store::fs`).
-static REGISTRY: LazyLock<Mutex<HashMap<CompanyId, broadcast::Sender<TurnStreamEvent>>>> =
+static REGISTRY: LazyLock<Mutex<HashMap<CompanyId, broadcast::Sender<LiveFrame>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Ring capacity per company. A console that lags past this many un-drained
@@ -52,6 +52,111 @@ static REGISTRY: LazyLock<Mutex<HashMap<CompanyId, broadcast::Sender<TurnStreamE
 /// timeline still arrives folded on the final reply, so a dropped live frame is
 /// cosmetic, never lost state.
 const CAPACITY: usize = 256;
+
+/// Anything this bus carries.
+///
+/// `untagged` because every variant already serializes its own `type` key, so
+/// the wire form of a turn frame is **byte-identical** to what it was before
+/// presence existed — no envelope, no nesting, no second discriminant. The
+/// console keeps switching on `type` exactly as it does for `agent_reply`.
+///
+/// Presence and typing belong here rather than on the durable event log for
+/// the reason stated in this module's header: they are high-volume, worthless
+/// a second later, and journaling them would bloat the audit log and every
+/// chat history read for no lasting value. They are also, unlike a turn frame,
+/// facts about *people* — which is why the projection that puts them on the
+/// wire lives beside the route that authenticates one.
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum LiveFrame {
+    /// Tool-call progress while a turn runs.
+    Turn(Box<TurnStreamEvent>),
+    /// Somebody arrived, went idle, or left.
+    Presence(PresenceFrame),
+    /// Somebody is typing in a channel.
+    Typing(TypingFrame),
+}
+
+impl LiveFrame {
+    /// The turn frame this carries, or `None` for a presence/typing frame.
+    ///
+    /// The bus is mostly turn frames and every pre-existing reader wants one,
+    /// so this keeps those call sites reading as they did rather than matching
+    /// on a union they do not care about.
+    pub fn as_turn(&self) -> Option<&TurnStreamEvent> {
+        match self {
+            Self::Turn(event) => Some(event),
+            _ => None,
+        }
+    }
+}
+
+impl From<TurnStreamEvent> for LiveFrame {
+    fn from(event: TurnStreamEvent) -> Self {
+        // Boxed because `TurnStreamEvent` is much the largest variant, and an
+        // un-boxed union would make every presence frame on the broadcast ring
+        // pay for it. The ring holds `CAPACITY` of these per company.
+        Self::Turn(Box::new(event))
+    }
+}
+
+impl From<PresenceFrame> for LiveFrame {
+    fn from(frame: PresenceFrame) -> Self {
+        Self::Presence(frame)
+    }
+}
+
+impl From<TypingFrame> for LiveFrame {
+    fn from(frame: TypingFrame) -> Self {
+        Self::Typing(frame)
+    }
+}
+
+/// One person's presence changed.
+///
+/// Published on a change only — an arrival, a status flip, a departure — never
+/// on a routine heartbeat renewal, or a company of ten would put ten frames a
+/// minute on every open console for no visible difference.
+///
+/// Carries a user id and no label: every signed-in member already holds the
+/// directory that names them (`GET {scope}/chat/mentionables`), so a label here
+/// would be a second copy to keep in step.
+#[derive(Clone, Debug, Serialize)]
+pub struct PresenceFrame {
+    /// Always `"presence"`.
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    #[serde(rename = "userId")]
+    pub user_id: String,
+    /// `online` / `away` / `offline`.
+    pub status: &'static str,
+    #[serde(rename = "atMillis")]
+    pub at_millis: u64,
+}
+
+/// Somebody is typing.
+///
+/// Stored nowhere at all, not even in the presence registry: a typing
+/// indicator is eight seconds of leased truth, and the console expires it on
+/// its own. There is deliberately no "stopped typing" frame — the absence of a
+/// renewal is the stop signal, which means a console that closes mid-word
+/// clears itself with no teardown to get wrong.
+#[derive(Clone, Debug, Serialize)]
+pub struct TypingFrame {
+    /// Always `"typing"`.
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    #[serde(rename = "userId")]
+    pub user_id: String,
+    /// The channel being typed in.
+    #[serde(rename = "chatId")]
+    pub chat_id: String,
+    /// The thread inside it, when it is one.
+    #[serde(rename = "parentId", skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    #[serde(rename = "atMillis")]
+    pub at_millis: u64,
+}
 
 /// One live progress frame for the console's in-flight tool timeline.
 ///
@@ -177,7 +282,7 @@ pub struct TurnStreamCtx {
 /// The sender for a company, created on first use. Mirrors `store::fs`'s
 /// `sender_for`: a subscribers-may-be-zero broadcast whose `send` error (no
 /// listeners) is ignored — a turn streams whether or not a console is watching.
-fn sender_for(company: &CompanyId) -> broadcast::Sender<TurnStreamEvent> {
+fn sender_for(company: &CompanyId) -> broadcast::Sender<LiveFrame> {
     let mut reg = REGISTRY.lock().expect("turn-stream registry poisoned");
     reg.entry(company.clone())
         .or_insert_with(|| broadcast::channel(CAPACITY).0)
@@ -185,9 +290,12 @@ fn sender_for(company: &CompanyId) -> broadcast::Sender<TurnStreamEvent> {
 }
 
 /// Publish one live frame for `company`. A no-op (send error ignored) when no
-/// console is subscribed. Called only from the `openhuman` harness collector.
-pub fn publish(company: &CompanyId, event: TurnStreamEvent) {
-    let _ = sender_for(company).send(event);
+/// console is subscribed.
+///
+/// Takes `impl Into<LiveFrame>` so every existing harness call site — which
+/// passes a bare [`TurnStreamEvent`] — is unchanged by the bus being widened.
+pub fn publish(company: &CompanyId, event: impl Into<LiveFrame>) {
+    let _ = sender_for(company).send(event.into());
 }
 
 /// Subscribe to a company's live turn frames as a stream, for merging into the
@@ -195,7 +303,7 @@ pub fn publish(company: &CompanyId, event: TurnStreamEvent) {
 /// receiver — it simply stays quiet until the first `publish`. A `Lagged` gap is
 /// skipped (see [`CAPACITY`]); `Closed` never happens because `REGISTRY` holds a
 /// sender for the process lifetime.
-pub fn subscribe(company: &CompanyId) -> BoxStream<'static, TurnStreamEvent> {
+pub fn subscribe(company: &CompanyId) -> BoxStream<'static, LiveFrame> {
     let rx = sender_for(company).subscribe();
     let stream = futures::stream::unfold(rx, |mut rx| async move {
         loop {
@@ -214,6 +322,18 @@ mod tests {
     use super::*;
     use futures::StreamExt;
 
+    /// Unwraps the turn frame a test just published.
+    ///
+    /// Every assertion here predates the bus carrying anything but turns, and
+    /// panicking on the wrong variant is the right failure: a test that
+    /// published a turn frame and received a presence one has found a real bug.
+    fn turn(frame: LiveFrame) -> TurnStreamEvent {
+        frame
+            .as_turn()
+            .cloned()
+            .expect("this bus published a turn frame")
+    }
+
     fn frame(kind: &'static str, seq: u64) -> TurnStreamEvent {
         TurnStreamEvent {
             kind,
@@ -230,6 +350,47 @@ mod tests {
     /// A published frame reaches an already-subscribed console, agent stamp and
     /// all. (Broadcast only delivers to receivers that existed at publish time,
     /// so subscribe first — exactly the SSE route's order.)
+    /// The whole reason [`LiveFrame`] is `untagged`: widening the bus must not
+    /// change one byte of what a turn frame looks like on the wire, or every
+    /// console in the field starts ignoring frames it used to render.
+    #[test]
+    fn wrapping_a_turn_frame_in_the_union_does_not_change_its_wire_form() {
+        let event = frame("tool_call", 7);
+        let bare = serde_json::to_string(&event).expect("serialize");
+        let wrapped = serde_json::to_string(&LiveFrame::from(event)).expect("serialize");
+        assert_eq!(bare, wrapped);
+    }
+
+    #[test]
+    fn presence_and_typing_carry_their_own_type_discriminant() {
+        let presence = serde_json::to_value(LiveFrame::Presence(PresenceFrame {
+            kind: "presence",
+            user_id: "u1".to_string(),
+            status: "online",
+            at_millis: 5,
+        }))
+        .expect("serialize");
+        assert_eq!(presence["type"], "presence");
+        assert_eq!(presence["userId"], "u1");
+        // No label: the console already holds the directory that names people.
+        assert!(presence.get("label").is_none());
+
+        let typing = serde_json::to_value(LiveFrame::Typing(TypingFrame {
+            kind: "typing",
+            user_id: "u1".to_string(),
+            chat_id: "eng".to_string(),
+            parent_id: None,
+            at_millis: 5,
+        }))
+        .expect("serialize");
+        assert_eq!(typing["type"], "typing");
+        assert_eq!(typing["chatId"], "eng");
+        assert!(
+            typing.get("parentId").is_none(),
+            "a channel-level typing frame omits the thread key"
+        );
+    }
+
     #[tokio::test]
     async fn publish_reaches_subscriber() {
         let company = CompanyId::new("turn-stream-roundtrip");
@@ -238,7 +399,7 @@ mod tests {
             &company,
             frame("tool_call", 0).with_agent("ceo").with_chat("General"),
         );
-        let got = stream.next().await.expect("a frame arrives");
+        let got = turn(stream.next().await.expect("a frame arrives"));
         assert_eq!(got.kind, "tool_call");
         assert_eq!(got.seq, 0);
         assert_eq!(got.agent_id.as_deref(), Some("ceo"));
@@ -268,8 +429,8 @@ mod tests {
                 .with_agent("ceo")
                 .with_chat("eng_desk"),
         );
-        let a = stream.next().await.expect("first frame");
-        let b = stream.next().await.expect("second frame");
+        let a = turn(stream.next().await.expect("first frame"));
+        let b = turn(stream.next().await.expect("second frame"));
         assert_eq!(a.agent_id.as_deref(), Some("ceo"));
         assert_eq!(b.agent_id.as_deref(), Some("ceo"));
         // agentId alone is ambiguous; chatId disambiguates the two threads.


### PR DESCRIPTION
Stacked on #1645. The awareness half: who is here, and who is typing.

`frontend/src/lib/team-workload.ts:6` used to say it outright — *"there is no
presence plane to ask."* There is one now.

## Presence is a lease, not a connection table

A console heartbeats every 60s; an entry is good for 180s. The 3x margin is the
point: one dropped request must not flap somebody offline and back, and a
browser that **crashes needs no cleanup at all** — nothing has to notice, the
lease simply expires.

Tracking sockets instead would mean every disconnect path (tab close, sleep,
network drop, pod restart) had to be handled correctly, and the failure mode of
missing one is a person who looks online forever. Same shape `RunnerRegistry`
already uses, including its rule that a heartbeat only counts for a caller the
host has authenticated.

Three states, and deliberately no more: anything a browser cannot honestly
distinguish is not a state. There is no "invisible", because a peer that stops
beating is indistinguishable from one that closed its laptop.

## The subject is always the caller

**No route here takes a `userId`.** A body that could name somebody else would
let any member mark a colleague online, offline, or typing — and the resulting
frames would be identical to the real thing. A test sends
`{"status":"away","userId":"somebody-else"}` and asserts the *caller's* dot
moved instead. This is the rule `block/buzz` states in its own presence code.

## The live bus, widened without changing a byte

`LiveFrame` is an `untagged` union, so every existing turn frame serializes
**byte-identically** to before — pinned by
`wrapping_a_turn_frame_in_the_union_does_not_change_its_wire_form`. `publish`
takes `impl Into<LiveFrame>`, so no harness call site changes.

Neither new frame is journaled. Presence publishes on a *change* only, never on
a routine renewal — a company of ten would otherwise put ten frames a minute on
every open console for no visible difference. Typing stores nothing anywhere,
and there is deliberately **no stopped-typing frame**: the absence of a renewal
is the stop signal, so a console that closes mid-word clears itself with no
teardown to get wrong.

## Three de-flicker rules

Each was a visible flicker before it was a rule:

1. A frame already older than its own TTL is dead on arrival — a delayed or
   replayed frame must not resurrect an indicator.
2. A frame at or before that author's last message here is stale. Their message
   and their final typing ping race constantly, and the ping loses.
3. For a short window after their message, ignore them entirely — rule 2 only
   catches frames stamped *before* it, and one stamped a few milliseconds after
   is the same in-flight ping.

Plus: typers are ordered by **first seen**, not by latest frame, so renewals
arriving every few seconds do not reshuffle the line although nobody started or
stopped.

## Two console decisions worth flagging

**Activity tracking is a ref, never state.** The idle timer needs a listener on
every `keydown` and `pointermove` in the document; held in state, that
re-renders the app shell — 2233 lines of `useState` — on every keystroke
*anywhere in the application*. buzz has a performance regression test for
exactly this mistake. Only a status transition may call `setState`.

**No dot means no live signal, not offline.** Presence is replica-local (two
hosted replicas share a database, not this map), so somebody connected to the
other host is unknown here — and drawing them as offline would be a confident
claim the console cannot support. A hollow ring says "not seen" honestly.

**Teammates get no dot.** An agent has no session and no machine to be at; its
live state is already `WorkingIndicator`. A dot on one would be decoration that
reads as fact. Hence a separate People section in the members pane rather than
folding people into the teammate lists — desk membership is a teammate concept,
and every signed-in person can already see every desk.

## Away means away

Not "the window is unfocused" — people read a channel in a background tab
constantly, and marking them away for it makes the dot mean nothing. A browser
has no OS-idle API, so document-level input idleness (10 min) is the honest
analogue. Manual override is `auto | away | offline` in `localStorage`.

## This is not read receipts

`read_state` stays exactly what it is: a private floor for computing *your own*
unread badge. Nothing here exposes what another person has read. Worth a
sentence, because "who is here" and "who has read this" look adjacent and are
not.

## Commands run

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test                                  # 3517 passed, 0 failed
cargo check --all-features --all-targets
pnpm typecheck                              # tsc -b --noEmit
pnpm test                                   # 252 files, 2303 passed
```

**No new cargo feature**, so `feature-lanes.txt` needs no row — checked, not
assumed (issue #770).

## Tests

- `src/server/presence.rs` — 12: a missed beat does not flap; a crashed console
  needs no cleanup; a clean disconnect is immediate and idempotent; an
  unchanged beat reports no change (so the bus stays quiet); a beat after a
  lapse is an arrival again; presence does not leak between companies; a beat
  from a slightly fast clock is not expired (saturating, not wrapping).
- `src/server/ops/presence.rs` — 6, including the impersonation guard and a
  `401` on all four routes for a machine credential.
- `src/turn_stream.rs` — the byte-identical wire proof, plus the new frames'
  discriminants.
- `frontend/test/unit/chat-awareness.test.ts` — 23 over the pure rules: all
  three de-flicker rules, out-of-order frame handling, TTL clamping, stable
  ordering.

## One overlap to note

This branch adds a `client.mentionables()` method that #1662 also adds — both
need the directory, presence for the user-id → label map the frames deliberately
do not carry. Whichever lands second will conflict on one appended method; it is
the same code and a trivial resolve.

## Not in this PR

The mention badge and the `NotificationStore` writer — that slice is still
unstarted.
