### PR TITLE
feat(workflows): live-stream workflow run trace tool calls (#1702)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2089,17 +2089,23 @@ export function AppShell({
     [typing.typers, companyPeople],
   );
   const onTurnEvent = useCallback((event: CompanyStreamEvent) => {
+    // Workflow agent-node frames carry `workflowRunId`/`nodeId` instead of a
+    // `chatId` (issue #1702) and belong to the run-trace sheet's own
+    // subscription, not to any chat timeline. Route them out BEFORE the legacy
+    // no-`chatId` fallback below, which would otherwise fold them into
+    // whichever chat turn is currently in flight.
+    if ("workflowRunId" in event && event.workflowRunId) return;
     // Route by the frame's own thread id so concurrent turns (even from the same
     // desk member) never cross-attribute; fall back to the in-flight ref only
     // when a frame carries no chatId (older host / background turn).
     const threadId =
       ("chatId" in event && event.chatId) || activeTurnThreadRef.current;
     if (!threadId) {
-      // No chat bubble to fold the frame into. Background turns (workflow
-      // nodes, dispatched cards) stream nothing at all — `run_background` runs
-      // with `LiveStream::Off` — so a chat-less frame here is a host emitting a
-      // shape this console does not render, and the Observatory's live re-read
-      // is instead driven by the workflow node events in `onWorkflowRunEvent`.
+      // No chat bubble to fold the frame into. A dispatched card streams
+      // nothing at all — `run_steered_background` runs with `LiveStream::Off` —
+      // so a chat-less frame here is a host emitting a shape this console does
+      // not render, and the Observatory's live re-read is instead driven by the
+      // workflow node events in `onWorkflowRunEvent`.
       return;
     }
     setLiveStepsByThread((prev) => {

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -349,6 +349,16 @@ export type CompanyStreamEvent =
       seq: number;
       agentId?: string;
       chatId?: string;
+      /**
+       * The workflow run this frame belongs to (issue #1702) — present instead
+       * of `chatId` when the turn is a workflow agent node rather than a chat
+       * turn. The run-trace sheet keys its live tool timeline on this so a
+       * node's in-flight frames append to the right run.
+       */
+      workflowRunId?: string;
+      /** The workflow node inside that run (issue #1702), so the sheet groups a
+       * run's live frames under the node the durable trace attributes them to. */
+      nodeId?: string;
       toolCallId?: string;
       label?: string;
       status?: string;
@@ -358,6 +368,10 @@ export type CompanyStreamEvent =
       seq: number;
       agentId?: string;
       chatId?: string;
+      /** See {@link CompanyStreamEvent} `tool_call.workflowRunId` (issue #1702). */
+      workflowRunId?: string;
+      /** See {@link CompanyStreamEvent} `tool_call.nodeId` (issue #1702). */
+      nodeId?: string;
       toolCallId?: string;
       label?: string;
       detail?: string;

--- a/frontend/src/views/workflows/RunTraceSheet.tsx
+++ b/frontend/src/views/workflows/RunTraceSheet.tsx
@@ -38,6 +38,7 @@ import { workflowHref } from "@/lib/task-output";
 import { RunHistoryRow, useRunningClock } from "./RunHistoryPanel";
 import { isRunning } from "./run-health";
 import { parseRunNodes } from "./run-output";
+import { useLiveNodeActivity, type LiveNode } from "./run-live-activity";
 
 /** One past run's output fetch, keyed by run id so a second sheet open for a
  * DIFFERENT run cannot paint a stale record over it while its own request is
@@ -71,6 +72,20 @@ export function RunTraceSheet({
   // this flips from `false` to `true` in place as the SAME run finishes —
   // rather than only ever being read once at mount.
   const runSettled = run !== null && !isRunning(run);
+
+  // Issue #1702: the live delta on top of #596's snapshot. While the run is in
+  // flight, fold this run's `tool_call`/`tool_result` frames (tagged with the
+  // workflow run + node) into a per-node tool timeline, so a workflow agent
+  // node's tool calls appear *as they happen* rather than only as output text
+  // once the run settles. The hook keeps the stream open only while running and
+  // retains what it collected after the run finishes, so the live trace stays
+  // beside the durable snapshot instead of vanishing on settle.
+  const liveActivity = useLiveNodeActivity(
+    client,
+    company,
+    runId,
+    run !== null && isRunning(run),
+  );
 
   // Issue #596's durable snapshot. A run journaled before output capture, a
   // dry run (persists nothing), or a hard-aborted run 404s — settled to
@@ -154,6 +169,18 @@ export function RunTraceSheet({
                   }}
                 />
 
+                {/* Issue #1702: the live tool timeline, shown once any frame
+                    has arrived for this run. Additive — it sits above the
+                    durable node output and never replaces it. */}
+                {liveActivity.length > 0 && (
+                  <div className="space-y-2" data-testid="run-trace-live-activity">
+                    <p className="text-3xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Live activity
+                    </p>
+                    <LiveActivityList nodes={liveActivity} live={!runSettled} />
+                  </div>
+                )}
+
                 <div className="space-y-2">
                   <p className="text-3xs font-medium uppercase tracking-wide text-muted-foreground">
                     Node output
@@ -172,6 +199,85 @@ export function RunTraceSheet({
       </SheetContent>
     </Sheet>
   );
+}
+
+/** The live tool timeline (issue #1702): a workflow agent node's `tool_call`/
+ * `tool_result` frames as they stream, grouped by node. Complements — never
+ * replaces — the durable {@link NodeOutputList}: this shows *what the node did*
+ * as it happens, that shows *what it produced* once it settles. */
+function LiveActivityList({ nodes, live }: { nodes: LiveNode[]; live: boolean }) {
+  return (
+    <div className="space-y-3" data-testid="run-trace-live">
+      {nodes.map((node) => (
+        <div
+          key={node.nodeId}
+          className="rounded-lg border bg-background/40 p-2"
+          data-testid="run-trace-live-node"
+        >
+          <p className="mb-1 text-2xs font-medium">{node.nodeId}</p>
+          <ul className="space-y-1">
+            {node.rows.map((row) => (
+              <li
+                key={row.key}
+                className="flex items-center gap-2 text-2xs"
+                data-testid="run-trace-live-row"
+              >
+                <Badge
+                  variant="outline"
+                  className={`font-normal ${liveStatusClass(row.status)}`}
+                >
+                  {liveStatusWord(row.status, live)}
+                </Badge>
+                <span className="truncate">{row.label}</span>
+                {row.detail && (
+                  <span className="truncate text-muted-foreground">
+                    {row.detail}
+                  </span>
+                )}
+                {typeof row.elapsedMs === "number" && (
+                  <span className="ml-auto shrink-0 text-muted-foreground">
+                    {row.elapsedMs} ms
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** The badge tint for a live tool row's status, reusing the run-status tokens so
+ * a live row reads the same as the folded step it becomes. */
+function liveStatusClass(status: string): string {
+  switch (status) {
+    case "ok":
+      return "border-status-done/40 bg-status-done-soft";
+    case "error":
+      return "border-status-failed/40 bg-status-failed-soft";
+    case "awaiting_approval":
+      return "border-status-blocked/40 bg-status-blocked-soft";
+    default:
+      return "border-status-running/40 bg-status-running-soft";
+  }
+}
+
+/** The word a live status shows. A still-`running` row reads "running" only
+ * while the run itself is live; once the run settles, an unfinished row is one
+ * the stream never closed, so it reads "incomplete" rather than implying it is
+ * still going. */
+function liveStatusWord(status: string, live: boolean): string {
+  switch (status) {
+    case "ok":
+      return "ok";
+    case "error":
+      return "error";
+    case "awaiting_approval":
+      return "awaiting approval";
+    default:
+      return live ? "running" : "incomplete";
+  }
 }
 
 /** What each node in the run produced, read from the durable output snapshot —

--- a/frontend/src/views/workflows/run-live-activity.ts
+++ b/frontend/src/views/workflows/run-live-activity.ts
@@ -75,13 +75,21 @@ export function foldLiveFrame(
 
   const row: LiveToolRow = {
     key,
-    // Keep the start's seq so a result does not reorder the row.
-    seq: prev?.seq ?? frame.seq,
+    // A start's seq is the row's canonical position: a result arriving after
+    // its start (the normal order) inherits the start's seq, while a start
+    // arriving after its result (broadcast reordering) uses its OWN seq rather
+    // than inheriting the later result's — so the row sits where the call began.
+    seq: isResult ? (prev?.seq ?? frame.seq) : frame.seq,
     label: frame.label ?? prev?.label ?? "Tool call",
     // The result carries detail/elapsed; a start does not, so never let a
     // start frame blank a value the result already wrote (out-of-order arrival).
     detail: isResult ? (frame.detail ?? prev?.detail) : prev?.detail,
-    status: frame.status ?? prev?.status ?? "running",
+    // A result's status is terminal; a start's is only ever "running". When a
+    // start arrives late, keep the status the result already wrote so a
+    // completed call is not shown as running again.
+    status: isResult
+      ? (frame.status ?? prev?.status ?? "running")
+      : (prev?.status ?? frame.status ?? "running"),
     elapsedMs: isResult ? (frame.elapsedMs ?? prev?.elapsedMs) : prev?.elapsedMs,
   };
 

--- a/frontend/src/views/workflows/run-live-activity.ts
+++ b/frontend/src/views/workflows/run-live-activity.ts
@@ -1,0 +1,153 @@
+// The live-streaming delta for the run-trace sheet (issue #1702).
+//
+// Issue #596 gave the sheet a durable, SNAPSHOT-only view of a finished run: the
+// per-node output text, fetched once the run settles. Nothing showed a workflow
+// agent node's tool calls *as they happened* — the sheet's in-flight state was a
+// single "Still running…" line.
+//
+// This module folds the transient `tool_call`/`tool_result` frames the host now
+// tags with `workflowRunId`/`nodeId` (see `src/turn_stream.rs`) into a per-node
+// tool timeline the sheet can render live. It is a pure reducer plus the hook
+// that drives it off the existing SSE subscription, kept out of the component so
+// the fold — where the dedup rule lives — is unit-testable without a DOM.
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { CompanyStreamEvent } from "@/hooks/use-events";
+
+/** One tool call in a node's live timeline. A start and its matching result are
+ * ONE row, not two: they share a `toolCallId`, so the result updates the row the
+ * start created in place (running → ok/error). */
+export interface LiveToolRow {
+  /** The dedup key: the frame's `toolCallId`, or `seq:<n>` when a frame carries
+   * none, so a replayed frame (a reconnect, a test) rewrites its row rather than
+   * appending a second one. */
+  key: string;
+  /** The start frame's dense per-turn sequence, so rows order by when the call
+   * began and a later result cannot jump the row to the end. */
+  seq: number;
+  label: string;
+  detail?: string;
+  /** `running` on a start; `ok` / `error` / `awaiting_approval` on the result. */
+  status: string;
+  /** Wall-clock the completed call took, on the result only. */
+  elapsedMs?: number;
+}
+
+/** The fold's internal shape: node id → (dedup key → row). Keyed maps rather
+ * than arrays so both the start/result merge and the replay dedup are O(1) and
+ * cannot double a row. */
+export type LiveActivityState = Record<string, Record<string, LiveToolRow>>;
+
+/** A node's live rows, ready to render — ordered by the call's start seq. */
+export interface LiveNode {
+  nodeId: string;
+  rows: LiveToolRow[];
+}
+
+/** When a frame carries no `nodeId` (a graph compiled before node identity, or a
+ * hand-built test request), its rows still have somewhere honest to land rather
+ * than being dropped. */
+const UNATTRIBUTED_NODE = "—";
+
+/**
+ * Folds one live frame into the per-node activity state.
+ *
+ * A no-op for any frame that is not a `tool_call`/`tool_result` for THIS run —
+ * the caller passes every frame on the company feed, so the run filter lives
+ * here rather than being trusted to the subscription. A `tool_result` merges
+ * onto the row its `tool_call` created (same `toolCallId`), which is the whole
+ * dedup: the two frames are one row, and a replay of either just rewrites it.
+ */
+export function foldLiveFrame(
+  state: LiveActivityState,
+  frame: CompanyStreamEvent,
+  workflowRunId: string,
+): LiveActivityState {
+  if (frame.type !== "tool_call" && frame.type !== "tool_result") return state;
+  if (frame.workflowRunId !== workflowRunId) return state;
+
+  const nodeId = frame.nodeId ?? UNATTRIBUTED_NODE;
+  const key = frame.toolCallId ?? `seq:${frame.seq}`;
+  const prev = state[nodeId]?.[key];
+  const isResult = frame.type === "tool_result";
+
+  const row: LiveToolRow = {
+    key,
+    // Keep the start's seq so a result does not reorder the row.
+    seq: prev?.seq ?? frame.seq,
+    label: frame.label ?? prev?.label ?? "Tool call",
+    // The result carries detail/elapsed; a start does not, so never let a
+    // start frame blank a value the result already wrote (out-of-order arrival).
+    detail: isResult ? (frame.detail ?? prev?.detail) : prev?.detail,
+    status: frame.status ?? prev?.status ?? "running",
+    elapsedMs: isResult ? (frame.elapsedMs ?? prev?.elapsedMs) : prev?.elapsedMs,
+  };
+
+  return {
+    ...state,
+    [nodeId]: { ...(state[nodeId] ?? {}), [key]: row },
+  };
+}
+
+/** Projects the keyed fold into render-ready nodes: rows sorted by start seq,
+ * nodes sorted by their earliest row so a node that started first sits first. */
+export function liveNodes(state: LiveActivityState): LiveNode[] {
+  return Object.entries(state)
+    .map(([nodeId, rows]) => ({
+      nodeId,
+      rows: Object.values(rows).sort((a, b) => a.seq - b.seq),
+    }))
+    .filter((node) => node.rows.length > 0)
+    .sort((a, b) => a.rows[0].seq - b.rows[0].seq);
+}
+
+/**
+ * Subscribes to the company SSE feed and folds this run's live tool frames into
+ * a per-node timeline, for the run-trace sheet to render while a run executes
+ * (issue #1702).
+ *
+ * `active` gates the subscription — the sheet passes `isRunning(run)`, so the
+ * stream is open only while the run is in flight. When it settles the hook stops
+ * folding but KEEPS what it collected, so the live trace stays on screen beside
+ * the durable snapshot rather than vanishing the instant the run finishes. The
+ * collected rows reset only when `workflowRunId` changes (a different run opened
+ * in the sheet).
+ */
+export function useLiveNodeActivity(
+  client: OpenCompanyClient,
+  company: string | null,
+  workflowRunId: string | null,
+  active: boolean,
+): LiveNode[] {
+  const [state, setState] = useState<LiveActivityState>({});
+
+  // A new run in the sheet starts from an empty timeline; a settle does not.
+  useEffect(() => {
+    setState({});
+  }, [workflowRunId]);
+
+  useEffect(() => {
+    if (!active || !workflowRunId) return;
+    const unsubscribe = client.subscribeToEvents(company, {
+      onMessage: (data) => {
+        let frame: CompanyStreamEvent;
+        try {
+          frame = JSON.parse(data) as CompanyStreamEvent;
+        } catch {
+          return;
+        }
+        if (
+          (frame.type === "tool_call" || frame.type === "tool_result") &&
+          frame.workflowRunId === workflowRunId
+        ) {
+          setState((prev) => foldLiveFrame(prev, frame, workflowRunId));
+        }
+      },
+    });
+    return unsubscribe;
+  }, [client, company, workflowRunId, active]);
+
+  return useMemo(() => liveNodes(state), [state]);
+}

--- a/frontend/src/views/workflows/run-live-activity.ts
+++ b/frontend/src/views/workflows/run-live-activity.ts
@@ -138,22 +138,31 @@ export function useLiveNodeActivity(
 
   useEffect(() => {
     if (!active || !workflowRunId) return;
-    const unsubscribe = client.subscribeToEvents(company, {
-      onMessage: (data) => {
-        let frame: CompanyStreamEvent;
-        try {
-          frame = JSON.parse(data) as CompanyStreamEvent;
-        } catch {
-          return;
-        }
-        if (
-          (frame.type === "tool_call" || frame.type === "tool_result") &&
-          frame.workflowRunId === workflowRunId
-        ) {
-          setState((prev) => foldLiveFrame(prev, frame, workflowRunId));
-        }
-      },
-    });
+    let unsubscribe: (() => void) | undefined;
+    try {
+      unsubscribe = client.subscribeToEvents(company, {
+        onMessage: (data) => {
+          let frame: CompanyStreamEvent;
+          try {
+            frame = JSON.parse(data) as CompanyStreamEvent;
+          } catch {
+            return;
+          }
+          if (
+            (frame.type === "tool_call" || frame.type === "tool_result") &&
+            frame.workflowRunId === workflowRunId
+          ) {
+            setState((prev) => foldLiveFrame(prev, frame, workflowRunId));
+          }
+        },
+      });
+    } catch {
+      // Streaming unavailable (no `EventSource`, a malformed URL, …): the
+      // contract lets `subscribeToEvents` throw synchronously, and the sheet
+      // must simply omit the live half and keep the durable snapshot rather
+      // than surface a React effect error and blank the view.
+      return;
+    }
     return unsubscribe;
   }, [client, company, workflowRunId, active]);
 

--- a/frontend/test/unit/run-live-activity.test.ts
+++ b/frontend/test/unit/run-live-activity.test.ts
@@ -104,10 +104,15 @@ describe("folding a workflow node's live tool frames (issue #1702)", () => {
 
   it("does not let an out-of-order start blank a value the result already wrote", () => {
     // If the start arrives after its result (broadcast reordering), the merge
-    // must not clobber the result's detail/elapsed with the start's absence.
+    // must not clobber the result's detail/elapsed/status with the start's
+    // absence — the call completed, and it started where its own start says.
     const nodes = liveNodes(fold([toolResult({}), toolCall({})]));
     const row = nodes[0].rows[0];
     expect(row.detail).toBe("brave · search");
     expect(row.elapsedMs).toBe(42);
+    expect(row.status).toBe("ok");
+    // The late start still anchors the row to the call's own start sequence,
+    // rather than inheriting the later result's.
+    expect(row.seq).toBe(0);
   });
 });

--- a/frontend/test/unit/run-live-activity.test.ts
+++ b/frontend/test/unit/run-live-activity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompanyStreamEvent } from "@/hooks/use-events";
+import {
+  foldLiveFrame,
+  liveNodes,
+  type LiveActivityState,
+} from "@/views/workflows/run-live-activity";
+
+/**
+ * The live-streaming delta for the run-trace sheet (issue #1702).
+ *
+ * The fold is where the whole feature's correctness lives: a start and its
+ * result are ONE row, a frame for another run is ignored, and a replayed frame
+ * never doubles a row. These are pure-reducer facts, tested here without a DOM
+ * so the sheet component stays a thin renderer over them.
+ */
+const RUN = "wfr-1";
+
+function toolCall(
+  over: Partial<Extract<CompanyStreamEvent, { type: "tool_call" }>>,
+): CompanyStreamEvent {
+  return {
+    type: "tool_call",
+    seq: 0,
+    workflowRunId: RUN,
+    nodeId: "summarise",
+    toolCallId: "c1",
+    label: "Search the web",
+    status: "running",
+    ...over,
+  };
+}
+
+function toolResult(
+  over: Partial<Extract<CompanyStreamEvent, { type: "tool_result" }>>,
+): CompanyStreamEvent {
+  return {
+    type: "tool_result",
+    seq: 1,
+    workflowRunId: RUN,
+    nodeId: "summarise",
+    toolCallId: "c1",
+    label: "Search the web",
+    detail: "brave · search",
+    status: "ok",
+    elapsedMs: 42,
+    ...over,
+  };
+}
+
+function fold(frames: CompanyStreamEvent[], run = RUN): LiveActivityState {
+  return frames.reduce<LiveActivityState>(
+    (state, frame) => foldLiveFrame(state, frame, run),
+    {},
+  );
+}
+
+describe("folding a workflow node's live tool frames (issue #1702)", () => {
+  it("groups a running tool call under its node", () => {
+    const nodes = liveNodes(fold([toolCall({})]));
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].nodeId).toBe("summarise");
+    expect(nodes[0].rows).toHaveLength(1);
+    expect(nodes[0].rows[0].status).toBe("running");
+    expect(nodes[0].rows[0].label).toBe("Search the web");
+  });
+
+  it("merges a result onto the row its call created — one row, not two", () => {
+    const nodes = liveNodes(fold([toolCall({}), toolResult({})]));
+    expect(nodes[0].rows).toHaveLength(1);
+    const row = nodes[0].rows[0];
+    expect(row.status).toBe("ok");
+    expect(row.detail).toBe("brave · search");
+    expect(row.elapsedMs).toBe(42);
+    // The row keeps the start's seq so a later result cannot reorder it.
+    expect(row.seq).toBe(0);
+  });
+
+  it("ignores a frame that belongs to a different run", () => {
+    const nodes = liveNodes(
+      fold([toolCall({ workflowRunId: "some-other-run" })]),
+    );
+    expect(nodes).toHaveLength(0);
+  });
+
+  it("does not double a row when a frame is replayed", () => {
+    // A reconnect re-delivers the same start; the keyed fold must rewrite the
+    // one row rather than append a second.
+    const nodes = liveNodes(fold([toolCall({}), toolCall({}), toolResult({})]));
+    expect(nodes[0].rows).toHaveLength(1);
+    expect(nodes[0].rows[0].status).toBe("ok");
+  });
+
+  it("keeps rows from different nodes apart, ordered by when each started", () => {
+    const nodes = liveNodes(
+      fold([
+        toolCall({ nodeId: "fetch", toolCallId: "a", seq: 0 }),
+        toolCall({ nodeId: "summarise", toolCallId: "b", seq: 1 }),
+      ]),
+    );
+    expect(nodes.map((n) => n.nodeId)).toEqual(["fetch", "summarise"]);
+  });
+
+  it("does not let an out-of-order start blank a value the result already wrote", () => {
+    // If the start arrives after its result (broadcast reordering), the merge
+    // must not clobber the result's detail/elapsed with the start's absence.
+    const nodes = liveNodes(fold([toolResult({}), toolCall({})]));
+    const row = nodes[0].rows[0];
+    expect(row.detail).toBe("brave · search");
+    expect(row.elapsedMs).toBe(42);
+  });
+});

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -815,12 +815,20 @@ impl CompanyAgent {
                 if let Some(ctx) = &stream
                     && let Some(frame) = steps::stream_event_from(&event, seq, &mut thinking_open)
                 {
-                    crate::turn_stream::publish(
-                        &ctx.company,
-                        frame
-                            .with_agent(ctx.agent_id.clone())
-                            .with_chat(ctx.chat_id.clone()),
-                    );
+                    let frame = frame.with_agent(ctx.agent_id.clone());
+                    // Route by the turn's surface: a chat turn stamps `chatId`;
+                    // a workflow agent node stamps `workflowRunId`/`nodeId`
+                    // instead, since it has no chat thread and the console's
+                    // run-trace sheet keys the live timeline on the run (#1702).
+                    let frame = match &ctx.route {
+                        crate::turn_stream::LiveRoute::Chat { chat_id } => {
+                            frame.with_chat(chat_id.clone())
+                        }
+                        crate::turn_stream::LiveRoute::Workflow { run_id, node_id } => {
+                            frame.with_workflow(run_id.clone(), node_id.clone())
+                        }
+                    };
+                    crate::turn_stream::publish(&ctx.company, frame);
                     seq += 1;
                 }
                 // Durable half (#242): persist the step before moving on, so a
@@ -1330,7 +1338,18 @@ impl Default for HarnessPool {
 #[derive(Clone, Copy)]
 enum LiveStream<'a> {
     Off,
-    On { chat_id: Option<&'a str> },
+    On {
+        chat_id: Option<&'a str>,
+    },
+    /// A workflow agent node (issue #1702): it streams live like `On`, but its
+    /// frames route by the workflow run + node rather than a chat thread — the
+    /// node has no chat bubble, and the console's run-trace sheet keys the live
+    /// timeline on the run. This is what makes a node's tool calls appear live
+    /// without misattributing to whatever thread most recently sent (#125).
+    Workflow {
+        run_id: &'a str,
+        node_id: &'a str,
+    },
 }
 
 /// Per-company serialization of the roster's policy-axis decision through its
@@ -2399,6 +2418,42 @@ impl HarnessPool {
         .await
     }
 
+    /// Like [`run_background`](Self::run_background) but tees the node's live
+    /// tool-call frames onto the turn-stream bus (issue #1702).
+    ///
+    /// A workflow agent node still shows no operator chat bubble, so its frames
+    /// cannot route by a chat thread — they carry the workflow `run_id`/`node_id`
+    /// instead, and the console's run-trace sheet keys the in-flight tool
+    /// timeline on the run. This is the only difference from `run_background`:
+    /// the durable per-attempt trace (`run_sink`) is unchanged, and a
+    /// tag/publish hiccup can never fail the turn (the collector's publish is
+    /// best-effort and the frame carries only the already-scrubbed projection).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_background_workflow(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        deps: &HarnessDeps,
+        run_sink: Option<Arc<RunTraceSink>>,
+        workflow_run_id: &str,
+        node_id: &str,
+    ) -> crate::Result<TurnOutcome> {
+        self.run_inner(
+            company,
+            agent_id,
+            message,
+            deps,
+            None,
+            LiveStream::Workflow {
+                run_id: workflow_run_id,
+                node_id,
+            },
+            run_sink,
+        )
+        .await
+    }
+
     /// Routes a message to one agent with an operator **steer** control installed
     /// (issue #111), so a dispatched task / desk delegation can be paused,
     /// cancelled, or redirected mid-flight. Otherwise identical to
@@ -2571,9 +2626,11 @@ impl HarnessPool {
         let stream_ctx = Some(crate::turn_stream::TurnStreamCtx {
             company: company.clone(),
             agent_id: confine::CONFINED_AGENT_ID.to_string(),
-            chat_id: chat_id
-                .map(str::to_string)
-                .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
+            route: crate::turn_stream::LiveRoute::Chat {
+                chat_id: chat_id
+                    .map(str::to_string)
+                    .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
+            },
         });
 
         // The message goes to the model AS SENT. This is the retrieve→inject
@@ -2804,9 +2861,22 @@ impl HarnessPool {
                 // cross-attribute. Falls back to the default desk to match the
                 // durable reply when the caller addressed no desk (e.g. an API
                 // client that omits `chat`).
-                chat_id: chat_id
-                    .map(str::to_string)
-                    .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
+                route: crate::turn_stream::LiveRoute::Chat {
+                    chat_id: chat_id
+                        .map(str::to_string)
+                        .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
+                },
+            }),
+            // A workflow agent node (issue #1702): streams live, but keyed on
+            // the workflow run + node so its frames land on the console's
+            // run-trace sheet rather than misattributing to a chat thread.
+            LiveStream::Workflow { run_id, node_id } => Some(crate::turn_stream::TurnStreamCtx {
+                company: company.clone(),
+                agent_id: agent_id.to_string(),
+                route: crate::turn_stream::LiveRoute::Workflow {
+                    run_id: run_id.to_string(),
+                    node_id: node_id.to_string(),
+                },
             }),
             LiveStream::Off => None,
         };

--- a/src/harness/built_in/run_turn.rs
+++ b/src/harness/built_in/run_turn.rs
@@ -96,6 +96,28 @@ impl RunTurn for HarnessRunTurn {
             .await
     }
 
+    async fn run_background_workflow(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        run_sink: Option<Arc<RunTraceSink>>,
+        workflow_run_id: &str,
+        node_id: &str,
+    ) -> Result<TurnOutcome> {
+        self.pool
+            .run_background_workflow(
+                company,
+                agent_id,
+                message,
+                &self.deps,
+                run_sink,
+                workflow_run_id,
+                node_id,
+            )
+            .await
+    }
+
     async fn ensure(&self, company: &CompanyRecord) -> Result<()> {
         self.pool.ensure(company, &self.deps).await
     }

--- a/src/harness/router.rs
+++ b/src/harness/router.rs
@@ -240,6 +240,27 @@ impl RunTurn for HarnessRouter {
             .await
     }
 
+    async fn run_background_workflow(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        run_sink: Option<Arc<RunTraceSink>>,
+        workflow_run_id: &str,
+        node_id: &str,
+    ) -> Result<TurnOutcome> {
+        self.engine_for(agent_id)?
+            .run_background_workflow(
+                company,
+                agent_id,
+                message,
+                run_sink,
+                workflow_run_id,
+                node_id,
+            )
+            .await
+    }
+
     async fn ensure(&self, company: &CompanyRecord) -> Result<()> {
         // Warm every engine's roster before the first turn, recording each
         // lane's failure rather than stopping at the first: one bad lane must

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -123,6 +123,32 @@ pub trait RunTurn: Send + Sync {
         self.run(company, agent_id, message, None).await
     }
 
+    /// Like [`run_background`](Self::run_background) but streams the node's live
+    /// tool-call frames onto the turn-stream bus tagged with the workflow
+    /// `run_id`/`node_id` (issue #1702), so the console's run-trace sheet can
+    /// render a workflow agent node's tool calls *live* — the one dimension the
+    /// merged snapshot trace does not carry.
+    ///
+    /// Defaults to [`run_background`](Self::run_background) so the sentinel and
+    /// every test double inherit the existing un-streamed behaviour unchanged;
+    /// only the streaming harness engines override it to actually publish the
+    /// live frames.
+    async fn run_background_workflow(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        run_sink: Option<Arc<RunTraceSink>>,
+        workflow_run_id: &str,
+        node_id: &str,
+    ) -> Result<TurnOutcome> {
+        // The default cannot stream (it has no turn-stream seam), so the ids are
+        // unused and the turn runs exactly as an un-streamed background node.
+        let _ = (workflow_run_id, node_id);
+        self.run_background(company, agent_id, message, run_sink)
+            .await
+    }
+
     /// Warms whatever roster this engine caches before the first turn. The
     /// default is a no-op; a harness that builds its roster lazily behind a
     /// pool overrides it so a caller can ensure every lane before dispatch.

--- a/src/turn_stream.rs
+++ b/src/turn_stream.rs
@@ -220,6 +220,18 @@ pub struct TurnStreamEvent {
     /// Wall-clock the completed call took, on `tool_result` only.
     #[serde(rename = "elapsedMs", skip_serializing_if = "Option::is_none")]
     pub elapsed_ms: Option<u64>,
+    /// The workflow **run** this frame belongs to, when the turn is a workflow
+    /// agent node rather than a chat turn (issue #1702). The console's run-trace
+    /// sheet keys the live tool timeline on this so a node's in-flight frames
+    /// append to the right run. Absent on a chat turn, which routes by `chatId`
+    /// instead — the two are mutually exclusive routing dimensions, never both.
+    #[serde(rename = "workflowRunId", skip_serializing_if = "Option::is_none")]
+    pub workflow_run_id: Option<String>,
+    /// The workflow **node** inside that run this frame belongs to (issue
+    /// #1702), so the sheet groups a run's live frames under the same node the
+    /// durable trace attributes them to. Absent on a chat turn.
+    #[serde(rename = "nodeId", skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
 }
 
 impl Default for TurnStreamEvent {
@@ -241,6 +253,8 @@ impl Default for TurnStreamEvent {
             truncated: false,
             status: None,
             elapsed_ms: None,
+            workflow_run_id: None,
+            node_id: None,
         }
     }
 }
@@ -258,6 +272,17 @@ impl TurnStreamEvent {
         self.chat_id = Some(chat_id.into());
         self
     }
+
+    /// Stamp the workflow run + node onto a frame just before publish, so the
+    /// console's run-trace sheet routes it under the right run and node (issue
+    /// #1702). Used instead of [`with_chat`](Self::with_chat) on a workflow
+    /// agent node, which carries no chat thread — the two routing dimensions
+    /// are mutually exclusive.
+    pub fn with_workflow(mut self, run_id: impl Into<String>, node_id: impl Into<String>) -> Self {
+        self.workflow_run_id = Some(run_id.into());
+        self.node_id = Some(node_id.into());
+        self
+    }
 }
 
 /// Routing context a turn carries so its live frames reach the right console
@@ -272,11 +297,30 @@ pub struct TurnStreamCtx {
     pub company: CompanyId,
     /// The responding agent/desk, stamped onto each frame's `agentId`.
     pub agent_id: String,
+    /// Where this turn's live frames route on the console: a chat thread, or a
+    /// workflow run+node. The two are mutually exclusive, so an enum keeps a
+    /// frame from ever carrying both (or neither) routing key.
+    pub route: LiveRoute,
+}
+
+/// Which console surface a turn's live frames route to.
+///
+/// A chat turn keys its in-flight tool timeline on `chatId`; a workflow agent
+/// node has no chat thread and keys on the workflow run + node instead (issue
+/// #1702). Modelled as an enum rather than two `Option`s so a frame cannot be
+/// built with both keys set or neither — the same "make the illegal state
+/// unrepresentable" posture the run-trace sink takes.
+#[derive(Clone, Debug)]
+pub enum LiveRoute {
     /// The chat/desk thread this turn answers, stamped onto each frame's
     /// `chatId` so the console routes the live timeline to the same thread the
     /// durable `agent_reply` lands on. Matches the id journaled as
     /// `AgentReply.chat_id` for this turn.
-    pub chat_id: String,
+    Chat { chat_id: String },
+    /// The workflow run + node this turn belongs to, stamped onto each frame's
+    /// `workflowRunId`/`nodeId` so the console's run-trace sheet appends the
+    /// node's in-flight frames to the right run while it is still executing.
+    Workflow { run_id: String, node_id: String },
 }
 
 /// The sender for a company, created on first use. Mirrors `store::fs`'s
@@ -439,6 +483,48 @@ mod tests {
         assert_ne!(a.chat_id, b.chat_id);
     }
 
+    /// Issue #1702: a workflow agent node's frame carries the workflow run +
+    /// node instead of a chat thread, and serializes them as `workflowRunId` /
+    /// `nodeId`. This is what lets the console's run-trace sheet key the live
+    /// tool timeline on the run.
+    #[test]
+    fn with_workflow_stamps_run_and_node_on_the_wire() {
+        let f = frame("tool_call", 3)
+            .with_agent("researcher")
+            .with_workflow("wfr-42", "summarise");
+        assert_eq!(f.workflow_run_id.as_deref(), Some("wfr-42"));
+        assert_eq!(f.node_id.as_deref(), Some("summarise"));
+        // A workflow node has no chat thread, so `with_workflow` must not invent
+        // one — the two routing dimensions are mutually exclusive.
+        assert!(f.chat_id.is_none());
+
+        let j = serde_json::to_value(&f).expect("serialize");
+        assert_eq!(j["workflowRunId"], "wfr-42");
+        assert_eq!(j["nodeId"], "summarise");
+        assert!(
+            j.get("chatId").is_none(),
+            "a workflow-tagged frame carries no chatId"
+        );
+    }
+
+    /// The tagging is additive: a chat turn's frame still stamps `chatId` and
+    /// omits the workflow ids entirely, so an existing chat console reads the
+    /// wire form byte-for-byte as it did before #1702.
+    #[test]
+    fn a_chat_frame_omits_the_workflow_ids() {
+        let j =
+            serde_json::to_value(frame("tool_call", 0).with_chat("General")).expect("serialize");
+        assert_eq!(j["chatId"], "General");
+        assert!(
+            j.get("workflowRunId").is_none(),
+            "a chat frame must not carry a workflowRunId"
+        );
+        assert!(
+            j.get("nodeId").is_none(),
+            "a chat frame must not carry a nodeId"
+        );
+    }
+
     /// A publish with no subscriber is a silent no-op — a turn streams whether or
     /// not a console is watching.
     #[test]
@@ -465,6 +551,8 @@ mod tests {
             truncated: false,
             status: Some("ok"),
             elapsed_ms: Some(12),
+            workflow_run_id: None,
+            node_id: None,
         };
         let j = serde_json::to_value(f.with_chat("General")).expect("serialize");
         assert_eq!(j["type"], "tool_result");

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -2069,6 +2069,169 @@ mod tests {
         ))
     }
 
+    /// A [`RunTurn`] that records the workflow-route ids each
+    /// `run_background_workflow` call receives, standing in for the harness pool
+    /// so the #1702 dispatch test can assert the run and node ids actually reach
+    /// the turn rather than being silently dropped by a fallback to the
+    /// un-streamed `run_background`.
+    struct RecordingWorkflowTurn {
+        /// `(agent_ref, workflow_run_id, node_id)` per call, in order.
+        calls: std::sync::Mutex<Vec<(String, String, String)>>,
+    }
+
+    impl RecordingWorkflowTurn {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    /// The shape every recorded turn answers with — the dispatch under test only
+    /// cares about the ids it is handed, not what the (absent) agent did.
+    fn ok_outcome() -> crate::harness::TurnOutcome {
+        crate::harness::TurnOutcome {
+            reply: "ok".to_string(),
+            steps: Vec::new(),
+            hit_iteration_cap: false,
+            halted_for_spend: None,
+        }
+    }
+
+    #[async_trait]
+    impl RunTurn for RecordingWorkflowTurn {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _chat_id: Option<&str>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            Ok(ok_outcome())
+        }
+
+        async fn run_steered(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat_id: Option<&str>,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            Ok(ok_outcome())
+        }
+
+        async fn run_steered_background(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            Ok(ok_outcome())
+        }
+
+        async fn run_background_workflow(
+            &self,
+            _company: &CompanyId,
+            agent_id: &str,
+            _message: &str,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+            workflow_run_id: &str,
+            node_id: &str,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            self.calls.lock().expect("calls").push((
+                agent_id.to_string(),
+                workflow_run_id.to_string(),
+                node_id.to_string(),
+            ));
+            Ok(ok_outcome())
+        }
+    }
+
+    /// Issue #1702: the workflow agent-node dispatch routes through
+    /// `run_background_workflow`, not the un-streamed `run_background`, so the
+    /// node's live tool frames stream tagged with the run and node ids. This
+    /// pins the forward: a regression that swapped the arguments or fell back
+    /// to `run_background` would leave the node functional but its live
+    /// activity silently gone.
+    #[tokio::test]
+    async fn an_agent_node_dispatches_through_run_background_workflow_with_run_and_node_ids() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1702-")
+            .tempdir()
+            .expect("tempdir");
+        let (deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        let record = crate::workflows::gated_tool_turn_test::record();
+        let turn = Arc::new(RecordingWorkflowTurn::new());
+        let board_claim = Arc::new(deps.delegations.claim_board("run-1702"));
+        let publish_refusal_claim =
+            Arc::new(deps.pending_publishes.claim_refusals_for_run("run-1702"));
+        let runner = HarnessAgentRunner::new(
+            turn.clone(),
+            deps,
+            record,
+            CompanyId::new("acme"),
+            "wf-1".to_string(),
+            "run-1702".to_string(),
+            None,
+            RunNotices::default(),
+            RunBoard::default(),
+            RunBlocks::default(),
+            RunApprovals::default(),
+            board_claim,
+            publish_refusal_claim,
+        );
+
+        // A node resolved from the graph: `node_id` present, so the resolved
+        // `lineage_node` is that id, and the turn must receive the runner's OWN
+        // run id.
+        let (_, outcome) = runner
+            .run_turn(
+                "researcher",
+                json!({ "node_id": "gather", "prompt": "collect the numbers" }),
+            )
+            .await
+            .expect("agent node turn");
+        assert_eq!(outcome.reply, "ok");
+        assert_eq!(
+            turn.calls.lock().expect("calls").as_slice(),
+            &[(
+                "researcher".to_string(),
+                "run-1702".to_string(),
+                "gather".to_string(),
+            )],
+            "the node's live frames must be tagged with the runner's run id and the resolved node id"
+        );
+
+        // A node with no graph id (a hand-built request, or a graph compiled
+        // before #881) resolves lineage to the agent ref — and the ids still
+        // route through, tagged with that fallback.
+        runner
+            .run_turn("researcher", json!({ "prompt": "no node id" }))
+            .await
+            .expect("agent node turn without a node id");
+        assert_eq!(
+            turn.calls.lock().expect("calls").as_slice(),
+            &[
+                (
+                    "researcher".to_string(),
+                    "run-1702".to_string(),
+                    "gather".to_string(),
+                ),
+                (
+                    "researcher".to_string(),
+                    "run-1702".to_string(),
+                    "researcher".to_string(),
+                ),
+            ],
+            "a node with no graph id resolves lineage to the agent ref"
+        );
+    }
+
     /// Issue #638: a node that gates more calls than the cap allows leaves the
     /// operator a **notice**, not only a log line.
     ///

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1455,11 +1455,19 @@ impl HarnessAgentRunner {
         // first spawning run without these.
         let turn = Box::pin(async {
             let outcome = claim
-                .scoped(Box::pin(self.turn.run_background(
+                .scoped(Box::pin(self.turn.run_background_workflow(
                     &self.company,
                     agent_ref,
                     &message,
                     run_sink.clone(),
+                    // The workflow run + node this turn belongs to (issue #1702):
+                    // its live tool-call frames stream tagged with these so the
+                    // console's run-trace sheet appends them under the right run
+                    // while the node is still executing. `lineage_node` is the
+                    // resolved node id (graph node, else the agent ref) — the
+                    // same id the durable trace attributes the node's steps to.
+                    &self.run_id,
+                    &lineage_node,
                 )))
                 .await;
             // Drained on BOTH arms, deliberately. A turn that errored may still have


### PR DESCRIPTION
## Summary

This is the **live-streaming delta only** for the workflow run trace (#1702),
rebuilt on top of the merged observability foundation (`4a6929132`, "record and
surface what happens inside a workflow agent").

That foundation already gives a run its durable, **snapshot/replay** trace: a
deep `RunTraceSink` with node-attributed `RunStepRecord`s, `run_background`
threading the sink per node, the `runs/{rid}/output` route, and the whole
run-trace / Observatory surface in the console. What none of it does is stream a
workflow agent node's tool calls **live** — the node's in-flight view was a
single "Still running…" line, and #1702 is titled *real-time*.

This PR adds exactly that missing dimension and nothing else. It deliberately
does **not** duplicate main's durable sink, step store, `runs/{rid}/output`
route, or Observatory views — those already exist and own durability. The old 5
commits on this branch (which predated the merge and re-implemented that
foundation) were discarded; the branch was reset onto `main` and rebuilt as this
delta.

**Backend** — a workflow agent node already publishes a scrubbed live tool frame
at the collector choke point where it writes its durable trace row; that frame
now also carries the workflow identity:

- `TurnStreamEvent` gains additive `workflowRunId?` / `nodeId?`
  (`skip_serializing_if`), so a chat turn's frame is byte-for-byte unchanged.
- A `with_workflow(run_id, node_id)` builder + a `LiveStream::Workflow` /
  `LiveRoute::Workflow` variant so a node's frames route by the run+node instead
  of a chat thread (a node has no chat bubble — the reason these turns published
  nothing before, per #125).
- `RunTurn::run_background_workflow` (default delegates to `run_background`, so
  test doubles and the sentinel are unchanged) supplies the ids the runner
  already has in scope; publish stays best-effort in the always-draining
  collector, so a tag/publish hiccup can never fail the turn.
- Privacy: it reuses main's existing scrubbed frame only — no raw
  args/output/error, no new raw field.

**Frontend** — the existing `RunTraceSheet` is made live: while a run is in
flight it subscribes to that run's `tool_call`/`tool_result` frames (filtered by
`workflowRunId`), groups them by `nodeId`, and appends a per-node tool timeline
above the durable node-output snapshot. A start and its result are one row (keyed
on the call id), so a row is never shown twice and a reconnect replay cannot
double it. The settled snapshot (#596) still renders unchanged.

## API Or Behavior Changes

- **SSE (additive, wire-compatible):** `tool_call` / `tool_result` live frames
  may now carry `workflowRunId` + `nodeId` when the turn is a workflow agent
  node. A chat turn still stamps `chatId` and carries neither id; both fields are
  omitted when absent, so existing chat consumers are unaffected.
- **New behavior:** a workflow agent node's tool calls now stream live onto the
  company SSE feed and render in the run-trace sheet while the run executes.
  Previously these turns published no live frames at all.
- No durable store, route, or schema changes — durability is unchanged from
  `4a6929132`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (and `--features openhuman,mcp,media,composio --all-targets`)
- [x] `cargo test` — scoped: `turn_stream` (default 8; openhuman + `runtime::delegation` / `harness::router` / `harness::built_in::run_turn` = 101), `workflows::caps` (105)
- [x] Frontend: `npm run typecheck` / `typecheck:unit` / `typecheck:e2e`, `npx vitest run` (3160 passed), `npm run build`

New tests, each red-proofed against unfixed code then restored:

- `turn_stream`: a workflow frame carries `workflowRunId`+`nodeId` and no
  `chatId`; a chat frame carries `chatId` and omits both ids (wire-compat).
- `run-live-activity` (frontend): start+result merge into one row; a frame for
  another run is ignored; a replayed frame does not double a row; per-node
  grouping and ordering.

## Documentation

None — no public API, route, or schema changed. The live SSE frames extend the
transient turn-stream bus documented in `src/turn_stream.rs`, whose module docs
and the frame types' doc comments are updated in place.

## Related

Closes #1702
Builds on `4a6929132` (workflow-agent observability foundation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live activity tracking to workflow run traces, showing tool calls and results as nodes execute.
  * Live activity is linked to the relevant workflow run and node.
  * Activity remains visible after completion, including incomplete statuses when applicable.

* **Bug Fixes**
  * Improved handling of duplicate, delayed, and out-of-order activity events.
  * Prevented workflow activity from appearing in unrelated chat timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->