### PR TITLE
fix(chat): surface background task progress and completion

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -877,6 +877,41 @@ export interface InflightRun {
   pendingAction: string | null;
 }
 
+/**
+ * The live board state Chat needs for a card-linked background turn (#1758).
+ *
+ * `column` is the task's stage when the current three-column API provides one,
+ * otherwise its column. `startedAt` is present only while the task appears in
+ * the in-flight read, so it supplies the elapsed clock and wins a brief race
+ * where the board has already moved but the run has not disappeared yet.
+ */
+export interface TaskStatus {
+  column: string;
+  startedAt?: number;
+}
+
+/** Task id -> status, merged from the board and in-flight reads (#1758). */
+export function taskStatusesById(
+  tasks: readonly Task[],
+  inflight: readonly InflightRun[],
+): Record<string, TaskStatus> {
+  const statuses: Record<string, TaskStatus> = {};
+
+  for (const task of tasks) {
+    statuses[task.id] = { column: task.stage ?? task.column };
+  }
+
+  for (const run of inflight) {
+    if (!run.taskId) continue;
+    statuses[run.taskId] = {
+      column: statuses[run.taskId]?.column ?? "in_progress",
+      startedAt: run.startedAt,
+    };
+  }
+
+  return statuses;
+}
+
 /** The steer body. `redirect` requires `instruction`; `cancel` requires `confirm`. */
 export interface SteerInput {
   action: SteerAction;

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2335,6 +2335,17 @@ export function AppShell({
     // moves a card between columns and needs saying in the conversation the
     // card came from.
     onDispatchTerminal: injectDispatchMarker,
+    // The inline terminal marker is enough only while its origin channel is
+    // actually on screen. Elsewhere — including another chat channel — the
+    // event hook raises the linked completion toast (#1758).
+    isViewingTaskOrigin: useCallback(
+      (event: CompanyStreamEvent) => {
+        if (event.type !== "desk_task_completed" || view !== "chat") return false;
+        const origin = dispatchMarkerPlacement(event, chatChannelByThread)?.channelId;
+        return origin != null && activeChatChannelRef.current === origin;
+      },
+      [view, chatChannelByThread],
+    ),
     // Issue #327. The payload is carried, not folded into a counter — see
     // `workspaceEvent` above. The view still re-reads the tree from the host
     // rather than patching it from the frame: the frame carries no node name

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -59,6 +59,12 @@ import {
 import { TourController } from "@/tour/TourController";
 import { useCompany } from "@/hooks/use-company";
 import { getRun, listRuns } from "@/api/runs";
+import {
+  listInflight,
+  listTasks,
+  taskStatusesById,
+  type TaskStatus,
+} from "@/api/tasks";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import { mergeOpenTurns, openTurnsFromRuns, PendingSyncPosts, type OpenTurn } from "@/lib/live-reply";
 import { type AgentReplyEvent, type CompanyStreamEvent, useEvents } from "@/hooks/use-events";
@@ -596,6 +602,15 @@ export function AppShell({
   // React batch still means "re-read" — the frame-loss the workflow canvas had
   // to fold an event window to avoid cannot happen to a tick.
   const [taskEventTick, setTaskEventTick] = useState(0);
+  /**
+   * Board-card state for chat's durable background-work indicator (#1758).
+   * Owned here because ChatView unmounts on navigation while the task keeps
+   * running, and because the task SSE tick already terminates in this shell.
+   */
+  const [taskStatusByTaskId, setTaskStatusByTaskId] = useState<
+    Record<string, TaskStatus>
+  >({});
+  const taskStatusRead = useRef(0);
   // Issue #1015: bumped on every `run_status_changed`, so the task detail screen
   // sees an attempt move rather than waiting up to four seconds for its poll —
   // and sees it at all while the tab is hidden, which the poll deliberately does
@@ -753,6 +768,36 @@ export function AppShell({
   // decisions are in flight or freshly settled, which is never many.
   const ownApprovalDecisionsRef = useRef<Set<string>>(new Set());
   const feed = useCompany(client, company, initialStatus);
+
+  const refreshTaskStatuses = useCallback(async () => {
+    const read = ++taskStatusRead.current;
+    const [tasks, inflight] = await Promise.allSettled([
+      listTasks(client, company),
+      listInflight(client, company),
+    ]);
+    if (read !== taskStatusRead.current) return;
+    // Both reads are best-effort, like the board's own decoration read. Keep a
+    // last good snapshot when the host is offline instead of making a running
+    // pill disappear because one poll failed.
+    if (tasks.status === "rejected" && inflight.status === "rejected") return;
+    setTaskStatusByTaskId(
+      taskStatusesById(
+        tasks.status === "fulfilled" ? tasks.value : [],
+        inflight.status === "fulfilled" ? inflight.value : [],
+      ),
+    );
+  }, [client, company]);
+
+  useEffect(() => {
+    taskStatusRead.current += 1;
+    setTaskStatusByTaskId({});
+  }, [client, company]);
+
+  // Ride the existing visible-tab company poll, and also re-read immediately
+  // when the task stream reports a dispatch, move or settle (#1758).
+  useEffect(() => {
+    void refreshTaskStatuses();
+  }, [feed.now, taskEventTick, refreshTaskStatuses]);
   // Issue #379: the inline approval cards' console-local state, owned here
   // rather than in `ChatView` for the same reason `transcripts` is — the shell
   // mounts and unmounts that view per route, and an operator who approves in a
@@ -2562,6 +2607,7 @@ export function AppShell({
               mentions={mentionCounts}
               approvals={feed.approvals}
               chatChannelByThread={chatChannelByThread}
+              taskStatusByTaskId={taskStatusByTaskId}
               now={feed.now}
               onDecideApproval={(approval, verdict, scope) =>
                 void decideApproval(approval, verdict, scope)

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -585,6 +585,17 @@ export function AppShell({
   // because it outlives `ChatView`: it is what an unaddressed system line is
   // addressed to after the operator has walked off to Approvals (issue #368).
   const activeChatChannelRef = useRef<string | null>(null);
+  // Whether `ChatView`'s transcript is actually rendered right now, as opposed
+  // to `activeChatChannelRef` merely still *naming* the channel last shown
+  // before the operator dropped to the mobile channel rail. Starts `true` to
+  // match `ChatView`'s own initial pane state; kept out of `activeChatChannelRef`
+  // because that ref has a second job — addressing an unaddressed system line
+  // after a walk to Approvals — that must keep using the last channel even
+  // while the rail is what's on screen (#1768 codex review).
+  const chatPaneVisibleRef = useRef(true);
+  const onChatPaneVisibilityChange = useCallback((visible: boolean) => {
+    chatPaneVisibleRef.current = visible;
+  }, []);
   // When each channel was last looked at, and the floor for a channel never
   // looked at. Together with `transcripts` these *derive* the unread counts
   // below — nothing increments a counter, so a message that turns out to be a
@@ -2341,6 +2352,11 @@ export function AppShell({
     isViewingTaskOrigin: useCallback(
       (event: CompanyStreamEvent) => {
         if (event.type !== "desk_task_completed" || view !== "chat") return false;
+        // Below `lg`, selecting the channel rail hides the transcript while
+        // leaving `activeChatChannelRef` naming whatever was last shown — a
+        // completion from that channel must not suppress its toast while the
+        // operator cannot actually see the inline marker (#1768 codex review).
+        if (!chatPaneVisibleRef.current) return false;
         const origin = dispatchMarkerPlacement(event, chatChannelByThread)?.channelId;
         return origin != null && activeChatChannelRef.current === origin;
       },
@@ -2614,6 +2630,7 @@ export function AppShell({
               liveStepsByThread={liveStepsByThread}
               unread={unread}
               onChannelViewed={onChannelViewed}
+              onChatPaneVisibilityChange={onChatPaneVisibilityChange}
               mentionFeedRevision={mentionFeedVersion}
               mentions={mentionCounts}
               approvals={feed.approvals}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -511,6 +511,12 @@ interface Options {
    */
   onDispatchTerminal?: (event: CompanyStreamEvent) => void;
   /**
+   * Whether this console is currently showing the channel a completed task
+   * came from (#1758). Only that exact view suppresses the completion toast;
+   * the channel's inline terminal marker is already the notification there.
+   */
+  isViewingTaskOrigin?: (event: CompanyStreamEvent) => boolean;
+  /**
    * Called for each `workspace_changed` frame (issue #327) so the Workspace
    * view can re-read the tree — and the open note — live.
    *
@@ -626,6 +632,7 @@ export function useEvents(
     onTaskEvent,
     onRunEvent,
     onDispatchTerminal,
+    isViewingTaskOrigin,
     onWorkspaceEvent,
     onTurnEvent,
     onPresenceEvent,
@@ -655,6 +662,10 @@ export function useEvents(
   useEffect(() => {
     onDispatchTerminalRef.current = onDispatchTerminal;
   }, [onDispatchTerminal]);
+  const isViewingTaskOriginRef = useRef(isViewingTaskOrigin);
+  useEffect(() => {
+    isViewingTaskOriginRef.current = isViewingTaskOrigin;
+  }, [isViewingTaskOrigin]);
   const onWorkspaceEventRef = useRef(onWorkspaceEvent);
   useEffect(() => {
     onWorkspaceEventRef.current = onWorkspaceEvent;
@@ -772,6 +783,7 @@ export function useEvents(
             onTaskEvent: onTaskEventRef.current,
             onRunEvent: onRunEventRef.current,
             onDispatchTerminal: onDispatchTerminalRef.current,
+            isViewingTaskOrigin: isViewingTaskOriginRef.current,
             onWorkspaceEvent: onWorkspaceEventRef.current,
             onTurnEvent: onTurnEventRef.current,
             onPresenceEvent: onPresenceEventRef.current,
@@ -826,6 +838,7 @@ export function handleEvent(
     onTaskEvent,
     onRunEvent,
     onDispatchTerminal,
+    isViewingTaskOrigin,
     onWorkspaceEvent,
     onTurnEvent,
     onPresenceEvent,
@@ -902,13 +915,23 @@ export function handleEvent(
     // missing: a reader watching only the relay prose could not tell a card
     // that parked in `paused` from one that finished.
     //
-    // Still **no toast**, and for the reason written above the board arm: this
-    // fires on every settle, and the marker appearing in the channel IS the
-    // notification. A toast on top would be the second notification for one
-    // action that #379 argues against.
+    // The origin channel's inline marker remains the notification while it is
+    // on screen. Away from that exact channel, #1758 adds one linked toast so a
+    // background turn cannot finish silently while the operator works elsewhere.
     case "desk_task_completed":
       onTaskEvent?.(event);
       onDispatchTerminal?.(event);
+      if (!isViewingTaskOrigin?.(event)) {
+        toast("Task run finished", {
+          description: "Background work has stopped. Open the card for its result and next state.",
+          action: {
+            label: "Open task",
+            onClick: () => {
+              window.location.hash = `/tasks/${encodeURIComponent(event.taskId)}`;
+            },
+          },
+        });
+      }
       break;
     // Issue #327, and **no toast** for the same reason the board frames above
     // raise none — more strongly, if anything. A workspace write is not an

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -14,7 +14,7 @@ import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
-import { deleteTask, type MessageIntent } from "@/api/tasks";
+import { deleteTask, type MessageIntent, type TaskStatus } from "@/api/tasks";
 import type { OpenTurn } from "@/lib/live-reply";
 import { setInboxEnabled } from "@/api/inbox";
 import { uploadChatAttachment } from "@/api/chat";
@@ -268,6 +268,8 @@ interface Props {
    */
   approvals?: ApprovalSummary[];
   chatChannelByThread?: Record<string, string>;
+  /** Board task id -> live state for card-linked background turns (#1758). */
+  taskStatusByTaskId?: Readonly<Record<string, TaskStatus>>;
   /** Now, for a card's "waiting N minutes" line. */
   now?: number;
   /**
@@ -331,6 +333,7 @@ export function ChatView({
   onChannelViewed,
   approvals,
   chatChannelByThread,
+  taskStatusByTaskId,
   now,
   onDecideApproval,
   decidingApprovals,
@@ -1606,6 +1609,7 @@ export function ChatView({
               onDismissCard={(taskId) => void dismissCard(taskId)}
               dismissingCardId={dismissingCardId}
               resolveAttachmentUrl={resolveAttachmentUrl}
+              taskStatusByTaskId={taskStatusByTaskId}
               onStartBrief={() =>
                 setComposerPrefill((current) => ({
                   text: FIRST_TEAM_BRIEF,

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -256,6 +256,18 @@ interface Props {
     loadedMessageIds?: ReadonlySet<string>,
   ) => void;
   /**
+   * Reports whether the transcript is actually on screen right now — below
+   * `lg`, `mobilePane === "rail"` hides it behind the channel list even
+   * though `onChannelViewed`'s last report still names that channel.
+   * Distinct from `onChannelViewed`'s own channel memory (which the shell
+   * also uses to address an unaddressed system line after the operator walks
+   * off to Approvals, and must keep doing even while the rail is showing):
+   * this is only for "is a completion's inline marker visible right now",
+   * so a stale-but-correct channel name does not suppress its toast for a
+   * transcript the operator cannot see (#1768 codex review).
+   */
+  onChatPaneVisibilityChange?: (visible: boolean) => void;
+  /**
    * Every approval currently awaiting the operator, straight off the shell's
    * feed, plus the host thread → channel map that places them (#379).
    *
@@ -331,6 +343,7 @@ export function ChatView({
   mentions,
   mentionFeedRevision,
   onChannelViewed,
+  onChatPaneVisibilityChange,
   approvals,
   chatChannelByThread,
   taskStatusByTaskId,
@@ -915,6 +928,17 @@ export function ChatView({
     loadedMessageIds,
     chatPaneVisible,
   ]);
+
+  // The visibility half of the report above: `onChannelViewed` only ever says
+  // *which* channel, and only while it is visible, so nothing tells the shell
+  // the moment that stops being true — its "last channel seen" memory keeps
+  // naming whatever was visible before the operator dropped to the rail. A
+  // plain mirror of `chatPaneVisible`, not folded into that report, because
+  // the two callbacks answer different questions the shell must not conflate
+  // (see the prop doc).
+  useEffect(() => {
+    onChatPaneVisibilityChange?.(chatPaneVisible);
+  }, [chatPaneVisible, onChatPaneVisibilityChange]);
 
   // Upload one attachment's bytes for the composer (issue #1682). Bound to the
   // active connection's client/company so the composer stays agnostic of both.

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -5,6 +5,7 @@ import { AgentAvatarButton, useAgentProfileOpener } from "@/components/agent-pro
 import { Markdown } from "@/components/markdown";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Button } from "@/components/ui/button";
+import { IN_FLIGHT_COLUMNS } from "@/lib/board-columns";
 import { isHostMessageId, type ChatMessage } from "@/lib/chat";
 import { timeAgo } from "@/lib/language";
 import { MessageAttachments } from "./MessageAttachments";
@@ -43,17 +44,19 @@ interface Props {
   now?: number;
 }
 
-const TERMINAL_TASK_COLUMNS = new Set(["in_review", "done", "paused"]);
-
 /**
  * Whether a card-linked reply still represents background work (#1758).
  *
- * An in-flight row wins over a briefly stale terminal board column. Otherwise
- * the board is authoritative: review, done and paused are all stopped states.
+ * An in-flight row wins over a briefly stale board read. Otherwise the board
+ * is authoritative, and {@link IN_FLIGHT_COLUMNS} is the one place that says
+ * which stages are actually active (`board-columns.ts`) — reused rather than
+ * re-derived here so a card back in `pending` (a planning failure, a cancel,
+ * or a revision) reads as stopped, the same as review, done or paused, rather
+ * than defaulting to "working" for anything that isn't a known terminal word.
  */
 export function isTaskWorking(status: TaskStatus | undefined): boolean {
   if (!status) return false;
-  return status.startedAt !== undefined || !TERMINAL_TASK_COLUMNS.has(status.column);
+  return status.startedAt !== undefined || IN_FLIGHT_COLUMNS.includes(status.column);
 }
 
 /** The requested stable elapsed sentence, or nothing without a run clock. */

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -1,5 +1,6 @@
 import { MessageSquareReply } from "lucide-react";
 
+import type { TaskStatus } from "@/api/tasks";
 import { AgentAvatarButton, useAgentProfileOpener } from "@/components/agent-profile-sheet";
 import { Markdown } from "@/components/markdown";
 import { TeammateAvatar } from "@/components/teammate-avatar";
@@ -18,6 +19,7 @@ import {
   type TimelineEntry,
 } from "./model";
 import { CardChip, StepTimeline } from "./StepTimeline";
+import { WorkingIndicator } from "./WorkingIndicator";
 
 interface Props {
   entry: TimelineEntry;
@@ -35,6 +37,35 @@ interface Props {
    * client the blob route needs.
    */
   resolveAttachmentUrl?: (nodeId: string) => Promise<string>;
+  /** Board task id -> live state for card-linked background turns (#1758). */
+  taskStatusByTaskId?: Readonly<Record<string, TaskStatus>>;
+  /** Shared shell clock for elapsed background-work copy. */
+  now?: number;
+}
+
+const TERMINAL_TASK_COLUMNS = new Set(["in_review", "done", "paused"]);
+
+/**
+ * Whether a card-linked reply still represents background work (#1758).
+ *
+ * An in-flight row wins over a briefly stale terminal board column. Otherwise
+ * the board is authoritative: review, done and paused are all stopped states.
+ */
+export function isTaskWorking(status: TaskStatus | undefined): boolean {
+  if (!status) return false;
+  return status.startedAt !== undefined || !TERMINAL_TASK_COLUMNS.has(status.column);
+}
+
+/** The requested stable elapsed sentence, or nothing without a run clock. */
+export function taskElapsedLabel(
+  startedAt: number | undefined,
+  now: number,
+): string | null {
+  if (startedAt === undefined || !Number.isFinite(startedAt) || !Number.isFinite(now)) {
+    return null;
+  }
+  const minutes = Math.max(0, Math.floor((now - startedAt) / 60_000));
+  return `${minutes} min elapsed, still working`;
 }
 
 /**
@@ -75,10 +106,15 @@ export function MessageRow({
   onDismissCard,
   dismissingCardId,
   resolveAttachmentUrl,
+  taskStatusByTaskId,
+  now = Date.now(),
 }: Props) {
   const { message, sender, continuation, replies } = entry;
   const chips = reactionChips(message.reactions);
   const actionsUnavailable = actionsUnavailableFor(message);
+  const taskStatus = message.taskId ? taskStatusByTaskId?.[message.taskId] : undefined;
+  const taskWorking = isTaskWorking(taskStatus);
+  const elapsed = taskWorking ? taskElapsedLabel(taskStatus?.startedAt, now) : null;
 
   if (sender.kind === "system") return <SystemPill message={message} />;
 
@@ -125,12 +161,27 @@ export function MessageRow({
 
         {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
         {message.taskId && (
-          <CardChip
-            taskId={message.taskId}
-            busy={dismissingCardId === message.taskId}
-            disabled={dismissingCardId !== null && dismissingCardId !== message.taskId}
-            onDismiss={onDismissCard}
-          />
+          <div className="flex flex-wrap items-center gap-2">
+            <CardChip
+              taskId={message.taskId}
+              busy={dismissingCardId === message.taskId}
+              disabled={dismissingCardId !== null && dismissingCardId !== message.taskId}
+              onDismiss={onDismissCard}
+            />
+            {taskWorking && (
+              <div className="mt-1.5 flex min-w-0 items-center gap-2">
+                <WorkingIndicator
+                  srLabel="This task is still working."
+                  className="shrink-0 px-2 py-0.5 text-2xs"
+                />
+                {elapsed && (
+                  <span className="text-2xs text-muted-foreground tabular-nums">
+                    {elapsed}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
         )}
 
         {chips.length > 0 && (

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { Bot, CircleDot, Hash, Lock, Send, UserPlus } from "lucide-react";
 
 import type { ApprovalSummary, GrantScope, TurnStep, Verdict } from "@/api/types";
+import type { TaskStatus } from "@/api/tasks";
 import { TeammateAvatar } from "@/components/teammate-avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -59,6 +60,8 @@ interface Props {
    * client the blob route needs. Absent where nothing renders attachments.
    */
   resolveAttachmentUrl?: (nodeId: string) => Promise<string>;
+  /** Board task id -> live state for card-linked background turns (#1758). */
+  taskStatusByTaskId?: Readonly<Record<string, TaskStatus>>;
   /**
    * Places a first brief into the composer on an empty channel.
    * Optional so the thread panel — which renders no intro — need not pass it.
@@ -123,6 +126,7 @@ export function MessageTimeline({
   onDismissCard,
   dismissingCardId,
   resolveAttachmentUrl,
+  taskStatusByTaskId,
   onStartBrief,
   onAddPeople,
   now,
@@ -296,6 +300,8 @@ export function MessageTimeline({
                 onDismissCard={onDismissCard}
                 dismissingCardId={dismissingCardId}
                 resolveAttachmentUrl={resolveAttachmentUrl}
+                taskStatusByTaskId={taskStatusByTaskId}
+                now={now ?? Date.now()}
               />
             </div>
           ) : (

--- a/frontend/test/unit/chat-task-completion-toast.test.ts
+++ b/frontend/test/unit/chat-task-completion-toast.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toast = vi.hoisted(() => vi.fn());
+vi.mock("sonner", () => ({ toast }));
+
+import { handleEvent, type CompanyStreamEvent } from "@/hooks/use-events";
+
+function completed(): Extract<CompanyStreamEvent, { type: "desk_task_completed" }> {
+  return {
+    type: "desk_task_completed",
+    seq: 19,
+    atMillis: 1_700_000_000_000,
+    taskId: "task 7",
+    desk: "engineering",
+    column: "in_review",
+    chatId: "engineering",
+  };
+}
+
+beforeEach(() => {
+  toast.mockReset();
+  window.location.hash = "#/chat/strategy";
+});
+
+describe("background task completion attention", () => {
+  it("toasts off the origin channel and links straight to the task", () => {
+    const onTaskEvent = vi.fn();
+    const onDispatchTerminal = vi.fn();
+
+    handleEvent(completed(), {
+      onTaskEvent,
+      onDispatchTerminal,
+      isViewingTaskOrigin: () => false,
+    });
+
+    expect(onTaskEvent).toHaveBeenCalledOnce();
+    expect(onDispatchTerminal).toHaveBeenCalledOnce();
+    expect(toast).toHaveBeenCalledOnce();
+    expect(toast.mock.calls[0][0]).toBe("Task run finished");
+
+    const options = toast.mock.calls[0][1];
+    expect(options.action.label).toBe("Open task");
+    options.action.onClick();
+    expect(window.location.hash).toBe("#/tasks/task%207");
+  });
+
+  it("does not stack a toast over the origin channel's terminal pill", () => {
+    const onDispatchTerminal = vi.fn();
+
+    handleEvent(completed(), {
+      onDispatchTerminal,
+      isViewingTaskOrigin: () => true,
+    });
+
+    expect(onDispatchTerminal).toHaveBeenCalledOnce();
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("toasts when no origin channel can be resolved", () => {
+    handleEvent({ ...completed(), chatId: undefined }, {});
+
+    expect(toast).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/test/unit/chat-task-origin-visibility.test.ts
+++ b/frontend/test/unit/chat-task-origin-visibility.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A completed background task must not have its toast suppressed by a
+ * transcript the operator cannot actually see (#1768 codex review).
+ *
+ * Below `lg`, selecting the channel rail hides `ChatView`'s transcript
+ * (`chatPaneVisible === false`) while leaving it mounted — but
+ * `activeChatChannelRef` in the shell only updates from `onChannelViewed`,
+ * which stops firing the moment the pane hides. So the ref keeps naming
+ * whichever channel was on screen right before the rail was opened, and a
+ * `desk_task_completed` event from that channel makes `isViewingTaskOrigin`
+ * report "still watching it" even though the inline marker it is deferring
+ * to is off screen. The operator gets no toast and no visible marker.
+ *
+ * A jsdom render of `app-shell` cannot prove this — it needs the whole
+ * client and every hook, the same reason `chat-rail-focus.test.ts` and
+ * `responsive-two-rail-band.test.ts` fall back to a source-contract check.
+ * This guards the wiring the fix rests on: ChatView reports pane visibility
+ * on its own channel, separate from `onChannelViewed`'s channel-identity
+ * report, and the shell's origin check consults it before trusting the
+ * remembered channel id.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+
+describe("a hidden mobile chat pane cannot suppress a completion toast (#1768)", () => {
+  const chatView = read("views/ChatView.tsx");
+  const appShell = read("components/app-shell.tsx");
+
+  it("ChatView reports chatPaneVisible on its own dedicated channel", () => {
+    // Not folded into `onChannelViewed`, which only fires — and only ever
+    // fired — while the pane is visible, so it cannot report the hide edge.
+    expect(chatView).toContain("onChatPaneVisibilityChange?.(chatPaneVisible);");
+  });
+
+  it("the shell tracks pane visibility separately from the remembered channel", () => {
+    // Distinct from `activeChatChannelRef`: that ref has a second job
+    // (addressing an unaddressed system line after a walk to Approvals) that
+    // must keep using the last-known channel even while the rail is showing,
+    // so visibility cannot be folded into clearing it.
+    expect(appShell).toContain("const chatPaneVisibleRef = useRef(true);");
+    expect(appShell).toContain(
+      "const onChatPaneVisibilityChange = useCallback((visible: boolean) => {\n    chatPaneVisibleRef.current = visible;\n  }, []);",
+    );
+  });
+
+  it("wires the shell's tracker to ChatView's report", () => {
+    expect(appShell).toContain("onChatPaneVisibilityChange={onChatPaneVisibilityChange}");
+  });
+
+  it("isViewingTaskOrigin refuses to claim visibility while the pane is hidden", () => {
+    const idx = appShell.indexOf("isViewingTaskOrigin: useCallback(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = appShell.slice(idx, idx + 900);
+    expect(body).toContain('if (!chatPaneVisibleRef.current) return false;');
+    // The visibility check must come before the origin channel is trusted.
+    expect(body.indexOf("chatPaneVisibleRef.current")).toBeLessThan(
+      body.indexOf("activeChatChannelRef.current === origin"),
+    );
+  });
+});

--- a/frontend/test/unit/chat-task-working-state.test.ts
+++ b/frontend/test/unit/chat-task-working-state.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  taskStatusesById,
+  type InflightRun,
+  type Task,
+  type TaskStatus,
+} from "@/api/tasks";
+import {
+  isTaskWorking,
+  MessageRow,
+  taskElapsedLabel,
+} from "@/views/chat/MessageRow";
+import type { TimelineEntry } from "@/views/chat/model";
+
+const NOW = 1_700_000_300_000;
+const here = dirname(fileURLToPath(import.meta.url));
+const appShell = readFileSync(resolve(here, "../../src/components/app-shell.tsx"), "utf8");
+
+const ENTRY: TimelineEntry = {
+  message: {
+    id: "h1",
+    from: "company",
+    channel: "engineering",
+    text: "I’ll get back to you when the research is ready.",
+    at: NOW - 6 * 60_000,
+    taskId: "task-7",
+  },
+  sender: { key: "engineering", name: "Engineering", kind: "company" },
+  continuation: false,
+  replies: [],
+  replySenders: [],
+};
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "task-7",
+    title: "Research the market",
+    column: "working",
+    stage: "in_progress",
+    priority: "medium",
+    assignee: "engineering",
+    updatedAt: NOW,
+    ...over,
+  };
+}
+
+function run(over: Partial<InflightRun> = {}): InflightRun {
+  return {
+    taskId: "task-7",
+    key: "task-7",
+    kind: "task",
+    title: "Research the market",
+    agentId: "engineering",
+    startedAt: NOW - 5 * 60_000,
+    pendingAction: null,
+    ...over,
+  };
+}
+
+describe("the shell's task-status merge", () => {
+  it("refreshes both sources on the existing poll clock and task-event tick", () => {
+    expect(appShell).toContain("listTasks(client, company)");
+    expect(appShell).toContain("listInflight(client, company)");
+    expect(appShell).toContain("[feed.now, taskEventTick, refreshTaskStatuses]");
+  });
+
+  it("uses the board stage and adds the in-flight start clock", () => {
+    expect(taskStatusesById([task()], [run()])).toEqual({
+      "task-7": { column: "in_progress", startedAt: NOW - 5 * 60_000 },
+    });
+  });
+
+  it("keeps an in-flight task visible during a board-read race", () => {
+    expect(taskStatusesById([], [run()])).toEqual({
+      "task-7": { column: "in_progress", startedAt: NOW - 5 * 60_000 },
+    });
+  });
+
+  it("does not turn a delegation with no board task into a chat status", () => {
+    expect(taskStatusesById([], [run({ taskId: null, kind: "delegation" })])).toEqual({});
+  });
+});
+
+describe("background task working semantics", () => {
+  it("stops at review, done or paused unless the in-flight read still owns it", () => {
+    for (const column of ["in_review", "done", "paused"]) {
+      expect(isTaskWorking({ column })).toBe(false);
+      expect(isTaskWorking({ column, startedAt: NOW - 60_000 })).toBe(true);
+    }
+    expect(isTaskWorking({ column: "in_progress" })).toBe(true);
+    expect(isTaskWorking(undefined)).toBe(false);
+  });
+
+  it("reports whole elapsed minutes without allowing a negative clock", () => {
+    expect(taskElapsedLabel(NOW - 5 * 60_000, NOW)).toBe("5 min elapsed, still working");
+    expect(taskElapsedLabel(NOW + 30_000, NOW)).toBe("0 min elapsed, still working");
+    expect(taskElapsedLabel(undefined, NOW)).toBeNull();
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(status: TaskStatus) {
+  act(() => {
+    root.render(
+      createElement(MessageRow, {
+        entry: ENTRY,
+        threadOpen: false,
+        onOpenThread: () => {},
+        onReact: () => {},
+        onDismissCard: () => {},
+        dismissingCardId: null,
+        taskStatusByTaskId: { "task-7": status },
+        now: NOW,
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("a card-linked background reply", () => {
+  it("keeps a compact Working pill and elapsed clock beside the card", () => {
+    render({ column: "in_progress", startedAt: NOW - 5 * 60_000 });
+
+    expect(container.querySelector('[data-testid="working-indicator"]')).not.toBeNull();
+    expect(container.textContent).toContain("Working…");
+    expect(container.textContent).toContain("5 min elapsed, still working");
+    expect(container.textContent).toContain("Card opened");
+  });
+
+  it("removes only the working state when the card reaches In review", () => {
+    render({ column: "in_progress", startedAt: NOW - 5 * 60_000 });
+    render({ column: "in_review" });
+
+    expect(container.querySelector('[data-testid="working-indicator"]')).toBeNull();
+    expect(container.textContent).not.toContain("still working");
+    expect(container.textContent).toContain("Card opened");
+  });
+});

--- a/frontend/test/unit/chat-task-working-state.test.ts
+++ b/frontend/test/unit/chat-task-working-state.test.ts
@@ -99,6 +99,17 @@ describe("background task working semantics", () => {
     expect(isTaskWorking(undefined)).toBe(false);
   });
 
+  it("does not keep a card Working once it is back in To-do (#1768)", () => {
+    // A planning failure, a cancel, or a revision all return a card to
+    // `pending` with no stage (Task.stage is "absent on a pending or done
+    // card" — frontend/src/api/tasks.ts). That is a stopped state, the same
+    // as review/done/paused, and must not read as still working just
+    // because it isn't in the terminal set.
+    expect(isTaskWorking({ column: "pending" })).toBe(false);
+    // ...unless the in-flight read still owns it (board-read race).
+    expect(isTaskWorking({ column: "pending", startedAt: NOW - 60_000 })).toBe(true);
+  });
+
   it("reports whole elapsed minutes without allowing a negative clock", () => {
     expect(taskElapsedLabel(NOW - 5 * 60_000, NOW)).toBe("5 min elapsed, still working");
     expect(taskElapsedLabel(NOW + 30_000, NOW)).toBe("0 min elapsed, still working");


### PR DESCRIPTION
## Summary

- merge board state with in-flight run clocks in the shell and refresh it on the existing visible poll plus task events
- keep a compact Working pill and elapsed-minute line beside card-linked background replies until the task stops
- raise a linked completion toast when the operator is away from the task origin channel

## API Or Behavior Changes

Chat now keeps dispatched background work visibly active after the synchronous reply turn ends. Tasks in review, done, or paused stop showing as working, while the existing synchronous typing indicator and terminal marker remain unchanged. No backend or public API changes.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run`
- [x] `npm run build`

## Documentation

No documentation changes were needed; this is an operator-console state and notification fix covered by focused unit tests.

Closes #1758