### PR TITLE
fix(chat): resolve thread-panel avatar per message sender (#1729)

### DIFF
--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1669,6 +1669,7 @@ export function ChatView({
             <ThreadPanel
               channel={channel}
               members={members}
+              youAvatar={youAvatar}
               parent={parent}
               replies={threadReplies}
               sending={sending}

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -21,6 +21,13 @@ interface Props {
    * agent up by id (issue #1185).
    */
   members: TeamMember[];
+  /**
+   * Your own avatar reference, so a reply *you* wrote wears your face here the
+   * same way it does in the main timeline (issue #1729). Without it a "you"
+   * line resolves through `senderOf` with no avatar and `TeammateAvatar` seeds
+   * a mascot off the literal string "You" — a wrong (agent-looking) face.
+   */
+  youAvatar?: string;
   /** The message the thread hangs off. */
   parent: ChatMessage;
   replies: ChatMessage[];
@@ -77,6 +84,7 @@ interface Props {
 export function ThreadPanel({
   channel,
   members,
+  youAvatar,
   parent,
   replies,
   sending,
@@ -104,6 +112,7 @@ export function ThreadPanel({
         <Line
           channel={channel}
           members={members}
+          youAvatar={youAvatar}
           message={parent}
           resolveAttachmentUrl={resolveAttachmentUrl}
         />
@@ -118,6 +127,7 @@ export function ThreadPanel({
             key={r.id}
             channel={channel}
             members={members}
+            youAvatar={youAvatar}
             message={r}
             resolveAttachmentUrl={resolveAttachmentUrl}
           />
@@ -141,15 +151,17 @@ export function ThreadPanel({
 function Line({
   channel,
   members,
+  youAvatar,
   message,
   resolveAttachmentUrl,
 }: {
   channel: Channel;
   members: TeamMember[];
+  youAvatar?: string;
   message: ChatMessage;
   resolveAttachmentUrl?: (nodeId: string) => Promise<string>;
 }) {
-  const sender = senderOf(message, channel, members);
+  const sender = senderOf(message, channel, members, youAvatar);
 
   if (sender.kind === "system") {
     return (


### PR DESCRIPTION
## Summary

In the thread panel the current user's reply avatar rendered as the agent avatar (green mascot) instead of the user's own (yellow), breaking message attribution.

Root cause: `ThreadPanel`'s internal `Line` called `senderOf(message, channel, members)` **without** the 4th `youAvatar` argument. For a current-user line `senderOf` returns `{ kind: "you", avatar: youAvatar }`; with it `undefined`, `AvatarTile` fell back to `avatarFor("You")` — a mascot hashed off the literal string `"You"`, which renders green. The main timeline was correct because `buildTimeline(...)` already threads `youAvatar` into the same `senderOf`.

Fix: add a `youAvatar` prop to `ThreadPanel`, thread it into both `Line` renders (parent message + each reply) and pass it as the 4th arg to `senderOf`, then wire `youAvatar={youAvatar}` at the `ChatView` call site (state already existed and already feeds `buildTimeline`). `MessageRow` unchanged. Reuses the exact resolution path the main timeline uses.

Closes #1729

## API Or Behavior Changes

None (rendering fix only). Thread-panel avatars now resolve per message sender.

## Tests

Frontend-only change; Rust gates not applicable.

- [x] `npm run typecheck` (`tsc -b --noEmit`) — PASS
- [ ] `cargo fmt --all -- --check` — N/A: no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust changed
- [ ] `cargo build --all-targets` — N/A: no Rust changed
- [ ] `cargo test` — N/A: no Rust changed

## Documentation

None needed — UI rendering fix, no public API or docs surface affected.