### PR TITLE
feat(company): uploadable company logo via API

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -3136,17 +3136,19 @@ impl CompanyRuntime {
     /// A status snapshot, loading the company record for name and lifecycle.
     pub async fn status(&self) -> Result<CompanyStatus> {
         let record = self.store.load(&self.id).await?;
-        let (name, lifecycle, template_provenance) = match record {
+        let (name, logo_url, lifecycle, template_provenance) = match record {
             Some(record) => (
                 record.manifest.company.name,
+                record.manifest.company.logo_url,
                 record.lifecycle,
                 record.template_provenance,
             ),
-            None => (self.id.to_string(), "running".to_string(), None),
+            None => (self.id.to_string(), None, "running".to_string(), None),
         };
         Ok(CompanyStatus {
             id: self.id.clone(),
             name,
+            logo_url,
             lifecycle,
             pending_approvals: self.journal.pending().len(),
             template_provenance,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -483,6 +483,9 @@ pub struct Company {
     /// tiny.place `@handle`; only used when `[place].discoverable = true`.
     #[serde(default)]
     pub handle: Option<String>,
+    /// Company logo as a self-contained data:image/... URL (issue: operator-set brand logo).
+    #[serde(default)]
+    pub logo_url: Option<String>,
 }
 
 /// A `[[agent]]` roster entry.

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -86,6 +86,9 @@ pub struct CompanyStatus {
     pub id: CompanyId,
     /// The display name.
     pub name: String,
+    /// The operator-set company logo, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logo_url: Option<String>,
     /// Lifecycle state, e.g. `running`, `paused`, `archived`.
     pub lifecycle: String,
     /// The number of approvals currently awaiting the operator.

--- a/src/server/ops/company_logo.rs
+++ b/src/server/ops/company_logo.rs
@@ -1,0 +1,100 @@
+//! Company-logo settings, persisted in the company manifest.
+
+use axum::routing::put;
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::error::OpenCompanyError;
+use crate::runtime::CompanyStatus;
+use crate::server::error::ApiError;
+use crate::server::ops::{AdminScopedCompany, scoped};
+
+const COMPANY_LOGO_MAX_CHARS: usize = 1_000_000;
+const ALLOWED_IMAGE_MIMES: [&str; 4] = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CompanyLogoBody {
+    #[serde(default)]
+    logo_url: Option<String>,
+}
+
+/// Builds both `PUT /api/v1/company/logo` addressing variants.
+pub fn router() -> Router<AppState> {
+    scoped("/logo", put(put_logo))
+}
+
+fn invalid_logo(message: impl Into<String>) -> ApiError {
+    ApiError(OpenCompanyError::InvalidRequest(message.into()))
+}
+
+/// Accepts only bounded, self-contained image data URLs. `None` clears the logo.
+fn company_logo_value(value: Option<String>) -> Result<Option<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.len() > COMPANY_LOGO_MAX_CHARS {
+        return Err(invalid_logo(format!(
+            "company logo exceeds the {COMPANY_LOGO_MAX_CHARS}-character limit"
+        )));
+    }
+
+    let (header, payload) = value
+        .split_once(',')
+        .ok_or_else(|| invalid_logo("company logo must be a base64 image data URL"))?;
+    let mime = header
+        .strip_prefix("data:")
+        .and_then(|header| header.strip_suffix(";base64"))
+        .filter(|mime| ALLOWED_IMAGE_MIMES.contains(mime))
+        .ok_or_else(|| {
+            invalid_logo("company logo must be a base64 PNG, JPEG, GIF, or WebP data URL")
+        })?;
+    let padding = payload.len() - payload.trim_end_matches('=').len();
+    if payload.is_empty()
+        || payload.len() % 4 != 0
+        || padding > 2
+        || !payload[..payload.len() - padding]
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/'))
+    {
+        return Err(invalid_logo(format!(
+            "company logo contains invalid base64 data for {mime}"
+        )));
+    }
+
+    Ok(Some(value))
+}
+
+/// `PUT …/logo` — replace or clear the company logo and return fresh status.
+async fn put_logo(
+    company: AdminScopedCompany,
+    Json(body): Json<CompanyLogoBody>,
+) -> Result<Json<CompanyStatus>, ApiError> {
+    let logo_url = company_logo_value(body.logo_url)?;
+    let mut record = company
+        .runtime
+        .store()
+        .load(company.id())
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
+    record.manifest.company.logo_url = logo_url;
+    company.runtime.store().save(&record).await?;
+    Ok(Json(company.runtime.status().await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logo_value_accepts_images_and_rejects_external_or_oversized_values() {
+        let valid = "data:image/png;base64,iVBORw==".to_string();
+        assert_eq!(
+            company_logo_value(Some(valid.clone())).unwrap(),
+            Some(valid)
+        );
+        assert!(company_logo_value(Some("https://example.com/logo.png".into())).is_err());
+        assert!(company_logo_value(Some("x".repeat(COMPANY_LOGO_MAX_CHARS + 1))).is_err());
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -22,6 +22,8 @@ pub mod avatars;
 pub mod billing;
 pub mod capabilities;
 pub mod company_key;
+/// Operator-set company logo, stored in the company manifest.
+pub mod company_logo;
 pub mod composio;
 pub mod composio_toolkits;
 pub mod connections_read;
@@ -195,6 +197,7 @@ pub fn router() -> Router<AppState> {
         .merge(billing::router())
         .merge(hosting::router())
         .merge(search::router())
+        .merge(company_logo::router())
         .merge(company_key::router())
         .merge(composio::router())
         .merge(domain::router())


### PR DESCRIPTION
## What

A company gets an uploadable **logo** (an image data URL) that is stored on the company and delivered to the frontend through the existing company status API. Backend-only.

## API

- `PUT /api/v1/company/logo` and `PUT /api/v1/companies/{id}/logo`
  - body: `{ "logoUrl": "data:image/png;base64,…" }`
  - admin-only (`AdminScopedCompany`), mirroring the search/hosting settings write plane
  - `null`/omitted `logoUrl` clears the logo
  - returns the fresh `CompanyStatus`
- `logo_url` is added to `CompanyStatus`, so it is delivered by the existing status read (REST `…/status` and the GraphQL company node) — no new read path.

## Storage & validation

- Persisted as `Company.logo_url` on the `[company]` manifest section (`#[serde(default)]`, additive).
- Accepts only self-contained base64 image data URLs: `data:image/{png|jpeg|gif|webp};base64,…`.
- Rejects external URLs, wrong MIME, invalid base64, and payloads over a 1,000,000-char cap → `400 InvalidRequest`.
- SVG is rejected (can carry script), consistent with the avatar upload route.

## Tests / checks

- Added a unit test covering valid / external-URL / oversized inputs.
- `cargo fmt --all -- --check` → clean
- `cargo clippy --features openhuman --lib -- -D warnings` → clean (only a pre-existing `vendor/openhuman` warning)
- `cargo test --features openhuman --lib` → `5495 passed; 0 failed; 3 ignored`

## Files

- `src/company/types.rs` — `Company.logo_url`
- `src/runtime/types.rs` — `CompanyStatus.logo_url`
- `src/company/runtime.rs` — status snapshot reads the manifest logo
- `src/server/ops/mod.rs` — register the logo router
- `src/server/ops/company_logo.rs` — new `PUT …/logo` route + validation + test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting and clearing a company logo.
  * Company logos can be uploaded as validated PNG, JPEG, GIF, or WebP data URLs.
  * Company status responses now include the configured logo when available.
* **Bug Fixes**
  * Invalid, external, oversized, or malformed logo values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->