### PR TITLE
fix(ledgers): repair the empty-board spec, and give the view-mode toggle a testid

### DIFF
--- a/frontend/src/views/LedgersView.tsx
+++ b/frontend/src/views/LedgersView.tsx
@@ -881,6 +881,12 @@ export function LedgersView({
                   variant="outline"
                   size="sm"
                   onClick={() => setMode(mode === "board" ? "list" : "board")}
+                  // Both the label and the title flip with the mode, so neither
+                  // is a stable handle for a test — and "Board" additionally
+                  // collides with the list switcher's own trigger. A testid is
+                  // what this screen's specs already prefer (see
+                  // `columnLabels`: "by testid, not by shape").
+                  data-testid="ledger-mode-toggle"
                   title={
                     mode === "board"
                       ? "Show every field on each row"

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -140,6 +140,16 @@ test("an empty board leaves its column affordances to explain the empty state", 
   try {
     await page.goto(`/#/ledgers/${slug}`);
     await dismissTour(page);
+
+    // Switch to the board explicitly. `defaultLedgerMode` gives columns to the
+    // native `tasks` ledger and rows to every other one — "columns for
+    // dispatched tasks; rows for every agent-written ledger" — so a ledger
+    // declared here opens as a list, and waiting for `ledger-board` without
+    // asking for it waits forever.
+    //
+    // By testid: the toggle's label and title both flip with the mode, and
+    // "Board" also matches the list switcher's trigger.
+    await page.getByTestId("ledger-mode-toggle").click();
     await expect(page.getByTestId("ledger-board")).toBeVisible({ timeout: 15_000 });
 
     // Board columns already say what an empty board is for. A second status
@@ -153,7 +163,7 @@ test("an empty board leaves its column affordances to explain the empty state", 
 
     // The list has no per-status-column affordance, so it retains both forms
     // of the above-list notice.
-    await page.getByRole("button", { name: "List" }).click();
+    await page.getByTestId("ledger-mode-toggle").click();
     await expect(page.getByTestId("ledger-filtered-empty")).toBeVisible({ timeout: 15_000 });
     await search.fill("");
     await expect(page.getByTestId("ledger-empty")).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
`board-columns.spec.ts:116` — *"an empty board leaves its column affordances to explain the empty state"* — has failed on **every run since it was added**, including on `main` itself. It is currently red on `main` (run 32651092054) and was blocking unrelated PRs.

## The test was wrong, not the product

It declares a **custom** ledger and then waits for `ledger-board` without ever switching to board mode. That can never pass:

```ts
defaultLedgerMode(ledger) // "board" only for the native `tasks` ledger
```

Every other ledger opens as a list, by design and by comment: *"Columns for dispatched tasks; rows for every agent-written ledger."*

I checked whether the intent was "board for any ledger with statuses" before touching anything. It isn't — the list default is deliberate. Changing the product to satisfy the test would have been the wrong repair.

## Why a testid rather than a name

The obvious fix — click the `Board` button — hits a strict-mode violation: **two** elements match, the mode toggle and the list switcher's trigger. And the toggle has no stable text at all, because its label *and* its `title` both flip with the mode:

| mode | label | title |
|---|---|---|
| list | Board | Group rows by status |
| board | List | Show every field on each row |

So the toggle gets `data-testid="ledger-mode-toggle"` and the spec uses it in both directions. That is the convention this very file states for itself, in `columnLabels`:

> By testid, not by shape. An empty column collapses to a rail (issue #1101) […] so a structural selector would silently stop counting the very columns this asserts the order of.

The original spec's later `getByRole("button", { name: "List" })` had the same latent fragility; it is now on the testid too.

## Scope

One `data-testid` attribute and two selector lines. No behaviour change.

## Verified

```
npx playwright test test/e2e/board-columns.spec.ts --workers=1
  1 skipped
  5 passed
```

Plus `pnpm typecheck` and `pnpm typecheck:e2e` clean. Confirmed failing before the change and passing after, against the same host.