### PR TITLE
fix(observatory): roll long durations into hours and days

### DIFF
--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -470,7 +470,7 @@ export function runDuration(
   return ms >= 0 ? ms : null;
 }
 
-/** A duration in the console's compact form: `840ms`, `12.4s`, `3m 07s`. */
+/** A duration in the console's compact form: `840ms`, `12.4s`, `1h 03m 07s`. */
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.round(ms)}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
@@ -478,5 +478,15 @@ export function formatDuration(ms: number): string {
   // disagree — `${Math.floor(ms / 60_000)}m ${Math.round(…)}s` renders "3m 60s"
   // for anything within half a second of the minute.
   const total = Math.round(ms / 1000);
-  return `${Math.floor(total / 60)}m ${String(total % 60).padStart(2, "0")}s`;
+  const days = Math.floor(total / 86_400);
+  const hours = Math.floor((total % 86_400) / 3_600);
+  const minutes = Math.floor((total % 3_600) / 60);
+  const seconds = total % 60;
+  const tail = `${String(minutes).padStart(2, "0")}m ${String(seconds).padStart(2, "0")}s`;
+
+  if (days > 0) {
+    return `${days}d ${String(hours).padStart(2, "0")}h ${tail}`;
+  }
+  if (hours > 0) return `${hours}h ${tail}`;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
 }

--- a/frontend/test/unit/workflow-run-failure.test.ts
+++ b/frontend/test/unit/workflow-run-failure.test.ts
@@ -424,4 +424,9 @@ describe("how long a run took", () => {
     expect(formatDuration(179_800)).toBe("3m 00s");
     expect(formatDuration(187_000)).toBe("3m 07s");
   });
+
+  it("rolls long durations into hours and days", () => {
+    expect(formatDuration(3_967_000)).toBe("1h 06m 07s");
+    expect(formatDuration((28_741 * 60 + 19) * 1_000)).toBe("19d 23h 01m 19s");
+  });
 });


### PR DESCRIPTION
## Summary

- Roll Observatory and workflow run durations into hours and days instead of displaying unbounded minute counts.
- Add regression coverage for hour rollover and the reported 28741m 19s case.

## API Or Behavior Changes

Long elapsed durations now render in compact day/hour/minute/second form. Existing millisecond, second, and minute formatting remains unchanged.

## Tests

- [x] npm run typecheck
- [x] npm run typecheck:unit
- [x] npm run typecheck:e2e
- [x] npx vitest run
- [x] npm run build

Manual UI verification on staging is pending.

## Documentation

No documentation changes were needed for this focused display-formatting correction.

## Related

Closes #1799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration displays for long-running workflow executions, including durations measured in hours and days.
  * Preserved clear formatting for milliseconds, seconds, and minutes with consistent zero-padding.

* **Tests**
  * Added coverage for formatting extended durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->