### PR TITLE
fix(overview): refresh last-visit baseline on scope change (#1700)

### DIFF
--- a/frontend/src/views/OperatorOverview.tsx
+++ b/frontend/src/views/OperatorOverview.tsx
@@ -52,7 +52,7 @@ export function OperatorOverview({
   scope,
   attemptEventTick,
 }: Props) {
-  const [previousVisit] = useState(() => readOverviewVisit(scope));
+  const [previousVisit, setPreviousVisit] = useState(() => readOverviewVisit(scope));
   const [stoppedRuns, setStoppedRuns] = useState<RunSummary[]>([]);
   const [failedRuns, setFailedRuns] = useState<RunSummary[]>([]);
   const [runLoad, setRunLoad] = useState<RunLoad>("loading");
@@ -160,6 +160,17 @@ export function OperatorOverview({
         /* the current lists stay; the next event or reload re-reads */
       });
   }, [attemptEventTick, fetchRuns]);
+
+  // Refresh the "since your previous visit" baseline whenever `scope` changes
+  // while this page stays mounted — the lazy `useState` initialiser above reads
+  // it only once, so without this a scope switch would keep comparing against
+  // the old scope's boundary. This effect is declared *before* the write effect
+  // below so, on both first mount and every scope change, React runs the read
+  // first and the baseline captures the stored *previous* visit before the
+  // write records the current one — the current time never clobbers it.
+  useEffect(() => {
+    setPreviousVisit(readOverviewVisit(scope));
+  }, [scope]);
 
   useEffect(() => {
     writeOverviewVisit(scope, Date.now());

--- a/frontend/src/views/OperatorOverview.tsx
+++ b/frontend/src/views/OperatorOverview.tsx
@@ -52,7 +52,29 @@ export function OperatorOverview({
   scope,
   attemptEventTick,
 }: Props) {
-  const [previousVisit, setPreviousVisit] = useState(() => readOverviewVisit(scope));
+  /**
+   * The previous-visit boundary for the current `scope`, captured once per
+   * scope during *render* rather than in an effect.
+   *
+   * `scope` is memoized by its owner ([`ConnectionConsole`]) on
+   * `[connectionId, company]`, so comparing it by reference below only
+   * re-reads when the connection or company actually changes — the same
+   * semantics the write effect's `[scope]` dependency already relies on.
+   *
+   * Reading here, before any effect has run, is what keeps the boundary safe
+   * under React 18 StrictMode's mount→cleanup→remount effect replay. A
+   * `[scope]` *read* effect paired with a `[scope]` *write* effect looks
+   * idempotent, but it is not: StrictMode's replay reruns both effects in
+   * declaration order, so the replay's read would observe the timestamp the
+   * first pass's write had just recorded, silently replacing the true
+   * previous boundary with "now" on every dev mount (#1745).
+   */
+  const visitRef = useRef<{ scope: LocalScope; previousVisit: number | null }>();
+  if (!visitRef.current || visitRef.current.scope !== scope) {
+    visitRef.current = { scope, previousVisit: readOverviewVisit(scope) };
+  }
+  const previousVisit = visitRef.current.previousVisit;
+
   const [stoppedRuns, setStoppedRuns] = useState<RunSummary[]>([]);
   const [failedRuns, setFailedRuns] = useState<RunSummary[]>([]);
   const [runLoad, setRunLoad] = useState<RunLoad>("loading");
@@ -161,17 +183,10 @@ export function OperatorOverview({
       });
   }, [attemptEventTick, fetchRuns]);
 
-  // Refresh the "since your previous visit" baseline whenever `scope` changes
-  // while this page stays mounted — the lazy `useState` initialiser above reads
-  // it only once, so without this a scope switch would keep comparing against
-  // the old scope's boundary. This effect is declared *before* the write effect
-  // below so, on both first mount and every scope change, React runs the read
-  // first and the baseline captures the stored *previous* visit before the
-  // write records the current one — the current time never clobbers it.
-  useEffect(() => {
-    setPreviousVisit(readOverviewVisit(scope));
-  }, [scope]);
-
+  // Record that this browser opened this scope's overview. This is the only
+  // actual side effect in the read/write pair — the read lives at render time
+  // above — so StrictMode replaying it twice on mount is harmless: the
+  // boundary was already captured before this effect's first pass ever ran.
   useEffect(() => {
     writeOverviewVisit(scope, Date.now());
   }, [scope]);

--- a/frontend/test/unit/operator-overview.test.ts
+++ b/frontend/test/unit/operator-overview.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
+import { act, createElement, StrictMode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -135,6 +135,94 @@ describe("the operator overview landing page (#1321)", () => {
 
     expect(container.textContent).toContain("Failed attempts recorded after the previous visit.");
     expect(container.querySelector('[href="#/tasks/task-1?run=run-1"]')?.textContent).toContain("Open");
+  });
+
+  it("keeps the previous-visit boundary intact across StrictMode's mount replay (#1745)", async () => {
+    // StrictMode double-invokes mount effects (setup → cleanup → setup) in
+    // development. A `[scope]` *read* effect paired with a `[scope]` *write*
+    // effect looks idempotent but is not: the replay's read effect would
+    // observe the timestamp the first pass's write effect had just recorded,
+    // silently clobbering the true previous-visit boundary with "now" and
+    // hiding this failure on every dev mount.
+    window.localStorage.setItem("oc.overview.last-visit:test-host::acme", "1700000000000");
+    await act(async () => {
+      root.render(
+        createElement(
+          StrictMode,
+          null,
+          createElement(OperatorOverview, {
+            // Answer only the failed-only page so the run is unambiguously a
+            // "since you last opened" hit, not also a "stopped work" hit —
+            // the header text ("Failed attempts recorded after the previous
+            // visit.") is a static description shown whenever a boundary
+            // exists at all, so it cannot prove the boundary is the *right*
+            // one; the run's presence can.
+            client: clientByUrl((url) =>
+              url.includes("status=failed%2Cpaused") ? Promise.resolve([]) : Promise.resolve([run()]),
+            ),
+            company: "acme",
+            companyName: "Acme",
+            feed: readyFeed,
+            scope,
+          }),
+        ),
+      );
+    });
+    await settle();
+
+    // A clobbered boundary ("now") would push this run's finish time before
+    // it, so it silently drops out of the since-visit panel.
+    expect(container.querySelector('[href="#/tasks/task-1?run=run-1"]')).not.toBeNull();
+  });
+
+  it("uses the new scope's own boundary immediately on a scope switch, never the old scope's", async () => {
+    const scopeA = { connection: "host-a", company: "acme" };
+    const scopeB = { connection: "host-b", company: "acme" };
+    window.localStorage.setItem("oc.overview.last-visit:host-a::acme", "1700000000000");
+    window.localStorage.setItem("oc.overview.last-visit:host-b::acme", "1800000000000");
+    // Finished after A's boundary but before B's — only a stale read of A's
+    // boundary after switching to B would surface it as "since your visit".
+    const failedAfterAOnly = run({ finishedAtMillis: 1_750_000_000_000 });
+
+    // Mount directly on scope A rather than the module-level `scope` used by
+    // the `render()` helper — this test cares about the transition between
+    // two specific scopes.
+    await act(async () => {
+      root.render(
+        createElement(OperatorOverview, {
+          client: client(Promise.resolve([])),
+          company: "acme",
+          companyName: "Acme",
+          feed: readyFeed,
+          scope: scopeA,
+        }),
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        createElement(OperatorOverview, {
+          // Answer only the failed-only page so the run appears solely in the
+          // "since you last opened" panel, not the unrelated stopped-work
+          // panel above it — isolates the assertion to the boundary this
+          // test is about.
+          client: clientByUrl((url) =>
+            url.includes("status=failed%2Cpaused") ? Promise.resolve([]) : Promise.resolve([failedAfterAOnly]),
+          ),
+          company: "acme",
+          companyName: "Acme",
+          feed: readyFeed,
+          scope: scopeB,
+        }),
+      );
+    });
+    await settle();
+
+    // A stale read of A's boundary would surface this failure under "since
+    // your visit"; B's own (later) boundary must instead read it as absent.
+    expect(container.textContent).toContain("No failed attempts were recorded since the previous visit.");
+    expect(container.querySelector('[href="#/tasks/task-1?run=run-1"]')).toBeNull();
   });
 
   it("reads failures on their own page, so paused attempts cannot crowd one out of the since-visit answer", async () => {


### PR DESCRIPTION
## Summary

Fixes the "Since you last opened" baseline in `OperatorOverview` going stale when `scope` changes while the component stays mounted. `previousVisit` was seeded once via the lazy `useState` initialiser and never refreshed (its setter was not even destructured), so a scope change left the baseline frozen on the previous scope.

Fix: destructure `setPreviousVisit` and add a `useEffect` keyed on `scope` that re-reads the stored baseline. It is declared **immediately before** the existing `writeOverviewVisit` effect so React runs the read before the current-visit write for every scope value — first-mount semantics (baseline = previous session) are preserved and the just-written `Date.now()` never clobbers the baseline.

Closes #1700

## API Or Behavior Changes

None (behavior fix only). Overview baseline now updates correctly on in-session scope changes.

## Tests

Frontend-only change; Rust gates not applicable.

- [x] `npm run typecheck` (`tsc -b --noEmit`) — PASS
- [ ] `cargo fmt --all -- --check` — N/A: no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust changed
- [ ] `cargo build --all-targets` — N/A: no Rust changed
- [ ] `cargo test` — N/A: no Rust changed

## Documentation

None needed — internal component behavior fix, no public API or docs surface affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected “since last visit” results when switching between scopes while staying on the overview.
  - Improved visit tracking so recently completed runs are shown or excluded accurately according to the selected scope.
  - Resolved an issue that could cause visit history to be recorded inconsistently, ensuring reliable results after revisiting the overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->