### PR TITLE
test(workspace): freeze the clock so the residual-reveal guard stops racing autosave

### DIFF
--- a/frontend/test/unit/workspace-repair-reveal-no-write.test.ts
+++ b/frontend/test/unit/workspace-repair-reveal-no-write.test.ts
@@ -21,6 +21,29 @@ import { WorkspaceView } from "@/views/WorkspaceView";
  * *different* note open and dirty, revealing a file residual must not touch
  * the network, and the dirty note's draft must still read as unsaved
  * afterward — not "saving" or "saved" out from under the operator.
+ *
+ * # Why this file owns the clock (issue #1783)
+ *
+ * A dirty draft is the precondition here, and a dirty draft arms the editor's
+ * 800ms autosave debounce (`AUTOSAVE_DELAY_MS` in `WorkspaceView`). That
+ * autosave is correct and wanted — issue #1372 exists to make sure typing
+ * reaches the host — but it writes through the very same `client.put` these
+ * tests watch, so on real timers the file was a race: every `expect(...).not
+ * .toHaveBeenCalled()` below was really asserting "the reveal did not write
+ * *and* this test finished in under 800ms of wall clock".
+ *
+ * It did not always finish in time. Measured on `upstream/main` at 27b42eda0
+ * with no source changes, the first test reached its assertion 729ms after the
+ * keystroke in one full-suite run (green, 91% of the budget) and overran it in
+ * the next (red, one `put` to `/workspace/file/note-1` carrying the draft) —
+ * the autosave firing, not the reveal. Run alone the file finished in ~400ms
+ * and always passed, which is why it read as a `main`-only failure.
+ *
+ * So the timers are faked and only advanced deliberately. Nothing about the
+ * invariant is relaxed: the regression this file guards is `open()`'s
+ * `await flush()`, a direct call on the click path that no clock can hide.
+ * Freezing the clock removes the *other* writer, so a `put` here can only mean
+ * the click made it.
  */
 
 const ENG = "eng";
@@ -72,7 +95,15 @@ let client: ReturnType<typeof host>;
 let container: HTMLDivElement;
 let root: Root;
 
+/** `AUTOSAVE_DELAY_MS` in `WorkspaceView`. Only ever advanced past on purpose. */
+const AUTOSAVE_DELAY_MS = 800;
+
 beforeEach(() => {
+  // Only the two functions the debounce uses. Faking `Date`, `setInterval` or
+  // `queueMicrotask` as well would buy nothing here and would put React's
+  // scheduler and the mocked host's promises on a clock this file has no
+  // reason to drive.
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   Element.prototype.scrollIntoView = vi.fn();
   localStorage.clear();
@@ -84,6 +115,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  vi.useRealTimers();
 });
 
 function button(label: string): HTMLButtonElement {
@@ -107,8 +139,9 @@ function residualRows(): HTMLElement[] {
 /**
  * Open `Notes.md`, switch it to Edit, and type a paragraph the host has never
  * seen — the exact "staged draft" precondition the finding names — then open
- * the repair dialog on top of it without letting the autosave debounce (800ms,
- * real timers here) ever fire.
+ * the repair dialog on top of it. The keystroke arms the autosave debounce and
+ * deliberately leaves it armed: the clock is frozen (see the file header), so
+ * it stays pending until a test advances past it on purpose.
  */
 async function openRepairWithADirtyNoteBehindIt() {
   client = host();
@@ -165,6 +198,19 @@ describe("a residual reveal never flushes a dirty draft (PR #1498 review)", () =
     expect(client.put).not.toHaveBeenCalled();
     expect(client.patch).not.toHaveBeenCalled();
     expect(client.del).not.toHaveBeenCalled();
+
+    // …and the silence above has to be the click's doing, not an empty buffer's.
+    // Release the frozen autosave: the draft is still staged, so it writes now.
+    // If a future change ever stopped staging it — or stopped arming the
+    // debounce — the three assertions above would pass for the wrong reason and
+    // this file would guard nothing. That is the failure mode #1783 was really
+    // about, so it gets an assertion rather than a comment.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTOSAVE_DELAY_MS);
+    });
+    expect(client.put).toHaveBeenCalledWith("/api/v1/company/acme/workspace/file/note-1", {
+      content: "a paragraph the host has never seen",
+    });
   });
 
   it("leaves the open note's draft reading as unsaved, not saving or saved", async () => {


### PR DESCRIPTION
Closes #1783

## Which was wrong: the test

The code is correct. The test was racing an 800ms real timer and losing about half the time.

## The mechanism

`workspace-repair-reveal-no-write.test.ts` needs **a dirty draft** as its precondition — that is the whole point of the #1498 finding it guards. But a dirty draft arms `WorkspaceView`'s autosave debounce (`AUTOSAVE_DELAY_MS = 800`, real timers), and that autosave writes through **`client.put` — the same spy the test watches**.

So `expect(client.put).not.toHaveBeenCalled()` was never asserting only "the reveal did not write". It was asserting "the reveal did not write **and** this test finished in under 800ms of wall clock".

The `put` in the failure is the autosave doing exactly what issue #1372 asks of it:

```
"/api/v1/company/acme/workspace/file/note-1", { content: "a paragraph the host has never seen" }
```

That is `note-1`, the open note — not the residual that was clicked.

## Evidence the code is innocent

Instrumented probes against `upstream/main` at `27b42eda0`, source untouched:

| Probe | Result |
|---|---|
| Type a draft, **click nothing at all**, sample every 200ms | 0 puts at 622ms → **1 put at 855ms**, `saveState` flips to `saved`. The debounce fires on its own. |
| Type, open repair, wait 900ms (autosave fires, 1 put), **then** click the file residual | puts before click 1 → puts after click 1. **Delta 0.** The reveal click writes nothing, even with a staged draft sitting there. |

Static confirmation: `onReveal`'s non-folder branch is `setExpanded(...)` + `setRevealId(id)`. Pure state. It never reaches `open()`, so it never reaches `open()`'s `await flush()`.

## When it started failing

It has been fragile since the day it landed — `2b75d1e56`, 2026-08-21, the only commit ever to touch the file. Nothing drifted under it: `AUTOSAVE_DELAY_MS = 800` has been in place since `b49f07b3a` (#177), well before the test existed. The test was born with a hard 800ms wall-clock budget and no protection against exceeding it.

It reads as a "main-only failure" because run **alone** the file finishes in ~400ms and always passes; only the loaded full suite crosses the line.

Two full-suite runs on identical, unmodified `upstream/main` code, instrumented to print the elapsed time at the assertion:

- run A — **red**, budget overrun
- run B — **green**, `{"budgetMs":800,"msFromKeystrokeToAssertion":729,"puts":0}` — 91% of the budget

Same commit, same machine, opposite results. That is the flake, measured.

## CI vs local

They disagree, and the disagreement is luck rather than a real environment difference — which is the more worrying reading.

CI runs the same `npx vitest run` (`npm test` in the `Console` job); there is no shard, pool or worker override in `vitest.config.ts`. Recent `main` runs show `Console` = `success` whenever it runs. But it is under the same 800ms budget, so **CI has been passing a coin-flip, not a gate** — a latent CI flake, not a stable green.

Worth noting separately: on the exact base SHA `27b42eda0`, the `Console` job was **`skipped`** by the changed-areas path filter, so that run's green says nothing at all about vitest. Three of the last six `main` runs skipped `Console` the same way.

## The change

Test file only. `git diff upstream/main -- frontend/src` is empty.

- Fake **only** `setTimeout`/`clearTimeout` — the two functions the debounce uses. `Date`, `setInterval` and microtasks stay real, so React's scheduler and the mocked host's promises are not put on a clock this file has no reason to drive.
- Advance past the debounce only on purpose.
- Add a **non-vacuity assertion**: after the three silences, release the frozen debounce and require the write to land with the draft's exact payload. Without it, a future change that stopped staging the draft would make all three silences pass for the wrong reason and the file would guard nothing — which is the failure mode #1783 is actually about.

Nothing is relaxed. Every original assertion is still there, unchanged.

## Mutations proving it is non-vacuous

**1 — the fix still catches the bug it exists for.** Reverted the #1498 source fix (`else void open(id)`), left the new test as written:

```
× does not call the write route when the residual is a file
    expected "spy" to not be called at all, but actually been called 1 times
× leaves the open note's draft reading as unsaved, not saving or saved
× still does the reveal: closes the dialog and does not disturb the open note
  Tests  3 failed (3)
```

All three go red under the frozen clock. Coverage is strictly better than before — previously only one caught it in isolation. Source then restored byte-identical.

**2 — the frozen clock is what removes the race.** Injected a deliberate 900ms delay before the reveal click into two throwaway copies:

- **original** test (real timers) + 900ms → **RED**, `put` called 1 time
- **fixed** test (fake timers) + 900ms of genuine busy-waited wall clock → **GREEN**, with the non-vacuity assertion still passing inside it

## Verification

Commands run in `frontend/`, on the branch with the merge of `upstream/main` in place:

- `npx vitest run` — **340 files / 3171 tests passed, 0 failed**, run **twice** post-merge (and three consecutive fully-green runs pre-merge). Fully green, not "the one test passes".
- `npm run typecheck` — clean
- `npm run typecheck:unit` — clean
- `npm run typecheck:e2e` — clean
- `./scripts/ci/assert-design-tokens.sh` — clean

No Rust changed, so the cargo gates do not apply.
