### PR TITLE
fix(usage): write harness usage to the selected backend, not always fs

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2451,7 +2451,14 @@ impl RuntimeBuilder {
                                 serves: None,
                                 context: context.clone(),
                                 store: store.clone(),
-                                meter: Some(fs_ops.clone()),
+                                // The harness must write usage to the SELECTED
+                                // backend, not always the filesystem. The read
+                                // side (`company.usage`) reads `ops.usage` — the
+                                // selected backend — so on a non-fs store the
+                                // samples were written to disk while the console
+                                // read an empty table. Same handle the read side
+                                // resolves to (see the `usage:` field below).
+                                meter: Some(ops.usage.clone()),
                                 workspace_root: home.join("harness"),
                                 // The company's own MCP store, so the
                                 // registry tools on the belt read the same


### PR DESCRIPTION
## Problem

The harness usage meter is hardcoded to `fs_ops`:

```rust
meter: Some(fs_ops.clone()),
```

but the read side (`company.usage`, WS5) resolves `ops.usage` — the **configured** usage backend (see the `usage:` field a few lines up: `usage: self.usage.unwrap_or_else(|| fs_ops.clone())`).

On a non-filesystem store (e.g. MongoDB) the two diverge: the harness (WS4 cost hook) writes samples to `<data>/companies/<id>/usage.jsonl` on disk, while the console reads an empty `usage_samples` collection. The Usage tab then shows zero tokens and zero cost while real turns are running.

## Fix

Point the meter at the same handle the read side uses:

```rust
meter: Some(ops.usage.clone()),
```

`OpsStores.usage` is `Arc<dyn UsageMeter>`, so this is type-identical to the old value on a filesystem store (no behaviour change there) and correct on every other backend.

Observed on a MongoDB-backed deployment: hundreds of on-disk `usage.jsonl` lines, zero documents in the store the console reads, and a Usage tab reporting nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage metering now records data through the selected usage backend, ensuring configured storage destinations are respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->