### PR TITLE
fix(team): hide the raw agent ID chip

### DIFF
--- a/frontend/src/views/team/AgentDetailView.tsx
+++ b/frontend/src/views/team/AgentDetailView.tsx
@@ -713,9 +713,6 @@ function Identity({ agent, action }: { agent: AgentDetailDto; action?: ReactNode
                 <Mail className="size-3" /> Inbox
               </Badge>
             )}
-            <span className="font-mono text-xs text-muted-foreground" data-testid="agent-id">
-              {agent.id}
-            </span>
           </div>
         </div>
       </div>

--- a/frontend/test/e2e/agent-detail.spec.ts
+++ b/frontend/test/e2e/agent-detail.spec.ts
@@ -90,7 +90,6 @@ test("a company agent opens from its card and shows what it is", async ({ page }
   await expect(page).toHaveURL(/#\/team\/ceo$/);
 
   await expect(page.getByTestId("agent-name")).toHaveText("Chief Executive");
-  await expect(page.getByTestId("agent-id")).toHaveText("ceo");
 
   // The tier, resolved by the host rather than read off the manifest string.
   await expect(page.getByTestId("agent-tier")).toContainText("Orchestrator");


### PR DESCRIPTION
## Summary

Removes the prominent raw `agent.id` chip from the Agent Detail identity header while preserving the teammate name and role. Internal ID consumers such as routing, keys, and avatar tone remain unchanged.

## API Or Behavior Changes

The Agent Detail header no longer displays the raw snake_case agent identifier. No API or DTO changes.

## Tests

- `npm run typecheck`
- `npm run typecheck:unit`
- `npm run typecheck:e2e`
- `npx vitest run` (286 files, 2512 tests)
- `npm run build`

Manual UI verification on staging is pending.

## Documentation

Not needed; this is a small presentation-only change with no public API or workflow changes.

## Related

Closes #1688.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the agent ID from the Identity header in agent details.
* **Tests**
  * Updated agent detail coverage to focus on visible agent information, permissions, membership, and editing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->