### PR TITLE
fix(users): log mail-delivery failures at error, not warn

### DIFF
--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -352,7 +352,10 @@ async fn send_invite_mail(
         Err(err) => {
             // The error, never the message: a body echoed into a log or into
             // telemetry carries the recipient's address off this host.
-            tracing::warn!(company = %runtime.id(), "invite mail failed: {err}");
+            // `error!`, not `warn!`: the default `EnvFilter` (no `RUST_LOG`)
+            // shows errors only, and this is the only line that records why an
+            // invite could not be delivered.
+            tracing::error!(company = %runtime.id(), "invite mail failed: {err}");
             InviteDelivery::Failed
         }
     }

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -820,7 +820,10 @@ async fn deliver_code(
         Ok(()) => true,
         Err(err) => {
             // Logged, not returned: the caller must not learn the address exists.
-            tracing::warn!(company = %runtime.id(), "login mail failed: {err}");
+            // `error!`, not `warn!`: without `RUST_LOG` the default
+            // `EnvFilter` shows errors only, and this is the sole record of why
+            // nobody can sign in.
+            tracing::error!(company = %runtime.id(), "login mail failed: {err}");
             false
         }
     }


### PR DESCRIPTION
A failed invite or login-code mail is logged at `warn!`:

```rust
tracing::warn!(company = %runtime.id(), "invite mail failed: {err}");
tracing::warn!(company = %runtime.id(), "login mail failed: {err}");
```

but the default `EnvFilter` (no `RUST_LOG` set) shows errors only. These two lines are the *sole* record of why a mail could not be delivered — and therefore why a user cannot sign in. At the default log level the cause is silently dropped, so an operator sees "login failed" with no reason in the logs.

Raise both to `error!` so the cause is visible without having to reconfigure logging first.