### PR TITLE
fix: sort workspace tree by most-recently-modified (#1687)

### DIFF
--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -35,6 +35,10 @@ export function childrenOf(nodes: FsNode[], parentId: string | null): FsNode[] {
       const bDerived =
         b.kind === "folder" && b.name.toLowerCase() === DERIVED_DIR;
       if (aDerived !== bDerived) return aDerived ? 1 : -1;
+      if (a.updatedAt != null && b.updatedAt != null) {
+        const updatedAt = b.updatedAt - a.updatedAt;
+        if (updatedAt !== 0) return updatedAt;
+      }
       return a.name.localeCompare(b.name);
     });
 }

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -2084,10 +2084,20 @@ interface TreeProps {
  * {@link childrenOf} sorts everywhere else (issue #973). The pre-#686 ULID ids
  * all sort before every readable slug under the plain id ordering, which is
  * not an order an operator can read anything into.
+ *
+ * Most-recently-modified still comes first here (issue #1687) — `Tree` routes
+ * a roster root through this comparator instead of {@link childrenOf}'s, so
+ * without its own `updatedAt` check the two visible roots that need id
+ * resolution the most would be the two the MRU fix never reached, and stayed
+ * alphabetical underneath it.
  */
 function sortRosterFolders(items: FsNode[], names: RosterNames): FsNode[] {
   return [...items].sort((a, b) => {
     if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+    if (a.updatedAt != null && b.updatedAt != null) {
+      const updatedAt = b.updatedAt - a.updatedAt;
+      if (updatedAt !== 0) return updatedAt;
+    }
     // Only a roster folder's name is an id worth resolving. A direct file
     // under `agents/` is unusual but not impossible, and its raw name could
     // coincidentally collide with a roster id — that must not reorder it by

--- a/frontend/test/unit/workspace-operator-content.test.ts
+++ b/frontend/test/unit/workspace-operator-content.test.ts
@@ -20,6 +20,7 @@ function node(over: {
   name: string;
   kind: "folder" | "file";
   parentId?: string | null;
+  updatedAt?: number;
 }): FsNode {
   return {
     parentId: null,
@@ -122,6 +123,28 @@ describe("hasOperatorContent", () => {
 });
 
 describe("childrenOf pins derived last (issue #1382)", () => {
+  it("sorts each sibling group by modified time, then name", () => {
+    const tree = [
+      node({ id: "old", name: "Older", kind: "folder", updatedAt: 10 }),
+      node({ id: "tie-z", name: "Zebra", kind: "folder", updatedAt: 20 }),
+      node({ id: "derived", name: "derived", kind: "folder", updatedAt: 40 }),
+      node({ id: "new", name: "Newest", kind: "folder", updatedAt: 30 }),
+      node({ id: "tie-a", name: "Alpha", kind: "folder", updatedAt: 20 }),
+      node({ id: "file-old", name: "Older.md", kind: "file", updatedAt: 10 }),
+      node({ id: "file-new", name: "Newest.md", kind: "file", updatedAt: 30 }),
+    ];
+
+    expect(childrenOf(tree, null).map((n) => n.name)).toEqual([
+      "Newest",
+      "Alpha",
+      "Zebra",
+      "Older",
+      "derived",
+      "Newest.md",
+      "Older.md",
+    ]);
+  });
+
   it("sorts the read-only folder after the ones a person made", () => {
     const tree = [
       node({ id: "z", name: "Zebra", kind: "folder" }),

--- a/frontend/test/unit/workspace-tree-roster-names.test.ts
+++ b/frontend/test/unit/workspace-tree-roster-names.test.ts
@@ -30,8 +30,9 @@ function node(over: {
   name: string;
   kind: "folder" | "file";
   parentId?: string;
+  updatedAt?: number;
 }) {
-  return { ...over, updatedAt: 1 };
+  return { updatedAt: 1, ...over };
 }
 
 function member(id: string, name: string): TeamMemberDto {
@@ -113,6 +114,24 @@ describe("the workspace tree", () => {
     const text = container.textContent ?? "";
     expect(text.indexOf("Alex")).toBeGreaterThanOrEqual(0);
     expect(text.indexOf("Zoe")).toBeGreaterThan(text.indexOf("Alex"));
+  });
+
+  it("sorts agents/ folders by modified time first, display name only as a tie-breaker (issue #1687)", async () => {
+    // Display-name order (Alex, Zoe) and modified-time order disagree: Zoe's
+    // folder is the more recently touched one, so it must lead despite
+    // sorting after Alex alphabetically.
+    const tree = [
+      node({ id: "agents-root", name: "Agents", kind: "folder" }),
+      node({ id: "n-alpha", name: "alpha-id", kind: "folder", parentId: "agents-root", updatedAt: 10 }),
+      node({ id: "n-zeta", name: "zeta-id", kind: "folder", parentId: "agents-root", updatedAt: 20 }),
+    ];
+    const team = [member("alpha-id", "Alex"), member("zeta-id", "Zoe")];
+
+    await render(client(tree, team));
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Zoe")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("Alex")).toBeGreaterThan(text.indexOf("Zoe"));
   });
 
   it("names an artifacts/ folder by its teammate too", async () => {


### PR DESCRIPTION
## Summary

- Sort workspace tree siblings by most-recently-modified within their existing groups.
- Preserve folders-first ordering and keep the generated `derived/` folder last.
- Fall back to alphabetical names when modified timestamps tie or are unavailable.

## API Or Behavior Changes

The Workspace explorer now shows the most recently updated folders and notes first within the folders-first / files-second grouping. There are no API changes.

Manual UI verification on staging is pending.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (286 files, 2,513 tests)
- [x] `npm run build`
- [x] Red proof: the focused ordering test fails with the previous alphabetical comparator and passes with this change.

## Documentation

No documentation changes were needed; this is a frontend ordering correction covered by unit tests.

## Related

Part of #1687
