### PR TITLE
feat(workspace): readable names in the tree — title-named folders (#1687) + resolved agent badge (#1723)

### DIFF
--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -479,6 +479,33 @@ export function folderPathLabel(
 }
 
 /**
+ * The agent-provenance badge for a tree row, or `null` when none is shown
+ * (issue #1723).
+ *
+ * The tree marks agent-authored nodes with a chip so "what have the company's
+ * agents been writing?" is answerable by scanning. The chip used to print the
+ * raw roster handle (`analytics_analyst`) — the node's real folder name, but
+ * not what an operator recognizes the teammate by. Resolved through the same
+ * roster lookup the row label uses, it reads as "Analytics Analyst" instead,
+ * with the raw handle kept on the tooltip for disambiguation.
+ *
+ * Returns `null` — no badge — for a node not authored by an agent, and for one
+ * whose resolved name would only repeat `rowLabel`: an agent's own root folder
+ * badging itself with its own name says nothing new.
+ */
+export function agentBadge(
+  node: Pick<FsNode, "createdBy">,
+  rowLabel: string,
+  names: RosterNames,
+): { readonly label: string; readonly handle: string } | null {
+  if (node.createdBy.kind !== "agent") return null;
+  const handle = node.createdBy.id;
+  const label = rosterDisplayName(handle, names);
+  if (label === rowLabel) return null;
+  return { label, handle };
+}
+
+/**
  * Every folder in the tree, in the order the explorer draws them (issue #1381).
  *
  * `fetchTree` returns the host's order unmodified, and the host calls its own

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -97,6 +97,7 @@ import { fromDto } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import { createSaveBuffer, createUnloadGuard, type SaveBuffer } from "@/lib/workspace-save-buffer";
 import {
+  agentBadge,
   ancestorFolderIds,
   applyRepair,
   breadcrumbOf,
@@ -2222,6 +2223,13 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
   const displayName = isRosterFolder ? rosterDisplayName(node.name, rosterNames) : node.name;
   /** What this row is actually called on screen. */
   const label = isFolder ? displayName : titleOf(node);
+  // The agent-provenance badge is named by the same roster lookup the row
+  // label already uses (issue #1723): an operator recognizes "Analytics
+  // Analyst", not the raw `analytics_analyst` handle the id carries. The raw
+  // handle stays on the badge's `title` tooltip for disambiguation, and the
+  // badge is dropped when its resolved name would only repeat the row's own
+  // resolved label. See `agentBadge` for the rule.
+  const badge = agentBadge(node, label, rosterNames);
   /**
    * Whether the name is being cut off (issue #1459).
    *
@@ -2372,14 +2380,14 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
               the company been writing" is answerable by scanning rather than by
               opening each note. Only the agent case — badging the operator's
               own notes back at them says nothing. */}
-          {node.createdBy.kind === "agent" && (
+          {badge && (
             <Badge
               variant="outline"
               className={cn("shrink-0 px-1 py-0 text-3xs", ORIGIN_STYLES.agent)}
-              title={`Created by teammate ${node.createdBy.id}`}
+              title={`Created by teammate ${badge.handle}`}
               data-testid="workspace-tree-agent-badge"
             >
-              {node.createdBy.id}
+              {badge.label}
             </Badge>
           )}
         </button>

--- a/frontend/test/unit/workspace-agent-badge.test.ts
+++ b/frontend/test/unit/workspace-agent-badge.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { FsNode } from "@/api/workspace";
+import { agentBadge } from "@/lib/workspace";
+import { rosterNameMap } from "@/lib/roster-names";
+
+/**
+ * The workspace tree's agent-provenance badge (issue #1723).
+ *
+ * The chip marking an agent-authored node used to print the raw roster handle
+ * (`analytics_analyst`) — the node's real folder name, but not what an
+ * operator recognizes the teammate by. It now resolves through the same roster
+ * lookup the row label uses, so it reads "Analytics Analyst", with the raw
+ * handle kept on the tooltip. These tests are red against the pre-#1723 badge
+ * that rendered `node.createdBy.id` verbatim.
+ */
+
+function agentNode(id: string): Pick<FsNode, "createdBy"> {
+  return { createdBy: { kind: "agent", id } } as Pick<FsNode, "createdBy">;
+}
+
+const ROSTER = rosterNameMap([{ id: "analytics_analyst", name: "Analytics Analyst" }]);
+
+describe("agentBadge", () => {
+  it("resolves the raw handle to the roster display name", () => {
+    const badge = agentBadge(agentNode("analytics_analyst"), "report.md", ROSTER);
+    expect(badge).not.toBeNull();
+    // The label is the human name — never the snake_case handle the id carries.
+    expect(badge?.label).toBe("Analytics Analyst");
+  });
+
+  it("keeps the raw handle reachable for the tooltip", () => {
+    // Disambiguation still needs the underlying id, so it rides `handle`
+    // (which the row spends on the badge's `title`) even as the label reads
+    // as a name.
+    const badge = agentBadge(agentNode("analytics_analyst"), "report.md", ROSTER);
+    expect(badge?.handle).toBe("analytics_analyst");
+  });
+
+  it("falls back to the id when the roster has not resolved it", () => {
+    // The roster listing may not have loaded, or may not carry this id — the
+    // badge must still render the handle rather than go blank, exactly as the
+    // shared resolver does.
+    const badge = agentBadge(agentNode("analytics_analyst"), "report.md", rosterNameMap([]));
+    expect(badge?.label).toBe("analytics_analyst");
+    expect(badge?.handle).toBe("analytics_analyst");
+  });
+
+  it("shows no badge for a node not authored by an agent", () => {
+    const operator = { createdBy: { kind: "operator" } } as Pick<FsNode, "createdBy">;
+    const seed = { createdBy: { kind: "seed" } } as Pick<FsNode, "createdBy">;
+    expect(agentBadge(operator, "report.md", ROSTER)).toBeNull();
+    expect(agentBadge(seed, "report.md", ROSTER)).toBeNull();
+  });
+
+  it("suppresses the badge when its name would only repeat the row label", () => {
+    // An agent's own root folder is already labelled with the agent's name;
+    // a chip repeating it beside the label says nothing new.
+    expect(agentBadge(agentNode("analytics_analyst"), "Analytics Analyst", ROSTER)).toBeNull();
+  });
+});

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -79,7 +79,7 @@ use crate::ports::now_millis;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
-use super::workspace_names::{kebab_name, kebab_name_or, FALLBACK_NAME};
+use super::workspace_names::{FALLBACK_NAME, kebab_name, kebab_name_or};
 use super::workspace_scaffold::ensure_artifact_folder;
 
 /// One publish, as [`materialize`] needs it.
@@ -1275,11 +1275,7 @@ mod test {
         .expect("first card again")
         .node_id;
         assert_eq!(first, first_again);
-        let (_, body) = ws
-            .read(&co, &first_again)
-            .await
-            .unwrap()
-            .expect("the node");
+        let (_, body) = ws.read(&co, &first_again).await.unwrap().expect("the node");
         assert_eq!(body, "launch v3");
 
         let second_again = materialize(

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -232,8 +232,8 @@ pub async fn materialize(
     // its second segment against the first segment it just minted rather than
     // against a snapshot that predates it.
     let mut nodes = workspace.tree(company).await?;
+    let task_folder = task_folder_name(&nodes, &agent_folder, target);
     let mut parent = agent_folder;
-    let task_folder = kebab_name_or(target.title.unwrap_or(target.task_id), target.task_id);
     for name in std::iter::once(task_folder.as_str()).chain(dirs.iter().map(String::as_str)) {
         parent = resolve_folder(
             workspace,

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1429,6 +1429,7 @@ mod test {
                 payload: MirrorPayload::Text("summary"),
                 existing_node_id: None,
                 prior_node_ids: &[first.clone()],
+                recorded_before: false,
             },
         )
         .await

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1499,11 +1499,7 @@ mod test {
             path_of(ws, &co, &healed).await,
             format!("{ARTIFACTS_ROOT}/cmo/launch-plan/report.md")
         );
-        let (_, body) = ws
-            .read(&co, &healed)
-            .await
-            .unwrap()
-            .expect("the node");
+        let (_, body) = ws.read(&co, &healed).await.unwrap().expect("the node");
         assert_eq!(body, "v2");
     }
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -79,7 +79,7 @@ use crate::ports::now_millis;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
-use super::workspace_names::{FALLBACK_NAME, kebab_name, kebab_name_or};
+use super::workspace_names::{has_usable_name, kebab_name, kebab_name_or};
 use super::workspace_scaffold::ensure_artifact_folder;
 
 /// One publish, as [`materialize`] needs it.
@@ -783,9 +783,14 @@ fn task_folder_name(
         return owned;
     }
     let base = kebab_name_or(target.title.unwrap_or(target.task_id), target.task_id);
-    let titled = target
-        .title
-        .is_some_and(|title| kebab_name(title) != FALLBACK_NAME);
+    // Whether a title was actually *given* and normalizes to something, not
+    // whether the normalized result happens to read as the fallback word: a
+    // card literally titled "Untitled" normalizes to the same string
+    // `FALLBACK_NAME` is, but it is a real title that can collide with a
+    // same-titled sibling and needs the same disambiguation protection —
+    // comparing the normalized value to `FALLBACK_NAME` would wrongly treat it
+    // as if no title had been given at all.
+    let titled = target.title.is_some_and(has_usable_name);
     // An orphan-repair has no node id to name its folder, but the prior
     // publish chose one of the two deterministic spellings. The suffixed one
     // is uniquely this task's (`task_id` is unique) — adopt it when present —
@@ -1386,6 +1391,58 @@ mod test {
             .unwrap()
             .expect("the node");
         assert_eq!(body, "launch v4");
+    }
+
+    /// A card literally titled "Untitled" normalizes to the same string the
+    /// fallback name is, but it is a real title, not the absence of one —
+    /// so two such cards need the same same-title disambiguation as any other
+    /// matching pair (issue #1687). Comparing the normalized title to the
+    /// fallback sentinel used to conflate the two, skipping the occupied-folder
+    /// guard and letting the second card's first publish resolve to the
+    /// first's node and overwrite it.
+    #[tokio::test]
+    async fn cards_literally_titled_untitled_keep_their_deliverables_apart() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-1",
+                title: Some("Untitled"),
+                ..target("report.md", "first")
+            },
+        )
+        .await
+        .expect("first card")
+        .node_id;
+        let second = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-2",
+                title: Some("Untitled"),
+                ..target("report.md", "second")
+            },
+        )
+        .await
+        .expect("second card")
+        .node_id;
+
+        assert_ne!(
+            first, second,
+            "two cards literally titled Untitled keep their like-named files apart"
+        );
+        assert_eq!(
+            path_of(ws, &co, &first).await,
+            format!("{ARTIFACTS_ROOT}/cmo/untitled/report.md")
+        );
+        assert_eq!(
+            path_of(ws, &co, &second).await,
+            format!("{ARTIFACTS_ROOT}/cmo/untitled--t-2/report.md"),
+            "the second card's folder appends the stable task id, same as any other same-titled pair"
+        );
     }
 
     /// One titled card publishing two different sources keeps both in the same

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -708,6 +708,49 @@ fn split_source(source: &str) -> Result<Vec<String>> {
 /// The node pushed back into the snapshot is the one the **store** returned, so
 /// a publisher that adopted somebody else's folder walks on with the winner's
 /// id rather than one it invented.
+///
+/// # The task folder is named by the card's title, disambiguated by task id
+///
+/// The name a publish uses for the task folder is the card's title when it has
+/// a usable one, and the stable task id otherwise (issue #1687). A title is a
+/// spelling choice, not identity — the `(task_id, source)` pairing owns
+/// identity, and the title only chooses how the folder is spelled. That would
+/// be a lie if two cards of one agent shared a title (or two titles normalized
+/// to the same slug): both would walk to the same folder, and the second task's
+/// first publish — which carries no
+/// [`existing_node_id`](PublishTarget::existing_node_id) — would resolve to the
+/// first task's node and overwrite it, pointing two artifact chains at one
+/// workspace node.
+///
+/// So when a folder already answers to the bare title beneath the agent's
+/// artifacts root, the stable task id is appended: the first card lands in
+/// `launch-plan/`, the second in `launch-plan--t-2/`. The suffix is
+/// deterministic — the same `(agent, task_id, title)` always derives the same
+/// folder — and a re-publish never consults this name at all, because its
+/// `existing_node_id` revises the node directly. The cost is honest and
+/// narrow: a task whose bare title folder is claimed by a same-titled sibling
+/// files its *later* new sources under the suffixed folder beside its first,
+/// rather than guessing that the shared name is its own — ambiguity is refused,
+/// never guessed, exactly as it is everywhere else in this module. The occupied
+/// check reads the tree snapshot; the store's
+/// [`adopt_or_create_folder`](WorkspaceStore::adopt_or_create_folder) remains
+/// the arbiter of who actually owns a name when two publishes race to mint it.
+fn task_folder_name(nodes: &[WorkspaceNode], agent_folder: &str, target: PublishTarget<'_>) -> String {
+    let base = kebab_name_or(target.title.unwrap_or(target.task_id), target.task_id);
+    let titled = target
+        .title
+        .is_some_and(|title| kebab_name(title) != FALLBACK_NAME);
+    if titled
+        && children_named(nodes, agent_folder, &base)
+            .iter()
+            .any(|node| node.kind == NodeKind::Folder)
+    {
+        format!("{base}--{}", target.task_id)
+    } else {
+        base
+    }
+}
+
 async fn resolve_folder(
     workspace: &dyn WorkspaceStore,
     company: &CompanyId,

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -124,6 +124,14 @@ pub struct PublishTarget<'a> {
     /// keep a second source beside the first, rather than re-deriving the name
     /// from a tree snapshot and splitting one task across two folders.
     pub prior_node_ids: &'a [String],
+    /// Whether an artifact record for this exact source already exists. A
+    /// re-publish normally passes [`existing_node_id`](Self::existing_node_id),
+    /// but a record whose link was never stamped — an orphan — has no node id
+    /// to pass. This flag tells the mirror the publish is a repair, so the
+    /// task's own folder is treated as its own rather than a same-titled
+    /// sibling's: an orphan is re-adopted, never rivaled, and never suffixed
+    /// into a second folder (see [`task_folder_name`]).
+    pub recorded_before: bool,
 }
 
 /// What [`materialize`] is being asked to put in the tree.

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -736,19 +736,38 @@ fn split_source(source: &str) -> Result<Vec<String>> {
 /// `launch-plan/`, the second in `launch-plan--t-2/`. The suffix is
 /// deterministic — the same `(agent, task_id, title)` always derives the same
 /// folder — and a re-publish never consults this name at all, because its
-/// `existing_node_id` revises the node directly. The cost is honest and
-/// narrow: a task whose bare title folder is claimed by a same-titled sibling
-/// files its later new sources under the suffixed folder, rather than guessing
-/// that the shared name is its own — ambiguity is refused, never guessed,
-/// exactly as it is everywhere else in this module. The occupied check reads
-/// the tree snapshot; the store's
+/// `existing_node_id` revises the node directly.
+///
+/// Two rules keep that spelling from splitting a task. First, a card that
+/// already owns nodes in the tree keeps the folder those nodes live in,
+/// whatever it is currently called: the second source of a "Launch Plan" card
+/// files into the same `launch-plan/` (or `launch-plan--t-2/`) the first did,
+/// because its `prior_node_ids` name the folder it already uses. Re-deriving
+/// from the title alone would see `launch-plan/` occupied and mis-suffix it,
+/// pointing one task's deliverables at two folders. Second, the occupied check
+/// reads the tree snapshot, so two same-titled cards first-publishing at the
+/// same instant can both pick the bare name; the store's
 /// [`adopt_or_create_folder`](WorkspaceStore::adopt_or_create_folder) remains
-/// the arbiter of who actually owns a name when two publishes race to mint it.
+/// the arbiter of who actually owns the folder, and a task that loses that race
+/// simply files its sources beside the winner's — the folder is shared, never
+/// one task's chain overwriting the other's node. The cost of the rule is
+/// honest and narrow: a task whose bare title folder is claimed by a
+/// same-titled sibling files its later new sources under the suffixed folder,
+/// rather than guessing that the shared name is its own — ambiguity is refused,
+/// never guessed, exactly as it is everywhere else in this module.
 fn task_folder_name(
     nodes: &[WorkspaceNode],
     agent_folder: &str,
     target: PublishTarget<'_>,
 ) -> String {
+    // A task that already has nodes in the tree keeps the folder holding them.
+    // That folder may carry the bare title, a `--task-id` suffix a sibling
+    // forced, or a name the operator renamed it to; whichever it is, it is the
+    // stable home this task files under, and re-deriving from the title would
+    // split one card's deliverables across two folders.
+    if let Some(owned) = owned_folder_name(nodes, agent_folder, target.prior_node_ids) {
+        return owned;
+    }
     let base = kebab_name_or(target.title.unwrap_or(target.task_id), target.task_id);
     let titled = target
         .title
@@ -762,6 +781,28 @@ fn task_folder_name(
     } else {
         base
     }
+}
+
+/// The name of the folder directly beneath `agent_folder` that holds the first
+/// of `prior_node_ids` still present in the tree, if any.
+///
+/// Walks each owned node up to its immediate child of `agent_folder` — so a
+/// node at `artifacts/<agent>/<task>/specs/launch.md` names `specs`'s parent,
+/// the `<task>` folder itself. A node the operator deleted is skipped, and a
+/// card that owns nothing has no folder to reuse.
+fn owned_folder_name(
+    nodes: &[WorkspaceNode],
+    agent_folder: &str,
+    prior_node_ids: &[String],
+) -> Option<String> {
+    prior_node_ids.iter().find_map(|id| {
+        let mut cursor = nodes.iter().find(|node| node.id.as_str() == id.as_str())?;
+        while cursor.parent_id.as_deref() != Some(agent_folder) {
+            let parent_id = cursor.parent_id.as_ref()?;
+            cursor = nodes.iter().find(|node| node.id.as_str() == parent_id.as_str())?;
+        }
+        Some(cursor.name.clone())
+    })
 }
 
 async fn resolve_folder(

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -79,7 +79,7 @@ use crate::ports::now_millis;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
-use super::workspace_names::{kebab_name, kebab_name_or};
+use super::workspace_names::{kebab_name, kebab_name_or, FALLBACK_NAME};
 use super::workspace_scaffold::ensure_artifact_folder;
 
 /// One publish, as [`materialize`] needs it.

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -116,6 +116,13 @@ pub struct PublishTarget<'a> {
     /// The node the previous version of this artifact was mirrored into, when
     /// there was one. Reused if it still resolves; see [`materialize`].
     pub existing_node_id: Option<&'a str>,
+    /// The workspace node ids every artifact record of this card already owns
+    /// — the file nodes its earlier sources were mirrored into, from prior
+    /// runs and from earlier publishes in this same run. They let
+    /// [`task_folder_name`] find the folder this task already files under and
+    /// keep a second source beside the first, rather than re-deriving the name
+    /// from a tree snapshot and splitting one task across two folders.
+    pub prior_node_ids: &'a [String],
 }
 
 /// What [`materialize`] is being asked to put in the tree.

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -104,7 +104,8 @@ pub struct PublishTarget<'a> {
     /// identity — the `(task_id, source)` pairing above still owns that — it
     /// only chooses how the folder is spelled. When two cards of one agent
     /// share a title, the second is spelled `title--task-id` so the two tasks
-    /// stay apart (see [`task_folder_name`]).
+    /// stay apart, and a card's later sources keep the folder its first one
+    /// established (see [`task_folder_name`]).
     pub title: Option<&'a str>,
     /// The normalized workspace-relative path the agent published, e.g.
     /// `specs/launch.md`. Interior segments become folders.

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1134,8 +1134,8 @@ mod test {
     /// rather than minting a rival (issue #1687).
     ///
     /// Distinct titles yield distinct folders, so a common filename cannot
-    /// collide across tasks; a second publish of the same source into the same
-    /// title folder resolves to the one node already there.
+    /// collide across tasks; a re-publish carries its `existing_node_id` (as
+    /// the brain's publish path does) and revises the one node it already has.
     #[tokio::test]
     async fn title_folders_keep_the_task_source_identity() {
         let (_dir, ops, co) = stores();
@@ -1179,13 +1179,15 @@ mod test {
             format!("{ARTIFACTS_ROOT}/cmo/retro-notes/report.md")
         );
 
-        // Same card, same source, published again: one node, revised in place.
+        // Same card, same source, published again: the inherited node id
+        // revises it in place — one node, never a rival.
         let launch_again = materialize(
             ws,
             &co,
             PublishTarget {
                 task_id: "t-1",
                 title: Some("Launch Plan"),
+                existing_node_id: Some(&launch),
                 ..target("report.md", "launch v2")
             },
         )
@@ -1199,6 +1201,103 @@ mod test {
             .unwrap()
             .expect("the node");
         assert_eq!(body, "launch v2");
+    }
+
+    /// Two cards of one agent with the **same** title cannot share a folder
+    /// (issue #1687): the title is a spelling choice, not identity, and two
+    /// tasks whose titles normalize to the same slug would otherwise resolve
+    /// the second task's first publish to the first task's node and overwrite
+    /// it — pointing two artifact chains at one workspace node.
+    ///
+    /// The first card claims the bare title folder; the second files under
+    /// `launch-plan--t-2`, and each card's re-publish still revises its own
+    /// node rather than the other's.
+    #[tokio::test]
+    async fn same_titled_cards_keep_their_deliverables_apart() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-1",
+                title: Some("Launch Plan"),
+                ..target("report.md", "launch v1")
+            },
+        )
+        .await
+        .expect("first card")
+        .node_id;
+        let second = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-2",
+                title: Some("Launch Plan"),
+                ..target("report.md", "launch v2")
+            },
+        )
+        .await
+        .expect("second card")
+        .node_id;
+
+        assert_ne!(
+            first, second,
+            "two same-titled cards keep their like-named files apart"
+        );
+        assert_eq!(
+            path_of(ws, &co, &first).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan/report.md")
+        );
+        assert_eq!(
+            path_of(ws, &co, &second).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan--t-2/report.md"),
+            "the second card's folder appends the stable task id to the title"
+        );
+
+        // Each card re-publishes its own node, never the other's.
+        let first_again = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-1",
+                title: Some("Launch Plan"),
+                existing_node_id: Some(&first),
+                ..target("report.md", "launch v3")
+            },
+        )
+        .await
+        .expect("first card again")
+        .node_id;
+        assert_eq!(first, first_again);
+        let (_, body) = ws
+            .read(&co, &first_again)
+            .await
+            .unwrap()
+            .expect("the node");
+        assert_eq!(body, "launch v3");
+
+        let second_again = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-2",
+                title: Some("Launch Plan"),
+                existing_node_id: Some(&second),
+                ..target("report.md", "launch v4")
+            },
+        )
+        .await
+        .expect("second card again")
+        .node_id;
+        assert_eq!(second, second_again);
+        let (_, body) = ws
+            .read(&co, &second_again)
+            .await
+            .unwrap()
+            .expect("the node");
+        assert_eq!(body, "launch v4");
     }
 
     /// A **binary** publish lands real bytes in the tree (issue #553).

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -102,7 +102,9 @@ pub struct PublishTarget<'a> {
     /// normalizes to nothing) falls back to [`task_id`](Self::task_id), which
     /// keeps the folder identifiable. The title never changes the folder's
     /// identity — the `(task_id, source)` pairing above still owns that — it
-    /// only chooses how the folder is spelled.
+    /// only chooses how the folder is spelled. When two cards of one agent
+    /// share a title, the second is spelled `title--task-id` so the two tasks
+    /// stay apart (see [`task_folder_name`]).
     pub title: Option<&'a str>,
     /// The normalized workspace-relative path the agent published, e.g.
     /// `specs/launch.md`. Interior segments become folders.

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -80,6 +80,7 @@ use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
 use super::workspace_names::{has_usable_name, kebab_name, kebab_name_or};
+use super::workspace_paths::MAX_PATH_DEPTH;
 use super::workspace_scaffold::ensure_artifact_folder;
 
 /// One publish, as [`materialize`] needs it.
@@ -840,6 +841,13 @@ fn task_folder_name(
 /// deliverable the operator relocated could never publish another source.
 /// Only a folder counts as a home to reuse; a node parented straight to
 /// `agent_folder` has none, and later prior ids are tried instead.
+///
+/// Bounded by [`MAX_PATH_DEPTH`], the same guard
+/// [`workspace_paths::render_path`](super::workspace_paths::render_path) uses:
+/// normal moves reject a parent cycle, but a hand-edited or corrupted backing
+/// row could still present one, and without the bound a cycle that never
+/// reaches `agent_folder` would spin this walk forever. A prior id whose chain
+/// runs past the bound is skipped, same as one that dangles.
 fn owned_folder_name(
     nodes: &[WorkspaceNode],
     agent_folder: &str,
@@ -847,7 +855,12 @@ fn owned_folder_name(
 ) -> Option<String> {
     prior_node_ids.iter().find_map(|id| {
         let mut cursor = nodes.iter().find(|node| node.id.as_str() == id.as_str())?;
+        let mut depth = 0;
         while cursor.parent_id.as_deref() != Some(agent_folder) {
+            depth += 1;
+            if depth > MAX_PATH_DEPTH {
+                return None;
+            }
             let parent_id = cursor.parent_id.as_ref()?;
             cursor = nodes
                 .iter()
@@ -1653,6 +1666,44 @@ mod test {
         );
         let (_, body) = ws.read(&co, &healed).await.unwrap().expect("the node");
         assert_eq!(body, "v2");
+    }
+
+    /// A parent cycle that never reaches `agent_folder` — the shape a
+    /// hand-edited or corrupted backing row could present, per
+    /// `workspace_paths::render_path`'s own guard — must not spin
+    /// [`owned_folder_name`]'s walk forever. It bails past
+    /// [`MAX_PATH_DEPTH`] and is skipped, same as a dangling prior id.
+    #[test]
+    fn owned_folder_name_bails_on_a_parent_cycle_instead_of_spinning() {
+        fn node(id: &str, name: &str, kind: NodeKind, parent: Option<&str>) -> WorkspaceNode {
+            WorkspaceNode {
+                id: id.to_string(),
+                name: name.to_string(),
+                kind,
+                parent_id: parent.map(str::to_string),
+                updated_at_millis: 1,
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
+                mime: None,
+                size: None,
+                sha256: None,
+            }
+        }
+
+        // `a` and `b` are each other's parent, and neither chain ever reaches
+        // `agent-folder`.
+        let nodes = vec![
+            node("a", "A", NodeKind::Folder, Some("b")),
+            node("b", "B", NodeKind::Folder, Some("a")),
+            node("file", "report.md", NodeKind::File, Some("a")),
+        ];
+        let prior_node_ids = vec!["file".to_string()];
+
+        assert_eq!(
+            owned_folder_name(&nodes, "agent-folder", &prior_node_ids),
+            None,
+            "a cycle that never reaches the agent folder is skipped, not looped on forever"
+        );
     }
 
     /// A **binary** publish lands real bytes in the tree (issue #553).

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1030,6 +1030,7 @@ mod test {
             source,
             payload: MirrorPayload::Text(body),
             existing_node_id: None,
+            prior_node_ids: &[],
         }
     }
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1068,6 +1068,7 @@ mod test {
             payload: MirrorPayload::Text(body),
             existing_node_id: None,
             prior_node_ids: &[],
+            recorded_before: false,
         }
     }
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -753,9 +753,14 @@ fn split_source(source: &str) -> Result<Vec<String>> {
 /// files into the same `launch-plan/` (or `launch-plan--t-2/`) the first did,
 /// because its `prior_node_ids` name the folder it already uses. Re-deriving
 /// from the title alone would see `launch-plan/` occupied and mis-suffix it,
-/// pointing one task's deliverables at two folders. Second, the occupied check
-/// reads the tree snapshot, so two same-titled cards first-publishing at the
-/// same instant can both pick the bare name; the store's
+/// pointing one task's deliverables at two folders. Second, a re-publish of a
+/// source whose record lost its link — an orphan — has no node id to name its
+/// folder, but the folder is one of the two deterministic spellings the prior
+/// publish could have chosen; the suffixed one is uniquely this task's, so it
+/// is adopted when present, and a bare title folder the task minted itself is
+/// treated as its own rather than a same-titled sibling's. Third, the occupied
+/// check reads the tree snapshot, so two same-titled cards first-publishing at
+/// the same instant can both pick the bare name; the store's
 /// [`adopt_or_create_folder`](WorkspaceStore::adopt_or_create_folder) remains
 /// the arbiter of who actually owns the folder, and a task that loses that race
 /// simply files its sources beside the winner's — the folder is shared, never
@@ -781,6 +786,28 @@ fn task_folder_name(
     let titled = target
         .title
         .is_some_and(|title| kebab_name(title) != FALLBACK_NAME);
+    // An orphan-repair has no node id to name its folder, but the prior
+    // publish chose one of the two deterministic spellings. The suffixed one
+    // is uniquely this task's (`task_id` is unique) — adopt it when present —
+    // and a bare title folder reached only when the suffixed one is absent was
+    // minted by this task itself, since a same-titled sibling would have forced
+    // the suffix on the prior publish too. Reaching for the sibling's bare
+    // folder here would re-link this task's chain to a foreign node.
+    if target.recorded_before && titled {
+        let suffixed = format!("{base}--{}", target.task_id);
+        if children_named(nodes, agent_folder, &suffixed)
+            .iter()
+            .any(|node| node.kind == NodeKind::Folder)
+        {
+            return suffixed;
+        }
+        if children_named(nodes, agent_folder, &base)
+            .iter()
+            .any(|node| node.kind == NodeKind::Folder)
+        {
+            return base;
+        }
+    }
     if titled
         && children_named(nodes, agent_folder, &base)
             .iter()

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -800,7 +800,9 @@ fn owned_folder_name(
         let mut cursor = nodes.iter().find(|node| node.id.as_str() == id.as_str())?;
         while cursor.parent_id.as_deref() != Some(agent_folder) {
             let parent_id = cursor.parent_id.as_ref()?;
-            cursor = nodes.iter().find(|node| node.id.as_str() == parent_id.as_str())?;
+            cursor = nodes
+                .iter()
+                .find(|node| node.id.as_str() == parent_id.as_str())?;
         }
         Some(cursor.name.clone())
     })

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1428,7 +1428,7 @@ mod test {
                 source: "summary.md",
                 payload: MirrorPayload::Text("summary"),
                 existing_node_id: None,
-                prior_node_ids: &[first.clone()],
+                prior_node_ids: std::slice::from_ref(&first),
                 recorded_before: false,
             },
         )

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -831,6 +831,15 @@ fn task_folder_name(
 /// node at `artifacts/<agent>/<task>/specs/launch.md` names `specs`'s parent,
 /// the `<task>` folder itself. A node the operator deleted is skipped, and a
 /// card that owns nothing has no folder to reuse.
+///
+/// The walk can end on a **file**, not a folder: an operator is free to move a
+/// published file so it sits directly under `agent_folder`, with no task
+/// folder between them at all. Returning that file's own name here would hand
+/// `resolve_folder` a filename to resolve as a folder, and it would refuse —
+/// the file "already exists as a note, not a folder" — so a card whose
+/// deliverable the operator relocated could never publish another source.
+/// Only a folder counts as a home to reuse; a node parented straight to
+/// `agent_folder` has none, and later prior ids are tried instead.
 fn owned_folder_name(
     nodes: &[WorkspaceNode],
     agent_folder: &str,
@@ -844,7 +853,7 @@ fn owned_folder_name(
                 .iter()
                 .find(|node| node.id.as_str() == parent_id.as_str())?;
         }
-        Some(cursor.name.clone())
+        (cursor.kind == NodeKind::Folder).then(|| cursor.name.clone())
     })
 }
 
@@ -1503,6 +1512,91 @@ mod test {
             format!("{ARTIFACTS_ROOT}/cmo/launch-plan/summary.md"),
             "the card's second source files beside its first, not under a \
              title--task-id split"
+        );
+    }
+
+    /// A card whose deliverable the operator moved to sit directly under the
+    /// agent folder — no task folder in between — still lets its card publish
+    /// a second source (issue #1687 follow-up).
+    ///
+    /// `owned_folder_name`'s walk-up stops as soon as a node's parent is the
+    /// agent folder, which a **file** moved there satisfies immediately: the
+    /// walk never reaches a folder at all. Returning that file's own name
+    /// (`report.md`) as the task folder would have `resolve_folder` refuse it
+    /// — a note, not a folder — and the card could never publish again. The
+    /// fix derives a fresh task folder from the title instead, exactly as if
+    /// the card owned nothing yet. The empty `launch-plan/` folder the move
+    /// left behind still occupies that name, so the ordinary same-title
+    /// disambiguation applies on top and the second source is suffixed — the
+    /// win here is that the publish succeeds at all, not which exact name it
+    /// lands under.
+    #[tokio::test]
+    async fn a_prior_node_moved_directly_under_the_agent_folder_is_not_read_as_a_task_folder() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                title: Some("Launch Plan"),
+                ..target("report.md", "launch v1")
+            },
+        )
+        .await
+        .expect("first source")
+        .node_id;
+
+        let nodes = ws.tree(&co).await.unwrap();
+        let agent_folder_id = nodes
+            .iter()
+            .find(|n| n.id == first)
+            .and_then(|file| file.parent_id.clone())
+            .and_then(|task_folder_id| {
+                nodes
+                    .iter()
+                    .find(|n| n.id == task_folder_id)
+                    .and_then(|task_folder| task_folder.parent_id.clone())
+            })
+            .expect("the file sits two levels under the agent folder");
+
+        // The operator moves the deliverable straight under the agent folder,
+        // dissolving the task folder around it.
+        ws.rename_move(&co, &first, None, Some(Some(&agent_folder_id)))
+            .await
+            .expect("operator move");
+        assert_eq!(
+            path_of(ws, &co, &first).await,
+            format!("{ARTIFACTS_ROOT}/cmo/report.md"),
+            "the move landed the file directly under the agent folder"
+        );
+
+        // A second source of the same card must still be able to publish.
+        let second = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                agent_id: "cmo",
+                task_id: "t-1",
+                title: Some("Launch Plan"),
+                source: "summary.md",
+                payload: MirrorPayload::Text("summary"),
+                existing_node_id: None,
+                prior_node_ids: std::slice::from_ref(&first),
+                recorded_before: false,
+            },
+        )
+        .await
+        .expect("second source still publishes after the operator's move");
+
+        // The empty `launch-plan/` folder the move left behind still occupies
+        // that name, so the ordinary same-title disambiguation suffixes the
+        // second source rather than mis-resolving `report.md` as a folder.
+        assert_eq!(
+            path_of(ws, &co, &second.node_id).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan--t-1/summary.md"),
+            "falls back to deriving the task folder from the title, not the \
+             moved file's own name, and the publish succeeds"
         );
     }
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -93,9 +93,17 @@ pub struct PublishTarget<'a> {
     /// folder it lands under, and the authorship stamped on every node created
     /// or written along the way.
     pub agent_id: &'a str,
-    /// The card the publish belongs to. Names the folder beneath the agent's,
-    /// so two tasks by one agent cannot collide on a common filename.
+    /// The card the publish belongs to. Its id is the stable identity of the
+    /// folder beneath the agent's — so two tasks by one agent cannot collide on
+    /// a common filename — and its fallback name when the card has no title.
     pub task_id: &'a str,
+    /// The card's human title, used to *name* the task folder so the tree reads
+    /// as "Launch Plan" rather than a raw ULID. `None` (or a title that
+    /// normalizes to nothing) falls back to [`task_id`](Self::task_id), which
+    /// keeps the folder identifiable. The title never changes the folder's
+    /// identity — the `(task_id, source)` pairing above still owns that — it
+    /// only chooses how the folder is spelled.
+    pub title: Option<&'a str>,
     /// The normalized workspace-relative path the agent published, e.g.
     /// `specs/launch.md`. Interior segments become folders.
     pub source: &'a str,
@@ -225,7 +233,7 @@ pub async fn materialize(
     // against a snapshot that predates it.
     let mut nodes = workspace.tree(company).await?;
     let mut parent = agent_folder;
-    let task_folder = kebab_name_or(target.task_id, target.task_id);
+    let task_folder = kebab_name_or(target.title.unwrap_or(target.task_id), target.task_id);
     for name in std::iter::once(task_folder.as_str()).chain(dirs.iter().map(String::as_str)) {
         parent = resolve_folder(
             workspace,
@@ -920,6 +928,7 @@ mod test {
         PublishTarget {
             agent_id: "cmo",
             task_id: "t-1",
+            title: None,
             source,
             payload: MirrorPayload::Text(body),
             existing_node_id: None,
@@ -1008,6 +1017,143 @@ mod test {
         assert_eq!(first, second, "one deliverable, one node");
         let (_, body) = ws.read(&co, &second).await.unwrap().expect("the node");
         assert_eq!(body, "v2");
+    }
+
+    /// The task folder is named by the card's **title**, not its raw id
+    /// (issue #1687).
+    ///
+    /// The tree is what the operator reads, and a column of ULIDs answers
+    /// "which task produced this?" with a lookup rather than at a glance. The
+    /// title carries that meaning; the id only has to be there when a title
+    /// does not. Red against the id-named folder this replaced
+    /// (`kebab_name_or(task_id, task_id)`), which would file this under `t-1/`.
+    #[tokio::test]
+    async fn the_task_folder_is_named_by_the_card_title() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let id = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                title: Some("Launch Plan"),
+                ..target("brief.md", "# Brief")
+            },
+        )
+        .await
+        .expect("materialize")
+        .node_id;
+
+        assert_eq!(
+            path_of(ws, &co, &id).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan/brief.md"),
+            "the folder reads as the kebab-cased title, not the task id"
+        );
+    }
+
+    /// A title that normalizes to nothing — whitespace, punctuation, an emoji,
+    /// or simply absent — falls back to the task id, so the folder stays
+    /// identifiable rather than joining every other unnameable task at
+    /// `untitled` (issue #1687).
+    ///
+    /// This is the pre-#1687 behaviour, kept as the floor: a publish with no
+    /// usable title lands exactly where it always did.
+    #[tokio::test]
+    async fn an_unusable_title_falls_back_to_the_task_id() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let id = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "01h8xgjabcdef",
+                title: Some("   "),
+                ..target("brief.md", "# Brief")
+            },
+        )
+        .await
+        .expect("materialize")
+        .node_id;
+
+        assert_eq!(
+            path_of(ws, &co, &id).await,
+            format!("{ARTIFACTS_ROOT}/cmo/01h8xgjabcdef/brief.md"),
+            "an empty title leaves the id-named folder in place, never `untitled`"
+        );
+    }
+
+    /// Naming the folder by title does not weaken the `(task_id, source)`
+    /// identity the struct's own doc promises: two different cards keep their
+    /// like-named files apart, and a re-publish of one source revises its node
+    /// rather than minting a rival (issue #1687).
+    ///
+    /// Distinct titles yield distinct folders, so a common filename cannot
+    /// collide across tasks; a second publish of the same source into the same
+    /// title folder resolves to the one node already there.
+    #[tokio::test]
+    async fn title_folders_keep_the_task_source_identity() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let launch = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-1",
+                title: Some("Launch Plan"),
+                ..target("report.md", "launch v1")
+            },
+        )
+        .await
+        .expect("launch")
+        .node_id;
+        let retro = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-2",
+                title: Some("Retro Notes"),
+                ..target("report.md", "retro v1")
+            },
+        )
+        .await
+        .expect("retro")
+        .node_id;
+
+        assert_ne!(
+            launch, retro,
+            "two cards' like-named files stay in separate title folders"
+        );
+        assert_eq!(
+            path_of(ws, &co, &launch).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan/report.md")
+        );
+        assert_eq!(
+            path_of(ws, &co, &retro).await,
+            format!("{ARTIFACTS_ROOT}/cmo/retro-notes/report.md")
+        );
+
+        // Same card, same source, published again: one node, revised in place.
+        let launch_again = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-1",
+                title: Some("Launch Plan"),
+                ..target("report.md", "launch v2")
+            },
+        )
+        .await
+        .expect("launch again")
+        .node_id;
+        assert_eq!(launch, launch_again, "one source in one task, one node");
+        let (_, body) = ws
+            .read(&co, &launch_again)
+            .await
+            .unwrap()
+            .expect("the node");
+        assert_eq!(body, "launch v2");
     }
 
     /// A **binary** publish lands real bytes in the tree (issue #553).

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1384,11 +1384,13 @@ mod test {
             ws,
             &co,
             PublishTarget {
+                agent_id: "cmo",
+                task_id: "t-1",
                 title: Some("Launch Plan"),
                 source: "summary.md",
                 payload: MirrorPayload::Text("summary"),
+                existing_node_id: None,
                 prior_node_ids: &[first.clone()],
-                ..target("", "")
             },
         )
         .await

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -731,13 +731,17 @@ fn split_source(source: &str) -> Result<Vec<String>> {
 /// folder — and a re-publish never consults this name at all, because its
 /// `existing_node_id` revises the node directly. The cost is honest and
 /// narrow: a task whose bare title folder is claimed by a same-titled sibling
-/// files its *later* new sources under the suffixed folder beside its first,
-/// rather than guessing that the shared name is its own — ambiguity is refused,
-/// never guessed, exactly as it is everywhere else in this module. The occupied
-/// check reads the tree snapshot; the store's
+/// files its later new sources under the suffixed folder, rather than guessing
+/// that the shared name is its own — ambiguity is refused, never guessed,
+/// exactly as it is everywhere else in this module. The occupied check reads
+/// the tree snapshot; the store's
 /// [`adopt_or_create_folder`](WorkspaceStore::adopt_or_create_folder) remains
 /// the arbiter of who actually owns a name when two publishes race to mint it.
-fn task_folder_name(nodes: &[WorkspaceNode], agent_folder: &str, target: PublishTarget<'_>) -> String {
+fn task_folder_name(
+    nodes: &[WorkspaceNode],
+    agent_folder: &str,
+    target: PublishTarget<'_>,
+) -> String {
     let base = kebab_name_or(target.title.unwrap_or(target.task_id), target.task_id);
     let titled = target
         .title

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1448,6 +1448,65 @@ mod test {
         );
     }
 
+    /// An orphan is re-adopted, not rivaled: a re-publish whose record lost its
+    /// link has no node id to name its folder, but the bare title folder it
+    /// minted is its own, so the repair lands beside the orphan and revises it
+    /// rather than suffixing into a `launch-plan--t-1` rival.
+    #[tokio::test]
+    async fn an_unlinked_republish_re_adopts_its_orphan_instead_of_suffixing() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        // The first publish mints the bare title folder; its record then loses
+        // the link, leaving the node an orphan.
+        let orphan = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                title: Some("Launch Plan"),
+                ..target("report.md", "v1")
+            },
+        )
+        .await
+        .expect("first publish")
+        .node_id;
+
+        // The repair: the record exists (`recorded_before`) but holds no node
+        // id, exactly the state brain.rs reaches after a failed link stamp.
+        let healed = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                agent_id: "cmo",
+                task_id: "t-1",
+                title: Some("Launch Plan"),
+                source: "report.md",
+                payload: MirrorPayload::Text("v2"),
+                existing_node_id: None,
+                prior_node_ids: &[],
+                recorded_before: true,
+            },
+        )
+        .await
+        .expect("repairing publish")
+        .node_id;
+
+        assert_eq!(
+            healed, orphan,
+            "the very same note is re-adopted, which is what makes the orphan self-healing"
+        );
+        assert_eq!(
+            path_of(ws, &co, &healed).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan/report.md")
+        );
+        let (_, body) = ws
+            .read(&co, &healed)
+            .await
+            .unwrap()
+            .expect("the node");
+        assert_eq!(body, "v2");
+    }
+
     /// A **binary** publish lands real bytes in the tree (issue #553).
     ///
     /// This is the payoff of the whole issue: before it, a generated image

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1350,6 +1350,64 @@ mod test {
         assert_eq!(body, "launch v4");
     }
 
+    /// One titled card publishing two different sources keeps both in the same
+    /// folder.
+    ///
+    /// The second source carries no `existing_node_id` (its record is new), so
+    /// a folder name re-derived from the tree snapshot alone would see
+    /// `launch-plan/` occupied and mis-file the card under `launch-plan--t-1`,
+    /// splitting one task's deliverables across two folders. The card's
+    /// `prior_node_ids` — the node its first source established — name the
+    /// folder it already files under, so the second source lands beside the
+    /// first.
+    #[tokio::test]
+    async fn one_card_publishing_two_sources_keeps_both_in_the_same_folder() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                title: Some("Launch Plan"),
+                ..target("report.md", "launch v1")
+            },
+        )
+        .await
+        .expect("first source")
+        .node_id;
+
+        // A second source of the SAME card, filed in a later run: its record
+        // has no node yet, but the first source's node says where this card
+        // lives.
+        let second = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                title: Some("Launch Plan"),
+                source: "summary.md",
+                payload: MirrorPayload::Text("summary"),
+                prior_node_ids: &[first.clone()],
+                ..target("", "")
+            },
+        )
+        .await
+        .expect("second source")
+        .node_id;
+
+        assert_ne!(first, second, "two sources are two nodes");
+        assert_eq!(
+            path_of(ws, &co, &first).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan/report.md")
+        );
+        assert_eq!(
+            path_of(ws, &co, &second).await,
+            format!("{ARTIFACTS_ROOT}/cmo/launch-plan/summary.md"),
+            "the card's second source files beside its first, not under a \
+             title--task-id split"
+        );
+    }
+
     /// A **binary** publish lands real bytes in the tree (issue #553).
     ///
     /// This is the payoff of the whole issue: before it, a generated image

--- a/src/company/workspace_names.rs
+++ b/src/company/workspace_names.rs
@@ -100,6 +100,19 @@ pub fn kebab_name_or(raw: &str, fallback: &str) -> String {
     }
 }
 
+/// Whether `raw` normalizes to something at all, as opposed to falling back to
+/// [`FALLBACK_NAME`] (or a caller's own fallback).
+///
+/// This is the distinction a caller needs when deciding whether a name was
+/// actually *given*, not just whether the normalized result happens to read as
+/// the fallback word — a card titled literally "Untitled" normalizes to the
+/// same string [`FALLBACK_NAME`] is, but it is a real, disambiguation-worthy
+/// title, not the absence of one. Comparing the normalized value to
+/// `FALLBACK_NAME` cannot tell those two cases apart; this can.
+pub fn has_usable_name(raw: &str) -> bool {
+    normalize(raw).is_some()
+}
+
 /// Whether `name` is already in the canonical form — i.e. whether
 /// [`kebab_name`] would leave it alone.
 ///

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1831,9 +1831,10 @@ impl HarnessBrain {
         // The workspace nodes this card already owns, from every source it has
         // published before. The mirror uses them to keep the card's folders
         // stable: a fresh source files beside its predecessors, and a node is
-        // only ever treated as the card's own if one of these ids says so. The
-        // list also grows as this loop mints nodes, so a run publishing two
-        // new sources names the first's folder for the second.
+        // only ever revised as the card's own if one of these ids (or the
+        // source's own link) says so. The list also grows as this loop mints
+        // nodes, so a run publishing two new sources names the first's folder
+        // for the second.
         let mut prior_node_ids: Vec<String> = on_card
             .iter()
             .filter_map(|record| record.workspace_node_id().map(str::to_string))

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1955,6 +1955,7 @@ impl HarnessBrain {
                     },
                     existing_node_id: prior_node.as_deref(),
                     prior_node_ids: &prior_node_ids,
+                    recorded_before: existing.is_some(),
                 };
                 match artifact_mirror::materialize(workspace.as_ref(), &self.record().id, target)
                     .await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1954,6 +1954,7 @@ impl HarnessBrain {
                         }
                     },
                     existing_node_id: prior_node.as_deref(),
+                    prior_node_ids: &prior_node_ids,
                 };
                 match artifact_mirror::materialize(workspace.as_ref(), &self.record().id, target)
                     .await

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1961,6 +1961,9 @@ impl HarnessBrain {
                 {
                     Ok(mirrored) => {
                         let node_id = mirrored.node_id;
+                        // A later source in this same run files beside this
+                        // one, so the card's folder stays one folder.
+                        prior_node_ids.push(node_id.clone());
                         // Issue #663/#668: the version body was composed before
                         // the store was asked, so it describes an outcome that
                         // had not happened. Now it has — say what it was, and

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1933,6 +1933,7 @@ impl HarnessBrain {
                 let target = artifact_mirror::PublishTarget {
                     agent_id: author,
                     task_id: &card.id,
+                    title: Some(&card.title),
                     source: &pending.source,
                     payload: match &pending.payload {
                         crate::harness::publish::PublishPayload::Text(text) => {
@@ -4136,7 +4137,10 @@ members = ["engineer"]
             .expect("records");
 
         // Agent B knows nothing about the artifact. It walks the shared tree by
-        // path, exactly as `workspace_list` / `workspace_read` do.
+        // path, exactly as `workspace_list` / `workspace_read` do. The task
+        // folder is named by the card's title, not its raw id (issue #1687):
+        // `card("t-1", …)` carries the title "Ship the thing", so the folder
+        // reads as `ship-the-thing` rather than the ULID-like `t-1`.
         let nodes = WorkspaceStore::tree(&*ops, &company).await.unwrap();
         let name_of = |id: &str| nodes.iter().find(|n| n.id == id).map(|n| n.name.clone());
         let found = nodes
@@ -4146,7 +4150,7 @@ members = ["engineer"]
                     && n.parent_id
                         .as_deref()
                         .and_then(name_of)
-                        .is_some_and(|parent| parent == "t-1")
+                        .is_some_and(|parent| parent == "ship-the-thing")
             })
             .expect("agent B finds the deliverable by browsing the shared tree");
 

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -1828,6 +1828,16 @@ impl HarnessBrain {
         };
 
         let mut on_card = artifacts.list(&self.record().id, Some(&card.id)).await?;
+        // The workspace nodes this card already owns, from every source it has
+        // published before. The mirror uses them to keep the card's folders
+        // stable: a fresh source files beside its predecessors, and a node is
+        // only ever treated as the card's own if one of these ids says so. The
+        // list also grows as this loop mints nodes, so a run publishing two
+        // new sources names the first's folder for the second.
+        let mut prior_node_ids: Vec<String> = on_card
+            .iter()
+            .filter_map(|record| record.workspace_node_id().map(str::to_string))
+            .collect();
         let mut written = Vec::with_capacity(published.len());
         for pending in published {
             let at = now_millis();


### PR DESCRIPTION
## Summary

Two related Workspace-tree readability fixes, so the tree shows human names instead of raw ids.

- **#1687 (backend)** — Agent work folders were named by the raw task ULID, so the tree read as a column of ids where the operator wanted titles. `PublishTarget` now carries the card's `title`, and the mirror files the folder under `kebab_name_or(title, task_id)` — the title when present, the id as an identity-preserving fallback. The brain threads `card.title` at the publish call site. This is the second half of #1687; the board-sort half shipped in #1691. Two same-titled cards of one agent are told apart by appending the stable task id to the later card's folder (`launch-plan` vs `launch-plan--t-2`), and a card that already has nodes in the tree keeps the folder those nodes live in, so a second source files beside its first rather than splitting one task across two folders.
- **#1723 (frontend)** — The agent-provenance badge on each tree row printed the raw snake_case handle (`analytics_analyst`). It now resolves through the same `rosterDisplayName` lookup the row label already uses, so it reads "Analytics Analyst", with the raw handle kept on the badge's `title` tooltip for disambiguation. The badge is suppressed when its resolved name would only repeat the row's own label.

Fix A needed no frontend change: the tree already renders `node.name` for these folders (confirmed in `WorkspaceView.tsx`), so a title-named folder simply displays readably.

## API Or Behavior Changes

- `PublishTarget<'a>` gains `title: Option<&'a str>` and `prior_node_ids: &[String]`. Internal to the crate (no wire/JSON shape changes); every construction site is updated. `prior_node_ids` are the workspace nodes the card already owns — the brain collects them from the card's artifact records and from each node it mints in the same run — so the mirror can keep a card's folders stable without re-deriving a name from a tree snapshot.
- Behavior: an agent's published deliverable now lands under `artifacts/<agent>/<kebab-title>/…` instead of `artifacts/<agent>/<task-id>/…`. When a card has no usable title, the id-named folder is preserved exactly as before. The `(task_id, source)` identity contract is unchanged — a re-publish still revises the same node, two same-titled cards get distinct folders, and one card's second source stays in the folder its first established.
- Frontend: the tree agent badge renders the resolved display name (raw handle moves to the tooltip).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` (default) and `--features openhuman` — both clean
- [x] `cargo check`
- [x] `cargo test` — `company::artifact_mirror` (29 pass, default + `--features openhuman`) and `harness::built_in::brain` (107 pass, `--features openhuman`)
- [x] Frontend: `npm run typecheck`, `typecheck:unit`, `typecheck:e2e`, `npx vitest run` (339 files / 3159 tests pass), `npm run build`

New tests:
- Backend: folder named by title; unusable/empty title falls back to task id; `(task_id, source)` identity holds under title folders (distinct tasks don't collide, re-publish revises one node); same-titled cards keep their deliverables apart; one card publishing two sources keeps both in the same folder. Updated the brain integration test that hard-coded the old id-named folder.
- Frontend: `workspace-agent-badge.test.ts` — badge resolves the display name, keeps the raw handle reachable, falls back to the id when unresolved, shows nothing for non-agent origins, and suppresses the redundant self-name.

## Documentation

No doc changes needed — no route or architecture surface changed; the naming rule and both new `PublishTarget` fields are documented inline in `artifact_mirror.rs`.

## Related

Closes #1687
Closes #1723



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace items created by agents now display a resolved teammate name, with the original handle available in a tooltip.
  - Artifact folders now use task titles when available, with automatic fallback and disambiguation for duplicate titles.
  - Existing folders are reused across multiple published sources and recovered during orphan republishing.

- **Bug Fixes**
  - Prevented redundant agent badges when the displayed name already matches the workspace row label.
  - Improved recovery of previously associated workspace folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->