### PR TITLE
fix(inference): make the Inference card say what it knows (#1736, #1737)

### DIFF
--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -76,6 +76,20 @@ export interface InferenceStatus {
    * cannot end.
    */
   harnessReachable: boolean;
+  /**
+   * Whether this host can rebuild the company's runtime in place, so the
+   * console may offer to perform the restart `restartRequired` names (issue
+   * #1736).
+   *
+   * The two are independent, and the card only had the first: it rendered a
+   * "Restart now" button on hosts where `POST …/inference/restart` can only
+   * answer "this host cannot rebuild a company runtime in place". An operator
+   * was told a restart was required, handed the control for it, and the control
+   * could never work. `false` means name the remedy instead of offering the
+   * action — the same rule the setup capability flags exist for (`api/setup.ts`):
+   * say "not in this build" rather than offer a switch that does nothing.
+   */
+  canRebuildInPlace: boolean;
 }
 
 /** The set-provider body. `key` is write-only (never returned). */

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -79,7 +79,17 @@ const PROVIDERS: Record<
     label: "Managed (TinyHumans)",
     acceptsKey: true,
     requiresBaseUrl: false,
-    keyKind: "a TinyHumans API key",
+    // The managed brain is OpenRouter with the platform paying: the host treats
+    // `managed` as a legacy alias for `openrouter` (`LEGACY_MANAGED`, since
+    // OpenCompany stopped exposing its own model SKUs), so a key saved here is
+    // resolved onto OpenRouter's own endpoint and sent there.
+    //
+    // This line used to read "a TinyHumans API key" — true when `managed` was a
+    // provider of its own, and never updated when it stopped being one. It is
+    // what issue #1737 actually cost: the operator was asked for one vendor's
+    // key on a card that stored it against another, and every turn and every
+    // Test since has presented it to OpenRouter, which rejects it (issue #1737).
+    keyKind: "an OpenRouter key (`sk-or-…`) — the managed brain is OpenRouter, so that is where a key set here is sent",
     preset: { baseUrl: "", models: {} },
   },
   openrouter: {
@@ -183,10 +193,67 @@ export function InferenceSection({
   const [models, setModels] = useState<Partial<Record<Tier, string>>>({});
   const [key, setKey] = useState("");
   const [pendingProvider, setPendingProvider] = useState<InferenceProvider | null>(null);
+  /**
+   * The values the form last started from — a provider's preset, or what the
+   * host actually holds. Anything differing from this is something the operator
+   * typed, which is the only thing the destructive-draft dialog exists to
+   * protect (issue #1474).
+   *
+   * Kept as state rather than recomputed from `presetFor(provider)` because the
+   * form no longer always starts at a preset: seeding it from the stored
+   * configuration means the baseline can be a saved endpoint and model table
+   * that no preset matches, and comparing those against the preset would ask an
+   * operator to confirm discarding a draft nobody wrote.
+   */
+  const [baseline, setBaseline] = useState<{
+    baseUrl: string;
+    models: Partial<Record<Tier, string>>;
+  }>({ baseUrl: "", models: {} });
+
+  /**
+   * Point the switch form at what the host actually holds.
+   *
+   * Without this the Provider select was a constant: `useState("managed")` and
+   * nothing ever wrote it back, so the card opened on "Managed (TinyHumans)"
+   * whatever was stored — on first load, after a Save, and after a full process
+   * restart, which re-runs the same initializer. The header beside it renders
+   * the *host's* provider, so the two named different providers on the same
+   * card at the same moment, and an operator could store a key against a
+   * provider they never chose without anything on screen saying so (#1737).
+   *
+   * Seeded from `status.provider` verbatim, never from a mapping of our own:
+   * that value is what the header renders, so taking it as-is is what makes
+   * "the header and the select can never disagree" structural rather than
+   * something to keep in step by hand.
+   *
+   * `baseUrl` is seeded only for the providers that require one. `managed` and
+   * `openrouter` resolve theirs from the environment or a well-known default,
+   * and putting the *resolved* value in the form would pin the company to it on
+   * the next Save — silently overriding `OPENCOMPANY_INFERENCE_URL`. Same
+   * reasoning as `removeKey` below.
+   */
+  const seedFromStatus = useCallback((next: InferenceStatus) => {
+    const seeded = (
+      next.provider in PROVIDERS ? next.provider : "openrouter"
+    ) as InferenceProvider;
+    const nextBaseUrl = PROVIDERS[seeded].requiresBaseUrl
+      ? next.baseUrl
+      : presetFor(seeded).baseUrl;
+    const nextModels = next.models as Partial<Record<Tier, string>>;
+    setProvider(seeded);
+    setBaseUrl(nextBaseUrl);
+    setModels(nextModels);
+    setBaseline({ baseUrl: nextBaseUrl, models: nextModels });
+  }, []);
 
   const refresh = useCallback(async () => {
     try {
-      setStatus(await getInferenceStatus(client, company));
+      const next = await getInferenceStatus(client, company);
+      setStatus(next);
+      // Safe to reseed on every refresh because `refresh` runs on mount and
+      // after a *completed* mutation only — there is no poll here, so this can
+      // never pull a draft out from under someone mid-edit.
+      seedFromStatus(next);
       setLoad("ready");
     } catch (err) {
       // A 404 is a host with no inference plane; anything else is a host that
@@ -195,7 +262,7 @@ export function InferenceSection({
       // likely and disappearing is least helpful (issue #1470).
       setLoad(classifyLoadFailure(err));
     }
-  }, [client, company]);
+  }, [client, company, seedFromStatus]);
 
   useEffect(() => {
     setLoad("loading");
@@ -207,24 +274,27 @@ export function InferenceSection({
     const preset = presetFor(next);
     setBaseUrl(preset.baseUrl);
     setModels(preset.models);
+    setBaseline({ baseUrl: preset.baseUrl, models: preset.models });
     setTest({ kind: "idle" });
   }
 
   /**
    * Whether the operator has typed anything into the Base URL or model fields
-   * since the current provider's preset was applied.
+   * since the form last started from a known baseline.
    *
    * The destructive-draft dialog exists to protect values the operator typed —
    * the copy promises "confirmation is only required for values the operator
-   * typed", and a provider's *preset* is not a typed draft. OpenRouter pre-fills
-   * model ids and Ollama a local base URL, so switching away from either without
-   * editing anything must not ask to discard a draft nobody wrote (issue #1474).
+   * typed", and neither a provider's *preset* nor the configuration the host
+   * already holds is a typed draft. OpenRouter pre-fills model ids and Ollama a
+   * local base URL, so switching away from either without editing anything must
+   * not ask to discard a draft nobody wrote (issue #1474) — and since the form
+   * is now seeded from the stored configuration, a saved endpoint and model
+   * table must not either.
    */
   function hasTypedDraft(): boolean {
-    const preset = presetFor(provider);
     return (
-      baseUrl !== preset.baseUrl ||
-      TIERS.some((tier) => (models[tier] ?? "") !== (preset.models[tier] ?? ""))
+      baseUrl !== baseline.baseUrl ||
+      TIERS.some((tier) => (models[tier] ?? "") !== (baseline.models[tier] ?? ""))
     );
   }
 
@@ -334,6 +404,11 @@ export function InferenceSection({
    * The resulting status is read from the response rather than assumed. A host
    * that wired no rebuilder genuinely cannot do this and says so, and reporting
    * success there would replace a visible dead end with an invisible one.
+   *
+   * Since #1736 the button is only rendered where `canRebuildInPlace` holds, so
+   * that arm is defence in depth rather than the everyday path: the capability
+   * is read at load and the rebuilder could still be absent by the time the
+   * click lands.
    */
   async function restartNow() {
     if (busy) return;
@@ -365,8 +440,13 @@ export function InferenceSection({
       // declares none. Claiming "managed" here would be wrong for a company
       // whose manifest names its own provider (issue #1474).
       toast.success(result.note);
-      pickProvider("managed");
       setKey("");
+      setTest({ kind: "idle" });
+      // The form is not reset to a guess here: `refresh` reseeds it from what
+      // the host holds after the revert, which for a company whose manifest
+      // names its own provider is not `managed` (issue #1474). Assuming a
+      // provider here is what put a value in the select that the header
+      // disagreed with (issue #1737).
       await refresh();
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Couldn't revert inference.");
@@ -494,28 +574,53 @@ export function InferenceSection({
                           so this rebuilds the runtime in place instead (#290).
                           Only rendered for an admin, matching the route's own
                           authority check, so a member is not shown a control
-                          that can only 403. */}
-                      {canManage && (
-                        <div className="space-y-1">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={busy !== null}
-                            data-testid="inference-restart-now"
-                            onClick={() => void restartNow()}
-                          >
-                            {busy === "restart" ? (
-                              <Loader2 className="size-3.5 animate-spin" />
-                            ) : (
-                              <RotateCcw className="size-3.5" />
-                            )}
-                            Restart now
-                          </Button>
-                          <p className="text-xs">
-                            The current turn finishes; journals, parked approvals, and single-use grants
-                            carry over to the replacement runtime.
-                          </p>
-                        </div>
+                          that can only 403.
+
+                          And only on a host that can honour it. `POST
+                          …/inference/restart` needs a `RuntimeRebuilder` wired
+                          into the host; where none is, it fails
+                          unconditionally with "this host cannot rebuild a
+                          company runtime in place". This card used to render
+                          the button anyway, so the operator was told a restart
+                          was required, handed the control for it, and the
+                          control could only ever fail (#1736). */}
+                      {status.canRebuildInPlace ? (
+                        canManage && (
+                          <div className="space-y-1">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              disabled={busy !== null}
+                              data-testid="inference-restart-now"
+                              onClick={() => void restartNow()}
+                            >
+                              {busy === "restart" ? (
+                                <Loader2 className="size-3.5 animate-spin" />
+                              ) : (
+                                <RotateCcw className="size-3.5" />
+                              )}
+                              Restart now
+                            </Button>
+                            <p className="text-xs">
+                              The current turn finishes; journals, parked approvals, and single-use grants
+                              carry over to the replacement runtime.
+                            </p>
+                          </div>
+                        )
+                      ) : (
+                        /* Named for everyone, admin or not: it is the only
+                           thing that changes this state, and it is not an
+                           action the console can take on anyone's behalf.
+                           Both spellings are given because the host reports
+                           the capability, not the shell it is packaged in —
+                           and a desktop console can be pointed at a remote
+                           host, so guessing from the window would name the
+                           wrong one. */
+                        <p className="text-xs" data-testid="inference-restart-manual">
+                          This host cannot restart a company on its own, so the saved configuration
+                          is picked up the next time OpenCompany starts: quit and reopen the app, or
+                          restart the server process it runs on.
+                        </p>
                       )}
                     </div>
                   </div>

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InferenceStatus } from "@/api/inference";
+import { InferenceSection } from "@/views/connections/InferenceSection";
+
+/**
+ * The Inference card must not say two things at once (issues #1736, #1737).
+ *
+ * Both defects are the same defect: the card knew a fact about the host or
+ * about the stored configuration and rendered something that contradicted it.
+ * It offered a "Restart now" button on hosts where the route behind it can only
+ * fail, and it rendered a Provider select that was a constant while the header
+ * beside it rendered whatever the host actually holds.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** A status with everything nailed down; each test varies only what it is about. */
+function status(over: Partial<InferenceStatus> = {}): InferenceStatus {
+  return {
+    provider: "managed",
+    slug: "managed",
+    baseUrl: "https://openrouter.ai/api/v1",
+    models: {},
+    source: "runtime",
+    keyConfigured: true,
+    cognition: "echo",
+    usageMetering: "none",
+    restartRequired: true,
+    harnessReachable: true,
+    canRebuildInPlace: true,
+    ...over,
+  };
+}
+
+/**
+ * A client stub answering `GET …/inference` from a queue, so a test can stage
+ * what the host holds before a save and what it holds after one.
+ */
+function stubClient(replies: InferenceStatus[], mutation?: InferenceStatus) {
+  let reads = 0;
+  const read = () => replies[Math.min(reads++, replies.length - 1)];
+  const settled = () => mutation ?? replies[replies.length - 1];
+  return {
+    scopeFor: (company: string | null) =>
+      company ? `/api/v1/companies/${company}` : "/api/v1/company",
+    get: async () => read(),
+    put: async () => ({ status: settled(), note: "" }),
+    del: async () => ({ status: settled(), note: "" }),
+    post: async () => ({ status: settled(), note: "" }),
+  } as unknown as OpenCompanyClient;
+}
+
+async function mount(client: OpenCompanyClient, canManage = true) {
+  await act(async () => {
+    root.render(createElement(InferenceSection, { client, company: "acme", canManage }));
+  });
+}
+
+function testId(id: string) {
+  return container.querySelector(`[data-testid="${id}"]`);
+}
+
+/**
+ * What the Provider select currently reads, as the operator sees it. The
+ * trigger renders its own chevron glyph into the same text node, so strip
+ * anything that is not part of a provider label.
+ */
+function providerSelect(): string {
+  const text = container.querySelector("#inference-provider")?.textContent ?? "";
+  return text.replace(/[^\w\s()-]/g, "").trim();
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the restart notice offers an action only where one exists (issue #1736)", () => {
+  it("offers Restart now when the host can rebuild a runtime in place", async () => {
+    await mount(stubClient([status({ canRebuildInPlace: true })]));
+
+    expect(testId("inference-restart-required")).not.toBeNull();
+    expect(testId("inference-restart-now")).not.toBeNull();
+    expect(testId("inference-restart-manual")).toBeNull();
+  });
+
+  it("withholds the button and names the real remedy when the host cannot", async () => {
+    // `POST …/inference/restart` needs a `RuntimeRebuilder` wired into the
+    // host. Where none is, it fails unconditionally with "this host cannot
+    // rebuild a company runtime in place" — so a button here is a control whose
+    // only possible outcome is a toast the operator can do nothing about.
+    await mount(stubClient([status({ canRebuildInPlace: false })]));
+
+    expect(testId("inference-restart-required")).not.toBeNull();
+    expect(testId("inference-restart-now")).toBeNull();
+
+    const manual = testId("inference-restart-manual");
+    expect(manual).not.toBeNull();
+    // The remedy, in both spellings the host could mean — the capability comes
+    // from the host, which does not know which shell it is packaged in.
+    expect(manual?.textContent).toContain("quit and reopen the app");
+    expect(manual?.textContent).toContain("restart the server process");
+  });
+
+  it("keeps the notice itself either way — the restart is still required", async () => {
+    await mount(stubClient([status({ canRebuildInPlace: false })]), false);
+    expect(testId("inference-restart-required")?.textContent).toContain("Restart required.");
+  });
+});
+
+describe("the Provider select shows the provider the host holds (issue #1737)", () => {
+  it("opens on the stored provider rather than a hardcoded default", async () => {
+    // The select was `useState("managed")` with nothing ever writing it back, so
+    // it read "Managed (TinyHumans)" whatever was stored — including after a
+    // full process restart, which just re-runs the same initializer. The header
+    // beside it renders the host's provider, so the two disagreed on one card.
+    await mount(stubClient([status({ provider: "openrouter" })]));
+    expect(providerSelect()).toBe("OpenRouter");
+  });
+
+  it("follows the host to a provider it normalized on the way in", async () => {
+    // `managed` is a legacy alias the host resolves to `openrouter`. The value
+    // the select shows has to be the value the host came back with, or an
+    // operator sees one vendor named in the header and another in the select
+    // while their key is stored against exactly one of them.
+    await mount(stubClient([status({ provider: "openai_compatible" })]));
+    expect(providerSelect()).toBe("Custom (OpenAI-compatible)");
+  });
+
+  it("rehydrates after a save rather than snapping back to the default", async () => {
+    // The reported sequence: save under one provider, and the select goes on
+    // reading "Managed (TinyHumans)" while the header reads the saved one.
+    const client = stubClient(
+      [status({ provider: "managed" }), status({ provider: "openrouter" })],
+      status({ provider: "openrouter" }),
+    );
+    await mount(client);
+    expect(providerSelect()).toBe("Managed (TinyHumans)");
+
+    await act(async () => {
+      (testId("inference-save") as HTMLButtonElement).click();
+    });
+    await act(async () => {});
+
+    expect(providerSelect()).toBe("OpenRouter");
+  });
+
+  it("names the key that belongs in the field, for the provider it is stored against", async () => {
+    // The managed brain is OpenRouter with the platform paying, so a key set
+    // here is sent to OpenRouter. This line asked for a TinyHumans key — true
+    // when `managed` was a provider of its own, and never updated when it
+    // stopped being one. It is what the reported 401 actually was.
+    await mount(stubClient([status({ provider: "managed" })]));
+    expect(testId("inference-key-note")?.textContent).toContain("an OpenRouter key");
+  });
+});

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -605,6 +605,23 @@ impl AppState {
         self.rebuilder.clone()
     }
 
+    /// Whether this host can rebuild a registered company's runtime in place
+    /// (issue #290) — the capability behind every surface that offers to apply
+    /// a configuration change without a process restart.
+    ///
+    /// [`crate::server::setup`] and [`crate::server::ops::memory_engine`]
+    /// establish the same fact by *attempting* a rebuild and reporting the
+    /// failure. That is the right shape for an action already under way, and
+    /// the wrong one for a surface deciding whether to *offer* the action at
+    /// all: a console that cannot ask up front renders a control whose only
+    /// possible outcome is the `Config` error [`rebuild_company`] returns
+    /// (issue #1736). Asking is what lets it say "not on this host" instead.
+    ///
+    /// [`rebuild_company`]: crate::runtime::rebuild_company
+    pub fn can_rebuild_in_place(&self) -> bool {
+        self.rebuilder.is_some()
+    }
+
     /// Records the boot-only builder inputs for `id`, at registration.
     ///
     /// Cloned state shares this map (it is `Arc`-backed), so a company

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -130,6 +130,21 @@ struct InferenceStatusDto {
     /// dead end — the setup dialog uses this to omit it rather than send the
     /// operator round a redesign loop that cannot end.
     harness_reachable: bool,
+    /// Whether this host can rebuild a company's runtime in place, so the
+    /// console may offer the restart instead of only naming it (issue #1736).
+    ///
+    /// [`Self::restart_required`] says a restart is needed; this says whether
+    /// the console is allowed to offer to perform one. They are independent
+    /// facts and the card had only the first, so it rendered a "Restart now"
+    /// button on hosts where `POST …/inference/restart` can only answer "this
+    /// host cannot rebuild a company runtime in place; restart the process to
+    /// pick up the new configuration". The operator was told a restart was
+    /// required, handed the control for it, and the control could never work.
+    ///
+    /// Derived from [`AppState::can_rebuild_in_place`] rather than inferred
+    /// from the deployment shape: the rebuilder is wired by the binary, and
+    /// only the binary knows whether it wired one.
+    can_rebuild_in_place: bool,
 }
 
 /// A mutating response: the resulting status plus the switch reminder.
@@ -325,11 +340,16 @@ fn platform_default(env: &dyn EnvSource) -> Option<EnvDefault> {
     }
 }
 
-/// Resolves the effective status DTO against the real process environment.
-async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto, ApiError> {
+/// Resolves the effective status DTO against the real process environment and
+/// this host's own capabilities.
+async fn effective_status(
+    state: &AppState,
+    runtime: &CompanyRuntime,
+) -> Result<InferenceStatusDto, ApiError> {
     effective_status_with(
         runtime,
         platform_default(&crate::app::config::ProcessEnv).as_ref(),
+        state.can_rebuild_in_place(),
     )
     .await
 }
@@ -356,6 +376,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto
 async fn effective_status_with(
     runtime: &CompanyRuntime,
     platform: Option<&EnvDefault>,
+    can_rebuild_in_place: bool,
 ) -> Result<InferenceStatusDto, ApiError> {
     let manifest = manifest_inference(runtime).await?;
     let secrets = runtime.secrets().as_ref();
@@ -393,6 +414,7 @@ async fn effective_status_with(
             usage_metering: cognition.metering,
             restart_required,
             harness_reachable: harness_reachable(runtime),
+            can_rebuild_in_place,
         },
         None => InferenceStatusDto {
             provider: "managed".to_string(),
@@ -409,13 +431,19 @@ async fn effective_status_with(
             // drift apart.
             restart_required,
             harness_reachable: harness_reachable(runtime),
+            can_rebuild_in_place,
         },
     })
 }
 
 /// `GET …/inference` — the company's effective inference status.
-async fn get_status(company: ScopedCompany) -> Result<Json<InferenceStatusDto>, ApiError> {
-    Ok(Json(effective_status(company.runtime.as_ref()).await?))
+async fn get_status(
+    State(state): State<AppState>,
+    company: ScopedCompany,
+) -> Result<Json<InferenceStatusDto>, ApiError> {
+    Ok(Json(
+        effective_status(&state, company.runtime.as_ref()).await?,
+    ))
 }
 
 /// `PUT …/inference` — set (or replace) the runtime provider override, and
@@ -460,7 +488,7 @@ async fn set_config(
             .map_err(ApiError)?;
     }
 
-    let status = effective_status(runtime).await?;
+    let status = effective_status(&state, runtime).await?;
     // Issue #290: the not-configured → configured transition is the one a save
     // alone cannot deliver, because the brain was chosen at build time. Rather
     // than telling the operator to restart a container they may have no access
@@ -469,7 +497,7 @@ async fn set_config(
     if status.restart_required {
         match crate::runtime::rebuild_company(&state, runtime.id()).await {
             Ok(successor) => {
-                let status = effective_status(successor.as_ref()).await?;
+                let status = effective_status(&state, successor.as_ref()).await?;
                 return Ok(Json(MutationResponse {
                     // Read off the *successor*, so a rebuild that somehow landed
                     // on the same brain still reports honestly rather than
@@ -514,7 +542,10 @@ async fn set_config(
 /// manifest provider) — clear it explicitly with `PUT { key: "" }`.
 /// Requires authority over the company (issue #403) — same reasoning as the
 /// set: reverting decides which model the company thinks with.
-async fn revert_config(company: AdminScopedCompany) -> Result<Json<MutationResponse>, ApiError> {
+async fn revert_config(
+    State(state): State<AppState>,
+    company: AdminScopedCompany,
+) -> Result<Json<MutationResponse>, ApiError> {
     let runtime = company.runtime.as_ref();
     let secrets = runtime.secrets();
     clear_runtime_config(runtime.id(), secrets.as_ref())
@@ -530,7 +561,7 @@ async fn revert_config(company: AdminScopedCompany) -> Result<Json<MutationRespo
         .await
         .map_err(ApiError)?;
     Ok(Json(MutationResponse {
-        status: effective_status(runtime).await?,
+        status: effective_status(&state, runtime).await?,
         note: "Reverted to the committed manifest (or managed) configuration.".to_string(),
     }))
 }
@@ -568,7 +599,7 @@ async fn restart_runtime(
     // Read the status off the *successor*, never off the runtime we came in
     // with: a rebuild that landed on the same brain must still report honestly
     // rather than claim a success the runtime cannot back up.
-    let status = effective_status(successor.as_ref()).await?;
+    let status = effective_status(&state, successor.as_ref()).await?;
     Ok(Json(MutationResponse {
         note: if status.restart_required {
             RESTART_NOTE
@@ -578,6 +609,73 @@ async fn restart_runtime(
         .to_string(),
         status,
     }))
+}
+
+/// Why a resolved config could not authenticate against its own endpoint, or
+/// `None` when the probe is worth sending (issue #1737).
+///
+/// [`send_plan`](crate::harness::provider::request_plan) omits the
+/// `Authorization` header entirely when no bearer resolves, so a keyless config
+/// aimed at an endpoint that demands one produces a vendor 401 that reads like a
+/// rejected key. That is a fact this process holds before the request leaves it.
+///
+/// **Only the `openrouter` kind is judged**, which after
+/// [`normalize_provider`](inference::normalize_provider) is also every legacy
+/// `managed` config. Both endpoints it can resolve to — OpenRouter's own and the
+/// platform proxy in front of it — reject an unauthenticated request
+/// unconditionally, so refusing there can never be wrong. `ollama` takes no
+/// bearer by design, and an `openai_compatible` endpoint is the operator's own
+/// and may legitimately want none; refusing either would turn a working
+/// configuration into a false alarm, which is worse than the outbound request it
+/// would save.
+#[cfg(feature = "openhuman")]
+async fn unauthenticated_reason(
+    decl: &inference::InferenceDecl,
+) -> Result<Option<String>, OpenCompanyError> {
+    if inference::normalize_provider(&decl.provider) != inference::DEFAULT_PROVIDER {
+        return Ok(None);
+    }
+    // `bearer()` rather than `key_configured()`: a platform token source reports
+    // itself configured while its projected file can still yield nothing, and it
+    // is the value on the wire that decides whether the request authenticates.
+    if decl.bearer().await?.is_some() {
+        return Ok(None);
+    }
+    Ok(Some(format!(
+        "No inference key is stored for this company, and this host has no platform credential to \
+         fall back on — a request to {} would carry no Authorization header and be rejected, so \
+         none was sent. Save an OpenRouter key above, or point this company at an endpoint that \
+         needs none.",
+        decl.base_url
+    )))
+}
+
+/// The operator-facing reading of a failed probe, and its response code.
+///
+/// A vendor's own 401 is evidence and is kept verbatim, but it is not an
+/// explanation: OpenRouter answers a key it cannot parse with `Missing
+/// Authentication header`, which reads as "nothing was sent" and is how issue
+/// #1737 came to be filed against the wrong layer. The header *was* sent. What
+/// this route knows, and the vendor does not, is that the credential is stored
+/// against whichever provider was selected when it was saved — so a key for
+/// another vendor fails here while the card still reports one is set. Saying so
+/// is the difference between a dead end and a next step.
+#[cfg(feature = "openhuman")]
+fn probe_failure(decl: &inference::InferenceDecl, raw: &str) -> (String, &'static str) {
+    if raw.contains("401 Unauthorized") {
+        return (
+            format!(
+                "{} rejected the credential stored for this company. The request did carry an \
+                 Authorization header — the provider would not accept what was in it. A key is \
+                 stored against the provider selected when it was saved, so a key for another \
+                 vendor fails here even while this card reports one is set. Re-save the key under \
+                 {}, or Remove key to fall back. The provider said: {raw}",
+                decl.base_url, decl.provider
+            ),
+            "credential_rejected",
+        );
+    }
+    (format!("Inference probe failed: {raw}"), "probe_failed")
 }
 
 /// `POST …/inference/test` — a live one-message probe of the resolved provider.
@@ -634,6 +732,26 @@ async fn test_config(company: ScopedCompany) -> Response {
                     }
                 }
             };
+            // Issue #1737: refuse locally rather than send a request this
+            // process already knows cannot authenticate. The card warns that
+            // Test "sends one real message… and your provider may charge for
+            // it", so a doomed request is not merely untidy — and relaying a
+            // vendor's 401 for it hides a configuration fact we hold here.
+            match unauthenticated_reason(&decl).await {
+                Err(err) => return ApiError(err).into_response(),
+                Ok(Some(reason)) => {
+                    return (
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({
+                            "ok": false,
+                            "error": reason,
+                            "code": "no_key",
+                        })),
+                    )
+                        .into_response();
+                }
+                Ok(None) => {}
+            }
             match crate::harness::provider::probe(&decl).await {
                 Ok(()) => Json(serde_json::json!({
                     "ok": true,
@@ -641,15 +759,18 @@ async fn test_config(company: ScopedCompany) -> Response {
                     "note": "Reached the provider and got a reply.",
                 }))
                 .into_response(),
-                Err(err) => (
-                    StatusCode::BAD_GATEWAY,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("Inference probe failed: {err}"),
-                        "code": "probe_failed",
-                    })),
-                )
-                    .into_response(),
+                Err(err) => {
+                    let (error, code) = probe_failure(&decl, &err.to_string());
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        Json(serde_json::json!({
+                            "ok": false,
+                            "error": error,
+                            "code": code,
+                        })),
+                    )
+                        .into_response()
+                }
             }
         }
     }
@@ -877,6 +998,135 @@ base_url = "https://byo.example/v1"
         assert_eq!(status, StatusCode::OK);
     }
 
+    /// Issue #1736: the console cannot offer a restart it has no way to know is
+    /// available, so the status carries the capability rather than leaving the
+    /// card to guess from the deployment shape.
+    ///
+    /// The pairing is the whole point — a flag that is always `false` would
+    /// satisfy the "no button on a host that cannot" half while silently
+    /// removing the action from every host that can.
+    #[tokio::test]
+    async fn the_status_says_whether_this_host_can_rebuild_in_place() {
+        let bare_home = home();
+        let bare = state_with_company(bare_home.path()).await;
+        let (status, body, raw) = send(&bare, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(
+            body["canRebuildInPlace"],
+            json!(false),
+            "a host with no rebuilder must say so, or the console renders a \
+             Restart now button whose route can only answer with a config error: {raw}"
+        );
+
+        let wired_home = home();
+        let wired =
+            state_with_company(wired_home.path())
+                .await
+                .with_rebuilder(std::sync::Arc::new(Working {
+                    home: wired_home.path().to_path_buf(),
+                }));
+        let (status, body, raw) = send(&wired, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(
+            body["canRebuildInPlace"],
+            json!(true),
+            "a host that wired one must keep offering the action: {raw}"
+        );
+    }
+
+    /// Issue #1737: a probe the process already knows cannot authenticate is
+    /// refused here rather than sent.
+    ///
+    /// The endpoint is the discard port, so a regression does not merely fail
+    /// this assertion — it makes an outbound connection, which is the behaviour
+    /// under test. A keyless `openrouter` carrying its own `base_url` resolves
+    /// direct and credential-less by construction, so this does not depend on
+    /// whatever the process environment happens to hold.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_probe_with_no_credential_is_refused_before_it_is_sent() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+
+        let (status, _, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "openrouter", "baseUrl": "http://127.0.0.1:9/v1" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let (status, body, raw) =
+            send(&state, "POST", "/api/v1/company/inference/test", None).await;
+        assert_eq!(status, StatusCode::CONFLICT, "{raw}");
+        assert_eq!(body["code"], json!("no_key"), "{raw}");
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no Authorization header"),
+            "the refusal names the cause the vendor's 401 would have hidden: {raw}"
+        );
+    }
+
+    /// The other half of that judgement: an endpoint the operator supplied may
+    /// legitimately want no bearer, so it is still probed. Refusing there would
+    /// turn a working local server into a false alarm — worse than the outbound
+    /// request it saves.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_keyless_custom_endpoint_is_still_probed() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+
+        let (status, _, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "openai_compatible", "baseUrl": "http://127.0.0.1:9/v1" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let (status, body, raw) =
+            send(&state, "POST", "/api/v1/company/inference/test", None).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY, "{raw}");
+        assert_eq!(body["code"], json!("probe_failed"), "{raw}");
+    }
+
+    /// Issue #1737, the sentence that would have saved an hour: OpenRouter
+    /// answers a credential it cannot parse with `Missing Authentication
+    /// header`, which reads as "nothing was sent" and is how the issue came to
+    /// be filed against the wrong layer. The header *was* sent.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn a_401_is_reported_as_a_rejected_credential_rather_than_a_missing_header() {
+        let decl = inference::decl_for_probe(
+            "openrouter",
+            None,
+            Some("a-key-for-some-other-vendor"),
+            None,
+        );
+        let raw = "inference returned 401 Unauthorized: \
+                   {\"error\":{\"message\":\"Missing Authentication header\",\"code\":401}}";
+        let (message, code) = probe_failure(&decl, raw);
+
+        assert_eq!(code, "credential_rejected");
+        assert!(
+            message.contains("did carry an Authorization header"),
+            "the console must not repeat the vendor's reading back at the operator: {message}"
+        );
+        assert!(
+            message.contains("stored against the provider selected when it was saved"),
+            "and it must name the reason a stored key can still be the wrong one: {message}"
+        );
+        assert!(
+            message.contains("Missing Authentication header"),
+            "the vendor's own words stay attached as evidence: {message}"
+        );
+    }
+
     async fn send(
         state: &AppState,
         method: &str,
@@ -948,11 +1198,11 @@ base_url = "https://byo.example/v1"
 
         // No platform endpoint on this deployment — the built-in constant is
         // still the only honest answer, and this arm must not regress.
-        let dto = effective_status_with(&runtime, None).await.unwrap();
+        let dto = effective_status_with(&runtime, None, false).await.unwrap();
         assert_eq!(dto.base_url, inference::PLATFORM_BASE_URL);
 
         // Pointed at staging, the card follows — and *only* the URL moves.
-        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+        let dto = effective_status_with(&runtime, Some(&staging_platform()), false)
             .await
             .unwrap();
         assert_eq!(dto.base_url, STAGING_URL);
@@ -985,10 +1235,10 @@ base_url = "https://byo.example/v1"
         let home_dir = home();
         let runtime = runtime_with(home_dir.path(), MANAGED_MANIFEST).await;
 
-        let dto = effective_status_with(&runtime, None).await.unwrap();
+        let dto = effective_status_with(&runtime, None, false).await.unwrap();
         assert_eq!(dto.base_url, inference::PLATFORM_BASE_URL);
 
-        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+        let dto = effective_status_with(&runtime, Some(&staging_platform()), false)
             .await
             .unwrap();
         assert_eq!(dto.base_url, STAGING_URL);
@@ -1017,7 +1267,7 @@ base_url = "https://byo.example/v1"
 
         // The platform credential is doing the outbound work, and the card still
         // says no key is configured — because none of it is the tenant's.
-        let dto = effective_status_with(&runtime, Some(&platform))
+        let dto = effective_status_with(&runtime, Some(&platform), false)
             .await
             .unwrap();
         assert!(
@@ -1031,7 +1281,7 @@ base_url = "https://byo.example/v1"
             .await
             .unwrap();
 
-        let dto = effective_status_with(&runtime, Some(&platform))
+        let dto = effective_status_with(&runtime, Some(&platform), false)
             .await
             .unwrap();
         assert!(
@@ -1055,7 +1305,7 @@ base_url = "https://byo.example/v1"
         )
         .await;
 
-        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+        let dto = effective_status_with(&runtime, Some(&staging_platform()), false)
             .await
             .unwrap();
         assert_eq!(dto.base_url, "https://byo.example/v1");
@@ -1074,7 +1324,7 @@ base_url = "https://byo.example/v1"
         )
         .await;
 
-        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+        let dto = effective_status_with(&runtime, Some(&staging_platform()), false)
             .await
             .unwrap();
         assert_eq!(dto.base_url, "http://localhost:11434/v1");
@@ -1096,7 +1346,7 @@ base_url = "https://byo.example/v1"
         .await;
         let platform = staging_platform();
 
-        let dto = effective_status_with(&runtime, Some(&platform))
+        let dto = effective_status_with(&runtime, Some(&platform), false)
             .await
             .unwrap();
         assert_eq!(dto.base_url, STAGING_URL, "proxied");
@@ -1107,7 +1357,7 @@ base_url = "https://byo.example/v1"
             .await
             .unwrap();
 
-        let dto = effective_status_with(&runtime, Some(&platform))
+        let dto = effective_status_with(&runtime, Some(&platform), false)
             .await
             .unwrap();
         assert_eq!(dto.base_url, inference::OPENROUTER_BASE_URL, "direct");


### PR DESCRIPTION
## Summary

Two reports against the Inference card, one defect: **the card held a fact and rendered something that contradicted it.**

`frontend/src/api/setup.ts:58` already states the rule this violates — capability flags exist "so the flow can say 'not in this build' instead of offering a switch that does nothing." That is what both of these are.

Closes #1736
Closes #1737

## What I found, and where the issues were wrong

Both issue bodies flag parts of themselves as inferred. Both inferences turned out to be wrong, in ways worth recording.

### #1736 — the stated root cause is stale, the console defect is real

The issue says the desktop host wires no `RuntimeRebuilder`. That was true of the build the operator was running, but `1466f0dfc` added `DesktopRebuilder` (`src-tauri/src/embedded.rs:224`) and it is an ancestor of `upstream/main` (`git merge-base --is-ancestor 1466f0dfc upstream/main` → yes). `serve` has wired `BootRebuilder` all along. **On today's shipped hosts the button works.**

What is still wrong is the console: it rendered the button with no check at all. Any host that wires no rebuilder — an embedder, a test host, or the desktop before that commit — gets a control whose only possible outcome is a config error the operator cannot act on. So this lands as the narrow, accurate fix: the host reports the capability, and the console offers the action only where it exists.

There is a second thing worth naming. `crate::server::setup` and `crate::server::ops::memory_engine` already need this fact and both discover it by *attempting* a rebuild and catching the failure. That is the right shape for an action already under way and the wrong one for a surface deciding whether to *offer* the action. `AppState::can_rebuild_in_place()` is that missing predicate, and their doc comments now point at it.

### #1737 — the diagnosis in the issue is refuted; here is what actually happened

The issue reasons from `Missing Authentication header` that **no** `Authorization` header was sent. I asked OpenRouter directly:

```
no Authorization header      → {"error":{"message":"No cookie auth credentials found","code":401}}
bogus Authorization header   → {"error":{"message":"Missing Authentication header","code":401}}
```

It is the **second** one. A header *was* sent, carrying a credential OpenRouter could not parse. The message means the opposite of how it reads, and the issue was filed against the wrong layer because of it.

The chain, established from the operator's own live instance:

1. **The select never rehydrated.** `useState<InferenceProvider>("managed")`, and `setProvider` was only ever reached through `pickProvider` — an operator action. `refresh()` never touched it. So it read "Managed (TinyHumans)" on every mount. A full process restart does not clear this; it *re-runs the same initializer*, which is why the contradiction survived one.
2. **Under that stuck selection the key field asked for the wrong vendor's key.** `PROVIDERS.managed.keyKind` read `"a TinyHumans API key"` — true when `managed` was a provider of its own, never updated when it became `LEGACY_MANAGED`, an alias `normalize_provider` maps to `openrouter`.
3. **So the card asked for one vendor's key and stored it against another.** The live instance's stored config is literally `{"provider":"managed","base_url":null,"models":{}}`; `GET …/inference` on it returns `provider: "openrouter"`, `baseUrl: "https://openrouter.ai/api/v1"`, `keyConfigured: true`. The stored credential is 53 characters, contains underscores, and carries no `sk-or-` prefix — not an OpenRouter key. Every turn and every Test has been presenting it to `openrouter.ai`.
4. **The header/select contradiction is the same bug, one layer up:** the header renders the host's normalized `openrouter`, the select rendered the un-rehydrated `managed`.

I reproduced the operator's exact error end to end on a local host with an obviously fake key — see below.

One correction to a mid-task hypothesis: `Cognition: harness` after a restart does **not** prove the harness authenticated. `restart_pending` and brain selection only require `resolve_effective(...).is_some()`, and a keyless config resolves to `Some` too. The harness and the probe resolve through the identical `resolve_effective_scoped` call; there is no asymmetry between them.

## What changed

**`src/app/types.rs`** — `AppState::can_rebuild_in_place()`, the predicate three surfaces needed and none had.

**`src/server/ops/inference.rs`**
- `InferenceStatusDto.can_rebuild_in_place`, threaded from the state rather than guessed from the deployment shape.
- The probe refuses locally when no bearer resolves for an endpoint that requires one (`code: "no_key"`), instead of sending a request it knows will be rejected — the card warns Test "sends one real message… and your provider may charge for it", so a doomed request should not be billable. Gated on `decl.bearer()`, the exact value the request would carry, rather than `key_configured()`, which is true for a token source whose `current()` yields nothing.
- Judged **only** for the `openrouter` kind (which after normalization is also every legacy `managed` config). Both endpoints it can resolve to reject an unauthenticated request unconditionally, so refusing there can never be wrong. `ollama` takes no bearer by design and an `openai_compatible` endpoint is the operator's own; refusing either would turn a working local server into a false alarm, which is worse than the request it saves. There is a test pinning that half of the judgement too.
- A vendor 401 is now read as a rejected credential (`code: "credential_rejected"`) with the vendor's own words kept attached as evidence — rather than relaying wording that means the opposite of what it says.

**`frontend/src/views/connections/InferenceSection.tsx`**
- `seedFromStatus` points the switch form at what the host holds, on load and after every completed mutation. Seeded from `status.provider` **verbatim**, never through a mapping of our own — that is what makes "header and select can never disagree" structural instead of something to keep in step by hand. `refresh` runs on mount and after a completed mutation only (no poll), so this cannot pull a draft out from under anyone.
- A `baseline` replaces `presetFor(provider)` in `hasTypedDraft()`. The form no longer always starts at a preset, and comparing a *saved* endpoint against a preset would ask an operator to confirm discarding a draft nobody wrote — the exact thing #1474 fixed.
- `reset()` no longer guesses `pickProvider("managed")`; `refresh` seeds it from what the revert actually produced, which for a company whose manifest names its own provider is not `managed`.
- The restart banner **stays** — the restart really is required — and offers the button only where `canRebuildInPlace` holds. Where it does not, it names the remedy. Both spellings are given deliberately: the host reports the capability and does not know which shell it is packaged in, and a desktop console can be pointed at a remote host, so guessing from the window would name the wrong one.
- `PROVIDERS.managed.keyKind` now says an OpenRouter key, because that is where a key set there is sent.

## The copy

> **Restart required.** … This host cannot restart a company on its own, so the saved configuration is picked up the next time OpenCompany starts: quit and reopen the app, or restart the server process it runs on.

> No inference key is stored for this company, and this host has no platform credential to fall back on — a request to `https://api.tinyhumans.ai/openai/v1` would carry no Authorization header and be rejected, so none was sent. Save an OpenRouter key above, or point this company at an endpoint that needs none.

> `https://openrouter.ai/api/v1` rejected the credential stored for this company. The request did carry an Authorization header — the provider would not accept what was in it. A key is stored against the provider selected when it was saved, so a key for another vendor fails here even while this card reports one is set. Re-save the key under `openrouter`, or Remove key to fall back. The provider said: …

Each names the cause, then the next step, in the host's own vocabulary. None apologises, and none says "something went wrong".

## The shared abstraction

Across #1734/#1735 (PR #1740) and these two, all four are the same shape: **a surface that knows it is degraded and offers the un-degraded affordance anyway.** The console already has the vocabulary for it in `api/setup.ts` — capability flags whose whole purpose is to say "not in this build". What was missing is that the flags stop at first-run setup. `harnessReachable` was on this DTO already and used only by the setup dialog; `canRebuildInPlace` is the second, and the pattern generalises: *a control is offered only where the host reports it can be honoured, and where it cannot, the surface names the remedy instead.*

## Tests

Rust, in `src/server/ops/inference.rs`:
- `the_status_says_whether_this_host_can_rebuild_in_place` — both arms, so a flag hardcoded `false` cannot pass.
- `a_probe_with_no_credential_is_refused_before_it_is_sent` — endpoint is the discard port, so a regression does not merely fail an assertion, it makes an outbound connection.
- `a_keyless_custom_endpoint_is_still_probed` — pins the other half of the judgement.
- `a_401_is_reported_as_a_rejected_credential_rather_than_a_missing_header`.

Frontend, `frontend/test/unit/inference-card-honesty.test.ts` (7 tests, jsdom): the button present/absent by capability, the banner surviving either way, the select opening on the stored provider, following a normalized one, rehydrating after Save, and the key-field vendor.

### Non-vacuity

Each fix was reverted and the tests watched to fail.

| Mutation | Result |
|---|---|
| `state.can_rebuild_in_place()` → `false` | `the_status_says_whether_this_host_can_rebuild_in_place` FAILED |
| `unauthenticated_reason(&decl)` → `Ok(None)` | `a_probe_with_no_credential_is_refused_before_it_is_sent` FAILED, and the failure output shows the suppressed request going out: `error sending request for url (http://127.0.0.1:9/v1/chat/completions)` |
| `raw.contains("401 Unauthorized")` → `false` | `a_401_is_reported_as_a_rejected_credential…` FAILED |
| `{status.canRebuildInPlace ? (` → `{true ? (` | "withholds the button and names the real remedy" FAILED |
| `seedFromStatus(next)` removed from `refresh` | 3 select tests FAILED |
| `keyKind` back to `"a TinyHumans API key"` | "names the key that belongs in the field" FAILED |

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo clippy --features openhuman --all-targets -- -D warnings` | clean for `opencompany` |
| `cargo test` | exit 0 |
| `cargo test --features openhuman --lib server::ops::inference` | 28 passed |
| `npm run typecheck` / `typecheck:unit` / `typecheck:e2e` | all three clean |
| `npx vitest run` | 340 files, 3167 tests passed |
| `scripts/ci/assert-design-tokens.sh` | clean |
| `npx playwright test test/e2e/inference.spec.ts` | 3 passed |

## Browser verification

Real Chromium against a real `opencompany serve --features openhuman` host, seeded with the operator's exact stored config (`{"provider":"managed","base_url":null,"models":{}}`) and an obviously fake key. Light and dark, 1440px and 420px — twelve screenshots.

**Before** (fixes reverted, same host): header `OpenRouter · runtime · ✓ key set`, endpoint `https://openrouter.ai/api/v1`, select `Managed (TinyHumans)`. The operator's screenshot, reproduced.

**After, host with a rebuilder:** select reads `OpenRouter`, agreeing with the header; banner and **Restart now** both present, unchanged.

**After, host with no rebuilder** (same binary built with the `with_rebuilder` line removed): banner kept, **no button**, remedy named, select still agreeing.

The probe, live on that host:

```
POST …/inference/test   (fake key stored)
  → "https://openrouter.ai/api/v1 rejected the credential stored for this company. The request
     did carry an Authorization header … The provider said: inference returned 401 Unauthorized:
     {"error":{"message":"Missing Authentication header","code":401}}"     code: credential_rejected

POST …/inference/test   (key cleared)
  → "No inference key is stored for this company … so none was sent."      code: no_key
```

The first line is the operator's exact error, reproduced from a key that is obviously fake and demonstrably present — which is the proof that `Missing Authentication header` means *sent and rejected*.

## Follow-up, not done here

`managed` is offered in the select as a provider while the host treats it as a legacy alias for `openrouter`. Seeding the select from `status.provider` makes that visible and consistent — pick Managed, save a key, and the card comes back saying OpenRouter, which is the truth — but the vocabulary mismatch itself is a product decision, not a bug fix, and it touches the e2e lane. Worth a separate issue.
