### PR TITLE
fix(e2e): give each worktree its own host port, so concurrent runs stop adopting each other's host

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -106,7 +106,34 @@ const providedBaseURL = process.env.PW_BASE_URL;
 /** Whether this config is responsible for the host, as opposed to driving yours. */
 const managesHost = !providedBaseURL;
 
-const baseURL = providedBaseURL || "http://127.0.0.1:8080";
+/**
+ * The default port, derived from this checkout's own path.
+ *
+ * A fixed default collides across worktrees, and it collides SILENTLY:
+ * `reuseExistingServer` below is on outside CI, so a second run does not fail
+ * with "port in use" — it adopts the host the first run started and reports on
+ * that binary, that console bundle and that data directory. The suite goes
+ * green or red against code which is not the code under test, which is
+ * indistinguishable from a real result. With ~200 worktrees on this repository
+ * and agents running the suite in several at once, that is the normal case
+ * rather than a corner one.
+ *
+ * Hashing the checkout path gives every worktree its own port, stable across
+ * runs (so a host you left up is still reused by the next run in the SAME
+ * worktree, which is what `reuseExistingServer` is for) and distinct from every
+ * other worktree's. `test/e2e/host.sh` derives the identical default from the
+ * same path, so running it directly agrees with running it through Playwright.
+ *
+ * 8100-8899 avoids 8080 itself, and stays clear of the ephemeral range so the
+ * kernel does not hand a derived port to something else first.
+ */
+const repoRoot = resolve(here, "..");
+const derivedPort =
+  8100 +
+  (parseInt(createHash("sha256").update(repoRoot).digest("hex").slice(0, 4), 16) %
+    800);
+
+const baseURL = providedBaseURL || `http://127.0.0.1:${derivedPort}`;
 
 /**
  * Where the shared signed-in session lands. Defaulted only when we manage the

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -125,14 +125,18 @@ const managesHost = !providedBaseURL;
  * other worktree's. `test/e2e/host.sh` derives the identical default from the
  * same path, so running it directly agrees with running it through Playwright.
  *
- * 8100-8899 avoids 8080 itself, and stays clear of the ephemeral range so the
- * kernel does not hand a derived port to something else first.
+ * 8100-16899 avoids 8080 itself and stays below the ephemeral range
+ * (net.ipv4.ip_local_port_range starts at 32768), so the kernel cannot hand a
+ * derived port to something else first. The width matters: this repository has
+ * ~200 worktrees, and birthday collisions over 800 ports put ~23 of them on a
+ * shared number. Over 8800 it is closer to two, and two worktrees that do
+ * collide are still only as broken as every worktree is today.
  */
 const repoRoot = resolve(here, "..");
 const derivedPort =
   8100 +
-  (parseInt(createHash("sha256").update(repoRoot).digest("hex").slice(0, 4), 16) %
-    800);
+  (parseInt(createHash("sha256").update(repoRoot).digest("hex").slice(0, 8), 16) %
+    8800);
 
 const baseURL = providedBaseURL || `http://127.0.0.1:${derivedPort}`;
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@playwright/test";
+import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/test/e2e/host.sh
+++ b/frontend/test/e2e/host.sh
@@ -31,10 +31,10 @@ root="$(cd "$here/../../.." && pwd)"
 # Default port derived from this checkout's path, so two worktrees running the
 # suite at once do not land on one port. Playwright normally passes PW_HOST_BIND
 # in; this is the standalone path, and it computes the SAME number from the same
-# path (first 2 bytes of sha256, mod 800, offset 8100) so the two agree. See the
+# path (first 4 bytes of sha256, mod 8800, offset 8100) so the two agree. See the
 # `derivedPort` comment in ../../playwright.config.ts for why a fixed default is
 # actively dangerous here rather than merely inconvenient.
-derived_port=$(( 8100 + 16#$(printf '%s' "$root" | sha256sum | cut -c1-4) % 800 ))
+derived_port=$(( 8100 + 16#$(printf '%s' "$root" | sha256sum | cut -c1-8) % 8800 ))
 bind="${PW_HOST_BIND:-127.0.0.1:$derived_port}"
 company="${PW_HOST_COMPANY:-$root/companies/e2e_harness}"
 data_dir="${PW_HOST_DATA_DIR:-$root/target/e2e/data}"

--- a/frontend/test/e2e/host.sh
+++ b/frontend/test/e2e/host.sh
@@ -28,7 +28,14 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/../../.." && pwd)"
 
-bind="${PW_HOST_BIND:-127.0.0.1:8080}"
+# Default port derived from this checkout's path, so two worktrees running the
+# suite at once do not land on one port. Playwright normally passes PW_HOST_BIND
+# in; this is the standalone path, and it computes the SAME number from the same
+# path (first 2 bytes of sha256, mod 800, offset 8100) so the two agree. See the
+# `derivedPort` comment in ../../playwright.config.ts for why a fixed default is
+# actively dangerous here rather than merely inconvenient.
+derived_port=$(( 8100 + 16#$(printf '%s' "$root" | sha256sum | cut -c1-4) % 800 ))
+bind="${PW_HOST_BIND:-127.0.0.1:$derived_port}"
 company="${PW_HOST_COMPANY:-$root/companies/e2e_harness}"
 data_dir="${PW_HOST_DATA_DIR:-$root/target/e2e/data}"
 binary="${PW_HOST_BINARY:-$root/target/debug/opencompany}"

--- a/frontend/test/e2e/host.sh
+++ b/frontend/test/e2e/host.sh
@@ -15,7 +15,8 @@
 # how a suite comes to report on code that is not the code under test.
 #
 # Env:
-#   PW_HOST_BIND            address to bind         (default 127.0.0.1:8080)
+#   PW_HOST_BIND            address to bind         (default 127.0.0.1:<port derived
+#                           from this checkout's path, so worktrees do not collide)
 #   PW_HOST_COMPANY         company to load         (default companies/e2e_harness)
 #   PW_HOST_DATA_DIR        instance data root      (default target/e2e/data; wiped
 #                           each run ONLY while it stays inside target/e2e — see below)


### PR DESCRIPTION
## The problem

`playwright.config.ts` defaulted to `http://127.0.0.1:8080`, and every checkout used it. Combined with `reuseExistingServer: !process.env.CI`, a second concurrent run does **not** fail with "port in use" — it adopts the host the first run started, and reports on that binary, that console bundle and that data directory.

The suite then goes green or red against code that is not the code under test, which is indistinguishable from a real result. That is the failure mode this fixes: not a crash, a **wrong answer**.

This repository currently has **193 worktrees**, all of which resolved to the same port. Observed in practice: an `opencompany` host was found listening on `:8080` owned by a babysitter run in a different worktree, while other runs in other worktrees were driving the suite.

## The fix

Derive the default port from the checkout's own path, in both places that pick one:

- `frontend/playwright.config.ts` — `derivedPort = 8100 + sha256(repoRoot)[0..4] % 8800`
- `frontend/test/e2e/host.sh` — the identical derivation, so running the script standalone agrees with running it through Playwright

The port is stable per worktree, so a host you left up **is** still reused by the next run in the *same* worktree — which is what `reuseExistingServer` is for. It is simply no longer shared with unrelated checkouts.

## Range

`8100-16899`: clear of 8080 itself, and below the ephemeral floor (`net.ipv4.ip_local_port_range` starts at 32768) so the kernel cannot hand a derived port to something else first.

Width was chosen by measurement rather than taste. Over 800 ports, birthday collisions put **23 of the 193 worktrees** on a shared number; over 8800 it is **2**. And two worktrees that do collide are only as broken as every worktree is today, so this strictly improves the situation.

## Not changed, deliberately

- `reuseExistingServer` stays on outside CI — the derived port makes same-worktree reuse safe, which was the point of the setting.
- `PW_BASE_URL` and `PW_HOST_BIND` still override everything. CI (which sets neither and runs one host per job) and any manual setup are unaffected.

## Verification

| Check | Result |
|---|---|
| bash and node derive the same port | agree (15764 for this worktree) |
| collisions across all 193 real worktrees | 2 (was 193 on one port) |
| resulting range | 8136-16859 |
| `npm run typecheck:e2e` | pass (`tsconfig.e2e.json` includes `playwright.config.ts`) |
| `npm run typecheck` | pass |
| `npx playwright test --list` | 294 tests in 76 files — config executes on load |
| `bash -n host.sh` | pass |

The two derivations agreeing is the load-bearing check: they are independent implementations of one formula, and a drift between them would silently reintroduce the bug for anyone invoking `host.sh` directly.

## Not run

The e2e suite itself — it needs a built `target/debug/opencompany`, and the change is to which port the host binds rather than to any behaviour the specs assert. CI's `Console E2E` lanes exercise that path.