### PR TITLE
ci(desktop): fix tauri build --locked arg placement

### DIFF
--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -104,7 +104,7 @@ jobs:
           # Keep in sync with bundle.macOS.minimumSystemVersion in
           # src-tauri/tauri.conf.json — the Wry system-WebView floor.
           MACOSX_DEPLOYMENT_TARGET: "12.0"
-        run: ../frontend/node_modules/.bin/tauri build --locked --target aarch64-apple-darwin
+        run: ../frontend/node_modules/.bin/tauri build --target aarch64-apple-darwin -- --locked
 
       # Guard: a public Release must never carry an unsigned DMG.
       - name: Guard release-requires-signing


### PR DESCRIPTION
## Summary
The macOS DMG pipeline's first live run (32877758039) failed at the `tauri build` step. This moves `--locked` to where the Tauri CLI expects cargo args.

## Problem
`tauri build --locked --target aarch64-apple-darwin` errors:
```
error: unexpected argument '--locked' found
tip: to pass '--locked' as a value, use '-- --locked'
```
The Tauri CLI does not accept `--locked` as its own flag — cargo args must follow a `--` separator.

## Solution
`tauri build --target aarch64-apple-darwin -- --locked` — `--locked` is now forwarded to the underlying `cargo build`.

## Submission Checklist
- [x] actionlint clean
- [ ] Live-run validated — N/A pre-merge: `workflow_dispatch` resolves the workflow ref on upstream, and this branch lives on the fork, so the fixed workflow can only run once it is on `main`. Will dispatch off `main` immediately after merge and confirm the `.dmg` artifact.

## Impact
Unblocks the unsigned DMG build. No behavior change beyond fixing the invocation.

## Related
Follow-up to #1733 (the pipeline). First live-run failure: run 32877758039.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS desktop release builds for Apple Silicon by ensuring the correct architecture target and locked dependency configuration are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->