### PR TITLE
fix(tasks): open board on first populated column

### DIFF
--- a/frontend/src/views/LedgerBoard.tsx
+++ b/frontend/src/views/LedgerBoard.tsx
@@ -64,6 +64,15 @@
 // operator collapses it again. Nothing else may re-collapse it: a column that
 // folded itself back up while somebody was reading it would be this bug's
 // mirror image.
+//
+// # Open on the work, not on the empty lead-in (issue #1800)
+//
+// The rails make later work discoverable, but the board should still put that
+// work in front of the operator. Once the first complete set of rows is on the
+// page, the board aligns its first populated column with the viewport's left
+// edge. It does this once: a later push update must not pull the board away
+// from wherever the operator has scrolled, and an all-empty board has nowhere
+// truthful to move.
 
 import {
   useCallback,
@@ -252,6 +261,8 @@ export function LedgerBoard<T extends BoardRow>({
    * conservative answer and the one the pre-existing collapse tests assert.
    */
   const [viewport, setViewport] = useState(0);
+  /** Whether this mounted board has made its one initial positioning choice. */
+  const positionedInitially = useRef(false);
   /**
    * Whether the board is scrolled to its last column.
    *
@@ -299,6 +310,39 @@ export function LedgerBoard<T extends BoardRow>({
     for (const row of rows) buckets.get(statusOf(row))?.push(row);
     return buckets;
   }, [columns, rows, statusOf]);
+
+  /**
+   * Put the first column holding work at the start of the viewport.
+   *
+   * Waiting for a measured viewport means the empty-column rails have reached
+   * their final widths before the target's position is read. The assignment is
+   * deliberately one-shot: live row updates should never override a person's
+   * own scroll position. A loaded, all-empty board consumes the choice without
+   * moving, so the first card created later does not make the page jump.
+   */
+  useLayoutEffect(() => {
+    if (positionedInitially.current || loading || viewport === 0) return;
+    if (columns.length === 0) return;
+
+    positionedInitially.current = true;
+    const firstPopulated = columns.find(
+      (column) => (held.get(column.id)?.length ?? 0) > 0,
+    );
+    if (!firstPopulated) return;
+
+    const board = boardRef.current;
+    if (!board) return;
+    const target = Array.from(board.children).find(
+      (child): child is HTMLElement =>
+        child instanceof HTMLElement &&
+        child.dataset.column === firstPopulated.id,
+    );
+    if (!target) return;
+
+    const boardLeft = board.getBoundingClientRect().left;
+    const targetLeft = target.getBoundingClientRect().left;
+    board.scrollLeft = Math.max(0, board.scrollLeft + targetLeft - boardLeft);
+  }, [columns, held, loading, viewport]);
 
   /**
    * Whether every column would fit side by side at full width.

--- a/frontend/test/unit/board-collapsed-columns.test.ts
+++ b/frontend/test/unit/board-collapsed-columns.test.ts
@@ -186,6 +186,36 @@ describe("a board with room for every column", () => {
 });
 
 describe("a board whose work has moved to the later columns", () => {
+  it("opens on its first populated column", async () => {
+    widenViewportTo(5 * (COLUMN_PX + GUTTER_PX));
+    const originalRect = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      const left = this.dataset.column === "paused" ? 164 : 24;
+      return {
+        x: left,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        right: left,
+        bottom: 0,
+        left,
+        toJSON: () => ({}),
+      };
+    };
+
+    try {
+      await render(laterColumnsOnly());
+
+      expect(
+        container.querySelector<HTMLElement>("[data-testid=ledger-board]")
+          ?.scrollLeft,
+      ).toBe(140);
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalRect;
+    }
+  });
+
   it("collapses the empty columns and leaves the populated ones alone", async () => {
     await render(laterColumnsOnly());
 
@@ -211,9 +241,14 @@ describe("a board whose work has moved to the later columns", () => {
   it("collapses nothing when the board is empty everywhere", async () => {
     // Six rails and no board is a worse answer to "show me the work" than the
     // three honest zeros this issue is about.
+    widenViewportTo(5 * (COLUMN_PX + GUTTER_PX));
     await render([]);
 
     for (const held of COLUMNS) expect(isCollapsed(held.id)).toBe(false);
+    expect(
+      container.querySelector<HTMLElement>("[data-testid=ledger-board]")
+        ?.scrollLeft,
+    ).toBe(0);
   });
 
   it("keeps a column open when its header slot holds a control", async () => {


### PR DESCRIPTION
## Summary

- Open a populated Tasks board at the first column that contains work.
- Keep all-empty boards still and preserve the operator's position after the initial scroll.
- Cover the initial alignment and empty-board guard in the rendered-board unit suite.

## Problem

When the leading Tasks columns are empty, the board opens on those empty columns while the first real work can sit beyond the right edge. The existing drag-edge scrolling and edge fade help after interaction, but the board's initial viewport still reads as empty.

## Solution

After the shared board has measured its final column layout, it finds the first populated column in declaration order and aligns that column with the left edge. The positioning runs only once per mounted board, does nothing for an all-empty board, and therefore cannot override later manual scrolling when live updates arrive.

The handoff named the retired `TasksView.tsx`; current `main` moved that board behavior into `LedgerBoard.tsx`, so the fix is re-anchored to the shared board component and its existing collapsed-column test suite.

## Submission Checklist

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run`
- [x] `npm run build`
- [x] Change is frontend-only and scoped to the board and its focused unit coverage.
- [x] Commit is GPG-signed and contains no AI co-author trailer.

## Impact

Operators land directly on the earliest active work instead of seeing an apparently empty Tasks board. There are no API, persistence, column-order, or card-behavior changes.

## Related

Closes #1800
