### PR TITLE
fix(acp): stop offering a coding CLI the build cannot run (#1814)

### DIFF
--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -594,6 +594,35 @@ impl AppState {
         self.acp_agents.clone()
     }
 
+    /// Whether a `transport = "local"` ACP harness can actually run here.
+    ///
+    /// Issue #1814. Two callers — the harness picker and the teammate `PATCH`
+    /// validator — used to ask [`acp_agents`](Self::acp_agents) directly, which
+    /// answers a different question: whether a factory was HANDED OVER, not
+    /// whether this build can use one. Those coincide on every server build and
+    /// on a desktop compiled with `acp`, and diverge on exactly one
+    /// configuration — a desktop compiled WITHOUT it:
+    ///
+    /// * [`with_acp_agents`](Self::with_acp_agents) is deliberately ungated, so
+    ///   that `src-tauri` can hand over a factory without pulling the whole
+    ///   embedded harness in behind `crate::harness` (`crate::ports::acp` exists
+    ///   for that reason). The desktop shell calls it unconditionally.
+    /// * The runtime cannot use what it was given: `RuntimeBuilder` forces
+    ///   `acp_agents = None` under `cfg(not(feature = "acp"))`, and
+    ///   `lanes::resolve_acp_engine` is an unconditional `Err` there — its
+    ///   factory parameter is typed `Infallible`, so `Some` is uninhabited.
+    ///
+    /// The result was a picker that offered `claude` and `codex`, a `PATCH`
+    /// that accepted the binding, and then every turn failing with `lanes.rs`'s
+    /// "run it from the desktop app" — advice for somebody already in it.
+    ///
+    /// One method rather than the same conjunct at both call sites: they were
+    /// already copy-paste siblings, comments included, and a predicate the two
+    /// can state differently is what opened the gap in the first place.
+    pub fn can_run_local_acp(&self) -> bool {
+        cfg!(feature = "acp") && self.acp_agents.is_some()
+    }
+
     /// Sessions opened through the host's ACP HTTP transport.
     #[cfg(feature = "acp")]
     pub fn acp_sessions(&self) -> Arc<crate::server::acp::SessionRegistry> {

--- a/src/server/ops/harnesses.rs
+++ b/src/server/ops/harnesses.rs
@@ -123,7 +123,12 @@ async fn list_harnesses(
     // Declared entries are untouched: a manifest that names a `[[harness]]`
     // is stating what that deployment has, and this route does not get to
     // second-guess it.
-    let can_run_local = state.acp_agents().is_some();
+    //
+    // Issue #1814: `can_run_local_acp()`, not `acp_agents().is_some()`. The
+    // desktop wires a factory on every build, so the bare accessor said yes on
+    // a desktop compiled without `acp` — the one host where this route's whole
+    // purpose applied and it silently did nothing.
+    let can_run_local = state.can_run_local_acp();
     let runs_here = |harness: &Harness| match harness.kind.as_str() {
         "built_in" => true,
         "acp" => {
@@ -309,10 +314,18 @@ agent = "claude"
     ///
     /// Issue #1245's detected-harness follow-up made every CLI this build
     /// drives bindable without a `[[harness]]`. That is true only where the
-    /// host has an `AcpAgentFactory`, which just the embedded desktop wires —
-    /// `opencompany serve` builds `AppState` without one. Offering them
-    /// anyway let an admin bind a hosted teammate to a CLI on somebody else's
-    /// machine: accepted by `PATCH`, then dead on the next rebuild.
+    /// host can actually run one. Offering them anyway let an admin bind a
+    /// hosted teammate to a CLI on somebody else's machine: accepted by
+    /// `PATCH`, then dead on the next rebuild.
+    ///
+    /// Issue #1814 corrects what "can run one" means. It is NOT "an
+    /// `AcpAgentFactory` was wired" — the desktop shell wires one on every
+    /// build, including one compiled without `acp`, where the runtime then
+    /// forces `acp_agents = None` and every such lane resolves `unavailable`.
+    /// So the wired-factory half below asserts the CLIs are offered only under
+    /// `acp`, and asserts the opposite without it: this test used to encode
+    /// the bug, passing in the default lane precisely because it agreed with
+    /// it.
     #[tokio::test]
     async fn a_coding_cli_is_offered_only_where_this_host_can_run_one() {
         // Two homes, not one: `state_with_manifest` seeds a fixed admin, and
@@ -352,15 +365,28 @@ agent = "claude"
         assert_eq!(status, StatusCode::OK, "{body}");
         let list = body.as_array().unwrap();
         for id in ["claude", "codex"] {
-            let found = list.iter().find(|h| h["id"] == id).expect("cli listed");
-            assert_eq!(found["kind"], "acp", "{id}");
-            assert_eq!(found["transport"], "local", "{id}");
-            assert_eq!(found["agent"], id);
-            assert_eq!(found["detected"], true, "{id}");
-            assert_eq!(
-                found["default"], false,
-                "a detected CLI must never become the company default"
-            );
+            let found = list.iter().find(|h| h["id"] == id);
+            if cfg!(feature = "acp") {
+                let found = found.expect("cli listed");
+                assert_eq!(found["kind"], "acp", "{id}");
+                assert_eq!(found["transport"], "local", "{id}");
+                assert_eq!(found["agent"], id);
+                assert_eq!(found["detected"], true, "{id}");
+                assert_eq!(
+                    found["default"], false,
+                    "a detected CLI must never become the company default"
+                );
+            } else {
+                // Issue #1814. A factory alone is not enough: without `acp`
+                // this build cannot turn it into an engine, so offering `{id}`
+                // here would be the desktop reproducing the very trap this
+                // route exists to close.
+                assert!(
+                    found.is_none(),
+                    "a build that cannot run `{id}` must not offer it, \
+                     even with a factory wired: {body}"
+                );
+            }
         }
     }
 

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -791,8 +791,10 @@ async fn edit_agent(
             .effective_harnesses()
             .iter()
             .any(|h| h.id == *id);
-        let bindable =
-            declared || (ACP_AGENTS.contains(&id.as_str()) && state.acp_agents().is_some());
+        // `can_run_local_acp()` rather than `acp_agents().is_some()` — see
+        // issue #1814 and the method's own doc. The picker above uses the same
+        // predicate, which is the point of it being one method.
+        let bindable = declared || (ACP_AGENTS.contains(&id.as_str()) && state.can_run_local_acp());
         if !bindable {
             return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
                 "no harness named `{id}` is available for this company."
@@ -2930,8 +2932,13 @@ prompt = "Lead decisively."
     /// implicit-local fallback, so without this gate a hosted admin could bind
     /// a teammate to a CLI the server has nothing to launch — accepted by
     /// `PATCH`, then dead on the next rebuild. The picker (`GET
-    /// {scope}/harnesses`) already refuses to offer detected CLIs without an
-    /// `AcpAgentFactory`; the write path must agree.
+    /// {scope}/harnesses`) refuses to offer such CLIs; the write path must
+    /// agree, and this test is what holds the two together.
+    ///
+    /// Issue #1814: "can run one" is `can_run_local_acp()`, not "a factory was
+    /// wired". The desktop wires one even when compiled without `acp`, where
+    /// nothing can be built from it — so the wired-factory half below expects
+    /// a refusal in that configuration, matching the picker.
     #[tokio::test]
     async fn an_undeclared_coding_cli_is_bindable_only_where_this_host_can_run_one() {
         struct StubFactory;
@@ -2955,15 +2962,25 @@ prompt = "Lead decisively."
         let (status, refusal) = patch_agent(&hosted, &jamie, json!({"harness": "claude"})).await;
         assert_eq!(status, StatusCode::BAD_REQUEST, "{refusal}");
 
-        // Desktop shape (factory wired): the same id is bindable.
+        // Desktop shape (factory wired): bindable only where this build can
+        // actually build an engine from that factory (issue #1814).
         let desktop_home = home();
         let desktop = state_with_manifest(desktop_home.path(), ACP_ROSTER)
             .await
             .with_acp_agents(std::sync::Arc::new(StubFactory));
         let jamie = add_overlay(&desktop, "Jamie", "Growth").await;
         let (status, set) = patch_agent(&desktop, &jamie, json!({"harness": "claude"})).await;
-        assert_eq!(status, StatusCode::OK, "{set}");
-        assert_eq!(set["harness"], "claude");
+        if cfg!(feature = "acp") {
+            assert_eq!(status, StatusCode::OK, "{set}");
+            assert_eq!(set["harness"], "claude");
+        } else {
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "a build without `acp` cannot run `claude`, so the write path \
+                 must refuse it exactly as the picker declines to offer it: {set}"
+            );
+        }
 
         // A factory must not widen the vocabulary beyond the coding CLIs.
         let (status, refusal) =


### PR DESCRIPTION
## Summary

Closes #1814.

`can_run_local` asked whether an `AcpAgentFactory` was **handed over**, and used that to answer whether a local ACP harness can **run**. Those coincide on every server build and on a desktop compiled with `acp` — and diverge on exactly one configuration, a desktop compiled *without* it, which is what `src-tauri/Cargo.toml` produces today.

| Build | Factory wired? | Runtime can use it? | old `can_run_local` | Correct? |
|---|---|---|---|---|
| `opencompany serve` | no | no | `false` | ✅ |
| desktop **with** `acp` | yes | yes | `true` | ✅ |
| desktop **without** `acp` | **yes** | **no** | **`true`** | ❌ |

- `AppState::with_acp_agents` is deliberately ungated, so `src-tauri` can hand over a factory without pulling the embedded harness in behind `crate::harness` — `crate::ports::acp` exists for that reason. The desktop shell calls it unconditionally.
- The runtime cannot use what it was given: `RuntimeBuilder` forces `acp_agents = None` under `cfg(not(feature = "acp"))`, and `lanes::resolve_acp_engine` is an unconditional `Err` there — its factory parameter is typed `Infallible`, so `Some` is uninhabited.

The result: the picker offered `claude` and `codex` as detected and runnable, the teammate `PATCH` accepted the binding, and every turn then failed with `lanes.rs`'s *"run it from the desktop app"* — advice for somebody already in the desktop app.

The comments above **both** call sites describe stopping precisely this ("accepted by `PATCH`, then dead on the next rebuild"). They worked for the server and missed the desktop, because they tested the wrong thing.

`AppState::can_run_local_acp()` is now the predicate, living next to the accessor it qualifies. One method rather than the same conjunct twice: the two sites were already copy-paste siblings, comments included, and a predicate they can state differently is what opened the gap in the first place.

## API Or Behavior Changes

Behavior change, on a desktop build compiled **without** `acp` only. Nothing changes for `opencompany serve` or for a desktop build with the feature.

- `GET {scope}/harnesses` no longer lists `claude`/`codex` as detected, and no longer reports `runsHere: true` for a declared local ACP harness.
- `PATCH` on a teammate now refuses an undeclared `ACP_AGENTS` id with the existing "no harness named `{id}` is available for this company."

Both are the *intended* behavior of the guards as their own comments describe them — the write path and the picker agree again. A user who previously bound a teammate this way had a binding that could never run a turn.

No public API surface changes; `can_run_local_acp` is a new `AppState` method.

## Tests

Both lanes, since the `cfg!` branches must compile *and* assert correctly in each:

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean on the default lane and on `--features acp,runner,tinymemory`
- [x] `cargo build --all-targets` — covered by the clippy runs above (`--all-targets`)
- [x] `cargo test` — `server::ops::harnesses` 6 passed, `server::ops::team_agent` 53 passed, on **both** the default lane and `--features acp,runner,tinymemory` (the lane `feature-lanes.txt` names for `acp`)

**The tests were encoding the bug.** `a_coding_cli_is_offered_only_where_this_host_can_run_one` and `an_undeclared_coding_cli_is_bindable_only_where_this_host_can_run_one` both asserted that a wired factory *alone* makes the CLIs available. `default` does not include `acp`, so they ran in the default `Rust` lane and passed *because they agreed with the bug*. They now assert the corrected invariant in both configurations.

**Verified by mutation.** Reverting `can_run_local_acp` to the old `acp_agents().is_some()` fails the picker test, with exactly the bug in the assertion output:

```
a build that cannot run `claude` must not offer it, even with a factory wired:
[… {"id":"claude","kind":"acp","detected":true,"runsHere":true},
    {"id":"codex","kind":"acp","detected":true,"runsHere":true}]
```

So the regression test guards the thing it claims to.

## Documentation

No doc files change. The rationale lives on `can_run_local_acp`'s own doc comment — why the two questions differ, which configuration separates them, and why it is one method instead of two conjuncts — with short pointers at both call sites, matching how the surrounding code documents its own guards.

## Notes

Deliberately **not** fixed here: `src/server/setup.rs` already reports `acp_in_build: cfg!(feature = "acp")` accurately, and `frontend/src/api/setup.ts` only declares the field — so the honest signal is already on the wire and nothing renders it. That is a console change and belongs on its own.

Related: #1813 makes the released DMG carry `acp`, so shipped artifacts stop landing in the broken row of the table above. It does not fix this — anyone running the desktop from source at default features still hits it, which is why this is separate.
