### PR TITLE
Seed MCP servers and setup cards into every company template

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -121,6 +121,9 @@ fn embed_globals(root: &Path) {
     }
 
     let manifest = std::fs::read_to_string(globals.join("globals.toml")).unwrap_or_default();
+    // The baseline's seed board cards. A file at the `globals/` root, so the
+    // watch above already covers it — no `rerun-if-changed` of its own needed.
+    let tasks = std::fs::read_to_string(globals.join("tasks.toml")).unwrap_or_default();
 
     let mut agents = Vec::new();
     collect(
@@ -168,6 +171,10 @@ fn embed_globals(root: &Path) {
     out.push_str(&format!(
         "/// `globals/globals.toml`, verbatim (empty when the directory is absent).\n\
          pub static EMBEDDED_GLOBALS_MANIFEST: &str = {manifest:?};\n"
+    ));
+    out.push_str(&format!(
+        "/// `globals/tasks.toml`, verbatim (empty when the file is absent).\n\
+         pub static EMBEDDED_GLOBAL_TASKS: &str = {tasks:?};\n"
     ));
     write_pairs(
         &mut out,

--- a/companies/README.md
+++ b/companies/README.md
@@ -21,6 +21,16 @@ Every folder follows the same shape:
   shared library at [`../skills/`](../skills/) uses.
 - `workflows/<id>.toml` — the graphs `[workflows].enabled` turns on.
 - `workspace/**` — the Obsidian-style notes the company starts with, seeded once.
+- `mcp.json` — the MCP tool servers this vertical's work needs, in the
+  `{"mcpServers": {…}}` shape every other MCP host uses. Merged into the
+  manifest at load, so a bundle server is held to the same rules an inline
+  `[[mcp_server]]` is; a name declared in both is refused rather than resolved.
+  Anything needing a credential ships disabled — see
+  [`../docs/spec/runtime/tools.md`](../docs/spec/runtime/tools.md).
+- `tasks.toml` — the setup work this vertical starts with, seeded onto the
+  board in To-do at first boot, on top of the baseline's own cards in
+  [`../globals/tasks.toml`](../globals/tasks.toml). Seeded cards never enter a
+  column that dispatches a run.
 
 Adding a business is a new folder, not a new crate. The behavior lives entirely
 in the host and the vendored runtimes; each definition just configures it.

--- a/companies/agentic_accounting_firm/README.md
+++ b/companies/agentic_accounting_firm/README.md
@@ -24,6 +24,20 @@
 
 Humans keep **sign-off on filings**; the agents run everything else. The output of this harness is **books, taxes, payroll, and forecasts**.
 
+## Tool servers
+
+The books close against the payment processor that is the ledger of record, and client documents arrive through a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `stripe` | Payments, subscriptions and invoices as the ledger of record. Needs a token. | off — needs a token |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_accounting_firm/mcp.json
+++ b/companies/agentic_accounting_firm/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "The books close against the payment processor that is the ledger of record, and client documents arrive through a shared workspace.",
+  "mcpServers": {
+    "stripe": {
+      "url": "https://mcp.stripe.com",
+      "description": "Payments, subscriptions and invoices as the ledger of record. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/stripe/auth"
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_accounting_firm/tasks.toml
+++ b/companies/agentic_accounting_firm/tasks.toml
@@ -1,0 +1,54 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup an accounting firm is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-book-flow"
+title = "Set up the book flow"
+priority = "high"
+note = """
+Decide how a period closes: what is reconciled, in what order, who signs \
+it off, and what opens a `closes` row. Put the sequence in the workspace \
+as the close checklist.
+
+This is the flow the whole firm runs on. Left implicit, every close is \
+done slightly differently and the differences are only found in an audit.
+
+Done when the checklist exists and the next period has a `closes` row \
+against it.\
+"""
+
+[[task]]
+id = "set-up-the-exception-rule"
+title = "Set up the exception rule"
+priority = "high"
+note = """
+State what makes something an `exceptions` row rather than a note: a \
+threshold, a category, a missing document. Record the rule on `decisions`.
+
+An exception log everyone fills in differently is a log nobody can read \
+for patterns, which is the only reason to keep one.
+
+Done when the rule is recorded and open exceptions have rows.\
+"""
+
+[[task]]
+id = "set-up-the-filing-calendar"
+title = "Set up the filing calendar"
+priority = "high"
+note = """
+Open a `filings` row for every statutory deadline this firm's clients face \
+in the next two quarters, each with its owner and its date.
+
+A missed filing is not a late deliverable, it is a penalty. A date living \
+in someone's memory is a date that gets missed.
+
+Done when the next two quarters are on `filings` with owners.\
+"""

--- a/companies/agentic_consultation_firm/README.md
+++ b/companies/agentic_consultation_firm/README.md
@@ -25,6 +25,19 @@
 
 Humans keep **executive workshops**; the agents run everything else. The output of this harness is **strategy decks and implementation plans**.
 
+## Tool servers
+
+Engagement documents and client deliverables live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_consultation_firm/mcp.json
+++ b/companies/agentic_consultation_firm/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Engagement documents and client deliverables live in a shared workspace.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_consultation_firm/tasks.toml
+++ b/companies/agentic_consultation_firm/tasks.toml
@@ -1,0 +1,52 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a consulting firm is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-engagement-shape"
+title = "Set up the engagement shape"
+priority = "high"
+note = """
+Decide what an `engagements` row carries from first call to final deck: \
+scope, the client's actual question, the deliverable, and what is out of \
+scope.
+
+Scope stated only in conversation is scope that grows, and the growth is \
+unpaid.
+
+Done when live engagements have rows naming what is and is not included.\
+"""
+
+[[task]]
+id = "set-up-the-assumption-register"
+title = "Set up the assumption register"
+priority = "high"
+note = """
+State what goes on `assumptions`: every load-bearing thing a \
+recommendation rests on that has not been verified, and what would falsify \
+it.
+
+A deck's recommendations are only as good as the assumptions under them, \
+and the ones nobody wrote down are the ones that turn out to be wrong.
+
+Done when the rule is recorded and current engagements have their \
+assumptions listed.\
+"""
+
+[[task]]
+id = "set-up-the-recommendation-bar"
+title = "Set up the recommendation bar"
+priority = "medium"
+note = """
+Decide what a `recommendations` row must carry before it reaches a client: \
+the evidence, the cost, and what happens if the client does nothing.
+
+Done when the bar is a `decisions` row.\
+"""

--- a/companies/agentic_customer_support/README.md
+++ b/companies/agentic_customer_support/README.md
@@ -24,6 +24,21 @@
 
 Humans keep **escalation and policy**; the agents run everything else. The output of this harness is **resolved tickets and current documentation**.
 
+## Tool servers
+
+Tickets arrive in the support inbox, escalations become engineering issues, and the documentation the answers cite is the workspace's.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `intercom` | Live conversations and help-centre articles. Needs a token. | off — needs a token |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_customer_support/mcp.json
+++ b/companies/agentic_customer_support/mcp.json
@@ -1,0 +1,23 @@
+{
+  "$comment": "Tickets arrive in the support inbox, escalations become engineering issues, and the documentation the answers cite is the workspace's.",
+  "mcpServers": {
+    "intercom": {
+      "url": "https://mcp.intercom.com/mcp",
+      "description": "Live conversations and help-centre articles. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/intercom/auth"
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_customer_support/tasks.toml
+++ b/companies/agentic_customer_support/tasks.toml
@@ -1,0 +1,52 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a support desk is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-escalation-path"
+title = "Set up the escalation path"
+priority = "high"
+note = """
+Decide what makes a ticket an `escalations` row, who receives it, and how \
+fast — then write it into the workspace where an agent will actually read \
+it.
+
+An escalation path invented per ticket means the urgent one waits behind \
+the routine one.
+
+Done when the path is written and its trigger is a `decisions` row.\
+"""
+
+[[task]]
+id = "set-up-the-known-issues-list"
+title = "Set up the known-issues list"
+priority = "high"
+note = """
+Open a `known-issues` row for everything currently being reported, each \
+with the answer to give and whether a fix is coming.
+
+Without it every agent re-diagnoses the same problem and customers get \
+three different answers on the same day.
+
+Done when everything currently reported has a row with a customer-facing \
+answer.\
+"""
+
+[[task]]
+id = "set-up-the-policy-call-record"
+title = "Set up the policy call record"
+priority = "medium"
+note = """
+Record on `policy-calls` the judgement calls this desk has already made — \
+refunds, exceptions, goodwill — so the next one is consistent with the \
+last.
+
+Done when the standing calls have rows.\
+"""

--- a/companies/agentic_design_studio/README.md
+++ b/companies/agentic_design_studio/README.md
@@ -23,6 +23,20 @@
 
 Humans keep **creative direction sign-off**; the agents run everything else. The output of this harness is **brand and product design systems**.
 
+## Tool servers
+
+Design systems ship as code against a real component API, and the brand documents a studio works from live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `context7` | Version-accurate API and library documentation, so answers match the release in use. | on |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_design_studio/mcp.json
+++ b/companies/agentic_design_studio/mcp.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "Design systems ship as code against a real component API, and the brand documents a studio works from live in a shared workspace.",
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "description": "Version-accurate API and library documentation, so answers match the release in use."
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_design_studio/tasks.toml
+++ b/companies/agentic_design_studio/tasks.toml
@@ -1,0 +1,49 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a design studio is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-design-decision-record"
+title = "Set up the design decision record"
+priority = "high"
+note = """
+Write down what a `design-decisions` row must carry: what was decided, \
+what it rules out, and which research finding it rests on.
+
+Design decisions get re-opened by whoever joins next unless the reasoning \
+is recorded, and re-deciding a settled question is how a design system \
+becomes two design systems.
+
+Done when the rule is recorded and the standing decisions have rows.\
+"""
+
+[[task]]
+id = "set-up-the-research-intake"
+title = "Set up the research intake"
+priority = "medium"
+note = """
+Decide how a `research-findings` row is opened and what makes a finding \
+usable rather than an anecdote: what was observed, how many times, and by \
+whom.
+
+Done when the rule is a `decisions` row and the findings already in hand \
+are recorded.\
+"""
+
+[[task]]
+id = "set-up-the-project-slate"
+title = "Set up the project slate"
+priority = "medium"
+note = """
+Get every live project onto `projects`, each with its client, its stage \
+and the deliverable it ends at.
+
+Done when nothing is being worked on that does not have a row.\
+"""

--- a/companies/agentic_enterprise_sales/README.md
+++ b/companies/agentic_enterprise_sales/README.md
@@ -25,6 +25,20 @@
 
 Humans keep **closing strategic accounts**; the agents run everything else. The output of this harness is **qualified pipeline and proposals**.
 
+## Tool servers
+
+Account plans and proposals live in a shared workspace; what a customer actually pays for is the billing system's answer, not the CRM's.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+| `stripe` | Payments, subscriptions and invoices as the ledger of record. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_enterprise_sales/mcp.json
+++ b/companies/agentic_enterprise_sales/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Account plans and proposals live in a shared workspace; what a customer actually pays for is the billing system's answer, not the CRM's.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    },
+    "stripe": {
+      "url": "https://mcp.stripe.com",
+      "description": "Payments, subscriptions and invoices as the ledger of record. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/stripe/auth"
+    }
+  }
+}

--- a/companies/agentic_enterprise_sales/tasks.toml
+++ b/companies/agentic_enterprise_sales/tasks.toml
@@ -1,0 +1,49 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup an enterprise sales team is defined
+# by — the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-qualification-bar"
+title = "Set up the qualification bar"
+priority = "high"
+note = """
+State what makes a `deals` row qualified rather than hopeful: budget, \
+authority, a real problem, and a date. Record it on `decisions`.
+
+An unqualified pipeline forecasts nothing, and the cost is paid at the end \
+of the quarter by everybody.
+
+Done when the bar is recorded and every deal is graded against it.\
+"""
+
+[[task]]
+id = "set-up-the-objection-library"
+title = "Set up the objection library"
+priority = "high"
+note = """
+Open an `objections` row for every objection this product actually meets, \
+with the answer that works and the evidence behind it.
+
+Objections are finite and repeat. A team that improvises each one \
+improvises badly under pressure.
+
+Done when the recurring objections have rows with answers.\
+"""
+
+[[task]]
+id = "set-up-the-account-record"
+title = "Set up the account record"
+priority = "medium"
+note = """
+Get the target accounts onto `accounts`, each with who is actually \
+involved in the decision and what they each want.
+
+Done when every live account names its decision-makers.\
+"""

--- a/companies/agentic_game_business/README.md
+++ b/companies/agentic_game_business/README.md
@@ -26,6 +26,21 @@
 
 Humans keep **monetization and growth strategy**; the agents run everything else. The output of this harness is **liveops, user acquisition, and monetization for a live game**.
 
+## Tool servers
+
+Monetization reads the payment system directly; LiveOps calendars live in a workspace and economy changes are tracked as work.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `stripe` | Payments, subscriptions and invoices as the ledger of record. Needs a token. | off — needs a token |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_game_business/mcp.json
+++ b/companies/agentic_game_business/mcp.json
@@ -1,0 +1,23 @@
+{
+  "$comment": "Monetization reads the payment system directly; LiveOps calendars live in a workspace and economy changes are tracked as work.",
+  "mcpServers": {
+    "stripe": {
+      "url": "https://mcp.stripe.com",
+      "description": "Payments, subscriptions and invoices as the ledger of record. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/stripe/auth"
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    }
+  }
+}

--- a/companies/agentic_game_business/tasks.toml
+++ b/companies/agentic_game_business/tasks.toml
@@ -1,0 +1,50 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a live-game business is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-liveops-calendar"
+title = "Set up the liveops calendar"
+priority = "high"
+note = """
+Get the next quarter's `events` onto the board — what runs, when, and what \
+each one is meant to move.
+
+A live game with no calendar runs whatever was ready, and players read the \
+gaps as a game being wound down.
+
+Done when the quarter is scheduled with an owner per event.\
+"""
+
+[[task]]
+id = "set-up-the-economy-change-rule"
+title = "Set up the economy change rule"
+priority = "high"
+note = """
+State what an `economy-changes` row must carry before a price or a drop \
+rate moves: the value before and after, the reason, and what would say it \
+was wrong.
+
+Economy changes compound, and an unattributed one is one nobody can undo \
+when the numbers turn.
+
+Done when the rule is a `decisions` row.\
+"""
+
+[[task]]
+id = "set-up-the-player-signal-watch"
+title = "Set up the player signal watch"
+priority = "medium"
+note = """
+Decide what goes on `player-signals`, how often it is read, and what a \
+change means — retention, spend, sentiment.
+
+Done when the watchlist is recorded and the baseline is captured.\
+"""

--- a/companies/agentic_game_studio/README.md
+++ b/companies/agentic_game_studio/README.md
@@ -26,6 +26,21 @@
 
 Humans keep **creative and design direction**; the agents run everything else. The output of this harness is **shippable games**.
 
+## Tool servers
+
+Engine and middleware documentation, plus the issue tracker a shipping game's feature and balance work is planned in.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `deepwiki` | Documentation and Q&A for any public GitHub repository. Public and no-auth. | on |
+| `context7` | Version-accurate API and library documentation, so answers match the release in use. | on |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_game_studio/mcp.json
+++ b/companies/agentic_game_studio/mcp.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "Engine and middleware documentation, plus the issue tracker a shipping game's feature and balance work is planned in.",
+  "mcpServers": {
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "description": "Documentation and Q&A for any public GitHub repository. Public and no-auth."
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "description": "Version-accurate API and library documentation, so answers match the release in use."
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    }
+  }
+}

--- a/companies/agentic_game_studio/tasks.toml
+++ b/companies/agentic_game_studio/tasks.toml
@@ -1,0 +1,54 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a game studio is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-playtest-loop"
+title = "Set up the playtest loop"
+priority = "high"
+note = """
+Decide how often the game is played by someone who did not build it, who \
+runs the session, and what gets written down. Open the first `playtests` \
+row for the next one.
+
+A studio that playtests when it remembers to ships what the team got used \
+to. The cadence is the whole mechanism.
+
+Done when `playtests` has a scheduled row naming a build and a question it \
+is meant to answer.\
+"""
+
+[[task]]
+id = "set-up-the-balance-change-record"
+title = "Set up the balance change record"
+priority = "high"
+note = """
+Write down what a `balance-changes` row must say before a number is \
+allowed to move: the value before and after, why, and what would say it \
+was wrong.
+
+Balance changes are indistinguishable from each other a month later, and a \
+regression nobody can attribute is one nobody can revert.
+
+Done when the rule is a `decisions` row and the first change is recorded.\
+"""
+
+[[task]]
+id = "set-up-the-feature-pipeline"
+title = "Set up the feature pipeline"
+priority = "medium"
+note = """
+Get the current slate onto `features` — one row per thing being built, \
+each with the state it is actually in rather than the state it was \
+announced in.
+
+Done when every in-flight feature has a row and nothing is being built \
+that does not.\
+"""

--- a/companies/agentic_influencer_business/README.md
+++ b/companies/agentic_influencer_business/README.md
@@ -26,6 +26,19 @@
 
 Humans keep **occasional appearance or ai avatar**; the agents run everything else. The output of this harness is **a creator brand that never sleeps**.
 
+## Tool servers
+
+The content calendar and the sponsorship terms live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_influencer_business/mcp.json
+++ b/companies/agentic_influencer_business/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "The content calendar and the sponsorship terms live in a shared workspace.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_influencer_business/tasks.toml
+++ b/companies/agentic_influencer_business/tasks.toml
@@ -1,0 +1,47 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a creator business is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-content-calendar"
+title = "Set up the content calendar"
+priority = "high"
+note = """
+Get the next month onto `content` — one row per planned piece, with its \
+channel, its date and its purpose.
+
+A creator business without a calendar publishes reactively, and reactive \
+publishing is what audience decline looks like from the inside.
+
+Done when the next month is on `content` with dates.\
+"""
+
+[[task]]
+id = "set-up-the-sponsorship-terms"
+title = "Set up the sponsorship terms"
+priority = "high"
+note = """
+Record on `decisions` what this brand will and will not take money for, \
+before an offer makes it tempting to decide case by case. Open \
+`sponsorships` rows for anything live.
+
+Done when the standing terms are a decision row and live deals have rows.\
+"""
+
+[[task]]
+id = "set-up-the-signal-watch"
+title = "Set up the signal watch"
+priority = "medium"
+note = """
+Decide what goes on `audience-signals` and how often it is read: which \
+numbers matter, and what a change in one would mean.
+
+Done when the rule is recorded and the current baseline is captured.\
+"""

--- a/companies/agentic_law_firm/README.md
+++ b/companies/agentic_law_firm/README.md
@@ -24,6 +24,19 @@
 
 Humans keep **approving filings**; the agents run everything else. The output of this harness is **research, drafts, and discovery**.
 
+## Tool servers
+
+Matter documents and client files live in a shared workspace. Deliberately narrow: a firm should decide what its agents may reach before granting it.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_law_firm/mcp.json
+++ b/companies/agentic_law_firm/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Matter documents and client files live in a shared workspace. Deliberately narrow: a firm should decide what its agents may reach before granting it.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_law_firm/tasks.toml
+++ b/companies/agentic_law_firm/tasks.toml
@@ -1,0 +1,57 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a law firm is defined by — the flow
+# it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-matter-intake"
+title = "Set up the matter intake"
+priority = "high"
+note = """
+Make the intake real: what is captured when a client asks for something, \
+and the rule that nothing substantive happens on a `matters` row until the \
+conflict check has run.
+
+Conflicts before content is the one place in this firm where the correct \
+action is to stop, and a stop that is not built into intake is one that \
+gets skipped when someone is busy.
+
+Done when `playbooks/intake-checklist.md` states the sequence and the open \
+matters have rows with a conflicts status.\
+"""
+
+[[task]]
+id = "set-up-the-deadline-docket"
+title = "Set up the deadline docket"
+priority = "high"
+note = """
+Open a `deadlines` row for every statutory, contractual and court-imposed \
+date currently live, each with its owner and the rule that imposes it.
+
+Missing one is not a late deliverable, it is a lost right. Every working \
+session is supposed to start by reading this, which only works if it is \
+complete.
+
+Done when every live date is on the docket with an owner.\
+"""
+
+[[task]]
+id = "set-up-the-position-library"
+title = "Set up the position library"
+priority = "medium"
+note = """
+Record on `positions` what this firm has concluded about the questions it \
+answers repeatedly, each with its authority and its jurisdiction.
+
+Research starts here — the cheapest research is the research already done \
+— and a position with neither authority nor jurisdiction is an opinion in \
+a citation style.
+
+Done when the recurring questions have rows carrying both.\
+"""

--- a/companies/agentic_marketing_agency/README.md
+++ b/companies/agentic_marketing_agency/README.md
@@ -44,6 +44,19 @@ Brand / Campaigns / Playbooks workspace and SEO, landing-page, email, and
 brand-positioning skills. Shared, non-company skills live in the repo-level
 [`skills/`](../../skills/) library and can be installed into any company.
 
+## Tool servers
+
+Campaign briefs, audience notes and the copy under review live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_marketing_agency/mcp.json
+++ b/companies/agentic_marketing_agency/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Campaign briefs, audience notes and the copy under review live in a shared workspace.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_marketing_agency/tasks.toml
+++ b/companies/agentic_marketing_agency/tasks.toml
@@ -1,0 +1,50 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a marketing agency is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-campaign-flow"
+title = "Set up the campaign flow"
+priority = "high"
+note = """
+Decide how a campaign goes from brief to live: who approves, what is \
+measured, and what opens a `campaigns` row. Put the sequence in the \
+workspace.
+
+A campaign flow that is different every time cannot be improved, because \
+nothing is comparable to anything.
+
+Done when the sequence is written and live campaigns have rows.\
+"""
+
+[[task]]
+id = "set-up-the-experiment-rule"
+title = "Set up the experiment rule"
+priority = "high"
+note = """
+State what an `experiments` row must declare before it runs: the \
+hypothesis, the metric, and the result that would end it.
+
+A test whose success criterion is chosen after the numbers arrive is not a \
+test.
+
+Done when the rule is a `decisions` row and running tests have rows.\
+"""
+
+[[task]]
+id = "set-up-the-audience-record"
+title = "Set up the audience record"
+priority = "medium"
+note = """
+Open an `audiences` row for each audience this agency actually targets, \
+with what is known about it and how that was learned.
+
+Done when each audience has a row citing its evidence.\
+"""

--- a/companies/agentic_math_lab/README.md
+++ b/companies/agentic_math_lab/README.md
@@ -26,3 +26,18 @@ cargo run --bin opencompany -- serve --company companies/agentic_math_lab
 The end-to-end proof is `frontend/test/e2e/euler-live.spec.ts`, which states a
 problem in the main line against a real model and checks the integer the lab
 reaches against the published one.
+
+## Tool servers
+
+An answer here ships with the program that produced it, so the library documentation has to match the version that ran.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `deepwiki` | Documentation and Q&A for any public GitHub repository. Public and no-auth. | on |
+| `context7` | Version-accurate API and library documentation, so answers match the release in use. | on |
+| `huggingface` | Models, datasets and papers on the Hugging Face Hub. Public and no-auth. | on |

--- a/companies/agentic_math_lab/mcp.json
+++ b/companies/agentic_math_lab/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "An answer here ships with the program that produced it, so the library documentation has to match the version that ran.",
+  "mcpServers": {
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "description": "Documentation and Q&A for any public GitHub repository. Public and no-auth."
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "description": "Version-accurate API and library documentation, so answers match the release in use."
+    },
+    "huggingface": {
+      "url": "https://huggingface.co/mcp",
+      "description": "Models, datasets and papers on the Hugging Face Hub. Public and no-auth."
+    }
+  }
+}

--- a/companies/agentic_math_lab/tasks.toml
+++ b/companies/agentic_math_lab/tasks.toml
@@ -1,0 +1,39 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a computational lab is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-verification-bar"
+title = "Set up the verification bar"
+priority = "high"
+note = """
+State what makes an `answers` row verified rather than merely computed: \
+the program that produced it, the inputs it ran on, and an independent \
+check.
+
+An unverified answer with a confident number attached is worse than no \
+answer, because it is the one that gets used.
+
+Done when the bar is a `decisions` row and every existing answer meets it \
+or is marked as not meeting it.\
+"""
+
+[[task]]
+id = "set-up-the-attempt-log"
+title = "Set up the attempt log"
+priority = "medium"
+note = """
+Decide what an `attempts` row records, including the ones that failed — \
+the approach, why it was tried, and where it broke.
+
+A lab that only logs successes re-tries the same dead end every few weeks.
+
+Done when the rule is recorded and the attempts so far have rows.\
+"""

--- a/companies/agentic_media_company/README.md
+++ b/companies/agentic_media_company/README.md
@@ -27,6 +27,19 @@
 
 Humans keep **editorial standards**; the agents run everything else. The output of this harness is **published, distributed stories**.
 
+## Tool servers
+
+Drafts, source notes and the corrections log live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_media_company/mcp.json
+++ b/companies/agentic_media_company/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Drafts, source notes and the corrections log live in a shared workspace.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_media_company/tasks.toml
+++ b/companies/agentic_media_company/tasks.toml
@@ -1,0 +1,49 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a newsroom is defined by — the flow
+# it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-sourcing-standard"
+title = "Set up the sourcing standard"
+priority = "high"
+note = """
+State what this newsroom requires before a claim is published: how many \
+sources, what makes one independent, and what goes on `sources`.
+
+The standard is the masthead. A newsroom that decides it story by story \
+decides it under deadline pressure, which is when it decides it worst.
+
+Done when the standard is a `decisions` row and `sources` is kept to it.\
+"""
+
+[[task]]
+id = "set-up-the-corrections-policy"
+title = "Set up the corrections policy"
+priority = "high"
+note = """
+Decide how a mistake is corrected — how fast, how visibly, and what opens \
+a `corrections` row — while there is nothing to correct.
+
+Written afterwards, a corrections policy is written by whoever most wants \
+the mistake to be small.
+
+Done when the policy is recorded and public.\
+"""
+
+[[task]]
+id = "set-up-the-story-slate"
+title = "Set up the story slate"
+priority = "medium"
+note = """
+Get what is being worked on onto `stories`, each with its stage and \
+whether it has cleared the sourcing standard.
+
+Done when nothing is in progress that does not have a row.\
+"""

--- a/companies/agentic_pharma_startup/README.md
+++ b/companies/agentic_pharma_startup/README.md
@@ -22,6 +22,20 @@
 
 Humans keep **laboratory work**; the agents run everything else. The output of this harness is **candidate molecules and trial plans**.
 
+## Tool servers
+
+Published models and datasets for target and candidate work; the protocol documents a programme is run from live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `huggingface` | Models, datasets and papers on the Hugging Face Hub. Public and no-auth. | on |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_pharma_startup/mcp.json
+++ b/companies/agentic_pharma_startup/mcp.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "Published models and datasets for target and candidate work; the protocol documents a programme is run from live in a shared workspace.",
+  "mcpServers": {
+    "huggingface": {
+      "url": "https://huggingface.co/mcp",
+      "description": "Models, datasets and papers on the Hugging Face Hub. Public and no-auth."
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_pharma_startup/tasks.toml
+++ b/companies/agentic_pharma_startup/tasks.toml
@@ -1,0 +1,51 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a drug-discovery startup is defined
+# by — the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-programme-record"
+title = "Set up the programme record"
+priority = "high"
+note = """
+Open a `programs` row for each target being pursued, with its rationale, \
+its stage and the decision that would kill it.
+
+A programme with no stated kill criterion is one that runs until the money \
+does.
+
+Done when each live programme has a row naming what would stop it.\
+"""
+
+[[task]]
+id = "set-up-the-safety-signal-flow"
+title = "Set up the safety signal flow"
+priority = "high"
+note = """
+Decide what opens a `safety-signals` row, who is told, and how fast. Write \
+it down before there is a signal to argue about.
+
+This is the one flow in this company where being slow is the failure. It \
+must be decided while nobody is under pressure.
+
+Done when the rule is a `decisions` row naming the trigger and the \
+escalation.\
+"""
+
+[[task]]
+id = "set-up-the-experiment-record"
+title = "Set up the experiment record"
+priority = "medium"
+note = """
+State what an `experiments` row must carry — hypothesis, method, result, \
+and what it changes — so a result can be read a year later by someone who \
+was not there.
+
+Done when the rule is recorded and running experiments have rows.\
+"""

--- a/companies/agentic_product_team/README.md
+++ b/companies/agentic_product_team/README.md
@@ -53,6 +53,21 @@ everything that produces the evidence for them. Anything that is genuinely the
 operator's — cost, headcount, a customer commitment, a strategy change — is
 parked with options and a recommendation rather than decided.
 
+## Tool servers
+
+Triage reads the codebase the bug is in; the backlog and the roadmap usually live in a tracker and a workspace this team does not own.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `deepwiki` | Documentation and Q&A for any public GitHub repository. Public and no-auth. | on |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_product_team/mcp.json
+++ b/companies/agentic_product_team/mcp.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Triage reads the codebase the bug is in; the backlog and the roadmap usually live in a tracker and a workspace this team does not own.",
+  "mcpServers": {
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "description": "Documentation and Q&A for any public GitHub repository. Public and no-auth."
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_product_team/tasks.toml
+++ b/companies/agentic_product_team/tasks.toml
@@ -1,0 +1,53 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a product team is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-bug-triage-flow"
+title = "Set up the bug triage flow"
+priority = "high"
+note = """
+Decide what happens to a bug between arriving and being worked: who looks, \
+how fast, and what makes one urgent rather than merely annoying. Open \
+`bugs` rows for what is already known.
+
+An untriaged queue is not a backlog, it is a pile — and the cost of the \
+pile is that the urgent one is in it somewhere.
+
+Done when the triage rule is a `decisions` row and every known bug has a \
+row with a severity.\
+"""
+
+[[task]]
+id = "set-up-the-competitive-picture"
+title = "Set up the competitive picture"
+priority = "medium"
+note = """
+Open a `competitors` row for each product this one is genuinely chosen \
+against, with what it does better and what it does worse — stated plainly \
+enough to lose an argument to.
+
+A competitive picture kept in someone's head is one the roadmap cannot be \
+defended against.
+
+Done when the three real alternatives each have a row.\
+"""
+
+[[task]]
+id = "set-up-the-roadmap-defence"
+title = "Set up the roadmap defence"
+priority = "medium"
+note = """
+For each thing on the roadmap, record on `decisions` why it is there and \
+what was dropped for it. A roadmap is mostly the list of things being said \
+no to.
+
+Done when every roadmap item has a decision row naming its trade-off.\
+"""

--- a/companies/agentic_realestate_company/README.md
+++ b/companies/agentic_realestate_company/README.md
@@ -24,6 +24,19 @@
 
 Humans keep **purchase approvals**; the agents run everything else. The output of this harness is **underwritten deals and managed properties**.
 
+## Tool servers
+
+Deal files, leases and tenant correspondence live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_realestate_company/mcp.json
+++ b/companies/agentic_realestate_company/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Deal files, leases and tenant correspondence live in a shared workspace.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_realestate_company/tasks.toml
+++ b/companies/agentic_realestate_company/tasks.toml
@@ -1,0 +1,47 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a property company is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-underwriting-standard"
+title = "Set up the underwriting standard"
+priority = "high"
+note = """
+State what a `deals` row must carry before it is called underwritten: the \
+assumptions, the numbers they produce, and the sensitivity that says how \
+wrong they can be.
+
+Deals underwritten to no standard cannot be compared, and the one that \
+looked best was usually the one with the most optimistic assumptions.
+
+Done when the standard is a `decisions` row and live deals are held to it.\
+"""
+
+[[task]]
+id = "set-up-the-property-record"
+title = "Set up the property record"
+priority = "high"
+note = """
+Get the portfolio onto `properties`, each with its key dates, its \
+condition and who is responsible for it.
+
+Done when every owned or managed property has a row.\
+"""
+
+[[task]]
+id = "set-up-the-tenant-matter-flow"
+title = "Set up the tenant matter flow"
+priority = "medium"
+note = """
+Decide what opens a `tenant-matters` row, how fast each kind is answered, \
+and what has a legal deadline attached.
+
+Done when the flow is written and open matters have rows.\
+"""

--- a/companies/agentic_recruiting_company/README.md
+++ b/companies/agentic_recruiting_company/README.md
@@ -25,6 +25,20 @@
 
 Humans keep **final hiring decisions**; the agents run everything else. The output of this harness is **sourced, screened, and scheduled candidates**.
 
+## Tool servers
+
+Search briefs and scorecards live in a shared workspace; an open search is often tracked as work in the client's own tracker.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_recruiting_company/mcp.json
+++ b/companies/agentic_recruiting_company/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Search briefs and scorecards live in a shared workspace; an open search is often tracked as work in the client's own tracker.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    }
+  }
+}

--- a/companies/agentic_recruiting_company/tasks.toml
+++ b/companies/agentic_recruiting_company/tasks.toml
@@ -1,0 +1,47 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a recruiting firm is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-scorecard"
+title = "Set up the scorecard"
+priority = "high"
+note = """
+Decide what a `scorecards` row measures before anyone is interviewed: the \
+handful of things that actually predict success in the role, and what \
+evidence counts for each.
+
+A scorecard written after the interviews is a record of who was liked. \
+Written before, it is the only thing that makes candidates comparable.
+
+Done when the open searches each have a scorecard.\
+"""
+
+[[task]]
+id = "set-up-the-search-brief"
+title = "Set up the search brief"
+priority = "high"
+note = """
+Open a `searches` row for each live search with what the client actually \
+needs — not the job description, the problem the hire is meant to solve.
+
+Done when every live search has a brief the client has agreed to.\
+"""
+
+[[task]]
+id = "set-up-the-candidate-record"
+title = "Set up the candidate record"
+priority = "medium"
+note = """
+State what a `candidates` row carries and when it is updated, so a \
+pipeline can be read without asking anybody.
+
+Done when the rule is recorded and the live pipeline has rows.\
+"""

--- a/companies/agentic_research_lab/README.md
+++ b/companies/agentic_research_lab/README.md
@@ -103,3 +103,18 @@ implemented — the `context` key in particular is carried as data and not yet
 consumed, and the workflow expresses one pass rather than a retrying loop. See
 the [orchestration spec](../../docs/spec/runtime/orchestration/README.md) for
 what lands in which phase.
+
+## Tool servers
+
+A source-backed report needs primary sources it can cite: published models, datasets and papers, and the actual implementation behind a claim.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `deepwiki` | Documentation and Q&A for any public GitHub repository. Public and no-auth. | on |
+| `context7` | Version-accurate API and library documentation, so answers match the release in use. | on |
+| `huggingface` | Models, datasets and papers on the Hugging Face Hub. Public and no-auth. | on |

--- a/companies/agentic_research_lab/mcp.json
+++ b/companies/agentic_research_lab/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "A source-backed report needs primary sources it can cite: published models, datasets and papers, and the actual implementation behind a claim.",
+  "mcpServers": {
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "description": "Documentation and Q&A for any public GitHub repository. Public and no-auth."
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "description": "Version-accurate API and library documentation, so answers match the release in use."
+    },
+    "huggingface": {
+      "url": "https://huggingface.co/mcp",
+      "description": "Models, datasets and papers on the Hugging Face Hub. Public and no-auth."
+    }
+  }
+}

--- a/companies/agentic_research_lab/tasks.toml
+++ b/companies/agentic_research_lab/tasks.toml
@@ -1,0 +1,50 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a research lab is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-evidence-standard"
+title = "Set up the evidence standard"
+priority = "high"
+note = """
+State what this lab will accept as a source, and record it on `decisions`: \
+what counts as primary, what a single blog post is worth, and what a claim \
+must carry before it reaches `findings`.
+
+The standard is the lab. Without one written down, every report is as good \
+as whoever wrote it happened to feel that day.
+
+Done when the standard is a decision row and `sources` is graded by it.\
+"""
+
+[[task]]
+id = "set-up-the-question-queue"
+title = "Set up the question queue"
+priority = "high"
+note = """
+Open a `questions` row for each thing this lab is actually trying to \
+answer, phrased as a question with an answer that could be wrong.
+
+A question nobody wrote down is one three people research separately and \
+nobody finishes.
+
+Done when the open questions each have a row and an owner.\
+"""
+
+[[task]]
+id = "set-up-the-report-shape"
+title = "Set up the report shape"
+priority = "medium"
+note = """
+Decide what a finished report looks like — claim, evidence, confidence, \
+what would change the answer — and put the template in the workspace.
+
+Done when the template exists and the next report is written into it.\
+"""

--- a/companies/agentic_software_company/README.md
+++ b/companies/agentic_software_company/README.md
@@ -28,6 +28,22 @@
 
 Humans keep **product direction**; the agents run everything else. The output of this harness is **an entire SaaS product**.
 
+## Tool servers
+
+Engineers read other people's code and current API docs all day, and diagnose incidents from production evidence rather than from memory.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `deepwiki` | Documentation and Q&A for any public GitHub repository. Public and no-auth. | on |
+| `context7` | Version-accurate API and library documentation, so answers match the release in use. | on |
+| `sentry` | Production errors and their stack traces, for diagnosing an incident from evidence. Needs a token. | off — needs a token |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_software_company/mcp.json
+++ b/companies/agentic_software_company/mcp.json
@@ -1,0 +1,25 @@
+{
+  "$comment": "Engineers read other people's code and current API docs all day, and diagnose incidents from production evidence rather than from memory.",
+  "mcpServers": {
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "description": "Documentation and Q&A for any public GitHub repository. Public and no-auth."
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "description": "Version-accurate API and library documentation, so answers match the release in use."
+    },
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp",
+      "description": "Production errors and their stack traces, for diagnosing an incident from evidence. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/sentry/auth"
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    }
+  }
+}

--- a/companies/agentic_software_company/tasks.toml
+++ b/companies/agentic_software_company/tasks.toml
@@ -1,0 +1,59 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a software company is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-release-flow"
+title = "Set up the release flow"
+priority = "high"
+note = """
+Decide how a change reaches customers and write it down as a row on \
+`releases` for the next version, with the rollback plan filled in before \
+anything ships.
+
+A release is the only fact that lets an incident be correlated with a \
+cause and a support answer be accurate about what a customer is running. A \
+company that ships without cutting release rows cannot answer either \
+question later.
+
+Done when `releases` has a planned row with contents, risk and rollback, \
+and `playbooks/release-checklist.md` matches what the row assumes.\
+"""
+
+[[task]]
+id = "set-up-the-incident-runbook"
+title = "Set up the incident runbook"
+priority = "high"
+note = """
+Make `playbooks/incident-runbook.md` real for this product: who is paged, \
+what is checked first, when a customer is told, and what opens a row on \
+`incidents`.
+
+Written before the first incident or not at all — nobody drafts a runbook \
+at two in the morning, and the version written then is the one that gets \
+used for a year.
+
+Done when the runbook names the first three checks and the row it opens.\
+"""
+
+[[task]]
+id = "set-up-the-security-review-bar"
+title = "Set up the security review bar"
+priority = "medium"
+note = """
+Say which changes need a security review before they ship, and record the \
+answer on `decisions` so it is not re-argued per pull request.
+
+An unstated bar means every reviewer applies their own, which is the same \
+as having none. Open a `security-findings` row for anything already known.
+
+Done when the bar is a decision row and `standards/security-standards.md` \
+states it.\
+"""

--- a/companies/agentic_venture_capital/README.md
+++ b/companies/agentic_venture_capital/README.md
@@ -25,6 +25,19 @@
 
 Humans keep **investment decisions**; the agents run everything else. The output of this harness is **investment memos and a managed portfolio**.
 
+## Tool servers
+
+Diligence files and investment memos live in a shared workspace.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_venture_capital/mcp.json
+++ b/companies/agentic_venture_capital/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Diligence files and investment memos live in a shared workspace.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/agentic_venture_capital/tasks.toml
+++ b/companies/agentic_venture_capital/tasks.toml
@@ -1,0 +1,48 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup an investment firm is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-diligence-checklist"
+title = "Set up the diligence checklist"
+priority = "high"
+note = """
+Decide what `diligence` must cover before a cheque is written — market, \
+team, numbers, legal — and what a gap in each one means.
+
+Diligence improvised per deal is diligence that is thorough when there is \
+time and thin when there is a hot round, which is exactly backwards.
+
+Done when the checklist is in the workspace and open deals are graded on \
+it.\
+"""
+
+[[task]]
+id = "set-up-the-investment-thesis"
+title = "Set up the investment thesis"
+priority = "high"
+note = """
+Record on `decisions` what this firm invests in and what it passes on \
+regardless of quality, so a pipeline can be filtered by something other \
+than enthusiasm.
+
+Done when the thesis is a decision row naming what is out of scope.\
+"""
+
+[[task]]
+id = "set-up-the-portfolio-review"
+title = "Set up the portfolio review"
+priority = "medium"
+note = """
+Get the portfolio onto `portfolio` with each company's state and what it \
+needs, and decide how often that is refreshed.
+
+Done when every holding has a row and a review cadence is set.\
+"""

--- a/companies/agentic_venture_studio/README.md
+++ b/companies/agentic_venture_studio/README.md
@@ -28,6 +28,20 @@
 
 Humans keep **capital allocation and major strategic decisions**; the agents run everything else. The output of this harness is **a portfolio of startups**.
 
+## Tool servers
+
+Shared assets and venture documents live in a workspace; each venture's build is tracked where its team already works.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/agentic_venture_studio/mcp.json
+++ b/companies/agentic_venture_studio/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Shared assets and venture documents live in a workspace; each venture's build is tracked where its team already works.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    }
+  }
+}

--- a/companies/agentic_venture_studio/tasks.toml
+++ b/companies/agentic_venture_studio/tasks.toml
@@ -1,0 +1,49 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup a venture studio is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-validation-bar"
+title = "Set up the validation bar"
+priority = "high"
+note = """
+State what a `validations` row must show before an idea gets real \
+resources: what was tested, with whom, and the result that would have \
+stopped it.
+
+A studio without a bar builds whatever the loudest idea was, and finds out \
+at launch.
+
+Done when the bar is a `decisions` row and live ideas are graded against \
+it.\
+"""
+
+[[task]]
+id = "set-up-the-venture-record"
+title = "Set up the venture record"
+priority = "high"
+note = """
+Open a `ventures` row for each thing being built, with its stage, its \
+owner and the next decision due on it.
+
+Done when every venture has a row naming its next decision.\
+"""
+
+[[task]]
+id = "set-up-the-shared-asset-library"
+title = "Set up the shared asset library"
+priority = "medium"
+note = """
+Record on `shared-assets` what every venture can reuse — infrastructure, \
+contracts, playbooks — because building it once is the whole reason a \
+studio exists.
+
+Done when the reusable assets have rows.\
+"""

--- a/companies/signals_opportunity_studio/README.md
+++ b/companies/signals_opportunity_studio/README.md
@@ -58,6 +58,20 @@ host:
 Anyone can fork this manifest, point it at their market, and have their own
 opportunity studio — no changes to the kernel required.
 
+## Tool servers
+
+A weekly brief is only as good as its sources: current documentation for what a signal claims, and the workspace the briefs accumulate in.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `context7` | Version-accurate API and library documentation, so answers match the release in use. | on |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/signals_opportunity_studio/mcp.json
+++ b/companies/signals_opportunity_studio/mcp.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "A weekly brief is only as good as its sources: current documentation for what a signal claims, and the workspace the briefs accumulate in.",
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "description": "Version-accurate API and library documentation, so answers match the release in use."
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    }
+  }
+}

--- a/companies/signals_opportunity_studio/tasks.toml
+++ b/companies/signals_opportunity_studio/tasks.toml
@@ -1,0 +1,46 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup an opportunity studio is defined by —
+# the flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-signal-sources"
+title = "Set up the signal sources"
+priority = "high"
+note = """
+Open a `signals` row for each source this studio watches, with how often \
+it is read and what a meaningful change in it looks like.
+
+A brief is only as good as what it watched. Sources chosen ad hoc each \
+week produce a brief that reflects what was easy to find.
+
+Done when the standing sources have rows with a cadence.\
+"""
+
+[[task]]
+id = "set-up-the-opportunity-bar"
+title = "Set up the opportunity bar"
+priority = "high"
+note = """
+State what promotes a signal to an `opportunities` row: size, timing, and \
+why this studio in particular could act on it.
+
+Done when the bar is a `decisions` row.\
+"""
+
+[[task]]
+id = "set-up-the-weekly-brief"
+title = "Set up the weekly brief"
+priority = "medium"
+note = """
+Decide what a `briefs` row contains and when it is delivered, and put the \
+template in the workspace. The brief is the product.
+
+Done when the template exists and the first brief is scheduled.\
+"""

--- a/companies/startup_accelerator/README.md
+++ b/companies/startup_accelerator/README.md
@@ -27,6 +27,20 @@
 
 Humans keep **investment and demo-day decisions**; the agents run everything else. The output of this harness is **a funded, mentored startup cohort**.
 
+## Tool servers
+
+Applications and cohort records live in a shared workspace; a cohort company's own work is tracked in its own tracker.
+
+Declared in [`mcp.json`](mcp.json) and merged with anything the install
+ships and anything an operator adds from the console. A server marked
+*needs a token* is declared but off: write its credential from
+Settings → Connections, then enable it there.
+
+| Server | What it is for | Ships |
+| --- | --- | --- |
+| `notion` | The workspace this company's documents already live in. Needs a token. | off — needs a token |
+| `linear` | Issues and cycles, when the work is tracked outside this board. Needs a token. | off — needs a token |
+
 ## Run it
 
 ```sh

--- a/companies/startup_accelerator/mcp.json
+++ b/companies/startup_accelerator/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Applications and cohort records live in a shared workspace; a cohort company's own work is tracked in its own tracker.",
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "The workspace this company's documents already live in. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/notion/auth"
+    },
+    "linear": {
+      "url": "https://mcp.linear.app/mcp",
+      "description": "Issues and cycles, when the work is tracked outside this board. Needs a token.",
+      "enabled": false,
+      "authSecret": "mcp/linear/auth"
+    }
+  }
+}

--- a/companies/startup_accelerator/tasks.toml
+++ b/companies/startup_accelerator/tasks.toml
@@ -1,0 +1,46 @@
+# The setup work this company starts with, on the board in To-do at first
+# boot.
+#
+# Vertical-specific: the baseline in `globals/tasks.toml` already covers the
+# brief, the first goals, the standing decisions, the top risks and the
+# connections. What is here is the setup an accelerator is defined by — the
+# flow it runs on, and the ledgers it keeps.
+#
+# Each card names what it produces, so an agent picking it up hands back the
+# thing rather than an essay about the thing.
+
+[[task]]
+id = "set-up-the-application-bar"
+title = "Set up the application bar"
+priority = "high"
+note = """
+Decide what `applications` are scored on before the first batch arrives, \
+and record it. A bar set during review is a bar set by whoever reviewed \
+first.
+
+Done when the criteria are a `decisions` row and applications are scored \
+on them.\
+"""
+
+[[task]]
+id = "set-up-the-cohort-programme"
+title = "Set up the cohort programme"
+priority = "high"
+note = """
+Get the programme onto `cohort`: what happens each week, who runs it, and \
+what a company is meant to leave with.
+
+Done when the weeks are laid out and each has an owner.\
+"""
+
+[[task]]
+id = "set-up-the-introduction-flow"
+title = "Set up the introduction flow"
+priority = "medium"
+note = """
+Decide how an `introductions` row is opened and what makes an introduction \
+worth making — the currency an accelerator actually runs on, and the one \
+it can spend badly.
+
+Done when the rule is recorded.\
+"""

--- a/docs/spec/runtime/company-setup.md
+++ b/docs/spec/runtime/company-setup.md
@@ -302,6 +302,25 @@ screen states it. The fix is the sentence, not a wider grant.
 An `outreach` focus carrying `composio` was rejected: it would put credential
 reach behind a value a model chose from free text — what D7's enum prevents.
 
+## What is on the board on day one
+
+A company that boots with a correct roster, correct ledgers and an empty To-do
+column has agents with nothing to pick up and an operator with no idea where to
+start, so the first thing anybody does is invent the setup list — badly, and
+differently each time. So the board is seeded once, at first boot, from `globals/tasks.toml` (the setup
+every company has: the brief, the first goals, the standing decisions, the top
+risks, the connections) plus that bundle's own `companies/<name>/tasks.toml`
+(the setup its vertical is defined by, winning on a shared id). Each card names
+the ledger row or document it should produce, so an agent that picks one up
+hands back the thing rather than an essay about it.
+
+Every seeded card lands in **To-do**, unassigned, and none of them can dispatch:
+a seed file cannot name a column, and the seeder writes through the plain task
+store rather than the edge-firing path that turns `in_progress` into a run. A
+freshly provisioned company can boot with a full board and spend nothing.
+Seeding is first-boot only, so a card an operator deletes stays deleted. See
+[globals.md](globals.md) for the rules and the `disable = ["task:<id>"]` opt-out.
+
 ## What the host enforces, rather than asks for
 
 Five guarantees hold whatever a model returns — coverage checked against the

--- a/docs/spec/runtime/globals.md
+++ b/docs/spec/runtime/globals.md
@@ -38,6 +38,7 @@ the other three.
 | Workflows | `list_workflows_with_globals` / `load_workflow_with_globals` | Seed file, then saved overlay, then the global graph. |
 | Skills | `EffectiveSkills::materialize` | Installed as the bottom layer; a company bundle or `custom_doc` delta of the same slug supersedes it. |
 | Ledgers | `runtime::builder::seed_ledgers` | **Seeded once** into the company's own store at first boot, then owned by the company. A bundle declaration of the same slug replaces the global before either is stored. |
+| Setup cards | `runtime::builder::seed_tasks` | **Seeded once** onto the board at first boot, in To-do. A bundle card of the same id replaces the global one. Opt-in per caller — see below. |
 | Tools | `Tools::default` | `[tools].default_allow` is the belt a company with no `[tools]` section gets. |
 
 ### A company always wins
@@ -48,7 +49,7 @@ nobody's design. To drop a global rather than replace it, the manifest says so:
 
 ```toml
 [globals]
-disable = ["agent:researcher", "workflow:weekly_review", "skill:meeting-brief", "ledger:risks"]
+disable = ["agent:researcher", "workflow:weekly_review", "skill:meeting-brief", "ledger:risks", "task:name-the-top-risks"]
 ```
 
 Every entry is `<kind>:<id>` with a kind from `globals::DISABLE_KINDS`, and must
@@ -58,7 +59,7 @@ synthesized disabling deltas (`harness::globals_skill_disables`) so the manifest
 and the console's own toggle speak the same vocabulary; a disable beats an
 enable, so the manifest wins over a console re-enable.
 
-### Ledgers are the one surface that is seeded rather than resolved
+### Ledgers and setup cards are seeded rather than resolved
 
 Every other surface above is re-resolved on each read, so editing `globals/`
 changes what an existing company gets on its next load. Ledgers cannot work that
@@ -66,6 +67,36 @@ way, because a company **owns its record**: `docs/spec/runtime/ledgers.md` makes
 retiring a ledger a person's call, and a baseline re-applied on every boot would
 undo that call on the next restart. A `ledger:` disable entry therefore governs
 what a *new* company is seeded with, not what an existing one keeps.
+
+### Setup cards, and why they are opt-in
+
+`globals/tasks.toml` is the setup work every company starts with on its board —
+write the brief, set the first goals, record the standing decisions, name the
+top risks, wire the connections — on top of which each bundle's own
+`tasks.toml` adds the setup its vertical is defined by. Seeded once, at first
+boot, into To-do.
+
+Two properties are load-bearing:
+
+- **A seeded card can never dispatch.** A seed file has no `column` key at all,
+  and the seeder writes through the plain `TaskStore`, not
+  `CompanyRuntime::upsert_task` — the single site that edge-fires a dispatch
+  (`in_progress`) or a billed planning pass (`planning`). Either alone would be
+  enough; both are there because a freshly provisioned company spending
+  inference on work nobody asked for is the failure worth paying twice to avoid.
+- **Seeding is opt-in**, unlike ledger seeding, which is unconditional. Cards
+  are visible state that tests count: `tests/one_card_per_message.rs` asserts
+  exact board sizes against a company built straight from `RuntimeBuilder`, and
+  a baseline arriving unasked would quietly turn those assertions into
+  statements about the baseline. `RuntimeBuilder::with_task_seeding(true)` is
+  set by the product entry points and nothing else.
+
+The first-boot gate is `store.load(&id)` returning `None` — the last moment a
+first boot is distinguishable, since the `store.save` at the end of the build
+makes every later boot a returning one. That is stricter than the ledger
+seeder's "nothing declared yet" gate, and deliberately: clearing the board is
+routine, and a card an operator deleted reappearing on the next restart is the
+runtime arguing with them.
 
 Seeding runs only when the company has no declaration at all, and never on a
 rebuild. The honest limit that follows: a person who retires *every* declared

--- a/docs/spec/runtime/tools.md
+++ b/docs/spec/runtime/tools.md
@@ -112,6 +112,42 @@ A disabled `[[mcp_server]]` is listed with `granted: false` rather than omitted:
 an operator needs to see that the server exists and is switched off, which an
 absent row cannot say.
 
+## Where a company's MCP servers are declared
+
+A company's effective servers merge in four layers, lowest precedence first:
+
+1. **Default** — `[[default_mcp_server]]` in the instance `config.toml`, shipped
+   to every company on the install (`docs/spec/runtime/config.md`).
+2. **Bundle** — `companies/<name>/mcp.json`, in the `{"mcpServers": {…}}` shape
+   every other MCP host uses. Parsed by `src/company/mcp_file.rs` and merged into
+   `mcp_servers` by `CompanyManifest::from_located` **before** validation, so a
+   bundle server is held to exactly the rules an inline entry is — HTTP
+   transport only, no credential in the URL, unique name.
+3. **Manifest** — `[[mcp_server]]` in `company.toml`. Layer 2 and 3 are the same
+   layer once loaded: a name declared in **both** is a validation problem naming
+   both files, refused rather than resolved by precedence, for the reason the
+   roster refuses a bundle that declares agents twice — either precedence rule
+   silently discards a declaration somebody wrote down.
+4. **Runtime** — what an operator adds or overrides from the console.
+
+The server's name is the `mcp.json` map key, so it cannot disagree with itself.
+`url` and `endpoint` are both accepted; setting both to different values is
+refused. A `$comment` key is ignored at file and server level, because JSON
+carries no comments and a template's reasoning has to live somewhere.
+
+An invalid **entry** is dropped with a logged reason rather than failing the
+boot — an `mcp.json` copied from a vendor README usually carries a stdio
+`command`, which hosted v1 does not support — while a malformed **file** is a
+manifest problem. `content_test` is what makes either fatal for a shipped
+template, and additionally requires every shipped server to be `https`,
+described, documented in its bundle README, and disabled if it names an
+`authSecret` (an enabled server that needs a token fails at an agent's first
+tool call rather than here).
+
+Removing a server from `mcp.json` takes effect on the next `serve`, which
+re-parses the bundle — not on an in-place rebuild, which uses the persisted
+manifest. That is the same behaviour as editing `company.toml`.
+
 ## Runtime overrides
 
 An operator may narrow a desk from the console. The override is stored on the

--- a/frontend/src/lib/mcp-registry.ts
+++ b/frontend/src/lib/mcp-registry.ts
@@ -239,7 +239,7 @@ export function mcpProvenanceNote(source: McpSource): string {
 export function mcpRemovalNote(source: McpSource): string {
   switch (source) {
     case "manifest":
-      return "This server is declared in company.toml, so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn, and it returns on the next boot unless the manifest changes.";
+      return "This server is declared in the company's bundle (company.toml or mcp.json), so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn, and it returns on the next boot unless the manifest changes.";
     case "default":
       return "This server ships with the installation, so it cannot be removed from the console — turning it off drops it from every teammate's tool belt on the next turn.";
     case "registry":

--- a/globals/README.md
+++ b/globals/README.md
@@ -9,6 +9,7 @@ part that is the same in all of them.
 | Agents | `agents/*.toml` | Research, writing, and keeping the record straight are not a vertical. |
 | Workflows | `workflows/*.toml` | A weekly review and a research request run the same in a law firm and a game studio. |
 | Ledgers | `ledgers/*.toml` | Risks, promises made outward, and what was learned are axes every company keeps, whatever it sells. |
+| Setup cards | `tasks.toml` | Every company has the same first week of setup — a brief, its first goals, its standing decisions, its top risks, its connections — whatever it goes on to sell. Seeded onto the board once, in To-do. |
 | Skills | `[skills].always` in `globals.toml` | A few shared-library skills are installed rather than offered. |
 | Tools | `[tools].default_allow` in `globals.toml` | Every vertical starts from the same belt; where that belt is *authored* is global, and a company can still narrow it. |
 
@@ -28,7 +29,10 @@ To drop a global instead of replacing it, name it in the manifest:
 
 ```toml
 [globals]
-disable = ["agent:researcher", "workflow:weekly_review", "skill:meeting-brief", "ledger:risks"]
+disable = [
+  "agent:researcher", "workflow:weekly_review", "skill:meeting-brief",
+  "ledger:risks", "task:name-the-top-risks",
+]
 ```
 
 Every entry is `<kind>:<id>` and must name a global that exists — a typo is a

--- a/globals/tasks.toml
+++ b/globals/tasks.toml
@@ -1,0 +1,110 @@
+# The global baseline's setup board. Every company starts with these cards in
+# To-do, whichever vertical it started from.
+#
+# Not a tutorial and not a checklist of things the runtime could do itself.
+# Each card is real setup work that only this company's people and agents can
+# do, because it depends on facts nobody but them has: what this company sells,
+# who it answers to, what it has already decided. A company that boots with an
+# empty board has agents with nothing to pick up and an operator with no idea
+# where to start, and the first thing anyone does is invent this list badly.
+#
+# Rules for adding one here rather than to a vertical's own `tasks.toml`:
+#
+#   * It must make sense for a law firm, a game studio and a research lab
+#     alike. Anything that names a vertical's own artifact belongs beside that
+#     vertical.
+#   * It must name what it produces — a ledger row, a workspace document — so
+#     an agent picking it up knows what "done" looks like and does not hand
+#     back an essay.
+#   * It must not name an owner. This file ships to every company and cannot
+#     know any of their rosters, so every card here is unassigned and routes to
+#     whoever orchestrates.
+#
+# A company that does not want one of these drops it by id:
+# `[globals] disable = ["task:write-the-company-brief"]`.
+
+[[task]]
+id = "write-the-company-brief"
+title = "Write the company brief"
+priority = "high"
+note = """
+What this company does, who it does it for, and what it is trying to be true \
+a year from now — in the workspace, at `brief.md`, in prose a new teammate \
+could read once and then act on.
+
+Everything else on this board assumes this exists. Goals that do not ladder up \
+to a brief are a list of preferences, and an agent asked to decide anything \
+without one will substitute its own guess about what the company wants.
+
+Done when `brief.md` exists and says what we sell, who buys it, and what would \
+count as a good year.\
+"""
+
+[[task]]
+id = "set-the-first-goals"
+title = "Set the first goals"
+priority = "high"
+note = """
+Open three rows on the `goals` ledger — no more. Each names an outcome with a \
+date on it, not an activity: "sign the first ten paying customers by March" \
+rather than "do sales".
+
+Three, because a company with ten goals has none: every card on this board is \
+prioritised against them, and a priority order that points ten ways points \
+nowhere. Read `brief.md` first; a goal that does not serve it is either the \
+wrong goal or a sign the brief is wrong.
+
+Done when `goals` has three rows, each with an owner and a date.\
+"""
+
+[[task]]
+id = "record-the-decisions-already-made"
+title = "Record the decisions already made"
+priority = "medium"
+note = """
+Before this company existed, somebody already decided things — what it will \
+not do, which market it is aimed at, what it refuses to compromise on. Put \
+each on the `decisions` ledger with the reasoning that produced it.
+
+Undocumented decisions get silently re-litigated. An agent that cannot see \
+that a question was already settled will answer it again, differently, and \
+neither answer will know about the other.
+
+Done when every standing decision an operator can think of has a row saying \
+what was decided and why.\
+"""
+
+[[task]]
+id = "name-the-top-risks"
+title = "Name the top risks"
+priority = "medium"
+note = """
+Open a row on the `risks` ledger for each of the three things most likely to \
+stop this company doing what `brief.md` says it will. Each needs an owner \
+watching it, an observable trigger that says it is happening now, and what \
+would actually be done about it.
+
+A risk is watched, not worked — most rows here should have no card on the \
+board until the trigger fires. A risk with no trigger is a worry, and a risk \
+with no response is a note.
+
+Done when `risks` has three owned rows, each with a trigger and a response.\
+"""
+
+[[task]]
+id = "wire-the-connections-this-company-needs"
+title = "Wire the connections this company needs"
+priority = "medium"
+note = """
+Go through Settings → Connections and turn on the tool servers and providers \
+this company's work actually depends on. The bundle ships the ones its vertical \
+obviously needs already declared; anything holding a credential ships disabled, \
+waiting for a token to be written from the console.
+
+Worth doing early and deliberately: an agent that reaches for a tool it has \
+not been given does not fail loudly, it works around the gap and hands back a \
+worse answer without mentioning why.
+
+Done when every declared server is either enabled and answering, or turned off \
+on purpose.\
+"""

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -516,6 +516,11 @@ fn company_builder(
     // `[users].mode` to answer, which is the normal case.
     .with_auth_mode_override(state.auth_mode_override())
     .with_skills_registry(state.shared_skill_registry()?)
+    // The setup cards a real operator should find waiting on a real board. Turned
+    // on here rather than inferred from the seed directory, so a test or a
+    // fixture that builds a company gets the empty board it is asserting about —
+    // see `RuntimeBuilder::with_task_seeding`. First boot only.
+    .with_task_seeding(true)
     .with_id(company_id.clone());
     if let Some(source_dir) = source_dir {
         builder = builder.with_seed_dir(source_dir);

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -895,3 +895,249 @@ fn every_company_ledger_can_be_closed_and_says_why() {
         }
     }
 }
+
+/// The bundles that ship a vertical's own setup cards and tool servers.
+///
+/// Together with [`FIXTURE_COMPANIES`] this is a **partition** of `companies/`,
+/// asserted by [`every_company_declares_a_setup_posture`]. A partition rather
+/// than an allow-list for the reason [`every_company_declares_a_search_posture`]
+/// gives: an allow-list is satisfied by a new template nobody classified, and
+/// "the board is empty because this vertical has no setup work" and "the board
+/// is empty because whoever added this bundle forgot" are indistinguishable
+/// afterwards.
+const SETUP_SEEDED_COMPANIES: [&str; 22] = [
+    "agentic_accounting_firm",
+    "agentic_consultation_firm",
+    "agentic_customer_support",
+    "agentic_design_studio",
+    "agentic_enterprise_sales",
+    "agentic_game_business",
+    "agentic_game_studio",
+    "agentic_influencer_business",
+    "agentic_law_firm",
+    "agentic_marketing_agency",
+    "agentic_math_lab",
+    "agentic_media_company",
+    "agentic_pharma_startup",
+    "agentic_product_team",
+    "agentic_realestate_company",
+    "agentic_recruiting_company",
+    "agentic_research_lab",
+    "agentic_software_company",
+    "agentic_venture_capital",
+    "agentic_venture_studio",
+    "signals_opportunity_studio",
+    "startup_accelerator",
+];
+
+/// The bundles that deliberately ship neither, because they are fixtures.
+///
+/// A fixture proves a mechanism and is asserted against exactly — `e2e_harness`
+/// and `openhuman_demo` also declare their own `[[mcp_server]]` inline — so
+/// seeded cards and a second declaration of `deepwiki` would both perturb what
+/// they exist to pin down.
+const FIXTURE_COMPANIES: [&str; 3] = ["e2e_harness", "e2e_setup", "openhuman_demo"];
+
+/// Every company is either a vertical that ships setup content or a fixture that
+/// deliberately does not — and the classification is re-derived from the files
+/// on disk, so it cannot be made true by editing the lists alone.
+#[test]
+fn every_company_declares_a_setup_posture() {
+    use std::collections::BTreeSet;
+
+    let seeded: BTreeSet<&str> = SETUP_SEEDED_COMPANIES.iter().copied().collect();
+    let fixtures: BTreeSet<&str> = FIXTURE_COMPANIES.iter().copied().collect();
+    assert_eq!(
+        seeded.len(),
+        SETUP_SEEDED_COMPANIES.len(),
+        "SETUP_SEEDED_COMPANIES lists a company twice"
+    );
+    assert_eq!(
+        fixtures.len(),
+        FIXTURE_COMPANIES.len(),
+        "FIXTURE_COMPANIES lists a company twice"
+    );
+    let overlap: Vec<&&str> = seeded.intersection(&fixtures).collect();
+    assert!(
+        overlap.is_empty(),
+        "a company cannot be both a vertical and a fixture: {overlap:?}"
+    );
+
+    let on_disk: BTreeSet<String> = subdirs(&repo_root().join("companies"))
+        .iter()
+        .filter_map(|dir| dir.file_name()?.to_str().map(str::to_string))
+        .collect();
+    let classified: BTreeSet<String> = seeded
+        .union(&fixtures)
+        .map(|name| (*name).to_string())
+        .collect();
+    assert_eq!(
+        on_disk, classified,
+        "every company under `companies/` must be classified as a vertical or a fixture — \
+         add it to SETUP_SEEDED_COMPANIES or FIXTURE_COMPANIES"
+    );
+
+    // The classification has to match the files, not merely the lists.
+    for name in &seeded {
+        let dir = repo_root().join("companies").join(name);
+        assert!(
+            super::has_mcp_file(&dir),
+            "{name} is listed as a vertical but ships no `mcp.json`"
+        );
+        assert!(
+            super::has_task_file(&dir),
+            "{name} is listed as a vertical but ships no `tasks.toml`"
+        );
+    }
+    for name in &fixtures {
+        let dir = repo_root().join("companies").join(name);
+        assert!(
+            !super::has_task_file(&dir),
+            "{name} is a fixture and must not seed cards onto its board"
+        );
+    }
+}
+
+/// Every shipped `mcp.json` parses cleanly, and every server it declares is safe
+/// to hand an agent unattended: HTTP, credential-free, and either answering or
+/// deliberately off pending a token.
+///
+/// `every_company_manifest_is_valid` already runs each file through the real
+/// merge, so a malformed one fails there. This adds the rules that are about
+/// *shipping* a server to everyone who runs the bundle rather than about the
+/// declaration being well-formed.
+#[test]
+fn every_shipped_mcp_server_is_safe_to_ship() {
+    for company in subdirs(&repo_root().join("companies")) {
+        let name = company.file_name().unwrap().to_str().unwrap().to_string();
+        if !super::has_mcp_file(&company) {
+            continue;
+        }
+        let (servers, problems) = super::load_dir_mcp_servers(&company);
+        assert!(problems.is_empty(), "{name}/mcp.json: {problems:?}");
+        assert!(
+            !servers.is_empty(),
+            "{name} ships an `mcp.json` that declares nothing"
+        );
+
+        let readme = std::fs::read_to_string(company.join("README.md"))
+            .unwrap_or_else(|err| panic!("{name}/README.md: {err}"));
+
+        for server in &servers {
+            assert!(
+                server.endpoint.starts_with("https://"),
+                "{name}/mcp.json: `{}` must be https — a shipped template must not send an \
+                 agent's traffic in the clear",
+                server.name
+            );
+            assert!(
+                server
+                    .description
+                    .as_deref()
+                    .is_some_and(|d| !d.trim().is_empty()),
+                "{name}/mcp.json: `{}` has no `description` — JSON carries no comments, so the \
+                 description is the only place this choice can be explained",
+                server.name
+            );
+            // A server that needs a credential must ship off. Enabled plus a
+            // credential means it fails at an agent's first tool call, on every
+            // install, until somebody notices why.
+            if server.auth_secret.is_some() {
+                assert!(
+                    !server.enabled,
+                    "{name}/mcp.json: `{}` names an `authSecret` and ships enabled — it would \
+                     fail at the first tool call; ship it disabled",
+                    server.name
+                );
+            }
+            assert!(
+                readme.contains(&format!("`{}`", server.name)),
+                "{name}/README.md does not mention `{}` — an undocumented server is one nobody \
+                 can decide whether to enable",
+                server.name
+            );
+        }
+    }
+}
+
+/// Every shipped `tasks.toml` parses, and every card on it is one an agent can
+/// actually pick up.
+#[test]
+fn every_shipped_setup_card_is_pickable() {
+    use std::collections::BTreeSet;
+
+    let mut companies: Vec<(String, PathBuf)> = subdirs(&repo_root().join("companies"))
+        .into_iter()
+        .map(|dir| {
+            let name = dir.file_name().unwrap().to_str().unwrap().to_string();
+            (name, dir)
+        })
+        .collect();
+    // The baseline is held to exactly the same rules as a vertical's own file.
+    companies.push(("globals".to_string(), repo_root().join("globals")));
+
+    for (name, dir) in companies {
+        if !super::has_task_file(&dir) {
+            continue;
+        }
+        let cards =
+            super::load_dir_tasks(&dir).unwrap_or_else(|err| panic!("{name}/tasks.toml: {err}"));
+        assert!(
+            !cards.is_empty(),
+            "{name} ships a `tasks.toml` that seeds nothing"
+        );
+
+        let manifest =
+            (name != "globals").then(|| CompanyManifest::from_path(&dir).expect("manifest"));
+        let known: BTreeSet<String> = manifest
+            .as_ref()
+            .map(|m| {
+                m.agents
+                    .iter()
+                    .map(|a| a.id.clone())
+                    .chain(m.group_chats.iter().map(|g| g.id.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for card in &cards {
+            let rendered = card.to_record(0);
+            // The safety property, asserted against the shipped content and not
+            // only against the parser: nothing seeded can enter the column that
+            // dispatches a run or the one that bills a planning pass.
+            assert_eq!(
+                rendered.column,
+                crate::ports::tasks::COLUMN_TODO,
+                "{name}/tasks.toml: `{}` is not To-do",
+                card.id
+            );
+            assert!(
+                card.note.as_deref().is_some_and(|n| !n.trim().is_empty()),
+                "{name}/tasks.toml: `{}` has no note — a card that does not say what done looks \
+                 like gets handed back as an essay",
+                card.id
+            );
+            // A baseline card ships to every vertical and can know no roster, so
+            // it must name no owner; a vertical's card may, but only one that
+            // exists — seeding writes below `resolve_assignee`, so a typo would
+            // persist and only surface as a card that refuses to dispatch.
+            match card.assignee.as_deref().map(str::trim) {
+                None | Some("") => {}
+                Some(assignee) => {
+                    assert!(
+                        name != "globals",
+                        "globals/tasks.toml: `{}` names an assignee, but the baseline ships to \
+                         every company and can know no roster",
+                        card.id
+                    );
+                    assert!(
+                        known.contains(assignee),
+                        "{name}/tasks.toml: `{}` is assigned to `{assignee}`, which is neither a \
+                         teammate nor a desk in this company",
+                        card.id
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -163,8 +163,12 @@ impl CompanyManifest {
         Self::from_located(&discover(path.as_ref())?)
     }
 
-    /// Loads an already-[`discover`]ed manifest, reading the roster from
-    /// `agents/*.toml` when the bundle has one.
+    /// Loads an already-[`discover`]ed manifest, folding in what the bundle
+    /// around it declares: the roster from `agents/*.toml` when it has one, and
+    /// the MCP servers from `mcp.json`.
+    ///
+    /// This — not [`from_file`](Self::from_file) — is what every production
+    /// caller reaches through, which is why the bundle merge lives here.
     ///
     /// Split out from [`from_path`](Self::from_path) so callers that need the
     /// [`Located`] value for themselves — `opencompany check`, which prints the
@@ -179,45 +183,79 @@ impl CompanyManifest {
         // both, and deriving the root from the located manifest is what keeps
         // the two call forms from resolving `agents/` differently.
         match located.path.parent() {
-            Some(bundle) if super::agent_file::has_agent_files(bundle) => {
-                Self::from_file_with_agents(&located.path, bundle)
-            }
-            _ => Self::from_file(&located.path),
+            Some(bundle) => Self::from_file_in_bundle(&located.path, bundle),
+            None => Self::from_file(&located.path),
         }
+    }
+
+    /// [`from_file`](Self::from_file), with everything the bundle around the
+    /// manifest declares folded in: the roster from `agents/*.toml` and the MCP
+    /// servers from `mcp.json`.
+    ///
+    /// Both are merged **before** validation, so a bundle-declared server is
+    /// held to exactly the rules an inline `[[mcp_server]]` is — the HTTP-only
+    /// transport boundary, the credential-free endpoint, the unique name —
+    /// without a second copy of them living in the parser.
+    fn from_file_in_bundle(path: &Path, bundle: &Path) -> Result<Self> {
+        let mut manifest = Self::parse_file(path)?;
+
+        if super::agent_file::has_agent_files(bundle) {
+            if !manifest.agents.is_empty() {
+                return Err(OpenCompanyError::ManifestInvalid {
+                    path: path.to_path_buf(),
+                    problems: vec![format!(
+                        "this company defines its roster in `{dir}/*.toml`, but `{file}` also has `[[agent]]` entries — the two forms are exclusive, so remove the `[[agent]]` blocks or delete the `{dir}/` directory.",
+                        dir = super::agent_file::AGENTS_DIR,
+                        file = path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or(MANIFEST_FILE),
+                    )],
+                });
+            }
+            manifest.agents = super::agent_file::load_agents(bundle)?;
+        }
+
+        let problems = manifest.merge_bundle_mcp_servers(bundle, path);
+        manifest.into_validated_with(path, problems)
+    }
+
+    /// Folds `<bundle>/mcp.json` into `mcp_servers`, returning every problem the
+    /// file carried.
+    ///
+    /// A name declared in both `mcp.json` and an inline `[[mcp_server]]` is
+    /// refused rather than resolved by precedence — the rule the roster already
+    /// uses for the same situation, and for the same reason: either precedence
+    /// rule silently discards a declaration somebody wrote down, and a server
+    /// that quietly is not the one you configured is worse than one that
+    /// refuses to start.
+    fn merge_bundle_mcp_servers(&mut self, bundle: &Path, path: &Path) -> Vec<String> {
+        let (servers, mut problems) = super::mcp_file::load_dir_mcp_servers(bundle);
+        for server in servers {
+            if self
+                .mcp_servers
+                .iter()
+                .any(|existing| existing.name.trim() == server.name)
+            {
+                problems.push(format!(
+                    "mcp server `{}` is declared in both `{}` and `{}` — the two forms are \
+                     exclusive per server, so keep one.",
+                    server.name,
+                    super::mcp_file::MCP_FILE,
+                    path.file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or(MANIFEST_FILE),
+                ));
+                continue;
+            }
+            self.mcp_servers.push(server);
+        }
+        problems
     }
 
     /// Reads, parses, and validates a specific manifest file.
     pub fn from_file(path: &Path) -> Result<Self> {
         Self::parse_file(path)?.into_validated(path)
-    }
-
-    /// [`from_file`](Self::from_file), with the roster taken from
-    /// `<bundle>/agents/*.toml` rather than the manifest's `[[agent]]` entries.
-    ///
-    /// The bundle roster **replaces** the inline one; it does not merge with it.
-    /// Declaring both is refused rather than resolved by precedence, because
-    /// either precedence rule silently discards teammates an operator wrote
-    /// down — and the roster is the one part of a manifest where a silent
-    /// omission stays invisible until the missing teammate fails to answer.
-    fn from_file_with_agents(path: &Path, bundle: &Path) -> Result<Self> {
-        let mut manifest = Self::parse_file(path)?;
-
-        if !manifest.agents.is_empty() {
-            return Err(OpenCompanyError::ManifestInvalid {
-                path: path.to_path_buf(),
-                problems: vec![format!(
-                    "this company defines its roster in `{dir}/*.toml`, but `{file}` also has `[[agent]]` entries — the two forms are exclusive, so remove the `[[agent]]` blocks or delete the `{dir}/` directory.",
-                    dir = super::agent_file::AGENTS_DIR,
-                    file = path
-                        .file_name()
-                        .and_then(|name| name.to_str())
-                        .unwrap_or(MANIFEST_FILE),
-                )],
-            });
-        }
-
-        manifest.agents = super::agent_file::load_agents(bundle)?;
-        manifest.into_validated(path)
     }
 
     /// Reads and deserializes a manifest file, without validating it.
@@ -292,8 +330,19 @@ impl CompanyManifest {
     /// already parsed and checked by [`crate::globals`], and running it through
     /// this validator would let one malformed global fail every company on the
     /// host rather than only itself.
-    fn into_validated(mut self, path: &Path) -> Result<Self> {
-        let problems = self.validate();
+    fn into_validated(self, path: &Path) -> Result<Self> {
+        self.into_validated_with(path, Vec::new())
+    }
+
+    /// [`into_validated`](Self::into_validated), carrying problems the caller
+    /// already found.
+    ///
+    /// Bundle files that are not the manifest — `mcp.json` today — are parsed
+    /// before validation runs, and what they found has to reach the same
+    /// refusal. Reported first, because a file that would not parse is the
+    /// thing to fix before anything the manifest says about it.
+    fn into_validated_with(mut self, path: &Path, mut problems: Vec<String>) -> Result<Self> {
+        problems.extend(self.validate());
         if problems.is_empty() {
             self.apply_globals();
             Ok(self)
@@ -1816,6 +1865,71 @@ mod tests {
                 .iter()
                 .any(|p| p.contains("workflow id") && p.contains("Bad-Id")),
             "{problems:?}"
+        );
+    }
+
+    /// A bundle laying an `mcp.json` beside its `company.toml` gets those
+    /// servers, and they are held to the same validator an inline entry is.
+    #[test]
+    fn a_bundle_mcp_json_reaches_the_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(MANIFEST_FILE), "[company]\nname = \"X\"\n")
+            .expect("write manifest");
+        std::fs::write(
+            dir.path().join("mcp.json"),
+            r#"{"mcpServers": {"deepwiki": {"url": "https://mcp.deepwiki.com/mcp"}}}"#,
+        )
+        .expect("write mcp.json");
+
+        let manifest = CompanyManifest::from_path(dir.path()).expect("loads");
+        let names: Vec<&str> = manifest
+            .mcp_servers
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(names, ["deepwiki"]);
+    }
+
+    /// A server declared in both forms is refused rather than resolved by
+    /// precedence — the roster's rule, for the roster's reason: either
+    /// precedence rule silently discards a declaration somebody wrote down.
+    #[test]
+    fn a_server_declared_in_both_forms_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join(MANIFEST_FILE),
+            "[company]\nname = \"X\"\n[[mcp_server]]\nname = \"deepwiki\"\nendpoint = \"https://one.test/mcp\"\n",
+        )
+        .expect("write manifest");
+        std::fs::write(
+            dir.path().join("mcp.json"),
+            r#"{"mcpServers": {"deepwiki": {"url": "https://two.test/mcp"}}}"#,
+        )
+        .expect("write mcp.json");
+
+        let err = CompanyManifest::from_path(dir.path()).expect_err("must refuse");
+        let text = err.to_string();
+        assert!(text.contains("deepwiki"), "{text}");
+    }
+
+    /// A bad entry in `mcp.json` is reported against the manifest rather than
+    /// swallowed — the file is genuinely read, and its problems genuinely land.
+    #[test]
+    fn a_bad_bundle_server_is_reported_against_the_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(MANIFEST_FILE), "[company]\nname = \"X\"\n")
+            .expect("write manifest");
+        std::fs::write(
+            dir.path().join("mcp.json"),
+            r#"{"mcpServers": {"local": {"command": "npx some-mcp"}}}"#,
+        )
+        .expect("write mcp.json");
+
+        let err = CompanyManifest::from_path(dir.path()).expect_err("must refuse");
+        let text = err.to_string();
+        assert!(
+            text.contains("stdio") && text.contains("mcp.json"),
+            "{text}"
         );
     }
 

--- a/src/company/mcp.rs
+++ b/src/company/mcp.rs
@@ -41,6 +41,13 @@ use crate::ports::types::{CompanyId, SecretValue};
 /// overrides).
 pub const RUNTIME_INDEX_KEY: &str = "mcp/servers";
 
+/// The per-request timeout a server declaration gets when it names none.
+///
+/// Lives here rather than beside [`McpServer`] because every declaration path
+/// defaults it — the manifest through serde, `mcp.json` through
+/// [`super::mcp_file`] — and two spellings of "30" is how they come to disagree.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
 /// The canonical per-server credential key. A server's outbound token is stored
 /// here (write-only via the console); the value is a JSON [`StoredAuth`].
 pub fn auth_key(name: &str) -> String {
@@ -759,7 +766,7 @@ fn is_http_url(url: &str) -> bool {
 /// token in a query parameter is the other way a credential reaches a URL, and
 /// it is the shape a default is most likely to arrive in — an operator copying
 /// a "your MCP URL" string out of a vendor dashboard.
-fn has_query_credential(url: &str) -> bool {
+pub(crate) fn has_query_credential(url: &str) -> bool {
     let Some(query) = url.split_once('?').map(|(_, q)| q) else {
         return false;
     };

--- a/src/company/mcp_file.rs
+++ b/src/company/mcp_file.rs
@@ -1,0 +1,377 @@
+//! The bundle's MCP declaration file: `companies/<name>/mcp.json`.
+//!
+//! A vertical's tool servers were declarable only two ways: an `[[mcp_server]]`
+//! block in `company.toml`, or an operator adding one from the console. Both
+//! work, and neither is how a template ships: of the bundles in `companies/`,
+//! exactly two declared any server at all, so a law firm shipped with five
+//! agents, three ledgers and a workflow graph shipped with no research tools,
+//! and got them only if whoever booted it went and added them by hand.
+//!
+//! So a bundle may carry its servers the way it already carries its roster, its
+//! ledgers and its workflows: one file, authored beside the company it belongs
+//! to. [`load_dir_mcp_servers`] parses it and [`super::CompanyManifest`] merges
+//! the result into `mcp_servers` before validation — see `company::manifest`.
+//!
+//! # Why JSON, and why the map key is the name
+//!
+//! The `{"mcpServers": {...}}` object is the shape every other MCP host already
+//! uses, so a server can be copied from a vendor's setup instructions into a
+//! bundle without being transcribed into a different syntax first — and a
+//! transcription is where the endpoint typo comes from.
+//!
+//! The server's name is the **map key** rather than a field, which is the one
+//! thing this shape gets more right than the TOML array: a key cannot disagree
+//! with itself, so the `slug`-versus-filename refusal
+//! [`super::ledger_file`] needs has no equivalent here.
+//!
+//! # Why bad entries are dropped rather than the file refused
+//!
+//! An `mcp.json` copied out of a vendor's README almost always carries a stdio
+//! `command` and an `env` block, because that is what a desktop MCP client
+//! wants and this runtime does not support (hosted v1 is HTTP-only). Refusing
+//! the file would refuse the whole company over one row somebody pasted
+//! hopefully — so an invalid *entry* is dropped and reported, while a malformed
+//! *file* is a problem the manifest carries. `content_test` is what makes
+//! either one fatal for a bundle this repo ships.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::company::types::McpServer;
+
+/// The bundle file holding one company's MCP server declarations.
+pub const MCP_FILE: &str = "mcp.json";
+
+/// The on-disk shape of `mcp.json`.
+///
+/// `deny_unknown_fields` so a misspelled key is a reported problem rather than
+/// a server that silently does not have the setting its author wrote. The
+/// `$comment` escape hatch is whitelisted precisely so that strictness stays
+/// affordable: JSON has no comments, every other bundle file in this repo
+/// carries its reasoning inline, and prose with nowhere to live gets deleted.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct McpFile {
+    /// Free-form note about the bundle's server choices. Ignored by the parser.
+    #[serde(default, rename = "$comment")]
+    _comment: Option<serde_json::Value>,
+    /// Servers by name. A `BTreeMap` so iteration is sorted by name and two
+    /// machines seed a company in the same order.
+    #[serde(default, rename = "mcpServers")]
+    servers: BTreeMap<String, McpEntry>,
+}
+
+/// One entry under `mcpServers`.
+///
+/// camelCase on the wire, matching both the host convention this shape comes
+/// from and [`McpServer`]'s own console representation. Every field is optional:
+/// what a server must actually have is decided by
+/// [`validate_one`](super::mcp::validate_one), so this file and every other
+/// declaration path stay on one validator.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct McpEntry {
+    #[serde(default, rename = "$comment")]
+    _comment: Option<serde_json::Value>,
+    /// The MCP endpoint. `url` is the spelling every other host uses;
+    /// `endpoint` is the spelling `company.toml` uses. Both are accepted, and
+    /// declaring both is refused rather than resolved.
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    endpoint: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    /// A stdio command. Unsupported in hosted v1, and parsed only so the
+    /// refusal can name the real problem instead of "missing endpoint".
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    allowed_tools: Vec<String>,
+    #[serde(default)]
+    disallowed_tools: Vec<String>,
+    #[serde(default)]
+    read_only_tools: Vec<String>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    #[serde(default)]
+    enabled: Option<bool>,
+    /// Names a secret-store key holding this server's token — never the token.
+    #[serde(default)]
+    auth_secret: Option<String>,
+}
+
+/// Whether `dir` is a bundle carrying an `mcp.json`.
+pub fn has_mcp_file(dir: &Path) -> bool {
+    dir.join(MCP_FILE).is_file()
+}
+
+/// Loads the servers a bundle declares, from `<dir>/mcp.json`.
+///
+/// Returns the servers that are usable alongside every problem from the ones
+/// that are not — never an `Err`. A missing file is not a problem to report:
+/// most bundles declare no server of their own, which is a complete answer.
+///
+/// The caller decides what a problem costs. `CompanyManifest::from_located`
+/// carries them into `validate()`, where a bundle this repo ships is caught by
+/// `content_test` and a hand-edited one still reaches the console to be fixed.
+pub fn load_dir_mcp_servers(dir: &Path) -> (Vec<McpServer>, Vec<String>) {
+    let path = dir.join(MCP_FILE);
+    let src = match std::fs::read_to_string(&path) {
+        Ok(src) => src,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return (Vec::new(), Vec::new()),
+        Err(err) => {
+            return (
+                Vec::new(),
+                vec![format!("`{MCP_FILE}` could not be read — {err}")],
+            );
+        }
+    };
+    parse_mcp_file(MCP_FILE, &src)
+}
+
+/// Parses one `mcp.json`, named by `file_name` for the problem messages.
+///
+/// Every problem is written in prosumer language and against the file that
+/// carries it, matching [`super::ledger_file`] and [`super::agent_file`]: a
+/// template author reads the message, not the serde path.
+pub(crate) fn parse_mcp_file(file_name: &str, src: &str) -> (Vec<McpServer>, Vec<String>) {
+    let file: McpFile = match serde_json::from_str(src) {
+        Ok(file) => file,
+        Err(err) => {
+            return (
+                Vec::new(),
+                vec![format!("`{file_name}` is not valid JSON — {err}")],
+            );
+        }
+    };
+
+    let mut kept: Vec<McpServer> = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+
+    for (name, entry) in file.servers {
+        let name = name.trim().to_string();
+        let label = format!("mcp server `{name}`");
+
+        // Both spellings of the endpoint is an authoring mistake, not a
+        // precedence question: whichever one this file chose to honour would be
+        // the one somebody did not mean, and the other would silently vanish.
+        let endpoint = match (entry.url.as_deref(), entry.endpoint.as_deref()) {
+            (Some(url), Some(endpoint)) if url.trim() != endpoint.trim() => {
+                problems.push(format!(
+                    "{label} in `{file_name}` sets both `url` and `endpoint`, and they disagree — \
+                     keep one."
+                ));
+                continue;
+            }
+            (Some(url), _) => url.trim().to_string(),
+            (None, Some(endpoint)) => endpoint.trim().to_string(),
+            (None, None) => String::new(),
+        };
+
+        let server = McpServer {
+            name: name.clone(),
+            endpoint,
+            description: entry.description,
+            command: entry.command,
+            allowed_tools: entry.allowed_tools,
+            disallowed_tools: entry.disallowed_tools,
+            read_only_tools: entry.read_only_tools,
+            timeout_secs: entry
+                .timeout_secs
+                .unwrap_or(super::mcp::DEFAULT_TIMEOUT_SECS),
+            enabled: entry.enabled.unwrap_or(true),
+            auth_secret: entry.auth_secret,
+        };
+
+        // The shared validator: name, `http(s)` endpoint, no stdio `command`, no
+        // `user:pass@` userinfo. One set of rules for every declaration path.
+        let shared = super::mcp::validate_one(&label, &server);
+        if !shared.is_empty() {
+            problems.extend(
+                shared
+                    .into_iter()
+                    .map(|problem| format!("{problem} (in `{file_name}`)")),
+            );
+            continue;
+        }
+
+        // A token in the endpoint's query string is refused, not scrubbed: this
+        // file is committed to the repo and ships to everyone who runs the
+        // bundle, so a secret here is a secret everywhere. Scrubbing would ship
+        // a server whose auth silently no longer works, which fails at an
+        // agent's first tool call instead of here, where somebody is looking.
+        // Unlike a packaged default, a bundle server may name an `auth_secret`:
+        // that names a key, and the token itself is written per company.
+        if super::mcp::has_query_credential(&server.endpoint) {
+            problems.push(format!(
+                "{label} in `{file_name}` has a credential in its `endpoint` query string — this \
+                 file is committed, so name an `authSecret` key and write the token from the \
+                 console instead."
+            ));
+            continue;
+        }
+
+        kept.push(server);
+    }
+
+    (kept, problems)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn parse(src: &str) -> (Vec<McpServer>, Vec<String>) {
+        parse_mcp_file(MCP_FILE, src)
+    }
+
+    #[test]
+    fn reads_a_server_and_takes_its_name_from_the_key() {
+        let (servers, problems) = parse(
+            r#"{"mcpServers": {"deepwiki": {
+                "url": "https://mcp.deepwiki.com/mcp",
+                "description": "Docs for public repos."
+            }}}"#,
+        );
+        assert!(problems.is_empty(), "{problems:?}");
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "deepwiki");
+        assert_eq!(servers[0].endpoint, "https://mcp.deepwiki.com/mcp");
+        assert_eq!(
+            servers[0].description.as_deref(),
+            Some("Docs for public repos.")
+        );
+        // Defaults an author did not have to write.
+        assert!(servers[0].enabled);
+        assert_eq!(
+            servers[0].timeout_secs,
+            super::super::mcp::DEFAULT_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn accepts_endpoint_as_an_alias_for_url() {
+        let (servers, problems) =
+            parse(r#"{"mcpServers": {"a": {"endpoint": "https://example.test/mcp"}}}"#);
+        assert!(problems.is_empty(), "{problems:?}");
+        assert_eq!(servers[0].endpoint, "https://example.test/mcp");
+    }
+
+    #[test]
+    fn refuses_url_and_endpoint_that_disagree() {
+        let (servers, problems) = parse(
+            r#"{"mcpServers": {"a": {
+                "url": "https://one.test/mcp",
+                "endpoint": "https://two.test/mcp"
+            }}}"#,
+        );
+        assert!(servers.is_empty());
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("both `url` and `endpoint`")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn drops_a_stdio_server_and_names_the_real_problem() {
+        // The shape a vendor README hands you. It must not cost the sibling
+        // entry, and the message must say `command`, not "missing endpoint".
+        let (servers, problems) = parse(
+            r#"{"mcpServers": {
+                "local": {"command": "npx some-mcp"},
+                "remote": {"url": "https://example.test/mcp"}
+            }}"#,
+        );
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "remote");
+        assert!(
+            problems.iter().any(|p| p.contains("stdio `command`")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn drops_a_non_http_endpoint() {
+        let (servers, problems) = parse(r#"{"mcpServers": {"a": {"url": "ftp://x.test/mcp"}}}"#);
+        assert!(servers.is_empty());
+        assert!(
+            problems.iter().any(|p| p.contains("`http://`")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_a_credential_in_the_query_string() {
+        let (servers, problems) =
+            parse(r#"{"mcpServers": {"a": {"url": "https://x.test/mcp?apiKey=sk-live-1"}}}"#);
+        assert!(servers.is_empty());
+        assert!(
+            problems.iter().any(|p| p.contains("credential")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn allows_an_auth_secret_which_names_a_key_rather_than_a_token() {
+        let (servers, problems) = parse(
+            r#"{"mcpServers": {"a": {
+                "url": "https://x.test/mcp",
+                "enabled": false,
+                "authSecret": "mcp/a/auth"
+            }}}"#,
+        );
+        assert!(problems.is_empty(), "{problems:?}");
+        assert!(!servers[0].enabled);
+        assert_eq!(servers[0].auth_secret.as_deref(), Some("mcp/a/auth"));
+    }
+
+    #[test]
+    fn ignores_comments_but_still_refuses_a_typo() {
+        let (servers, problems) = parse(
+            r#"{"$comment": "why these", "mcpServers": {"a": {
+                "$comment": "why this one",
+                "url": "https://x.test/mcp"
+            }}}"#,
+        );
+        assert!(problems.is_empty(), "{problems:?}");
+        assert_eq!(servers.len(), 1);
+
+        let (_, problems) = parse(r#"{"mcpServers": {"a": {"urll": "https://x.test/mcp"}}}"#);
+        assert!(!problems.is_empty(), "a misspelled key must be reported");
+    }
+
+    #[test]
+    fn a_malformed_file_is_one_problem_and_no_servers() {
+        let (servers, problems) = parse("{not json");
+        assert!(servers.is_empty());
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("not valid JSON"), "{problems:?}");
+    }
+
+    #[test]
+    fn servers_come_back_sorted_by_name() {
+        let (servers, problems) = parse(
+            r#"{"mcpServers": {
+                "zulu": {"url": "https://z.test/mcp"},
+                "alpha": {"url": "https://a.test/mcp"}
+            }}"#,
+        );
+        assert!(problems.is_empty(), "{problems:?}");
+        let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, ["alpha", "zulu"]);
+    }
+
+    #[test]
+    fn a_missing_file_is_not_a_problem() {
+        let dir = std::env::temp_dir().join("oc-mcp-file-absent");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let (servers, problems) = load_dir_mcp_servers(&dir);
+        assert!(servers.is_empty());
+        assert!(problems.is_empty(), "{problems:?}");
+    }
+}

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -49,6 +49,11 @@ pub mod ledger_file;
 pub mod ledgers;
 mod manifest;
 pub mod mcp;
+/// The bundle's MCP declaration file: `companies/<name>/mcp.json`. A vertical
+/// ships the tool servers its work needs the way it already ships its ledgers,
+/// rather than starting with an empty tool surface somebody has to fill in by
+/// hand from the console before the company can do anything.
+pub mod mcp_file;
 pub mod paypal;
 // Console MCP OAuth (issue #90): discovery + PKCE + DCR + token exchange for the
 // per-tenant browser sign-in flow. Needs the vendored `oh::mcp::config_servers` discovery
@@ -87,6 +92,11 @@ pub mod smithery;
 // from the operator chat. Always compiled + openhuman-free so the operator
 // control plane can steer in any build and no agent tool can ever reach it.
 pub mod steer;
+/// Seed board cards: `globals/tasks.toml` and `companies/<name>/tasks.toml`. A
+/// company boots with the setup work it obviously has already on the board,
+/// rather than with an empty To-do column and agents that have nothing to pick
+/// up.
+pub mod task_file;
 pub mod task_intent;
 pub mod telegram;
 // The one list of tools a company can grant — built-ins, MCP servers and
@@ -148,7 +158,9 @@ pub use ledger_file::{LEDGERS_DIR, has_ledger_files, load_dir_ledgers};
 #[cfg(test)]
 pub(crate) use manifest::is_snake_case;
 pub use manifest::{DELEGATES_TO_WILDCARD, LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
+pub use mcp_file::{MCP_FILE, has_mcp_file, load_dir_mcp_servers};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md};
+pub use task_file::{TASKS_FILE, TaskSeed, has_task_file, load_dir_tasks};
 pub use types::{
     ACP_AGENTS, ACP_TRANSPORTS, AcpHarness, Agent, BRAIN_MODES, Brain, Budget, ChannelConfig,
     Company, CompanyManifest, ComposioTools, Connection, ContextAccess, ContextEntry,

--- a/src/company/task_file.rs
+++ b/src/company/task_file.rs
@@ -1,0 +1,416 @@
+//! Seed board cards: `globals/tasks.toml` and `companies/<name>/tasks.toml`.
+//!
+//! A company already boots knowing what it tracks — `seed_ledgers` seeds its
+//! axes and `seed_workspace` seeds its documents — and with nothing to do. The
+//! To-do column is empty, so the setup work every company obviously has (write
+//! the brief, wire the connections, set the flow this vertical runs on) exists
+//! only if somebody types it in, and the agents that were supposed to do the
+//! setting up have nothing to pick up.
+//!
+//! These files are that work, authored beside the company it belongs to and
+//! seeded onto the board once, at first boot — see `runtime::builder`.
+//!
+//! # Why the board and not a ledger
+//!
+//! `tasks` is the one built-in that is [`LedgerSource::Native`]: its rows live
+//! in the [`TaskStore`](crate::ports::TaskStore) and `ledgers::record` refuses
+//! to write it, because entering a phase on the board fires real work. So a
+//! seed card is a [`TaskRecord`], not a `LedgerEvent`.
+//!
+//! # Why a card cannot say which column it is in
+//!
+//! Moving a card into `in_progress` is the edge that **dispatches a run**, and
+//! `planning` bills a planning pass (`company::runtime::upsert_task`). A seed
+//! file that could name a column would be one paste away from every freshly
+//! provisioned company spending inference on work nobody asked for. So there is
+//! no `column` key: a seeded card is To-do by construction, and the seeder
+//! writes through the plain store rather than the edge-firing path.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{OpenCompanyError, Result};
+use crate::ports::tasks::{COLUMN_TODO, TaskDeliverable, TaskRecord};
+
+/// The bundle file holding one company's seed cards.
+pub const TASKS_FILE: &str = "tasks.toml";
+
+/// The priorities a card may be authored with, matching the board's own.
+const PRIORITIES: [&str; 3] = ["low", "medium", "high"];
+
+/// The longest a seed card's id may be, matching the ledger slug bound.
+const MAX_ID_CHARS: usize = 48;
+
+/// The on-disk shape of a `tasks.toml`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskSeedFile {
+    #[serde(default, rename = "task")]
+    tasks: Vec<TaskSeed>,
+}
+
+/// One `[[task]]` entry: a card the company starts with.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskSeed {
+    /// Stable id, lowercase and dashed. Stable because it is what a bundle card
+    /// overrides a baseline card by, and what `[globals].disable` names.
+    pub id: String,
+    /// What the card asks for, in one line.
+    pub title: String,
+    /// The longer note: what "done" looks like, and which ledger or document it
+    /// should produce.
+    #[serde(default)]
+    pub note: Option<String>,
+    /// `low` | `medium` | `high`. Defaults to `medium`.
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// The teammate or desk that owns it.
+    ///
+    /// Optional, and **empty by default** rather than resolved to a name here.
+    /// Seeding writes straight to the store, below `resolve_assignee` — which
+    /// lives at the REST boundary — so a typo'd id would persist unchecked and
+    /// surface much later as a card that refuses to dispatch. Empty is a legal,
+    /// meaningful value (unassigned, routed to the orchestrator), and it is the
+    /// only honest default for a baseline card that ships to every vertical and
+    /// cannot know any company's roster.
+    #[serde(default)]
+    pub assignee: Option<String>,
+}
+
+impl TaskSeed {
+    /// Renders this seed as a board card, stamped `at_millis`.
+    ///
+    /// Always [`COLUMN_TODO`], and always a lineage root: a seeded card came
+    /// from no conversation, no parent card and no workflow run, so every
+    /// provenance field is `None` rather than invented.
+    pub fn to_record(&self, at_millis: u64) -> TaskRecord {
+        TaskRecord {
+            id: self.id.clone(),
+            title: self.title.clone(),
+            note: self.note.clone(),
+            column: COLUMN_TODO.to_string(),
+            priority: self
+                .priority
+                .clone()
+                .unwrap_or_else(|| "medium".to_string()),
+            assignee: self.assignee.clone().unwrap_or_default(),
+            updated_at_millis: at_millis,
+            origin_chat_id: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+            planning_attempts: Vec::new(),
+            deliverable: TaskDeliverable::Once,
+            workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
+        }
+    }
+}
+
+/// Whether `dir` is a bundle carrying seed cards.
+pub fn has_task_file(dir: &Path) -> bool {
+    dir.join(TASKS_FILE).is_file()
+}
+
+/// Loads the cards a bundle seeds, from `<dir>/tasks.toml`.
+///
+/// A missing file is not a problem to report: most bundles seed no card of
+/// their own and get the baseline, which is a complete answer.
+///
+/// # Errors
+///
+/// Returns [`OpenCompanyError::ManifestInvalid`] listing every problem in the
+/// file. All-or-nothing, like [`super::ledger_file::load_dir_ledgers`]: a
+/// bundle's cards are a short hand-authored list, and shipping a vertical
+/// silently short the setup work it is about is the failure this exists to
+/// prevent. The seeder downgrades this to a warning so a hand-edited bundle
+/// still boots — see `runtime::builder::seed_tasks`.
+pub fn load_dir_tasks(dir: &Path) -> Result<Vec<TaskSeed>> {
+    let path = dir.join(TASKS_FILE);
+    let src = match std::fs::read_to_string(&path) {
+        Ok(src) => src,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => return Err(OpenCompanyError::DataRead { path, source }),
+    };
+
+    let (tasks, problems) = parse_tasks(TASKS_FILE, &src);
+    if problems.is_empty() {
+        Ok(tasks)
+    } else {
+        Err(OpenCompanyError::ManifestInvalid { path, problems })
+    }
+}
+
+/// Parses one seed file, returning the cards that parsed alongside every
+/// problem from the ones that did not.
+///
+/// [`load_dir_tasks`] turns this into an all-or-nothing [`Result`] for a
+/// company's own bundle. The global baseline (`crate::globals`) wants the
+/// opposite — a malformed baseline must not cost every company its cards — so
+/// it calls this directly and keeps what parsed, exactly as it does for ledgers.
+pub(crate) fn parse_tasks(file_name: &str, src: &str) -> (Vec<TaskSeed>, Vec<String>) {
+    let file: TaskSeedFile = match toml::from_str(src) {
+        Ok(file) => file,
+        Err(err) => {
+            return (
+                Vec::new(),
+                vec![format!(
+                    "`{file_name}` is not valid TOML — {}",
+                    err.message()
+                )],
+            );
+        }
+    };
+
+    let mut kept: Vec<TaskSeed> = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for (index, mut task) in file.tasks.into_iter().enumerate() {
+        let label = if task.id.trim().is_empty() {
+            format!("`{file_name}` task #{}", index + 1)
+        } else {
+            format!("`{file_name}` task `{}`", task.id.trim())
+        };
+
+        match normalize_task_id(&task.id) {
+            Ok(id) => task.id = id,
+            Err(err) => {
+                problems.push(format!("{label} {err}"));
+                continue;
+            }
+        }
+
+        if task.title.trim().is_empty() {
+            problems.push(format!(
+                "{label} has no `title` — a card nobody can read is a card nobody picks up."
+            ));
+            continue;
+        }
+        task.title = task.title.trim().to_string();
+
+        if let Some(priority) = task.priority.as_deref() {
+            let priority = priority.trim().to_ascii_lowercase();
+            if !PRIORITIES.contains(&priority.as_str()) {
+                problems.push(format!(
+                    "{label} has `priority = \"{priority}\"`, which the board does not render — \
+                     use one of {}.",
+                    PRIORITIES.join(", ")
+                ));
+                continue;
+            }
+            task.priority = Some(priority);
+        }
+
+        // A duplicate id would put two cards on the board claiming one identity,
+        // and which one survived would depend on write order rather than on this
+        // file. It is also what a bundle card overrides a baseline card by, so an
+        // id that is not unique makes that precedence unresolvable.
+        if !seen.insert(task.id.clone()) {
+            problems.push(format!(
+                "{label} repeats an `id` used earlier in the file — ids must be unique."
+            ));
+            continue;
+        }
+
+        kept.push(task);
+    }
+
+    (kept, problems)
+}
+
+/// Holds a seed card's id to the same lowercase-and-dashed rule every other
+/// name the runtime puts on a surface follows.
+fn normalize_task_id(raw: &str) -> std::result::Result<String, String> {
+    let value = raw.trim().to_ascii_lowercase();
+    if value.is_empty() {
+        return Err(
+            "has no `id` — a seed card needs one so a bundle can override it and \
+                    `[globals].disable` can name it."
+                .to_string(),
+        );
+    }
+    if value.chars().count() > MAX_ID_CHARS
+        || value.starts_with('-')
+        || value.ends_with('-')
+        || !value
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(format!(
+            "has `id = \"{value}\"`, which is not a usable id — use lowercase letters, digits and \
+             hyphens, up to {MAX_ID_CHARS} characters, not starting or ending with a hyphen."
+        ));
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn parse(src: &str) -> (Vec<TaskSeed>, Vec<String>) {
+        parse_tasks(TASKS_FILE, src)
+    }
+
+    #[test]
+    fn reads_a_card_and_defaults_what_an_author_left_out() {
+        let (tasks, problems) = parse(
+            r#"
+            [[task]]
+            id = "set-up-the-book-flow"
+            title = "Set up the book flow"
+            "#,
+        );
+        assert!(problems.is_empty(), "{problems:?}");
+        assert_eq!(tasks.len(), 1);
+
+        let card = tasks[0].to_record(1_000);
+        assert_eq!(card.id, "set-up-the-book-flow");
+        assert_eq!(card.priority, "medium");
+        // Unassigned, not a guessed name — the seeder is below the resolver.
+        assert_eq!(card.assignee, "");
+        assert_eq!(card.updated_at_millis, 1_000);
+    }
+
+    #[test]
+    fn a_seeded_card_is_always_todo_and_carries_no_invented_provenance() {
+        let (tasks, _) = parse(
+            r#"
+            [[task]]
+            id = "a"
+            title = "A"
+            "#,
+        );
+        let card = tasks[0].to_record(0);
+        // The whole safety property: nothing seeded can enter the dispatching
+        // or the billing column.
+        assert_eq!(card.column, COLUMN_TODO);
+        assert!(card.origin_chat_id.is_none());
+        assert!(card.parent_task_id.is_none());
+        assert!(card.origin_run_id.is_none());
+        assert!(card.origin_workflow_id.is_none());
+        assert!(card.plan.is_none());
+        assert!(card.output.is_none());
+    }
+
+    #[test]
+    fn a_column_key_is_refused_rather_than_honoured() {
+        // `deny_unknown_fields` is what enforces "a card cannot name a column".
+        let (tasks, problems) = parse(
+            r#"
+            [[task]]
+            id = "a"
+            title = "A"
+            column = "in_progress"
+            "#,
+        );
+        assert!(tasks.is_empty());
+        assert!(!problems.is_empty(), "a column key must be refused");
+    }
+
+    #[test]
+    fn refuses_a_duplicate_id() {
+        let (tasks, problems) = parse(
+            r#"
+            [[task]]
+            id = "a"
+            title = "First"
+
+            [[task]]
+            id = "a"
+            title = "Second"
+            "#,
+        );
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "First");
+        assert!(
+            problems.iter().any(|p| p.contains("repeats an `id`")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_an_unrenderable_priority() {
+        let (tasks, problems) = parse(
+            r#"
+            [[task]]
+            id = "a"
+            title = "A"
+            priority = "urgent"
+            "#,
+        );
+        assert!(tasks.is_empty());
+        assert!(
+            problems.iter().any(|p| p.contains("priority")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_a_title_that_says_nothing() {
+        let (tasks, problems) = parse(
+            r#"
+            [[task]]
+            id = "a"
+            title = "   "
+            "#,
+        );
+        assert!(tasks.is_empty());
+        assert!(
+            problems.iter().any(|p| p.contains("`title`")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn refuses_an_id_that_is_not_lowercase_and_dashed() {
+        for bad in ["Set_Up", "-leading", "trailing-", "has space"] {
+            let (tasks, problems) = parse(&format!("[[task]]\nid = \"{bad}\"\ntitle = \"A\"\n"));
+            assert!(tasks.is_empty(), "`{bad}` should be refused");
+            assert!(!problems.is_empty(), "`{bad}` should report a problem");
+        }
+    }
+
+    #[test]
+    fn one_bad_card_does_not_cost_the_others() {
+        let (tasks, problems) = parse(
+            r#"
+            [[task]]
+            id = "good-one"
+            title = "Good"
+
+            [[task]]
+            id = "bad one"
+            title = "Bad"
+
+            [[task]]
+            id = "good-two"
+            title = "Also good"
+            "#,
+        );
+        let ids: Vec<&str> = tasks.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, ["good-one", "good-two"]);
+        assert_eq!(problems.len(), 1);
+    }
+
+    #[test]
+    fn a_malformed_file_is_one_problem_and_no_cards() {
+        let (tasks, problems) = parse("[[task]\nid = ");
+        assert!(tasks.is_empty());
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("not valid TOML"), "{problems:?}");
+    }
+
+    #[test]
+    fn a_missing_file_is_not_a_problem() {
+        let dir = std::env::temp_dir().join("oc-task-file-absent");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        assert!(!has_task_file(&dir));
+        assert!(load_dir_tasks(&dir).expect("absent is fine").is_empty());
+    }
+}

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1008,7 +1008,7 @@ pub struct McpServer {
 }
 
 fn default_mcp_timeout_secs() -> u64 {
-    30
+    super::mcp::DEFAULT_TIMEOUT_SECS
 }
 
 fn default_true() -> bool {

--- a/src/globals/mod.rs
+++ b/src/globals/mod.rs
@@ -52,7 +52,7 @@ mod test;
 /// Closed, and each variant maps to exactly one surface below. A free-form kind
 /// would let a typo (`agents:researcher`) read as a disable that never fires,
 /// which is the one failure mode an opt-out list must not have.
-pub const DISABLE_KINDS: &[&str] = &["agent", "workflow", "skill", "ledger"];
+pub const DISABLE_KINDS: &[&str] = &["agent", "workflow", "skill", "ledger", "task"];
 
 /// The parsed `globals/globals.toml`.
 #[derive(Debug, Default, serde::Deserialize)]
@@ -81,6 +81,7 @@ struct Baseline {
     agents: Vec<Agent>,
     workflows: Vec<WorkflowFile>,
     ledgers: Vec<LedgerSpec>,
+    tasks: Vec<crate::company::TaskSeed>,
     skills: Vec<SkillDoc>,
     default_tool_allow: Vec<String>,
     faults: Vec<String>,
@@ -106,6 +107,7 @@ fn build() -> Baseline {
         agents: build_agents(&mut faults),
         workflows: build_workflows(&mut faults),
         ledgers: build_ledgers(&mut faults),
+        tasks: build_tasks(&mut faults),
         skills: build_skills(&manifest.skills.always, &mut faults),
         default_tool_allow: manifest.tools.default_allow,
         faults,
@@ -208,6 +210,24 @@ fn build_ledgers(faults: &mut Vec<String>) -> Vec<LedgerSpec> {
     specs
 }
 
+/// Parses `globals/tasks.toml` into the baseline's seed cards.
+///
+/// Fault-isolated like every other global surface: a malformed baseline costs
+/// its own cards and nothing else, because the alternative is one bad line
+/// stopping every company on the install from booting.
+fn build_tasks(faults: &mut Vec<String>) -> Vec<crate::company::TaskSeed> {
+    let (tasks, problems) = crate::company::task_file::parse_tasks(
+        "globals/tasks.toml",
+        generated::EMBEDDED_GLOBAL_TASKS,
+    );
+    faults.extend(
+        problems
+            .into_iter()
+            .map(|problem| format!("a global seed card is malformed: {problem}")),
+    );
+    tasks
+}
+
 fn build_skills(always: &[String], faults: &mut Vec<String>) -> Vec<SkillDoc> {
     let mut out = Vec::new();
     for slug in always {
@@ -246,6 +266,17 @@ pub fn workflows() -> &'static [WorkflowFile] {
 /// back. See `runtime::builder`.
 pub fn ledgers() -> &'static [LedgerSpec] {
     &baseline().ledgers
+}
+
+/// The setup cards every company starts with on its board.
+///
+/// Seeded once, at first boot, alongside whatever its own bundle seeds — and
+/// never re-seeded, for the reason [`ledgers`] is not: clearing a card is a
+/// person's call, and a baseline that re-asserted it on the next restart would
+/// take that call back. Clearing the board is routine, so this matters more
+/// here than it does for a ledger. See `runtime::builder`.
+pub fn tasks() -> &'static [crate::company::TaskSeed] {
+    &baseline().tasks
 }
 
 /// The shared-library skills installed in every company.
@@ -296,6 +327,7 @@ pub fn has(key: &str) -> bool {
         "workflow" => workflows().iter().any(|workflow| workflow.id == id),
         "skill" => skills().iter().any(|skill| skill.slug == id),
         "ledger" => ledgers().iter().any(|ledger| ledger.slug == id),
+        "task" => tasks().iter().any(|task| task.id == id),
         _ => false,
     }
 }

--- a/src/globals/test.rs
+++ b/src/globals/test.rs
@@ -338,6 +338,7 @@ fn every_disable_kind_has_a_surface_behind_it() {
             "workflow" => workflows()[0].id.clone(),
             "skill" => skills()[0].slug.clone(),
             "ledger" => ledgers()[0].slug.clone(),
+            "task" => tasks()[0].id.clone(),
             other => panic!("`{other}` is a disable kind with no surface behind it"),
         };
         assert!(has(&format!("{kind}:{id}")), "{kind}:{id}");

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -443,6 +443,17 @@ pub struct RuntimeBuilder {
     /// the next container replacement.
     journal_store: Option<Arc<dyn crate::ports::journal::JournalStore>>,
     seed_dir: Option<PathBuf>,
+    /// Whether this company's board is seeded with setup cards on first boot.
+    ///
+    /// Off by default, and deliberately **not** inferred from `seed_dir` the way
+    /// workspace seeding is. Ledger seeding runs on every company because a
+    /// company that tracks nothing is broken; a company with an empty board is
+    /// merely new. Cards, meanwhile, are visible state that tests and fixtures
+    /// count — `tests/one_card_per_message.rs` asserts exact board sizes against
+    /// a company built straight from this builder — so an unconditional baseline
+    /// would quietly turn those assertions into statements about the baseline.
+    /// The product entry points turn it on; nothing else does.
+    seed_tasks: bool,
     /// The repo-level shared skill library, passed to the harness so a pre-fix
     /// registry install (whose stored `SKILL.md` is a one-line stub) is healed
     /// from the live library. Empty when no repo checkout backs the host.
@@ -557,6 +568,7 @@ impl RuntimeBuilder {
             login_codes: None,
             journal_store: None,
             seed_dir: None,
+            seed_tasks: false,
             skills_registry: Arc::from([]),
             template_provenance: None,
             feedback: None,
@@ -879,6 +891,17 @@ impl RuntimeBuilder {
     /// tree is seeded from on first build. Without it, no seeding runs.
     pub fn with_seed_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.seed_dir = Some(dir.into());
+        self
+    }
+
+    /// Seeds the board with the baseline's setup cards, plus whatever the seed
+    /// directory's own `tasks.toml` adds, on this company's **first** boot.
+    ///
+    /// Opt-in, so a test or a fixture that boots a company gets the empty board
+    /// it is asserting about. Call it from a product entry point — where a real
+    /// operator is about to look at a real board — and nowhere else.
+    pub fn with_task_seeding(mut self, seed: bool) -> Self {
+        self.seed_tasks = seed;
         self
     }
 
@@ -1924,6 +1947,27 @@ impl RuntimeBuilder {
         // company.toml + meta.json; the append-only ledger file is left untouched,
         // so an existing ledger survives a rebuild.
         let existing = store.load(&id).await?;
+
+        // Boot lifecycle: the setup work this company starts with, put on the
+        // board once and never again.
+        //
+        // Gated on `existing.is_none()` — this `store.load` is the last moment a
+        // first boot is distinguishable, because the `store.save` at the end of
+        // this function makes every later boot a returning one. That is a
+        // stronger gate than "the board is empty", which the ledger seeder can
+        // afford and this cannot: clearing the board is routine, and a card an
+        // operator deleted coming back on the next restart is the runtime
+        // arguing with them.
+        //
+        // `handover` is the rebuild arm: a rebuilt company is already running
+        // and already has whatever board it has.
+        if self.seed_tasks
+            && handover.is_none()
+            && existing.is_none()
+            && ops.tasks.list(&id).await?.is_empty()
+        {
+            seed_tasks(&ops, &self.manifest, &id, self.seed_dir.as_deref()).await?;
+        }
         let lifecycle = existing
             .as_ref()
             .map(|r| r.lifecycle.clone())
@@ -3337,6 +3381,105 @@ async fn seed_ledgers(
     Ok(())
 }
 
+/// Seeds a company's board with the setup work it starts with: the global
+/// baseline ([`crate::globals::tasks`]) plus whatever its own bundle adds under
+/// `companies/<name>/tasks.toml`.
+///
+/// Runs only on a company's first boot, and only when the caller opted in — see
+/// the call site and [`RuntimeBuilder::with_task_seeding`].
+///
+/// # Why this cannot dispatch anything
+///
+/// Two independent reasons, because one would be a footgun:
+///
+/// * A seed card has no authorable column ([`crate::company::task_file`]), so
+///   every card written here is [`COLUMN_TODO`](crate::ports::tasks::COLUMN_TODO).
+/// * The write goes through `ops.tasks.upsert` — the plain store — and never
+///   through [`CompanyRuntime::upsert_task`](crate::company::CompanyRuntime::upsert_task),
+///   which is the single site that edge-fires a dispatch or a planning pass.
+///
+/// So a company can boot with fifty cards on it and spend nothing.
+///
+/// # Precedence and ordering
+///
+/// A company's own card **wins** on a shared id: bundle cards are applied after
+/// the baseline's, replacing rather than duplicating, which is how every other
+/// global surface resolves an id collision. A baseline card the manifest
+/// disables (`[globals] disable = ["task:<id>"]`) is dropped before either.
+///
+/// Timestamps are staggered **descending** so the authored order is the order
+/// the board shows. The board sorts by `updated_at_millis` descending, and cards
+/// written inside one millisecond tie — a tie the fs backend happens to break by
+/// insertion order and SQLite does not, which would make the board's reading
+/// order depend on which backend a tenant runs.
+///
+/// A malformed bundle file is a warning and not a boot failure, exactly as it is
+/// for a bundle ledger: `content_test` fails CI on a shipped template that has
+/// one, so this arm is for a hand-edited bundle, where reaching the console to
+/// fix it beats refusing to start.
+async fn seed_tasks(
+    ops: &OpsStores,
+    manifest: &CompanyManifest,
+    id: &CompanyId,
+    seed_dir: Option<&std::path::Path>,
+) -> Result<()> {
+    let seeds = resolve_seed_cards(&manifest.globals.disable, seed_dir, |err| {
+        tracing::warn!(company = %id, "company setup cards not seeded ({err})");
+    });
+
+    // Descending from now, one millisecond apart, so the first card authored is
+    // the first card read.
+    let now = crate::ports::now_millis();
+    for (index, seed) in seeds.iter().enumerate() {
+        let at = now.saturating_sub(index as u64);
+        let card = seed.to_record(at);
+        debug_assert_eq!(card.column, crate::ports::tasks::COLUMN_TODO);
+        ops.tasks.upsert(id, &card).await?;
+    }
+
+    Ok(())
+}
+
+/// The cards a company would be seeded with: the baseline minus what the
+/// manifest disables, with the bundle's own applied over the top.
+///
+/// Split out from [`seed_tasks`] so the precedence and the opt-out are testable
+/// without standing up a store — the write loop above is the only part that
+/// needs one, and it does nothing a test could not read off this list.
+///
+/// `on_error` is called with a bundle file that would not load. It is a callback
+/// rather than a `Result` because a bad bundle file must not stop a boot: the
+/// company still gets the baseline, and `content_test` is what makes a shipped
+/// template's bad file fatal.
+fn resolve_seed_cards(
+    disable: &[String],
+    seed_dir: Option<&std::path::Path>,
+    on_error: impl FnOnce(crate::error::OpenCompanyError),
+) -> Vec<crate::company::TaskSeed> {
+    let mut seeds: Vec<crate::company::TaskSeed> = crate::globals::tasks()
+        .iter()
+        .filter(|seed| !crate::globals::disabled(disable, "task", &seed.id))
+        .cloned()
+        .collect();
+
+    if let Some(dir) = seed_dir {
+        match crate::company::load_dir_tasks(dir) {
+            Ok(bundled) => {
+                for seed in bundled {
+                    // A company's own card wins outright rather than merging
+                    // field by field, the way its own ledger and its own agent
+                    // supersede the baseline's.
+                    seeds.retain(|global| global.id != seed.id);
+                    seeds.push(seed);
+                }
+            }
+            Err(err) => on_error(err),
+        }
+    }
+
+    seeds
+}
+
 /// Auto-wires the tiny.place economy for a discoverable company (feature build).
 ///
 /// Returns `None` unless `[place].discoverable` is set and a `@handle` is
@@ -3581,6 +3724,124 @@ mod test {
             .prefix(prefix)
             .tempdir()
             .expect("tempdir")
+    }
+
+    mod seed_cards {
+        use super::*;
+
+        fn bundle(body: &str) -> tempfile::TempDir {
+            let dir = tmp_home("opencompany-seed-cards-");
+            std::fs::write(dir.path().join("tasks.toml"), body).expect("write tasks.toml");
+            dir
+        }
+
+        fn resolve(disable: &[&str], dir: Option<&std::path::Path>) -> Vec<String> {
+            let disable: Vec<String> = disable.iter().map(|d| (*d).to_string()).collect();
+            resolve_seed_cards(&disable, dir, |err| {
+                panic!("unexpected load failure: {err}")
+            })
+            .into_iter()
+            .map(|seed| seed.id)
+            .collect()
+        }
+
+        /// A company with no bundle still gets the baseline: a
+        /// platform-provisioned tenant carries no `companies/<name>` directory
+        /// and is still a company somebody has to start using.
+        #[test]
+        fn a_company_with_no_bundle_gets_the_baseline() {
+            let ids = resolve(&[], None);
+            assert!(!ids.is_empty(), "the baseline must seed something");
+            let baseline: Vec<String> = crate::globals::tasks()
+                .iter()
+                .map(|seed| seed.id.clone())
+                .collect();
+            assert_eq!(ids, baseline);
+        }
+
+        /// The bundle's cards land after the baseline's, so the setup work every
+        /// company shares is read first.
+        #[test]
+        fn a_bundle_appends_its_own_cards_after_the_baseline() {
+            let dir = bundle("[[task]]\nid = \"set-up-the-thing\"\ntitle = \"Set up the thing\"\n");
+            let ids = resolve(&[], Some(dir.path()));
+            assert_eq!(
+                ids.last().map(String::as_str),
+                Some("set-up-the-thing"),
+                "{ids:?}"
+            );
+            assert_eq!(ids.len(), crate::globals::tasks().len() + 1);
+        }
+
+        /// A bundle card of the same id **replaces** the baseline's rather than
+        /// duplicating it — the precedence every other global surface uses.
+        #[test]
+        fn a_bundle_card_supersedes_the_baseline_card_of_the_same_id() {
+            let shared = &crate::globals::tasks()[0].id;
+            let dir = bundle(&format!(
+                "[[task]]\nid = \"{shared}\"\ntitle = \"Ours instead\"\n"
+            ));
+            let seeds = resolve_seed_cards(&[], Some(dir.path()), |err| panic!("{err}"));
+            let matching: Vec<&crate::company::TaskSeed> =
+                seeds.iter().filter(|s| &s.id == shared).collect();
+            assert_eq!(matching.len(), 1, "the id must not appear twice");
+            assert_eq!(matching[0].title, "Ours instead");
+            assert_eq!(seeds.len(), crate::globals::tasks().len());
+        }
+
+        /// `[globals].disable` drops a baseline card, using the same
+        /// `<kind>:<id>` vocabulary that already drops a baseline agent,
+        /// workflow, skill or ledger.
+        #[test]
+        fn disable_drops_one_baseline_card_and_keeps_the_rest() {
+            let dropped = crate::globals::tasks()[0].id.clone();
+            let ids = resolve(&[&format!("task:{dropped}")], None);
+            assert!(!ids.contains(&dropped), "{ids:?}");
+            assert_eq!(ids.len(), crate::globals::tasks().len() - 1);
+        }
+
+        /// A bundle file that will not load costs its own cards and nothing
+        /// else. Refusing the boot would strand a hand-edited bundle where the
+        /// console that could fix it is unreachable.
+        #[test]
+        fn a_malformed_bundle_file_still_leaves_the_baseline() {
+            let dir = bundle("[[task]\nid = ");
+            let mut reported = None;
+            let seeds = resolve_seed_cards(&[], Some(dir.path()), |err| {
+                reported = Some(err.to_string());
+            });
+            assert!(
+                reported.is_some(),
+                "the failure must be reported, not swallowed"
+            );
+            assert_eq!(seeds.len(), crate::globals::tasks().len());
+        }
+
+        /// Every seeded card is To-do, whatever it came from. `in_progress`
+        /// dispatches a run and `planning` bills a pass, so this is the property
+        /// that keeps a freshly provisioned company from spending money at boot.
+        #[test]
+        fn every_seeded_card_is_todo() {
+            let dir = bundle("[[task]]\nid = \"ours\"\ntitle = \"Ours\"\n");
+            for seed in resolve_seed_cards(&[], Some(dir.path()), |err| panic!("{err}")) {
+                let card = seed.to_record(0);
+                assert_eq!(card.column, crate::ports::tasks::COLUMN_TODO, "{}", seed.id);
+            }
+        }
+
+        /// Seeding is opt-in. `tests/one_card_per_message.rs` asserts exact board
+        /// sizes against a company built straight from this builder, so a
+        /// baseline that arrived unasked would quietly turn those assertions into
+        /// statements about the baseline.
+        #[test]
+        fn task_seeding_is_off_unless_a_caller_asks_for_it() {
+            let home = tmp_home("opencompany-seed-flag-");
+            let manifest: CompanyManifest =
+                toml::from_str("[company]\nname = \"Acme\"\n").expect("manifest");
+            let builder = RuntimeBuilder::new(home.path().to_path_buf(), manifest);
+            assert!(!builder.seed_tasks, "board seeding must default to off");
+            assert!(builder.with_task_seeding(true).seed_tasks);
+        }
     }
 
     /// Automatic Git checkpoints are opt-in and stay off unless the operator

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -516,7 +516,7 @@ async fn add_server(
     let manifest = manifest_servers(runtime).await?;
     if manifest.iter().any(|m| m.name.trim() == name) {
         return Err(ApiError(OpenCompanyError::Conflict(format!(
-            "`{name}` is declared in company.toml — update it to override, don't re-add it."
+            "`{name}` is declared in this company's bundle (`company.toml` or `mcp.json`) — update it to override, don't re-add it."
         ))));
     }
 
@@ -661,7 +661,7 @@ async fn delete_server(
     let manifest = manifest_servers(runtime).await?;
     if manifest.iter().any(|m| m.name.trim() == name) {
         return Err(ApiError(OpenCompanyError::Conflict(format!(
-            "`{name}` is declared in company.toml — disable it instead of deleting."
+            "`{name}` is declared in this company's bundle (`company.toml` or `mcp.json`) — disable it instead of deleting."
         ))));
     }
     // Same guard, same reason, for an install-wide default (issue #527): the


### PR DESCRIPTION
## Summary

A company bundle already ships a roster, its own ledger axes, workflow graphs, skills and a seed workspace. It shipped neither of the two things that make a fresh company usable on day one:

- **MCP servers.** Only two of the 25 bundles declared any (`openhuman_demo` and `e2e_harness`, both the same `deepwiki` entry). Every other vertical booted with an empty tool surface that somebody had to fill in by hand from the console.
- **Anything on the board.** `seed_ledgers` seeds declarations and `seed_workspace` seeds documents, but nothing seeded *records* — so a company came up knowing exactly what it tracks and with nothing to do, and its agents had nothing to pick up.

This adds two bundle files, both read from disk through `seed_dir` the way `ledgers/` and `workspace/` already are.

### `companies/<name>/mcp.json`

The `{"mcpServers": {…}}` shape every other MCP host uses, so a server can be copied from a vendor's setup instructions rather than transcribed — a transcription is where the endpoint typo comes from. The server's name is the map key, so it cannot disagree with itself.

Parsed by `company::mcp_file` and merged into `mcp_servers` by `CompanyManifest::from_located` **before** validation, so a bundle server is held to exactly the rules an inline `[[mcp_server]]` is (HTTP only, credential-free endpoint, unique name) with no second copy of them living in the parser.

- A name declared in **both** forms is a validation problem naming both files — refused rather than resolved by precedence, the rule the roster already uses for the same situation.
- An invalid **entry** is dropped and reported rather than failing the boot: an `mcp.json` pasted from a vendor README usually carries a stdio `command` this runtime cannot honour, and that must not cost the whole company. A malformed **file** is a manifest problem.
- `$comment` is whitelisted at file and server level, because JSON carries no comments and every other bundle file here keeps its reasoning inline.

### `globals/tasks.toml` + `companies/<name>/tasks.toml`

Seeded onto the board at first boot by `runtime::builder::seed_tasks`. The baseline is the setup every company has whichever vertical it started from (brief, first goals, standing decisions, top risks, connections); a bundle adds what its vertical is defined by and wins on a shared id. `[globals] disable = ["task:<id>"]` drops a baseline card, using the vocabulary that already drops a baseline agent, workflow, skill or ledger.

## Two properties that are load-bearing

**A seeded card can never dispatch**, enforced twice because once is a footgun:

1. A seed file has no `column` key at all — seeded cards are To-do by construction.
2. The seeder writes through the plain `TaskStore`, never `CompanyRuntime::upsert_task` — the single site that edge-fires a dispatch (`in_progress`) or a billed planning pass (`planning`).

**Seeding is opt-in**, deliberately unlike ledger seeding, which is unconditional. Cards are visible state that tests count: `tests/one_card_per_message.rs` asserts exact board sizes (`:513` "exactly one card", `:1022` `cards.len() == 3`) against a company built straight from `RuntimeBuilder`. A baseline arriving unasked would quietly turn those assertions into statements about the baseline. Only the `serve` entry point calls `with_task_seeding(true)`.

The first-boot gate is `store.load(&id)` returning `None` — the last moment a first boot is distinguishable, since the `store.save` at the end of the build makes every later boot a returning one. That is stricter than the ledger seeder's "nothing declared yet" gate, and deliberately: clearing the board is routine, and a card an operator deleted reappearing on the next restart is the runtime arguing with them.

## Content

22 verticals each get an `mcp.json` and a `tasks.toml` — **70 seeded cards** in total, each naming the ledger row or workspace document it should produce so an agent that picks one up hands back the thing rather than an essay about it. Public no-auth servers ship enabled; anything needing a credential ships **disabled** with an `authSecret` naming a key (never a token), because an enabled server that needs auth fails at an agent's first tool call instead of where somebody is looking.

The three fixture bundles (`e2e_harness`, `e2e_setup`, `openhuman_demo`) get neither, so they stay deterministic.

## Commands run locally

```
cargo fmt --all -- --check                 # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test --features openhuman            # 5095 passed, 0 failed (+ all integration targets)
bash scripts/ci/assert-md-line-cap.sh      # pass
bash scripts/ci/assert-feature-lanes.sh    # pass (no new features)
```

End to end, against a scratch data dir:

```
OPENCOMPANY_DATA_DIR=<scratch> cargo run --bin opencompany -- serve --company companies/agentic_law_firm
```

- 8 cards on the board — 5 baseline then 3 law-firm — **all `todo`**, unassigned, staggered so authored order is board order.
- The bundle's Notion server persisted into the manifest with `enabled = false` and `auth_secret = "mcp/notion/auth"`.
- **Zero dispatches and zero warnings** in the boot log.
- Restart against the same data dir: nothing re-seeded. Deleted a card, restarted: it stayed deleted.

I also confirmed the new CI guards actually bite by deliberately enabling a credentialed server and watching `every_shipped_mcp_server_is_safe_to_ship` fail.

## Behaviour changes

- `CompanyManifest::from_located` now folds in `mcp.json`. `from_file_with_agents` became `from_file_in_bundle` (private; no production caller used the old name). No path bypasses it — every production caller reaches the manifest through `from_path`/`from_located`.
- Removing a server from `mcp.json` takes effect on the next `serve`, which re-parses the bundle — **not** on an in-place rebuild, which uses the persisted manifest. Same semantics as editing `company.toml`; documented.
- The console's delete refusal said *"declared in company.toml"*, which is no longer always true. Reworded to name the bundle, in `server/ops/mcp.rs` and the frontend copy.
- `globals::DISABLE_KINDS` gains `"task"`.

## Known limit, deliberately not fixed here

The desktop registers presets with **no `seed_dir`** (`desktop.rs:325`), so it gets neither file — its roster survives only because `build.rs` embeds `agents/**`. Hosted tenants still get the global baseline cards, since `seed_tasks` is not gated on `seed_dir`. If the desktop should have them, the follow-up is contained: an `EMBEDDED_BUNDLE_MCP`/`EMBEDDED_BUNDLE_TASKS` table in `build.rs` with a per-file `cargo:rerun-if-changed`, applied in `desktop::first_run_manifest`, plus a mirror test modelled on `the_embedded_roster_matches_the_bundle_on_disk`.

## Worth a reviewer's eye

The MCP endpoints are real, well-known remote servers (`deepwiki`, `context7`, `huggingface`, `notion`, `linear`, `sentry`, `stripe`, `intercom`), but they are worth confirming against each vendor's current docs before this ships. The credentialed ones are all disabled, so a wrong URL surfaces when an operator enables it rather than at an agent's first tool call.

## Docs

`docs/spec/runtime/tools.md` (the four declaration layers and the rebuild-vs-restart asymmetry), `globals.md` (the new seeded surface and the `task` disable kind), `company-setup.md` (what is on the board on day one), `companies/README.md`, `globals/README.md`, and a **Tool servers** section in each of the 22 bundle READMEs.
