### PR TITLE
ci(desktop): build the release DMG for x86_64 too, with the shipped feature set (#1732)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2047,13 +2047,29 @@ jobs:
       # the previous step had already fixed. The guard read as present and was
       # decorative. The console wrapper's clippy below always passed it, so this
       # was an inconsistency inside one job rather than a deliberate choice.
+      #
+      # `--features` matches `DESKTOP_RELEASE_FEATURES` in
+      # `release-desktop-macos.yml` — see that file for why `acp` and
+      # `composio` are passed on the command line instead of being written into
+      # `src-tauri/Cargo.toml`. The short version: they are pure `cfg` switches
+      # that add no package, so the release build can turn them on and still
+      # satisfy `--locked`, and the default build stays lean.
+      #
+      # THIS LANE IS WHY THAT IS SAFE. Without these two flags here, clippy and
+      # the tests below would inspect the DEFAULT feature set while the shipped
+      # DMG carried a different one — a configuration nothing in CI had ever
+      # compiled, found first by whoever downloaded the release. That is the
+      # `feature-lanes.txt` pathology (issue #770) wearing a new hat: a build
+      # everybody reads as covered, selected by no lane. If the release
+      # workflow's feature string changes, change it here in the same commit.
       - name: Clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --no-deps -- -D warnings
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --no-deps --features opencompany/acp,opencompany/composio -- -D warnings
 
       # `--locked`, so a manifest edit whose lock was never regenerated is named
-      # here rather than absorbed — the desktop keeps its own `Cargo.lock`.
+      # here rather than absorbed — the desktop keeps its own `Cargo.lock`. The
+      # `--features` are the release set, for the reason above the clippy step.
       - name: Test
-        run: cargo test --manifest-path src-tauri/Cargo.toml --locked
+        run: cargo test --manifest-path src-tauri/Cargo.toml --locked --features opencompany/acp,opencompany/composio
 
       # There used to be a SECOND Tauri app here, `frontend/src-tauri/`, with
       # three more steps of its own. It is deleted, and its absence is the

--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -1,11 +1,28 @@
 # Issue #1732. Package the OpenCompany Tauri desktop shell as a macOS DMG.
 #
-# By default this produces an UNSIGNED arm64 (aarch64-apple-darwin) .dmg and
-# uploads it as an Actions artifact — the fast path for internal / CI builds.
+# By default this produces UNSIGNED .dmgs — one per macOS architecture — and
+# uploads them as Actions artifacts, the fast path for internal / CI builds.
 # Developer-ID signing + Apple notarization is GATED behind the `sign` input
 # and the presence of the six APPLE_* secrets; only a signed+notarized DMG is
 # ever attached to a GitHub Release (`create_release`). An unsigned DMG never
 # goes to a public Release.
+#
+# BOTH ARCHITECTURES, issue #1732 phase 2. The job is a matrix over `target`:
+# `aarch64-apple-darwin` and `x86_64-apple-darwin`. Both legs run on
+# `macos-latest`, which is Apple Silicon — the Intel leg CROSS-COMPILES rather
+# than booking an Intel runner. That is deliberate: `macos-13` is retired and
+# the surviving Intel label has narrower availability, so a native leg would
+# make a release depend on a second, scarcer runner pool for no gain that a
+# user can observe. Apple's clang cross-compiles the C dependencies (bundled
+# SQLite, SecurityFramework) from the same SDK, and `hdiutil` does not care
+# which architecture the .app inside the image is. Nothing here EXECUTES the
+# built binary, so the absence of Rosetta on the runner does not bite.
+#
+# Tauri names the outputs per-arch (`OpenCompany_<version>_aarch64.dmg` and
+# `..._x64.dmg`), so both legs can attach to one Release without colliding.
+#
+# FEATURES ARE PASSED AT BUILD TIME, not committed to `src-tauri/Cargo.toml`.
+# See `DESKTOP_RELEASE_FEATURES` on the build job for the whole argument.
 #
 # Issue #590. Every `uses:` below is a full commit SHA with the resolved version
 # in a trailing comment — `actions/*` included, no exemptions. The rationale is
@@ -40,10 +57,98 @@ permissions:
   contents: write
 
 jobs:
+  # Everything knowable about the DISPATCH, checked before anything is built.
+  #
+  # Both checks below used to be steps inside the build job, sitting AFTER the
+  # ~60-minute Tauri compile: a dispatch asking for a Release without signing,
+  # or asking to sign without the secrets, burned a full build before saying
+  # so. The matrix doubles that bill — two architectures, both wasted, on an
+  # input combination that was wrong at dispatch time. As its own job this
+  # fails in seconds, and `needs: guard` keeps both legs from starting.
+  #
+  # It also makes the header's "fails fast if any is missing" true, which it
+  # was not while the secret validation ran after the build.
+  guard:
+    name: Guard dispatch
+    runs-on: ubuntu-latest
+    steps:
+      # A public Release must never carry an unsigned DMG.
+      - name: Guard release-requires-signing
+        if: inputs.create_release && !inputs.sign
+        run: |
+          echo "::error::create_release=true requires sign=true — an unsigned DMG must not be attached to a GitHub Release. Re-dispatch with sign=true (and the APPLE_* secrets set)." >&2
+          exit 1
+
+      - name: Validate signing prerequisites
+        if: inputs.sign
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          # Match the resolution used by the sign/notarize steps in `build`:
+          # prefer the app-specific password, fall back to the legacy name.
+          # Validating a different secret than we use would let a run pass this
+          # check and then fail mid-notarization.
+          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=0
+          for var in APPLE_CERTIFICATE_BASE64 APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!var}" ]; then
+              echo "::error::sign=true but required macOS signing secret is missing: $var" >&2
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+
   build:
-    name: "Desktop: aarch64-apple-darwin"
+    name: "Desktop: ${{ matrix.target }}"
+    needs: guard
     runs-on: macos-latest
     timeout-minutes: 90
+    strategy:
+      # One arch failing must not cancel the other: a green arm64 DMG is worth
+      # having even while the Intel leg is being fixed, and the two failure
+      # modes are usually unrelated.
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+    env:
+      # The feature set the SHIPPED desktop build carries, over and above the
+      # default set in `src-tauri/Cargo.toml`.
+      #
+      # Deliberately here and not in that manifest. `acp` and `composio` are
+      # both `= ["openhuman"]` in the root `Cargo.toml` — pure `cfg` switches
+      # that pull no `dep:` entry, and `openhuman` is already on via `mcp`. So
+      # enabling them adds ZERO packages to the graph and leaves
+      # `src-tauri/Cargo.lock` byte-identical, which is what lets the `--locked`
+      # below still hold. A feature that gated an optional dependency could not
+      # be passed this way; it would have to move into the manifest.
+      #
+      # What they buy, and why a DMG without them is worse than lean:
+      #
+      # * `acp` — `RuntimeBuilder::with_acp_agents` is `#[cfg(feature = "acp")]`
+      #   (src/runtime/builder.rs) and `src/desktop.rs` only calls it under the
+      #   same gate, so without the feature `builder.rs` forces `acp_agents =
+      #   None` and EVERY `transport = "local"` harness resolves `unavailable`.
+      #   The desktop is the only host that has an `AcpAgentFactory` to give —
+      #   `src-tauri/src/embedded.rs` hands one over unconditionally, and the
+      #   seam on `AppState` is ungated, so it compiled and was silently
+      #   dropped. Shipping without `acp` ships that dead lane (issue #1245).
+      # * `composio` — `src/server/ops/composio.rs` reports
+      #   `in_build: cfg!(feature = "composio")`, so without it the console's
+      #   connector tiles render "this build was compiled without", an
+      #   instruction no desktop user can follow. With it they ask for the
+      #   credential they need, which a desktop operator can actually supply.
+      #   It still fails closed with none; that was never the rebuild's job.
+      #
+      # `ci.yml`'s `Desktop` lane passes this SAME string to clippy and test —
+      # otherwise the release would ship a feature combination nothing ever
+      # compiled. Keep the two in step.
+      DESKTOP_RELEASE_FEATURES: opencompany/acp,opencompany/composio
     steps:
       # Check out the exact `tag` being published, NOT the dispatch ref. If the
       # branch advanced since the tag was cut, an unpinned checkout would build
@@ -63,17 +168,18 @@ jobs:
         run: scripts/ci/init-vendored-submodules.sh
 
       # Reads the pinned toolchain; `toolchain:` must match rust-toolchain.toml
-      # (asserted by scripts/ci/assert-toolchain-pin.sh). Add the macOS arm64
-      # cross target on the same toolchain the build uses.
+      # (asserted by scripts/ci/assert-toolchain-pin.sh). Adds this leg's macOS
+      # target on the same toolchain the build uses — `x86_64-apple-darwin` is
+      # a cross target on this runner, `aarch64-apple-darwin` is native.
       - name: Install Rust (rust-toolchain.toml)
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.98.0"
           components: rustfmt, clippy
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
-      - name: Ensure aarch64-apple-darwin target
-        run: rustup target add aarch64-apple-darwin
+      - name: Ensure ${{ matrix.target }} target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -104,19 +210,15 @@ jobs:
           # Keep in sync with bundle.macOS.minimumSystemVersion in
           # src-tauri/tauri.conf.json — the Wry system-WebView floor.
           MACOSX_DEPLOYMENT_TARGET: "12.0"
-        run: ../frontend/node_modules/.bin/tauri build --target aarch64-apple-darwin -- --locked
-
-      # Guard: a public Release must never carry an unsigned DMG.
-      - name: Guard release-requires-signing
-        if: inputs.create_release && !inputs.sign
         run: |
-          echo "::error::create_release=true requires sign=true — an unsigned DMG must not be attached to a GitHub Release. Re-dispatch with sign=true (and the APPLE_* secrets set)." >&2
-          exit 1
+          ../frontend/node_modules/.bin/tauri build \
+            --target ${{ matrix.target }} \
+            -- --locked --features "$DESKTOP_RELEASE_FEATURES"
 
       - name: Locate .app and .dmg bundles
         id: locate
         env:
-          TARGET: aarch64-apple-darwin
+          TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
           BUNDLE_DIR="src-tauri/target/${TARGET}/release/bundle"
@@ -141,29 +243,8 @@ jobs:
           echo "Found .dmg: $DMG_PATH"
 
       # ---- Optional: Developer-ID sign + notarize (gated on `sign`) ----------
-      - name: Validate signing prerequisites
-        if: inputs.sign
-        env:
-          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          # Match the resolution used by the sign/notarize steps below: prefer
-          # the app-specific password, fall back to the legacy name. Validating
-          # a different secret than we use would let a run pass this check and
-          # then fail mid-notarization.
-          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          missing=0
-          for var in APPLE_CERTIFICATE_BASE64 APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
-            if [ -z "${!var}" ]; then
-              echo "::error::sign=true but required macOS signing secret is missing: $var" >&2
-              missing=1
-            fi
-          done
-          [ "$missing" -eq 0 ] || exit 1
-
+      # The six APPLE_* secrets were already proved present by the `guard` job,
+      # which is why there is no validation step here.
       - name: Sign and notarize .app
         if: inputs.sign
         env:
@@ -195,9 +276,21 @@ jobs:
           xcrun stapler validate "${{ steps.locate.outputs.dmg_path }}"
 
       # ---- Publish -----------------------------------------------------------
-      # Signed → attach to the GitHub Release. (The guard above proves sign=true
+      # Signed → attach to the GitHub Release. (The `guard` job proves sign=true
       # whenever create_release is true, so this only ever attaches a notarized
       # DMG.)
+      #
+      # BOTH matrix legs reach this step, each with its own per-arch filename,
+      # so the Release ends up carrying both DMGs. They upload as separate
+      # assets and do not overwrite each other.
+      #
+      # RUN `release.yml` FOR THE TAG FIRST. This action creates the Release
+      # when one does not exist, and with `fail-fast: false` the two legs can
+      # arrive at that create concurrently — a race whose loser gets a 422. The
+      # intended order makes it moot: `release.yml` cuts the Release (it owns
+      # `generate_release_notes`), and this workflow only ever attaches to one
+      # that is already there. `max-parallel: 1` would also close it, at the
+      # cost of doubling the wall-clock of every release.
       - name: Attach signed DMG to release
         if: inputs.create_release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -206,10 +299,12 @@ jobs:
           files: ${{ steps.locate.outputs.dmg_path }}
 
       # Otherwise upload the DMG (unsigned by default) as an Actions artifact.
+      # The name carries the target, or the second leg to finish would collide
+      # with the first and the run would fail after both builds succeeded.
       - name: Upload DMG as Actions artifact
         if: "!inputs.create_release"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: opencompany-macos-aarch64-dmg
+          name: opencompany-macos-${{ matrix.target }}-dmg
           path: ${{ steps.locate.outputs.dmg_path }}
           if-no-files-found: error

--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -79,6 +79,32 @@ jobs:
           echo "::error::create_release=true requires sign=true — an unsigned DMG must not be attached to a GitHub Release. Re-dispatch with sign=true (and the APPLE_* secrets set)." >&2
           exit 1
 
+      # `softprops/action-gh-release` CREATES a missing Release, and with
+      # `fail-fast: false` both matrix legs can reach that create at once — the
+      # loser gets a 422, so the run fails AFTER two ~60-minute builds and
+      # publishes only one architecture. Requiring the Release to already exist
+      # removes the race outright instead of relying on operators to dispatch
+      # `release.yml` first (raised in review on #1813).
+      #
+      # `max-parallel: 1` would also close it, by serialising two long builds
+      # that have no reason to be sequential. This costs seconds instead.
+      #
+      # `tag` reaches the script through the environment, never interpolated
+      # into the shell: it is operator-supplied `workflow_dispatch` input, and
+      # `${{ }}` splicing it into `run:` would be a command-injection seam in a
+      # job that holds `contents: write`.
+      - name: Require an existing Release to attach to
+        if: inputs.create_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! gh release view "$TAG" -R "$REPO" >/dev/null 2>&1; then
+            echo "::error::create_release=true but no GitHub Release exists for tag '$TAG'. Run the \`Release\` workflow (release.yml) for that tag first — it owns \`generate_release_notes\` — then re-dispatch this workflow to attach the DMGs." >&2
+            exit 1
+          fi
+
       - name: Validate signing prerequisites
         if: inputs.sign
         env:
@@ -284,13 +310,11 @@ jobs:
       # so the Release ends up carrying both DMGs. They upload as separate
       # assets and do not overwrite each other.
       #
-      # RUN `release.yml` FOR THE TAG FIRST. This action creates the Release
-      # when one does not exist, and with `fail-fast: false` the two legs can
-      # arrive at that create concurrently — a race whose loser gets a 422. The
-      # intended order makes it moot: `release.yml` cuts the Release (it owns
-      # `generate_release_notes`), and this workflow only ever attaches to one
-      # that is already there. `max-parallel: 1` would also close it, at the
-      # cost of doubling the wall-clock of every release.
+      # This action would CREATE the Release if none existed, which both legs
+      # could race. The `guard` job proves one already exists whenever
+      # `create_release` is true, so by here this step only ever ATTACHES —
+      # and two concurrent attaches of differently-named assets do not race.
+      # `release.yml` is what cuts the Release; it owns `generate_release_notes`.
       - name: Attach signed DMG to release
         if: inputs.create_release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2


### PR DESCRIPTION
## Summary

Phase 2 of #1732, which deferred exactly these two things: *"flip signing on once secrets exist + x86_64 leg"*.

**The x86_64 leg.** `release-desktop-macos.yml` becomes a matrix over `target`. Both legs run on `macos-latest` — Apple Silicon — so the Intel leg **cross-compiles** rather than booking an Intel runner. `macos-13` is retired and the surviving Intel label has narrower availability; a native leg would make every release depend on a second, scarcer runner pool for nothing a user can observe. Nothing here executes the built binary, so the runner's lack of Rosetta does not bite.

Five sites were hardcoded to `aarch64-apple-darwin` and now read `${{ matrix.target }}`. The artifact name is one of them, and that one is not cosmetic: two legs uploading `opencompany-macos-aarch64-dmg` would collide and fail the run *after* both builds had succeeded. `fail-fast: false`, so a broken Intel leg does not discard a good arm64 DMG.

**The feature set.** The shipped DMG now carries `acp` and `composio`, passed on the build command rather than written into `src-tauri/Cargo.toml`. That works because both are `= ["openhuman"]` in the root manifest — pure `cfg` switches pulling no `dep:` entry, with `openhuman` already on via `mcp`. Enabling them adds **zero** packages and leaves `src-tauri/Cargo.lock` byte-identical, which is what keeps `--locked` honest. A feature that gated an optional dependency could not ship this way.

Why they matter:

- **`composio`** — `in_build: cfg!(feature = "composio")`, so without it the console's connector tiles render *"this build was compiled without"*, an instruction no desktop user can act on.
- **`acp`** — worse than absent. `src-tauri/src/embedded.rs` hands over a `LocalAcpAgentFactory` unconditionally (the `AppState` seam is ungated), so `harnesses.rs`'s `can_run_local` is true on a desktop build *without* the feature and the console offers `claude`/`codex` as bindable. `PATCH` accepts. Then every turn fails, because `builder.rs` forces `acp_agents = None` under `cfg(not(feature = "acp"))` — with the message *"run it from the desktop app"*, shown to somebody in the desktop app. That guard bug is filed separately as #1814; this PR stops the shipped DMG from being the build that triggers it.

**Why `ci.yml` changes too.** The `Desktop` lane's clippy and test take the same feature string. Without that, the release would ship a combination nothing in CI had ever compiled — the `feature-lanes.txt` pathology (#770) in a new place: a build everybody reads as covered, selected by no lane.

**Guard hoisted.** Both pre-flight checks — release-requires-signing, and the `APPLE_*` secret validation — sat *after* the ~60-minute Tauri compile, so a dispatch that was knowably wrong at submission burned a full build before saying so. The matrix doubles that bill. They are now a `guard` job the matrix `needs:`, failing in seconds — which also makes the header's "fails fast if any is missing" true, as it was not while the secret check ran last.

## API Or Behavior Changes

No API change. Two behavior changes, both to what CI and the release produce:

- A dispatch now yields **two** DMGs (one per arch) instead of one. Tauri names them per-arch (`OpenCompany_<version>_aarch64.dmg`, `..._x64.dmg`), so both attach to one Release without colliding. Unsigned runs upload two separate artifacts, now named by target.
- The shipped desktop build gains `acp` and `composio`. The `Desktop` CI lane compiles and tests that same set.

Ordering note, documented at the attach step: run `release.yml` for the tag **first**. `action-gh-release` creates a Release when absent, and with `fail-fast: false` the two legs can race that create. The intended order makes it moot — `release.yml` owns `generate_release_notes`; this workflow only attaches. `max-parallel: 1` would also close it, at the cost of doubling every release's wall-clock.

## Tests

Run locally on an arm64 host — the same architecture as `macos-latest`:

- [x] `cargo fmt --all -- --check` — N/A, no Rust source changed (workflow YAML only)
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --no-deps --features opencompany/acp,opencompany/composio -- -D warnings` — clean. This is the exact command the amended `Desktop` lane runs.
- [x] `cargo build --all-targets` — covered by `cargo check --target x86_64-apple-darwin --locked --features opencompany/acp,opencompany/composio` with `MACOSX_DEPLOYMENT_TARGET=12.0`: clean, and `ring`'s per-arch assembly built to `Mach-O 64-bit object x86_64`, confirming the cross-compile selected the right path.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --locked --features opencompany/acp,opencompany/composio` — 156 passed, 0 failed.

Also checked:

- `src-tauri/Cargo.lock` is unchanged by the feature flags, so `--locked` still holds.
- `scripts/ci/assert-toolchain-pin.sh`, `assert-merge-group-workflow.sh`, `assert-single-tauri-app.sh`, `assert-feature-lanes.sh` — all pass.
- Both workflows parse as YAML.

**Not covered locally:** Tauri's DMG bundler for a *cross* target. That path is `hdiutil`-based and host-native, and the locate step derives `BUNDLE_DIR` from `${{ matrix.target }}` to match Tauri's layout — but the first `sign=false` dispatch is what actually confirms it. Cheap to check, since an unsigned dispatch only uploads artifacts.

## Documentation

No docs change. The rationale lives in the workflow comments, matching how the rest of `.github/workflows/` documents itself: the cross-compile-vs-native-runner decision and the artifact-name collision in `release-desktop-macos.yml`'s header, the full feature argument on the `DESKTOP_RELEASE_FEATURES` env, and the "keep these in step" note on both sides of the `ci.yml` / release-workflow pair.

Refs #1732. The `acp` guard bug this works around is #1814.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * Desktop CI now validates and tests the same feature configuration used for desktop releases.
  * macOS desktop builds now support both Apple Silicon and Intel architectures.
  * Unsigned macOS builds can be produced for testing, while release attachments remain limited to signed builds.
  * Release validation now occurs before builds begin, improving feedback for missing or invalid signing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->