### PR TITLE
Open a teammate's profile from their avatar

### DIFF
--- a/frontend/src/components/agent-profile-sheet.tsx
+++ b/frontend/src/components/agent-profile-sheet.tsx
@@ -1,0 +1,394 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { Mail, Pencil, Sparkles, Users, Wrench } from "lucide-react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { ApiError, type AgentDetailDto } from "@/api/types";
+import { TeammateAvatar } from "@/components/teammate-avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { agentHref, agentProfile } from "@/lib/agent-profile";
+import { cn } from "@/lib/utils";
+
+/** What a click on a teammate's face can do, from anywhere under the provider. */
+interface AgentProfileApi {
+  /** Open the panel on this roster agent id. */
+  open: (agentId: string) => void;
+  close: () => void;
+}
+
+const AgentProfileContext = createContext<AgentProfileApi | null>(null);
+
+/**
+ * The opener, or `null` where no provider is mounted.
+ *
+ * Null rather than a no-op on purpose: a caller is expected to render a plain
+ * avatar when this returns null, not a button that looks clickable and does
+ * nothing. The styleguide and the unit-rendered pieces of chat both mount
+ * outside the shell, and a dead control there would be a lie about the surface
+ * rather than a missing convenience.
+ */
+export function useAgentProfileOpener(): ((agentId: string) => void) | null {
+  return useContext(AgentProfileContext)?.open ?? null;
+}
+
+/**
+ * A teammate's face, clickable where there is a profile behind it.
+ *
+ * Falls back to the bare avatar — not a dead button — when the voice has no
+ * roster id (a desk, the company, "you") or when no provider is mounted. That
+ * distinction is the whole reason this wrapper exists rather than every surface
+ * writing its own `<button>`: a face that looks pressable and is not is worse
+ * than one that never claimed to be.
+ */
+export function AgentAvatarButton({
+  agentId,
+  name,
+  className,
+  children,
+}: {
+  agentId?: string;
+  /** For the control's accessible name — the face itself is `aria-hidden`. */
+  name: string;
+  className?: string;
+  /** The avatar to draw, so each surface keeps its own sizing and variant. */
+  children: ReactNode;
+}) {
+  const open = useAgentProfileOpener();
+  if (!agentId || !open) return <>{children}</>;
+  return (
+    <button
+      type="button"
+      onClick={() => open(agentId)}
+      // `rounded-md` matches the tile it wraps, so the focus ring follows the
+      // avatar's own corners rather than boxing it.
+      className={cn(
+        "rounded-md transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+        className,
+      )}
+      aria-label={`Open ${name}'s profile`}
+      data-testid="agent-profile-open-avatar"
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Clicking a teammate opens who they are, beside what you were reading.
+ *
+ * Before this, a face in a transcript or a member list was inert: the only way
+ * to find out what an agent is — its persona, its tools, the desks it sits on —
+ * was to leave the conversation for `#/team/<id>` and find your way back. The
+ * panel answers the question in place and keeps the full page one button away,
+ * which is the right split: a summary is what a click on an avatar is asking
+ * for, and editing is a page's worth of controls.
+ *
+ * Mounted once, near the root, rather than per surface. Every avatar in the
+ * console would otherwise need the client, the company scope and a piece of
+ * open state threaded to it, and each surface would answer the same question in
+ * its own slightly different words.
+ */
+export function AgentProfileProvider({
+  client,
+  company,
+  children,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  children: ReactNode;
+}) {
+  const [agentId, setAgentId] = useState<string | null>(null);
+
+  const api = useMemo<AgentProfileApi>(
+    () => ({ open: (id: string) => setAgentId(id), close: () => setAgentId(null) }),
+    [],
+  );
+
+  // The panel's own actions are hash links, and so are the desk badges inside
+  // it. A navigation is the operator saying "take me there" — leaving the panel
+  // floating over the page they asked for would make them close it first.
+  useEffect(() => {
+    const onHashChange = () => setAgentId(null);
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
+  return (
+    <AgentProfileContext.Provider value={api}>
+      {children}
+      <AgentProfileSheet
+        client={client}
+        company={company}
+        agentId={agentId}
+        onClose={() => setAgentId(null)}
+      />
+    </AgentProfileContext.Provider>
+  );
+}
+
+type Load = "loading" | "ready" | "unavailable" | "error";
+
+/**
+ * The panel itself.
+ *
+ * Exported for the styleguide and for a surface that wants one without the
+ * context; ordinary callers open it through {@link useAgentProfileOpener}.
+ */
+export function AgentProfileSheet({
+  client,
+  company,
+  agentId,
+  onClose,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  agentId: string | null;
+  onClose: () => void;
+}) {
+  const [load, setLoad] = useState<Load>("loading");
+  const [agent, setAgent] = useState<AgentDetailDto | null>(null);
+
+  useEffect(() => {
+    if (!agentId) return;
+    let live = true;
+    setLoad("loading");
+    setAgent(null);
+    void (async () => {
+      try {
+        const detail = await client.getAgent(agentId, company);
+        if (!live) return;
+        setAgent(detail);
+        setLoad("ready");
+      } catch (error) {
+        if (!live) return;
+        // A `404` here is two facts at once — a host with no detail route, or a
+        // teammate that is gone — and this panel has no roster to tell them
+        // apart the way the detail page does. So it says both, rather than
+        // picking one and sending the operator after a deletion that may never
+        // have happened.
+        setLoad(error instanceof ApiError && error.status === 404 ? "unavailable" : "error");
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company, agentId]);
+
+  return (
+    <Sheet open={agentId !== null} onOpenChange={(next) => !next && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full overflow-y-auto sm:max-w-sm"
+        data-testid="agent-profile-panel"
+      >
+        {load === "loading" && <ProfileSkeleton />}
+        {load === "unavailable" && (
+          <Message
+            title="Can't open this teammate."
+            body="Either they've been removed from the roster, or this company host is too old to serve a teammate's profile."
+          />
+        )}
+        {load === "error" && (
+          <Message
+            title="Couldn't load this teammate."
+            body="The company host didn't answer. Try again in a moment."
+          />
+        )}
+        {load === "ready" && agent && <ProfileBody agent={agent} />}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ProfileBody({ agent }: { agent: AgentDetailDto }) {
+  const profile = agentProfile(agent);
+  // The host's own `editable` list decides whether editing is offered, exactly
+  // as it does on the detail page. An empty list means this host does not
+  // support the edit at all — a current one offers name, role and instructions
+  // on every teammate, blueprint ones included.
+  const editable = agent.editable.length > 0;
+
+  return (
+    <>
+      <SheetHeader className="gap-3 pr-10">
+        <div className="flex items-start gap-3">
+          <TeammateAvatar
+            name={profile.display}
+            tone={profile.tone}
+            avatar={profile.avatar}
+            className="size-12 rounded-xl text-sm"
+            data-testid="agent-profile-avatar"
+          />
+          <div className="min-w-0 flex-1">
+            <SheetTitle className="truncate text-lg" data-testid="agent-profile-name">
+              {profile.display}
+            </SheetTitle>
+            {profile.subtitle && (
+              <SheetDescription className="truncate" data-testid="agent-profile-role">
+                {profile.subtitle}
+              </SheetDescription>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="secondary" className="gap-1" data-testid="agent-profile-tier">
+            <Sparkles className="size-3" aria-hidden /> {profile.tier}
+          </Badge>
+          <Badge variant="outline">{profile.origin}</Badge>
+          {agent.inboxEnabled && (
+            <Badge variant="outline" className="gap-1">
+              <Mail className="size-3" aria-hidden /> Inbox
+            </Badge>
+          )}
+        </div>
+      </SheetHeader>
+
+      <div className="space-y-5 px-4">
+        <Section title="What they do">
+          {profile.about ? (
+            <p
+              className="whitespace-pre-wrap text-sm text-muted-foreground"
+              data-testid="agent-profile-about"
+            >
+              {profile.about}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No instructions have been written for this teammate yet.
+            </p>
+          )}
+          {profile.aboutTruncated && (
+            <p className="text-xs text-muted-foreground">
+              Shortened here — the full text is on their page.
+            </p>
+          )}
+        </Section>
+
+        {agent.desks.length > 0 && (
+          <Section title="Desks">
+            <div className="flex flex-wrap gap-1.5">
+              {agent.desks.map((desk) => (
+                <a
+                  key={desk.id}
+                  href={`#/company/${encodeURIComponent(desk.id)}`}
+                  className="inline-flex"
+                  data-testid={`agent-profile-desk-${desk.id}`}
+                >
+                  <Badge variant="secondary" className="gap-1">
+                    <Users className="size-3" aria-hidden /> {desk.name}
+                    {desk.lead && <span className="text-xs opacity-70">(lead)</span>}
+                  </Badge>
+                </a>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        <Section title="Tools">
+          {/* An empty `requested` is the company's standard grant, not "no
+              tools" — saying "none" for exactly those agents would report the
+              opposite of what they hold. */}
+          {profile.tools.standardGrant ? (
+            <p className="text-sm text-muted-foreground" data-testid="agent-profile-tools">
+              Everything this company allows — {profile.tools.effective.length}{" "}
+              {profile.tools.effective.length === 1 ? "grant" : "grants"}.
+            </p>
+          ) : profile.tools.effective.length === 0 ? (
+            <p className="text-sm text-muted-foreground" data-testid="agent-profile-tools">
+              No tools. Nothing this teammate asked for is on the company's allow-list.
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5" data-testid="agent-profile-tools">
+              {profile.tools.effective.map((glob) => (
+                <Badge key={glob} variant="outline" className="gap-1 font-mono text-xs">
+                  <Wrench className="size-3" aria-hidden /> {glob}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {profile.tools.dropped.length > 0 && (
+            <p className="text-xs text-muted-foreground" data-testid="agent-profile-tools-dropped">
+              Asked for but not allowed: {profile.tools.dropped.join(", ")}.
+            </p>
+          )}
+        </Section>
+
+        <p className="font-mono text-xs text-muted-foreground" data-testid="agent-profile-id">
+          {agent.id}
+        </p>
+      </div>
+
+      {/* Anchors rather than handlers: these are addresses (`#/team/<id>`), so
+          they open in a new tab, copy, and land in history like every other
+          link in the console. */}
+      <div className="mt-auto flex gap-2 p-4">
+        <Button
+          className="flex-1"
+          render={<a href={agentHref(agent.id, { edit: true })} />}
+          disabled={!editable}
+          title={editable ? undefined : "This teammate can't be edited from here."}
+          data-testid="agent-profile-edit"
+        >
+          <Pencil className="size-4" aria-hidden /> Edit agent
+        </Button>
+        <Button
+          variant="outline"
+          className="flex-1"
+          render={<a href={agentHref(agent.id)} />}
+          data-testid="agent-profile-open"
+        >
+          Full profile
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-1.5" aria-label={title}>
+      <h4 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{title}</h4>
+      {children}
+    </section>
+  );
+}
+
+function Message({ title, body }: { title: string; body: string }) {
+  return (
+    <SheetHeader className="gap-1 pr-10">
+      <SheetTitle>{title}</SheetTitle>
+      <SheetDescription>{body}</SheetDescription>
+    </SheetHeader>
+  );
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="space-y-4 p-4" data-testid="agent-profile-loading">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-12 rounded-xl" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      </div>
+      <Skeleton className="h-16 w-full" />
+      <Skeleton className="h-8 w-2/3" />
+    </div>
+  );
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -40,6 +40,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { AgentProfileProvider } from "@/components/agent-profile-sheet";
 import { ContentSurface } from "@/components/content-surface";
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import { HostSwitcher } from "@/components/host-switcher";
@@ -1929,6 +1930,12 @@ export function AppShell({
             #1178). A `div`, not `main` — `SidebarInset` above is already the
             console's one `<main>` landmark, and a second nested one gave every
             page two identical "skip to content" destinations (issue #1221). */}
+        {/* Every teammate's face in here is a way into who they are (issue
+            #1653): the panel is mounted once around the whole surface so a
+            click on an avatar in a transcript, a member list or a channel
+            header opens the same summary, over the page rather than instead of
+            it. */}
+        <AgentProfileProvider client={client} company={company}>
         <ContentSurface>
           {view === "overview" && (
             <Overview client={client} company={company} companyName={feed.status.name} />
@@ -2255,6 +2262,7 @@ export function AppShell({
           )}
           {view === "feedback" && <FeedbackView client={client} company={company} />}
         </ContentSurface>
+        </AgentProfileProvider>
 
         {/* Mobile only: dedicated chrome for the way back to navigation, not an
             overlay on top of it. A `fixed` trigger here used to float over

--- a/frontend/src/lib/agent-profile.ts
+++ b/frontend/src/lib/agent-profile.ts
@@ -1,0 +1,88 @@
+// The pure half of the agent profile panel: what a teammate's face is worth
+// summarising when you click it, and the two addresses the panel hands off to.
+//
+// Kept out of the component because both are quietly easy to get wrong. A
+// summary that shows the blueprint text where an override is in force describes
+// an agent nobody is running, and an "Edit" button that navigates to the plain
+// detail address lands the operator on a read-only page with the control they
+// asked for one more click away.
+
+import type { AgentDetailDto } from "@/api/types";
+import { summarizeGrants, tierLabel, type ToolGrantSummary } from "@/lib/agent";
+import { avatarFor, roleSubtitle, toneFor } from "@/lib/team";
+
+/** How many characters of the persona the panel shows before it truncates. */
+const ABOUT_LIMIT = 320;
+
+/** A teammate as the profile panel renders them. */
+export interface AgentProfile {
+  /** Name where the teammate has one, else the role — same fallback as the card. */
+  display: string;
+  /** The role, or `null` when it would only repeat {@link display}. */
+  subtitle: string | null;
+  /** Avatar seed: the id where there is one, so a rename never changes the face. */
+  seed: string;
+  tone: string;
+  avatar: string;
+  /** "Orchestrator" or "Worker", resolved by the host rather than by the tier string. */
+  tier: string;
+  /** Where this teammate came from, in the operator's words. */
+  origin: string;
+  /**
+   * The persona actually in force, clipped for a panel. The **effective**
+   * instructions first — that is the text the agent runs on — and the
+   * description only as a fallback, because a teammate can have one without the
+   * other.
+   */
+  about: string | null;
+  /** True when `about` had to be cut, so the panel can say "read the rest". */
+  aboutTruncated: boolean;
+  tools: ToolGrantSummary;
+}
+
+export function agentProfile(detail: AgentDetailDto): AgentProfile {
+  const display = detail.name?.trim() || detail.role;
+  const seed = detail.id || display;
+  const full = detail.instructions?.trim() || detail.description?.trim() || "";
+  const clipped = clip(full, ABOUT_LIMIT);
+  return {
+    display,
+    subtitle: roleSubtitle(display, detail.role),
+    seed,
+    tone: toneFor(seed),
+    avatar: avatarFor(seed),
+    tier: tierLabel(detail),
+    origin: detail.source === "manifest" ? "Company blueprint" : "Added here",
+    about: clipped || null,
+    aboutTruncated: clipped !== full,
+    tools: summarizeGrants(detail.tools),
+  };
+}
+
+/**
+ * Cut on a word boundary where there is one near the limit, so the panel ends
+ * on a word rather than mid-syllable. Text at or under the limit comes back
+ * untouched — `agentProfile` compares the two to decide whether anything was
+ * lost, so returning an equal-but-shortened string would claim a truncation
+ * that never happened.
+ */
+function clip(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const head = text.slice(0, limit);
+  const space = head.lastIndexOf(" ");
+  return `${(space > limit * 0.6 ? head.slice(0, space) : head).trimEnd()}…`;
+}
+
+/**
+ * The teammate's own page.
+ *
+ * `edit: true` appends the `?edit` flag `AgentDetailView` opens its form on
+ * (`use-hash-flag.ts`). A query suffix rather than a third path segment because
+ * `useHashView` splits the hash at `?` before it parses segments — so the flag
+ * rides along without the router ever seeing it, and Back closes the editor
+ * instead of leaving the page.
+ */
+export function agentHref(agentId: string, options: { edit?: boolean } = {}): string {
+  const path = `#/team/${encodeURIComponent(agentId)}`;
+  return options.edit ? `${path}?edit` : path;
+}

--- a/frontend/src/views/chat/ChatHeader.tsx
+++ b/frontend/src/views/chat/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Check, CircleDot, Copy, Hash, Lock, PanelLeft, Users } from "lucide-react";
 
+import { AgentAvatarButton } from "@/components/agent-profile-sheet";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -126,7 +127,15 @@ function KindIcon({ channel }: { channel: Channel }) {
     const face = dmFace(channel);
     // A DM with no roster entry behind it has nobody to draw — the rail falls
     // back to the same glyph rather than inventing a face for a stranger.
-    return face ? <TeammateAvatar {...face} className="size-6" /> : <CircleDot className={cls} aria-hidden />;
+    return face ? (
+      // The teammate this line is *with* — clicking their face here opens who
+      // they are (issue #1653), same as clicking it in the transcript below.
+      <AgentAvatarButton agentId={channel.member?.id} name={channel.name}>
+        <TeammateAvatar {...face} className="size-6" />
+      </AgentAvatarButton>
+    ) : (
+      <CircleDot className={cls} aria-hidden />
+    );
   }
   if (channel.private) return <Lock className={cls} aria-hidden />;
   return <Hash className={cls} aria-hidden />;

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Mail, MessageSquare, MoreHorizontal, UserPlus, Wallet } from "lucide-react";
 
+import { AgentAvatarButton } from "@/components/agent-profile-sheet";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -287,13 +288,19 @@ function MemberRow({
 
   return (
     <div className="group/member flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-accent/60">
+      {/* Outside the row button, not inside it: a button inside a button is
+          invalid HTML, and the two want different things anyway — the face
+          opens who this teammate is (issue #1653), the row opens a line to
+          them. */}
+      <AgentAvatarButton agentId={member.id} name={member.name}>
+        <TeammateAvatar name={member.name} tone={member.tone} avatar={member.avatar} className="size-8" />
+      </AgentAvatarButton>
       <button
         type="button"
         onClick={onMessage}
         className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
         title={member.description || member.role}
       >
-        <TeammateAvatar name={member.name} tone={member.tone} avatar={member.avatar} className="size-8" />
         <span className="min-w-0">
           <span className="flex items-center gap-1">
             <span className="truncate text-sm font-medium">{member.name}</span>

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -1,5 +1,6 @@
 import { MessageSquareReply } from "lucide-react";
 
+import { AgentAvatarButton, useAgentProfileOpener } from "@/components/agent-profile-sheet";
 import { Markdown } from "@/components/markdown";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
@@ -88,13 +89,18 @@ export function MessageRow({
             {formatTime(message.at)}
           </span>
         ) : (
-          <TeammateAvatar
-            name={sender.name}
-            tone={sender.tone}
-            avatar={sender.avatar}
-            company={sender.kind === "company"}
-            className="size-9"
-          />
+          // The face in the gutter is the way into who is talking (issue
+          // #1653) — for a voice that resolves to a roster teammate. A desk,
+          // the company and "you" have no profile behind them and stay plain.
+          <AgentAvatarButton agentId={sender.agentId} name={sender.name}>
+            <TeammateAvatar
+              name={sender.name}
+              tone={sender.tone}
+              avatar={sender.avatar}
+              company={sender.kind === "company"}
+              className="size-9"
+            />
+          </AgentAvatarButton>
         )}
       </div>
 
@@ -185,9 +191,25 @@ function SystemPill({ message }: { message: ChatMessage }) {
 }
 
 function AuthorLine({ sender, at }: { sender: Sender; at: number }) {
+  const openProfile = useAgentProfileOpener();
+  const { agentId } = sender;
+  // The name is the other half of the same target as the avatar beside it: a
+  // reader who wants to know who this is aims at whichever of the two their
+  // eye landed on.
+  const name = agentId && openProfile ? (
+    <button
+      type="button"
+      onClick={() => openProfile(agentId)}
+      className="truncate rounded-sm text-sm font-semibold tracking-tight hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+    >
+      {sender.name}
+    </button>
+  ) : (
+    <span className="truncate text-sm font-semibold tracking-tight">{sender.name}</span>
+  );
   return (
     <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 leading-5">
-      <span className="truncate text-sm font-semibold tracking-tight">{sender.name}</span>
+      {name}
       <span className="shrink-0 text-2xs text-muted-foreground tabular-nums">
         {formatTime(at)}
       </span>

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -191,6 +191,24 @@ it looks that id up against the roster (`members.find`) the same way
 falling back to the name seed, never a wrong face — when the id names a desk
 rather than a teammate.
 
+## A face is a way in
+
+Clicking a teammate's face — in the gutter of a message, in the member pane, or
+in a DM's header — opens `AgentProfileSheet`
+(`@/components/agent-profile-sheet`): a right-hand panel with that agent's
+persona, tier, desks and **resolved** tool grants, and two links out to their
+own page (`#/team/<id>`, and `#/team/<id>?edit` for the page with its edit form
+already open). The panel is mounted once by `AgentProfileProvider` in
+`app-shell.tsx`, so no chat surface threads a client, a company scope or an open
+flag of its own.
+
+Only a voice that resolves to a roster teammate is clickable. `Sender.agentId`
+is set exactly where `senderOf` **matched** the roster, never from the channel
+slug that seeded the face — that slug is a desk id for a cross-posted line, and
+a desk has no profile to open. `AgentAvatarButton` renders the bare avatar
+rather than a dead button wherever there is no id behind it (a desk, the
+company, you), which is also what it does outside the provider.
+
 ## One name per teammate
 
 The header's title is `channel.name`; the muted slot past the divider is

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -451,6 +451,17 @@ export interface Sender {
    * issue #1185.
    */
   avatar?: string;
+  /**
+   * The roster agent id behind this voice, when there is one — what a click on
+   * the face opens the profile panel on (issue #1653).
+   *
+   * Set only on a voice that actually **matched** the roster, never on the
+   * channel slug that seeded the face. A desk-originated cross-post carries a
+   * desk id in that slot (see `api/types.ts` on `thread`), and opening a
+   * teammate profile on a desk id would ask the host for an agent that does not
+   * exist.
+   */
+  agentId?: string;
 }
 
 /** Channel names the host uses for its own voice rather than a named agent. */
@@ -484,6 +495,7 @@ export function senderOf(m: ChatMessage, channel: Channel, members: TeamMember[]
       kind: "agent",
       tone: named,
       avatar: agent?.avatar,
+      agentId: agent?.id,
     };
   }
 
@@ -496,6 +508,9 @@ export function senderOf(m: ChatMessage, channel: Channel, members: TeamMember[]
     kind: channel.kind === "dm" || channel.tone ? "agent" : "company",
     tone: channel.tone,
     avatar: channel.member?.avatar,
+    // A DM's other end is a roster teammate; a desk channel's voice is the desk
+    // itself, which has no profile of its own to open.
+    agentId: channel.member?.id,
   };
 }
 

--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -23,6 +23,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { useHashFlag } from "@/hooks/use-hash-flag";
 import {
   agentEdits,
   draftFrom,
@@ -126,7 +127,22 @@ export function AgentDetailView({
   useEffect(() => {
     displayedAgentIdRef.current = agent?.id ?? null;
   }, [agent]);
-  const [editing, setEditing] = useState(false);
+  /**
+   * The edit form is an address, not a piece of local state (issue #1653).
+   *
+   * `#/team/<id>?edit` is what the profile panel's "Edit agent" button links
+   * to, so the form has to be openable by the hash rather than only by the
+   * button on this page. Deriving it from the flag rather than mirroring the
+   * flag into `useState` leaves one source of truth: the browser's Back button
+   * closes the editor, and a link into it lands with the form already open.
+   *
+   * Gated on the host's own `editable` list, so a hand-typed `?edit` on a
+   * teammate this host will not edit does not open a form whose Save can only
+   * fail.
+   */
+  const [editRequested, setEditRequested] = useHashFlag("edit");
+  const setEditing = setEditRequested;
+  const editing = editRequested && (agent?.editable.length ?? 0) > 0;
   const [draft, setDraft] = useState<AgentDraft>(emptyDraft());
   const [saving, setSaving] = useState(false);
   /**

--- a/frontend/test/e2e/agent-profile-panel.spec.ts
+++ b/frontend/test/e2e/agent-profile-panel.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Proof for issue #1653: a teammate's face is a way into who they are.
+ *
+ * The complaint is that an avatar was inert everywhere it appeared. You could
+ * be three hundred lines into a channel, wonder what the agent answering you is
+ * actually allowed to do, and have no way to find out that did not mean leaving
+ * the conversation for `#/team/<id>` and navigating back.
+ *
+ * So the evidence is the click that used to do nothing: open a DM, click the
+ * teammate's face in the header, and read their persona, tier, desks and
+ * resolved tool grants **over the transcript**. Then take the panel's own
+ * offer — Edit agent — and land on their page with the form already open,
+ * because a summary that cannot hand off to the real controls is a dead end of
+ * its own.
+ *
+ * Runs against the same live host as `agent-detail.spec.ts`
+ * (`companies/e2e_harness`), whose manifest declares `engineer` on the
+ * Engineering desk. Default features are enough.
+ */
+
+/** Same tour suppression as `agent-detail.spec.ts` — seeded before boot. */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+/** The DM with one teammate, open and rendered. */
+async function openDm(page: Page, agentId: string) {
+  await page.goto(`/#/chat/dm:${agentId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+test("a teammate's face opens who they are, without leaving the channel", async ({ page }) => {
+  await openDm(page, "engineer");
+
+  await page.getByRole("button", { name: /Open .*'s profile/ }).first().click();
+
+  const panel = page.getByTestId("agent-profile-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.getByTestId("agent-profile-id")).toHaveText("engineer");
+  // The three facts the transcript could not answer: what the agent is, where
+  // it sits, and what it may actually use.
+  await expect(panel.getByTestId("agent-profile-tier")).toBeVisible();
+  await expect(panel.getByTestId("agent-profile-desk-engineering")).toBeVisible();
+  await expect(panel.getByTestId("agent-profile-tools")).toBeVisible();
+
+  // Over the channel, not instead of it: the address never changed, so closing
+  // the panel returns to the same transcript rather than to whatever the
+  // browser's Back button would have found.
+  await expect(page).toHaveURL(/#\/chat\/dm:engineer$/);
+});
+
+test("the panel hands off to the teammate's own page, with the form open", async ({ page }) => {
+  await openDm(page, "engineer");
+  await page.getByRole("button", { name: /Open .*'s profile/ }).first().click();
+  await expect(page.getByTestId("agent-profile-panel")).toBeVisible();
+
+  await page.getByTestId("agent-profile-edit").click();
+
+  // The flag is what makes this a hand-off rather than a second dead end: the
+  // page opens *editing*, so the operator is not asked to find the Edit button
+  // again on arrival.
+  await expect(page).toHaveURL(/#\/team\/engineer\?edit$/);
+  await expect(page.getByTestId("agent-save")).toBeVisible({ timeout: 30_000 });
+
+  // And the panel got out of the way of the page it sent them to.
+  await expect(page.getByTestId("agent-profile-panel")).toHaveCount(0);
+});
+
+test("Back closes the editor and leaves the teammate's page standing", async ({ page }) => {
+  await page.goto("/#/team/engineer");
+  await page.getByTestId("agent-edit").click();
+  await expect(page).toHaveURL(/#\/team\/engineer\?edit$/);
+  await expect(page.getByTestId("agent-save")).toBeVisible({ timeout: 30_000 });
+
+  await page.goBack();
+
+  await expect(page).toHaveURL(/#\/team\/engineer$/);
+  await expect(page.getByTestId("agent-save")).toHaveCount(0);
+  await expect(page.getByTestId("agent-edit")).toBeVisible();
+});

--- a/frontend/test/unit/agent-profile.test.ts
+++ b/frontend/test/unit/agent-profile.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { agentHref, agentProfile } from "@/lib/agent-profile";
+import type { AgentDetailDto } from "@/api/types";
+
+/**
+ * The derivations behind the profile panel a teammate's avatar opens (issue
+ * #1653).
+ *
+ * Each is a place where being wrong renders as a perfectly ordinary panel: a
+ * summary quoting a blueprint persona the agent is not running, "no tools" over
+ * an agent that holds everything the company allows, or an Edit button that
+ * lands on the read-only page.
+ */
+
+function agent(over: Partial<AgentDetailDto> = {}): AgentDetailDto {
+  return {
+    id: "jamie",
+    name: "Jamie",
+    role: "Growth",
+    description: "Runs paid acquisition.",
+    source: "overlay",
+    editable: ["name", "role", "description"],
+    isOrchestrator: false,
+    tools: { requested: [], companyAllow: ["workspace.*"], effective: ["workspace.*"] },
+    desks: [],
+    inboxEnabled: false,
+    ...over,
+  };
+}
+
+describe("what the panel says a teammate is", () => {
+  it("shows the instructions in force, not the blueprint they mask", () => {
+    const profile = agentProfile(
+      agent({
+        description: "Runs paid acquisition.",
+        instructions: "Confirm the budget before launching anything.",
+        blueprintInstructions: "Spend freely.",
+        instructionsOverridden: true,
+      }),
+    );
+    expect(profile.about).toBe("Confirm the budget before launching anything.");
+  });
+
+  it("falls back to the description for a teammate with no instructions", () => {
+    expect(agentProfile(agent({ instructions: null })).about).toBe("Runs paid acquisition.");
+  });
+
+  it("has nothing to say about a teammate defined with neither", () => {
+    const profile = agentProfile(agent({ description: undefined, instructions: null }));
+    expect(profile.about).toBeNull();
+    expect(profile.aboutTruncated).toBe(false);
+  });
+
+  it("clips a long persona and admits that it did", () => {
+    const profile = agentProfile(agent({ instructions: `${"word ".repeat(200)}end` }));
+    expect(profile.aboutTruncated).toBe(true);
+    expect(profile.about?.endsWith("…")).toBe(true);
+    expect(profile.about!.length).toBeLessThanOrEqual(321);
+  });
+
+  it("leaves a persona that fits exactly as written", () => {
+    const short = "Answers the front desk.";
+    const profile = agentProfile(agent({ instructions: short }));
+    expect(profile.about).toBe(short);
+    expect(profile.aboutTruncated).toBe(false);
+  });
+
+  it("shows a manifest teammate by its role, and says so once", () => {
+    const profile = agentProfile(
+      agent({ name: undefined, role: "Chief Executive", source: "manifest" }),
+    );
+    expect(profile.display).toBe("Chief Executive");
+    // The role would only repeat the title, so the subtitle is dropped rather
+    // than rendered as the same words twice (issue #1208).
+    expect(profile.subtitle).toBeNull();
+    expect(profile.origin).toBe("Company blueprint");
+  });
+
+  it("reads the tier from the resolved orchestrator, not the tier string", () => {
+    expect(agentProfile(agent({ tier: "worker", isOrchestrator: true })).tier).toBe("Orchestrator");
+  });
+
+  it("seeds the face on the id, so a rename keeps the same avatar", () => {
+    const before = agentProfile(agent());
+    const after = agentProfile(agent({ name: "Jay" }));
+    expect(after.avatar).toBe(before.avatar);
+    expect(after.tone).toBe(before.tone);
+  });
+
+  it("keeps an empty tool request legible as the standard grant", () => {
+    const profile = agentProfile(agent());
+    expect(profile.tools.standardGrant).toBe(true);
+    expect(profile.tools.effective).toEqual(["workspace.*"]);
+  });
+
+  it("names the globs an agent asked for that the company does not allow", () => {
+    const profile = agentProfile(
+      agent({
+        tools: {
+          requested: ["workspace.*", "finance.*"],
+          companyAllow: ["workspace.*"],
+          effective: ["workspace.*"],
+        },
+      }),
+    );
+    expect(profile.tools.standardGrant).toBe(false);
+    expect(profile.tools.dropped).toEqual(["finance.*"]);
+  });
+});
+
+describe("where the panel's buttons go", () => {
+  it("links to the teammate's page", () => {
+    expect(agentHref("jamie")).toBe("#/team/jamie");
+  });
+
+  it("asks for the edit form with the flag the page opens on", () => {
+    expect(agentHref("jamie", { edit: true })).toBe("#/team/jamie?edit");
+  });
+
+  it("escapes an id that would otherwise change the address", () => {
+    // A tenant-namespaced id carries characters the hash reads structurally;
+    // an unescaped `/` would name a teammate of some other view entirely.
+    expect(agentHref("acme/ceo")).toBe("#/team/acme%2Fceo");
+  });
+});


### PR DESCRIPTION
## Summary

Clicking a teammate's avatar — in a message gutter, the member pane, or a DM header — now opens a right-hand panel with their profile summary, instead of doing nothing. The panel answers what an agent *is* without leaving the conversation, and hands off to the teammate's own page rather than trying to be it.

The panel shows:

- the persona **in force** (the override where one is set, else the blueprint seed), clipped with an admission that it was clipped
- tier (resolved by the host, so a company that tags nobody still shows its orchestrator) and whether the teammate came from the blueprint or was added here
- desks, each linking to its place on the org chart, lead badged
- **resolved** tool grants — with an empty `requested` rendered as the company's standard grant rather than "no tools", and any glob the allow-list dropped named explicitly

Two links out: **Edit agent** → `#/team/<id>?edit`, and **Full profile** → `#/team/<id>`.

## What changed

- `frontend/src/lib/agent-profile.ts` — the pure half: `agentProfile(detail)` and `agentHref(id, { edit })`.
- `frontend/src/components/agent-profile-sheet.tsx` — `AgentProfileProvider` (mounted once in `app-shell.tsx`), the sheet, and `AgentAvatarButton`.
- `views/chat/model.ts` — `Sender.agentId`, set **only** where `senderOf` matched the roster. A cross-posted line carries a desk id in that slot, and a desk has no profile to open.
- `views/chat/MessageRow.tsx`, `MembersPane.tsx`, `ChatHeader.tsx` — the click sites. In the member pane the avatar moved *outside* the row button: a button inside a button is invalid HTML, and the two want different things — the face opens who this teammate is, the row opens a line to them.
- `views/team/AgentDetailView.tsx` — the edit form is now derived from the `?edit` hash flag (`use-hash-flag.ts`) rather than local state, so the panel can link into it and Back closes the editor instead of leaving the page.

`AgentAvatarButton` renders the bare avatar, not a dead button, wherever there is no roster id behind the face (a desk, the company, "you") or no provider is mounted.

## Deliberately unchanged

The Company roster card and the org-chart seats. Both already sit inside a single click target that opens the full page, and issue #1206 explicitly removed the nested tab stop there — adding an avatar button back would reintroduce it.

## Commands run locally

- `pnpm typecheck`, `npx tsc -p tsconfig.unit.json`, `npx tsc -p tsconfig.e2e.json` — clean
- `npm run build`, `./scripts/ci/assert-design-tokens.sh` — clean
- `npx vitest run test/unit/agent-profile.test.ts` — 13 passed
- `npx playwright test test/e2e/agent-profile-panel.spec.ts` — 3 passed against a freshly built host
- `npx playwright test test/e2e/agent-detail.spec.ts test/e2e/company-cards.spec.ts test/e2e/chat-channel-membership.spec.ts` — 26 passed

Two unit tests unrelated to this change (`workflow-id-derivation`, `workspace-repair-reveal-no-write`) fail only under full-suite parallel load and pass in isolation — pre-existing timing flakiness.

## Coverage note

The panel component's own load/error branches are covered end-to-end rather than by a unit render; the derivations behind it are unit-tested.