### PR TITLE
feat(companies): grant chargebee as a ceiling, held by finance roles only

### DIFF
--- a/companies/agentic_accounting_firm/agents/audit_prep.toml
+++ b/companies/agentic_accounting_firm/agents/audit_prep.toml
@@ -38,3 +38,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/audit_prep.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_accounting_firm/agents/bookkeeper.toml
+++ b/companies/agentic_accounting_firm/agents/bookkeeper.toml
@@ -12,3 +12,16 @@ tier = "orchestrator"
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/bookkeeper.md"]
+
+# Billing (#788). The one teammate in this company that holds `chargebee`.
+# Recording transactions and reconciling accounts is the job invoicing belongs
+# to, so the grant sits here rather than on the company at large.
+#
+# The company belt restated verbatim, then extended — the same rule
+# `[tools].allow` follows, and for the same reason: a short list here REPLACES
+# the belt rather than adding to it.
+#
+# `chargebee_send_invoice` and `chargebee_create_customer` are declared
+# `Reach::Consequence`, so they still park for approval under this company's
+# `auto` policy. Holding the tools is not the same as invoicing unattended.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*", "chargebee"]

--- a/companies/agentic_accounting_firm/agents/forecaster.toml
+++ b/companies/agentic_accounting_firm/agents/forecaster.toml
@@ -37,3 +37,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/forecaster.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_accounting_firm/agents/payroll_agent.toml
+++ b/companies/agentic_accounting_firm/agents/payroll_agent.toml
@@ -38,3 +38,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/payroll_agent.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_accounting_firm/agents/tax_preparer.toml
+++ b/companies/agentic_accounting_firm/agents/tax_preparer.toml
@@ -38,3 +38,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/tax_preparer.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -7,6 +7,20 @@ name = "Agentic Accounting Firm"
 output = "Books, taxes, payroll, and forecasts"
 human_role = "Sign-off on filings"
 
+[tools]
+# The default belt plus `chargebee` (#788) — the CEILING, not the grant. An accounting firm that cannot raise an invoice is a hole in the
+# template, so this is the one shipped company where billing plainly belongs.
+#
+# `allow` REPLACES the default rather than extending it, so the inherited belt
+# is restated verbatim before `chargebee` is appended. `*` does not cover
+# `chargebee`: these tools mail invoices to a real business's real customers,
+# so the namespace is opted into by name.
+#
+# Every teammate below states its own `tools` line for the same reason — an
+# omitted line takes this whole ceiling, so silence would hand billing to all
+# of them.
+allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*", "chargebee"]
+
 # The close-review desk keeps the people who reconcile, file, and substantiate the books together.
 [[group_chat]]
 id = "close_review"

--- a/companies/agentic_marketing_agency/agents/analytics_analyst.toml
+++ b/companies/agentic_marketing_agency/agents/analytics_analyst.toml
@@ -38,3 +38,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/analytics_analyst.md"]
+
+# The company belt minus `chargebee` (#788). Stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/brand_strategist.toml
+++ b/companies/agentic_marketing_agency/agents/brand_strategist.toml
@@ -43,3 +43,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/brand_strategist.md"]
+
+# The company belt minus `chargebee` (#788). Stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -48,14 +48,12 @@ ledgers = [
     { name = "experiments", access = "record" },
 ]
 
-# The creative desk ceiling restated as this member's own belt (#788): stated
-# explicitly rather than left empty because an omitted `tools` line inherits
-# the WHOLE company grant, billing included, and desks combine by UNION — a
-# member scoped only by the desk ceiling would be widened back to that full
-# grant the moment they sit on any unrestricted desk (e.g. a console
-# `POST /desks/strategy/members`). This line is exactly the desk's
-# `["*", "workspace.write"]`, so the `chargebee` exclusion and the
-# search/media/composio withholdings ride on the member too. `workspace.write`
-# is explicit because `*` confers no workspace writes; an operator naming this
-# member the biller from the console adds `chargebee` here.
-tools = ["*", "workspace.write"]
+# The company belt minus `chargebee` (#788), stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. The creative desk ceiling already strips `search`/`media`/`composio`
+# from this member; stating the belt here additionally keeps the `chargebee`
+# exclusion riding on the member, so a future cross-seat onto an unrestricted
+# desk (desks combine by UNION) cannot widen them to billing. An operator naming
+# this member the biller from the console adds `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -47,3 +47,15 @@ ledgers = [
     { name = "audiences", access = "read" },
     { name = "experiments", access = "record" },
 ]
+
+# The creative desk ceiling restated as this member's own belt (#788): stated
+# explicitly rather than left empty because an omitted `tools` line inherits
+# the WHOLE company grant, billing included, and desks combine by UNION — a
+# member scoped only by the desk ceiling would be widened back to that full
+# grant the moment they sit on any unrestricted desk (e.g. a console
+# `POST /desks/strategy/members`). This line is exactly the desk's
+# `["*", "workspace.write"]`, so the `chargebee` exclusion and the
+# search/media/composio withholdings ride on the member too. `workspace.write`
+# is explicit because `*` confers no workspace writes; an operator naming this
+# member the biller from the console adds `chargebee` here.
+tools = ["*", "workspace.write"]

--- a/companies/agentic_marketing_agency/agents/creative_director.toml
+++ b/companies/agentic_marketing_agency/agents/creative_director.toml
@@ -18,14 +18,12 @@ delegates_to = ["creative"]
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/creative_director.md"]
 
-# The creative desk ceiling restated as this member's own belt (#788): stated
-# explicitly rather than left empty because an omitted `tools` line inherits
-# the WHOLE company grant, billing included, and desks combine by UNION — a
-# member scoped only by the desk ceiling would be widened back to that full
-# grant the moment they sit on any unrestricted desk (e.g. a console
-# `POST /desks/strategy/members`). This line is exactly the desk's
-# `["*", "workspace.write"]`, so the `chargebee` exclusion and the
-# search/media/composio withholdings ride on the member too. `workspace.write`
-# is explicit because `*` confers no workspace writes; an operator naming this
-# member the biller from the console adds `chargebee` here.
-tools = ["*", "workspace.write"]
+# The company belt minus `chargebee` (#788), stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. The creative desk ceiling already strips `search`/`media`/`composio`
+# from this member; stating the belt here additionally keeps the `chargebee`
+# exclusion riding on the member, so a future cross-seat onto an unrestricted
+# desk (desks combine by UNION) cannot widen them to billing. An operator naming
+# this member the biller from the console adds `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/creative_director.toml
+++ b/companies/agentic_marketing_agency/agents/creative_director.toml
@@ -17,3 +17,15 @@ delegates_to = ["creative"]
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/creative_director.md"]
+
+# The creative desk ceiling restated as this member's own belt (#788): stated
+# explicitly rather than left empty because an omitted `tools` line inherits
+# the WHOLE company grant, billing included, and desks combine by UNION — a
+# member scoped only by the desk ceiling would be widened back to that full
+# grant the moment they sit on any unrestricted desk (e.g. a console
+# `POST /desks/strategy/members`). This line is exactly the desk's
+# `["*", "workspace.write"]`, so the `chargebee` exclusion and the
+# search/media/composio withholdings ride on the member too. `workspace.write`
+# is explicit because `*` confers no workspace writes; an operator naming this
+# member the biller from the console adds `chargebee` here.
+tools = ["*", "workspace.write"]

--- a/companies/agentic_marketing_agency/agents/email_marketer.toml
+++ b/companies/agentic_marketing_agency/agents/email_marketer.toml
@@ -38,3 +38,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/email_marketer.md"]
+
+# The company belt minus `chargebee` (#788). Stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/landing_page_builder.toml
+++ b/companies/agentic_marketing_agency/agents/landing_page_builder.toml
@@ -38,3 +38,15 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/landing_page_builder.md"]
+
+# The creative desk ceiling restated as this member's own belt (#788): stated
+# explicitly rather than left empty because an omitted `tools` line inherits
+# the WHOLE company grant, billing included, and desks combine by UNION — a
+# member scoped only by the desk ceiling would be widened back to that full
+# grant the moment they sit on any unrestricted desk (e.g. a console
+# `POST /desks/strategy/members`). This line is exactly the desk's
+# `["*", "workspace.write"]`, so the `chargebee` exclusion and the
+# search/media/composio withholdings ride on the member too. `workspace.write`
+# is explicit because `*` confers no workspace writes; an operator naming this
+# member the biller from the console adds `chargebee` here.
+tools = ["*", "workspace.write"]

--- a/companies/agentic_marketing_agency/agents/landing_page_builder.toml
+++ b/companies/agentic_marketing_agency/agents/landing_page_builder.toml
@@ -39,14 +39,12 @@ context = [
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/landing_page_builder.md"]
 
-# The creative desk ceiling restated as this member's own belt (#788): stated
-# explicitly rather than left empty because an omitted `tools` line inherits
-# the WHOLE company grant, billing included, and desks combine by UNION — a
-# member scoped only by the desk ceiling would be widened back to that full
-# grant the moment they sit on any unrestricted desk (e.g. a console
-# `POST /desks/strategy/members`). This line is exactly the desk's
-# `["*", "workspace.write"]`, so the `chargebee` exclusion and the
-# search/media/composio withholdings ride on the member too. `workspace.write`
-# is explicit because `*` confers no workspace writes; an operator naming this
-# member the biller from the console adds `chargebee` here.
-tools = ["*", "workspace.write"]
+# The company belt minus `chargebee` (#788), stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. The creative desk ceiling already strips `search`/`media`/`composio`
+# from this member; stating the belt here additionally keeps the `chargebee`
+# exclusion riding on the member, so a future cross-seat onto an unrestricted
+# desk (desks combine by UNION) cannot widen them to billing. An operator naming
+# this member the biller from the console adds `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
+++ b/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
@@ -43,3 +43,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/paid_ads_manager.md"]
+
+# The company belt minus `chargebee` (#788). Stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/agents/seo_specialist.toml
+++ b/companies/agentic_marketing_agency/agents/seo_specialist.toml
@@ -38,3 +38,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/seo_specialist.md"]
+
+# The company belt minus `chargebee` (#788). Stated explicitly rather than left
+# empty because an omitted `tools` line inherits the WHOLE company grant,
+# billing included — omission is how capability arrives here, not how it is
+# withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -86,9 +86,12 @@ members = ["creative_director", "copywriter", "landing_page_builder"]
 # AGENTS.md documents as always writable, so the write token has to ride through
 # the ceiling or the desk's own charter silently stops holding.
 #
-# Members of this desk sit on no other desk. That matters: a teammate on two
-# desks takes the UNION of their ceilings, so seating one of these agents on an
-# unrestricted desk would hand the company grant straight back.
+# This desk's scope is also stated per member: each member's `tools` line
+# restates this ceiling, so the exclusions ride on the member as well as the
+# desk. That matters because a teammate on two desks takes the UNION of their
+# ceilings — without the belt on them, seating one of these agents on an
+# unrestricted desk would hand the company grant, billing included, straight
+# back.
 tools = ["*", "workspace.write"]
 
 [[group_chat]]

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -86,12 +86,13 @@ members = ["creative_director", "copywriter", "landing_page_builder"]
 # AGENTS.md documents as always writable, so the write token has to ride through
 # the ceiling or the desk's own charter silently stops holding.
 #
-# This desk's scope is also stated per member: each member's `tools` line
-# restates this ceiling, so the exclusions ride on the member as well as the
-# desk. That matters because a teammate on two desks takes the UNION of their
+# The billing exclusion also rides on each member: their `tools` lines are the
+# company belt minus `chargebee` (#788), so this ceiling is not their only
+# guard. That matters because a teammate on two desks takes the UNION of their
 # ceilings — without the belt on them, seating one of these agents on an
 # unrestricted desk would hand the company grant, billing included, straight
-# back.
+# back. The ceiling still narrows the belt further, keeping `search`, `media`
+# and `composio` off the desk.
 tools = ["*", "workspace.write"]
 
 [[group_chat]]

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -26,7 +26,18 @@ human_role = "Campaign review and sign-off"
 #
 # Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
 # setting it to `0` pauses search without editing this list.
-allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]
+#
+# `chargebee` (#788) is a CEILING, not a grant. Every desk below narrows it
+# away, so no teammate this file ships holds billing tools. An agency that
+# bills its clients names the teammate who does from the console, and that
+# edit is an overlay this manifest never sees.
+#
+# Listing it here is what makes that possible at all: an agent's own `tools`
+# line and an operator's per-teammate override are both INTERSECTED with this
+# line, so a grant absent here can never be handed out by anyone. The ceiling
+# says what this kind of company may do; who actually does it is the
+# operator's call.
+allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*", "chargebee"]
 
 # Group chats — the desks the human talks to. Each pulls in a few agents.
 # Members must be ids declared under `agents/`.
@@ -35,12 +46,20 @@ allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "
 # `[tools].allow ∩ desk.tools ∩ agent.tools`. Stating a ceiling here restricts
 # every member at once, so a teammate seated on the desk later inherits the
 # restriction instead of quietly arriving with the company's full belt. Omitting
-# it (as `strategy` and `growth` do below) narrows nothing.
+# it narrows nothing — which is why `strategy` and `growth` now state one:
+# the company ceiling carries `chargebee`, and an unstated ceiling would hand
+# billing tools to every member.
 [[group_chat]]
 id = "strategy"
 name = "Strategy desk"
 description = "Plans, priorities, and direction."
 members = ["brand_strategist", "seo_specialist", "analytics_analyst"]
+# The company belt minus `chargebee`: this desk plans and measures, it does not
+# raise invoices. Stated as a ceiling rather than per teammate so someone seated
+# here later inherits the exclusion instead of arriving with billing tools —
+# what an unstated ceiling would do, since a teammate with no `tools` line of
+# its own takes the whole company grant.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]
 
 [[group_chat]]
 id = "creative"
@@ -76,6 +95,10 @@ id = "growth"
 name = "Growth desk"
 description = "Acquisition and lifecycle."
 members = ["paid_ads_manager", "email_marketer"]
+# The company belt minus `chargebee`, for the reason the strategy desk states.
+# Growth buys attention and runs lifecycle email; billing a client for it is
+# somebody else's job.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]
 
 # Integrations to prioritize wiring. Intent only — scopes and why, never
 # secrets. Nothing here provisions a credential: the manager injects no

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -27,12 +27,16 @@ human_role = "Campaign review and sign-off"
 # Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
 # setting it to `0` pauses search without editing this list.
 #
-# `chargebee` (#788) is a CEILING, not a grant. Every desk below narrows it
-# away, so no teammate this file ships holds billing tools. An agency that
-# bills its clients names the teammate who does from the console, and that
+# `chargebee` (#788) is a CEILING, not a grant: every shipped teammate below
+# states a `tools` line that omits it, so nobody this file ships holds billing
+# tools. An agency that bills its clients names the teammate who does from the
+# console — `PATCH {scope}/team/{agent_id}` with `chargebee` added — and that
 # edit is an overlay this manifest never sees.
 #
-# Listing it here is what makes that possible at all: an agent's own `tools`
+# The exclusion lives at the per-agent layer rather than on a desk ceiling
+# because that layer is the one an operator can rewrite: desk ceilings are
+# manifest-only and cannot be widened from the console, so a ceiling-based
+# exclusion would make the billing grant unreachable. An agent's own `tools`
 # line and an operator's per-teammate override are both INTERSECTED with this
 # line, so a grant absent here can never be handed out by anyone. The ceiling
 # says what this kind of company may do; who actually does it is the
@@ -46,21 +50,18 @@ allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "
 # `[tools].allow ∩ desk.tools ∩ agent.tools`. Stating a ceiling here restricts
 # every member at once, so a teammate seated on the desk later inherits the
 # restriction instead of quietly arriving with the company's full belt. Omitting
-# it narrows nothing — which is why `strategy` and `growth` now state one:
-# the company ceiling carries `chargebee`, and an unstated ceiling would hand
-# billing tools to every member.
+# it narrows nothing — which is what `strategy` and `growth` do here: the
+# `chargebee` exclusion is stated per teammate (in `agents/`) so an operator can
+# still name a biller from the console without hitting an unwidenable ceiling.
 [[group_chat]]
 id = "strategy"
 name = "Strategy desk"
 description = "Plans, priorities, and direction."
 members = ["brand_strategist", "seo_specialist", "analytics_analyst"]
-# The company belt minus `chargebee`: this desk plans and measures, it does not
-# raise invoices. Stated as a ceiling rather than per teammate so someone seated
-# here later inherits the exclusion instead of arriving with billing tools —
-# what an unstated ceiling would do, since a teammate with no `tools` line of
-# its own takes the whole company grant.
-tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]
-
+# No ceiling. This desk plans and measures; its members' `tools` lines carry
+# the `chargebee` exclusion instead, which keeps nobody billing by default while
+# leaving the per-teammate layer — the one the console can rewrite — open for
+# an operator to name who does.
 [[group_chat]]
 id = "creative"
 name = "Creative studio"
@@ -95,10 +96,11 @@ id = "growth"
 name = "Growth desk"
 description = "Acquisition and lifecycle."
 members = ["paid_ads_manager", "email_marketer"]
-# The company belt minus `chargebee`, for the reason the strategy desk states.
+# No ceiling, for the reason the strategy desk states: the `chargebee`
+# exclusion lives on the members' `tools` lines, and an operator naming one of
+# them as the biller from the console must not hit an unwidenable desk layer.
 # Growth buys attention and runs lifecycle email; billing a client for it is
 # somebody else's job.
-tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]
 
 # Integrations to prioritize wiring. Intent only — scopes and why, never
 # secrets. Nothing here provisions a credential: the manager injects no

--- a/companies/agentic_venture_studio/agents/customer_support.toml
+++ b/companies/agentic_venture_studio/agents/customer_support.toml
@@ -37,3 +37,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/customer_support.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/designer.toml
+++ b/companies/agentic_venture_studio/agents/designer.toml
@@ -37,3 +37,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/designer.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/engineer.toml
+++ b/companies/agentic_venture_studio/agents/engineer.toml
@@ -38,3 +38,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/engineer.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/finance.toml
+++ b/companies/agentic_venture_studio/agents/finance.toml
@@ -37,3 +37,16 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/finance.md"]
+
+# Billing (#788). The one teammate in this company that holds `chargebee`.
+# Recording transactions and reconciling accounts is the job invoicing belongs
+# to, so the grant sits here rather than on the company at large.
+#
+# The company belt restated verbatim, then extended — the same rule
+# `[tools].allow` follows, and for the same reason: a short list here REPLACES
+# the belt rather than adding to it.
+#
+# `chargebee_send_invoice` and `chargebee_create_customer` are declared
+# `Reach::Consequence`, so they still park for approval under this company's
+# `auto` policy. Holding the tools is not the same as invoicing unattended.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*", "chargebee"]

--- a/companies/agentic_venture_studio/agents/founder.toml
+++ b/companies/agentic_venture_studio/agents/founder.toml
@@ -38,3 +38,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/founder.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/lawyer.toml
+++ b/companies/agentic_venture_studio/agents/lawyer.toml
@@ -37,3 +37,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/lawyer.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/marketer.toml
+++ b/companies/agentic_venture_studio/agents/marketer.toml
@@ -37,3 +37,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/marketer.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/opportunity_scout.toml
+++ b/companies/agentic_venture_studio/agents/opportunity_scout.toml
@@ -12,3 +12,8 @@ tier = "orchestrator"
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/opportunity_scout.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/agents/recruiter.toml
+++ b/companies/agentic_venture_studio/agents/recruiter.toml
@@ -36,3 +36,8 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/recruiter.md"]
+
+# The company belt minus `chargebee`. Stated explicitly rather than left empty
+# because an omitted `tools` line inherits the WHOLE company grant, billing
+# included — omission is how capability arrives here, not how it is withheld.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -7,6 +7,21 @@ name = "Agentic Venture Studio"
 output = "A portfolio of startups"
 human_role = "Capital allocation and major strategic decisions"
 
+[tools]
+# The default belt plus `chargebee` (#788) — the CEILING, not the grant. A studio that stands up companies bills for the
+# work, and `finance` is the teammate that does it. `founder` is deliberately
+# not among them: it can ask finance.
+#
+# `allow` REPLACES the default rather than extending it, so the inherited belt
+# is restated verbatim before `chargebee` is appended. `*` does not cover
+# `chargebee`: these tools mail invoices to a real business's real customers,
+# so the namespace is opted into by name.
+#
+# Every teammate below states its own `tools` line for the same reason — an
+# omitted line takes this whole ceiling, so silence would hand billing to all
+# of them.
+allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*", "chargebee"]
+
 # The venture-launch desk keeps the founding, product, and market owners aligned on the new company.
 [[group_chat]]
 id = "venture_launch"

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -939,8 +939,7 @@ fn a_creative_member_cross_seated_on_an_unrestricted_desk_stays_billing_less() {
 
         // Seated on the creative desk AND the unrestricted strategy desk: the
         // union would otherwise be the company grant.
-        let desk_refs: Vec<&[String]> =
-            vec![creative.tools.as_slice(), strategy.tools.as_slice()];
+        let desk_refs: Vec<&[String]> = vec![creative.tools.as_slice(), strategy.tools.as_slice()];
         let grants = agent_scoped_grants(&manifest.tools.allow, &desk_refs, &agent.tools);
         assert!(
             !grants_chargebee_explicit(&grants),

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -522,6 +522,46 @@ fn a_teammate_created_with_no_grant_never_inherits_billing() {
     assert!(grants_search_explicit(&defaulted), "{defaulted:?}");
 }
 
+/// The second half of the same hole: a teammate MINTED by an orchestrator whose
+/// own scope comes from its desk rather than its `tools` line. The minter copies
+/// its (empty) line, the new teammate is on no desk, and an empty line reads
+/// back as the whole company grant — so it would hold billing its own minter
+/// does not. Pinned as a data property of the shipped templates: no marketing
+/// teammate may be in a position to mint a biller by accident.
+#[test]
+fn a_deskless_teammate_minted_with_no_scope_never_inherits_billing() {
+    use super::{CreationGrant, creation_default_grants};
+
+    for company in [
+        "agentic_marketing_agency",
+        "agentic_accounting_firm",
+        "agentic_venture_studio",
+    ] {
+        let manifest = load_company(company);
+        // The state that makes the escalation reachable: a minter scoped only by
+        // its desk has an empty `tools` line, so "copy the minter's line" stores
+        // an empty grant on a teammate that sits on no desk.
+        let deskless = agent_scoped_grants(&manifest.tools.allow, &[], &[]);
+        assert!(
+            grants_chargebee_explicit(&deskless),
+            "{company}: precondition — an empty line on no desk must resolve to \
+             the company ceiling, or this test proves nothing"
+        );
+
+        // What both creation paths now store instead.
+        match creation_default_grants(&manifest.tools.allow) {
+            CreationGrant::Narrowed(narrowed) => {
+                let resolved = agent_scoped_grants(&manifest.tools.allow, &[], &narrowed);
+                assert!(
+                    !grants_chargebee_explicit(&resolved),
+                    "{company}: a minted teammate must not inherit billing: {resolved:?}"
+                );
+            }
+            other => panic!("{company}: expected a narrowed creation grant, got {other:?}"),
+        }
+    }
+}
+
 #[test]
 fn a_billing_namespace_is_granted_bare_or_dotted_and_never_by_its_sibling() {
     assert!(grants_chargebee_explicit(&["chargebee".to_string()]));

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -904,7 +904,7 @@ fn a_marketing_biller_can_be_named_from_the_console() {
 /// ceiling would resolve to the full company grant — billing included — the
 /// moment an operator seats them on the strategy or growth desk, which state
 /// no ceiling. The `chargebee` exclusion must therefore ride on the member's
-/// own `tools` line (which restates the desk's ceiling), not on the desk
+/// own `tools` line (the company belt minus `chargebee`), not on the desk
 /// alone. Pinned through the same three-level narrowing the roster build uses.
 #[test]
 fn a_creative_member_cross_seated_on_an_unrestricted_desk_stays_billing_less() {

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -174,13 +174,20 @@ const SEARCH_UNGRANTED_COMPANIES: [&str; 0] = [];
 /// are opt-in spend. `agentic_product_team` is excluded on that same
 /// research-lab argument: it produces documents and ledger rows, so it drops
 /// both opt-in namespaces too.
-const FULL_BELT_PLUS_SEARCH: [&str; 6] = [
+const FULL_BELT_PLUS_SEARCH: [&str; 8] = [
+    // Both restate the belt verbatim and append `chargebee` (#788) rather than
+    // `search`, which is already inherited. They belong here for the property
+    // this list actually guards — that an extended `allow` did not silently
+    // drop an inherited entry — which is independent of *which* namespace the
+    // template extended it with.
+    "agentic_accounting_firm",
     "agentic_consultation_firm",
     "agentic_design_studio",
     "agentic_law_firm",
     "agentic_marketing_agency",
     "agentic_media_company",
     "agentic_software_company",
+    "agentic_venture_studio",
 ];
 
 fn load_company(name: &str) -> CompanyManifest {

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -446,6 +446,60 @@ fn a_wildcard_never_confers_a_billing_namespace() {
     }
 }
 
+/// Issue #788 follow-up, raised in review of the template ceilings: narrowing
+/// the *manifest* teammates does not protect a teammate an operator adds at
+/// runtime. `POST …/team` with no `tools` and no `focus` stores an empty grant,
+/// and empty means "the standard company-wide grant" — which, on a company that
+/// carries `chargebee`, silently included billing.
+#[test]
+fn a_teammate_created_with_no_grant_never_inherits_billing() {
+    use super::creation_default_grants;
+
+    // The overwhelming majority: nothing withheld, so the inherit-everything
+    // contract is untouched and the stored teammate stays empty.
+    let plain = Tools::default().allow;
+    assert!(
+        creation_default_grants(&plain).is_empty(),
+        "a company granting no BYO money namespace must keep `empty = standard`"
+    );
+
+    // A company that named `chargebee` for one teammate does not hand it to the
+    // next one somebody types into the console.
+    let mut billing = plain.clone();
+    billing.push("chargebee".to_string());
+    let defaulted = creation_default_grants(&billing);
+    assert!(
+        !grants_chargebee_explicit(&defaulted),
+        "a new teammate must not inherit `chargebee`: {defaulted:?}"
+    );
+    // ...and loses nothing else on the way.
+    for inherited in &plain {
+        assert!(
+            defaulted.contains(inherited),
+            "withholding billing dropped the inherited `{inherited}`: {defaulted:?}"
+        );
+    }
+
+    // The same for the other two namespaces `*` refuses to confer.
+    for money in ["paypal", "hosting"] {
+        let mut allow = plain.clone();
+        allow.push(money.to_string());
+        let defaulted = creation_default_grants(&allow);
+        assert!(
+            !defaulted.iter().any(|g| g == money),
+            "a new teammate must not inherit `{money}`: {defaulted:?}"
+        );
+    }
+
+    // `media`/`composio`/`search` ship in the default belt (#1674) and are NOT
+    // withheld — doing so would re-create that issue's complaint for every new
+    // teammate.
+    let defaulted = creation_default_grants(&billing);
+    assert!(grants_media_explicit(&defaulted), "{defaulted:?}");
+    assert!(grants_composio_explicit(&defaulted), "{defaulted:?}");
+    assert!(grants_search_explicit(&defaulted), "{defaulted:?}");
+}
+
 #[test]
 fn a_billing_namespace_is_granted_bare_or_dotted_and_never_by_its_sibling() {
     assert!(grants_chargebee_explicit(&["chargebee".to_string()]));

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -897,6 +897,59 @@ fn a_marketing_biller_can_be_named_from_the_console() {
     );
 }
 
+/// A creative member cross-seated onto an unrestricted desk must not widen to
+/// the company grant.
+///
+/// Desks combine by **union**, and a member scoped only by the creative desk
+/// ceiling would resolve to the full company grant — billing included — the
+/// moment an operator seats them on the strategy or growth desk, which state
+/// no ceiling. The `chargebee` exclusion must therefore ride on the member's
+/// own `tools` line (which restates the desk's ceiling), not on the desk
+/// alone. Pinned through the same three-level narrowing the roster build uses.
+#[test]
+fn a_creative_member_cross_seated_on_an_unrestricted_desk_stays_billing_less() {
+    let manifest = load_company("agentic_marketing_agency");
+    let strategy = manifest
+        .group_chats
+        .iter()
+        .find(|chat| chat.id == "strategy")
+        .unwrap();
+    assert!(
+        strategy.tools.is_empty(),
+        "precondition: the strategy desk must be unrestricted or this test \
+         proves nothing"
+    );
+    let creative = manifest
+        .group_chats
+        .iter()
+        .find(|chat| chat.id == "creative")
+        .unwrap();
+
+    for id in ["creative_director", "copywriter", "landing_page_builder"] {
+        let agent = manifest
+            .agents
+            .iter()
+            .find(|agent| agent.id == id)
+            .unwrap_or_else(|| panic!("{id} is a member of the creative desk"));
+        assert!(
+            !agent.tools.is_empty(),
+            "{id}: the `chargebee` exclusion must ride on the member's own \
+             `tools` line, not only on the creative desk ceiling"
+        );
+
+        // Seated on the creative desk AND the unrestricted strategy desk: the
+        // union would otherwise be the company grant.
+        let desk_refs: Vec<&[String]> =
+            vec![creative.tools.as_slice(), strategy.tools.as_slice()];
+        let grants = agent_scoped_grants(&manifest.tools.allow, &desk_refs, &agent.tools);
+        assert!(
+            !grants_chargebee_explicit(&grants),
+            "{id}: cross-seating a creative member onto an unrestricted desk \
+             must not hand back billing; effective grants: {grants:?}"
+        );
+    }
+}
+
 /// Every seeded `output` node names a destination its own manifest can resolve,
 /// except the research lab, which deliberately proves that workflows can
 /// coordinate without desks (issue #963).

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -755,6 +755,86 @@ fn a_restricting_desk_does_not_strip_the_workspace_write_token() {
     }
 }
 
+/// The marketing agency's `chargebee` exclusion lives at the per-agent layer,
+/// not on the strategy/growth desk ceilings, so the console flow the manifest
+/// documents — naming a biller from the console — actually works.
+///
+/// A desk ceiling is manifest-only and cannot be widened from the console, so
+/// an exclusion stated there would make the billing grant unreachable by any
+/// shipped teammate. Pinned through the real three-level narrowing
+/// (`agent_scoped_grants`): a shipped member's own `tools` line excludes
+/// `chargebee`, while the desk level (no ceiling) admits an operator override
+/// that names it.
+#[test]
+fn a_marketing_biller_can_be_named_from_the_console() {
+    let manifest = load_company("agentic_marketing_agency");
+
+    // The desks this PR touched state no ceiling — the exclusion must not live
+    // on an unwidenable layer.
+    for id in ["strategy", "growth"] {
+        let desk = manifest
+            .group_chats
+            .iter()
+            .find(|chat| chat.id == id)
+            .unwrap_or_else(|| panic!("{id} desk"));
+        assert!(
+            desk.tools.is_empty(),
+            "{id}: the `chargebee` exclusion must not live on the desk ceiling \
+             (an unwidenable layer); found {:?}",
+            desk.tools
+        );
+    }
+
+    // Every shipped strategy/growth member holds the belt minus `chargebee`.
+    for id in [
+        "brand_strategist",
+        "seo_specialist",
+        "analytics_analyst",
+        "paid_ads_manager",
+        "email_marketer",
+    ] {
+        let agent = manifest
+            .agents
+            .iter()
+            .find(|agent| agent.id == id)
+            .unwrap_or_else(|| panic!("{id} is a marketing teammate"));
+        let desk_refs: Vec<&[String]> = manifest
+            .group_chats
+            .iter()
+            .filter(|chat| chat.members.iter().any(|member| member == id))
+            .map(|chat| chat.tools.as_slice())
+            .collect();
+        let grants = agent_scoped_grants(&manifest.tools.allow, &desk_refs, &agent.tools);
+        assert!(
+            !grants_chargebee_explicit(&grants),
+            "{id}: a shipped marketing teammate must not hold billing tools; \
+             effective grants: {grants:?}"
+        );
+    }
+
+    // An operator naming the biller from the console — adding `chargebee` to a
+    // strategy member's override — now survives the desk level.
+    let brand = manifest
+        .agents
+        .iter()
+        .find(|agent| agent.id == "brand_strategist")
+        .unwrap();
+    let mut override_tools = brand.tools.clone();
+    override_tools.push("chargebee".to_string());
+    let strategy = manifest
+        .group_chats
+        .iter()
+        .find(|chat| chat.id == "strategy")
+        .unwrap();
+    let desk_refs: Vec<&[String]> = vec![strategy.tools.as_slice()];
+    let grants = agent_scoped_grants(&manifest.tools.allow, &desk_refs, &override_tools);
+    assert!(
+        grants_chargebee_explicit(&grants),
+        "the console override naming the biller must survive the desk layer; \
+         effective grants: {grants:?}"
+    );
+}
+
 /// Every seeded `output` node names a destination its own manifest can resolve,
 /// except the research lab, which deliberately proves that workflows can
 /// coordinate without desks (issue #963).

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -453,21 +453,43 @@ fn a_wildcard_never_confers_a_billing_namespace() {
 /// carries `chargebee`, silently included billing.
 #[test]
 fn a_teammate_created_with_no_grant_never_inherits_billing() {
-    use super::creation_default_grants;
+    use super::{CreationGrant, creation_default_grants};
+
+    let narrowed = |allow: &[String]| match creation_default_grants(allow) {
+        CreationGrant::Narrowed(list) => list,
+        other => panic!("expected a narrowed line for {allow:?}, got {other:?}"),
+    };
 
     // The overwhelming majority: nothing withheld, so the inherit-everything
     // contract is untouched and the stored teammate stays empty.
     let plain = Tools::default().allow;
-    assert!(
-        creation_default_grants(&plain).is_empty(),
+    assert_eq!(
+        creation_default_grants(&plain),
+        CreationGrant::Standard,
         "a company granting no BYO money namespace must keep `empty = standard`"
     );
+
+    // The degenerate belt: filtering removes everything, and an empty line
+    // would read back as "inherit the whole company grant" — handing over the
+    // exact namespace the filter just removed. It must be refusable instead.
+    for only_money in [
+        vec!["chargebee"],
+        vec!["paypal"],
+        vec!["chargebee", "paypal", "hosting"],
+    ] {
+        let allow: Vec<String> = only_money.iter().map(|g| (*g).to_string()).collect();
+        assert_eq!(
+            creation_default_grants(&allow),
+            CreationGrant::NothingLeft,
+            "an all-withheld belt must not decode as inheritance: {allow:?}"
+        );
+    }
 
     // A company that named `chargebee` for one teammate does not hand it to the
     // next one somebody types into the console.
     let mut billing = plain.clone();
     billing.push("chargebee".to_string());
-    let defaulted = creation_default_grants(&billing);
+    let defaulted = narrowed(&billing);
     assert!(
         !grants_chargebee_explicit(&defaulted),
         "a new teammate must not inherit `chargebee`: {defaulted:?}"
@@ -484,7 +506,7 @@ fn a_teammate_created_with_no_grant_never_inherits_billing() {
     for money in ["paypal", "hosting"] {
         let mut allow = plain.clone();
         allow.push(money.to_string());
-        let defaulted = creation_default_grants(&allow);
+        let defaulted = narrowed(&allow);
         assert!(
             !defaulted.iter().any(|g| g == money),
             "a new teammate must not inherit `{money}`: {defaulted:?}"
@@ -494,7 +516,7 @@ fn a_teammate_created_with_no_grant_never_inherits_billing() {
     // `media`/`composio`/`search` ship in the default belt (#1674) and are NOT
     // withheld — doing so would re-create that issue's complaint for every new
     // teammate.
-    let defaulted = creation_default_grants(&billing);
+    let defaulted = narrowed(&billing);
     assert!(grants_media_explicit(&defaulted), "{defaulted:?}");
     assert!(grants_composio_explicit(&defaulted), "{defaulted:?}");
     assert!(grants_search_explicit(&defaulted), "{defaulted:?}");

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -164,7 +164,7 @@ pub use task_file::{TASKS_FILE, TaskSeed, has_task_file, load_dir_tasks};
 pub use types::{
     ACP_AGENTS, ACP_TRANSPORTS, AcpHarness, Agent, BRAIN_MODES, Brain, Budget, ChannelConfig,
     Company, CompanyManifest, ComposioTools, Connection, ContextAccess, ContextEntry,
-    DEFAULT_ALWAYS_APPROVE, DEFAULT_HARNESS_KIND, DEFAULT_MAX_DELEGATION_DEPTH,
+    CreationGrant, DEFAULT_ALWAYS_APPROVE, DEFAULT_HARNESS_KIND, DEFAULT_MAX_DELEGATION_DEPTH,
     DEFAULT_MAX_IN_FLIGHT_RUNS, DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, GroupChat,
     HARNESS_KINDS, Harness, IMPLICIT_HARNESS_ID, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference,
     KNOWN_CHANNELS, LedgerAccess, LedgerGrant, MAX_DELEGATION_DEPTH_BOUNDS, McpServer,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -170,9 +170,10 @@ pub use types::{
     KNOWN_CHANNELS, LedgerAccess, LedgerGrant, MAX_DELEGATION_DEPTH_BOUNDS, McpServer,
     ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROMPT_CLASSES,
     PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
-    TOOL_PROVIDERS, Tools, grants_chargebee_explicit, grants_composio_explicit,
-    grants_files_or_docs, grants_hosting_explicit, grants_media_explicit, grants_paypal_explicit,
-    grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
+    TOOL_PROVIDERS, Tools, creation_default_grants, grants_chargebee_explicit,
+    grants_composio_explicit, grants_files_or_docs, grants_hosting_explicit, grants_media_explicit,
+    grants_paypal_explicit, grants_search_explicit, grants_workspace_write_explicit,
+    orchestrator_id,
 };
 pub use workflow_file::{
     STAGELESS_SCHEDULE_REFUSAL, STAGELESS_WORKFLOW_NOTICE, UNDELIVERABLE_SCHEDULE_REFUSAL,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -247,7 +247,7 @@ pub fn grants_hosting_explicit(grants: &[String]) -> bool {
 /// that grant none of these. A non-empty return is the allow-list minus the
 /// withheld namespaces, materialised so the stored teammate carries its own
 /// narrowed line rather than inheriting a ceiling that later widens.
-pub fn creation_default_grants(allow: &[String]) -> Vec<String> {
+pub fn creation_default_grants(allow: &[String]) -> CreationGrant {
     let withheld = |grant: &String| {
         let one = std::slice::from_ref(grant);
         grants_chargebee_explicit(one)
@@ -255,9 +255,36 @@ pub fn creation_default_grants(allow: &[String]) -> Vec<String> {
             || grants_hosting_explicit(one)
     };
     if !allow.iter().any(withheld) {
-        return Vec::new();
+        return CreationGrant::Standard;
     }
-    allow.iter().filter(|g| !withheld(g)).cloned().collect()
+    let kept: Vec<String> = allow.iter().filter(|g| !withheld(g)).cloned().collect();
+    if kept.is_empty() {
+        return CreationGrant::NothingLeft;
+    }
+    CreationGrant::Narrowed(kept)
+}
+
+/// What [`creation_default_grants`] decided for a teammate created with no
+/// stated `tools`.
+///
+/// Three cases rather than a `Vec`, because a `Vec` cannot express the third
+/// one: an empty list is already spoken for — it means "the standard company
+/// grant" — so returning the filtered-to-nothing result as `vec![]` would hand
+/// back the exact capability the filter just removed. The orchestrator's
+/// `add_agent` refuses on the same reasoning when narrowing a requested scope
+/// yields nothing, and this mirrors it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CreationGrant {
+    /// Nothing was withheld. Store an empty line, which keeps tracking
+    /// `[tools].allow` the way an unstated grant always has.
+    Standard,
+    /// Store this narrowed line: the allow-list minus the withheld namespaces.
+    Narrowed(Vec<String>),
+    /// The company's whole belt is withheld namespaces (`allow = ["chargebee"]`
+    /// and nothing else). There is no safe line to store — empty would read
+    /// back as inheritance — so the caller refuses and asks for an explicit
+    /// grant instead.
+    NothingLeft,
 }
 
 /// Whether a tool-grant list **explicitly** grants the `paypal` namespace

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -224,6 +224,42 @@ pub fn grants_hosting_explicit(grants: &[String]) -> bool {
         .any(|grant| grant == "hosting" || grant.starts_with("hosting."))
 }
 
+/// The grant list a teammate created with **no stated `tools`** should receive.
+///
+/// An omitted `tools` line means "the company's standard grant", and the
+/// standard grant is the whole of `[tools].allow`. That is the right default
+/// for the belt a company runs on — issue #1674 made it wider on purpose,
+/// because a teammate minted from three sentences in a wizard reporting its
+/// own tools as "not enabled" is the worse failure. It is the wrong default
+/// for a namespace `*` deliberately refuses to confer: a company that added
+/// `chargebee` by name so that ONE teammate could invoice should not hand
+/// billing to the next teammate an operator types into the console.
+///
+/// So this withholds exactly the **BYO real-money** namespaces — the ones a
+/// company only ever holds because somebody named them, and that reach a real
+/// business's customers, wallet, or public identity. `media`, `composio` and
+/// `search` are deliberately NOT withheld: they ship in the default belt, so
+/// withholding them would re-create the #1674 complaint for every new
+/// teammate.
+///
+/// Returns **empty** when nothing is withheld, preserving the "empty means the
+/// standard company grant" contract for the overwhelming majority of companies
+/// that grant none of these. A non-empty return is the allow-list minus the
+/// withheld namespaces, materialised so the stored teammate carries its own
+/// narrowed line rather than inheriting a ceiling that later widens.
+pub fn creation_default_grants(allow: &[String]) -> Vec<String> {
+    let withheld = |grant: &String| {
+        let one = std::slice::from_ref(grant);
+        grants_chargebee_explicit(one)
+            || grants_paypal_explicit(one)
+            || grants_hosting_explicit(one)
+    };
+    if !allow.iter().any(withheld) {
+        return Vec::new();
+    }
+    allow.iter().filter(|g| !withheld(g)).cloned().collect()
+}
+
 /// Whether a tool-grant list **explicitly** grants the `paypal` namespace
 /// (issue #789).
 ///

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -3006,16 +3006,22 @@ impl Tool for AddAgentTool {
         // Issue #619: the company grant is the wrong ceiling. Clamp to the
         // MINTER's own scope, resolved before the store is touched so a refused
         // scope never leaves a half-written roster.
-        let mut tools = match requested {
+        //
+        // The boolean says whether the request LEFT the grant unstated — the
+        // `None` and empty-list cases, which inherit the minter — rather than
+        // stating one explicitly. Only an unstated grant is filtered for the BYO
+        // real-money namespaces below; an explicitly requested billing namespace
+        // survives, narrowed to what the minter holds.
+        let (mut tools, unstated) = match requested {
             // Nothing asked for: copy the minter's own line. Copying the *line*
             // rather than its resolved grant is deliberate — an unscoped minter
             // mints an unscoped teammate that keeps tracking `[tools].allow`,
             // instead of freezing today's allow-list into the record as an
             // explicit scope a later company-wide narrowing would not reach.
-            None => self.minter_tools.clone(),
+            None => (self.minter_tools.clone(), true),
             // An explicitly empty list is the same request as none at all —
             // "give them what you have" — not "grant everything".
-            Some(globs) if globs.is_empty() => self.minter_tools.clone(),
+            Some(globs) if globs.is_empty() => (self.minter_tools.clone(), true),
             Some(globs) => {
                 // Narrow against what the minter actually holds. An empty result
                 // means nothing asked for was within reach, and storing that
@@ -3034,7 +3040,7 @@ impl Tool for AddAgentTool {
                         },
                     )));
                 }
-                narrowed
+                (narrowed, false)
             }
         };
 
@@ -3053,20 +3059,28 @@ impl Tool for AddAgentTool {
             .ok_or_else(|| OpenCompanyError::CompanyNotFound(self.company.to_string()))?;
 
         // The BYO real-money namespaces are not inherited by a minted teammate
-        // either (#788/#789). The branches above copy the MINTER'S LINE when
-        // nothing was asked for, and a minter scoped by its desk rather than by
-        // its own `tools` has an empty line — so an unscoped-looking mint from,
-        // say, a desk-restricted creative director would store an empty grant,
-        // which reads back as the whole company allow-list and hands the new
-        // deskless teammate billing tools its own minter does not hold.
+        // (#788/#789). What an unstated grant inherits depends on the minter:
+        // an empty minter line means the whole company allow-list (so an
+        // unscoped-looking mint from, say, a desk-restricted creative director
+        // would otherwise store an empty grant that reads back as billing it
+        // does not hold), and a non-empty minter line that itself names billing
+        // (the shipped bookkeeper) would hand it on. Both are filtered — the
+        // company allow-list when the minter line is empty, the minter's own
+        // line otherwise — before persistence.
         //
         // Same helper and same reasoning as the console `POST .../team` route,
         // deliberately rather than incidentally: two creation paths that answer
         // "what does an unstated grant mean" differently is how the first hole
         // got here. `CreationGrant::Standard` leaves the copied line untouched,
-        // so nothing changes for the companies that grant none of these.
-        if tools.is_empty() {
-            match crate::company::creation_default_grants(&record.manifest.tools.allow) {
+        // so nothing changes for the companies that grant none of these, and an
+        // explicitly requested billing namespace is untouched too.
+        if unstated {
+            let inherited = if tools.is_empty() {
+                &record.manifest.tools.allow
+            } else {
+                &tools
+            };
+            match crate::company::creation_default_grants(inherited) {
                 crate::company::CreationGrant::Standard => {}
                 crate::company::CreationGrant::Narrowed(narrowed) => tools = narrowed,
                 crate::company::CreationGrant::NothingLeft => {
@@ -7397,6 +7411,109 @@ name = "Morning"
 
         let record = store.load(&company).await.unwrap().expect("record");
         assert!(record.overlay_agents[0].tools.is_empty());
+    }
+
+    /// A minter whose own line names `chargebee` (the shipped bookkeeper) hands
+    /// that line on when `tools` is omitted — but an unstated grant never
+    /// confers billing (#788/#789), so the copied line is filtered before it is
+    /// stored. The #619 copy-the-line rule still holds for the non-BYO parts.
+    #[tokio::test]
+    async fn an_unstated_mint_from_a_billing_holding_minter_withholds_chargebee() {
+        let company = CompanyId::new("acme");
+        let mut record = seeded_record(&company);
+        record.manifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\", \"chargebee\"]\n",
+        )
+        .expect("valid manifest");
+        let store = Arc::new(MemStore::seeded(record));
+        let belt = vec![
+            "*".to_string(),
+            "workspace.*".to_string(),
+            "workspace.write".to_string(),
+            "media".to_string(),
+            "composio".to_string(),
+            "search".to_string(),
+            "mcp:*".to_string(),
+            "chargebee".to_string(),
+        ];
+        let tool = AddAgentTool::new(
+            company.clone(),
+            store.clone(),
+            "bookkeeper".to_string(),
+            belt.clone(),
+            belt,
+        );
+
+        let result = tool
+            .execute(json!({ "name": "Jamie", "role": "Data Entry" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("persisted");
+        let added = &record.overlay_agents[0];
+        assert!(
+            !added
+                .tools
+                .iter()
+                .any(|g| g == "chargebee" || g.starts_with("chargebee.")),
+            "an unstated mint must not hand on billing: {:?}",
+            added.tools
+        );
+        assert!(
+            added.tools.contains(&"*".to_string()),
+            "the rest of the minter's line is still copied verbatim (#619): {:?}",
+            added.tools
+        );
+    }
+
+    /// An EXPLICIT `tools` request naming `chargebee` survives — an unstated
+    /// grant is withheld, a stated one is narrowed to what the minter holds.
+    #[tokio::test]
+    async fn an_explicit_chargebee_request_from_a_billing_minter_is_honored() {
+        let company = CompanyId::new("acme");
+        let mut record = seeded_record(&company);
+        record.manifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\", \"chargebee\"]\n",
+        )
+        .expect("valid manifest");
+        let store = Arc::new(MemStore::seeded(record));
+        let belt = vec![
+            "*".to_string(),
+            "workspace.*".to_string(),
+            "workspace.write".to_string(),
+            "media".to_string(),
+            "composio".to_string(),
+            "search".to_string(),
+            "mcp:*".to_string(),
+            "chargebee".to_string(),
+        ];
+        let tool = AddAgentTool::new(
+            company.clone(),
+            store.clone(),
+            "bookkeeper".to_string(),
+            belt.clone(),
+            belt,
+        );
+
+        let result = tool
+            .execute(json!({ "name": "Jamie", "role": "Data Entry", "tools": ["chargebee"] }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("persisted");
+        assert_eq!(
+            record.overlay_agents[0].tools,
+            vec!["chargebee".to_string()],
+            "a stated billing namespace is narrowed to the minter's grant, not dropped"
+        );
     }
 
     /// A non-string `tools` item is a clean argument error, the same shape as a

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -3006,7 +3006,7 @@ impl Tool for AddAgentTool {
         // Issue #619: the company grant is the wrong ceiling. Clamp to the
         // MINTER's own scope, resolved before the store is touched so a refused
         // scope never leaves a half-written roster.
-        let tools = match requested {
+        let mut tools = match requested {
             // Nothing asked for: copy the minter's own line. Copying the *line*
             // rather than its resolved grant is deliberate — an unscoped minter
             // mints an unscoped teammate that keeps tracking `[tools].allow`,
@@ -3051,6 +3051,31 @@ impl Tool for AddAgentTool {
             .load(&self.company)
             .await?
             .ok_or_else(|| OpenCompanyError::CompanyNotFound(self.company.to_string()))?;
+
+        // The BYO real-money namespaces are not inherited by a minted teammate
+        // either (#788/#789). The branches above copy the MINTER'S LINE when
+        // nothing was asked for, and a minter scoped by its desk rather than by
+        // its own `tools` has an empty line — so an unscoped-looking mint from,
+        // say, a desk-restricted creative director would store an empty grant,
+        // which reads back as the whole company allow-list and hands the new
+        // deskless teammate billing tools its own minter does not hold.
+        //
+        // Same helper and same reasoning as the console `POST .../team` route,
+        // deliberately rather than incidentally: two creation paths that answer
+        // "what does an unstated grant mean" differently is how the first hole
+        // got here. `CreationGrant::Standard` leaves the copied line untouched,
+        // so nothing changes for the companies that grant none of these.
+        if tools.is_empty() {
+            match crate::company::creation_default_grants(&record.manifest.tools.allow) {
+                crate::company::CreationGrant::Standard => {}
+                crate::company::CreationGrant::Narrowed(narrowed) => tools = narrowed,
+                crate::company::CreationGrant::NothingLeft => {
+                    return Ok(ToolResult::error(format!(
+                        "This company grants only billing namespaces, so \"{name}\" would inherit them. Pass an explicit `tools` list naming what they should hold."
+                    )));
+                }
+            }
+        }
 
         // Deduplication guard: reject a call whose `name` already names an
         // existing overlay teammate, so a trigger-happy orchestrator can't

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2347,10 +2347,23 @@ impl RuntimeBuilder {
         // except when the upgraded manifest newly confers a BYO real-money
         // namespace (issue #788): an empty `tools` line would silently hand it
         // to a teammate that never asked. Preserve their pre-upgrade scope.
-        let overlay_agents = Self::preserve_pre_upgrade_grant_scope(
+        //
+        // The operator's per-agent edits (issue #1530) ride along for the same
+        // reason every overlay does — the manifest is a read-only boot snapshot
+        // on a hosted tenant, so dropping them would silently revert every
+        // console edit on the next restart. Their empty form is the same
+        // freeze: `AgentOverride.tools = Some([])` is the stored spelling of
+        // "give this teammate the company's standard grant", and copied
+        // verbatim it would replace the new manifest's explicit non-billing
+        // `tools` line with the widened allow-list.
+        let (overlay_agents, overlay_agent_edits) = Self::preserve_pre_upgrade_grant_scope(
             existing
                 .as_ref()
                 .map(|r| r.overlay_agents.clone())
+                .unwrap_or_default(),
+            existing
+                .as_ref()
+                .map(|r| r.overlay_agent_edits.clone())
                 .unwrap_or_default(),
             existing.as_ref().map(|r| &r.manifest),
             &self.manifest,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2469,15 +2469,6 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_budgets.clone())
             .unwrap_or_default();
-        // Issue #1530: the operator-set per-agent persona overrides. Carried
-        // across the rebuild for the same reason as the budget caps above — the
-        // manifest is a read-only boot snapshot on a hosted tenant, so dropping
-        // these would silently revert every console-edited persona to the text
-        // baked into the image on the next restart.
-        let overlay_agent_edits = existing
-            .as_ref()
-            .map(|r| r.overlay_agent_edits.clone())
-            .unwrap_or_default();
         // Issue #562: the operator's `[policy]` override, carried across the
         // rebuild — but ONLY while the seed's `[policy]` has not itself changed.
         // See `carry_policy_override` for why that condition is the whole point.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -42,8 +42,8 @@ use crate::policy::ManifestApprovalGate;
 #[cfg(feature = "openhuman")]
 use crate::ports::WorkflowRunner;
 use crate::ports::types::{
-    CompanyId, CompanyRecord, OverlayAgent, OverlayWorkflow, PolicyOverride, SecretValue,
-    TemplateProvenance, effective_policy,
+    AgentOverride, CompanyId, CompanyRecord, OverlayAgent, OverlayWorkflow, PolicyOverride,
+    SecretValue, TemplateProvenance, effective_policy,
 };
 use crate::ports::{
     AgentEconomy, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4105,8 +4105,8 @@ mod test {
             },
         ];
 
-        let migrated =
-            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Some(&old), &new);
+        let (migrated, _) =
+            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Vec::new(), Some(&old), &new);
 
         assert_eq!(
             migrated[0].tools, old.tools.allow,
@@ -4116,6 +4116,58 @@ mod test {
             migrated[1].tools,
             vec!["docs.*".to_string()],
             "a stated grant is untouched"
+        );
+    }
+
+    /// The console's per-agent edit half carries the same empty-means-standard
+    /// rule (`AgentOverride.tools = Some([])` is "give this teammate the
+    /// company's standard grant"), so an upgrade into a BYO namespace must
+    /// freeze its empty line to the previous allow-list as well — otherwise the
+    /// override, copied across the rebuild verbatim, replaces the new
+    /// manifest's explicit non-billing `tools` line with the widened list.
+    #[test]
+    fn an_upgrade_into_chargebee_freezes_an_empty_agent_override_scope() {
+        let old: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\"]\n",
+        )
+        .expect("old manifest");
+        let new: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\", \"chargebee\"]\n",
+        )
+        .expect("new manifest");
+        let edits = vec![
+            AgentOverride {
+                agent_id: "tax_preparer".to_string(),
+                // The stored spelling of "reset to the company's standard
+                // grant" — what the console writes for an empty tools list.
+                tools: Some(Vec::new()),
+                ..Default::default()
+            },
+            AgentOverride {
+                agent_id: "brand_strategist".to_string(),
+                tools: Some(vec!["docs.*".to_string()]),
+                ..Default::default()
+            },
+        ];
+
+        let (_, migrated) =
+            RuntimeBuilder::preserve_pre_upgrade_grant_scope(Vec::new(), edits, Some(&old), &new);
+
+        assert_eq!(
+            migrated[0].tools.as_deref().unwrap(),
+            old.tools.allow,
+            "an empty override is frozen to its pre-upgrade scope rather than silently inheriting chargebee"
+        );
+        assert_eq!(
+            migrated[1].tools.as_deref().unwrap(),
+            vec!["docs.*".to_string()],
+            "a stated override grant is untouched"
         );
     }
 
@@ -4145,8 +4197,8 @@ mod test {
             harness: None,
         }];
 
-        let migrated =
-            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Some(&old), &new);
+        let (migrated, _) =
+            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Vec::new(), Some(&old), &new);
 
         assert!(
             migrated[0].tools.is_empty(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1391,13 +1391,22 @@ impl RuntimeBuilder {
     /// instead: the previous allow-list. Only then, and only for those
     /// teammates — a company that already granted the namespace keeps its
     /// tracking, and one that still does not is untouched.
+    ///
+    /// The console's per-agent edit half ([`AgentOverride`]) is covered the
+    /// same way. `tools: Some([])` is its stored spelling of "give this
+    /// teammate the company's standard grant" — the same empty-means-standard
+    /// rule — and an override row is otherwise carried across a rebuild
+    /// verbatim, so a teammate an operator reset to the standard grant before
+    /// the upgrade would silently follow the widened allow-list into the new
+    /// namespace. Its empty line is frozen to the previous allow-list too.
     fn preserve_pre_upgrade_grant_scope(
         overlay_agents: Vec<OverlayAgent>,
+        overlay_agent_edits: Vec<AgentOverride>,
         previous_manifest: Option<&CompanyManifest>,
         manifest: &CompanyManifest,
-    ) -> Vec<OverlayAgent> {
+    ) -> (Vec<OverlayAgent>, Vec<AgentOverride>) {
         let Some(previous) = previous_manifest else {
-            return overlay_agents;
+            return (overlay_agents, overlay_agent_edits);
         };
         let newly_conferred = |detect: fn(&[String]) -> bool| {
             detect(&manifest.tools.allow) && !detect(&previous.tools.allow)
@@ -1406,9 +1415,9 @@ impl RuntimeBuilder {
             || newly_conferred(crate::company::grants_paypal_explicit)
             || newly_conferred(crate::company::grants_hosting_explicit))
         {
-            return overlay_agents;
+            return (overlay_agents, overlay_agent_edits);
         }
-        overlay_agents
+        let overlay_agents = overlay_agents
             .into_iter()
             .map(|mut agent| {
                 if agent.tools.is_empty() {
@@ -1416,7 +1425,17 @@ impl RuntimeBuilder {
                 }
                 agent
             })
-            .collect()
+            .collect();
+        let overlay_agent_edits = overlay_agent_edits
+            .into_iter()
+            .map(|mut edit| {
+                if edit.tools.as_ref().is_some_and(Vec::is_empty) {
+                    edit.tools = Some(previous.tools.allow.clone());
+                }
+                edit
+            })
+            .collect();
+        (overlay_agents, overlay_agent_edits)
     }
 
     /// Assembles the runtime, materializing `company.toml` and replaying the

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -42,8 +42,8 @@ use crate::policy::ManifestApprovalGate;
 #[cfg(feature = "openhuman")]
 use crate::ports::WorkflowRunner;
 use crate::ports::types::{
-    CompanyId, CompanyRecord, OverlayWorkflow, PolicyOverride, SecretValue, TemplateProvenance,
-    effective_policy,
+    CompanyId, CompanyRecord, OverlayAgent, OverlayWorkflow, PolicyOverride, SecretValue,
+    TemplateProvenance, effective_policy,
 };
 use crate::ports::{
     AgentEconomy, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
@@ -1378,6 +1378,47 @@ impl RuntimeBuilder {
         Self::new(home, manifest).build().await
     }
 
+    /// Preserve the pre-upgrade scope of persisted overlay teammates whose
+    /// grant was left unstated.
+    ///
+    /// An empty `OverlayAgent.tools` means "inherit the whole company
+    /// allow-list", and it keeps tracking that list across rebuilds on purpose
+    /// — an operator who left the line empty asked for whatever the company
+    /// allows. When a manifest upgrade widens the allow-list into a BYO
+    /// real-money namespace (issue #788) that the previous manifest did not
+    /// grant, that tracking hands billing to a teammate that never asked for
+    /// it. Freeze such a teammate's pre-upgrade scope into an explicit line
+    /// instead: the previous allow-list. Only then, and only for those
+    /// teammates — a company that already granted the namespace keeps its
+    /// tracking, and one that still does not is untouched.
+    fn preserve_pre_upgrade_grant_scope(
+        overlay_agents: Vec<OverlayAgent>,
+        previous_manifest: Option<&CompanyManifest>,
+        manifest: &CompanyManifest,
+    ) -> Vec<OverlayAgent> {
+        let Some(previous) = previous_manifest else {
+            return overlay_agents;
+        };
+        let newly_conferred = |detect: fn(&[String]) -> bool| {
+            detect(&manifest.tools.allow) && !detect(&previous.tools.allow)
+        };
+        if !(newly_conferred(crate::company::grants_chargebee_explicit)
+            || newly_conferred(crate::company::grants_paypal_explicit)
+            || newly_conferred(crate::company::grants_hosting_explicit))
+        {
+            return overlay_agents;
+        }
+        overlay_agents
+            .into_iter()
+            .map(|mut agent| {
+                if agent.tools.is_empty() {
+                    agent.tools = previous.tools.allow.clone();
+                }
+                agent
+            })
+            .collect()
+    }
+
     /// Assembles the runtime, materializing `company.toml` and replaying the
     /// journal to rebuild the approval queue.
     pub async fn build(mut self) -> Result<CompanyRuntime> {
@@ -2283,10 +2324,18 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.lifecycle.clone())
             .unwrap_or_else(|| "running".to_string());
-        let overlay_agents = existing
-            .as_ref()
-            .map(|r| r.overlay_agents.clone())
-            .unwrap_or_default();
+        // Existing overlay teammates are carried across the rebuild verbatim —
+        // except when the upgraded manifest newly confers a BYO real-money
+        // namespace (issue #788): an empty `tools` line would silently hand it
+        // to a teammate that never asked. Preserve their pre-upgrade scope.
+        let overlay_agents = Self::preserve_pre_upgrade_grant_scope(
+            existing
+                .as_ref()
+                .map(|r| r.overlay_agents.clone())
+                .unwrap_or_default(),
+            existing.as_ref().map(|r| &r.manifest),
+            &self.manifest,
+        );
         // The roster edits and removals an operator has made from the console.
         // Carried across the rebuild for the reason the overlay model exists at
         // all: neither is written back to `company.toml`, so the seed manifest
@@ -3991,6 +4040,95 @@ mod test {
             .prefix(prefix)
             .tempdir()
             .expect("tempdir")
+    }
+
+    /// A manifest upgrade that widens the allow-list into a BYO namespace must
+    /// not hand billing to persisted teammates whose grant was left unstated
+    /// (#788). Their pre-upgrade scope is frozen into an explicit line instead.
+    #[test]
+    fn an_upgrade_into_chargebee_preserves_the_pre_upgrade_scope_of_empty_lines() {
+        let old: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\"]\n",
+        )
+        .expect("old manifest");
+        let new: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\", \"chargebee\"]\n",
+        )
+        .expect("new manifest");
+        let overlay_agents = vec![
+            OverlayAgent {
+                id: "clerk".to_string(),
+                name: "Clerk".to_string(),
+                role: "Data Entry".to_string(),
+                description: None,
+                tools: Vec::new(),
+                model: None,
+                harness: None,
+            },
+            OverlayAgent {
+                id: "finance_help".to_string(),
+                name: "Finance Help".to_string(),
+                role: "Assistant".to_string(),
+                description: None,
+                tools: vec!["docs.*".to_string()],
+                model: None,
+                harness: None,
+            },
+        ];
+
+        let migrated =
+            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Some(&old), &new);
+
+        assert_eq!(
+            migrated[0].tools, old.tools.allow,
+            "an empty line is frozen to its pre-upgrade scope rather than silently inheriting chargebee"
+        );
+        assert_eq!(
+            migrated[1].tools,
+            vec!["docs.*".to_string()],
+            "a stated grant is untouched"
+        );
+    }
+
+    /// When the upgrade does not newly confer a BYO namespace, empty lines keep
+    /// tracking the allow-list as they always have.
+    #[test]
+    fn an_upgrade_without_a_new_billing_namespace_leaves_empty_lines_tracking() {
+        let old: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"media\"]\n",
+        )
+        .expect("old manifest");
+        let new: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [tools]\n\
+             allow = [\"*\", \"workspace.*\", \"media\", \"search\"]\n",
+        )
+        .expect("new manifest");
+        let overlay_agents = vec![OverlayAgent {
+            id: "clerk".to_string(),
+            name: "Clerk".to_string(),
+            role: "Data Entry".to_string(),
+            description: None,
+            tools: Vec::new(),
+            model: None,
+            harness: None,
+        }];
+
+        let migrated =
+            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Some(&old), &new);
+
+        assert!(
+            migrated[0].tools.is_empty(),
+            "no BYO namespace was newly conferred, so tracking is preserved"
+        );
     }
 
     mod seed_cards {

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4105,8 +4105,12 @@ mod test {
             },
         ];
 
-        let (migrated, _) =
-            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Vec::new(), Some(&old), &new);
+        let (migrated, _) = RuntimeBuilder::preserve_pre_upgrade_grant_scope(
+            overlay_agents,
+            Vec::new(),
+            Some(&old),
+            &new,
+        );
 
         assert_eq!(
             migrated[0].tools, old.tools.allow,
@@ -4197,8 +4201,12 @@ mod test {
             harness: None,
         }];
 
-        let (migrated, _) =
-            RuntimeBuilder::preserve_pre_upgrade_grant_scope(overlay_agents, Vec::new(), Some(&old), &new);
+        let (migrated, _) = RuntimeBuilder::preserve_pre_upgrade_grant_scope(
+            overlay_agents,
+            Vec::new(),
+            Some(&old),
+            &new,
+        );
 
         assert!(
             migrated[0].tools.is_empty(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4035,7 +4035,7 @@ fn build_networked_brain(
 mod test {
     use super::*;
     use crate::openhuman::MockOpenHumanRpc;
-    use crate::ports::types::{CompanyId, CompressedTrace, ToolCall};
+    use crate::ports::types::{AgentOverride, CompanyId, CompressedTrace, ToolCall};
     use crate::runtime::journal::ExecutedEffect;
 
     #[derive(Clone)]

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -473,7 +473,7 @@ async fn add_member(
     // add that does not keeps working for any member, exactly as before. The
     // check is deliberately conditional: adding this field must not quietly
     // take the existing capability away from members.
-    let author = match body.budget_usd_daily {
+    let mut author = match body.budget_usd_daily {
         Some(cap) => {
             if let Some(refusal) = validate_cap(cap) {
                 return Err(refusal.into());
@@ -536,6 +536,23 @@ async fn add_member(
             .filter(|glob| !glob.is_empty())
             .collect(),
     };
+    // Naming a BYO real-money namespace for a NEW teammate is a billing
+    // decision. A budget that spends money is already admin-only above; an
+    // explicit `chargebee`/`paypal`/`hosting` grant without a cap must be too —
+    // otherwise the day a company's ceiling includes `chargebee`, any member
+    // could mint a billing-capable teammate, while editing an existing
+    // teammate's `tools` is already admin-only (`team_agent.rs`). Focus-derived
+    // belts never name these namespaces, so only a hand-typed grant trips this.
+    if author.is_none()
+        && tools.iter().any(|grant| {
+            let one = std::slice::from_ref(grant);
+            crate::company::grants_chargebee_explicit(one)
+                || crate::company::grants_paypal_explicit(one)
+                || crate::company::grants_hosting_explicit(one)
+        })
+    {
+        author = Some(require_admin(&headers, &state, &company.runtime, peer).await?);
+    }
     let mut record = load_record(&company).await?;
     // A teammate created with no stated grant does not inherit the BYO
     // real-money namespaces (#788/#789), even though "empty" otherwise means
@@ -1580,6 +1597,58 @@ mod tests {
             effective.contains(&"workspace.write"),
             "a focus-less add still inherits the company grant: {effective:?}"
         );
+    }
+
+    /// Issue #788/#789: naming a BYO billing namespace for a NEW teammate is a
+    /// billing decision, and a member must not be able to make it. A budget
+    /// that spends money is already admin-only; an explicit `chargebee` grant
+    /// without a budget must be too — otherwise any member could mint a
+    /// billing-capable teammate the day the company ceiling includes one, while
+    /// editing an existing teammate's `tools` is already admin-only.
+    #[tokio::test]
+    async fn a_member_may_not_create_a_teammate_with_a_billing_grant() {
+        use crate::ports::UserRole;
+        let home_dir = home();
+        let state = state_with_manifest(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[tools]\n\
+             allow = [\"*\", \"workspace.*\", \"workspace.write\", \"media\", \"composio\", \
+             \"search\", \"mcp:*\", \"chargebee\"]\n",
+        )
+        .await;
+        let member =
+            crate::server::test_support::seed_session(&state, "acme", UserRole::Member).await;
+
+        let (status, body) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Jamie", "role": "Billing", "tools": ["chargebee"]})),
+            Some(&member),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+
+        // The refused add must not have persisted a teammate.
+        let (list_status, team) = get_team(&state).await;
+        assert_eq!(list_status, StatusCode::OK, "{team}");
+        let rows = team.as_array().unwrap();
+        assert!(
+            rows.iter().all(|r| r["name"] != "Jamie"),
+            "a refused add must not persist a teammate: {team}"
+        );
+
+        // An admin can still mint the billing-capable teammate.
+        let (status, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Dana", "role": "Billing", "tools": ["chargebee"]})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        assert_eq!(created["id"], "dana", "{created}");
     }
 
     /// An **overlay** teammate can be capped after the fact too — the case the

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -551,7 +551,22 @@ async fn add_member(
     // line. Narrowing at read time instead would silently re-widen the day an
     // operator edited the teammate for an unrelated reason.
     if tools.is_empty() {
-        tools = crate::company::creation_default_grants(&record.manifest.tools.allow);
+        match crate::company::creation_default_grants(&record.manifest.tools.allow) {
+            crate::company::CreationGrant::Standard => {}
+            crate::company::CreationGrant::Narrowed(narrowed) => tools = narrowed,
+            // Nothing safe to store: see `CreationGrant::NothingLeft`. Refusing
+            // is the honest answer and the operator can still create the
+            // teammate by naming its tools.
+            crate::company::CreationGrant::NothingLeft => {
+                return Err(ApiError(crate::error::OpenCompanyError::InvalidRequest(
+                    "this company grants only billing namespaces, so a teammate created with no \
+                     `tools` would inherit them. State the teammate's tools explicitly."
+                        .to_string(),
+                ))
+                .into_response()
+                .into());
+            }
+        }
     }
     let agent = OverlayAgent {
         // A readable id derived from the name, unique against the roster this

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -525,7 +525,7 @@ async fn add_member(
     // host-side instead — the belt table lives in `src/company/setup.rs`, and
     // the console has no business choosing a permission boundary. An unreadable
     // focus fails closed to the Writing belt (`tools_for_focus`), never wider.
-    let tools: Vec<String> = match body.focus.as_deref().map(str::trim) {
+    let mut tools: Vec<String> = match body.focus.as_deref().map(str::trim) {
         Some(focus) if !focus.is_empty() => {
             crate::company::setup::tools_for_focus(AgentFocus::from_wire(focus))
         }
@@ -537,6 +537,22 @@ async fn add_member(
             .collect(),
     };
     let mut record = load_record(&company).await?;
+    // A teammate created with no stated grant does not inherit the BYO
+    // real-money namespaces (#788/#789), even though "empty" otherwise means
+    // the standard company-wide grant. A company holds `chargebee` because
+    // somebody named it so that ONE teammate could invoice; the next teammate
+    // an operator types into the console is not that teammate, and silence is
+    // not consent to bill a customer. `creation_default_grants` returns empty
+    // — leaving the inherit-everything contract untouched — for every company
+    // that grants none of them, which is all but a handful.
+    //
+    // Deliberately here rather than in the roster build: this materialises the
+    // narrowed list ONCE, at creation, so the stored teammate carries its own
+    // line. Narrowing at read time instead would silently re-widen the day an
+    // operator edited the teammate for an unrelated reason.
+    if tools.is_empty() {
+        tools = crate::company::creation_default_grants(&record.manifest.tools.allow);
+    }
     let agent = OverlayAgent {
         // A readable id derived from the name, unique against the roster this
         // record already holds (issue #686). Minted here rather than pushed and


### PR DESCRIPTION
## Summary

`[tools].allow` is the only capability axis with no operator-facing write path. An operator can already edit a teammate's tools (`AgentOverride.tools`, admin-gated on `PATCH {scope}/team/{agent_id}`) and that edit survives re-seed — but the company allow-list comes from the shipped template and nothing else can set it. Since both an agent's own `tools` line and an operator's per-teammate override are **intersected** with `allow`, a namespace absent from the template can never be handed out by anyone.

The visible symptom: a company saves a Chargebee credential in Settings → Billing, the key stores fine, and the panel reports *"Connected — but no teammate can use it… it cannot be fixed from this page."* There is no page that can fix it. `chargebee` shipped in `TENANT_FEATURES` back in c11fdf3d0, so the feature is compiled into every hosted tenant; only the grant is missing.

Three templates gain it, and the shape is deliberate:

- **`agentic_marketing_agency`** — ceiling, **no holder**. Every desk narrows it away, so no shipped teammate holds billing tools. An agency that bills its clients names the teammate who does, from the console. The ceiling is what makes that possible at all.
- **`agentic_accounting_firm`** — `bookkeeper` holds it. A firm that cannot raise an invoice is a hole in the template.
- **`agentic_venture_studio`** — `finance` holds it. `founder` deliberately does not; it can ask finance.

Every other teammate in those companies now states its `tools` line explicitly. That is load-bearing rather than tidy: **an omitted line inherits the whole company grant**, so silence would hand billing to the copywriter and the tax preparer. Each list restates the current `default_allow` verbatim before narrowing, so no teammate loses capability it has today — verified by diffing effective grants (via the real `agent_scoped_grants` narrowing) for all 24 templates before and after.

`agentic_accounting_firm` and `agentic_venture_studio` join `FULL_BELT_PLUS_SEARCH`, the guard asserting an extended `allow` did not drop an inherited entry. That is not incidental: an earlier draft of this change was written against the pre-#1674 three-item belt and would have silently stripped `workspace.*`, `workspace.write` and `mcp:*` from thirteen agents. This list is what catches that.

## API Or Behavior Changes

No code paths change. Behavior changes for three shipped templates:

- Two teammates gain `chargebee` (`agentic_accounting_firm/bookkeeper`, `agentic_venture_studio/finance`). Both write tools remain `Reach::Consequence`, so they park for approval under these companies' `auto` policy — holding the tools is not invoicing unattended. The three read tools never park.
- `agentic_marketing_agency` gains the ceiling with zero holders; nothing there can invoice until an operator grants it.
- Tools still fail closed without a per-company credential: an explicit grant with no key wires nothing and warns.

Existing tenants are unaffected until they redeploy — the manifest is re-seeded from the template on every boot, so no migration is needed and none is possible.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 3809 + 15 + 1 passed, 0 failed

## Documentation

No doc change. The rules this leans on are already documented where they are enforced: the `*`-excludes-real-money-namespaces rule in `grants_chargebee_explicit`, the empty-means-inherit-everything rule on `AgentOverride.tools` and `OverlayAgent.tools`, and the three-level narrowing in `agent_scoped_grants`. Every edited manifest carries a comment explaining why its list is stated rather than omitted.

**Not filed against an issue.** The underlying gap — no operator-facing write path for `[tools].allow`, which the same way blocks `paypal`, `hosting` and `search` — is worth its own issue; happy to open one and link it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit tool access controls for accounting, marketing, and venture studio roles.
  - Enabled billing-tool access where required while restricting it for other roles.
  - Added company-level permissions and clearer role-specific access boundaries.
  - Prevented newly created teammates from unintentionally inheriting billing tools; narrowed or rejected access when appropriate.
  - Preserved approval requirements for invoice and customer-creation actions.

- **Tests**
  - Expanded coverage for inherited permissions and billing exclusions across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->