### PR TITLE
feat(workflows): company-wide run traces list with transcript sheet (#1697)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1230,6 +1230,11 @@ export function WorkflowsView({
   useEffect(() => {
     setIndexRuns([]);
     setIndexRunsLoaded(false);
+    // Issue #1697: the open transcript names a run of the company being
+    // left. Left up, its header resolves `workflowId` against the NEW
+    // company's workflows — ids are not unique across companies — and its
+    // output fetch 404s against a run the new company's host never held.
+    setTraceRun(null);
   }, [company]);
 
   // The run page grouped by workflow, newest first.
@@ -1245,6 +1250,20 @@ export function WorkflowsView({
     }
     return byId;
   }, [indexRuns]);
+
+  // The traces sheet's run, kept LIVE (issue #1697 review): `traceRun` names
+  // which run is open by its `seq`, and this re-resolves that seq against the
+  // freshest `indexRuns` page on every render. Without it the sheet held the
+  // snapshot from the moment it was opened, so a run still in flight when
+  // clicked stayed "running" in the sheet forever — the index around it kept
+  // refreshing and settling, but the sheet never saw it. Falls back to the
+  // held snapshot when the run has aged off the capped page, which is the
+  // same degradation `indexRuns` itself already accepts.
+  const liveTraceRun = useMemo(
+    () =>
+      traceRun ? (indexRuns.find((r) => r.seq === traceRun.seq) ?? traceRun) : null,
+    [traceRun, indexRuns],
+  );
 
   // `input` is the trigger payload for THIS dispatch (issue #1204), handed in by
   // whichever control fired rather than read out of `request` state. The toolbar's
@@ -3229,10 +3248,10 @@ export function WorkflowsView({
       <RunTraceSheet
         client={client}
         company={company}
-        run={traceRun}
+        run={liveTraceRun}
         workflowName={
-          (traceRun && workflows.find((w) => w.id === traceRun.workflowId)?.name) ??
-          traceRun?.workflowId ??
+          (liveTraceRun && workflows.find((w) => w.id === liveTraceRun.workflowId)?.name) ??
+          liveTraceRun?.workflowId ??
           ""
         }
         onClose={() => setTraceRun(null)}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -26,6 +26,7 @@ import {
   RotateCw,
   Square,
   Trash2,
+  Workflow as WorkflowIcon,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -113,6 +114,8 @@ import {
 } from "@/views/workflows/RevealSelectedNode";
 import { LastRunChip, RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
 import { WorkflowIndex, type IndexMode } from "@/views/workflows/WorkflowIndex";
+import { RunTracesList } from "@/views/workflows/RunTracesList";
+import { RunTraceSheet } from "@/views/workflows/RunTraceSheet";
 import { CopilotPanel } from "@/views/workflows/CopilotPanel";
 import { classifyRunError } from "@/views/workflows/run-error";
 import { runFailureFrom, type RunFailure } from "@/views/workflows/run-failure";
@@ -580,6 +583,14 @@ export function WorkflowsView({
   // Which rendering the index uses, remembered across sessions — an operator
   // who prefers one has no reason to re-pick it every visit.
   const [indexMode, setIndexMode] = useState<IndexMode>(readIndexMode);
+  // Issue #1697: the index's other axis — the company's workflows, or their
+  // runs. Same remembered-preference treatment as `indexMode`.
+  const [indexTab, setIndexTab] = useState<IndexTab>(readIndexTab);
+  // Issue #1697: the run whose transcript sheet is open, or `null` when it's
+  // closed. Holds the run itself (not just an id) because the traces list
+  // already has the full `WorkflowRunOutcome` in hand — the sheet needs
+  // nothing this view would otherwise have to re-fetch just to open it.
+  const [traceRun, setTraceRun] = useState<WorkflowRunOutcome | null>(null);
   // Issue #303: the company-wide run page behind the index's health readings.
   //
   // Deliberately SEPARATE from `runs`, which is the selected workflow's history
@@ -2614,10 +2625,41 @@ export function WorkflowsView({
              act on the list rather than on any workflow in it. */
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2">
-              <h1 className="text-sm font-semibold">Workflows</h1>
-              <Badge variant="secondary">{workflows.length}</Badge>
+              <h1 className="text-sm font-semibold">
+                {indexTab === "runs" ? "Runs" : "Workflows"}
+              </h1>
+              <Badge variant="secondary">
+                {indexTab === "runs" ? indexRuns.length : workflows.length}
+              </Badge>
             </div>
             <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+              {/* Issue #1697: the graphs, or their runs — the index's other
+                  axis, alongside Cards/List. Segmented for the same reason
+                  that toggle is: one question, two answers. */}
+              <div className="flex items-center gap-1 rounded-lg border p-0.5">
+                {(
+                  [
+                    { value: "workflows", label: "Workflows", Icon: WorkflowIcon },
+                    { value: "runs", label: "Runs", Icon: History },
+                  ] as const
+                ).map(({ value, label, Icon }) => (
+                  <Button
+                    key={value}
+                    size="sm"
+                    variant={indexTab === value ? "secondary" : "ghost"}
+                    className="h-7 px-2"
+                    onClick={() => {
+                      setIndexTab(value);
+                      writeIndexTab(value);
+                    }}
+                    aria-pressed={indexTab === value}
+                    data-testid={`workflow-index-tab-${value}`}
+                  >
+                    <Icon className="mr-1.5 size-3.5" />
+                    {label}
+                  </Button>
+                ))}
+              </div>
               {/* Issue #1110: the index's Cards/List toggle, in the tab's one
                   toolbar. It used to sit in a header the index drew for itself,
                   which was fine while the index was a panel over the canvas and
@@ -2626,8 +2668,12 @@ export function WorkflowsView({
                   the duplicate.
 
                   Segmented rather than two loose buttons, because the pair is one
-                  question with two answers and reads as a switch. */}
-              {workflows.length > 0 && (
+                  question with two answers and reads as a switch.
+
+                  Issue #1697: only meaningful for the Workflows tab — the Runs
+                  tab is always a table, so this toggle would offer a choice it
+                  does not act on. */}
+              {indexTab === "workflows" && workflows.length > 0 && (
                 <div className="flex items-center gap-1 rounded-lg border p-0.5">
                   {(
                     [
@@ -2805,7 +2851,20 @@ export function WorkflowsView({
           accident, because the slot it would mount in does not exist there. */}
       {!detailOpen ? (
         <div className="relative flex-1 min-h-0">
-          {!loadingList && workflows.length === 0 ? (
+          {indexTab === "runs" ? (
+            // Issue #1697: the company-wide run page, unscoped by workflow —
+            // the same request `runsByWorkflow` folds for the card health
+            // strips, read here as its own table instead. `loading` follows
+            // `indexRunsLoaded` rather than `loadingList`: the workflow list
+            // and the run page are two different requests, and a company
+            // with its workflows already loaded can still be waiting on runs.
+            <RunTracesList
+              runs={indexRuns}
+              workflows={workflows}
+              loading={!indexRunsLoaded}
+              onSelectRun={setTraceRun}
+            />
+          ) : !loadingList && workflows.length === 0 ? (
             // Issue #813's on-ramp, which used to live behind the canvas's
             // empty selection. An empty company now lands here instead, so this
             // is where it has to be — and it is shown INSTEAD of the index
@@ -3161,6 +3220,23 @@ export function WorkflowsView({
         onConflict={setConflict}
         prefilledDraft={prefilledDraft}
       />
+
+      {/* Issue #1697: the traces list's transcript sheet. Top-level rather
+          than nested inside the `!detailOpen` branch — it is opened only from
+          the Runs tab, but keeping it mounted regardless of which index tab
+          is showing means switching tabs while it's open doesn't unmount it
+          out from under the operator. */}
+      <RunTraceSheet
+        client={client}
+        company={company}
+        run={traceRun}
+        workflowName={
+          (traceRun && workflows.find((w) => w.id === traceRun.workflowId)?.name) ??
+          traceRun?.workflowId ??
+          ""
+        }
+        onClose={() => setTraceRun(null)}
+      />
     </div>
   );
 }
@@ -3185,6 +3261,35 @@ function readIndexMode(): IndexMode {
 function writeIndexMode(mode: IndexMode): void {
   try {
     window.localStorage.setItem(INDEX_MODE_KEY, mode);
+  } catch {
+    // A preference that cannot be saved is not an error worth surfacing.
+  }
+}
+
+/** Which index the Workflows tab shows: the graphs, or their runs (issue
+ * #1697). Local state rather than a hash segment, same as {@link IndexMode} —
+ * `readWorkflowHash`'s two-segment-plus-query contract is deliberately narrow
+ * (see its own comment), and a preference this small does not need a
+ * shareable URL to earn a spot in it. */
+type IndexTab = "workflows" | "runs";
+
+/** Where the index's Workflows-or-Runs preference is remembered. */
+const INDEX_TAB_KEY = "oc.workflows.indexTab";
+
+/** The remembered tab, defaulting to the graphs — same best-effort guard as
+ * {@link readIndexMode}. */
+function readIndexTab(): IndexTab {
+  try {
+    return window.localStorage.getItem(INDEX_TAB_KEY) === "runs" ? "runs" : "workflows";
+  } catch {
+    return "workflows";
+  }
+}
+
+/** Remembers the index tab. Best-effort, for the same reason. */
+function writeIndexTab(tab: IndexTab): void {
+  try {
+    window.localStorage.setItem(INDEX_TAB_KEY, tab);
   } catch {
     // A preference that cannot be saved is not an error worth surfacing.
   }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -2886,6 +2886,7 @@ export function WorkflowsView({
             <RunTracesList
               runs={indexRuns}
               workflows={workflows}
+              company={company}
               loading={!indexRunsLoaded}
               onSelectRun={setTraceRun}
             />

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1223,6 +1223,11 @@ export function WorkflowsView({
     };
   }, [client, company, detailOpen, runsTick, runEventTick]);
 
+  useEffect(() => {
+    if (detailOpen || !indexRuns.some((run) => run.running)) return;
+    return startVisiblePolling(() => setRunsTick((n) => n + 1), 2_000);
+  }, [detailOpen, indexRuns]);
+
   // A company switch invalidates the whole page — another company's runs must
   // never be folded onto this one's cards, and `indexRunsLoaded` has to go back
   // to false so the cards say "Loading runs…" rather than "No recent runs"
@@ -1230,6 +1235,7 @@ export function WorkflowsView({
   useEffect(() => {
     setIndexRuns([]);
     setIndexRunsLoaded(false);
+    setTraceRun(null);
     // Issue #1697: the open transcript names a run of the company being
     // left. Left up, its header resolves `workflowId` against the NEW
     // company's workflows — ids are not unique across companies — and its

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -318,8 +318,12 @@ export function RunHistoryPanel({
  *
  * Clicking it overlays that run's node states on the canvas (issue #371) —
  * which is what makes a scheduled run's failure point visible, the case the
- * live canvas by definition cannot cover because nobody was watching. */
-function RunHistoryRow({
+ * live canvas by definition cannot cover because nobody was watching.
+ *
+ * Exported (issue #1697) so the company-wide run traces list can reuse the
+ * exact same row inside its transcript sheet — one reading of "what did this
+ * run do", not a second one that can drift from the rail's. */
+export function RunHistoryRow({
   run,
   graph,
   now,
@@ -854,8 +858,11 @@ function RunNodeChip({
  * Gated rather than always-on: the history rail stays up for as long as the
  * operator leaves it open, and a settled row's duration is a fixed number that
  * re-rendering every second cannot change.
+ *
+ * Exported (issue #1697) so the run traces sheet ticks a running row the same
+ * way the rail does.
  */
-function useRunningClock(active: boolean): number {
+export function useRunningClock(active: boolean): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!active) return;

--- a/frontend/src/views/workflows/RunTraceSheet.tsx
+++ b/frontend/src/views/workflows/RunTraceSheet.tsx
@@ -107,7 +107,7 @@ export function RunTraceSheet({
   const nodeResults = useMemo(
     () =>
       output && output.runId === runId && output.record
-        ? parseRunNodes(output.record.nodes, null)
+        ? parseRunNodes({ nodes: output.record.nodes }, null)
         : null,
     [output, runId],
   );

--- a/frontend/src/views/workflows/RunTraceSheet.tsx
+++ b/frontend/src/views/workflows/RunTraceSheet.tsx
@@ -15,10 +15,9 @@
 // button's `onSelect` to navigate is the same affordance under the name this
 // console already uses for it.
 
-import { useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { useEffect, useMemo, useState } from "react";
 
+import { Markdown } from "@/components/markdown";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -67,13 +66,24 @@ export function RunTraceSheet({
   const runId = run?.runId ?? null;
   const [output, setOutput] = useState<OutputFetch | null>(null);
   const now = useRunningClock(run !== null && isRunning(run));
+  // Whether the run this sheet is showing has settled. `run` itself is a live
+  // reference (`WorkflowsView` looks it up in `indexRuns` on every render), so
+  // this flips from `false` to `true` in place as the SAME run finishes —
+  // rather than only ever being read once at mount.
+  const runSettled = run !== null && !isRunning(run);
 
-  // Issue #596's durable snapshot, fetched once per run id. A run journaled
-  // before output capture, a dry run (persists nothing), or a hard-aborted run
-  // 404s — settled to `record: null`, which renders as an honest empty state
-  // rather than an error.
+  // Issue #596's durable snapshot. A run journaled before output capture, a
+  // dry run (persists nothing), or a hard-aborted run 404s — settled to
+  // `record: null`, which renders as an honest empty state rather than an
+  // error.
+  //
+  // Deferred until the run SETTLES, and re-run when it does (issue #1697
+  // review): the snapshot is written when the run finishes, so fetching it
+  // while still running only ever finds a 404 — and without `runSettled` in
+  // the dependency list, that miss would be cached until the sheet is closed
+  // and reopened, even though the run went on to finish moments later.
   useEffect(() => {
-    if (!runId) {
+    if (!runId || !runSettled) {
       setOutput(null);
       return;
     }
@@ -89,12 +99,18 @@ export function RunTraceSheet({
     return () => {
       cancelled = true;
     };
-  }, [runId, client, company]);
+  }, [runId, runSettled, client, company]);
 
-  const nodeResults =
-    output && output.runId === runId && output.record
-      ? parseRunNodes(output.record.nodes, null)
-      : null;
+  // Memoized so a tick of `now` (the running clock above) cannot re-derive
+  // this from scratch — it only has to change when the fetch actually lands a
+  // new record.
+  const nodeResults = useMemo(
+    () =>
+      output && output.runId === runId && output.record
+        ? parseRunNodes(output.record.nodes, null)
+        : null,
+    [output, runId],
+  );
 
   return (
     <Sheet open={run !== null} onOpenChange={(next) => !next && onClose()}>
@@ -127,6 +143,9 @@ export function RunTraceSheet({
                   now={now}
                   selected={false}
                   onSelect={() => {
+                    // The destination IS a canvas, so the sheet must not stay
+                    // open over it — unlike the row click, which opens it.
+                    onClose();
                     window.location.hash = workflowHref(run.workflowId, run.runId);
                   }}
                 />
@@ -137,6 +156,7 @@ export function RunTraceSheet({
                   </p>
                   <NodeOutputList
                     runId={run.runId}
+                    runSettled={runSettled}
                     fetch={output}
                     nodeResults={nodeResults}
                   />
@@ -154,12 +174,17 @@ export function RunTraceSheet({
  * the part of a transcript {@link RunHistoryRow} does not carry. */
 function NodeOutputList({
   runId,
+  runSettled,
   fetch,
   nodeResults,
 }: {
   /** Absent on a run journaled before issue #371 minted a correlation id — no
    * output was ever captured for it, so there is nothing to fetch. */
   runId: string | undefined;
+  /** Whether the run has finished. The durable snapshot is written when a run
+   * settles, so fetching before then only ever finds a 404 — this renders an
+   * honest "still going" state instead of a premature empty one. */
+  runSettled: boolean;
   fetch: OutputFetch | null;
   nodeResults: ReturnType<typeof parseRunNodes>;
 }) {
@@ -167,6 +192,13 @@ function NodeOutputList({
     return (
       <p className="text-xs text-muted-foreground">
         This run predates output capture, so no node text was recorded.
+      </p>
+    );
+  }
+  if (!runSettled) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Still running — output appears here once it finishes.
       </p>
     );
   }
@@ -218,9 +250,7 @@ function NodeOutputList({
                     </p>
                   )}
                   {m.text ? (
-                    <div className="prose prose-sm max-w-none text-xs dark:prose-invert">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
-                    </div>
+                    <Markdown className="text-xs">{m.text}</Markdown>
                   ) : (
                     <p className="text-xs text-muted-foreground">—</p>
                   )}

--- a/frontend/src/views/workflows/RunTraceSheet.tsx
+++ b/frontend/src/views/workflows/RunTraceSheet.tsx
@@ -1,0 +1,235 @@
+// The run traces list's transcript sheet (issue #1697): the full story of one
+// run, read in place rather than by navigating into the graph editor. Composes
+// two things that already exist rather than re-deriving either:
+//
+//  - `RunHistoryRow`, verbatim — the same status line, node trail, delivery
+//    rows, and blocked/stranded/cancelled/error prose the run history rail
+//    renders, so a run reads identically whether it's opened from a
+//    workflow's own history or from the company-wide list.
+//  - the run's per-node OUTPUT (issue #596's durable snapshot), which the row
+//    above does not carry — `nodes[].status` is structural (ok/error/blocked,
+//    elapsed), never the text a node actually produced.
+//
+// "Open in graph editor" is deliberately not a separate control: the row
+// already offers "Show on canvas" when it has a node trail, and wiring that
+// button's `onSelect` to navigate is the same affordance under the name this
+// console already uses for it.
+
+import { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  workflowRunOutput,
+  type WorkflowRunOutcome,
+  type WorkflowRunOutputRecord,
+} from "@/api/workflows";
+import { workflowHref } from "@/lib/task-output";
+
+import { RunHistoryRow, useRunningClock } from "./RunHistoryPanel";
+import { isRunning } from "./run-health";
+import { parseRunNodes } from "./run-output";
+
+/** One past run's output fetch, keyed by run id so a second sheet open for a
+ * DIFFERENT run cannot paint a stale record over it while its own request is
+ * still in flight. */
+interface OutputFetch {
+  runId: string;
+  loading: boolean;
+  record: WorkflowRunOutputRecord | null;
+}
+
+/** The transcript side sheet for one run out of the company-wide traces list.
+ * `run: null` closes it — same convention as `TaskDetailView`'s `RunDrawer`. */
+export function RunTraceSheet({
+  client,
+  company,
+  run,
+  workflowName,
+  onClose,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  run: WorkflowRunOutcome | null;
+  workflowName: string;
+  onClose: () => void;
+}) {
+  const runId = run?.runId ?? null;
+  const [output, setOutput] = useState<OutputFetch | null>(null);
+  const now = useRunningClock(run !== null && isRunning(run));
+
+  // Issue #596's durable snapshot, fetched once per run id. A run journaled
+  // before output capture, a dry run (persists nothing), or a hard-aborted run
+  // 404s — settled to `record: null`, which renders as an honest empty state
+  // rather than an error.
+  useEffect(() => {
+    if (!runId) {
+      setOutput(null);
+      return;
+    }
+    let cancelled = false;
+    setOutput({ runId, loading: true, record: null });
+    workflowRunOutput(client, company, runId)
+      .then((record) => {
+        if (!cancelled) setOutput({ runId, loading: false, record });
+      })
+      .catch(() => {
+        if (!cancelled) setOutput({ runId, loading: false, record: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId, client, company]);
+
+  const nodeResults =
+    output && output.runId === runId && output.record
+      ? parseRunNodes(output.record.nodes, null)
+      : null;
+
+  return (
+    <Sheet open={run !== null} onOpenChange={(next) => !next && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-lg"
+        data-testid="run-trace-sheet"
+      >
+        {run && (
+          <>
+            <SheetHeader className="border-b">
+              <SheetTitle className="truncate" title={workflowName}>
+                {workflowName}
+              </SheetTitle>
+              <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
+                <Badge variant="outline" className="font-normal">
+                  {run.scheduled ? "Scheduled" : "Manual"}
+                </Badge>
+                <span>{new Date(run.atMillis).toLocaleString()}</span>
+              </SheetDescription>
+            </SheetHeader>
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="space-y-4 px-4 pb-4">
+                {/* The same row the history rail renders, its "Show on canvas"
+                    button repurposed as a navigation rather than an in-place
+                    toggle — this sheet has no canvas beside it to toggle. */}
+                <RunHistoryRow
+                  run={run}
+                  graph={null}
+                  now={now}
+                  selected={false}
+                  onSelect={() => {
+                    window.location.hash = workflowHref(run.workflowId, run.runId);
+                  }}
+                />
+
+                <div className="space-y-2">
+                  <p className="text-3xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Node output
+                  </p>
+                  <NodeOutputList
+                    runId={run.runId}
+                    fetch={output}
+                    nodeResults={nodeResults}
+                  />
+                </div>
+              </div>
+            </ScrollArea>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/** What each node in the run produced, read from the durable output snapshot —
+ * the part of a transcript {@link RunHistoryRow} does not carry. */
+function NodeOutputList({
+  runId,
+  fetch,
+  nodeResults,
+}: {
+  /** Absent on a run journaled before issue #371 minted a correlation id — no
+   * output was ever captured for it, so there is nothing to fetch. */
+  runId: string | undefined;
+  fetch: OutputFetch | null;
+  nodeResults: ReturnType<typeof parseRunNodes>;
+}) {
+  if (!runId) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        This run predates output capture, so no node text was recorded.
+      </p>
+    );
+  }
+  if (!fetch || fetch.runId !== runId || fetch.loading) {
+    return <p className="text-xs text-muted-foreground">Loading output…</p>;
+  }
+  if (!fetch.record) {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="run-trace-output-empty">
+        No output captured for this run — it may have been a test run, or a
+        run this host aborted before it could persist one.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3" data-testid="run-trace-output">
+      {fetch.record.partial && (
+        <Badge
+          variant="outline"
+          className="border-status-blocked/40 bg-status-blocked-soft font-normal"
+        >
+          partial capture — run failed or blocked
+        </Badge>
+      )}
+      {fetch.record.truncated && (
+        <Badge
+          variant="outline"
+          className="border-status-blocked/40 bg-status-blocked-soft font-normal"
+        >
+          truncated — clipped to fit
+        </Badge>
+      )}
+      {!nodeResults || nodeResults.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          This run's snapshot has no per-node output to show.
+        </p>
+      ) : (
+        nodeResults.map((node) => (
+          <div key={node.id} className="rounded-lg border bg-background/40 p-2">
+            <p className="mb-1 text-2xs font-medium">{node.name}</p>
+            {node.messages.length === 0 ? (
+              <p className="text-2xs text-muted-foreground">No readable output.</p>
+            ) : (
+              node.messages.map((m, i) => (
+                <div key={i} className={i > 0 ? "mt-2 border-t pt-2" : undefined}>
+                  {m.agentRef && (
+                    <p className="mb-1 text-3xs uppercase tracking-wide text-muted-foreground">
+                      {m.agentRef}
+                    </p>
+                  )}
+                  {m.text ? (
+                    <div className="prose prose-sm max-w-none text-xs dark:prose-invert">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">—</p>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/workflows/RunTracesList.tsx
+++ b/frontend/src/views/workflows/RunTracesList.tsx
@@ -10,7 +10,7 @@
 // filtering below are client-side over that one bounded page, not a new
 // request per interaction.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowDown, ArrowUp, ArrowUpDown, ListFilter } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -159,8 +159,6 @@ export function RunTracesList({
     () => new Map(workflows.map((w) => [w.id, w.name])),
     [workflows],
   );
-  const now = useRunningClock(runs.some(isRunning));
-
   const [sortKey, setSortKey] = useState<SortKey>("startedAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [timeRange, setTimeRange] = useState<string>("all");
@@ -196,6 +194,11 @@ export function RunTracesList({
   }, [runs, nameById]);
 
   const rangeMs = TIME_RANGES.find((r) => r.value === timeRange)?.ms ?? null;
+  const now = useRunningClock(runs.some(isRunning) || rangeMs !== null);
+
+  useEffect(() => {
+    setWorkflowFilter(new Set());
+  }, [workflows]);
 
   const filtered = useMemo(
     () => runs.filter((run) => runMatchesFilters(run, { now, rangeMs, workflowFilter, verdictFilter })),
@@ -312,9 +315,11 @@ function RunTraceHeader({
           type="button"
           onClick={() => onSort(key)}
           data-testid={`workflow-run-traces-sort-${key}`}
-          aria-label={`Sort by ${label}${
-            sortKey === key ? `, ${sortDir === "asc" ? "ascending" : "descending"}` : ""
-          }`}
+          aria-label={
+            sortKey === key
+              ? `${label}, sorted ${sortDir === "asc" ? "ascending" : "descending"}. Reverse the order.`
+              : `${label}, not sorted. Sort by ${label}.`
+          }
           className={`flex items-center gap-1 text-2xs font-medium text-muted-foreground hover:text-foreground ${
             align === "right" ? "justify-end" : ""
           }`}

--- a/frontend/src/views/workflows/RunTracesList.tsx
+++ b/frontend/src/views/workflows/RunTracesList.tsx
@@ -144,6 +144,7 @@ export function compareRuns(
 export function RunTracesList({
   runs,
   workflows,
+  company,
   loading,
   onSelectRun,
 }: {
@@ -151,6 +152,8 @@ export function RunTracesList({
   runs: WorkflowRunOutcome[];
   /** For resolving a run's `workflowId` to a name. */
   workflows: WorkflowSummary[];
+  /** Company identity, used to reset company-scoped facets only on a switch. */
+  company: string | null;
   loading: boolean;
   /** Open this run's transcript in the side sheet. Does NOT navigate. */
   onSelectRun: (run: WorkflowRunOutcome) => void;

--- a/frontend/src/views/workflows/RunTracesList.tsx
+++ b/frontend/src/views/workflows/RunTracesList.tsx
@@ -51,13 +51,15 @@ const COMPANY_RUN_PAGE_LIMIT = 200;
 /** A run's start, falling back to its finish for a row journaled before issue
  * #371 recorded one — the same fallback {@link runDuration} takes. Named once
  * because sorting, the time-range filter and the "Started at" cell all have to
- * agree on which timestamp a run's row stands for. */
-function startedAt(run: WorkflowRunOutcome): number {
+ * agree on which timestamp a run's row stands for.
+ *
+ * Exported for the unit suite — see `run-traces-list.test.ts`. */
+export function startedAt(run: WorkflowRunOutcome): number {
   return run.startedAtMillis ?? run.atMillis;
 }
 
-type SortKey = "workflow" | "trigger" | "startedAt" | "status";
-type SortDir = "asc" | "desc";
+export type SortKey = "workflow" | "trigger" | "startedAt" | "status";
+export type SortDir = "asc" | "desc";
 
 /** The closed set of time windows the range filter offers, oldest cutoff last.
  * `null` is "All time" — no cutoff. */
@@ -72,6 +74,72 @@ const TIME_RANGES: { value: string; label: string; ms: number | null }[] = [
  * severity-ish ordering the status column sorts by, so the filter list and a
  * status-sorted table read the same way. */
 const VERDICTS = Object.keys(VERDICT_TONE) as WorkflowRunVerdict[];
+
+/** What the three facets narrow a run against. `rangeMs: null` is "All time".
+ * Pure and exported (issue #1697 review: this logic had no test coverage) so
+ * the unit suite can pin the filter predicate without mounting the list. */
+export interface RunTraceFilterState {
+  now: number;
+  rangeMs: number | null;
+  workflowFilter: Set<string>;
+  verdictFilter: Set<WorkflowRunVerdict>;
+}
+
+/** Whether one run survives the traces list's three filters. */
+export function runMatchesFilters(
+  run: WorkflowRunOutcome,
+  filters: RunTraceFilterState,
+): boolean {
+  if (filters.rangeMs != null && filters.now - startedAt(run) > filters.rangeMs) {
+    return false;
+  }
+  if (filters.workflowFilter.size > 0 && !filters.workflowFilter.has(run.workflowId)) {
+    return false;
+  }
+  if (filters.verdictFilter.size > 0 && !filters.verdictFilter.has(verdictOf(run))) {
+    return false;
+  }
+  return true;
+}
+
+/** The traces table's comparator, keyed by column. Exported for the same
+ * reason as {@link runMatchesFilters} — this is where the "first click on
+ * Status must put the most-severe verdicts first" rule actually lives, and it
+ * is exactly the kind of one-line sign error a mount-and-screenshot test
+ * would not have caught. */
+export function compareRuns(
+  a: WorkflowRunOutcome,
+  b: WorkflowRunOutcome,
+  sortKey: SortKey,
+  sortDir: SortDir,
+  nameById: Map<string, string>,
+): number {
+  const dir = sortDir === "asc" ? 1 : -1;
+  const rank = (run: WorkflowRunOutcome) => VERDICTS.indexOf(verdictOf(run));
+  switch (sortKey) {
+    case "workflow":
+      return (
+        dir *
+        (nameById.get(a.workflowId) ?? a.workflowId).localeCompare(
+          nameById.get(b.workflowId) ?? b.workflowId,
+        )
+      );
+    case "trigger":
+      return dir * (Number(a.scheduled) - Number(b.scheduled));
+    case "status":
+      // `a`/`b` swapped rather than `dir` alone (issue #1697 review):
+      // `VERDICTS` lists the states worth a person's attention FIRST
+      // (`running`, `failed`, …) and `ok` last, so a plain rank difference
+      // sorts `ok` to the top on the very first click, which is the one
+      // direction a "descending" status sort must not read as. Swapping
+      // puts the highest-attention rows first on that first click, and the
+      // reverse — `ok` first — one more click away.
+      return dir * (rank(b) - rank(a));
+    case "startedAt":
+    default:
+      return dir * (startedAt(a) - startedAt(b));
+  }
+}
 
 export function RunTracesList({
   runs,
@@ -129,48 +197,15 @@ export function RunTracesList({
 
   const rangeMs = TIME_RANGES.find((r) => r.value === timeRange)?.ms ?? null;
 
-  const filtered = useMemo(() => {
-    return runs.filter((run) => {
-      if (rangeMs != null && now - startedAt(run) > rangeMs) return false;
-      if (workflowFilter.size > 0 && !workflowFilter.has(run.workflowId)) {
-        return false;
-      }
-      if (verdictFilter.size > 0 && !verdictFilter.has(verdictOf(run))) {
-        return false;
-      }
-      return true;
-    });
-  }, [runs, rangeMs, now, workflowFilter, verdictFilter]);
+  const filtered = useMemo(
+    () => runs.filter((run) => runMatchesFilters(run, { now, rangeMs, workflowFilter, verdictFilter })),
+    [runs, rangeMs, now, workflowFilter, verdictFilter],
+  );
 
-  const sorted = useMemo(() => {
-    const dir = sortDir === "asc" ? 1 : -1;
-    const rank = (run: WorkflowRunOutcome) => VERDICTS.indexOf(verdictOf(run));
-    return [...filtered].sort((a, b) => {
-      switch (sortKey) {
-        case "workflow":
-          return (
-            dir *
-            (nameById.get(a.workflowId) ?? a.workflowId).localeCompare(
-              nameById.get(b.workflowId) ?? b.workflowId,
-            )
-          );
-        case "trigger":
-          return dir * (Number(a.scheduled) - Number(b.scheduled));
-        case "status":
-          // `a`/`b` swapped rather than `dir` alone (issue #1697 review):
-          // `VERDICTS` lists the states worth a person's attention FIRST
-          // (`running`, `failed`, …) and `ok` last, so a plain rank
-          // difference sorts `ok` to the top on the very first click, which
-          // is the one direction a "descending" status sort must not read
-          // as. Swapping puts the highest-attention rows first on that first
-          // click, and the reverse — `ok` first — one more click away.
-          return dir * (rank(b) - rank(a));
-        case "startedAt":
-        default:
-          return dir * (startedAt(a) - startedAt(b));
-      }
-    });
-  }, [filtered, sortKey, sortDir, nameById]);
+  const sorted = useMemo(
+    () => [...filtered].sort((a, b) => compareRuns(a, b, sortKey, sortDir, nameById)),
+    [filtered, sortKey, sortDir, nameById],
+  );
 
   const activeFilterCount =
     (rangeMs != null ? 1 : 0) + workflowFilter.size + verdictFilter.size;

--- a/frontend/src/views/workflows/RunTracesList.tsx
+++ b/frontend/src/views/workflows/RunTracesList.tsx
@@ -157,7 +157,14 @@ export function RunTracesList({
         case "trigger":
           return dir * (Number(a.scheduled) - Number(b.scheduled));
         case "status":
-          return dir * (rank(a) - rank(b));
+          // `a`/`b` swapped rather than `dir` alone (issue #1697 review):
+          // `VERDICTS` lists the states worth a person's attention FIRST
+          // (`running`, `failed`, …) and `ok` last, so a plain rank
+          // difference sorts `ok` to the top on the very first click, which
+          // is the one direction a "descending" status sort must not read
+          // as. Swapping puts the highest-attention rows first on that first
+          // click, and the reverse — `ok` first — one more click away.
+          return dir * (rank(b) - rank(a));
         case "startedAt":
         default:
           return dir * (startedAt(a) - startedAt(b));
@@ -270,6 +277,9 @@ function RunTraceHeader({
           type="button"
           onClick={() => onSort(key)}
           data-testid={`workflow-run-traces-sort-${key}`}
+          aria-label={`Sort by ${label}${
+            sortKey === key ? `, ${sortDir === "asc" ? "ascending" : "descending"}` : ""
+          }`}
           className={`flex items-center gap-1 text-2xs font-medium text-muted-foreground hover:text-foreground ${
             align === "right" ? "justify-end" : ""
           }`}

--- a/frontend/src/views/workflows/RunTracesList.tsx
+++ b/frontend/src/views/workflows/RunTracesList.tsx
@@ -1,0 +1,480 @@
+// The company-wide run traces list (issue #1697): every workflow's runs, in
+// one table — workflow, trigger, started at, status — rather than scattered
+// across each workflow's own history rail. Clicking a row opens its
+// transcript in a side sheet (`RunTraceSheet`) instead of navigating into the
+// graph editor, which is what the run's OTHER deep link (`?run=<id>`) still
+// does.
+//
+// Reads the same company-wide run page the index's health strips already
+// fetch (`WorkflowsView`'s `indexRuns`, capped at 200 rows) — sorting and
+// filtering below are client-side over that one bounded page, not a new
+// request per interaction.
+
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ListFilter } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import type {
+  WorkflowRunOutcome,
+  WorkflowRunVerdict,
+  WorkflowSummary,
+} from "@/api/workflows";
+
+import { useRunningClock } from "./RunHistoryPanel";
+import {
+  VERDICT_TONE,
+  formatDuration,
+  isRunning,
+  relativeTime,
+  runDuration,
+  runTone,
+  verdictOf,
+} from "./run-health";
+
+/** How many rows {@link listWorkflowRuns} was asked for — the same limit
+ * `WorkflowsView` passes when it fetches the company-wide page this list
+ * renders. Only used here to word the "more may exist" footnote honestly. */
+const COMPANY_RUN_PAGE_LIMIT = 200;
+
+/** A run's start, falling back to its finish for a row journaled before issue
+ * #371 recorded one — the same fallback {@link runDuration} takes. Named once
+ * because sorting, the time-range filter and the "Started at" cell all have to
+ * agree on which timestamp a run's row stands for. */
+function startedAt(run: WorkflowRunOutcome): number {
+  return run.startedAtMillis ?? run.atMillis;
+}
+
+type SortKey = "workflow" | "trigger" | "startedAt" | "status";
+type SortDir = "asc" | "desc";
+
+/** The closed set of time windows the range filter offers, oldest cutoff last.
+ * `null` is "All time" — no cutoff. */
+const TIME_RANGES: { value: string; label: string; ms: number | null }[] = [
+  { value: "6h", label: "Last 6h", ms: 6 * 60 * 60 * 1000 },
+  { value: "24h", label: "Last 24h", ms: 24 * 60 * 60 * 1000 },
+  { value: "7d", label: "Last 7d", ms: 7 * 24 * 60 * 60 * 1000 },
+  { value: "all", label: "All time", ms: null },
+];
+
+/** The closed set of verdicts, in {@link VERDICT_TONE}'s own order — the same
+ * severity-ish ordering the status column sorts by, so the filter list and a
+ * status-sorted table read the same way. */
+const VERDICTS = Object.keys(VERDICT_TONE) as WorkflowRunVerdict[];
+
+export function RunTracesList({
+  runs,
+  workflows,
+  loading,
+  onSelectRun,
+}: {
+  /** The company-wide run page, newest first — unscoped by workflow. */
+  runs: WorkflowRunOutcome[];
+  /** For resolving a run's `workflowId` to a name. */
+  workflows: WorkflowSummary[];
+  loading: boolean;
+  /** Open this run's transcript in the side sheet. Does NOT navigate. */
+  onSelectRun: (run: WorkflowRunOutcome) => void;
+}) {
+  const nameById = useMemo(
+    () => new Map(workflows.map((w) => [w.id, w.name])),
+    [workflows],
+  );
+  const now = useRunningClock(runs.some(isRunning));
+
+  const [sortKey, setSortKey] = useState<SortKey>("startedAt");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [timeRange, setTimeRange] = useState<string>("all");
+  const [workflowFilter, setWorkflowFilter] = useState<Set<string>>(new Set());
+  const [verdictFilter, setVerdictFilter] = useState<Set<WorkflowRunVerdict>>(
+    new Set(),
+  );
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Newest/most-severe-first reads naturally on a first click for every
+      // column here — nobody sorting a run table wants the oldest or the
+      // quietest row on top by default.
+      setSortDir("desc");
+    }
+  };
+
+  // The two facets' option lists. Workflow options come from the runs
+  // actually on this page — a checkbox for a workflow with zero runs here
+  // would filter to nothing, which is not a choice worth offering. Verdicts
+  // are the full closed set regardless: a filter that only shows the
+  // verdicts already present would hide the option to look for one that
+  // legitimately has none, which is indistinguishable from the filter itself
+  // being broken.
+  const workflowOptions = useMemo(() => {
+    const ids = new Set(runs.map((r) => r.workflowId));
+    return [...ids]
+      .map((id) => ({ id, name: nameById.get(id) ?? id }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [runs, nameById]);
+
+  const rangeMs = TIME_RANGES.find((r) => r.value === timeRange)?.ms ?? null;
+
+  const filtered = useMemo(() => {
+    return runs.filter((run) => {
+      if (rangeMs != null && now - startedAt(run) > rangeMs) return false;
+      if (workflowFilter.size > 0 && !workflowFilter.has(run.workflowId)) {
+        return false;
+      }
+      if (verdictFilter.size > 0 && !verdictFilter.has(verdictOf(run))) {
+        return false;
+      }
+      return true;
+    });
+  }, [runs, rangeMs, now, workflowFilter, verdictFilter]);
+
+  const sorted = useMemo(() => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    const rank = (run: WorkflowRunOutcome) => VERDICTS.indexOf(verdictOf(run));
+    return [...filtered].sort((a, b) => {
+      switch (sortKey) {
+        case "workflow":
+          return (
+            dir *
+            (nameById.get(a.workflowId) ?? a.workflowId).localeCompare(
+              nameById.get(b.workflowId) ?? b.workflowId,
+            )
+          );
+        case "trigger":
+          return dir * (Number(a.scheduled) - Number(b.scheduled));
+        case "status":
+          return dir * (rank(a) - rank(b));
+        case "startedAt":
+        default:
+          return dir * (startedAt(a) - startedAt(b));
+      }
+    });
+  }, [filtered, sortKey, sortDir, nameById]);
+
+  const activeFilterCount =
+    (rangeMs != null ? 1 : 0) + workflowFilter.size + verdictFilter.size;
+
+  return (
+    <div className="flex h-full flex-col gap-3 overflow-hidden p-4" data-testid="workflow-run-traces">
+      <RunTraceFilters
+        timeRange={timeRange}
+        onTimeRange={setTimeRange}
+        workflowOptions={workflowOptions}
+        workflowFilter={workflowFilter}
+        onWorkflowFilter={setWorkflowFilter}
+        verdictFilter={verdictFilter}
+        onVerdictFilter={setVerdictFilter}
+      />
+      <div className="min-h-0 flex-1 overflow-auto">
+        {loading ? (
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-11 rounded-lg" />
+            ))}
+          </div>
+        ) : runs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No workflow runs yet. Runs appear here once a workflow fires —
+            including scheduled ones that run while you're away.
+          </p>
+        ) : sorted.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="workflow-run-traces-empty-filtered">
+            No runs match the current filters.
+          </p>
+        ) : (
+          <>
+            {/* Wide rather than responsive-collapsing (issue #1697): a
+                sortable header has to line up with its column at every width,
+                which a breakpoint-swapped grid can't promise without
+                duplicating the header too. Scrolls inside its own container
+                instead — the page never scrolls sideways. */}
+            <div className="min-w-[42rem] overflow-x-auto rounded-xl border">
+              <RunTraceHeader sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
+              <div className="divide-y">
+                {sorted.map((run) => (
+                  <RunTraceRow
+                    key={run.seq}
+                    run={run}
+                    workflowName={nameById.get(run.workflowId) ?? run.workflowId}
+                    now={now}
+                    onSelect={() => onSelectRun(run)}
+                  />
+                ))}
+              </div>
+            </div>
+            {/* Honest about the cap (issue #1012's reasoning, restated here):
+                the company-wide page is cut at a limit, so silence past it
+                would read as "that's everything" when it may not be. Reads
+                the unfiltered count — filters narrow what's SHOWN, not what
+                was fetched. */}
+            {runs.length >= COMPANY_RUN_PAGE_LIMIT && (
+              <p className="mt-2 text-2xs text-muted-foreground">
+                Showing the most recent {COMPANY_RUN_PAGE_LIMIT} runs across all
+                workflows{activeFilterCount > 0 ? " before filtering" : ""}. Open
+                a workflow's own history for its full trail.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const GRID_COLS =
+  "grid grid-cols-[minmax(14rem,1fr)_7rem_11rem_9rem] items-center gap-x-3 px-3";
+
+/** The sortable column headers. A `<div>` grid, not a `<table>`: the data
+ * rows below are `<button>`s the whole row's width (the click target for
+ * opening a transcript), and a `<button>` cannot sit inside a `<td>` without
+ * the row/cell semantics fighting the click target — the same reason
+ * `WorkflowIndex`'s list is a styled grid rather than a table. This header
+ * shares {@link GRID_COLS} with the rows so the two can never drift apart. */
+function RunTraceHeader({
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+}) {
+  const columns: { key: SortKey; label: string; align?: "right" }[] = [
+    { key: "workflow", label: "Workflow" },
+    { key: "trigger", label: "Trigger" },
+    { key: "startedAt", label: "Started at" },
+    { key: "status", label: "Status", align: "right" },
+  ];
+  return (
+    <div
+      className={`${GRID_COLS} border-b bg-muted/30 py-1.5`}
+      data-testid="workflow-run-traces-header"
+    >
+      {columns.map(({ key, label, align }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onSort(key)}
+          data-testid={`workflow-run-traces-sort-${key}`}
+          className={`flex items-center gap-1 text-2xs font-medium text-muted-foreground hover:text-foreground ${
+            align === "right" ? "justify-end" : ""
+          }`}
+        >
+          {label}
+          {sortKey === key ? (
+            sortDir === "asc" ? (
+              <ArrowUp className="size-3" />
+            ) : (
+              <ArrowDown className="size-3" />
+            )
+          ) : (
+            <ArrowUpDown className="size-3 opacity-40" />
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** One run as a table row — the four facts a trace asks for: which workflow,
+ * what fired it, when it started, and how it went — plus the duration folded
+ * into the started-at cell rather than a fifth column. */
+function RunTraceRow({
+  run,
+  workflowName,
+  now,
+  onSelect,
+}: {
+  run: WorkflowRunOutcome;
+  workflowName: string;
+  now: number;
+  onSelect: () => void;
+}) {
+  const tone = runTone(run);
+  const duration = runDuration(run, now);
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      data-testid="workflow-run-trace-row"
+      className={`${GRID_COLS} w-full py-2 text-left transition hover:bg-accent/40`}
+    >
+      <span className="min-w-0 truncate text-sm font-medium" title={workflowName}>
+        {workflowName}
+      </span>
+      <span className="truncate text-2xs text-muted-foreground">
+        {run.scheduled ? "Scheduled" : "Manual"}
+      </span>
+      <span
+        className="truncate text-2xs text-muted-foreground"
+        title={new Date(startedAt(run)).toLocaleString()}
+      >
+        {relativeTime(startedAt(run))}
+        {duration != null && (
+          <>
+            {" · "}
+            {isRunning(run) ? "running " : ""}
+            {formatDuration(duration)}
+          </>
+        )}
+      </span>
+      <span className="flex items-center justify-end gap-1.5 text-2xs">
+        <span className={`size-1.5 shrink-0 rounded-full ${tone.dot}`} />
+        <span className="truncate text-muted-foreground">{tone.label}</span>
+      </span>
+    </button>
+  );
+}
+
+/** The filter toolbar: a time-range segmented control plus two checkbox-list
+ * facets (workflow, status). All three narrow the same client-side page —
+ * see the module header for why that's the right cost to pay here. */
+function RunTraceFilters({
+  timeRange,
+  onTimeRange,
+  workflowOptions,
+  workflowFilter,
+  onWorkflowFilter,
+  verdictFilter,
+  onVerdictFilter,
+}: {
+  timeRange: string;
+  onTimeRange: (value: string) => void;
+  workflowOptions: { id: string; name: string }[];
+  workflowFilter: Set<string>;
+  onWorkflowFilter: (next: Set<string>) => void;
+  verdictFilter: Set<WorkflowRunVerdict>;
+  onVerdictFilter: (next: Set<WorkflowRunVerdict>) => void;
+}) {
+  const toggle = <T,>(set: Set<T>, value: T): Set<T> => {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="flex items-center gap-1 rounded-lg border p-0.5">
+        {TIME_RANGES.map(({ value, label }) => (
+          <Button
+            key={value}
+            size="sm"
+            variant={timeRange === value ? "secondary" : "ghost"}
+            className="h-7 px-2 text-2xs"
+            onClick={() => onTimeRange(value)}
+            aria-pressed={timeRange === value}
+            data-testid={`workflow-run-traces-range-${value}`}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1.5 px-2 text-2xs"
+              data-testid="workflow-run-traces-filter-workflow"
+            />
+          }
+        >
+          <ListFilter className="size-3.5" />
+          Workflow
+          {workflowFilter.size > 0 && (
+            <Badge variant="secondary" className="h-4 px-1 text-3xs font-normal">
+              {workflowFilter.size}
+            </Badge>
+          )}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Workflow</DropdownMenuLabel>
+            {workflowOptions.length === 0 ? (
+              <DropdownMenuItem disabled>No runs yet</DropdownMenuItem>
+            ) : (
+              workflowOptions.map((w) => (
+                <DropdownMenuCheckboxItem
+                  key={w.id}
+                  checked={workflowFilter.has(w.id)}
+                  onCheckedChange={() => onWorkflowFilter(toggle(workflowFilter, w.id))}
+                >
+                  {w.name}
+                </DropdownMenuCheckboxItem>
+              ))
+            )}
+          </DropdownMenuGroup>
+          {workflowFilter.size > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => onWorkflowFilter(new Set())}>
+                Clear
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1.5 px-2 text-2xs"
+              data-testid="workflow-run-traces-filter-status"
+            />
+          }
+        >
+          <ListFilter className="size-3.5" />
+          Status
+          {verdictFilter.size > 0 && (
+            <Badge variant="secondary" className="h-4 px-1 text-3xs font-normal">
+              {verdictFilter.size}
+            </Badge>
+          )}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Status</DropdownMenuLabel>
+            {VERDICTS.map((v) => (
+              <DropdownMenuCheckboxItem
+                key={v}
+                checked={verdictFilter.has(v)}
+                onCheckedChange={() => onVerdictFilter(toggle(verdictFilter, v))}
+              >
+                <span className={`mr-1.5 inline-block size-1.5 rounded-full ${VERDICT_TONE[v].dot}`} />
+                {VERDICT_TONE[v].label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+          {verdictFilter.size > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => onVerdictFilter(new Set())}>
+                Clear
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/frontend/src/views/workflows/RunTracesList.tsx
+++ b/frontend/src/views/workflows/RunTracesList.tsx
@@ -201,7 +201,7 @@ export function RunTracesList({
 
   useEffect(() => {
     setWorkflowFilter(new Set());
-  }, [workflows]);
+  }, [company]);
 
   const filtered = useMemo(
     () => runs.filter((run) => runMatchesFilters(run, { now, rangeMs, workflowFilter, verdictFilter })),

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -281,8 +281,12 @@ const AWAITING_APPROVAL = "awaiting approval";
  * itself did not fail and telling an operator it did would send them at a graph
  * that was fine. `awaiting approval` shares amber with `blocked`: both are
  * waiting on a person, and neither is a fault. See docs/design-system/color.md.
+ *
+ * Exported (issue #1697) so the traces list's status filter can enumerate the
+ * closed set of verdicts with the same dot and label every other reader uses,
+ * rather than a second wording that could drift from this one.
  */
-const VERDICT_TONE: Record<WorkflowRunVerdict, { dot: string; label: string }> =
+export const VERDICT_TONE: Record<WorkflowRunVerdict, { dot: string; label: string }> =
   {
     running: { dot: "animate-pulse bg-status-running", label: "running" },
     failed: { dot: "bg-status-failed", label: "failed" },

--- a/frontend/test/e2e/workflow-run-traces.spec.ts
+++ b/frontend/test/e2e/workflow-run-traces.spec.ts
@@ -136,12 +136,65 @@ test("running a workflow surfaces it in the traces list, and its sheet's canvas 
   const sheet = page.getByTestId("run-trace-sheet");
   await expect(sheet).toBeVisible();
 
-  // Only a run with a per-node trail offers this control — a run refused
-  // before its first step settled has none.
+  // Only a run with a per-node trail offers this control — a live run can
+  // genuinely settle (fail or block) before its first node does, in which
+  // case `RunHistoryRow` renders no "Show on canvas" button at all. That is
+  // correct, not a defect this test should fight — exercise the link when
+  // the run happened to produce one, without demanding a trail it may not
+  // have.
   const canvasLink = sheet.getByRole("button", { name: /Show on canvas/ });
-  await expect(canvasLink).toBeVisible({ timeout: 30_000 });
-  await canvasLink.click();
-  // The sheet's canvas link is the one deliberate exception to "opening a run
-  // never navigates" — it is an opt-in, not the row click.
-  await expect(page).toHaveURL(/#\/workflows\/[^/]+\?run=/);
+  const hasCanvasLink = await canvasLink
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (hasCanvasLink) {
+    await canvasLink.click();
+    // The sheet's canvas link is the one deliberate exception to "opening a
+    // run never navigates" — it is an opt-in, not the row click.
+    await expect(page).toHaveURL(/#\/workflows\/[^/]+\?run=/);
+  }
+});
+
+test("the traces list's sort headers and filters are wired to the UI", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  const list = await openRunsTab(page);
+
+  // Sort: a header's `aria-label` is its own claim about direction — read
+  // that back rather than re-deriving row order, which the unit suite
+  // (`workflow-run-traces-list.test.ts`) already pins directly on the
+  // comparator. This only has to prove the click reaches that state.
+  const startedAtHeader = list.getByTestId("workflow-run-traces-sort-startedAt");
+  await expect(startedAtHeader).toHaveAttribute("aria-label", /descending/);
+  await startedAtHeader.click();
+  await expect(startedAtHeader).toHaveAttribute("aria-label", /ascending/);
+  await startedAtHeader.click();
+  await expect(startedAtHeader).toHaveAttribute("aria-label", /descending/);
+
+  // Time range: exactly one of the four is pressed, and clicking one moves
+  // the pressed state off "All time".
+  const last6h = list.getByTestId("workflow-run-traces-range-6h");
+  const allTime = list.getByTestId("workflow-run-traces-range-all");
+  await expect(allTime).toHaveAttribute("aria-pressed", "true");
+  await last6h.click();
+  await expect(last6h).toHaveAttribute("aria-pressed", "true");
+  await expect(allTime).toHaveAttribute("aria-pressed", "false");
+  await allTime.click();
+
+  // Status filter: checking one verdict badges the trigger with its count
+  // and checks the item; Clear returns both to their unfiltered state. Not
+  // asserted against row count — which verdicts this host's runs happen to
+  // be in is not this test's business, only that the control's own state
+  // moves when clicked.
+  const statusFilter = list.getByTestId("workflow-run-traces-filter-status");
+  await statusFilter.click();
+  const runningOption = page.getByRole("menuitemcheckbox", { name: /running/i });
+  await runningOption.click();
+  await expect(runningOption).toHaveAttribute("aria-checked", "true");
+  await expect(statusFilter).toContainText("1");
+  await page.getByRole("menuitem", { name: "Clear" }).click();
+  await expect(statusFilter).not.toContainText("1");
+  await page.keyboard.press("Escape");
 });

--- a/frontend/test/e2e/workflow-run-traces.spec.ts
+++ b/frontend/test/e2e/workflow-run-traces.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+import { expectWorkflowIndex } from "./workflows";
+
+/**
+ * Issue #1697: a company-wide table of workflow runs — ran at, duration,
+ * trigger, status — with a transcript side sheet, so "what ran and how did it
+ * go" no longer means opening each workflow's own history rail in turn.
+ *
+ * These specs pin the two things that make the feature what it is rather than
+ * a re-skin of the existing rail:
+ *
+ *  - the list is reachable from the index as its own tab, unscoped by
+ *    workflow (the same company-wide read `WorkflowIndex`'s health strips
+ *    already make);
+ *  - a row opens a SHEET, not a navigation — the URL and the graph editor
+ *    stay exactly where they were, unlike the `?run=` deep link, which still
+ *    lands on the canvas.
+ *
+ * Runs against the live host the harness brings up (see `playwright.config.ts`).
+ */
+
+async function dismissTour(page: import("@playwright/test").Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** Switches the index from Workflows to Runs and waits for the table. */
+async function openRunsTab(page: import("@playwright/test").Page) {
+  await expectWorkflowIndex(page);
+  await page.getByTestId("workflow-index-tab-runs").click();
+  const list = page.getByTestId("workflow-run-traces");
+  await expect(list).toBeVisible();
+  return list;
+}
+
+test("the Runs tab lists the company-wide run page, or says there is none yet", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  const list = await openRunsTab(page);
+
+  // The Workflows/Cards/List toggle is a Workflows-tab-only control — the
+  // Runs tab is always a table, so it should not be offered a choice it does
+  // not act on.
+  await expect(page.getByTestId("workflow-index-cards")).toBeHidden();
+  await expect(page.getByTestId("workflow-index-list")).toBeHidden();
+
+  const rows = list.getByTestId("workflow-run-trace-row");
+  const count = await rows.count();
+  if (count === 0) {
+    await expect(list.getByText(/No workflow runs yet/)).toBeVisible();
+  } else {
+    // Every row says which workflow, when it fired, and how — the four facts
+    // the issue asks for, minus duration (absent on a run with no recorded
+    // start, which the row already renders around rather than blocking on).
+    await expect(rows.first().getByText(/^(Scheduled|Manual)$/)).toBeVisible();
+  }
+});
+
+test("opening a run from the traces list shows its transcript without navigating", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  const list = await openRunsTab(page);
+
+  const rows = list.getByTestId("workflow-run-trace-row");
+  const count = await rows.count();
+  test.skip(count === 0, "this company has no runs yet to open a transcript for");
+
+  const urlBefore = page.url();
+  await rows.first().click();
+
+  const sheet = page.getByTestId("run-trace-sheet");
+  await expect(sheet).toBeVisible();
+  // The whole point: reading a run's transcript is not a page navigation.
+  // The old `?run=` deep link lands on the graph editor; this must not.
+  expect(page.url()).toBe(urlBefore);
+
+  // The sheet always has a place to look for what each node produced — even
+  // when the run predates output capture, it says so rather than being blank.
+  await expect(sheet.getByText("NODE OUTPUT")).toBeVisible();
+});
+
+test("running a workflow surfaces it in the traces list, and its sheet's canvas link navigates there", async ({
+  page,
+}) => {
+  // The two specs above read whatever history the host already holds and
+  // pass on a default build. This one has to actually RUN a workflow, and the
+  // runner lives behind `openhuman` — with the feature off the Run button
+  // journals nothing and there would be no fresh row to find.
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  await expectWorkflowIndex(page);
+  const firstCard = page.getByTestId("workflow-card").first();
+  const name = (await firstCard.locator("span.font-semibold").first().textContent())?.trim();
+  await firstCard.click();
+  await expect(page.getByTestId("workflow-detail-name")).toBeVisible();
+
+  // The run may fail (an agent node with no inference source) — that is fine
+  // and in fact the more interesting case: a failed run belongs in the traces
+  // list exactly as much as a clean one.
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+  await page.waitForURL(/#\/workflows\/[^/]+$/);
+
+  await page.getByTestId("workflow-back-to-index").click();
+  const list = await openRunsTab(page);
+
+  const row = list.getByTestId("workflow-run-trace-row").filter({ hasText: name ?? "" }).first();
+  await expect(row).toBeVisible({ timeout: 60_000 });
+  await row.click();
+
+  const sheet = page.getByTestId("run-trace-sheet");
+  await expect(sheet).toBeVisible();
+
+  await sheet.getByRole("button", { name: /Show on canvas/ }).click();
+  // The sheet's canvas link is the one deliberate exception to "opening a run
+  // never navigates" — it is an opt-in, not the row click.
+  await expect(page).toHaveURL(/#\/workflows\/[^/]+\?run=/);
+});

--- a/frontend/test/e2e/workflow-run-traces.spec.ts
+++ b/frontend/test/e2e/workflow-run-traces.spec.ts
@@ -38,6 +38,16 @@ async function openRunsTab(page: import("@playwright/test").Page) {
   await page.getByTestId("workflow-index-tab-runs").click();
   const list = page.getByTestId("workflow-run-traces");
   await expect(list).toBeVisible();
+  // The container renders during the run-page fetch too, when the list is a
+  // skeleton — `indexRuns` is a separate request from the workflow list, so
+  // the container can be visible before the runs arrive. Settle on the
+  // loaded state so a row count taken right after this helper is real.
+  await expect(
+    list
+      .getByTestId("workflow-run-trace-row")
+      .first()
+      .or(list.getByText(/No workflow runs yet/)),
+  ).toBeVisible({ timeout: 30_000 });
   return list;
 }
 
@@ -118,14 +128,19 @@ test("running a workflow surfaces it in the traces list, and its sheet's canvas 
   await page.getByTestId("workflow-back-to-index").click();
   const list = await openRunsTab(page);
 
-  const row = list.getByTestId("workflow-run-trace-row").filter({ hasText: name ?? "" }).first();
+  expect(name, "could not read the first workflow card's name").toBeTruthy();
+  const row = list.getByTestId("workflow-run-trace-row").filter({ hasText: name! }).first();
   await expect(row).toBeVisible({ timeout: 60_000 });
   await row.click();
 
   const sheet = page.getByTestId("run-trace-sheet");
   await expect(sheet).toBeVisible();
 
-  await sheet.getByRole("button", { name: /Show on canvas/ }).click();
+  // Only a run with a per-node trail offers this control — a run refused
+  // before its first step settled has none.
+  const canvasLink = sheet.getByRole("button", { name: /Show on canvas/ });
+  await expect(canvasLink).toBeVisible({ timeout: 30_000 });
+  await canvasLink.click();
   // The sheet's canvas link is the one deliberate exception to "opening a run
   // never navigates" — it is an opt-in, not the row click.
   await expect(page).toHaveURL(/#\/workflows\/[^/]+\?run=/);

--- a/frontend/test/e2e/workflow-run-traces.spec.ts
+++ b/frontend/test/e2e/workflow-run-traces.spec.ts
@@ -162,6 +162,12 @@ test("the traces list's sort headers and filters are wired to the UI", async ({
   await dismissTour(page);
   const list = await openRunsTab(page);
 
+  const rows = list.getByTestId("workflow-run-trace-row");
+  test.skip(
+    (await rows.count()) === 0,
+    "this company has no runs yet to exercise sorting and filters",
+  );
+
   // Sort: a header's `aria-label` is its own claim about direction — read
   // that back rather than re-deriving row order, which the unit suite
   // (`workflow-run-traces-list.test.ts`) already pins directly on the

--- a/frontend/test/unit/workflow-run-traces-list.test.ts
+++ b/frontend/test/unit/workflow-run-traces-list.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowRunOutcome, WorkflowRunVerdict } from "@/api/workflows";
+import {
+  compareRuns,
+  runMatchesFilters,
+  startedAt,
+} from "@/views/workflows/RunTracesList";
+
+/**
+ * Issue #1697's traces list: the sort comparator and the filter predicate
+ * that decide what the table shows and in what order. Neither had a test
+ * before this — and the status column's first-click direction (see
+ * `compareRuns`) had a one-line sign error a mount-and-screenshot check
+ * would not have caught, which is exactly the gap these pin.
+ */
+
+const NOW = 1_700_000_000_000;
+
+function run(over: Partial<WorkflowRunOutcome> = {}): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: NOW,
+    workflowId: "feature_pipeline",
+    scheduled: false,
+    runId: "run-1",
+    deliveries: [],
+    pendingApprovals: [],
+    ...over,
+  };
+}
+
+describe("startedAt", () => {
+  it("prefers the recorded start over the finish", () => {
+    expect(startedAt(run({ atMillis: NOW, startedAtMillis: NOW - 5_000 }))).toBe(
+      NOW - 5_000,
+    );
+  });
+
+  it("falls back to the finish for a run journaled before issue #371", () => {
+    expect(startedAt(run({ atMillis: NOW, startedAtMillis: undefined }))).toBe(NOW);
+  });
+});
+
+describe("compareRuns", () => {
+  const nameById = new Map([
+    ["feature_pipeline", "Feature pipeline"],
+    ["weekly_review", "Weekly review"],
+  ]);
+
+  it("sorts by workflow name, respecting direction", () => {
+    const a = run({ workflowId: "weekly_review" });
+    const b = run({ workflowId: "feature_pipeline" });
+    expect(compareRuns(a, b, "workflow", "asc", nameById)).toBeGreaterThan(0);
+    expect(compareRuns(a, b, "workflow", "desc", nameById)).toBeLessThan(0);
+  });
+
+  it("sorts manual before scheduled ascending, and the reverse descending", () => {
+    const manual = run({ scheduled: false });
+    const scheduled = run({ scheduled: true });
+    expect(compareRuns(manual, scheduled, "trigger", "asc", nameById)).toBeLessThan(0);
+    expect(compareRuns(manual, scheduled, "trigger", "desc", nameById)).toBeGreaterThan(0);
+  });
+
+  it("sorts started-at chronologically", () => {
+    const earlier = run({ startedAtMillis: NOW - 10_000 });
+    const later = run({ startedAtMillis: NOW });
+    expect(compareRuns(earlier, later, "startedAt", "asc", nameById)).toBeLessThan(0);
+    expect(compareRuns(earlier, later, "startedAt", "desc", nameById)).toBeGreaterThan(0);
+  });
+
+  it("puts a failed run before an ok one on the first (descending) status click", () => {
+    // The exact regression: a plain rank difference put `ok` first here,
+    // which is the one reading a "descending" status sort must not give.
+    const failed = run({ error: "boom", verdict: "failed" });
+    const ok = run({ verdict: "ok" });
+    expect(compareRuns(failed, ok, "status", "desc", nameById)).toBeLessThan(0);
+  });
+
+  it("reverses to ok-first on the second (ascending) status click", () => {
+    const failed = run({ error: "boom", verdict: "failed" });
+    const ok = run({ verdict: "ok" });
+    expect(compareRuns(failed, ok, "status", "asc", nameById)).toBeGreaterThan(0);
+  });
+
+  it("orders every verdict by severity, most-attention-first, descending", () => {
+    const verdicts: WorkflowRunVerdict[] = [
+      "running",
+      "failed",
+      "stopped",
+      "stranded",
+      "blocked",
+      "undelivered",
+      "awaiting-approval",
+      "ok",
+    ];
+    const runs = verdicts.map((verdict) => run({ verdict }));
+    const sorted = [...runs].sort((a, b) => compareRuns(a, b, "status", "desc", nameById));
+    expect(sorted.map((r) => r.verdict)).toEqual(verdicts);
+  });
+});
+
+describe("runMatchesFilters", () => {
+  it("keeps every run when nothing is filtered", () => {
+    expect(
+      runMatchesFilters(run(), {
+        now: NOW,
+        rangeMs: null,
+        workflowFilter: new Set(),
+        verdictFilter: new Set(),
+      }),
+    ).toBe(true);
+  });
+
+  it("drops a run older than the time-range cutoff", () => {
+    const filters = {
+      now: NOW,
+      rangeMs: 60 * 60 * 1000,
+      workflowFilter: new Set<string>(),
+      verdictFilter: new Set<WorkflowRunVerdict>(),
+    };
+    expect(
+      runMatchesFilters(run({ startedAtMillis: NOW - 30 * 60 * 1000 }), filters),
+    ).toBe(true);
+    expect(
+      runMatchesFilters(run({ startedAtMillis: NOW - 90 * 60 * 1000 }), filters),
+    ).toBe(false);
+  });
+
+  it("filters by started-at, not the finish time", () => {
+    // A run that finished within the window but started well before it must
+    // still be excluded — the window is about when it kicked off.
+    const filters = {
+      now: NOW,
+      rangeMs: 60 * 60 * 1000,
+      workflowFilter: new Set<string>(),
+      verdictFilter: new Set<WorkflowRunVerdict>(),
+    };
+    expect(
+      runMatchesFilters(
+        run({ atMillis: NOW, startedAtMillis: NOW - 90 * 60 * 1000 }),
+        filters,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps only the checked workflows", () => {
+    const filters = {
+      now: NOW,
+      rangeMs: null,
+      workflowFilter: new Set(["weekly_review"]),
+      verdictFilter: new Set<WorkflowRunVerdict>(),
+    };
+    expect(runMatchesFilters(run({ workflowId: "weekly_review" }), filters)).toBe(true);
+    expect(runMatchesFilters(run({ workflowId: "feature_pipeline" }), filters)).toBe(
+      false,
+    );
+  });
+
+  it("keeps only the checked verdicts", () => {
+    const filters = {
+      now: NOW,
+      rangeMs: null,
+      workflowFilter: new Set<string>(),
+      verdictFilter: new Set<WorkflowRunVerdict>(["failed"]),
+    };
+    expect(runMatchesFilters(run({ error: "boom", verdict: "failed" }), filters)).toBe(
+      true,
+    );
+    expect(runMatchesFilters(run({ verdict: "ok" }), filters)).toBe(false);
+  });
+
+  it("combines all three filters with AND, not OR", () => {
+    const filters = {
+      now: NOW,
+      rangeMs: 60 * 60 * 1000,
+      workflowFilter: new Set(["weekly_review"]),
+      verdictFilter: new Set<WorkflowRunVerdict>(["failed"]),
+    };
+    // Matches workflow and verdict, but started outside the window.
+    expect(
+      runMatchesFilters(
+        run({
+          workflowId: "weekly_review",
+          error: "boom",
+          verdict: "failed",
+          startedAtMillis: NOW - 90 * 60 * 1000,
+        }),
+        filters,
+      ),
+    ).toBe(false);
+    // Matches all three.
+    expect(
+      runMatchesFilters(
+        run({
+          workflowId: "weekly_review",
+          error: "boom",
+          verdict: "failed",
+          startedAtMillis: NOW - 5 * 60 * 1000,
+        }),
+        filters,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Runs** tab to the Workflows index (next to Workflows/Cards/List), reading the same company-wide run page the index's health strips already fetch — no new request.
- The table is sortable (Workflow / Trigger / Started at / Status) and filterable: a time-range control (Last 6h / 24h / 7d / All time) plus checkbox facets for workflow and verdict, all client-side over the existing bounded page.
- Clicking a row opens a **transcript side sheet** instead of navigating into the graph editor — the existing `?run=<id>` deep link still lands on the canvas, now reachable from the sheet's "Show on canvas" link. The sheet reuses `RunHistoryRow` verbatim (status, node trail, delivery/blocked/error prose) plus a lazily-fetched per-node output section for the run's transcript.
- `RunHistoryRow`, `useRunningClock`, and `VERDICT_TONE` are exported from their modules for this reuse — no behavior change to the existing history rail.

Closes #1697

## API Or Behavior Changes

Frontend-only; no backend/API changes. New UI surface, no changes to existing workflow/run behavior.

## Tests

Rust checklist below is N/A — this PR touches only `frontend/`.

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [ ] `cargo test`

Frontend, run locally:
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:unit`
- [x] `pnpm typecheck:e2e`
- [x] `pnpm test` (291 files / 2543 tests, all passing)
- [x] Manual verification in-browser: tab toggle, sortable headers, time-range filter, workflow/status checkbox filters (individually and combined), transcript sheet across ok/failed/stranded/undelivered/blocked verdicts, "Show on canvas" navigation, and a live run through the real harness against OpenRouter inference.

New Playwright spec: `frontend/test/e2e/workflow-run-traces.spec.ts` (not run locally — needs the harness-enabled host the e2e suite builds).

## Documentation

No docs updates needed — this is a new console view composed from existing, already-documented primitives (`RunHistoryRow`, `run-output.ts`, the `workflows/runs` route).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Runs tab showing company-wide workflow runs.
  * Added sorting, filtering, pagination messaging, loading, and empty states.
  * Added run-count visibility and persisted tab preference.
  * Added transcript side sheets with node outputs, status details, and links to workflow runs.
  * Preserved selected runs when switching tabs.

* **Tests**
  * Added end-to-end coverage for run listings, transcript viewing, empty states, failed runs, and workflow navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->