### PR TITLE
fix(harness): greeting fast-path + per-conversation context isolation (#1725)

### DIFF
--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -407,6 +407,21 @@ impl TriageOutcome {
     pub fn abstained(&self) -> bool {
         matches!(self.confidence, TriageConfidence::Abstained)
     }
+
+    /// Whether a rule *recognised* this message as chatter — a bare greeting
+    /// or acknowledgement (rule 2) or an empty message (rule 1) — as opposed to
+    /// `Chatter` being chosen because no rule matched at all (rule 6, the
+    /// abstention default; see [`abstained`](Self::abstained)).
+    ///
+    /// The distinction matters to callers that want to act on a *positive*
+    /// chatter classification (issue #1725's greeting fast path): an abstained
+    /// `Chatter` carries no claim about the message and is the escalation
+    /// trigger instead, so treating the two alike would fire the fast path on
+    /// every unclassifiable message, not just the ones the lexical layer
+    /// actually recognised as conversation.
+    pub fn is_matched_chatter(&self) -> bool {
+        self.confidence == TriageConfidence::Matched && self.triage == MessageTriage::Chatter
+    }
 }
 
 /// [`triage_message`], plus whether the answer was decided or fallen back to.

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -56,6 +56,7 @@ use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::harness::provider::{HostedProvider, HostedProviderConfig};
 use crate::harness::{CompanyAgent, HarnessDeps};
 use crate::ports::types::CompanyId;
+use crate::runtime::delegation::with_chat_only_hint;
 use crate::store::{FsCompanyStore, FsContextStore};
 
 /// The vendored `AgentConfig::default().max_tool_iterations` this crate used to
@@ -550,5 +551,159 @@ async fn exhausting_the_raised_cap_still_reports_an_iteration_cap_pause() {
         calls >= MAX_TOOL_ITERATIONS,
         "the turn paused after {calls} model calls, short of the stated \
          {MAX_TOOL_ITERATIONS} — the raised cap is not in effect"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1725 — the greeting fast-path + context-isolation regression.
+//
+// The direct reproduction of the screenshot bug, end to end through the real
+// `CompanyAgent::run_with_steer` turn path against the scripted model: a task
+// that fetched content (the "sport story ranking" HTML) leaves the agent's
+// in-memory history full, and a bare "hi" on a NEW chat used to run the whole
+// agentic loop AND reply against the prior task's replayed content. The four
+// unit tests cover the mechanisms individually (per-turn tool/memory/goal
+// suppression, the greeting classifier, the chat-only hint, per-conversation
+// history); this is the one test that exercises them together and asserts the
+// observable symptoms the screenshot showed.
+// ---------------------------------------------------------------------------
+
+/// A live turn-stream routing context for `chat`, so the pool binds this
+/// agent's history to that thread (issue #1725).
+fn stream_for(chat: &str) -> crate::turn_stream::TurnStreamCtx {
+    crate::turn_stream::TurnStreamCtx {
+        company: CompanyId::new("acme"),
+        agent_id: "ceo".to_string(),
+        chat_id: chat.to_string(),
+    }
+}
+
+/// A task fetches content and sets the agent's context; then a bare "hi" on a
+/// different chat must run **no** tools, open no loop, and carry **nothing**
+/// from the prior task. Reverting the fix (see the module note) makes the "hi"
+/// turn offer its tools and replay the fetched content — the screenshot bug.
+#[tokio::test]
+async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
+    // A body distinctive enough that its presence in a later turn's model
+    // request is unambiguous — this stands in for the replayed ranking HTML.
+    const FETCHED: &str = "SPORTBALL_RANKING_HTML_MARKER_9F3A";
+
+    let (model_url, script) = spawn_script(
+        vec![
+            // Task A: read the ranking note (a tool round), then answer.
+            Turn::Call {
+                tool: "file_read".to_string(),
+                args: json!({ "path": "note-00.md" }),
+            },
+            Turn::Say("Ranked the sport stories."),
+            // The bare greeting on a fresh chat: one plain reply, no tool call
+            // scripted — so if the turn tries to loop it runs off the script.
+            Turn::Say("Hi! How can I help you today?"),
+        ],
+        12,
+    )
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let agent = company_agent(model_url, dir.path(), None, 1).await;
+    // Overwrite the seeded note with the distinctive fetched body.
+    let workspace = agent_workspace(dir.path(), &CompanyId::new("acme"), "ceo");
+    std::fs::write(
+        workspace.join("note-00.md"),
+        format!("{FETCHED}\n<html>ranked sport stories</html>\n"),
+    )
+    .expect("seed the fetched note");
+
+    // ── Task A on chat "sports": a real work turn — tools attach and run. ──
+    let (outcome_a, _usage_a) = agent
+        .run_with_steer(
+            "rank the sport stories and read the ranking html",
+            None,
+            Some(stream_for("sports")),
+            None,
+        )
+        .await
+        .expect("task A runs");
+    assert!(
+        !outcome_a.steps.is_empty(),
+        "task A must actually run a tool step (the fetch) — otherwise the \
+         isolation below proves nothing"
+    );
+    {
+        let seen = script.seen.lock().unwrap();
+        // The fetched content really entered the model's context on task A.
+        assert!(
+            seen.iter().any(|r| r.to_string().contains(FETCHED)),
+            "task A's fetched content must reach the model on its own turn"
+        );
+        // And task A was offered its tools (the contrast the greeting breaks).
+        let a_tools = seen
+            .first()
+            .and_then(|r| r.get("tools"))
+            .and_then(|t| t.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        assert!(a_tools > 0, "a real work turn must be offered its tools");
+    }
+
+    let calls_before = model_calls(&script);
+
+    // ── A bare "hi" on a DIFFERENT chat — the greeting fast path. ──
+    let (outcome_b, _usage_b) = with_chat_only_hint(
+        true,
+        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None),
+    )
+    .await
+    .expect("the greeting runs");
+
+    // 1) Zero tool steps ran — the greeting never entered the agentic loop.
+    assert!(
+        outcome_b.steps.is_empty(),
+        "a greeting must run no tool steps, got {:?}",
+        outcome_b.steps
+    );
+    // 2) Exactly one model call — no tool-loop iterations.
+    assert_eq!(
+        model_calls(&script) - calls_before,
+        1,
+        "the greeting must be a single model call, not a loop"
+    );
+
+    let greeting_req = script
+        .seen
+        .lock()
+        .unwrap()
+        .last()
+        .cloned()
+        .expect("the greeting produced a model request");
+
+    // 3) The greeting turn was offered NO tools (suppress_tools).
+    let greeting_tools = greeting_req
+        .get("tools")
+        .and_then(|t| t.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert_eq!(
+        greeting_tools, 0,
+        "a chat-only turn must be sent an empty tool schema"
+    );
+
+    // 4) NOTHING from task A leaked into the greeting's context — no replayed
+    //    fetched HTML, no prior-task active-goal block. This is the screenshot
+    //    bug, asserted directly.
+    let greeting_str = greeting_req.to_string();
+    assert!(
+        !greeting_str.contains(FETCHED),
+        "task A's fetched content must NOT replay into an unrelated greeting"
+    );
+    assert!(
+        !greeting_str.contains("[active_goal]"),
+        "no prior task's goal may steer the greeting"
+    );
+
+    // 5) It still answered — abstain-or-reduce, never a silent non-answer.
+    assert!(
+        !outcome_b.reply.trim().is_empty(),
+        "the greeting still gets a reply"
     );
 }

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -317,6 +317,7 @@ async fn company_agent(
         role: "Chief Executive".to_string(),
         budget_usd_daily,
         agent: tokio::sync::Mutex::new(agent),
+        bound_chat: tokio::sync::Mutex::new(None),
     }
 }
 

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -574,7 +574,9 @@ fn stream_for(chat: &str) -> crate::turn_stream::TurnStreamCtx {
     crate::turn_stream::TurnStreamCtx {
         company: CompanyId::new("acme"),
         agent_id: "ceo".to_string(),
-        chat_id: chat.to_string(),
+        route: crate::turn_stream::LiveRoute::Chat {
+            chat_id: chat.to_string(),
+        },
     }
 }
 

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -709,3 +709,98 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
         "the greeting still gets a reply"
     );
 }
+
+/// A background task (`stream: None` — the same shape `run_background` and
+/// `run_steered_background` hand `run_with_steer`, since neither carries a
+/// chat thread) must not leave the agent bound to whichever chat happened to
+/// stream last. Reverting the unthreaded-turn branch in `run_with_steer`
+/// leaves `bound_chat` pointed at "sports" after the background turn runs, so
+/// the operator's SECOND turn on that same chat reads `switched == false`,
+/// skips the clear-and-reseed, and inherits the background task's fetched
+/// content — the cross-context leak review found on #1725.
+#[tokio::test]
+async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() {
+    const FETCHED: &str = "BACKGROUND_TASK_MARKER_71B2";
+
+    let (model_url, script) = spawn_script(
+        vec![
+            // Chat "sports", turn 1: a plain reply — binds bound_chat to "sports".
+            Turn::Say("Sure, tracking the sports desk."),
+            // The background task: a tool round, then an answer.
+            Turn::Call {
+                tool: "file_read".to_string(),
+                args: json!({ "path": "note-00.md" }),
+            },
+            Turn::Say("Background task done."),
+            // Chat "sports", turn 2 — the SAME chat id as turn 1.
+            Turn::Say("Sounds good."),
+        ],
+        12,
+    )
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let agent = company_agent(model_url, dir.path(), None, 1).await;
+    // Overwrite the seeded note with the distinctive background-task body.
+    let workspace = agent_workspace(dir.path(), &CompanyId::new("acme"), "ceo");
+    std::fs::write(
+        workspace.join("note-00.md"),
+        format!("{FETCHED}\n<html>background task content</html>\n"),
+    )
+    .expect("seed the fetched note");
+
+    // ── Chat "sports", turn 1: binds bound_chat to "sports". ──
+    agent
+        .run_with_steer("hello from sports", None, Some(stream_for("sports")), None)
+        .await
+        .expect("chat turn 1 runs");
+
+    // ── The background task: unthreaded — `stream: None`, same shared Agent. ──
+    let (outcome_bg, _usage_bg) = agent
+        .run_with_steer("run the background task", None, None, None)
+        .await
+        .expect("background task runs");
+    assert!(
+        !outcome_bg.steps.is_empty(),
+        "the background task must actually run a tool step (the fetch) — \
+         otherwise the isolation below proves nothing"
+    );
+    {
+        let seen = script.seen.lock().unwrap();
+        assert!(
+            seen.iter().any(|r| r.to_string().contains(FETCHED)),
+            "the background task's fetched content must reach the model on \
+             its own turn"
+        );
+    }
+
+    let calls_before = model_calls(&script);
+
+    // ── Chat "sports", turn 2 — same chat id the background task ran under
+    //    no binding for, so this must be treated as a switch and re-seed. ──
+    agent
+        .run_with_steer("still there?", None, Some(stream_for("sports")), None)
+        .await
+        .expect("chat turn 2 runs");
+
+    assert_eq!(
+        model_calls(&script) - calls_before,
+        1,
+        "chat turn 2 must be a single model call, not a loop"
+    );
+
+    let turn2_req = script
+        .seen
+        .lock()
+        .unwrap()
+        .last()
+        .cloned()
+        .expect("chat turn 2 produced a model request");
+
+    assert!(
+        !turn2_req.to_string().contains(FETCHED),
+        "the background task's fetched content must NOT leak into the next \
+         turn on the chat it happened to be bound to before the background \
+         task ran"
+    );
+}

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -861,16 +861,19 @@ impl CompanyAgent {
         let mut agent = self.agent.lock().await;
         agent.set_on_progress(Some(tx));
 
-        // Per-conversation history isolation (issue #1725). One `Agent` is reused
-        // for every chat of this `(company, agent_id)` pair, so its in-memory
-        // `history` would otherwise replay a prior thread's transcript into an
-        // unrelated one — the operator opens a new chat, types "hi", and the
-        // reply is grounded in the previous task. Bind the agent to the incoming
-        // chat thread: on a switch, clear the history and re-seed it from that
-        // thread's own durable transcript (best-effort — a cold thread seeds
-        // nothing and starts fresh). Runs inside the `agent` critical section,
-        // which already serialises this agent's turns, so the bound-chat pair
-        // cannot be read torn.
+        // Per-turn overrides for this turn (issue #1725), built once and applied
+        // in a single `set_next_turn_overrides` call so the chat-binding and the
+        // chat-only reductions cannot clobber each other.
+        let mut overrides = oh::agent::harness::session::TurnOverrides::default();
+
+        // Per-conversation history isolation. One `Agent` is reused for every
+        // chat of this `(company, agent_id)` pair, so its in-memory `history`
+        // would otherwise replay a prior thread's transcript into an unrelated
+        // one — the operator opens a new chat, types "hi", and the reply is
+        // grounded in the previous task. Bind the agent to the incoming chat
+        // thread: on a switch, clear the history and re-seed from THAT thread's
+        // own durable transcript. Runs inside the `agent` critical section,
+        // which already serialises this agent's turns.
         if let Some(incoming) = turn_chat_id.as_deref() {
             let mut bound = self.bound_chat.lock().await;
             let switched = bound.as_deref() != Some(incoming);
@@ -878,13 +881,16 @@ impl CompanyAgent {
                 tracing::debug!(
                     from = bound.as_deref().unwrap_or("<none>"),
                     to = incoming,
-                    "[harness] chat switched — resetting agent history and re-seeding from the incoming thread transcript"
+                    "[harness] chat switched — resetting agent history and re-binding to the incoming thread"
                 );
                 agent.clear_history();
-                // Seed the fresh history from the incoming thread's transcript so
-                // the same conversation continues, not a blank slate. No-op when
-                // no transcript exists yet for the thread.
                 let seeded = agent.seed_resume_from_thread_transcript(incoming);
+                // On a switch the agent-latest transcript is the WRONG thread, so
+                // never let the turn's fallback auto-resume run: a seed hit sets
+                // `cached_transcript_messages` (the fallback is skipped anyway); a
+                // miss must start fresh, NOT reload the previous chat's
+                // transcript and re-leak it (the exact screenshot bug).
+                overrides.suppress_transcript_autoload = true;
                 tracing::debug!(
                     chat = incoming,
                     seeded,
@@ -894,22 +900,24 @@ impl CompanyAgent {
             }
         }
 
-        // Reduced-scope chat turn (issue #1725). When the delegation runner
-        // marked this turn chat-only (an explicit "Just chatting" or a
-        // high-confidence greeting — see `delegation::with_chat_only_hint`), run
-        // it as a cheap conversational reply: no tools to loop on, no pre-turn
-        // memory-agent retrieval, and no prior task's thread goal re-injected. The
-        // override is one-shot (openhuman resets it after the turn), so the next
-        // real turn has its full agentic scope back.
+        // Reduced-scope chat turn. When the delegation runner marked this turn
+        // chat-only (an explicit "Just chatting" or a high-confidence greeting —
+        // see `delegation::with_chat_only_hint`), run it as a cheap conversational
+        // reply: no tools to loop on, no pre-turn memory retrieval, and no prior
+        // task's thread goal re-injected.
         if crate::runtime::delegation::is_chat_only_turn() {
             tracing::debug!(
-                "[harness] chat-only turn — running tool-less, memory-less, goal-less (fast path, #1725)"
+                "[harness] chat-only turn — tool-less, memory-less, goal-less (fast path, #1725)"
             );
-            agent.set_next_turn_overrides(oh::agent::harness::session::TurnOverrides {
-                suppress_active_goal: true,
-                suppress_tools: true,
-                suppress_memory_agent: true,
-            });
+            overrides.suppress_active_goal = true;
+            overrides.suppress_tools = true;
+            overrides.suppress_memory_agent = true;
+        }
+
+        // One-shot: openhuman resets it after this turn, so the next real turn
+        // gets its full agentic scope and normal transcript resume back.
+        if overrides != oh::agent::harness::session::TurnOverrides::default() {
+            agent.set_next_turn_overrides(overrides);
         }
 
         // Two hooks, both fired by openhuman between tool-loop iterations:

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -600,6 +600,19 @@ pub struct CompanyAgent {
     /// The embedded openhuman session. A [`Mutex`] because a `turn` takes
     /// `&mut self` and one agent must serialise its own turns.
     agent: Mutex<Agent>,
+    /// The chat/desk thread this pooled agent's in-memory history is currently
+    /// bound to (issue #1725).
+    ///
+    /// One `Agent` instance is reused for every chat of a `(company, agent_id)`
+    /// pair, so its `history` would otherwise carry one thread's transcript into
+    /// the next — the operator opens a new chat, types "hi", and the agent
+    /// replies against the prior task's transcript and goal. Before each turn
+    /// the pool compares the incoming `chat_id` to this value; on a switch it
+    /// clears the history and re-seeds it from the incoming thread's durable
+    /// transcript, so a thread only ever sees its own conversation. Guarded by
+    /// the same `agent` critical section (turns are already serialised), so the
+    /// pair cannot be read torn. `None` until the first bound turn.
+    bound_chat: Mutex<Option<String>>,
 }
 
 /// The graceful reply returned when a turn yields the transient empty-response
@@ -804,6 +817,11 @@ impl CompanyAgent {
         // live view and the final reply timeline are byte-identical. With `None`
         // (background turns, non-`openhuman` build) this is exactly the prior
         // buffer-only behaviour.
+        // The chat/desk thread this turn answers, captured before `stream` is
+        // moved into the collector task below — used for per-conversation history
+        // isolation (issue #1725). `None` for a background turn that streams
+        // nothing (a dispatched task card carries no operator chat to bind to).
+        let turn_chat_id: Option<String> = stream.as_ref().map(|ctx| ctx.chat_id.clone());
         let (tx, mut rx) = tokio::sync::mpsc::channel::<oh::agent::progress::AgentProgress>(1024);
         let collector = tokio::spawn(async move {
             let mut events = Vec::new();
@@ -842,6 +860,57 @@ impl CompanyAgent {
 
         let mut agent = self.agent.lock().await;
         agent.set_on_progress(Some(tx));
+
+        // Per-conversation history isolation (issue #1725). One `Agent` is reused
+        // for every chat of this `(company, agent_id)` pair, so its in-memory
+        // `history` would otherwise replay a prior thread's transcript into an
+        // unrelated one — the operator opens a new chat, types "hi", and the
+        // reply is grounded in the previous task. Bind the agent to the incoming
+        // chat thread: on a switch, clear the history and re-seed it from that
+        // thread's own durable transcript (best-effort — a cold thread seeds
+        // nothing and starts fresh). Runs inside the `agent` critical section,
+        // which already serialises this agent's turns, so the bound-chat pair
+        // cannot be read torn.
+        if let Some(incoming) = turn_chat_id.as_deref() {
+            let mut bound = self.bound_chat.lock().await;
+            let switched = bound.as_deref() != Some(incoming);
+            if switched {
+                tracing::debug!(
+                    from = bound.as_deref().unwrap_or("<none>"),
+                    to = incoming,
+                    "[harness] chat switched — resetting agent history and re-seeding from the incoming thread transcript"
+                );
+                agent.clear_history();
+                // Seed the fresh history from the incoming thread's transcript so
+                // the same conversation continues, not a blank slate. No-op when
+                // no transcript exists yet for the thread.
+                let seeded = agent.seed_resume_from_thread_transcript(incoming);
+                tracing::debug!(
+                    chat = incoming,
+                    seeded,
+                    "[harness] thread-transcript re-seed result"
+                );
+                *bound = Some(incoming.to_string());
+            }
+        }
+
+        // Reduced-scope chat turn (issue #1725). When the delegation runner
+        // marked this turn chat-only (an explicit "Just chatting" or a
+        // high-confidence greeting — see `delegation::with_chat_only_hint`), run
+        // it as a cheap conversational reply: no tools to loop on, no pre-turn
+        // memory-agent retrieval, and no prior task's thread goal re-injected. The
+        // override is one-shot (openhuman resets it after the turn), so the next
+        // real turn has its full agentic scope back.
+        if crate::runtime::delegation::is_chat_only_turn() {
+            tracing::debug!(
+                "[harness] chat-only turn — running tool-less, memory-less, goal-less (fast path, #1725)"
+            );
+            agent.set_next_turn_overrides(oh::agent::harness::session::TurnOverrides {
+                suppress_active_goal: true,
+                suppress_tools: true,
+                suppress_memory_agent: true,
+            });
+        }
 
         // Two hooks, both fired by openhuman between tool-loop iterations:
         //
@@ -2566,6 +2635,7 @@ impl HarnessPool {
                 confinement,
                 deps,
             )?),
+            bound_chat: Mutex::new(None),
         };
 
         let stream_ctx = Some(crate::turn_stream::TurnStreamCtx {
@@ -2774,11 +2844,19 @@ impl HarnessPool {
         // Retrieve→inject: pull the top-K prior task outcomes relevant to this
         // message and prepend them as context. On a cold store this yields no
         // hits and the message is passed through unchanged.
-        let hits = deps
-            .context
-            .search(company, message, memory_loop::RETRIEVE_TOP_K)
-            .await?;
-        let augmented = memory_loop::inject(message, &hits);
+        //
+        // Skipped entirely for a chat-only turn (issue #1725): a greeting /
+        // "Just chatting" reply must not be grounded in prior task outcomes, and
+        // pulling them is the exact context leak the fast path exists to stop.
+        let augmented = if crate::runtime::delegation::is_chat_only_turn() {
+            message.to_string()
+        } else {
+            let hits = deps
+                .context
+                .search(company, message, memory_loop::RETRIEVE_TOP_K)
+                .await?;
+            memory_loop::inject(message, &hits)
+        };
 
         // Run the turn and record its real cost. `CompanyAgent::run` reads each
         // attempt's token/cost totals from openhuman's public `last_turn_usage()`
@@ -3560,6 +3638,7 @@ pub(crate) fn build_roster(
             role: manifest_agent.role.clone(),
             budget_usd_daily: effective_budget,
             agent: Mutex::new(agent),
+            bound_chat: Mutex::new(None),
         }));
     }
 
@@ -3630,6 +3709,7 @@ pub(crate) fn build_roster(
             role: manifest_agent.role.clone(),
             budget_usd_daily: effective_budget,
             agent: Mutex::new(agent),
+            bound_chat: Mutex::new(None),
         }));
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -911,6 +911,33 @@ impl CompanyAgent {
                 );
                 *bound = Some(incoming.to_string());
             }
+        } else {
+            // Unthreaded turn (a dispatched background task or a workflow
+            // agent node): it still runs against this agent's shared,
+            // in-memory `history` — the same field a chat turn reads and
+            // extends — but carries no chat thread to bind that history to.
+            // Left alone, `bound_chat` keeps pointing at whichever chat was
+            // bound before this turn ran, so if the operator's next message
+            // lands on that same thread, `switched` above reads `false` and
+            // skips the clear-and-reseed entirely, silently grounding the
+            // reply in whatever this background turn just appended (the
+            // cross-context leak review found). Invalidate the binding so
+            // the next chat-routed turn is *always* treated as a switch,
+            // regardless of which thread it lands on.
+            //
+            // Deliberately does NOT clear `history` here: a single
+            // background task can span several unthreaded turns in a row
+            // (e.g. a steered continuation), and those legitimately depend
+            // on the history accumulated between them. The clear already
+            // happens on the switch branch above, the next time a chat turn
+            // actually claims the binding.
+            let mut bound = self.bound_chat.lock().await;
+            if bound.is_some() {
+                tracing::debug!(
+                    "[harness] unthreaded turn — invalidating chat binding so the next chat turn rebinds"
+                );
+                *bound = None;
+            }
         }
 
         // Reduced-scope chat turn. When the delegation runner marked this turn

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -1056,6 +1056,41 @@ impl CompanyAgent {
                             if steer.map(|c| c.requested()).unwrap_or(false) || spend_halted {
                                 Ok(crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]))
                             } else {
+                                // Issue #1725 review: `set_next_turn_overrides`
+                                // is one-shot — openhuman consumes it at the
+                                // top of the NEXT `Agent::turn` call and resets
+                                // to the default (`turn/core.rs`'s
+                                // `std::mem::take`). Applied only once, above,
+                                // a chat-only turn's suppression would cover
+                                // just the first attempt: were this retry ever
+                                // reached with the override already spent, it
+                                // would run with the agent's full,
+                                // un-suppressed scope — regaining the whole
+                                // tool belt, memory agent and active goal the
+                                // fast path exists to withhold. Reapply the
+                                // SAME overrides so every attempt in a
+                                // chat-only turn stays reduced, not just the
+                                // first.
+                                //
+                                // Defence in depth, like the guard above it:
+                                // an immediately-blank completion with no tool
+                                // call is retried INSIDE openhuman's own tool
+                                // loop under the SAME per-turn overrides
+                                // (verified by instrumenting a scripted blank
+                                // response — `first` came back
+                                // `Ok("...")` directly, never reaching this
+                                // arm at all), so this specific line is not
+                                // known to fire from any script this suite can
+                                // build. What it buys is that IF this arm ever
+                                // is reached — a terminal `EmptyProviderResponse`
+                                // openhuman raises after exhausting its own
+                                // internal budget — the retry does not silently
+                                // regress to full scope.
+                                if overrides
+                                    != oh::agent::harness::session::TurnOverrides::default()
+                                {
+                                    agent.set_next_turn_overrides(overrides);
+                                }
                                 let second = agent.turn(message).await;
                                 usages.push(read_turn_usage(&agent));
                                 match self.classify_turn(second) {

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -820,8 +820,13 @@ impl CompanyAgent {
         // The chat/desk thread this turn answers, captured before `stream` is
         // moved into the collector task below — used for per-conversation history
         // isolation (issue #1725). `None` for a background turn that streams
-        // nothing (a dispatched task card carries no operator chat to bind to).
-        let turn_chat_id: Option<String> = stream.as_ref().map(|ctx| ctx.chat_id.clone());
+        // nothing (a dispatched task card carries no operator chat to bind to),
+        // and also `None` for a workflow agent node (issue #1702) — it routes by
+        // run/node, not a chat thread, so there is nothing to bind history to.
+        let turn_chat_id: Option<String> = stream.as_ref().and_then(|ctx| match &ctx.route {
+            crate::turn_stream::LiveRoute::Chat { chat_id } => Some(chat_id.clone()),
+            crate::turn_stream::LiveRoute::Workflow { .. } => None,
+        });
         let (tx, mut rx) = tokio::sync::mpsc::channel::<oh::agent::progress::AgentProgress>(1024);
         let collector = tokio::spawn(async move {
             let mut events = Vec::new();

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1239,10 +1239,22 @@ impl<'a> DelegationRunner<'a> {
         } else {
             message
         };
-        let outcome = self
-            .run_turn
-            .run(self.company, responder, message, chat_id)
-            .await?;
+        // Issue #1725: mark this turn chat-only when the operator's own message
+        // is conversation, not work — either the explicit "Just chatting"
+        // (`not_work`, i.e. `deliverable: "chat"`) or a high-confidence greeting
+        // the model read as chatter. The harness pool reads the hint (same task,
+        // propagates through `RunTurn`) and runs a cheap tool-less/memory-less/
+        // goal-less turn instead of the full agentic loop. Only ever set on an
+        // operator turn — a dispatched task card is always real work — and a
+        // greeting that carries a request abstains via `is_pure_small_talk`, so
+        // the card-tracking paths above are untouched.
+        let chat_only =
+            operator_turn && (not_work || (chatter && is_pure_small_talk(operator_words(message))));
+        let outcome = with_chat_only_hint(
+            chat_only,
+            self.run_turn.run(self.company, responder, message, chat_id),
+        )
+        .await?;
         let parked = self.approvals_queued().saturating_sub(approvals_before);
         // The responder's own steps ride on the operator bubble; its reply is the
         // operator-facing text UNLESS a synchronous desk delegation runs, in which
@@ -3168,6 +3180,71 @@ pub(crate) fn is_trackable_work(text: &str) -> bool {
     true
 }
 
+/// Whether `text` is HIGH-CONFIDENCE small talk — a greeting or acknowledgement
+/// and nothing more — that the harness may answer with a cheap tool-less,
+/// memory-less, goal-less turn instead of running the full agentic task loop
+/// (issue #1725).
+///
+/// Deliberately far stricter than the [`is_trackable_work`] small-talk rung:
+/// that one returns `false` (not-work) for plain *questions* too, but a question
+/// deserves a real answer and possibly tools, so it must NOT take the fast path.
+/// This predicate abstains (returns `false`) on anything but a short
+/// greeting/acknowledgement:
+///
+/// 1. empty / punctuation-only → abstain (nothing to answer);
+/// 2. longer than [`SMALLTALK_MAX_WORDS`] → abstain;
+/// 3. contains any [`WORK_VERBS`] entry → abstain (a greeting in front of a
+///    request is a request — keep the regression at
+///    `a_greeting_in_front_of_a_request_does_not_hide_it` green);
+/// 4. ends in `?` or opens with an interrogative → abstain (a question);
+/// 5. opens with a [`SMALLTALK_OPENERS`] greeting/ack → **fast path**.
+///
+/// Abstention always falls through to the normal turn, never to a silent
+/// non-answer.
+pub(crate) fn is_pure_small_talk(text: &str) -> bool {
+    let trimmed = text.trim();
+    let words = work_words(trimmed);
+    if words.is_empty() {
+        return false;
+    }
+    if words.len() > SMALLTALK_MAX_WORDS {
+        return false;
+    }
+    if words.iter().any(|w| WORK_VERBS.contains(&w.as_str())) {
+        return false;
+    }
+    if trimmed.ends_with('?') || INTERROGATIVE_OPENERS.contains(&words[0].as_str()) {
+        return false;
+    }
+    SMALLTALK_OPENERS.contains(&words[0].as_str())
+}
+
+tokio::task_local! {
+    /// Set by the delegation runner around an operator turn it has classified as
+    /// conversation rather than work — either the operator's explicit
+    /// "Just chatting" (`deliverable: "chat"` → `not_work`) or a high-confidence
+    /// [`is_pure_small_talk`] greeting. The harness pool reads it (same task, so
+    /// it propagates through the `RunTurn` seam) and runs that turn with reduced
+    /// scope: no tools to loop on, no pre-turn memory retrieval, and no prior
+    /// task's thread goal re-injected (issue #1725). Absent = a normal turn.
+    pub(crate) static CHAT_ONLY_TURN: bool;
+}
+
+/// Run `fut` with the [`CHAT_ONLY_TURN`] hint set to `chat_only`.
+pub(crate) async fn with_chat_only_hint<F: std::future::Future>(
+    chat_only: bool,
+    fut: F,
+) -> F::Output {
+    CHAT_ONLY_TURN.scope(chat_only, fut).await
+}
+
+/// Whether the current turn was marked chat-only by the delegation runner.
+/// Reads the ambient [`CHAT_ONLY_TURN`] hint; `false` when unset (every path
+/// that does not opt in, e.g. dispatched task cards and background turns).
+pub(crate) fn is_chat_only_turn() -> bool {
+    CHAT_ONLY_TURN.try_with(|v| *v).unwrap_or(false)
+}
+
 /// How many characters of a request survive into the card's title.
 const TITLE_CHARS: usize = 80;
 
@@ -3320,6 +3397,103 @@ mod tests {
         assert!(is_trackable_work(
             "thanks! now write that up as a one-pager"
         ));
+    }
+
+    // ── the greeting fast path (issue #1725) ─────────────────────────────────
+
+    /// A bare greeting / acknowledgement is high-confidence small talk: it takes
+    /// the tool-less/memory-less/goal-less fast path.
+    #[test]
+    fn a_bare_greeting_is_pure_small_talk() {
+        for greeting in [
+            "hi",
+            "hello",
+            "hey there",
+            "yo",
+            "morning",
+            "thanks!",
+            "thank you so much",
+            "ok",
+            "cool",
+            "got it",
+        ] {
+            assert!(
+                is_pure_small_talk(greeting),
+                "should take the fast path: {greeting:?}"
+            );
+        }
+    }
+
+    /// The load-bearing constraint (mirror of
+    /// `a_greeting_in_front_of_a_request_does_not_hide_it`): a greeting that
+    /// carries a request is NOT small talk — the fast path must abstain so the
+    /// task still runs. This is the direct regression guard for the fast path.
+    #[test]
+    fn a_greeting_in_front_of_a_request_is_not_small_talk() {
+        for request in [
+            "hi — please draft the investor update",
+            "thanks! now write that up as a one-pager",
+            "hey, can you compile the pricing comparison",
+            "good morning, prepare the board memo",
+        ] {
+            assert!(
+                !is_pure_small_talk(request),
+                "must NOT take the fast path (carries a request): {request:?}"
+            );
+        }
+    }
+
+    /// A question is not small talk — it deserves a real answer and possibly
+    /// tools, so it must fall through to the normal turn rather than the fast
+    /// path (stricter than `is_trackable_work`, which treats a question as
+    /// not-work).
+    #[test]
+    fn a_question_is_not_small_talk() {
+        for question in [
+            "what's our runway?",
+            "who leads the engineering desk",
+            "how many cards are in review?",
+            "hey what's the status of the build?",
+        ] {
+            assert!(
+                !is_pure_small_talk(question),
+                "a question must not take the fast path: {question:?}"
+            );
+        }
+    }
+
+    /// Neither empty/punctuation nor a plain non-greeting statement takes the
+    /// fast path — the opener must actually be a greeting/ack.
+    #[test]
+    fn only_a_greeting_opener_takes_the_fast_path() {
+        for other in ["", "   ", "!!!", "the quarterly numbers", "runway"] {
+            assert!(
+                !is_pure_small_talk(other),
+                "only a greeting opener takes the fast path: {other:?}"
+            );
+        }
+    }
+
+    /// The chat-only hint is ambient over the turn future and defaults to
+    /// `false` when unset (every path that does not opt in).
+    #[tokio::test]
+    async fn chat_only_hint_is_scoped_and_defaults_false() {
+        assert!(
+            !is_chat_only_turn(),
+            "no hint set → a normal (full-scope) turn"
+        );
+        with_chat_only_hint(true, async {
+            assert!(is_chat_only_turn(), "inside the scope the hint is set");
+        })
+        .await;
+        with_chat_only_hint(false, async {
+            assert!(!is_chat_only_turn(), "an explicit false is still false");
+        })
+        .await;
+        assert!(
+            !is_chat_only_turn(),
+            "the hint does not leak past its scope"
+        );
     }
 
     /// The bias is one-directional and deliberate: an unclassifiable request

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1067,7 +1067,15 @@ impl<'a> DelegationRunner<'a> {
         // (the comment above says why — taking them away on a maybe turns a
         // triage miss into work the company silently refuses), while it *does*
         // stand the deterministic card paths down.
-        let mut chatter = false;
+        //
+        // Seeded from the lexical layer's OWN matched verdict (issue #1725
+        // review), not only the escalation below: a bare greeting or
+        // acknowledgement is `Chatter` by a rule firing (`is_matched_chatter`),
+        // not by abstention, so it never reaches the escalation branch at all —
+        // that branch only ever runs on an abstained triage. Without this seed
+        // the greeting fast path below could never fire for the exact messages
+        // it exists to optimise.
+        let mut chatter = triaged.is_matched_chatter();
         if !answering
             && triaged.abstained()
             && let Some(escalation) = self.triage
@@ -3780,6 +3788,14 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
         /// drain happened to run afterwards. Since #267's review it also
         /// distinguishes the narrowed answering claim from the full one.
         committed_at_turn: Mutex<Vec<orchestrator::DrainClaim>>,
+        /// The ambient [`is_chat_only_turn`] hint read from INSIDE each turn,
+        /// so a test proves the greeting fast path fired through the real
+        /// classification path (`handle_operator_message`) rather than the
+        /// caller forcing the scope directly (issue #1725 review — the
+        /// original end-to-end test only ever asserted the hint by wrapping
+        /// the call in `with_chat_only_hint(true, ..)` itself, which cannot
+        /// catch the classifier failing to derive it).
+        chat_only_at_turn: Mutex<Vec<bool>>,
         /// What the tool boundary answered for each
         /// [`Turn::tool_pushes`] entry, in order across all turns (issue #267).
         staged: Mutex<Vec<orchestrator::Staged>>,
@@ -3799,6 +3815,7 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
                 calls: Mutex::new(Vec::new()),
                 board_at_turn: Mutex::new(Vec::new()),
                 committed_at_turn: Mutex::new(Vec::new()),
+                chat_only_at_turn: Mutex::new(Vec::new()),
                 staged: Mutex::new(Vec::new()),
                 tasks: fx.tasks.clone(),
                 company: fx.record.id.clone(),
@@ -3844,6 +3861,12 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             self.committed_at_turn.lock().expect("committed")[n]
         }
 
+        /// Whether [`is_chat_only_turn`] read `true` from INSIDE turn `n` — the
+        /// real hint the harness pool would have read, not one the test forced.
+        fn chat_only_at_turn(&self, n: usize) -> bool {
+            self.chat_only_at_turn.lock().expect("chat_only")[n]
+        }
+
         async fn next(
             &self,
             agent_id: &str,
@@ -3867,6 +3890,10 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
                 .lock()
                 .expect("committed")
                 .push(self.queue.claim_state());
+            self.chat_only_at_turn
+                .lock()
+                .expect("chat_only")
+                .push(is_chat_only_turn());
             let turn = self
                 .script
                 .lock()
@@ -6335,6 +6362,46 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         assert_eq!(cards.len(), 1, "the delegation still ran: {cards:?}");
         assert_eq!(cards[0].title, "Follow up on the deck");
         assert_eq!(turn.spawned_task.as_deref(), Some(cards[0].id.as_str()));
+    }
+
+    /// A bare greeting is `Chatter` by a RULE FIRING (`is_matched_chatter`),
+    /// not by abstention like `an_ambiguous_message_keeps_its_board_tools`'s
+    /// fixture above — so it never reaches the escalation block, which only
+    /// ever runs on an abstained triage. The greeting fast path (issue #1725)
+    /// must still fire for it.
+    ///
+    /// Goes through the real classification path
+    /// (`handle_operator_message`) rather than forcing
+    /// `with_chat_only_hint(true, ..)` directly, per review: a test that
+    /// forces the scope itself cannot catch the classifier failing to derive
+    /// the hint in the first place.
+    #[tokio::test]
+    async fn a_bare_greeting_enters_the_chat_only_fast_path() {
+        let greeting = "hi";
+        let triaged = crate::company::task_intent::triage_message_detailed(greeting);
+        assert_eq!(
+            triaged.triage,
+            crate::company::task_intent::MessageTriage::Chatter,
+            "fixture must be chatter, or this proves nothing"
+        );
+        assert!(
+            !triaged.abstained(),
+            "fixture must be a MATCHED chatter (a bare-greeting rule firing) — \
+             the exact case that never reaches the escalation block, and the \
+             one the classifier used to miss"
+        );
+
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("Hi! How can I help you today?")]);
+        fx.runner(&turns)
+            .handle_operator_message("chief", greeting, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            turns.chat_only_at_turn(0),
+            "a bare greeting must enter CHAT_ONLY_TURN"
+        );
     }
 
     /// `Track` is unchanged: a real instruction still runs under a claim, still

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1075,7 +1075,25 @@ impl<'a> DelegationRunner<'a> {
         // that branch only ever runs on an abstained triage. Without this seed
         // the greeting fast path below could never fire for the exact messages
         // it exists to optimise.
-        let mut chatter = triaged.is_matched_chatter();
+        //
+        // Kept as its own fact (`matched_chatter`), not folded into `chatter`
+        // below, because the two need different amounts of trust at the
+        // fast-path gate (see the `chat_only` computation further down, issue
+        // #1725 review round 2): `matched_chatter` is a WHOLE-MESSAGE match
+        // against `task_intent::GREETINGS` — by construction already exactly a
+        // bare greeting/ack, nothing else — so it is safe to fast-path on
+        // directly. `chatter` also absorbs the escalation verdict below, which
+        // judges an ARBITRARY abstained message as "conversational"; that is
+        // broader than a greeting shape, so it still needs the separate
+        // `is_pure_small_talk` gate. Gating the lexical match through
+        // `is_pure_small_talk` too was the review-round-2 bug: that predicate's
+        // `SMALLTALK_OPENERS` is a first-WORD opener list, independently
+        // maintained from `GREETINGS`'s whole-MESSAGE vocabulary, so they drift
+        // ("hii", "sup", "good morning", "kk", "gotcha", "done", "lgtm" are all
+        // in `GREETINGS` but not recognised as an opener) — a lexically matched
+        // greeting was silently falling back to the full agentic turn anyway.
+        let matched_chatter = triaged.is_matched_chatter();
+        let mut chatter = matched_chatter;
         if !answering
             && triaged.abstained()
             && let Some(escalation) = self.triage
@@ -1275,15 +1293,22 @@ impl<'a> DelegationRunner<'a> {
         };
         // Issue #1725: mark this turn chat-only when the operator's own message
         // is conversation, not work — either the explicit "Just chatting"
-        // (`not_work`, i.e. `deliverable: "chat"`) or a high-confidence greeting
-        // the model read as chatter. The harness pool reads the hint (same task,
-        // propagates through `RunTurn`) and runs a cheap tool-less/memory-less/
-        // goal-less turn instead of the full agentic loop. Only ever set on an
-        // operator turn — a dispatched task card is always real work — and a
-        // greeting that carries a request abstains via `is_pure_small_talk`, so
-        // the card-tracking paths above are untouched.
-        let chat_only =
-            operator_turn && (not_work || (chatter && is_pure_small_talk(operator_words(message))));
+        // (`not_work`, i.e. `deliverable: "chat"`), a lexically MATCHED greeting
+        // (`matched_chatter` — trusted directly, see its own comment above), or
+        // a high-confidence greeting the model read as chatter on an abstained
+        // message (gated through `is_pure_small_talk`, since the model's
+        // "conversational" verdict is broader than a bare-greeting shape). The
+        // harness pool reads the hint (same task, propagates through `RunTurn`)
+        // and runs a cheap tool-less/memory-less/goal-less turn instead of the
+        // full agentic loop. Only ever set on an operator turn — a dispatched
+        // task card is always real work — and a greeting that carries a request
+        // abstains via `is_pure_small_talk` (or is never lexically MATCHED
+        // chatter in the first place — `GREETINGS` is a whole-message match),
+        // so the card-tracking paths above are untouched.
+        let chat_only = operator_turn
+            && (not_work
+                || matched_chatter
+                || (chatter && is_pure_small_talk(operator_words(message))));
         let outcome = with_chat_only_hint(
             chat_only,
             self.run_turn.run(self.company, responder, message, chat_id),
@@ -6401,6 +6426,42 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         assert!(
             turns.chat_only_at_turn(0),
             "a bare greeting must enter CHAT_ONLY_TURN"
+        );
+    }
+
+    /// Codex review round 2: `is_pure_small_talk`'s `SMALLTALK_OPENERS` (a
+    /// first-WORD opener list, `runtime::delegation`) is independently
+    /// maintained from `task_intent::GREETINGS` (a whole-MESSAGE match list) —
+    /// so a message the lexical triage matches as `Chatter` can still fail
+    /// `is_pure_small_talk` and fall back to the full agentic turn. "sup" is in
+    /// `GREETINGS` but has no corresponding entry in `SMALLTALK_OPENERS`,
+    /// making it a fixture the vocabularies disagree on.
+    #[tokio::test]
+    async fn a_matched_greeting_absent_from_smalltalk_openers_still_fast_paths() {
+        let greeting = "sup";
+        let triaged = crate::company::task_intent::triage_message_detailed(greeting);
+        assert_eq!(
+            triaged.triage,
+            crate::company::task_intent::MessageTriage::Chatter,
+            "fixture must be chatter, or this proves nothing"
+        );
+        assert!(
+            !triaged.abstained(),
+            "fixture must be a MATCHED chatter (a GREETINGS whole-message hit)"
+        );
+
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("Not much, what's up?")]);
+        fx.runner(&turns)
+            .handle_operator_message("chief", greeting, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            turns.chat_only_at_turn(0),
+            "a lexically matched greeting must enter CHAT_ONLY_TURN even when \
+             `is_pure_small_talk`'s independently maintained opener list has no \
+             matching entry for it"
         );
     }
 

--- a/tests/one_card_per_message.rs
+++ b/tests/one_card_per_message.rs
@@ -945,9 +945,22 @@ async fn a_publish_with_no_card_in_scope_mints_one() {
     let host = spawn_host(model).await;
     host.seed_file("ceo", "notes.md", "notes\n");
 
-    // "hi" is neither trackable work nor a recognised imperative, so nothing
-    // else in the turn can open a card.
-    let reply = host.chat("hi", None).await;
+    // Neither trackable work nor a recognised imperative, so nothing else in
+    // the turn can open a card — same property "hi" had before issue #1725's
+    // greeting fast path. NOT "hi" itself: a bare greeting is now a matched
+    // `Chatter` classification that runs the reduced-scope chat-only turn
+    // (no tools offered at all), so the model could never reach the
+    // `publish_artifact` call this test's whole point is to exercise. This
+    // fixture is ambiguous `Chatter` by abstention instead (it opens with
+    // neither a `SMALLTALK_OPENERS` greeting nor a work verb nor a `?`), which
+    // keeps the turn's tools available exactly like every non-greeting
+    // message did before #1725.
+    let neutral = "the deck looks good to me";
+    assert!(
+        detect_task_intent(neutral).is_none(),
+        "fixture must open no card via the REST handler, or this proves nothing"
+    );
+    let reply = host.chat(neutral, None).await;
     let board = host.board(&reply).await;
     assert_sole_card_carries(&host, &board, "ceo", "Some notes").await;
 }


### PR DESCRIPTION
## Summary

Fixes #1725: a bare greeting ran the full agentic task loop and leaked a prior task's context (a stale thread goal replayed every turn; the pooled agent's history — keyed only by `(company, agent_id)` — replayed one thread's transcript into another). There was also no small-talk fast path.

- **Per-conversation history isolation** (`harness/built_in`): each pooled agent is bound to the chat thread it answers. On a chat switch the in-memory history is cleared and re-seeded from that thread's own durable transcript. On a switch we also suppress openhuman's agent-latest (non-thread-scoped) transcript auto-resume, so a cleared history is not silently repopulated from the previous chat.
- **Greeting fast path** (`runtime/delegation`): a strict `is_pure_small_talk` classifier (greeting/ack only — abstains on questions and on any greeting that carries a work verb) plus a `CHAT_ONLY_TURN` hint set around an operator turn read as conversation (explicit "Just chatting" / `deliverable: "chat"`, or a high-confidence greeting).
- **Reduced-scope chat turns**: a chat-only turn runs with the vendored per-turn overrides — no tools to loop on, no pre-turn memory retrieval (openhuman `agent_memory` trigger and OpenCompany's own retrieve→inject both skipped), and no prior task's thread goal injected — so a greeting is a single cheap reply that skips the loop, the card, and the queue.
- **openhuman seam** (PR #5770): additive `TurnOverrides { suppress_active_goal, suppress_tools, suppress_memory_agent, suppress_transcript_autoload }` on the session `Agent`, plus `threads::goals::runtime::{complete,clear}_for_current_thread`.

A message that opens with a greeting but then asks for work still runs the task (the classifier abstains on a work verb — regression `a_greeting_in_front_of_a_request_is_not_small_talk`; the existing `a_greeting_in_front_of_a_request_does_not_hide_it` stays green).

## API Or Behavior Changes

- Behavior: a high-confidence greeting / acknowledgement, or an operator message marked "Just chatting", is answered by a tool-less, memory-less, goal-less turn that opens no card and enqueues no work. All other turns are unchanged (full toolbelt, memory, and goal).
- No public OpenCompany API change. New vendored-openhuman public items are additive and defaulted (existing callers unchanged).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default) and `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings` (gated)
- [x] `cargo build --features openhuman,mcp,media,composio --all-targets` (compiles the vendored change in-tree)
- [x] `cargo test` (scoped): `runtime::delegation::tests` 89/89, `harness::built_in` 1123/1123 — green with `--features openhuman`
- **End-to-end regression** (`harness::built_in::iteration_cap_turn_test::a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context`): drives the real `CompanyAgent` turn path against a scripted model — a task fetches distinctive content on one chat, then a bare "hi" on a different chat is asserted to run **0 tool steps**, be offered an **empty tool schema**, carry **none** of task A's fetched content or `[active_goal]`, and still reply. **Red-proofed**: disabling the history-clear + override application makes the "hi" turn get a tool schema (it would run the agentic loop) and replay the fetched content.

## Documentation

- None needed — behavior change to an internal turn path; no public API, route, or spec surface changed.

## Related

- Closes #1725
- **Depends on openhuman PR #5770** (`fix/chat-turn-goal-and-scope`): the per-turn `TurnOverrides` seam (incl. `suppress_transcript_autoload`) and the thread-goal complete/clear helpers this fix wires. `vendor/openhuman` is currently pinned to that branch tip **`01a436d73`**; **this PR must repin to the merged openhuman SHA before it merges.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more responsive handling for greetings and casual conversation.
  - Background workflow activity now provides live progress updates during execution.

- **Bug Fixes**
  - Prevented task history and fetched content from leaking between chat threads or unrelated turns.
  - Improved chat context switching so conversations remain properly isolated.
  - Refined message classification to distinguish greetings from actionable requests more reliably.

- **Tests**
  - Added regression coverage for greeting behavior, context isolation, and background workflow chat binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->