### PR TITLE
fix(workflows): clear fixingRunSeq and fixReason on workflow/company switch (#1704)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1987,6 +1987,12 @@ export function WorkflowsView({
     // lifetime; leaving one behind is how "this console watched that run" came
     // to outlive the console's view of it.
     liveRanRef.current = new Set();
+    // Issue #1704: and the copilot-fix state — both key off the global run `seq`,
+    // so a leftover fixing spinner or "could not fix" message would leak onto an
+    // unrelated workflow's run row that happens to share the same seq after a
+    // switch. Same category of stale-by-shared-id bug as the refs above.
+    setFixingRunSeq(null);
+    setFixReason(null);
   }, [selectedId, company]);
 
   // Issue #339: `?run=<runId>` — open the canvas showing that past run.


### PR DESCRIPTION
## Summary

`fixingRunSeq` and `fixReason` survived a workflow/company switch in `WorkflowsView`. The `[selectedId, company]` cleanup effect reset every other optimistic/run state but left these two. Because both key off the global run `seq`, switching to another workflow whose history has a run with the same `seq` leaked the copilot-fix spinner or the "could not fix" message onto an unrelated run row.

Fix: add `setFixingRunSeq(null)` and `setFixReason(null)` to the same cleanup effect.

Closes #1704

## API Or Behavior Changes

None (state-leak fix only). Copilot-fix indicators no longer bleed across workflow/company switches.

## Tests

Frontend-only change; Rust gates not applicable.

- [x] `npm run typecheck` (`tsc -b --noEmit`) — PASS
- [ ] `cargo fmt --all -- --check` — N/A: no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust changed
- [ ] `cargo build --all-targets` — N/A: no Rust changed
- [ ] `cargo test` — N/A: no Rust changed

## Documentation

None needed — internal state-cleanup fix, no public API or docs surface affected.