### PR TITLE
ci(desktop): macOS DMG release pipeline, unsigned by default (#1732)

### DIFF
--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -1,0 +1,210 @@
+# Issue #1732. Package the OpenCompany Tauri desktop shell as a macOS DMG.
+#
+# By default this produces an UNSIGNED arm64 (aarch64-apple-darwin) .dmg and
+# uploads it as an Actions artifact — the fast path for internal / CI builds.
+# Developer-ID signing + Apple notarization is GATED behind the `sign` input
+# and the presence of the six APPLE_* secrets; only a signed+notarized DMG is
+# ever attached to a GitHub Release (`create_release`). An unsigned DMG never
+# goes to a public Release.
+#
+# Issue #590. Every `uses:` below is a full commit SHA with the resolved version
+# in a trailing comment — `actions/*` included, no exemptions. The rationale is
+# at the top of `ci.yml`. `dtolnay/rust-toolchain` additionally passes an
+# explicit `toolchain:` matching `rust-toolchain.toml`; `scripts/ci/assert-toolchain-pin.sh`
+# enforces that agreement.
+name: Release Desktop (macOS DMG)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to publish/attach the DMG to, for example v0.1.0.
+        required: true
+        type: string
+      sign:
+        description:
+          When true, Developer-ID sign + notarize the .app and DMG. Requires the
+          six APPLE_* secrets; the run fails fast if any is missing.
+        type: boolean
+        default: false
+      create_release:
+        description:
+          When true, attach the DMG to the GitHub Release named by `tag`. Only a
+          signed DMG may be attached, so this requires `sign` to also be true.
+          When false, upload the DMG as an Actions artifact instead.
+        type: boolean
+        default: false
+
+# Needed by softprops/action-gh-release when create_release is true.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: "Desktop: aarch64-apple-darwin"
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+          persist-credentials: false
+
+      # `submodules: true` is not recursive. The vendored openhuman crate's own
+      # path-dependency crates must resolve for Cargo even on a default build.
+      # THE ONE PLACE this runs — see the script header (issue #592).
+      - name: Init vendored openhuman crate submodules
+        run: scripts/ci/init-vendored-submodules.sh
+
+      # Reads the pinned toolchain; `toolchain:` must match rust-toolchain.toml
+      # (asserted by scripts/ci/assert-toolchain-pin.sh). Add the macOS arm64
+      # cross target on the same toolchain the build uses.
+      - name: Install Rust (rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: "1.98.0"
+          components: rustfmt, clippy
+          targets: aarch64-apple-darwin
+
+      - name: Ensure aarch64-apple-darwin target
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # Build the frontend BEFORE the Tauri build. `beforeBuildCommand` is empty
+      # in tauri.conf.json, so nothing else compiles `frontend/dist` — the Tauri
+      # bundler would package a stale or missing dist otherwise.
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      # Vite ran above; here the Tauri CLI compiles the Rust shell and packages
+      # the .app + unsigned .dmg. macOS signing is intentionally skipped here and
+      # handled by the dedicated re-sign + notarize step below (hardened runtime
+      # + entitlements are required for notarization). Path-qualified CLI so the
+      # project resolves to src-tauri/ (assert-single-tauri-app.sh).
+      - name: Build and package Tauri app (unsigned)
+        working-directory: src-tauri
+        env:
+          # Keep in sync with bundle.macOS.minimumSystemVersion in
+          # src-tauri/tauri.conf.json — the Wry system-WebView floor.
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
+        run: ../frontend/node_modules/.bin/tauri build --locked --target aarch64-apple-darwin
+
+      # Guard: a public Release must never carry an unsigned DMG.
+      - name: Guard release-requires-signing
+        if: inputs.create_release && !inputs.sign
+        run: |
+          echo "::error::create_release=true requires sign=true — an unsigned DMG must not be attached to a GitHub Release. Re-dispatch with sign=true (and the APPLE_* secrets set)." >&2
+          exit 1
+
+      - name: Locate .app and .dmg bundles
+        id: locate
+        env:
+          TARGET: aarch64-apple-darwin
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="src-tauri/target/${TARGET}/release/bundle"
+          APP_PATH="$(find "$BUNDLE_DIR/macos" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -1 || true)"
+          DMG_PATH="$(find "$BUNDLE_DIR/dmg" -maxdepth 1 -name '*.dmg' ! -name 'rw.*.dmg' -type f 2>/dev/null | head -1 || true)"
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app found under $BUNDLE_DIR/macos" >&2
+            find "$BUNDLE_DIR" -type d 2>/dev/null || true
+            exit 1
+          fi
+          if [ -z "$DMG_PATH" ]; then
+            echo "::error::No .dmg found under $BUNDLE_DIR/dmg" >&2
+            find "$BUNDLE_DIR" -type f 2>/dev/null || true
+            exit 1
+          fi
+          {
+            echo "app_path=$APP_PATH"
+            echo "dmg_path=$DMG_PATH"
+            echo "bundle_dir=$BUNDLE_DIR"
+          } >> "$GITHUB_OUTPUT"
+          echo "Found .app: $APP_PATH"
+          echo "Found .dmg: $DMG_PATH"
+
+      # ---- Optional: Developer-ID sign + notarize (gated on `sign`) ----------
+      - name: Validate signing prerequisites
+        if: inputs.sign
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          # Match the resolution used by the sign/notarize steps below: prefer
+          # the app-specific password, fall back to the legacy name. Validating
+          # a different secret than we use would let a run pass this check and
+          # then fail mid-notarization.
+          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=0
+          for var in APPLE_CERTIFICATE_BASE64 APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!var}" ]; then
+              echo "::error::sign=true but required macOS signing secret is missing: $var" >&2
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+
+      - name: Sign and notarize .app
+        if: inputs.sign
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          bash scripts/release/sign-and-notarize-macos.sh \
+            "${{ steps.locate.outputs.app_path }}" \
+            "src-tauri/entitlements.plist"
+
+      - name: Re-package DMG after notarization
+        if: inputs.sign
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          bash scripts/release/repackage-dmg.sh \
+            "${{ steps.locate.outputs.app_path }}" \
+            "${{ steps.locate.outputs.bundle_dir }}"
+
+      - name: Verify notarization staple
+        if: inputs.sign
+        run: |
+          xcrun stapler validate "${{ steps.locate.outputs.dmg_path }}"
+
+      # ---- Publish -----------------------------------------------------------
+      # Signed → attach to the GitHub Release. (The guard above proves sign=true
+      # whenever create_release is true, so this only ever attaches a notarized
+      # DMG.)
+      - name: Attach signed DMG to release
+        if: inputs.create_release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: ${{ steps.locate.outputs.dmg_path }}
+
+      # Otherwise upload the DMG (unsigned by default) as an Actions artifact.
+      - name: Upload DMG as Actions artifact
+        if: "!inputs.create_release"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: opencompany-macos-aarch64-dmg
+          path: ${{ steps.locate.outputs.dmg_path }}
+          if-no-files-found: error

--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -45,9 +45,14 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     steps:
+      # Check out the exact `tag` being published, NOT the dispatch ref. If the
+      # branch advanced since the tag was cut, an unpinned checkout would build
+      # newer source and attach it to the older release — the drift Codex flagged
+      # on #1733. `tag` is a required input, so this ref always resolves.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.tag }}
           submodules: true
           persist-credentials: false
 

--- a/scripts/release/repackage-dmg.sh
+++ b/scripts/release/repackage-dmg.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Re-create and notarize a DMG after the .app has been notarized.
+#
+# Ported ~verbatim from openhuman. OpenCompany has no CEF assumptions, so the
+# only OpenCompany-specific bits are the volume name and the absence of a DMG
+# background image (Tauri did not declare one, so we rebuild without a
+# background; override with DMG_BACKGROUND_PATH if one is ever added).
+#
+# Usage:
+#   repackage-dmg.sh <app_path> <bundle_dir>
+#
+# Required environment variables:
+#   APPLE_ID
+#   APPLE_PASSWORD    (app-specific password)
+#   APPLE_TEAM_ID
+#
+# Why a full rebuild instead of mount-and-replace:
+#
+# Converting the original Tauri-built UDZO DMG to UDRW, mounting it, replacing
+# the .app, and converting back fails consistently on recent macOS runners with
+# `hdiutil: convert failed - internal error`. Tauri's own vendored
+# bundle_dmg.sh builds a fresh UDRW from a source folder via
+# `hdiutil create -srcfolder` and converts to UDZO; that path works. So we reuse
+# it (already on disk under `<bundle_dir>/dmg/bundle_dmg.sh` from the tauri-build
+# step) and rebuild the DMG around the now-notarized .app.
+set -euo pipefail
+
+APP_PATH="${1:?Usage: repackage-dmg.sh <app_path> <bundle_dir>}"
+BUNDLE_DIR="${2:?}"
+
+# Resolve all bundle paths to absolute form — we cd into $MACOS_DIR below to
+# invoke bundle_dmg.sh, and relative paths would break after the cd.
+BUNDLE_DIR_ABS="$(cd "$BUNDLE_DIR" && pwd)"
+DMG_DIR="$BUNDLE_DIR_ABS/dmg"
+MACOS_DIR="$BUNDLE_DIR_ABS/macos"
+BUNDLE_SCRIPT="$DMG_DIR/bundle_dmg.sh"
+SUPPORT_DIR="$BUNDLE_DIR_ABS/share/create-dmg/support"
+
+if [ ! -x "$BUNDLE_SCRIPT" ]; then
+  echo "[dmg] ERROR: bundle_dmg.sh not found at $BUNDLE_SCRIPT" >&2
+  echo "[dmg]        Did the original tauri-build step run successfully?" >&2
+  exit 1
+fi
+if [ ! -d "$SUPPORT_DIR" ]; then
+  echo "[dmg] ERROR: support dir not found at $SUPPORT_DIR" >&2
+  exit 1
+fi
+if [ ! -d "$APP_PATH" ]; then
+  echo "[dmg] ERROR: app bundle not found at $APP_PATH" >&2
+  exit 1
+fi
+APP_PATH_ABS="$(cd "$APP_PATH/.." && pwd)/$(basename "$APP_PATH")"
+APP_NAME="$(basename "$APP_PATH")"
+
+# The .app must be inside $MACOS_DIR for the bundle_dmg.sh srcfolder arg. If the
+# caller passed an .app from a different location, copy it into place so
+# bundle_dmg.sh picks up the right (notarized) bundle.
+if [ "$APP_PATH_ABS" != "$MACOS_DIR/$APP_NAME" ]; then
+  echo "[dmg] Staging $APP_NAME into $MACOS_DIR"
+  rm -rf "${MACOS_DIR:?}/${APP_NAME:?}"
+  ditto "$APP_PATH_ABS" "$MACOS_DIR/$APP_NAME"
+fi
+
+# Capture the existing DMG name so the rebuild outputs to the same path.
+# tauri-build always produces exactly one .dmg per target.
+ORIGINAL_DMG="$(find "$DMG_DIR" -maxdepth 1 -name '*.dmg' ! -name 'rw.*.dmg' -type f 2>/dev/null | head -1 || true)"
+if [ -z "$ORIGINAL_DMG" ]; then
+  echo "[dmg] No DMG found in $DMG_DIR — nothing to repackage" >&2
+  exit 0
+fi
+DMG_NAME="$(basename "$ORIGINAL_DMG")"
+FINAL_DMG="$DMG_DIR/$DMG_NAME"
+echo "[dmg] Rebuilding $DMG_NAME from notarized $APP_NAME"
+
+# OpenCompany's Tauri config declares no DMG background image, so we rebuild
+# without one. Override via env if a background is ever added.
+BACKGROUND_PATH="${DMG_BACKGROUND_PATH:-}"
+if [ -n "$BACKGROUND_PATH" ] && [ ! -f "$BACKGROUND_PATH" ]; then
+  echo "[dmg] WARNING: background image not found at $BACKGROUND_PATH — building without background" >&2
+  BACKGROUND_PATH=""
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────────────────────
+cleanup() {
+  set +e
+  if [ -n "${VERIFY_MOUNT:-}" ] && [ -d "$VERIFY_MOUNT" ]; then
+    hdiutil detach "$VERIFY_MOUNT" -force 2>/dev/null || true
+    rmdir "$VERIFY_MOUNT" 2>/dev/null || true
+  fi
+  # bundle_dmg.sh writes scratch files alongside the output — clean any leftovers.
+  find "$DMG_DIR" -maxdepth 1 -name 'rw.*.dmg' -delete 2>/dev/null || true
+  find "$MACOS_DIR" -maxdepth 1 -name 'rw.*.dmg' -delete 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Pre-clean any leftover scratch DMGs from prior failed runs.
+find "$DMG_DIR" -maxdepth 1 -name 'rw.*.dmg' -delete 2>/dev/null || true
+find "$MACOS_DIR" -maxdepth 1 -name 'rw.*.dmg' -delete 2>/dev/null || true
+rm -f "$FINAL_DMG"
+
+BUNDLE_ARGS=(
+  --volname "OpenCompany"
+  --icon "$APP_NAME" 180 170
+  --app-drop-link 480 170
+  --window-size 660 400
+  --hide-extension "$APP_NAME"
+  --skip-jenkins
+)
+if [ -n "$BACKGROUND_PATH" ]; then
+  BACKGROUND_ABS="$(cd "$(dirname "$BACKGROUND_PATH")" && pwd)/$(basename "$BACKGROUND_PATH")"
+  BUNDLE_ARGS+=(--background "$BACKGROUND_ABS")
+fi
+
+echo "[dmg] Running bundle_dmg.sh..."
+(
+  cd "$MACOS_DIR"
+  bash "$BUNDLE_SCRIPT" "${BUNDLE_ARGS[@]}" "$FINAL_DMG" "$APP_NAME"
+)
+
+if [ ! -f "$FINAL_DMG" ]; then
+  echo "[dmg] ERROR: bundle_dmg.sh did not produce $FINAL_DMG" >&2
+  exit 1
+fi
+echo "[dmg] Built fresh DMG at $FINAL_DMG ($(du -h "$FINAL_DMG" | cut -f1))"
+
+DMG_PATH="$FINAL_DMG"
+
+echo "[dmg] Notarizing DMG..."
+DMG_SUBMIT_OUT="$(mktemp /tmp/notarize-dmg-XXXXXX.json)"
+set +e
+xcrun notarytool submit "$DMG_PATH" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --output-format json \
+  --wait > "$DMG_SUBMIT_OUT"
+DMG_SUBMIT_RC=$?
+set -e
+cat "$DMG_SUBMIT_OUT"
+
+DMG_SUBMISSION_ID="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("id",""))' "$DMG_SUBMIT_OUT" 2>/dev/null || true)"
+DMG_SUBMISSION_STATUS="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("status",""))' "$DMG_SUBMIT_OUT" 2>/dev/null || true)"
+rm -f "$DMG_SUBMIT_OUT"
+
+if [ -n "$DMG_SUBMISSION_ID" ]; then
+  echo "[dmg] Fetching notarytool developer log for $DMG_SUBMISSION_ID:"
+  xcrun notarytool log "$DMG_SUBMISSION_ID" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" || true
+fi
+
+if [ "$DMG_SUBMISSION_STATUS" != "Accepted" ] || [ "$DMG_SUBMIT_RC" -ne 0 ]; then
+  echo "[dmg] ERROR: DMG notarization did not succeed (status=$DMG_SUBMISSION_STATUS, rc=$DMG_SUBMIT_RC)" >&2
+  exit 1
+fi
+
+xcrun stapler staple "$DMG_PATH"
+echo "[dmg] DMG notarization complete: $DMG_PATH"
+
+# ── Final verification ───────────────────────────────────────────────────────
+echo "[dmg] Verifying final DMG layout..."
+VERIFY_MOUNT="$(mktemp -d /tmp/OpenCompany-Verify-XXXXXX)"
+hdiutil attach "$DMG_PATH" -mountpoint "$VERIFY_MOUNT" -noautoopen
+
+if [ ! -d "$VERIFY_MOUNT/$APP_NAME" ]; then
+  echo "[dmg] ERROR: $APP_NAME missing in final DMG" >&2
+  exit 1
+fi
+if [ ! -L "$VERIFY_MOUNT/Applications" ]; then
+  echo "[dmg] ERROR: Applications symlink missing in final DMG" >&2
+  exit 1
+fi
+
+hdiutil detach "$VERIFY_MOUNT"
+rmdir "$VERIFY_MOUNT"
+VERIFY_MOUNT=""
+echo "[dmg] Verification successful: layout preserved."

--- a/scripts/release/sign-and-notarize-macos.sh
+++ b/scripts/release/sign-and-notarize-macos.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Developer-ID sign a macOS .app bundle with the Hardened Runtime and submit it
+# for Apple notarization.
+#
+# Ported from openhuman's script and SIMPLIFIED for OpenCompany: OpenCompany
+# uses the system WebKit via Wry — there is no bundled Chromium/CEF framework,
+# no nested Helper.app, and no external sidecar binary. So the whole inside-out
+# Frameworks pass, the Helper.app loop, and the MacOS/ + Resources/ sidecar
+# loops from the original are dropped. `codesign` on the single .app bundle
+# recursively seals everything it contains.
+#
+# Usage:
+#   sign-and-notarize-macos.sh <app_path> [entitlements_plist]
+#
+# Required environment variables:
+#   APPLE_CERTIFICATE_BASE64
+#   APPLE_CERTIFICATE_PASSWORD
+#   APPLE_SIGNING_IDENTITY
+#   APPLE_ID
+#   APPLE_PASSWORD          (app-specific password)
+#   APPLE_TEAM_ID
+set -euo pipefail
+
+APP_PATH="${1:?Usage: sign-and-notarize-macos.sh <app_path> [entitlements_plist]}"
+ENTITLEMENTS="${2:-src-tauri/entitlements.plist}"
+
+for var in APPLE_CERTIFICATE_BASE64 APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+  if [ -z "${!var:-}" ]; then
+    echo "[sign] ERROR: Missing required env var: $var"
+    exit 1
+  fi
+done
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "[sign] ERROR: app bundle not found at $APP_PATH" >&2
+  exit 1
+fi
+if [ ! -f "$ENTITLEMENTS" ]; then
+  echo "[sign] ERROR: entitlements plist not found at $ENTITLEMENTS" >&2
+  exit 1
+fi
+
+# ── Import signing certificate into a throwaway keychain ─────────────────────
+KEYCHAIN="resign-$$.keychain-db"
+KEYCHAIN_PW="$(openssl rand -base64 24)"
+CERT_FILE="$(mktemp /tmp/cert-XXXXXX.p12)"
+
+echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$CERT_FILE"
+security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+security import "$CERT_FILE" -k "$KEYCHAIN" \
+  -P "$APPLE_CERTIFICATE_PASSWORD" \
+  -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PW" "$KEYCHAIN"
+# Word-splitting is deliberate: the existing user keychains each become a
+# separate argument so our throwaway keychain is prepended without dropping them.
+# shellcheck disable=SC2046
+security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+rm -f "$CERT_FILE"
+echo "[sign] Signing identity imported into $KEYCHAIN"
+
+# ── Sign the .app bundle ─────────────────────────────────────────────────────
+# A single Wry .app: codesign --force seals the main executable and any
+# resources in one pass. Hardened runtime + entitlements + secure timestamp are
+# all required for notarization to accept the bundle.
+MAIN_EXE="$(defaults read "$APP_PATH/Contents/Info.plist" CFBundleExecutable 2>/dev/null || echo "OpenCompany")"
+echo "[sign] Main executable (from plist): $MAIN_EXE"
+echo "[sign] Bundle contents (MacOS/):"
+ls -la "$APP_PATH/Contents/MacOS/"
+
+echo "[sign] Signing .app bundle..."
+codesign --force --options runtime \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$APPLE_SIGNING_IDENTITY" \
+  --timestamp \
+  "$APP_PATH"
+
+# ── Verify ───────────────────────────────────────────────────────────────────
+echo "[sign] Verifying signatures"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+# ── Notarize ─────────────────────────────────────────────────────────────────
+echo "[sign] Notarizing..."
+NOTARIZE_ZIP="$(mktemp /tmp/OpenCompany-notarize-XXXXXX.zip)"
+ditto -c -k --keepParent "$APP_PATH" "$NOTARIZE_ZIP"
+
+SUBMIT_OUT="$(mktemp /tmp/notarize-submit-XXXXXX.json)"
+set +e
+xcrun notarytool submit "$NOTARIZE_ZIP" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --output-format json \
+  --wait > "$SUBMIT_OUT"
+SUBMIT_RC=$?
+set -e
+
+cat "$SUBMIT_OUT"
+rm -f "$NOTARIZE_ZIP"
+
+SUBMISSION_ID="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("id",""))' "$SUBMIT_OUT" 2>/dev/null || true)"
+SUBMISSION_STATUS="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("status",""))' "$SUBMIT_OUT" 2>/dev/null || true)"
+rm -f "$SUBMIT_OUT"
+
+echo "[sign] notarytool exit=$SUBMIT_RC id=$SUBMISSION_ID status=$SUBMISSION_STATUS"
+
+if [ -n "$SUBMISSION_ID" ]; then
+  echo "[sign] Fetching notarytool developer log for $SUBMISSION_ID:"
+  xcrun notarytool log "$SUBMISSION_ID" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" || true
+fi
+
+if [ "$SUBMISSION_STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
+  echo "[sign] ERROR: notarization did not succeed (status=$SUBMISSION_STATUS, rc=$SUBMIT_RC)" >&2
+  exit 1
+fi
+
+# ── Staple ───────────────────────────────────────────────────────────────────
+echo "[sign] Stapling..."
+xcrun stapler staple "$APP_PATH"
+
+echo "[sign] Notarization complete"

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      OpenCompany desktop shell entitlements — hardened runtime, NON-sandboxed.
+
+      Deliberately minimal. OpenCompany uses the system WebKit via Wry: there is
+      no bundled Chromium/CEF and no external sidecar process, so none of the
+      CEF-only relaxations (allow-jit / allow-unsigned-executable-memory /
+      disable-library-validation) nor the sidecar/device/apple-events keys that
+      openhuman carries apply here. Add a key only when a concrete feature needs
+      it under the Hardened Runtime.
+    -->
+
+    <!-- Outbound HTTPS to the platform/tenant APIs and SSH endpoints. Without
+         this, reqwest connections are silently blocked under the Hardened
+         Runtime in signed builds. -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+
+    <!-- The embedded host binds a loopback listener (127.0.0.1:0). Accepting
+         connections requires the server entitlement under the Hardened Runtime. -->
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,6 +34,10 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "entitlements.plist",
+      "minimumSystemVersion": "12.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds a net-new CI pipeline that packages the OpenCompany Tauri desktop shell as a **macOS DMG** (`aarch64-apple-darwin` / Apple Silicon).

By default the workflow produces an **unsigned** DMG and uploads it as an Actions artifact — the fast path for internal / CI builds. Developer-ID signing + Apple notarization is fully wired but **gated** behind a `sign` input and the presence of the six `APPLE_*` secrets, so it only runs for public releases once an admin adds those secrets. An unsigned DMG is never attached to a GitHub Release.

New files:

- `.github/workflows/release-desktop-macos.yml` — `workflow_dispatch` workflow (inputs: `tag`, `sign` default `false`, `create_release` default `false`), `macos-latest`, arm64 only. Checkout (`submodules: true`, `persist-credentials: false`) → `scripts/ci/init-vendored-submodules.sh` (policy #592) → Rust toolchain pinned to `rust-toolchain.toml` + `aarch64-apple-darwin` target → Node from `frontend/.nvmrc` → `npm ci` + `npm run build` in `frontend/` → path-qualified `tauri build --locked --target aarch64-apple-darwin` → gated sign/notarize/repackage → publish (Release attach when signed, else Actions artifact). Every `uses:` is SHA-pinned (policy #590), reusing the exact pins already in `ci.yml`/`release.yml`.
- `src-tauri/entitlements.plist` — hardened-runtime, **non-sandboxed**, minimal: only `com.apple.security.network.client` + `com.apple.security.network.server`. No app-sandbox, keychain, camera/mic/bluetooth/apple-events, or CEF-only keys — OC uses system WebKit via Wry (no CEF, no sidecars).
- `scripts/release/sign-and-notarize-macos.sh` — ported + simplified from openhuman: ephemeral-keychain cert import → `codesign --force --options runtime --entitlements … --timestamp` on the single `.app` → `codesign --verify --deep --strict` → `ditto` zip → `notarytool submit --wait` (require `Accepted`) → `stapler staple`. The openhuman CEF Frameworks/Helper.app/sidecar loops are dropped — OC has none.
- `scripts/release/repackage-dmg.sh` — ported ~verbatim: rebuilds the DMG from the notarized `.app` via Tauri's vendored `bundle_dmg.sh`, then notarizes + staples the DMG. OpenCompany-specific bits only: volume name and no background image.

Also adds the previously-missing `bundle.macOS` block to `src-tauri/tauri.conf.json` (`entitlements`, `minimumSystemVersion: "12.0"`); `bundle.targets` is left as `"all"` (unchanged).

### Secrets an admin must add for Phase 2 (signing)

All six are required when dispatching with `sign=true` (the run fails fast, naming any missing one):

| Secret | What it is |
|--------|-----------|
| `APPLE_CERTIFICATE_BASE64` | base64 of the "Developer ID Application" signing certificate exported as `.p12` |
| `APPLE_CERTIFICATE_PASSWORD` | password protecting that `.p12` |
| `APPLE_SIGNING_IDENTITY` | the identity string, e.g. `Developer ID Application: <Org> (<TEAMID>)` |
| `APPLE_ID` | Apple account email used for `notarytool` submission |
| `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password for that Apple ID (falls back to legacy `APPLE_PASSWORD` if set instead) |
| `APPLE_TEAM_ID` | 10-character Apple Developer Team ID |

## API Or Behavior Changes

None to the application. CI/build-only: adds one `workflow_dispatch` pipeline plus supporting scripts, entitlements, and the macOS bundle config. This pass ships an **unsigned arm64 DMG artifact only**; the signing/notarization path is present but gated and untested until the secrets above exist.

## Tests

Local validation (a macOS Tauri build cannot be run here — see note):

- YAML: workflow parses (`ruby -ryaml`) and `actionlint` is clean.
- SHA-pins: every `uses:` is a 40-hex SHA (repo policy #590 grep) — all pinned.
- `scripts/ci/assert-toolchain-pin.sh` passes (new `toolchain: "1.98.0"` call site agrees with `rust-toolchain.toml`).
- `scripts/ci/assert-single-tauri-app.sh` passes (still one Tauri app, no unqualified CLI invocation).
- JSON: `src-tauri/tauri.conf.json` valid; `bundle.macOS` block well-formed.
- `shellcheck` clean and `bash -n` OK on both scripts.
- **`tauri build` was NOT run locally** (needs the macOS toolchain + a heavy build). The first real end-to-end proof is dispatching this workflow on the branch; signing/notarization cannot be exercised until the `APPLE_*` secrets are added.

The template's Rust checklist is N/A — this PR changes no Rust source:

- [x] N/A: no Rust changed — `cargo fmt --all -- --check`
- [x] N/A: no Rust changed — `cargo clippy --all-targets -- -D warnings`
- [x] N/A: no Rust changed — `cargo build --all-targets`
- [x] N/A: no Rust changed — `cargo test`

## Documentation

The workflow, scripts, and entitlements each carry header comments explaining the gating, the ported-from-openhuman simplifications, and why each entitlement key is present. No separate docs page needed.

## Related

Closes #1732
