### PR TITLE
fix: capture workflow node files as run artifacts (#1753)

### DIFF
--- a/frontend/src/views/workflows/NodeDetailPanel.tsx
+++ b/frontend/src/views/workflows/NodeDetailPanel.tsx
@@ -13,7 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { nodeKindMeta } from "@/lib/workflow-sample";
 
-import { type NodeOutputView, parseNodeMessages } from "./run-output";
+import { type NodeOutputView, isRecord, parseNodeMessages } from "./run-output";
 
 /** A read-only inspector for a single graph node, overlaid on the canvas when
  * the operator clicks a node. Surfaces the fields already on the wire from
@@ -244,6 +244,7 @@ export function OutputSection({ output }: { output: NodeOutputView }) {
   }
 
   const messages = parseNodeMessages(output.value);
+  const artifacts = parseRunArtifacts(output.value);
   return (
     <DetailField label="Output">
       <div className="space-y-2" data-testid="node-output">
@@ -282,10 +283,32 @@ export function OutputSection({ output }: { output: NodeOutputView }) {
               )}
             </div>
           ))
-        ) : (
+        ) : artifacts.length === 0 ? (
           <p className="text-xs text-muted-foreground" data-testid="node-output-none">
             This node produced no readable text — see the raw value below.
           </p>
+        ) : null}
+        {artifacts.length > 0 && (
+          <div className="space-y-1.5" data-testid="node-output-artifacts">
+            <p className="text-3xs uppercase tracking-wide text-muted-foreground">
+              Artifacts
+            </p>
+            {artifacts.map((artifact) => (
+              <a
+                key={`${artifact.workspaceNodeId}-${artifact.source}`}
+                className="block rounded-md border bg-muted/30 px-2 py-1.5 hover:border-primary/40"
+                href={`#/workspace/${encodeURIComponent(artifact.workspaceNodeId)}`}
+                data-testid="node-output-artifact"
+              >
+                <span className="block truncate text-xs font-medium text-primary">
+                  {artifact.title}
+                </span>
+                <span className="block truncate text-3xs text-muted-foreground">
+                  {artifact.source}
+                </span>
+              </a>
+            ))}
+          </div>
         )}
         <details>
           <summary className="cursor-pointer text-xs text-muted-foreground">
@@ -298,6 +321,27 @@ export function OutputSection({ output }: { output: NodeOutputView }) {
       </div>
     </DetailField>
   );
+}
+
+interface RunArtifactView {
+  source: string;
+  title: string;
+  workspaceNodeId: string;
+}
+
+/** Reads the host's card-less run-artifact rows defensively. */
+function parseRunArtifacts(raw: unknown): RunArtifactView[] {
+  if (!isRecord(raw) || !Array.isArray(raw.artifacts)) return [];
+  return raw.artifacts.flatMap((row) => {
+    if (!isRecord(row)) return [];
+    const source = typeof row.source === "string" ? row.source : "";
+    const title = typeof row.title === "string" ? row.title : source;
+    const workspaceNodeId =
+      typeof row.workspaceNodeId === "string" ? row.workspaceNodeId : "";
+    return source && title && workspaceNodeId
+      ? [{ source, title, workspaceNodeId }]
+      : [];
+  });
 }
 
 /** A labelled block inside the node inspector. */

--- a/frontend/test/unit/node-output-partial.test.ts
+++ b/frontend/test/unit/node-output-partial.test.ts
@@ -67,4 +67,30 @@ describe("OutputSection partial badge (issue #1008)", () => {
     expect(empty?.textContent).toContain("predates output capture");
     expect(container.querySelector('[data-testid="node-output-partial"]')).toBeNull();
   });
+
+  it("surfaces a partial node's run artifacts even when it returned no text", () => {
+    render({
+      state: "present",
+      value: {
+        items: [],
+        artifacts: [
+          {
+            source: "reports/partial.md",
+            title: "partial.md",
+            kind: "markdown",
+            workspaceNodeId: "node-42",
+          },
+        ],
+      },
+      truncated: false,
+      partial: true,
+    });
+
+    const artifact = container.querySelector<HTMLAnchorElement>(
+      '[data-testid="node-output-artifact"]',
+    );
+    expect(artifact?.textContent).toContain("partial.md");
+    expect(artifact?.getAttribute("href")).toBe("#/workspace/node-42");
+    expect(container.querySelector('[data-testid="node-output-none"]')).toBeNull();
+  });
 });

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -336,6 +336,7 @@ pub async fn materialize_run(
         PublishTarget {
             agent_id: target.agent_id,
             task_id: "runs",
+            task_title: None,
             source: &source,
             payload: target.payload,
             existing_node_id: None,

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -108,6 +108,26 @@ pub struct PublishTarget<'a> {
     pub existing_node_id: Option<&'a str>,
 }
 
+/// One card-less workflow-run artifact.
+///
+/// Runs cannot use [`PublishTarget`] directly because its second path segment
+/// is a task id and a workflow agent node has no card. This target preserves
+/// the same author/source/payload contract while giving the mirror the two ids
+/// that make the destination unique within a run.
+#[derive(Debug, Clone, Copy)]
+pub struct RunTarget<'a> {
+    /// The roster agent whose sandbox produced the file.
+    pub agent_id: &'a str,
+    /// The workflow run that owns the capture.
+    pub run_id: &'a str,
+    /// The graph node whose turn wrote it.
+    pub node_id: &'a str,
+    /// The normalized path relative to that agent's workspace.
+    pub source: &'a str,
+    /// The captured file body.
+    pub payload: MirrorPayload<'a>,
+}
+
 /// What [`materialize`] is being asked to put in the tree.
 ///
 /// Borrowed rather than owned: the drain already holds the bytes it read, and a
@@ -274,6 +294,34 @@ pub async fn materialize(
         // edits the tree by hand.
         None => create_first(workspace, company, &parent, filename, target).await,
     }
+}
+
+/// Files a card-less workflow-node output into the shared workspace tree.
+///
+/// The layout is `artifacts/<agent>/runs/<run>/<node>/<source…>`. Reusing
+/// [`materialize`] keeps the same path validation, conflict handling, binary
+/// storage, and atomic create semantics as task artifacts while the `runs`
+/// segment prevents a run id from being mistaken for a task id.
+pub async fn materialize_run(
+    workspace: &dyn WorkspaceStore,
+    company: &CompanyId,
+    target: RunTarget<'_>,
+) -> Result<Mirrored> {
+    let run = kebab_name_or(target.run_id, target.run_id);
+    let node = kebab_name_or(target.node_id, target.node_id);
+    let source = format!("{run}/{node}/{}", target.source);
+    materialize(
+        workspace,
+        company,
+        PublishTarget {
+            agent_id: target.agent_id,
+            task_id: "runs",
+            source: &source,
+            payload: target.payload,
+            existing_node_id: None,
+        },
+    )
+    .await
 }
 
 /// Publishes a deliverable to a path that nothing occupies yet, and loses

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -72,6 +72,8 @@
 //! only under the `openhuman` feature). The shared half therefore cannot live
 //! in the harness, or the default build could not reach it.
 
+use sha2::{Digest, Sha256};
+
 use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord, ArtifactStore};
@@ -316,19 +318,40 @@ pub async fn materialize(
     }
 }
 
+/// A workflow node id's path segment within a run's artifact folder.
+///
+/// `kebab_name_or` is not injective — `write_up` and `write-up` both normalize
+/// to `write-up` — but workflow validation only requires raw node ids to be
+/// unique, not their kebab form. Two nodes that collide there would otherwise
+/// resolve to the same `materialize_run` destination, and the later capture
+/// would silently overwrite the earlier node's output. Appending a short
+/// stable hash of the RAW id (computed before normalization) makes the
+/// segment collision-resistant while keeping the kebab prefix for
+/// readability in the workspace tree.
+fn run_node_segment(node_id: &str) -> String {
+    let kebab = kebab_name_or(node_id, node_id);
+    let digest = Sha256::digest(node_id.as_bytes());
+    let mut suffix = String::with_capacity(8);
+    for byte in digest.iter().take(4) {
+        use std::fmt::Write as _;
+        let _ = write!(suffix, "{byte:02x}");
+    }
+    format!("{kebab}-{suffix}")
+}
+
 /// Files a card-less workflow-node output into the shared workspace tree.
 ///
-/// The layout is `artifacts/<agent>/runs/<run>/<node>/<source…>`. Reusing
-/// [`materialize`] keeps the same path validation, conflict handling, binary
-/// storage, and atomic create semantics as task artifacts while the `runs`
-/// segment prevents a run id from being mistaken for a task id.
+/// The layout is `artifacts/<agent>/runs/<run>/<node>-<hash>/<source…>`.
+/// Reusing [`materialize`] keeps the same path validation, conflict handling,
+/// binary storage, and atomic create semantics as task artifacts while the
+/// `runs` segment prevents a run id from being mistaken for a task id.
 pub async fn materialize_run(
     workspace: &dyn WorkspaceStore,
     company: &CompanyId,
     target: RunTarget<'_>,
 ) -> Result<Mirrored> {
     let run = kebab_name_or(target.run_id, target.run_id);
-    let node = kebab_name_or(target.node_id, target.node_id);
+    let node = run_node_segment(target.node_id);
     let source = format!("{run}/{node}/{}", target.source);
     materialize(
         workspace,
@@ -2938,6 +2961,63 @@ mod test {
             path_of(ws, &co, &second).await,
             format!("{ARTIFACTS_ROOT}/cmo/t-1/timeline.md"),
             "the older of the two folders must win, and win the same way every time"
+        );
+    }
+
+    /// Two workflow nodes whose raw ids differ only by underscore vs dash
+    /// still capture to distinct folders.
+    ///
+    /// `write_up` and `write-up` both kebab-normalize to `write-up`. Workflow
+    /// validation only requires the RAW ids to be unique, so both are legal
+    /// node ids in one graph. Without a raw-id-derived suffix on the path
+    /// segment, the second node's capture would resolve to the same
+    /// destination as the first and silently overwrite its output.
+    #[tokio::test]
+    async fn run_nodes_with_colliding_kebab_ids_capture_to_distinct_folders() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize_run(
+            ws,
+            &co,
+            RunTarget {
+                agent_id: "cmo",
+                run_id: "run-1",
+                node_id: "write_up",
+                source: "notes.md",
+                payload: MirrorPayload::Text("first node's body"),
+            },
+        )
+        .await
+        .expect("first node capture");
+
+        let second = materialize_run(
+            ws,
+            &co,
+            RunTarget {
+                agent_id: "cmo",
+                run_id: "run-1",
+                node_id: "write-up",
+                source: "notes.md",
+                payload: MirrorPayload::Text("second node's body"),
+            },
+        )
+        .await
+        .expect("second node capture");
+
+        assert_ne!(
+            first.node_id, second.node_id,
+            "colliding kebab node ids must not resolve to the same workspace node"
+        );
+
+        let (_, first_body) = ws
+            .read(&co, &first.node_id)
+            .await
+            .expect("read")
+            .expect("first node still present");
+        assert_eq!(
+            first_body, "first node's body",
+            "the second node's capture must not overwrite the first node's output"
         );
     }
 }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1061,14 +1061,34 @@ impl HarnessAgentRunner {
         let refusals = self.deps.pending_publishes.drain_refusals();
         let mut seen: Vec<String> = Vec::new();
         for source in refusals {
-            // The tool was built before runs had a card-less artifact target,
-            // so it may still have returned its historical refusal. The
-            // post-turn workspace capture below is authoritative: if that file
-            // was materialized, do not also tell the operator it is stranded.
-            if captured.iter().any(|path| path == &source) {
+            if seen.iter().any(|s| s == &source) {
                 continue;
             }
-            if seen.iter().any(|s| s == &source) {
+            // The tool was built before runs had a card-less artifact target,
+            // so it may still have returned its historical refusal — telling
+            // the model mid-turn that the file was not published. The
+            // post-turn workspace capture below can catch that same file
+            // anyway, which would otherwise leave the node's own turn reply
+            // ("I could not publish this") unreconciled against a run
+            // inspector that shows the file delivered. Say both are true
+            // rather than silently dropping one: the tool's refusal was real
+            // at call time, and the capture is what actually landed it.
+            if captured.iter().any(|path| path == &source) {
+                tracing::info!(
+                    company = %self.company,
+                    workflow = %self.workflow_id,
+                    run_id = %self.run_id,
+                    path = %source,
+                    "workflow agent node: a publish the tool refused was captured anyway by \
+                     the post-turn workspace scan; reconciling the notice"
+                );
+                self.notices.push(format!(
+                    "A step in this workflow was told \"{source}\" could not be published — a \
+                     workflow run had no destination for that tool call — but the file was \
+                     captured from that teammate's sandbox after the turn and is available as a \
+                     run artifact."
+                ));
+                seen.push(source);
                 continue;
             }
             tracing::warn!(
@@ -2571,6 +2591,73 @@ mod tests {
             .scoped(runner.park_gated_calls(Some("work"), &node_turn))
             .await;
         (notices.take(), queue)
+    }
+
+    /// PR #1775 review: a publish the tool refused mid-turn, but which the
+    /// post-turn workspace capture materialized anyway, must not be silently
+    /// dropped from the run's notices. The node's own turn reply already told
+    /// the operator delivery failed (the tool's response, at call time); going
+    /// silent here would leave that unreconciled against a run inspector that
+    /// shows the file delivered.
+    #[tokio::test]
+    async fn a_captured_publish_reconciles_its_earlier_refusal_notice() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1775-")
+            .tempdir()
+            .expect("tempdir");
+        let (deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        let pending_publishes = deps.pending_publishes.clone();
+        let notices = RunNotices::default();
+        let board_claim = Arc::new(deps.delegations.claim_board("run-1775"));
+        let publish_refusal_claim =
+            Arc::new(deps.pending_publishes.claim_refusals_for_run("run-1775"));
+        let runner = HarnessAgentRunner::new(
+            single_turn(&deps),
+            deps,
+            crate::workflows::gated_tool_turn_test::record(),
+            CompanyId::new("acme"),
+            "wf-1".to_string(),
+            "run-1775".to_string(),
+            None,
+            notices.clone(),
+            RunBoard::default(),
+            RunBlocks::default(),
+            RunApprovals::default(),
+            RunArtifacts::default(),
+            board_claim,
+            publish_refusal_claim.clone(),
+        );
+
+        // The tool's refusal, staged inside this run's scope exactly as the
+        // live `publish_artifact` call would have.
+        publish_refusal_claim
+            .scoped(async { pending_publishes.push_refusal("specs/plan.md".to_string()) })
+            .await;
+
+        // The post-turn drain, told that the workspace scan captured that
+        // same file anyway.
+        publish_refusal_claim
+            .scoped(async {
+                runner.drain_publish_refusals(&["specs/plan.md".to_string()]);
+            })
+            .await;
+
+        let recorded = notices.take();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "the refusal must be reconciled with a notice, not silenced: {recorded:?}"
+        );
+        assert!(
+            recorded[0].contains("specs/plan.md"),
+            "the notice must name the file: {recorded:?}"
+        );
+        assert!(
+            recorded[0].contains("captured"),
+            "the notice must say the file landed anyway, not just that it was refused: \
+             {recorded:?}"
+        );
     }
 
     #[test]

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -61,6 +61,7 @@ mod upstream;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use serde::Serialize;
 use serde_json::{Value, json};
 use tinyflows::caps::{
     AgentRunOutcome, AgentRunRequest, AgentRunner, Capabilities, CodeLanguage, CodeRunner,
@@ -130,6 +131,8 @@ pub struct RunContext<'a> {
     pub blocks: RunBlocks,
     /// Where an agent node records the approvals its turn parked (issue #880).
     pub approvals: RunApprovals,
+    /// Files agent nodes wrote during this run, keyed by node for durable output.
+    pub artifacts: RunArtifacts,
     /// Where each `agent` node's turn is recorded as an attempt. `None` on a
     /// dry run and in tests, which then behave exactly as they did before
     /// attempts existed.
@@ -198,6 +201,7 @@ pub async fn build_capabilities(
         board,
         blocks,
         approvals,
+        artifacts,
         runs,
         deep,
         attempts,
@@ -387,6 +391,7 @@ pub async fn build_capabilities(
                 board,
                 blocks,
                 approvals,
+                artifacts,
                 board_claim,
                 publish_refusal_claim,
             )
@@ -564,6 +569,8 @@ pub struct HarnessAgentRunner {
     blocks: RunBlocks,
     /// Where this node records the approvals its turn parked (issue #880).
     approvals: RunApprovals,
+    /// Run-scoped files captured after each node turn, including failed turns.
+    artifacts: RunArtifacts,
     /// The run's [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim)
     /// claim, taken once by [`build_capabilities`] and held for the whole run.
     ///
@@ -592,6 +599,53 @@ pub struct HarnessAgentRunner {
 #[derive(Clone, Default)]
 pub struct RunNotices {
     inner: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+/// One file a workflow agent node wrote during its turn.
+///
+/// A workflow run has no card, so this metadata rides beside the engine result
+/// and is folded into the durable per-node output snapshot by the runner. The
+/// body itself lives in the shared workspace node named here.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunArtifact {
+    source: String,
+    title: String,
+    kind: crate::ports::ArtifactKind,
+    workspace_node_id: String,
+    captured_at_millis: u64,
+}
+
+/// Run-scoped collector for node-written files.
+///
+/// Owned by the runner rather than the capability bundle so entries survive an
+/// engine failure or block, both of which drop the bundle before persistence.
+#[derive(Clone, Default)]
+pub struct RunArtifacts {
+    inner: Arc<std::sync::Mutex<std::collections::BTreeMap<String, Vec<RunArtifact>>>>,
+}
+
+impl RunArtifacts {
+    fn push(&self, node_id: &str, artifact: RunArtifact) {
+        let mut guard = self.inner.lock().expect("run artifacts poisoned");
+        let rows = guard.entry(node_id.to_string()).or_default();
+        if let Some(existing) = rows.iter_mut().find(|row| row.source == artifact.source) {
+            *existing = artifact;
+        } else {
+            rows.push(artifact);
+        }
+    }
+
+    /// Takes every captured row as JSON, keyed by graph node id.
+    pub fn take(&self) -> serde_json::Map<String, Value> {
+        std::mem::take(&mut *self.inner.lock().expect("run artifacts poisoned"))
+            .into_iter()
+            .map(|(node, rows)| {
+                let value = serde_json::to_value(rows).unwrap_or_else(|_| Value::Array(Vec::new()));
+                (node, value)
+            })
+            .collect()
+    }
 }
 
 impl RunNotices {
@@ -799,6 +853,7 @@ impl HarnessAgentRunner {
         board: RunBoard,
         blocks: RunBlocks,
         approvals: RunApprovals,
+        artifacts: RunArtifacts,
         board_claim: Arc<crate::harness::orchestrator::DelegationClaim>,
         publish_refusal_claim: Arc<crate::harness::publish::PublishRefusalClaim>,
     ) -> Self {
@@ -817,6 +872,7 @@ impl HarnessAgentRunner {
             board,
             blocks,
             approvals,
+            artifacts,
             board_claim,
             publish_refusal_claim,
         }
@@ -1001,10 +1057,17 @@ impl HarnessAgentRunner {
     /// `push_refusal` reads that scope at call time. Concurrent runs write to
     /// and drain distinct buckets while chat and task turns retain the default
     /// bucket and their existing behavior.
-    fn drain_publish_refusals(&self) {
+    fn drain_publish_refusals(&self, captured: &[String]) {
         let refusals = self.deps.pending_publishes.drain_refusals();
         let mut seen: Vec<String> = Vec::new();
         for source in refusals {
+            // The tool was built before runs had a card-less artifact target,
+            // so it may still have returned its historical refusal. The
+            // post-turn workspace capture below is authoritative: if that file
+            // was materialized, do not also tell the operator it is stranded.
+            if captured.iter().any(|path| path == &source) {
+                continue;
+            }
             if seen.iter().any(|s| s == &source) {
                 continue;
             }
@@ -1023,6 +1086,144 @@ impl HarnessAgentRunner {
             ));
             seen.push(source);
         }
+    }
+
+    /// Captures every file this node wrote and mirrors it into the run tree.
+    ///
+    /// The snapshot/diff is the same bounded mechanism task dispatch uses. Any
+    /// explicitly staged publish is drained first and its already-captured body
+    /// wins; the remaining changed paths are the unpublished files and are read
+    /// directly from the node's sandbox. Nothing here can change the node's
+    /// success/failure result: a mirror error is logged and the remaining files
+    /// continue, because the turn has already happened.
+    async fn capture_run_artifacts(
+        &self,
+        agent_ref: &str,
+        node_id: &str,
+        workspace: &std::path::Path,
+        before: &crate::harness::publish::WorkspaceSnapshot,
+    ) -> Vec<String> {
+        use crate::harness::publish;
+
+        let changed = before.changed_since(workspace);
+        let staged = self.deps.pending_publishes.drain();
+        let staged_sources: Vec<String> = staged.iter().map(|row| row.source.clone()).collect();
+        let unpublished = publish::unpublished(&changed.files, &staged_sources);
+
+        let mut candidates: std::collections::BTreeMap<String, publish::PendingPublish> = staged
+            .into_iter()
+            .map(|pending| (pending.source.clone(), pending))
+            .collect();
+        for source in unpublished {
+            let file = workspace.join(&source);
+            let inferred = publish::kind_for_extension(&file);
+            let payload = match publish::capture_body(&file, &source, inferred) {
+                Ok(payload) => payload,
+                Err(err) => {
+                    tracing::warn!(
+                        company = %self.company,
+                        workflow = %self.workflow_id,
+                        run_id = %self.run_id,
+                        node = node_id,
+                        path = %source,
+                        %err,
+                        "workflow agent node: could not read a changed file for run capture"
+                    );
+                    continue;
+                }
+            };
+            let kind = payload.forced_kind(inferred);
+            let title = file
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| source.clone());
+            candidates.insert(
+                source.clone(),
+                publish::PendingPublish {
+                    agent: agent_ref.to_string(),
+                    source,
+                    title,
+                    kind,
+                    note: None,
+                    payload,
+                },
+            );
+        }
+
+        if changed.partial {
+            tracing::warn!(
+                company = %self.company,
+                workflow = %self.workflow_id,
+                run_id = %self.run_id,
+                node = node_id,
+                "workflow agent node: the workspace scan was partial; run artifact capture may \
+                 be incomplete"
+            );
+        }
+
+        let Some(store) = self.deps.workspace.as_ref() else {
+            if !candidates.is_empty() {
+                tracing::warn!(
+                    company = %self.company,
+                    workflow = %self.workflow_id,
+                    run_id = %self.run_id,
+                    node = node_id,
+                    files = candidates.len(),
+                    "workflow agent node: files changed but no shared workspace store is wired"
+                );
+            }
+            return Vec::new();
+        };
+
+        let mut captured = Vec::new();
+        for pending in candidates.into_values() {
+            let payload = match &pending.payload {
+                publish::PublishPayload::Text(text) => {
+                    crate::company::artifact_mirror::MirrorPayload::Text(text)
+                }
+                publish::PublishPayload::Bytes { bytes, mime } => {
+                    crate::company::artifact_mirror::MirrorPayload::Bytes { bytes, mime }
+                }
+            };
+            let target = crate::company::artifact_mirror::RunTarget {
+                agent_id: agent_ref,
+                run_id: &self.run_id,
+                node_id,
+                source: &pending.source,
+                payload,
+            };
+            match crate::company::artifact_mirror::materialize_run(
+                store.as_ref(),
+                &self.company,
+                target,
+            )
+            .await
+            {
+                Ok(mirrored) => {
+                    captured.push(pending.source.clone());
+                    self.artifacts.push(
+                        node_id,
+                        RunArtifact {
+                            source: pending.source,
+                            title: pending.title,
+                            kind: pending.kind,
+                            workspace_node_id: mirrored.node_id,
+                            captured_at_millis: crate::ports::now_millis(),
+                        },
+                    );
+                }
+                Err(err) => tracing::error!(
+                    company = %self.company,
+                    workflow = %self.workflow_id,
+                    run_id = %self.run_id,
+                    node = node_id,
+                    path = %pending.source,
+                    %err,
+                    "workflow agent node: could not materialize a changed file as a run artifact"
+                ),
+            }
+        }
+        captured
     }
 
     /// Parks every approval-gated tool call this node's turn just recorded
@@ -1370,6 +1571,15 @@ impl HarnessAgentRunner {
         let lineage_node = node_id.clone().unwrap_or_else(|| agent_ref.to_string());
         let node_turn =
             crate::runtime::workflow_resume::workflow_node_turn_key(&self.run_id, &lineage_node);
+        // The node runs in its roster agent's sandbox, not the workflow tool
+        // workspace. Snapshot it immediately before inference so the post-turn
+        // drain can distinguish this node's writes from files already there.
+        let workspace = crate::harness::build::agent_workspace(
+            &self.deps.workspace_root,
+            &self.company,
+            agent_ref,
+        );
+        let workspace_before = crate::harness::publish::WorkspaceSnapshot::take(&workspace);
 
         // The attempt row. This is the thing that did not exist: a workflow
         // node's turn had no card and no conversation, so `RunStore` — keyed on
@@ -1493,11 +1703,16 @@ impl HarnessAgentRunner {
             // card would be opened; refusing to drain would make that receipt false
             // and destroy the write when the scope ends.
             Box::pin(self.drain_board_writes()).await;
-            // Issue #1192: likewise on both arms. A turn that failed after being
-            // refused a publish was still refused one, and the file it wrote is
-            // still stranded — dropping the fact because the turn ended badly is
-            // how the refusal became invisible in the first place.
-            self.drain_publish_refusals();
+            // Run artifacts are drained on BOTH arms. A provider/tool failure or
+            // a later approval block does not undo files the turn already wrote,
+            // so capture happens before either return below can discard them.
+            let captured = self
+                .capture_run_artifacts(agent_ref, &lineage_node, &workspace, &workspace_before)
+                .await;
+            // Issue #1192: likewise on both arms. A refusal is still surfaced
+            // when capture failed, but a file successfully mirrored above is no
+            // longer described as stranded.
+            self.drain_publish_refusals(&captured);
             (outcome, parked)
         });
         let turn = Box::pin(self.board_claim.scoped(turn));
@@ -2182,6 +2397,7 @@ mod tests {
             RunBoard::default(),
             RunBlocks::default(),
             RunApprovals::default(),
+            RunArtifacts::default(),
             board_claim,
             publish_refusal_claim,
         );
@@ -2322,6 +2538,7 @@ mod tests {
             RunBoard::default(),
             RunBlocks::default(),
             RunApprovals::default(),
+            RunArtifacts::default(),
             board_claim,
             publish_refusal_claim,
         );
@@ -2871,6 +3088,7 @@ mod tests {
                 board: RunBoard::default(),
                 blocks: Default::default(),
                 approvals: Default::default(),
+                artifacts: Default::default(),
                 runs: None,
                 deep: None,
                 attempts: Default::default(),
@@ -2921,6 +3139,7 @@ mod tests {
                 board: RunBoard::default(),
                 blocks: Default::default(),
                 approvals: Default::default(),
+                artifacts: Default::default(),
                 runs: None,
                 deep: None,
                 attempts: Default::default(),
@@ -3088,6 +3307,7 @@ mod tests {
                 board: RunBoard::default(),
                 blocks: Default::default(),
                 approvals: Default::default(),
+                artifacts: Default::default(),
                 runs: None,
                 deep: None,
                 attempts: Default::default(),
@@ -3145,6 +3365,7 @@ mod tests {
                 board: RunBoard::default(),
                 blocks: Default::default(),
                 approvals: Default::default(),
+                artifacts: Default::default(),
                 runs: None,
                 deep: None,
                 attempts: Default::default(),

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -412,6 +412,10 @@ async fn run_workflow_inner(
     // run that ended badly must still be able to say it opened one.
     let blocks = super::caps::RunBlocks::default();
     let approvals = super::caps::RunApprovals::default();
+    // Card-less files written by agent nodes. Kept outside the capability
+    // bundle so a failed/blocked engine future cannot drop the capture before
+    // the durable run-output snapshot is assembled.
+    let run_artifacts = super::caps::RunArtifacts::default();
     // Owned out here like `blocks` and `approvals`: the journal write that needs
     // it happens in the collector task, which outlives the capability bundle the
     // engine future drops.
@@ -440,6 +444,7 @@ async fn run_workflow_inner(
             board: board.clone(),
             blocks: blocks.clone(),
             approvals: approvals.clone(),
+            artifacts: run_artifacts.clone(),
             // A dry run records nothing: it makes no effects, so an attempt row
             // for it would be a receipt for work that never happened.
             runs: attempt_runs,
@@ -736,6 +741,11 @@ async fn run_workflow_inner(
             (Vec::new(), serde_json::Map::new(), serde_json::Map::new())
         }
     };
+    // The post-turn capture is a sideways channel because failed and blocked
+    // agent nodes return no engine output. Drain it only after the engine and
+    // progress collector are gone, then fold the same rows into every settle
+    // arm below.
+    let captured_artifacts = run_artifacts.take();
 
     // Resolved only AFTER the drain above, so a cancelled run's completed nodes
     // are journaled exactly like a completed run's before the caller writes the
@@ -763,8 +773,10 @@ async fn run_workflow_inner(
             // genuine-failure and the blocked branches — before #1008 both threw
             // it away, so the inspector wrongly reported "this run predates output
             // capture" for every failed or blocked run.
-            let partial_output =
-                merge_transcripts(&Value::Object(partial_nodes), &node_transcripts);
+            let partial_output = merge_run_artifacts(
+                merge_transcripts(&Value::Object(partial_nodes), &node_transcripts),
+                &captured_artifacts,
+            );
             if blocked.is_empty() || !only_blocked_nodes_errored(&nodes, &blocked) {
                 // A genuine failure. Persist the partial capture so the inspector
                 // shows what the nodes that ran produced.
@@ -824,7 +836,11 @@ async fn run_workflow_inner(
             // node; letting it ride the run inspector as the node's product would
             // re-open the same lie one surface over. The node's `blocked` chip and
             // the run's notice already say what happened.
-            let partial_output = without_nodes(partial_output, &blocked);
+            // Remove the blocked node's refusal prose, then restore only the
+            // files it actually wrote. A partial artifact is a deliverable; an
+            // apology about why the turn stopped is not.
+            let partial_output =
+                merge_run_artifacts(without_nodes(partial_output, &blocked), &captured_artifacts);
             // A blocked run DOES return a `WorkflowRun`, so a failed persist adds
             // an operator-facing notice rather than only a log line (Part 6).
             if !persist_run_output(
@@ -900,7 +916,10 @@ async fn run_workflow_inner(
         // The transcripts the observer collected are not in the engine's run state,
         // so a clean settle would otherwise persist a snapshot that says what every
         // node emitted and nothing about what its agent did.
-        let raw_nodes = merge_transcripts(&raw_nodes, &node_transcripts);
+        let raw_nodes = merge_run_artifacts(
+            merge_transcripts(&raw_nodes, &node_transcripts),
+            &captured_artifacts,
+        );
         if !persist_run_output(
             run_output_store.as_deref(),
             &record.id,
@@ -914,7 +933,7 @@ async fn run_workflow_inner(
             notices.push(run_output_persist_failed_notice());
         }
         return Ok(WorkflowRun {
-            output: outcome.output,
+            output: merge_run_artifacts_envelope(outcome.output, &captured_artifacts),
             pending_approvals: Vec::new(),
             deliveries: Vec::new(),
             cancelled: true,
@@ -1110,6 +1129,7 @@ async fn run_workflow_inner(
     // persists that canonical map with `partial = false`; a failed write adds an
     // operator notice (Part 6) since this arm returns a `WorkflowRun`.
     let raw_nodes = outcome.output.get("nodes").cloned().unwrap_or(Value::Null);
+    let raw_nodes = merge_run_artifacts(raw_nodes, &captured_artifacts);
     if !persist_run_output(
         run_output_store.as_deref(),
         &record.id,
@@ -1153,7 +1173,7 @@ async fn run_workflow_inner(
     }
 
     Ok(WorkflowRun {
-        output: outcome.output,
+        output: merge_run_artifacts_envelope(outcome.output, &captured_artifacts),
         pending_approvals,
         deliveries,
         cancelled: false,
@@ -1433,6 +1453,49 @@ fn merge_transcripts(nodes: &Value, transcripts: &serde_json::Map<String, Value>
         slot.insert("transcript".to_string(), transcript.clone());
     }
     Value::Object(merged)
+}
+
+/// Adds card-less run artifacts to their node slots without changing items.
+///
+/// Unlike transcripts, artifacts may legitimately belong to a node that ended
+/// in error and therefore has no engine output slot. Such a slot is created
+/// with an empty `items` array so the inspector can surface the files while
+/// still truthfully showing no reply text.
+fn merge_run_artifacts(nodes: Value, artifacts: &serde_json::Map<String, Value>) -> Value {
+    if artifacts.is_empty() {
+        return nodes;
+    }
+    let mut nodes = match nodes {
+        Value::Object(nodes) => nodes,
+        _ => serde_json::Map::new(),
+    };
+    for (node_id, rows) in artifacts {
+        let slot = nodes
+            .entry(node_id.clone())
+            .or_insert_with(|| serde_json::json!({ "items": [] }));
+        if let Value::Object(slot) = slot {
+            slot.insert("artifacts".to_string(), rows.clone());
+        }
+    }
+    Value::Object(nodes)
+}
+
+/// Applies [`merge_run_artifacts`] to a full engine output envelope.
+fn merge_run_artifacts_envelope(
+    mut output: Value,
+    artifacts: &serde_json::Map<String, Value>,
+) -> Value {
+    if artifacts.is_empty() {
+        return output;
+    }
+    let Value::Object(envelope) = &mut output else {
+        return serde_json::json!({
+            "nodes": merge_run_artifacts(Value::Null, artifacts),
+        });
+    };
+    let nodes = envelope.remove("nodes").unwrap_or(Value::Null);
+    envelope.insert("nodes".to_string(), merge_run_artifacts(nodes, artifacts));
+    output
 }
 
 async fn persist_run_output(
@@ -1929,6 +1992,194 @@ mod tests {
                 seen: std::sync::Mutex::new(Vec::new()),
             })
         }
+    }
+
+    /// A full workflow-node turn double that writes a real sandbox file before
+    /// either failing or parking an approval. It drives the real engine,
+    /// capability, mirror, output-store, and workspace-store seams; only model
+    /// inference is replaced.
+    struct ArtifactWritingTurn {
+        workspace_root: std::path::PathBuf,
+        approvals: crate::harness::policy::ApprovalRequestQueue,
+        blocked: bool,
+    }
+
+    impl ArtifactWritingTurn {
+        async fn execute(
+            &self,
+            company: &CompanyId,
+            agent_id: &str,
+        ) -> Result<crate::harness::TurnOutcome> {
+            let workspace =
+                crate::harness::build::agent_workspace(&self.workspace_root, company, agent_id);
+            let report = workspace.join("reports/partial.md");
+            tokio::fs::create_dir_all(report.parent().expect("report parent")).await?;
+            tokio::fs::write(&report, b"# Partial report\n\nCaptured before settle.\n").await?;
+
+            if !self.blocked {
+                return Err(OpenCompanyError::Harness(
+                    "synthetic node failure after writing its file".to_string(),
+                ));
+            }
+
+            self.approvals
+                .push(crate::harness::policy::ApprovalRequest {
+                    tool: "shell".to_string(),
+                    reason: "synthetic approval after writing".to_string(),
+                    effect: crate::ports::types::Effect {
+                        kind: "shell".to_string(),
+                        group: crate::ports::types::EffectGroup::Other,
+                        amount_usd: None,
+                        established_thread: false,
+                        first_time_counterparty: false,
+                        payload: serde_json::json!({ "command": "finish-report" }),
+                        agent: Some(agent_id.to_string()),
+                        run_id: None,
+                    },
+                });
+            Ok(crate::harness::TurnOutcome {
+                reply: "Waiting for approval.".to_string(),
+                steps: Vec::new(),
+                hit_iteration_cap: false,
+                halted_for_spend: None,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl crate::runtime::delegation::RunTurn for ArtifactWritingTurn {
+        async fn run(
+            &self,
+            company: &CompanyId,
+            agent_id: &str,
+            _message: &str,
+            _chat_id: Option<&str>,
+        ) -> Result<crate::harness::TurnOutcome> {
+            self.execute(company, agent_id).await
+        }
+
+        async fn run_steered(
+            &self,
+            company: &CompanyId,
+            agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat_id: Option<&str>,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> Result<crate::harness::TurnOutcome> {
+            self.execute(company, agent_id).await
+        }
+
+        async fn run_steered_background(
+            &self,
+            company: &CompanyId,
+            agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> Result<crate::harness::TurnOutcome> {
+            self.execute(company, agent_id).await
+        }
+    }
+
+    fn artifact_graph() -> WorkflowFile {
+        parse_workflow(
+            r#"
+id = "artifact_capture"
+name = "Artifact capture"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Write a report."
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "done"
+"#,
+        )
+        .expect("artifact graph parses")
+    }
+
+    async fn assert_partial_run_artifact(blocked: bool) {
+        use crate::ports::workspace::WorkspaceStore;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(FsOps::new(dir.path()));
+        let (mut deps, _journal) = crate::workflows::gated_tool_turn_test::deps(
+            "http://127.0.0.1:1/unused".to_string(),
+            dir.path(),
+        );
+        deps.workspace = Some(store.clone());
+        deps.run_output_store = Some(store.clone());
+        let record = crate::workflows::gated_tool_turn_test::record();
+        let turn = Arc::new(ArtifactWritingTurn {
+            workspace_root: deps.workspace_root.clone(),
+            approvals: deps.approval_requests.clone(),
+            blocked,
+        });
+        let ctx = WorkflowRunContext::new(false);
+
+        let result = run_workflow_lane_aware(
+            turn,
+            deps,
+            &record,
+            &artifact_graph(),
+            serde_json::json!({ "request": "make the report" }),
+            &ctx,
+        )
+        .await;
+        if blocked {
+            let run = result.expect("an approval-blocked run settles successfully");
+            assert!(
+                run.blocked_nodes.iter().any(|node| node.node_id == "work"),
+                "the synthetic approval must block work: {run:?}"
+            );
+        } else {
+            assert!(result.is_err(), "the synthetic failure must fail the run");
+        }
+
+        let stored = store
+            .get_run_output(&record.id, &ctx.run_id)
+            .await
+            .expect("run-output read")
+            .expect("failed and blocked runs both persist partial output");
+        assert!(stored.partial, "capture must be marked partial: {stored:?}");
+        let artifact = &stored.nodes["work"]["artifacts"][0];
+        assert_eq!(artifact["source"], "reports/partial.md");
+        let node_id = artifact["workspaceNodeId"]
+            .as_str()
+            .expect("capture links a workspace node");
+        let (node, body) = WorkspaceStore::read(store.as_ref(), &record.id, node_id)
+            .await
+            .expect("workspace read")
+            .expect("mirrored run artifact exists");
+        assert_eq!(node.name, "partial.md");
+        assert!(
+            body.contains("Captured before settle"),
+            "the mirrored node keeps the written body: {body:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_agent_node_keeps_the_file_it_wrote_as_a_run_artifact() {
+        assert_partial_run_artifact(false).await;
+    }
+
+    #[tokio::test]
+    async fn a_blocked_agent_node_keeps_the_file_it_wrote_as_a_run_artifact() {
+        assert_partial_run_artifact(true).await;
     }
 
     #[async_trait]


### PR DESCRIPTION
## Summary

- Snapshot each workflow agent nodes sandbox immediately before its turn.
- Capture changed and staged files after every turn, including failure and approval-block paths.
- Materialize card-less files under a run- and node-scoped workspace path and persist their links with node output.
- Render captured artifacts in the node inspector instead of the misleading no-readable-text empty state.

## API Or Behavior Changes

Workflow agent-node files are now mirrored under artifacts/<agent>/runs/<run>/<node>/... and included in durable per-node run output as artifact metadata. Failed and blocked nodes retain partial files without retaining blocker prose as output.

## Tests

- [x] cargo check
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --no-deps -- -D warnings
- [x] cargo clippy --no-deps --features openhuman --all-targets -- -D warnings
- [x] cargo test --features openhuman company::artifact_mirror
- [x] cargo test --features openhuman workflows::caps
- [x] cargo test --features openhuman workflows::runner
- [x] npx vitest run test/unit/node-output-partial.test.ts
- [x] npm run typecheck

## Documentation

No standalone documentation change is needed; this restores expected run-capture behavior and the code documents the run-scoped storage and persistence contract.

Closes #1753.