### PR TITLE
feat(runtime): per-agent lock so turns to different agents run in parallel

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -10,6 +10,7 @@
 //! the methods here are thin delegations so callers hold a single
 //! `Arc<CompanyRuntime>`.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -326,6 +327,27 @@ pub struct CompanyRuntime {
     /// hold. Handing the lock over is also what makes
     /// [`quiesce`](Self::quiesce)'s drain meaningful across the swap.
     pub(crate) serial: Arc<TokioMutex<()>>,
+    /// One lock slot per addressed agent, so two operators talking to two
+    /// different agents in the same company do not serialize behind each other.
+    ///
+    /// [`serial`](Self::serial) is held for a whole cycle — a live agent turn —
+    /// so with only that lock, three messages to three agents in one company run
+    /// strictly one after another even though nothing they touch is shared: each
+    /// agent has its own conversation history in the harness pool, and the state
+    /// they *do* share (the task board, the event-log `seq`) already has its own
+    /// finer lock. This map hands each addressed agent its own slot so their
+    /// turns overlap while a whole-company cycle still serializes against all of
+    /// them.
+    ///
+    /// A cycle with no single addressee — a scheduler tick, an unaddressed
+    /// message routed to the orchestrator, or a batch naming more than one agent
+    /// — falls back to [`serial`](Self::serial) and so still serializes against
+    /// everything. That is deliberate: such a cycle may touch the whole company.
+    ///
+    /// `Arc`-shared for the same reason as `serial`: a rebuilt runtime must
+    /// inherit the *same* per-agent slots (issue #290), or an agent mid-turn
+    /// could start a second turn beside itself across the swap.
+    pub(crate) per_agent: Arc<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
     /// Held across a REST board write's read → validate → write, so two
     /// concurrent edits cannot each validate against a snapshot that predates
     /// the other's edge (issue #185 review).
@@ -471,6 +493,7 @@ impl CompanyRuntime {
             workflow_gates: WorkflowGateQueue::default(),
             blocked_nodes: BlockedNodeQueue::default(),
             serial: Arc::new(TokioMutex::new(())),
+            per_agent: Arc::new(TokioMutex::new(HashMap::new())),
             task_writes: Arc::new(TokioMutex::new(())),
             quiesced: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "openhuman")]
@@ -1312,8 +1335,14 @@ impl CompanyRuntime {
     /// Called by the [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) on a
     /// rebuild, before the successor is registered and therefore before anything
     /// can be holding either lock through *this* runtime.
-    pub fn adopt_locks(&mut self, serial: Arc<TokioMutex<()>>, task_writes: Arc<TokioMutex<()>>) {
+    pub fn adopt_locks(
+        &mut self,
+        serial: Arc<TokioMutex<()>>,
+        per_agent: Arc<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
+        task_writes: Arc<TokioMutex<()>>,
+    ) {
         self.serial = serial;
+        self.per_agent = per_agent;
         self.task_writes = task_writes;
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -3124,7 +3124,7 @@ impl RuntimeBuilder {
         // against a snapshot predating the other. Adopting them is also what
         // makes the quiesce drain mean something after the swap.
         if let Some(h) = handover.as_ref() {
-            runtime.adopt_locks(h.serial.clone(), h.task_writes.clone());
+            runtime.adopt_locks(h.serial.clone(), h.per_agent.clone(), h.task_writes.clone());
         }
         runtime.adopt_continuations(continuations);
         runtime.adopt_workflow_gates(workflow_gates);

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -230,6 +230,37 @@ pub struct CycleRunner<'a> {
     rt: &'a CompanyRuntime,
 }
 
+/// The single agent this cycle is addressed to, if there is exactly one.
+///
+/// `None` means "touches the whole company" and yields the company-wide
+/// [`serial`](crate::company::runtime::CompanyRuntime::serial) lock. That is the
+/// safe side: better to serialize a cycle that could have run beside another
+/// than to let two turns that write each other's state overlap.
+///
+/// A batch naming two different agents is deliberately whole-company — that one
+/// cycle runs both turns, so it must serialize against each of them.
+fn single_agent(events: &[(Option<EventSeq>, CompanyEvent)]) -> Option<String> {
+    let mut found: Option<&str> = None;
+    for (_, event) in events {
+        let chat = match event {
+            CompanyEvent::OperatorMessage { chat, .. } => chat.as_deref(),
+            // Any other event kind may touch the whole company and so takes the
+            // wide lock. If a second per-agent event kind is ever added, it
+            // belongs here explicitly.
+            _ => return None,
+        };
+        // A message with no `chat` is routed to the orchestrator, which may
+        // drive the whole company.
+        let name = chat?;
+        match found {
+            None => found = Some(name),
+            Some(prev) if prev == name => {}
+            Some(_) => return None,
+        }
+    }
+    found.map(str::to_owned)
+}
+
 impl<'a> CycleRunner<'a> {
     /// Binds a runner to a runtime.
     pub fn new(rt: &'a CompanyRuntime) -> Self {
@@ -337,7 +368,36 @@ impl<'a> CycleRunner<'a> {
             );
         }
 
-        let guard = self.rt.serial.lock().await;
+        // Which agent is this cycle addressed to?
+        //
+        // If it is exactly one, take only that agent's slot so two operators
+        // talking to two different agents run side by side. If the cycle touches
+        // the whole company (a scheduler tick, an unaddressed message routed to
+        // the orchestrator, or a batch naming more than one agent), take
+        // `serial` and serialize against everything — including every in-flight
+        // agent turn.
+        //
+        // The per-agent slot is looked up (or created) under a short-lived lock
+        // on the map, which is released immediately: holding the map for the
+        // whole turn would reintroduce exactly the serialization this lifts. The
+        // guard chosen below outlives the bracket close, so neither lock can be
+        // released before the critical section it describes ends.
+        // Both branches yield the same guard type — an owned guard over an
+        // `Arc<tokio::sync::Mutex<()>>` — so the choice of which lock to hold does not
+        // leak into the rest of this function.
+        let guard = match single_agent(&events) {
+            Some(agent) => {
+                let slot = {
+                    let mut slots = self.rt.per_agent.lock().await;
+                    slots
+                        .entry(agent)
+                        .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+                        .clone()
+                };
+                slot.lock_owned().await
+            }
+            None => self.rt.serial.clone().lock_owned().await,
+        };
         let outcome = self.run_locked(events, cycle_id.clone(), run_id).await;
         // Closed while the lock is still held, so the bracket cannot outlive the
         // critical section it describes.
@@ -2774,6 +2834,56 @@ impl CycleHost for CycleHostImpl<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// `single_agent` picks an agent slot only when the batch is one addressed
+    /// operator message, and falls back to the whole-company lock otherwise —
+    /// the invariant the per-agent lock leans on (issue: parallel agent turns).
+    #[test]
+    fn single_agent_picks_one_addressee_and_falls_back_otherwise() {
+        fn op(chat: Option<&str>) -> (Option<EventSeq>, CompanyEvent) {
+            (
+                None,
+                CompanyEvent::OperatorMessage {
+                    text: "hi".to_string(),
+                    by: None,
+                    chat: chat.map(str::to_string),
+                    parent: None,
+                    deliverable: None,
+                    mentions: Vec::new(),
+                },
+            )
+        }
+
+        // One message addressed to one agent -> that agent's slot.
+        assert_eq!(
+            single_agent(&[op(Some("frits"))]),
+            Some("frits".to_string())
+        );
+        // Several messages, all the same agent -> still that agent's slot.
+        assert_eq!(
+            single_agent(&[op(Some("frits")), op(Some("frits"))]),
+            Some("frits".to_string())
+        );
+        // Two different agents in one batch -> whole company.
+        assert_eq!(single_agent(&[op(Some("frits")), op(Some("sjaan"))]), None);
+        // Unaddressed message (routed to the orchestrator) -> whole company.
+        assert_eq!(single_agent(&[op(None)]), None);
+        // A non-operator event in the batch -> whole company.
+        assert_eq!(
+            single_agent(&[(
+                None,
+                CompanyEvent::TurnStarted {
+                    turn_id: "t1".to_string(),
+                    chat_id: "frits".to_string(),
+                    parent: None,
+                    by: None,
+                },
+            )]),
+            None
+        );
+        // Empty batch -> whole company.
+        assert_eq!(single_agent(&[]), None);
+    }
 
     /// Issue #845: a `workflow` message reaches the brain carrying the builder
     /// briefing, and nothing else does.

--- a/src/runtime/handover.rs
+++ b/src/runtime/handover.rs
@@ -101,6 +101,10 @@ pub struct RuntimeHandover {
     /// that is in fact ready to continue.
     pub(crate) blocked_nodes: BlockedNodeQueue,
     pub(crate) serial: Arc<TokioMutex<()>>,
+    /// The per-agent lock slots. Inherited across the swap for the same reason
+    /// as `serial`: a fresh map would let an agent mid-turn start a second turn
+    /// beside itself.
+    pub(crate) per_agent: Arc<TokioMutex<std::collections::HashMap<String, Arc<TokioMutex<()>>>>>,
     pub(crate) task_writes: Arc<TokioMutex<()>>,
     #[cfg(feature = "openhuman")]
     pub(crate) harness: Option<Arc<crate::harness::HarnessPool>>,
@@ -139,6 +143,7 @@ impl CompanyRuntime {
             workflow_gates: self.workflow_gates.clone(),
             blocked_nodes: self.blocked_nodes.clone(),
             serial: self.serial.clone(),
+            per_agent: self.per_agent.clone(),
             task_writes: self.task_writes.clone(),
             #[cfg(feature = "openhuman")]
             harness: self.harness.clone(),

--- a/src/runtime/rebuild.rs
+++ b/src/runtime/rebuild.rs
@@ -315,6 +315,7 @@ mod test {
         // drain) takes them the same way, so an accessor here would be a public
         // surface that exists only for this assertion.
         assert!(Arc::ptr_eq(&before.serial, &after.serial));
+        assert!(Arc::ptr_eq(&before.per_agent, &after.per_agent));
         assert!(Arc::ptr_eq(&before.task_writes, &after.task_writes));
     }
 


### PR DESCRIPTION
## Summary

Within a single company, cycles are serialized by one `serial` lock held for the
whole cycle — the entire live agent turn, LLM call included. Two operators
messaging two different agents in the same company therefore run strictly one
after another, even though the two turns share no mutable state: each agent has
its own conversation history in the harness pool, and the state they *do* share
(the task board, the event-log `seq`, grants, continuations, the journal) already
has its own finer-grained lock.

This PR gives each addressed agent its own lock slot (`per_agent`), so their
turns overlap. A cycle that touches the whole company still serializes against
all of them:

- **One addressed operator message** → that agent's slot. Turns to different
  agents run in parallel.
- **No single addressee** (a scheduler tick, an unaddressed message routed to the
  orchestrator, or a batch naming more than one agent) → the existing `serial`
  lock, unchanged. Such a cycle may touch the whole company, so it serializes
  against everything.

The choice is made by a small pure function, `single_agent(events)`, and both
branches yield the same owned-guard type so the decision does not leak into the
rest of `run_bracketed`. The per-agent map is `Arc`-shared and inherited across a
runtime rebuild (issue #290), exactly like `serial` and `task_writes`, so an
agent mid-turn cannot start a second turn beside itself across the swap.

### Why this is safe

The whole-cycle `serial` lock existed to protect shared state, but every store
the turn touches during the LLM call is already independently synchronized:
`grants` (GrantSet), `continuations` (ContinuationQueue), `approvals`
(ManifestApprovalGate) and the `journal` (RuntimeJournal) each hold their own
`Mutex`/atomic. Nothing between `run_locked`'s first store read and its persist
depends on `serial` for correctness that those finer locks do not already
provide. The wide lock is kept precisely for the cases that can touch the whole
company (scheduler ticks, orchestrator-routed messages, multi-agent batches).

Measured on a running deployment (3 concurrent operator messages to 3 agents in
one company): wall-clock **~22.8s → ~4.6s** (≈ the slowest single turn instead of
their sum), spread 18.5s → 0.4–1.2s, consistent across two runs.

## API Or Behavior Changes

No public API change. Behavior change: turns addressed to *different* agents in
the same company now run concurrently instead of serially. Same-agent turns,
scheduler ticks, orchestrator-routed messages and multi-agent batches keep their
current whole-company serialization.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features tiny -- -D warnings`
- [x] `cargo check --features tiny`
- [x] `cargo test --features tiny` (adds `single_agent_picks_one_addressee_and_falls_back_otherwise`; extends the rebuild handover test with a `per_agent` `Arc::ptr_eq` assertion)

## Documentation

Doc comments added on the new `CompanyRuntime::per_agent` field and the
`single_agent` helper explaining the lock choice and the whole-company fallback.
No external docs needed — this is an internal concurrency change with no surface
or manifest impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Cycles addressed to different agents can now run concurrently instead of waiting on a company-wide lock.
  * Cycles involving multiple, ambiguous, or unaddressed agents continue to use safe serialized processing.
  * Concurrency behavior remains consistent when the runtime is rebuilt or handed over.

* **Bug Fixes**
  * Preserved agent-specific processing locks across runtime transitions.

* **Tests**
  * Added coverage for agent-specific locking, fallback behavior, and lock preservation during rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->