### PR TITLE
fix(workflows): open panes and sort by recent runs

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2855,7 +2855,11 @@ export function WorkflowsView({
             <WorkflowIndex
               workflows={workflows}
               runsByWorkflow={runsByWorkflow}
-              onSelect={(id) => setSelectedId(id)}
+              onSelect={(id) => {
+                setSelectedId(id);
+                setHistoryOpen(true);
+                setCopilotOpen(true);
+              }}
               mode={indexMode}
               loading={loadingList}
               runsLoaded={indexRunsLoaded}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2804,7 +2804,7 @@ export function WorkflowsView({
           panel makes that structural: the index cannot grow run chrome by
           accident, because the slot it would mount in does not exist there. */}
       {!detailOpen ? (
-        <div className="relative flex-1">
+        <div className="relative flex-1 min-h-0">
           {!loadingList && workflows.length === 0 ? (
             // Issue #813's on-ramp, which used to live behind the canvas's
             // empty selection. An empty company now lands here instead, so this

--- a/frontend/src/views/workflows/WorkflowIndex.tsx
+++ b/frontend/src/views/workflows/WorkflowIndex.tsx
@@ -209,6 +209,12 @@ export function WorkflowIndex({
    */
   runsLoaded: boolean;
 }) {
+  const sortedWorkflows = [...workflows].sort((a, b) => {
+    const aLastRun = runsByWorkflow.get(a.id)?.[0]?.atMillis ?? Number.NEGATIVE_INFINITY;
+    const bLastRun = runsByWorkflow.get(b.id)?.[0]?.atMillis ?? Number.NEGATIVE_INFINITY;
+    return aLastRun === bLastRun ? 0 : bLastRun > aLastRun ? 1 : -1;
+  });
+
   return (
     <div className="h-full overflow-auto p-4" data-testid="workflow-index">
       {loading ? (
@@ -223,7 +229,7 @@ export function WorkflowIndex({
         </p>
       ) : mode === "cards" ? (
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          {workflows.map((w) => (
+          {sortedWorkflows.map((w) => (
             <WorkflowCard
               key={w.id}
               workflow={w}
@@ -239,7 +245,7 @@ export function WorkflowIndex({
         // would drop the description while there was still room for it, and
         // keep it past the point where there wasn't (issue #1136).
         <div className="@container divide-y rounded-xl border">
-          {workflows.map((w) => (
+          {sortedWorkflows.map((w) => (
             <WorkflowRow
               key={w.id}
               workflow={w}

--- a/frontend/test/e2e/shell-two-layer.spec.ts
+++ b/frontend/test/e2e/shell-two-layer.spec.ts
@@ -205,6 +205,16 @@ test("the workflow canvas fills the card and keeps its minimap inside it", async
   await open(page, "light", "/#/workflows");
   await openFirstWorkflow(page);
 
+  // Issue #1683 opens the History rail on select. That rail is real,
+  // in-flow layout — it is what this spec's crop-bug class (#1259/#1261) is
+  // NOT about — so close it and measure the canvas against the bare card it
+  // was written against.
+  const historyToggle = page.getByTestId("workflow-history-toggle");
+  if (await historyToggle.isVisible().catch(() => false)) {
+    await historyToggle.click();
+    await expect(page.getByTestId("workflow-run-history")).toBeHidden();
+  }
+
   const canvas = await page.evaluate(() => {
     const card = document.querySelector('[data-testid="content-surface"]')!;
     const flow = document.querySelector(".react-flow");

--- a/frontend/test/e2e/workflow-canvas-escape.spec.ts
+++ b/frontend/test/e2e/workflow-canvas-escape.spec.ts
@@ -32,6 +32,19 @@ async function openCanvas(page: Page) {
   });
 }
 
+/**
+ * Issue #1683 opens the Copilot on select. Copilot and the node inspector
+ * share the canvas's right edge and Copilot wins while open (#303), so a spec
+ * driving the inspector has to close it first — same as an operator would.
+ */
+async function closeCopilotIfOpen(page: Page) {
+  const toggle = page.getByTestId("workflow-copilot-toggle");
+  if (await toggle.isVisible().catch(() => false)) {
+    await toggle.click();
+    await expect(page.getByTestId("workflow-copilot")).toBeHidden();
+  }
+}
+
 async function rightmostNode(page: Page) {
   const nodes = page.locator(".react-flow__node");
   const count = await nodes.count();
@@ -51,6 +64,7 @@ async function rightmostNode(page: Page) {
 
 test("Escape closes the node inspector and restores the canvas", async ({ page }) => {
   await openCanvas(page);
+  await closeCopilotIfOpen(page);
   const node = await rightmostNode(page);
   const before = await box(node);
 
@@ -75,7 +89,8 @@ test("Escape closes the copilot and does nothing once canvas overlays are gone",
 }) => {
   await openCanvas(page);
 
-  await page.getByTestId("workflow-copilot-toggle").click();
+  // Issue #1683 opens the Copilot on select — it is already up by the time
+  // the canvas is.
   const copilot = page.getByTestId("workflow-copilot");
   await expect(copilot).toBeVisible();
 
@@ -91,7 +106,8 @@ test("Escape closes the copilot and does nothing once canvas overlays are gone",
 test("the copilot leads with its purpose and mutes the unavailable composer", async ({ page }) => {
   await openCanvas(page);
 
-  await page.getByTestId("workflow-copilot-toggle").click();
+  // Issue #1683 opens the Copilot on select — it is already up by the time
+  // the canvas is.
   const copilot = page.getByTestId("workflow-copilot");
   await expect(copilot).toBeVisible();
   await expect(page.getByTestId("workflow-copilot-introduction")).toContainText(

--- a/frontend/test/e2e/workflow-list-columns.spec.ts
+++ b/frontend/test/e2e/workflow-list-columns.spec.ts
@@ -169,8 +169,12 @@ test("every column of the list shares one vertical edge", async ({ page }) => {
   expect(timeRights, `time right edges: ${timeRights.join(", ")}`).toHaveLength(1);
 
   // The three columns are in the order the operator reads them, and each one
-  // holds what it says it does.
-  const [name, description, status] = rows[0];
+  // holds what it says it does. Located by name rather than index 0: issue
+  // #1683 sorts the index by most-recently-run, so which row that fixture
+  // lands in is no longer "whichever is first in the fixture array".
+  const featurePipelineRow = rows.find((cells) => cells[0].text.includes("Feature pipeline"));
+  expect(featurePipelineRow, "the Feature pipeline row is rendered").toBeDefined();
+  const [name, description, status] = featurePipelineRow!;
   expect(name.right).toBeLessThan(description.left);
   expect(description.right).toBeLessThan(status.left);
   expect(name.text).toContain("Feature pipeline");
@@ -196,7 +200,11 @@ test("the description is the column that yields when the list narrows", async ({
   // item at all and the name takes the space it left.
   expect(distinct(rows.map((cells) => cells.length)).sort()).toEqual([2, 3]);
 
-  const [name, status] = rows[0];
+  // Located by name rather than index 0 — see the comment on the same lookup
+  // above.
+  const featurePipelineRow = rows.find((cells) => cells[0].text.includes("Feature pipeline"));
+  expect(featurePipelineRow, "the Feature pipeline row is rendered").toBeDefined();
+  const [name, status] = featurePipelineRow!;
   expect(name.text).toContain("Feature pipeline");
   expect(status.text).toContain("Manual run blocked");
   expect(rows.some((cells) => cells.some((cell) => cell.text.includes("A feature request goes")))).toBe(false);

--- a/frontend/test/e2e/workflow-node-inspector-reveal.spec.ts
+++ b/frontend/test/e2e/workflow-node-inspector-reveal.spec.ts
@@ -56,6 +56,19 @@ function inspector(page: Page) {
   return page.getByTestId("workflow-node-detail");
 }
 
+/**
+ * Issue #1683 opens the Copilot on select. Copilot and the node inspector
+ * share the canvas's right edge and Copilot wins while open (#303), so this
+ * spec — which is entirely about the inspector — has to close it first.
+ */
+async function closeCopilotIfOpen(page: Page) {
+  const toggle = page.getByTestId("workflow-copilot-toggle");
+  if (await toggle.isVisible().catch(() => false)) {
+    await toggle.click();
+    await expect(page.getByTestId("workflow-copilot")).toBeHidden();
+  }
+}
+
 async function box(locator: Locator) {
   const b = await locator.boundingBox();
   expect(b, "element has no box").not.toBeNull();
@@ -91,6 +104,7 @@ async function setup(page: Page, width: number, height = 900) {
   await page.goto("/#/workflows");
   await dismissTour(page);
   await openWorkflow(page, FIXTURE);
+  await closeCopilotIfOpen(page);
 
   const flow = canvas(page);
   await expect(flow).toBeVisible({ timeout: 30_000 });
@@ -177,6 +191,7 @@ test("a node nowhere near the panel does not move the canvas at all", async ({
   await page.goto("/#/workflows");
   await dismissTour(page);
   await openWorkflow(page, FIXTURE);
+  await closeCopilotIfOpen(page);
 
   const flow = canvas(page);
   await expect(flow).toBeVisible({ timeout: 30_000 });

--- a/frontend/test/e2e/workflow-run-history-rail.spec.ts
+++ b/frontend/test/e2e/workflow-run-history-rail.spec.ts
@@ -52,7 +52,8 @@ async function openHistory(page: Page) {
   } catch {
     test.skip(true, "this host does not serve …/workflows/runs");
   }
-  await toggle.click();
+  // Issue #1683: the toggle no longer needs a click to open the rail — index
+  // select already did, so clicking it here would close it instead.
   const panel = page.getByTestId("workflow-run-history");
   await expect(panel).toBeVisible();
   return panel;

--- a/frontend/test/e2e/workflow-run-history.spec.ts
+++ b/frontend/test/e2e/workflow-run-history.spec.ts
@@ -116,8 +116,9 @@ test("the run-history panel opens and shows only the selected workflow's runs", 
   // Issue #1110: History belongs to one workflow, so one has to be open.
   await openFirstWorkflow(page);
 
-  const toggle = await historyToggle(page);
-  await toggle.click();
+  // Issue #1683: index select already opens the History rail, so the toggle
+  // needs waiting on (host-support check) but not clicking.
+  await historyToggle(page);
 
   const panel = page.getByTestId("workflow-run-history");
   await expect(panel).toBeVisible();
@@ -151,8 +152,9 @@ test("running a workflow adds it to the durable history and it survives a reload
   // the same journal rather than of whichever workflow sorted first.
   await openFirstWorkflow(page);
 
-  const toggle = await historyToggle(page);
-  await toggle.click();
+  // Issue #1683: index select already opens the History rail, so the toggle
+  // needs waiting on (host-support check) but not clicking.
+  await historyToggle(page);
   const before = await page
     .getByTestId("workflow-run-history")
     .getByTestId("workflow-run-row")

--- a/frontend/test/e2e/workflow-run-result-rail.spec.ts
+++ b/frontend/test/e2e/workflow-run-result-rail.spec.ts
@@ -59,6 +59,15 @@ test("at xl the run result is a right rail, and the canvas keeps a usable width"
   await dismissTour(page);
   await openWorkflow(page, "Committed flow");
 
+  // Issue #1683 opens the History rail on select. "Only one rail open" is the
+  // scenario this case is about, so close it — the two-rail case is the third
+  // test in this file.
+  const historyToggle = page.getByTestId("workflow-history-toggle");
+  if (await historyToggle.isVisible().catch(() => false)) {
+    await historyToggle.click();
+    await expect(page.getByTestId("workflow-run-history")).toBeHidden();
+  }
+
   const flow = canvas(page);
   await expect(flow).toBeVisible();
 
@@ -121,9 +130,10 @@ test("both rails open at once: history left, run result right, canvas squeezed b
   const flow = canvas(page);
   await expect(flow).toBeVisible();
 
+  // Issue #1683: index select already opens the History rail, so the toggle
+  // needs waiting on (host-support check) but not clicking.
   const historyToggle = page.getByTestId("workflow-history-toggle");
   await historyToggle.waitFor({ state: "visible", timeout: 30_000 });
-  await historyToggle.click();
   const history = page.getByTestId("workflow-run-history");
   await expect(history).toBeVisible();
 

--- a/frontend/test/unit/workflow-index-first.test.ts
+++ b/frontend/test/unit/workflow-index-first.test.ts
@@ -245,7 +245,7 @@ describe("leaving a workflow behind", () => {
   // rather than on the back button: the one nobody remembers to update is the
   // delete, and it is the one that leaves the drawer open the longest.
   for (const route of ["the back button", "a delete"] as const) {
-    it(`closes the per-workflow drawers on ${route}, so the next one does not inherit them`, async () => {
+    it(`closes the per-workflow drawers on ${route}, then opens both defaults for the next selection`, async () => {
       const { client } = makeClient();
       await mountAt("#/workflows/alpha", client);
 
@@ -274,15 +274,19 @@ describe("leaving a workflow behind", () => {
       }
 
       expect(container.querySelector('[data-testid="workflow-index"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="workflow-run-history"]')).toBeNull();
+      expect(container.querySelector('[data-testid="workflow-copilot"]')).toBeNull();
+
       await act(async () => {
         cards()[route === "the back button" ? 1 : 0].click();
       });
 
       expect(detailName()).toBe("Beta report");
-      // `beta`'s history panel was never asked for. Left open across the index
-      // it would come up over a workflow the operator has only just opened,
-      // showing that workflow's runs under a drawer they opened for another.
-      expect(container.querySelector('[data-testid="workflow-run-history"]')).toBeNull();
+      // The old workflow's drawers did close on the index. Opening a workflow
+      // from that index is a new request, and #1683 deliberately starts both
+      // panes for the newly selected workflow.
+      expect(container.querySelector('[data-testid="workflow-run-history"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="workflow-copilot"]')).not.toBeNull();
     });
   }
 

--- a/frontend/test/unit/workflow-index-summary.test.ts
+++ b/frontend/test/unit/workflow-index-summary.test.ts
@@ -4,7 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { WorkflowSummary } from "@/api/workflows";
+import type { WorkflowRunOutcome, WorkflowSummary } from "@/api/workflows";
 import {
   WorkflowIndex,
   workflowTriggerLine,
@@ -38,12 +38,15 @@ afterEach(() => {
   container.remove();
 });
 
-function render(mode: "cards" | "list") {
+function render(
+  mode: "cards" | "list",
+  runsByWorkflow: Map<string, WorkflowRunOutcome[]> = new Map(),
+) {
   act(() => {
     root.render(
       createElement(WorkflowIndex, {
         workflows: WORKFLOWS,
-        runsByWorkflow: new Map(),
+        runsByWorkflow,
         onSelect: () => {},
         mode,
         loading: false,
@@ -81,6 +84,31 @@ describe("workflow index summary facts", () => {
       expect(older.textContent).not.toContain("0 steps");
     });
   }
+
+  it("orders list rows by the latest run and puts workflows without runs last", () => {
+    const run = (workflowId: string, atMillis: number): WorkflowRunOutcome => ({
+      seq: atMillis,
+      atMillis,
+      workflowId,
+      scheduled: false,
+      deliveries: [],
+      pendingApprovals: [],
+    });
+
+    render(
+      "list",
+      new Map([
+        ["scheduled", [run("scheduled", 1_000)]],
+        ["manual", [run("manual", 3_000)]],
+      ]),
+    );
+
+    expect(
+      Array.from(container.querySelectorAll('[data-testid="workflow-list-row"]')).map((row) =>
+        row.querySelector("span[title]")?.getAttribute("title"),
+      ),
+    ).toEqual(["Manual review", "Scheduled digest", "Older host row"]);
+  });
 });
 
 describe("workflowTriggerLine", () => {


### PR DESCRIPTION
## Summary

- Open Run history and Copilot by default when an operator selects a workflow from the index.
- Order both workflow cards and list rows by their most recent run, with workflows that have no run in the loaded page at the bottom.
- Bound the index body so its existing overflow container scrolls within the viewport.

## API Or Behavior Changes

- Selecting a workflow from the index now opens both per-workflow panes as soon as the graph becomes available.
- The index sorts a copy of the workflow list by `runsByWorkflow.get(id)?.[0]?.atMillis`, preserving the input prop and stable order for ties.
- The sort shares the existing company-wide run-page limitation: the page is capped at 200 runs, so a workflow whose latest run has fallen outside that page is treated like a workflow with no recent run.
- Known UI tradeoff: Copilot shares the right edge with the node inspector, so the inspector remains unavailable until Copilot is closed.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` (287 files, 2,515 tests)
- [x] `npm run build`
- [x] Red proof: bypassing the sort made the new ordering test fail with the original workflow order.
- [ ] Manual staging verification of pane defaults and viewport scrolling is pending.

## Documentation

No documentation changes were needed; this is console-only behavior covered by focused component contracts and the notes above.

## Related

Closes #1683
Closes #1685
