### PR TITLE
feat(operator): journal a visible notice when a chat turn aborts

### DIFF
--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2114,6 +2114,40 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
         let (mut report, feedback_note) = match outcome {
             Ok(both) => both,
             Err(err) => {
+                // A turn that aborts — most often a tool call that exceeded its
+                // wall-clock budget — was only ever logged server-side. To the
+                // operator watching the thread, the teammate simply vanished
+                // mid-answer with no word. Journal a visible system line in the
+                // same desk thread the reply would have gone to, naming the
+                // failure and what to do next. Same shape and author as the
+                // continuation-failure notice (SYSTEM_AUTHOR): a direct
+                // `AgentReply` so it round-trips through history like any other
+                // reply, and is distinguishable on disk from a real teammate
+                // bubble. `err.0` is the inner error (it carries `Display`);
+                // the `ApiError` newtype does not.
+                let notice = CompanyEvent::AgentReply {
+                    parent,
+                    chat_id: desk.clone(),
+                    agent_id: crate::ports::SYSTEM_AUTHOR.to_string(),
+                    text: format!(
+                        "This turn couldn't be finished — something went wrong or \
+                         a step took too long ({}). Nothing was left half-done. \
+                         Send the message again to retry; if it keeps failing, \
+                         try breaking it into a smaller request.",
+                        err.0
+                    ),
+                    steps: Vec::new(),
+                    task_id: None,
+                    mentions: Vec::new(),
+                    mention_depth: 0,
+                };
+                if let Err(journal_err) = runtime.events().append(&company, notice).await {
+                    tracing::warn!(
+                        company = %company,
+                        error = %journal_err,
+                        "an aborted chat turn could not be reported to the operator"
+                    );
+                }
                 settle_chat_turn(&runtime, &company, turn_id.as_deref(), Some(&err)).await;
                 return Err(err);
             }


### PR DESCRIPTION
## Problem

When a chat turn aborts in `spawn_chat_turn` (most often a tool call exceeding its wall-clock budget), the failure is only logged server-side. To the operator watching the thread, the teammate just disappears mid-answer — no message, no explanation.

## Change

In the error arm, journal a visible system line in the same desk thread the reply would have gone to, naming the failure and what to do next (retry, or split into a smaller request).

It reuses the exact shape and author of the existing continuation-failure notice: a direct `CompanyEvent::AgentReply` authored by `SYSTEM_AUTHOR`. So it:
- round-trips through `chat/history` like any other reply,
- is distinguishable on disk from a real teammate bubble,
- and needs no new event type or wire change.

`err.0` is formatted (the inner error carries `Display`; the `ApiError` newtype does not). A failed journal append degrades to a `warn!` rather than masking the original error.