### PR TITLE
test(e2e): identify the server Playwright adopted before trusting it

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -432,6 +432,25 @@ inside `../target/e2e`. Point it anywhere else and it is reused as it stands,
 with a line saying so — a mistyped or inherited value cannot take a directory
 you care about with it.
 
+A derived port makes a collision unlikely; it does not make one *loud*. On
+2026-08-25 a suite **passed** against the wrong server — a sibling agent's dev
+server held the port, `reuseExistingServer` adopted it, and the run drove another
+worktree's bundle serving a different company. No readiness check could have
+caught it: Playwright's `url` check reads the status code and discards the body,
+and `/healthz` is a hardcoded `{"status":"ok"}` naming no instance.
+
+So `test/e2e/global-setup.ts` — which runs *after* `webServer` resolves, and is
+therefore the only hook that sees the server actually adopted — asks `/spec` who
+answered and aborts before a single spec runs unless it is an OpenCompany host
+(`application/json`, `name` is `opencompany`) **and** the right one, by
+`instance_id` against the `instance-id` file the host mints under
+`PW_HOST_DATA_DIR`. Both halves are needed: a dev server proxies `/spec` to
+whatever host it points at, so the incident above satisfies the type check alone.
+Nothing is pinned or cached, so a host restarted between runs is not an impostor.
+Against a host you brought yourself there is no root of ours to compare against —
+set `PW_EXPECTED_INSTANCE_ID` to the id you expect. Full reasoning:
+[`test/e2e/host-identity.ts`](test/e2e/host-identity.ts).
+
 The `dist/` can be served as static files by any web server (or mounted by the
 OpenCompany host); use `window.OPENCOMPANY_CONFIG` to point it at the API.
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,6 +18,7 @@ import {
   MOCK_BRAIN_BIND,
   VISUAL,
 } from "./test/e2e/capabilities";
+import { MANAGED_HOST_HOME } from "./test/e2e/host-identity";
 
 // `package.json` is `"type": "module"`, so this file is ESM and `__dirname`
 // does not exist here — it type-checks against `@types/node` and then throws at
@@ -33,7 +34,10 @@ const here = dirname(fileURLToPath(import.meta.url));
  *
  * **`PW_BASE_URL` set** — you brought your own host and this config touches
  * nothing else: no `webServer`, and `PW_STORAGE_STATE` keeps its exact former
- * meaning (unset ⇒ no `globalSetup` ⇒ no sign-in). Unchanged contract.
+ * meaning (unset ⇒ no sign-in). Unchanged contract. `globalSetup` does run
+ * either way now, to identify what is on the address before the suite trusts
+ * it (issue #1773); it still authenticates only when a storage state is
+ * configured.
  *
  * **`PW_BASE_URL` unset** — the config brings a host up itself through
  * `test/e2e/host.sh` and authenticates against it, so `npm run e2e` is the
@@ -114,8 +118,15 @@ const VISUAL_SPEC = /visual\.spec\.ts$/;
 
 const providedBaseURL = process.env.PW_BASE_URL;
 
-/** Whether this config is responsible for the host, as opposed to driving yours. */
-const managesHost = !providedBaseURL;
+/**
+ * Whether this config is responsible for the host, as opposed to driving yours.
+ *
+ * Derived from `MANAGED_HOST_HOME` rather than from `providedBaseURL` directly,
+ * even though the two say the same thing (`!process.env.PW_BASE_URL`). One
+ * source, so the address this config manages and the data root behind it can
+ * never disagree about whether there is a host of ours at all.
+ */
+const managesHost = MANAGED_HOST_HOME !== undefined;
 
 /**
  * Where a host *we* manage listens.
@@ -244,10 +255,13 @@ const composioEnv: Record<string, string> = managesComposio
  * not go through `PW_HOST_PASSTHROUGH`.
  */
 const firstRunEnv: Record<string, string> =
-  managesHost && FIRST_RUN
+  // `MANAGED_HOST_HOME !== undefined` rather than `managesHost`, which is the
+  // same test: TypeScript narrows the data root away from `undefined` only
+  // through the comparison itself, not through a boolean aliasing it.
+  MANAGED_HOST_HOME !== undefined && FIRST_RUN
     ? {
         PW_HOST_COMPANY: resolve(here, "..", FIRST_RUN_COMPANY),
-        PW_HOST_DATA_DIR: resolve(here, "../target/e2e/first-run-data"),
+        PW_HOST_DATA_DIR: MANAGED_HOST_HOME,
       }
     : {};
 
@@ -264,10 +278,11 @@ const firstRunEnv: Record<string, string> =
  * not go through `PW_HOST_PASSTHROUGH`.
  */
 const eulerEnv: Record<string, string> =
-  managesHost && EULER
+  // See `firstRunEnv` for why this is not `managesHost`.
+  MANAGED_HOST_HOME !== undefined && EULER
     ? {
         PW_HOST_COMPANY: resolve(here, "..", EULER_COMPANY),
-        PW_HOST_DATA_DIR: resolve(here, "../target/e2e/euler-data"),
+        PW_HOST_DATA_DIR: MANAGED_HOST_HOME,
       }
     : {};
 
@@ -371,7 +386,18 @@ export default defineConfig({
         : VISUAL
           ? { testMatch: VISUAL_SPEC }
           : { testIgnore: [FIRST_RUN_SPEC, LIVE_LLM_SPEC, EULER_SPEC, VISUAL_SPEC] }),
-  globalSetup: storageState ? "./test/e2e/global-setup.ts" : undefined,
+  // UNCONDITIONAL, and it was not always (issue #1773). `global-setup.ts` runs
+  // after every `webServer` above has resolved, which makes it the only hook
+  // that sees the server Playwright *adopted* rather than the one it was
+  // configured to start — and `reuseExistingServer` will adopt anything
+  // answering 2xx, including a console dev server whose SPA fallback answers
+  // 200 for `/healthz`. So it now identifies the server before doing anything
+  // else, and that has to happen on every run, not only the ones that sign in.
+  //
+  // The sign-in contract is unchanged: `global-setup.ts` reads the resolved
+  // `storageState` off the config and returns before authenticating when there
+  // is none, exactly as an absent `globalSetup` did.
+  globalSetup: "./test/e2e/global-setup.ts",
   fullyParallel: false,
   workers: 1,
   timeout: 60_000,

--- a/frontend/test/e2e/global-setup.ts
+++ b/frontend/test/e2e/global-setup.ts
@@ -5,13 +5,22 @@ import {
   type FullConfig,
 } from "@playwright/test";
 
+import {
+  EXPECTED_INSTANCE_ID,
+  MANAGED_HOST_HOME,
+  SPEC_PATH,
+  identityFailure,
+  readHomeInstanceId,
+} from "./host-identity";
+
 const ADMIN_EMAIL = "harness-e2e@tinyhumans.ai";
 const REQUEST_PATH = "/api/v1/company/auth/request";
 const VERIFY_PATH = "/api/v1/company/auth/verify";
 
 /**
- * Authenticates once and shares the session with every spec through Playwright
- * storage state, so the suite signs in a single time.
+ * Identifies the server Playwright adopted, then authenticates once and shares
+ * the session with every spec through Playwright storage state, so the suite
+ * signs in a single time.
  *
  * Every failure here aborts the whole run before a single spec executes, so the
  * message has to carry enough to diagnose it without a second run: the endpoint,
@@ -19,8 +28,30 @@ const VERIFY_PATH = "/api/v1/company/auth/verify";
  * `202 {"sent": true}` for *every* outcome by design — it refuses to say whether
  * an address is a member — so a missing `dev_code` is otherwise indistinguishable
  * from a broken host, which is exactly what issue #271 sent people chasing.
+ *
+ * The identity check comes first, and ahead of the storage-state early return,
+ * because this hook runs after `webServer` has resolved and is therefore the
+ * only place that sees which server was actually adopted rather than which one
+ * was configured — issue #1773, and `host-identity.ts` for the whole story. A
+ * run with no sign-in still gets it: what is on the port is worth knowing even
+ * when nothing is about to log in to it.
  */
 export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use.baseURL as string | undefined;
+  if (!baseURL) {
+    throw new Error(
+      "[e2e global-setup] no baseURL is configured. Set PW_BASE_URL to the " +
+        "running OpenCompany host, e.g. PW_BASE_URL=http://127.0.0.1:8080.",
+    );
+  }
+
+  const identity = await request.newContext({ baseURL });
+  try {
+    await identifyServer(identity, baseURL);
+  } finally {
+    await identity.dispose();
+  }
+
   // Read the RESOLVED path off the config, not `process.env.PW_STORAGE_STATE`.
   // The config now defaults it when it is the one bringing the host up (issue
   // #406), and reading the raw variable meant this returned early in exactly
@@ -29,14 +60,6 @@ export default async function globalSetup(config: FullConfig) {
   // set: the config honours it first.
   const storageState = config.projects[0]?.use.storageState as string | undefined;
   if (!storageState) return;
-
-  const baseURL = config.projects[0]?.use.baseURL as string | undefined;
-  if (!baseURL) {
-    throw new Error(
-      "[e2e global-setup] no baseURL is configured. Set PW_BASE_URL to the " +
-        "running OpenCompany host, e.g. PW_BASE_URL=http://127.0.0.1:8080.",
-    );
-  }
 
   const context = await request.newContext({ baseURL });
   try {
@@ -88,6 +111,44 @@ export default async function globalSetup(config: FullConfig) {
   } finally {
     await context.dispose();
   }
+}
+
+/**
+ * Asks `/spec` who answered, and throws unless it is this run's host.
+ *
+ * The `instance-id` read happens **after** the request and not before: the id
+ * is minted lazily on first use, so answering us is what creates that file
+ * under the responder's own data root. Read in this order, a root of ours with
+ * no file is proof the responder does not serve it. See `host-identity.ts`.
+ */
+async function identifyServer(context: APIRequestContext, baseURL: string): Promise<void> {
+  const url = `${baseURL.replace(/\/$/, "")}${SPEC_PATH}`;
+
+  let response: APIResponse;
+  try {
+    response = await context.get(SPEC_PATH);
+  } catch (error) {
+    throw new Error(
+      `[e2e global-setup] GET ${url} did not answer: ${String(error)}\n` +
+        "Either nothing is serving this address, or something is holding the " +
+        "connection open without ever replying — a wedged process still owns " +
+        "the port. Either way the suite has no host to drive.",
+    );
+  }
+
+  const failure = identityFailure({
+    url,
+    status: response.status(),
+    contentType: response.headers()["content-type"] ?? null,
+    // Text, not JSON: a dev server's HTML fallback is exactly the body worth
+    // quoting back, and `.json()` would throw over it before it could be shown.
+    body: await response.text().catch(() => "<body could not be read>"),
+    expectedInstanceId: EXPECTED_INSTANCE_ID,
+    home: MANAGED_HOST_HOME,
+    homeInstanceId: MANAGED_HOST_HOME ? readHomeInstanceId(MANAGED_HOST_HOME) : undefined,
+  });
+
+  if (failure) throw new Error(`[e2e global-setup] ${failure}`);
 }
 
 /** A response paired with the request that produced it, for reporting. */

--- a/frontend/test/e2e/host-identity.ts
+++ b/frontend/test/e2e/host-identity.ts
@@ -1,0 +1,293 @@
+/**
+ * Whether the server the suite is about to drive is *this run's* host — not
+ * merely *a* server that answered (issue #1773).
+ *
+ * # The failure this exists to stop
+ *
+ * On 2026-08-25 an end-to-end suite **passed** against the wrong server. A
+ * sibling agent's Vite dev server held the port; `webServer.reuseExistingServer`
+ * adopted it; the whole suite ran against another worktree's bundle serving a
+ * different company, and every assertion passed. It was caught only because a
+ * stack trace named unbundled `/src/...` paths and the company read `acme`
+ * rather than the harness company. Hours later a second agent found `/healthz`
+ * answering `{"status":"ok"}` on its own port *from another process entirely*,
+ * while its own host had exited.
+ *
+ * A green suite against a stranger's server is worse than a red one, because it
+ * is reported as evidence.
+ *
+ * # Why the readiness check cannot catch it
+ *
+ * Two properties combine badly, and both are load-bearing:
+ *
+ *  1. **Playwright's `url` check reads the status code and nothing else.** Its
+ *     `isURLAvailable` resolves `statusCode >= 200 && statusCode < 404` and
+ *     calls `res.resume()` on the body without looking at it — so a Vite SPA
+ *     fallback, which answers `200 text/html` for *any* path including
+ *     `/healthz`, satisfies a check written for a Rust host. A 302 or a 403
+ *     satisfies it too.
+ *  2. **`/healthz` names no instance.** It returns a hardcoded
+ *     `{"status":"ok"}` (`src/server/routes.rs`), so even a real host is
+ *     indistinguishable from a *different* real host.
+ *
+ * The readiness check answers "something is listening" when the question is
+ * "is *my* server listening".
+ *
+ * # Where the check has to live
+ *
+ * In `globalSetup`, which Playwright runs **after** every `webServer` plugin
+ * has resolved (`createGlobalSetupTasks` orders plugin setup ahead of the
+ * global-setup files). That makes it the only hook that observes the server
+ * Playwright actually adopted, as opposed to the one it was configured to
+ * start.
+ *
+ * There is precedent one layer down: `scripts/desktop-dev.sh` refuses to adopt
+ * a console dev server unless the response body contains `OpenCompany Console`,
+ * "so it never reuses a stranger's". This is the same idea with an identifier
+ * instead of a page title.
+ *
+ * # Type, and then identity
+ *
+ * Catching "this is not an OpenCompany host" is the easy half and stops the
+ * first incident: `/spec` is JSON and names the crate. Catching "this is a
+ * *different* OpenCompany host" is the second incident, and needs something
+ * that differs between two hosts. That is `instance_id` — a random, stable,
+ * per-data-root id the host already serves unauthenticated on `/spec` (see
+ * `src/app/instance.rs`).
+ *
+ * Knowing which id to *expect* is the whole trick, and there are two answers:
+ *
+ *  - **You named one.** `PW_EXPECTED_INSTANCE_ID` is checked whenever it is
+ *    set, including against a host you brought yourself with `PW_BASE_URL`.
+ *    This is the seam for tooling that already pinned the id when it claimed
+ *    the port.
+ *
+ *  - **We started the host, so we know its data root.** A host mints its id
+ *    into `<data-root>/instance-id` and serves that same value, so the file is
+ *    the host's own signature on the root we told it to serve. The read happens
+ *    **after** the `/spec` request on purpose: the id is minted lazily on first
+ *    use, so a freshly booted host has written no file until something asks —
+ *    verified on 2026-08-25 against a host on a fresh root, where the file was
+ *    absent after `/healthz` answered and present, matching, immediately after
+ *    `/spec` did. Read in that order the absence of the file is itself
+ *    conclusive: had the responder been serving our root, answering us would
+ *    have created it.
+ *
+ * Nothing here is pinned, cached or written. The expectation is derived fresh
+ * from the run's own configuration every time, so a host legitimately restarted
+ * between runs — which `test/e2e/host.sh` does on every managed run, wiping the
+ * root — is not mistaken for an impostor.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { EULER, FIRST_RUN } from "./capabilities";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+
+/** The unauthenticated handshake that names the crate and the instance. */
+export const SPEC_PATH = "/spec";
+
+/** The file a host mints its identity into, directly under its data root. */
+const INSTANCE_ID_FILE = "instance-id";
+
+/**
+ * The instance data root a host **we** manage is told to serve, or `undefined`
+ * when `PW_BASE_URL` hands the host over to the caller entirely.
+ *
+ * Mirrors `test/e2e/host.sh`'s own resolution exactly, for the same reason
+ * `playwright.config.ts` mirrors its port derivation: the script computes a
+ * default when Playwright does not pass one, and the two must agree or a
+ * standalone run and a managed run would disagree about which root is in play.
+ *
+ * The lane defaults come first because `playwright.config.ts` *sets*
+ * `PW_HOST_DATA_DIR` for those lanes — it overrides whatever the caller had, so
+ * reading the caller's value here would name a root the host was never given.
+ * Outside those lanes the caller's value is what `host.sh` receives, so it wins.
+ */
+export const MANAGED_HOST_HOME: string | undefined = process.env.PW_BASE_URL
+  ? undefined
+  : FIRST_RUN
+    ? join(repoRoot, "target/e2e/first-run-data")
+    : EULER
+      ? join(repoRoot, "target/e2e/euler-data")
+      : process.env.PW_HOST_DATA_DIR || join(repoRoot, "target/e2e/data");
+
+/**
+ * The instance id the caller says this run must be talking to.
+ *
+ * The escape hatch for a host you brought yourself: `PW_BASE_URL` tells this
+ * config nothing about which host is at that address, but whoever claimed the
+ * port already read its `instance_id` and can say so here.
+ */
+export const EXPECTED_INSTANCE_ID: string | undefined = process.env
+  .PW_EXPECTED_INSTANCE_ID?.trim()
+  ? process.env.PW_EXPECTED_INSTANCE_ID.trim()
+  : undefined;
+
+/**
+ * The identity a host has already recorded under `home`, if any.
+ *
+ * `undefined` covers every way of not knowing — no file, an unreadable one, a
+ * root that does not exist — because they all mean the same thing to the caller
+ * and none of them is worth a distinct failure mode.
+ */
+export function readHomeInstanceId(home: string): string | undefined {
+  try {
+    const recorded = readFileSync(join(home, INSTANCE_ID_FILE), "utf8").trim();
+    return recorded || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Everything observed about the server that answered, in one place. */
+export type HostObservation = {
+  /** The absolute URL that was asked, so a failure needs no re-run to place. */
+  url: string;
+  status: number;
+  contentType: string | null;
+  /** The raw body, read as text — an HTML error page is the case worth quoting. */
+  body: string;
+  /** {@link EXPECTED_INSTANCE_ID}, when the caller named one. */
+  expectedInstanceId?: string;
+  /** {@link MANAGED_HOST_HOME}, when this run brought the host up itself. */
+  home?: string;
+  /** {@link readHomeInstanceId} over {@link home}, read AFTER the request. */
+  homeInstanceId?: string;
+};
+
+/**
+ * Why `seen` is not this run's host, or `undefined` when it is.
+ *
+ * A pure function of the observation, so the verdicts are unit-testable without
+ * a server (`test/unit/host-identity.test.ts`). Every message names the URL,
+ * the status, the content type and the first bytes of the body, because this
+ * aborts the run before a single spec executes and a person reading it has
+ * nothing else to go on.
+ */
+export function identityFailure(seen: HostObservation): string | undefined {
+  const evidence =
+    `GET ${seen.url} → ${seen.status}; content-type: ${seen.contentType ?? "<none>"}; ` +
+    `body: ${preview(seen.body)}`;
+
+  if (seen.status < 200 || seen.status >= 300) {
+    return (
+      `${evidence}\n` +
+      "An OpenCompany host answers /spec with 200 and JSON. Whatever is on " +
+      "this address either is not one, or is not ready."
+    );
+  }
+
+  if (!/^application\/json\b/i.test(seen.contentType ?? "")) {
+    return `${evidence}\n${NOT_A_HOST}`;
+  }
+
+  let spec: { name?: unknown; instance_id?: unknown };
+  try {
+    spec = JSON.parse(seen.body) as typeof spec;
+  } catch {
+    return (
+      `${evidence}\n` +
+      "The content type said JSON but the body does not parse as JSON.\n" +
+      NOT_A_HOST
+    );
+  }
+
+  if (spec.name !== "opencompany") {
+    return (
+      `${evidence}\n` +
+      `/spec parsed, but its "name" is ${JSON.stringify(spec.name)} rather ` +
+      `than "opencompany".\n${NOT_A_HOST}`
+    );
+  }
+
+  const instanceId = typeof spec.instance_id === "string" ? spec.instance_id : undefined;
+
+  // An explicit expectation outranks a derived one: the caller who set it knows
+  // something this config does not, and is the reason the variable exists.
+  if (seen.expectedInstanceId) {
+    if (instanceId !== seen.expectedInstanceId) {
+      return (
+        `${evidence}\n` +
+        `This is an OpenCompany host, but NOT the one this run was told to ` +
+        `drive.\n` +
+        `  PW_EXPECTED_INSTANCE_ID: ${seen.expectedInstanceId}\n` +
+        `  the host that answered:  ${instanceId ?? "<no instance_id in /spec>"}\n` +
+        `${WRONG_HOST_ADVICE}`
+      );
+    }
+    return undefined;
+  }
+
+  // No expectation to check against: a host we did not start and were not told
+  // how to recognise is as far as this can go, and saying so is better than
+  // implying a check that did not happen.
+  if (!seen.home) return undefined;
+
+  if (!instanceId) {
+    return (
+      `${evidence}\n` +
+      "/spec carries no instance_id, so this host cannot be told apart from " +
+      "any other. A host predating src/app/instance.rs would do this — check " +
+      "that PW_HOST_BINARY is not a stale build."
+    );
+  }
+
+  if (!seen.homeInstanceId) {
+    return (
+      `${evidence}\n` +
+      `This is an OpenCompany host, but it is NOT serving the data root this ` +
+      `run manages:\n` +
+      `  data root this run manages: ${seen.home}\n` +
+      `  the host that answered:     instance ${instanceId}\n` +
+      "Answering /spec is what mints that root's `instance-id` file, so a root " +
+      "with no file after the request above was never served by the responder. " +
+      "Something else is on this address.\n" +
+      `${WRONG_HOST_ADVICE}`
+    );
+  }
+
+  if (seen.homeInstanceId !== instanceId) {
+    return (
+      `${evidence}\n` +
+      `This is an OpenCompany host, but a DIFFERENT one from the host this ` +
+      `run manages:\n` +
+      `  ${join(seen.home, INSTANCE_ID_FILE)} records: ${seen.homeInstanceId}\n` +
+      `  the host that answered:                       ${instanceId}\n` +
+      `${WRONG_HOST_ADVICE}`
+    );
+  }
+
+  return undefined;
+}
+
+/** Said whenever the responder is not an OpenCompany host at all. */
+const NOT_A_HOST =
+  "This is not an OpenCompany host. `webServer.reuseExistingServer` adopts " +
+  "anything answering 2xx on the port — a console dev server (`npm run dev`) " +
+  "answers 200 for every path through its SPA fallback, and satisfies the " +
+  "/healthz readiness check exactly as a host would (issue #1773).\n" +
+  "Free the port, or point this run somewhere else with PW_BASE_URL.";
+
+/** Said whenever the responder is a host, but the wrong one. */
+const WRONG_HOST_ADVICE =
+  "Running the suite against it would report on another host's companies, " +
+  "bundle and data. Free the port, or name the host you meant with " +
+  "PW_BASE_URL / PW_HOST_BIND.";
+
+/**
+ * The first 200 bytes of a body, on one line.
+ *
+ * Whitespace is collapsed rather than preserved: the bodies worth quoting here
+ * are HTML pages whose first 200 bytes are mostly newlines and indentation, and
+ * a doctype followed by twelve blank lines identifies nothing.
+ */
+function preview(body: string): string {
+  const flattened = body.replace(/\s+/g, " ").trim();
+  if (!flattened) return "<empty>";
+  return flattened.length > 200 ? `${flattened.slice(0, 200)}…` : flattened;
+}

--- a/frontend/test/unit/host-identity.test.ts
+++ b/frontend/test/unit/host-identity.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type HostObservation,
+  identityFailure,
+} from "../e2e/host-identity";
+
+/**
+ * The verdicts behind issue #1773, tested without a server.
+ *
+ * The bug being guarded against is a suite that **passed** against the wrong
+ * server, so the property that matters is not "a good host is accepted" — it is
+ * that each specific wrong server is *refused*, and refused with a message
+ * someone can act on. A check that silently accepts is exactly the failure, so
+ * every case below asserts on the refusal itself and on what it says.
+ *
+ * `identityFailure` is a pure function of one observation for this reason: the
+ * only alternative place to exercise these branches is a live Playwright run
+ * against a deliberately wrong server, which is minutes per case and impossible
+ * in CI.
+ */
+
+const HOST_ID = "8b7abc408c8d4e3618424dcc8c052333";
+const OTHER_ID = "a334012b511584c99f6769dd2052c5bc";
+
+/** What a real host answers on `/spec`, trimmed to the fields checked here. */
+function specBody(instanceId = HOST_ID): string {
+  return JSON.stringify({
+    name: "opencompany",
+    version: "0.1.0",
+    instance_id: instanceId,
+    capabilities: ["rest", "graphql", "sse"],
+  });
+}
+
+/** A managed run whose host is serving the data root we manage. */
+function correct(): HostObservation {
+  return {
+    url: "http://127.0.0.1:8123/spec",
+    status: 200,
+    contentType: "application/json",
+    body: specBody(),
+    home: "/repo/target/e2e/data",
+    homeInstanceId: HOST_ID,
+  };
+}
+
+describe("identityFailure", () => {
+  it("accepts the host this run actually manages", () => {
+    expect(identityFailure(correct())).toBeUndefined();
+  });
+
+  it("accepts a JSON content type carrying a charset", () => {
+    // Axum sends `application/json`; a proxy in front of one may append a
+    // charset. Refusing that would be a false alarm on a real host.
+    expect(
+      identityFailure({ ...correct(), contentType: "application/json; charset=utf-8" }),
+    ).toBeUndefined();
+  });
+
+  it("refuses a console dev server, which is what actually happened", () => {
+    // The incident: Vite's SPA fallback answers 200 text/html for every path,
+    // so it satisfies both Playwright's status-code-only readiness check and a
+    // `/healthz` poll. This is the one case that must never pass.
+    const failure = identityFailure({
+      ...correct(),
+      contentType: "text/html",
+      body: '<!doctype html>\n<html lang="en">\n  <head>\n    <title>OpenCompany Console</title>\n',
+      homeInstanceId: undefined,
+    });
+
+    expect(failure).toBeDefined();
+    expect(failure).toContain("not an OpenCompany host");
+    // The evidence a reader needs without a second run.
+    expect(failure).toContain("http://127.0.0.1:8123/spec");
+    expect(failure).toContain("200");
+    expect(failure).toContain("text/html");
+    expect(failure).toContain("<!doctype html>");
+  });
+
+  it("refuses a DIFFERENT OpenCompany host, not merely a non-host", () => {
+    // The second incident on 2026-08-25: a real host answering on a port,
+    // from another agent's process, while this run's own host had exited.
+    const failure = identityFailure({ ...correct(), body: specBody(OTHER_ID) });
+
+    expect(failure).toBeDefined();
+    expect(failure).toContain("DIFFERENT one");
+    expect(failure).toContain(HOST_ID);
+    expect(failure).toContain(OTHER_ID);
+  });
+
+  it("refuses a host that never touched the data root this run manages", () => {
+    // Answering `/spec` is what mints the `instance-id` file under the
+    // responder's own root, so a root of ours still holding none *after* the
+    // request was not served by whoever answered.
+    const failure = identityFailure({ ...correct(), homeInstanceId: undefined });
+
+    expect(failure).toBeDefined();
+    expect(failure).toContain("NOT serving the data root");
+    expect(failure).toContain("/repo/target/e2e/data");
+  });
+
+  it("checks an explicitly named instance id, and in preference to the root", () => {
+    // `PW_EXPECTED_INSTANCE_ID` is the seam for a host you brought yourself,
+    // where there is no root of ours to compare against. It outranks the
+    // derived expectation: the caller knows something this config does not.
+    expect(
+      identityFailure({
+        url: "http://127.0.0.1:8591/spec",
+        status: 200,
+        contentType: "application/json",
+        body: specBody(OTHER_ID),
+        expectedInstanceId: HOST_ID,
+      }),
+    ).toContain("NOT the one this run was told to drive");
+
+    expect(
+      identityFailure({
+        ...correct(),
+        // A root disagreeing is ignored once the caller has named an id.
+        homeInstanceId: OTHER_ID,
+        expectedInstanceId: HOST_ID,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("refuses a non-2xx answer", () => {
+    const failure = identityFailure({ ...correct(), status: 502, body: "Bad Gateway" });
+
+    expect(failure).toContain("502");
+    expect(failure).toContain("Bad Gateway");
+  });
+
+  it("refuses JSON that is not this crate's spec", () => {
+    const failure = identityFailure({
+      ...correct(),
+      body: JSON.stringify({ name: "some-other-service", instance_id: HOST_ID }),
+    });
+
+    expect(failure).toContain('"some-other-service"');
+    expect(failure).toContain("not an OpenCompany host");
+  });
+
+  it("refuses a body that claims JSON and is not", () => {
+    const failure = identityFailure({ ...correct(), body: "<html>oops</html>" });
+
+    expect(failure).toContain("does not parse as JSON");
+  });
+
+  it("refuses a host too old to carry an instance id", () => {
+    const failure = identityFailure({
+      ...correct(),
+      body: JSON.stringify({ name: "opencompany", version: "0.1.0" }),
+    });
+
+    expect(failure).toContain("no instance_id");
+  });
+
+  it("says nothing when there is nothing to compare against", () => {
+    // A host the caller brought and did not identify. Passing here is honest:
+    // the type check ran and held, and claiming an identity check that could
+    // not happen would be worse than saying so in the docs.
+    expect(
+      identityFailure({
+        url: "http://127.0.0.1:8080/spec",
+        status: 200,
+        contentType: "application/json",
+        body: specBody(),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("quotes a long body without pasting the whole page", () => {
+    const failure = identityFailure({
+      ...correct(),
+      contentType: "text/html",
+      body: `<html>${"x".repeat(5000)}</html>`,
+    });
+
+    expect(failure).toContain("…");
+    // 200 bytes of body plus the surrounding explanation, not 5 KB of markup.
+    expect(failure!.length).toBeLessThan(1200);
+  });
+
+  it("collapses whitespace so the first 200 bytes carry 200 bytes of signal", () => {
+    // An HTML page's first 200 bytes are mostly newlines and indentation; a
+    // doctype followed by twelve blank lines identifies nothing.
+    const failure = identityFailure({
+      ...correct(),
+      contentType: "text/html",
+      body: "<!doctype html>\n\n\n        <title>Someone else</title>",
+    });
+
+    expect(failure).toContain("<!doctype html> <title>Someone else</title>");
+  });
+});


### PR DESCRIPTION
Closes #1773

## The failure

On 2026-08-25 an e2e suite **passed** against the wrong server. A sibling agent's console dev server held the port, `webServer.reuseExistingServer` adopted it, and the whole run drove another worktree's bundle serving a different company. Every assertion passed; it was caught only by a stack trace naming unbundled `/src/...` paths. Hours later a second agent found `/healthz` answering `{"status":"ok"}` on its own port from another process while its own host had exited.

## Both root-cause properties confirmed at the source

1. **Playwright's `url` check reads the status code and nothing else.** `isURLAvailable` in `playwright-core/lib/coreBundle.js` resolves `statusCode >= 200 && statusCode < 404` and calls `res.resume()` on the body without looking at it. Broader than the issue claimed — a 302 or a 403 satisfies it too.
2. **`/healthz` names no instance.** `healthz()` in `src/server/routes.rs` returns a hardcoded `HealthResponse { status: "ok" }`.

And the ordering the fix depends on: `createGlobalSetupTasks` in `playwright/lib/runner/index.js` orders `createPluginSetupTasks(config)` — where `webServerPluginsForConfig` pushes the `webServer` plugins — **ahead of** `config.globalSetups.map(createGlobalSetupTask)`. `globalSetup` is therefore the only hook that observes the server actually adopted.

## What this does

`frontend/playwright.config.ts` — `globalSetup` is now unconditional. The sign-in contract is unchanged: `global-setup.ts` reads the resolved `storageState` off the config and returns before authenticating when there is none, exactly as an absent `globalSetup` did.

`frontend/test/e2e/host-identity.ts` (new) — the expectations and the verdicts, as a pure function of one observation. `frontend/test/e2e/global-setup.ts` does the `GET /spec` and throws.

A run aborts before a single spec executes unless the responder is:

- **an OpenCompany host at all** — `application/json`, and `name` is `opencompany`; **and**
- **the right one**, by `instance_id`.

## Identity, not only type — and why it is not optional

The issue scoped the check to type and left identity as a stretch. It turns out **type checking alone would not have caught the reported incident.** `frontend/vite.config.ts` proxies `/spec`, `/healthz` and `/api` to `OC_API_TARGET`, so a console dev server answers `/spec` with a *real host's* JSON. `name === "opencompany"` holds. Reproduced below.

Knowing which id to expect, without making the config stateful:

- **A host we manage.** A host mints its id into `<PW_HOST_DATA_DIR>/instance-id` and serves the same value on `/spec`, so the file is its own signature on the root we told it to serve. Read **after** the request on purpose: the id is minted lazily (`OnceLock` in `AppState::instance_id`), so answering is what creates the file — measured on a fresh root, where the file was absent after `/healthz` answered and present, matching, immediately after `/spec` did. In that order, a root of ours holding no file is *proof* the responder never served it.
- **A host you brought (`PW_BASE_URL`).** `PW_EXPECTED_INSTANCE_ID`, checked whenever set. Whatever claimed the port already read the id.

Nothing is pinned, cached or written; the expectation is derived fresh each run, so a host legitimately restarted between runs — which `host.sh` does on every managed run — is never mistaken for an impostor.

`/healthz` is untouched, per the issue: adding an instance id there is a public API change and the wake-on-request proxy blocks on that route.

## Verification

Every run below was against a port claimed before anything was bound.

**A console dev server proxying to a real host — the exact incident.** Vite on `:8592` with `OC_API_TARGET` at a host on `:8591`; `/healthz` answers `200 application/json`, `/` answers the dev server's unbundled HTML. `PW_HOST_BIND=127.0.0.1:8592 npx playwright test …` → exit 1:

```
Error: [e2e global-setup] GET http://127.0.0.1:8592/spec → 200; content-type: application/json; body: {"name":"opencompany","version":"0.1.0",…
This is an OpenCompany host, but a DIFFERENT one from the host this run manages:
  …/target/e2e/data/instance-id records: 36ca2c5c83618336810c7951a83b72f6
  the host that answered:                       a334012b511584c99f6769dd2052c5bc
Running the suite against it would report on another host's companies, bundle and data. …
```

Note the content type: **a type-only check passes this run.**

**A plain SPA-fallback server** (200 `text/html` for every path) → exit 1, `This is not an OpenCompany host. …a console dev server (npm run dev) answers 200 for every path through its SPA fallback, and satisfies the /healthz readiness check exactly as a host would`, quoting the first 200 bytes of the page.

**A different real OpenCompany host** on the managed bind → exit 1 with the `DIFFERENT one` message and both ids.

**A wrong `PW_EXPECTED_INSTANCE_ID`** against a `PW_BASE_URL` host → exit 1, `NOT the one this run was told to drive`, naming both. With the correct id → **1 passed**.

**Happy path unchanged.** `PW_HOST_BIND=127.0.0.1:8593 npx playwright test alert-dialog-confirm.spec.ts agent-detail.spec.ts` → `host.sh` brought a host up, global-setup identified it and signed in, **4 passed (8.0s)**.

**CI path unaffected.** `reuseExistingServer: !process.env.CI` is untouched. Same run with `CI=1` → **1 passed (4.3s)**.

## Gates

| gate | result |
|---|---|
| `npm run typecheck` | exit 0 |
| `npm run typecheck:unit` | exit 0 |
| `npm run typecheck:e2e` | exit 0 (caught a narrowing bug during development) |
| `npx vitest run` | 3172 passed, **1 pre-existing failure** — see below |
| `npx vitest run test/unit/host-identity.test.ts` | 13 passed |

No Rust changed, so the Rust gates were not run.

### The one vitest failure is pre-existing and unrelated

`test/unit/workspace-repair-reveal-no-write.test.ts › does not call the write route when the residual is a file` fails on this branch **and fails when run alone**, where none of this change's files are collected by vitest — its import graph is `@/api/client`, `@/connections/ConnectionContext`, `@/views/WorkspaceView`, none of which this touches. It appears to be red on `upstream/main` (last touched by `2b75d1e56`, PR #1498) and wants an issue of its own.

## Not addressed here

The fixture `webServer` entries (`mock-brain.mjs`, `mcp-server.mjs`, `composio-backend.mjs`, `live-brain-proxy.mjs`) each wait on their own `/healthz` with `reuseExistingServer` on, and have the same class of exposure. Out of scope for this issue.
