### PR TITLE
ci(release-desktop-macos): matrix-build arm64 + x86_64 DMGs

### DIFF
--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -1,7 +1,9 @@
 # Issue #1732. Package the OpenCompany Tauri desktop shell as a macOS DMG.
 #
-# By default this produces an UNSIGNED arm64 (aarch64-apple-darwin) .dmg and
-# uploads it as an Actions artifact — the fast path for internal / CI builds.
+# A matrix runs both macOS targets — arm64 (aarch64-apple-darwin) and Intel
+# (x86_64-apple-darwin) — so one dispatch produces both DMGs. By default each
+# leg produces an UNSIGNED .dmg and uploads it as a per-target Actions
+# artifact — the fast path for internal / CI builds.
 # Developer-ID signing + Apple notarization is GATED behind the `sign` input
 # and the presence of the six APPLE_* secrets; only a signed+notarized DMG is
 # ever attached to a GitHub Release (`create_release`). An unsigned DMG never
@@ -41,9 +43,17 @@ permissions:
 
 jobs:
   build:
-    name: "Desktop: aarch64-apple-darwin"
+    name: "Desktop: ${{ matrix.target }}"
     runs-on: macos-latest
     timeout-minutes: 90
+    strategy:
+      # One target's failure must not cancel the other — each produces an
+      # independent DMG, and a partial success is still worth publishing.
+      fail-fast: false
+      matrix:
+        # macos-latest is an arm64 runner; it cross-compiles the x86_64 Intel
+        # target fine once `rustup target add` installs it below.
+        target: [aarch64-apple-darwin, x86_64-apple-darwin]
     steps:
       # Check out the exact `tag` being published, NOT the dispatch ref. If the
       # branch advanced since the tag was cut, an unpinned checkout would build
@@ -63,17 +73,17 @@ jobs:
         run: scripts/ci/init-vendored-submodules.sh
 
       # Reads the pinned toolchain; `toolchain:` must match rust-toolchain.toml
-      # (asserted by scripts/ci/assert-toolchain-pin.sh). Add the macOS arm64
-      # cross target on the same toolchain the build uses.
+      # (asserted by scripts/ci/assert-toolchain-pin.sh). Add the macOS cross
+      # target for this matrix leg on the same toolchain the build uses.
       - name: Install Rust (rust-toolchain.toml)
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.98.0"
           components: rustfmt, clippy
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
-      - name: Ensure aarch64-apple-darwin target
-        run: rustup target add aarch64-apple-darwin
+      - name: Ensure ${{ matrix.target }} target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -104,7 +114,7 @@ jobs:
           # Keep in sync with bundle.macOS.minimumSystemVersion in
           # src-tauri/tauri.conf.json — the Wry system-WebView floor.
           MACOSX_DEPLOYMENT_TARGET: "12.0"
-        run: ../frontend/node_modules/.bin/tauri build --target aarch64-apple-darwin -- --locked
+        run: ../frontend/node_modules/.bin/tauri build --target ${{ matrix.target }} -- --locked
 
       # Guard: a public Release must never carry an unsigned DMG.
       - name: Guard release-requires-signing
@@ -116,7 +126,7 @@ jobs:
       - name: Locate .app and .dmg bundles
         id: locate
         env:
-          TARGET: aarch64-apple-darwin
+          TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
           BUNDLE_DIR="src-tauri/target/${TARGET}/release/bundle"
@@ -194,22 +204,45 @@ jobs:
         run: |
           xcrun stapler validate "${{ steps.locate.outputs.dmg_path }}"
 
+      # Both matrix legs produce a DMG whose filename is derived only from the
+      # product name + version — identical across targets. Rename to embed the
+      # target so the two artifacts don't collide and both can attach to one
+      # Release with distinct asset names. Runs for every leg (signed or not);
+      # the staple lives inside the .dmg, so renaming the file preserves it.
+      - name: Name DMG per target
+        id: rename
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          SRC="${{ steps.locate.outputs.dmg_path }}"
+          DIR="$(dirname "$SRC")"
+          BASE="$(basename "$SRC" .dmg)"
+          DEST="${DIR}/${BASE}_${TARGET}.dmg"
+          if [ "$SRC" != "$DEST" ]; then
+            mv "$SRC" "$DEST"
+          fi
+          echo "dmg_path=$DEST" >> "$GITHUB_OUTPUT"
+          echo "Renamed DMG to: $DEST"
+
       # ---- Publish -----------------------------------------------------------
       # Signed → attach to the GitHub Release. (The guard above proves sign=true
       # whenever create_release is true, so this only ever attaches a notarized
-      # DMG.)
+      # DMG.) The per-target filename keeps each leg's asset distinct on the
+      # shared Release.
       - name: Attach signed DMG to release
         if: inputs.create_release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ inputs.tag }}
-          files: ${{ steps.locate.outputs.dmg_path }}
+          files: ${{ steps.rename.outputs.dmg_path }}
 
       # Otherwise upload the DMG (unsigned by default) as an Actions artifact.
+      # Per-target artifact name so the two matrix legs don't overwrite.
       - name: Upload DMG as Actions artifact
         if: "!inputs.create_release"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: opencompany-macos-aarch64-dmg
-          path: ${{ steps.locate.outputs.dmg_path }}
+          name: opencompany-macos-${{ matrix.target }}-dmg
+          path: ${{ steps.rename.outputs.dmg_path }}
           if-no-files-found: error


### PR DESCRIPTION
## Summary

Adds `x86_64-apple-darwin` (Intel) to the macOS DMG release pipeline. The single-target `build` job in `release-desktop-macos.yml` is now a `strategy.matrix.target` over `[aarch64-apple-darwin, x86_64-apple-darwin]`, so one dispatch produces both an Apple-Silicon and an Intel DMG.

- `fail-fast: false` — one leg's failure never cancels the other; a partial success still publishes.
- `runs-on: macos-latest` (arm64) cross-compiles the Intel target once `rustup target add` installs it.
- Every hardcoded `aarch64-apple-darwin` replaced with `${{ matrix.target }}` (toolchain `targets:`, `rustup target add`, `tauri build --target`, and the `TARGET` env that drives `bundle_dir`).
- New **Name DMG per target** step renames the bundle to `<base>_<target>.dmg` — Tauri names both DMGs identically (productName + version), so without this the two artifacts/Release assets would collide. The notarization staple lives inside the `.dmg`, so renaming the file on disk preserves it.
- Per-target-distinct publishing: Actions artifact `opencompany-macos-${{ matrix.target }}-dmg`; Release asset name derives from the per-target filename, so both attach to one Release.

Signing/notarization gating (`Guard release-requires-signing`, `if: inputs.sign`) and all SHA-pinned `uses:` are unchanged — they now run per matrix leg.

## API Or Behavior Changes

None (CI workflow only). One dispatch now emits two DMGs instead of one.

## Tests

CI-only change — no local Rust gates apply. Validated:

- [x] `actionlint` clean on the workflow
- [ ] Live matrix run — not possible pre-merge: `workflow_dispatch` resolves on the default branch, so the matrix run can only be dispatched after this lands on `main`.

## Documentation

The header comment block in the workflow is updated to describe the two-target matrix.

## Related

Part of #1732 (macOS DMG packaging).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS builds for both Apple Silicon and Intel devices.
  * Release downloads now include clearly labeled, architecture-specific DMG files.
  * Both macOS builds are uploaded as separate release assets and artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->