### PR TITLE
fix(workflows): define run statuses on the history row (#1798)

### DIFF
--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+/**
+ * Unlike `Tooltip.Trigger` (hover/focus only, by design — see Base UI's own
+ * `Tooltip` vs `Popover` split), this opens on click/tap out of the box, with
+ * `openOnHover` available as an opt-in on top for the mouse case. Use this
+ * primitive — not Tooltip — for any content a touch or keyboard user must be
+ * able to reach, not just glance at.
+ */
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50 outline-none"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 w-72 max-w-[calc(100vw-2rem)] origin-(--transform-origin) rounded-lg bg-popover p-3 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </PopoverPrimitive.Popup>
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -19,6 +19,25 @@ function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
+/**
+ * The popup's heading. `Popover.Popup` renders `role="dialog"` and reads this
+ * component's generated id back as its own `aria-labelledby` (Base UI wires
+ * the two through the shared store's `titleElementId`) — so a popover with a
+ * heading MUST render it through this component, not a plain element, or the
+ * dialog that opens has no accessible name at all: `aria-labelledby` is only
+ * set when a `Title` is present, and React drops the attribute outright when
+ * it's `undefined` rather than emitting an empty one.
+ */
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
 function PopoverContent({
   className,
   side = "bottom",
@@ -56,4 +75,4 @@ function PopoverContent({
   )
 }
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverContent, PopoverTitle }

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
@@ -938,6 +939,30 @@ function ComponentSection() {
               Nothing here.
             </TabsContent>
           </Tabs>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Popover</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-3 text-sm text-muted-foreground">
+            Tooltip is hover/focus-only by design — a mouse-only glance. Use
+            Popover instead for anything a touch or keyboard user must be able
+            to open, not just see: it opens on click/tap out of the box, with{" "}
+            <code>openOnHover</code> layered on top when the mouse case should
+            still work like a tooltip.
+          </p>
+          <Popover>
+            <PopoverTrigger
+              openOnHover
+              render={<Button variant="outline" size="sm" />}
+            >
+              Click or hover me
+            </PopoverTrigger>
+            <PopoverContent>Popovers open on click, tap, and hover.</PopoverContent>
+          </Popover>
         </CardContent>
       </Card>
 

--- a/frontend/src/views/StyleguideView.tsx
+++ b/frontend/src/views/StyleguideView.tsx
@@ -55,7 +55,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
@@ -961,7 +966,18 @@ function ComponentSection() {
             >
               Click or hover me
             </PopoverTrigger>
-            <PopoverContent>Popovers open on click, tap, and hover.</PopoverContent>
+            <PopoverContent>
+              {/* Codex review on #1821: this example's popup is the
+               * canonical Popover pattern shown in the styleguide, so it
+               * must demonstrate the accessible-name requirement it
+               * documents rather than contradict it — a bare-text popup has
+               * no PopoverTitle to supply Popover.Popup's aria-labelledby,
+               * so it opens as an unnamed dialog. */}
+              <PopoverTitle>Popover</PopoverTitle>
+              <p className="mt-1 text-muted-foreground">
+                Popovers open on click, tap, and hover.
+              </p>
+            </PopoverContent>
           </Popover>
         </CardContent>
       </Card>

--- a/frontend/src/views/styleguide-components.ts
+++ b/frontend/src/views/styleguide-components.ts
@@ -16,6 +16,7 @@ export const STYLEGUIDE_COMPONENTS = [
   "dropdown-menu",
   "input",
   "label",
+  "popover",
   "scroll-area",
   "select",
   "separator",

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -96,11 +96,17 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
 };
 
 /** The statuses worth a standing key, in the order the legend lists them: the
- * ones an operator hits without a definition anywhere else on the row. */
-const RUN_STATUS_LEGEND: readonly string[] = [
+ * ones an operator hits without a definition anywhere else on the row.
+ *
+ * Exported so a unit test can assert membership directly against the source
+ * of truth the header legend renders from, rather than opening the tooltip
+ * portal (which mounts to `document.body`, not the render container) to read
+ * it back out of the DOM. */
+export const RUN_STATUS_LEGEND: readonly string[] = [
   "blocked",
   "stranded",
   "not delivered",
+  "parked",
   "stopped",
   "failed",
 ];

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -6,10 +6,16 @@
 // same reading — see that file's header.
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { Info } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { observatoryHref } from "@/views/observatory/hash";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   fetchRunArtifacts,
@@ -51,6 +57,96 @@ const DELIVERY_TONE: Record<DeliveryStatus, string> = {
   failed: "border-status-failed/40 bg-status-failed-soft",
 };
 
+/**
+ * Plain-English definitions for the run statuses this panel surfaces (issue
+ * #1798).
+ *
+ * A run row spells its terminal state in prose, but its at-a-glance signals —
+ * the coloured status dot, the "not delivered" badge, the "parked" badge — are
+ * a private vocabulary an operator cannot act on if they cannot read it. These
+ * one-liners give each its meaning, and they are the ONE source the dot's hover
+ * title, the badge titles and the header legend all read, so the three can
+ * never drift.
+ *
+ * The wording follows the semantics these terms are actually computed from, not
+ * a guess: `not delivered` from {@link isUndelivered}/{@link undeliveredCount}
+ * in `run-health.ts` (a report that will not reach its destination without a
+ * change), `stranded` from {@link isStranded} (paused for an approval no
+ * decision can still move), `blocked` from {@link isBlocked} (a step waiting on
+ * an approval), `stopped` from a cancelled run, `parked` from
+ * {@link liveParkedApprovalCount}. Keyed by the labels {@link runTone} returns
+ * (see `VERDICT_TONE` in `run-health.ts`) so a dot can be looked up directly.
+ */
+const RUN_STATUS_DEFINITIONS: Record<string, string> = {
+  running: "Still working through its steps — nothing here is final yet.",
+  ok: "Finished, and every report reached its destination.",
+  failed:
+    "A step errored and the run stopped. Review the error, correct the workflow, and run it again.",
+  stopped:
+    "An operator stopped this run before it finished; the step that was mid-flight was dropped where it was.",
+  blocked:
+    "A step is waiting on your approval before the run can go on — decide it in Approvals.",
+  stranded:
+    "The run paused for an approval, but nothing is waiting on you any more and no decision left can move it. Run it again if you still need it.",
+  "not delivered":
+    "The step ran, but its report never reached its destination and won't without a change.",
+  "awaiting approval":
+    "The run is parked on an approval and needs your decision in Approvals.",
+  parked: "The run filed this into the Approvals queue for you to decide.",
+};
+
+/** The statuses worth a standing key, in the order the legend lists them: the
+ * ones an operator hits without a definition anywhere else on the row. */
+const RUN_STATUS_LEGEND: readonly string[] = [
+  "blocked",
+  "stranded",
+  "not delivered",
+  "stopped",
+  "failed",
+];
+
+/** The status hover title for the run dot: its verdict word, plus the one-line
+ * definition when there is one. Falls back to the bare word for a verdict this
+ * map does not name (a host could grow an eighth — see `verdictOf`). */
+function statusDotTitle(label: string): string {
+  const def = RUN_STATUS_DEFINITIONS[label];
+  return def ? `${label} — ${def}` : label;
+}
+
+/** The discoverable half of issue #1798: an info affordance in the panel header
+ * whose tooltip is a short key to the run statuses. The per-badge hover titles
+ * answer "what is THIS one"; this answers "what are all of them" for an
+ * operator who does not know a badge is hoverable. Reuses the app's tooltip
+ * primitive, so it themes and positions like every other tooltip in the
+ * console. */
+function RunStatusLegend() {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            aria-label="What these run statuses mean"
+            data-testid="workflow-run-legend"
+            className="inline-flex items-center text-muted-foreground hover:text-foreground"
+          />
+        }
+      >
+        <Info className="size-3.5" aria-hidden="true" />
+      </TooltipTrigger>
+      <TooltipContent className="flex max-w-xs flex-col items-start gap-1 text-left">
+        <span className="font-medium">What these statuses mean</span>
+        {RUN_STATUS_LEGEND.map((term) => (
+          <span key={term} className="block">
+            <span className="font-medium">{term}</span> —{" "}
+            {RUN_STATUS_DEFINITIONS[term]}
+          </span>
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 /** The delivery block of the run drawer: one line per attempt to route an
  * output node's report. This is the ONLY place an operator learns a report
  * didn't leave the building — a delivery failure never fails the run. */
@@ -80,6 +176,7 @@ export function DeliveryRows({ deliveries }: { deliveries: DeliveryReport[] }) {
           <Badge
             variant="outline"
             className="h-4 px-1.5 text-3xs font-normal border-status-failed/40 bg-status-failed-soft"
+            title={RUN_STATUS_DEFINITIONS["not delivered"]}
           >
             {undelivered} not delivered
           </Badge>
@@ -266,6 +363,7 @@ export function RunHistoryPanel({
         <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
           <span className="text-sm font-medium">Run history</span>
           <Badge variant="secondary">{runs.length}</Badge>
+          <RunStatusLegend />
           {workflowName && (
             <span className="max-w-full truncate text-xs text-muted-foreground">
               {workflowName}
@@ -434,7 +532,15 @@ export function RunHistoryRow({
       data-testid="workflow-run-row"
     >
       <div className="mb-1 flex flex-wrap items-center gap-2">
-        <span className={`size-1.5 rounded-full ${tone.dot}`} />
+        {/* Issue #1798: the run's verdict is otherwise a colour with no word.
+            Its hover title names the state and defines it — the same one-liner
+            the header legend lists — so the dot stops being a signal only a
+            reader who already knows the palette can act on. */}
+        <span
+          className={`size-1.5 rounded-full ${tone.dot}`}
+          data-testid="workflow-run-status-dot"
+          title={statusDotTitle(tone.label)}
+        />
         {run.scheduled && (
           <Badge variant="outline" className="h-4 px-1.5 text-3xs font-normal">
             scheduled
@@ -482,6 +588,7 @@ export function RunHistoryRow({
             variant="outline"
             className="h-4 px-1.5 text-3xs font-normal border-status-blocked/40 bg-status-blocked-soft"
             data-testid="workflow-run-parked"
+            title={RUN_STATUS_DEFINITIONS.parked}
           >
             parked {parked} approval{parked === 1 ? "" : "s"}
           </Badge>

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -78,7 +78,7 @@ const DELIVERY_TONE: Record<DeliveryStatus, string> = {
  * {@link liveParkedApprovalCount}. Keyed by the labels {@link runTone} returns
  * (see `VERDICT_TONE` in `run-health.ts`) so a dot can be looked up directly.
  */
-const RUN_STATUS_DEFINITIONS: Record<string, string> = {
+const RUN_STATUS_DEFINITIONS = {
   running: "Still working through its steps — nothing here is final yet.",
   ok: "Finished, with nothing left undelivered and nobody waiting on you — every report either reached its destination or didn't need to (a dry run, or one an earlier run already delivered).",
   failed:
@@ -111,7 +111,16 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   "awaiting approval":
     "The run is parked on an approval and needs your decision in Approvals.",
   parked: "The run filed this into the Approvals queue for you to decide.",
-};
+} satisfies Record<string, string>;
+
+/** CodeRabbit review on PR #1821: `RUN_STATUS_DEFINITIONS` was `Record<string,
+ * string>` and `RUN_STATUS_LEGEND` was `readonly string[]`, so TypeScript
+ * accepted a legend entry with no matching definition, and the legend's own
+ * render site (`RUN_STATUS_DEFINITIONS[term]`, no fallback) had no guard
+ * against one. Deriving the legend's element type from the map's own keys
+ * makes that pairing a compile error instead of a convention — see the
+ * `typecheck:unit` regression test in `workflow-run-status-legend.test.ts`. */
+type RunStatusTerm = keyof typeof RUN_STATUS_DEFINITIONS;
 
 /** The statuses worth a standing key, in the order the legend lists them: the
  * ones an operator hits without a definition anywhere else on the row.
@@ -120,7 +129,7 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
  * of truth the header legend renders from, rather than opening the tooltip
  * portal (which mounts to `document.body`, not the render container) to read
  * it back out of the DOM. */
-export const RUN_STATUS_LEGEND: readonly string[] = [
+export const RUN_STATUS_LEGEND: readonly RunStatusTerm[] = [
   "blocked",
   "stranded",
   "not delivered",
@@ -133,7 +142,12 @@ export const RUN_STATUS_LEGEND: readonly string[] = [
  * definition when there is one. Falls back to the bare word for a verdict this
  * map does not name (a host could grow an eighth — see `verdictOf`). */
 function statusDotTitle(label: string): string {
-  const def = RUN_STATUS_DEFINITIONS[label];
+  // `label` is any tone `verdictOf` returns, not narrowed to `RunStatusTerm` —
+  // that's the whole point of the fallback below — so the lookup is cast back
+  // to the pre-`satisfies` shape rather than widening the map's own type.
+  const def = (RUN_STATUS_DEFINITIONS as Record<string, string | undefined>)[
+    label
+  ];
   return def ? `${label} — ${def}` : label;
 }
 

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -860,7 +860,16 @@ export function RunHistoryRow({
                 // either would be a diagnosis the console cannot make. Re-run
                 // is offered as an option, not as a remedy for a stated cause.
                 "Nothing here is waiting on you any more, and this run cannot be continued. Run the workflow again if you still need it."
-              : "Nothing here can be approved; change the policy and run the workflow again."}
+              : // Codex review on #1821 (eighth pass, same site as the sixth):
+                // `parkFailed` fires both when the approvals queue itself
+                // refused the write AND when this runtime never wired one at
+                // all — the frontend has no field naming which, per the
+                // legend definition's own hedge two rounds ago ("the
+                // approvals queue itself can refuse the write, and no
+                // workflow change fixes that"). "Change the policy" names a
+                // cause that is never the one in either code path; nothing
+                // about policy content is what failed here.
+                "Nothing here could be queued for approval — the approvals queue itself may have refused it, which no workflow change fixes. Run it again once that's resolved."}
         </p>
         {/* Issue #1014 (PR-B): the gated tool names per blocked node and a link
             per parked card to the Approvals queue — the sentence above says

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -158,14 +158,23 @@ function statusDotTitle(label: string): string {
 function RunStatusLegend() {
   return (
     <Popover>
+      {/* Codex review on #1821 (eleventh pass): a bare `<button>` with no
+          padding, height or width sizes itself to its one child — the
+          `size-3.5` icon, ~14×14px — which is fine for a mouse but far below
+          what a touch tap can reliably hit. `icon-xs` is the smallest sized
+          hit-area the button scale already defines (`size-6`, 24×24px) and is
+          the same fix `TaskDetailView`'s redact trigger and the styleguide's
+          own Popover example (`render={<Button ... />}`) already use for an
+          icon-only trigger, rather than inventing a one-off pixel value here. */}
       <PopoverTrigger
         openOnHover
         render={
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon-xs"
             aria-label="What these run statuses mean"
             data-testid="workflow-run-legend"
-            className="inline-flex items-center text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
           />
         }
       >

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -537,6 +537,17 @@ export function RunHistoryRow({
   // names what the run was standing on; a settled run pairs every entry with
   // a `nodes` finish row UNLESS that node is the one the stop actually cut
   // off mid-flight (see `startedNodes`'s own doc comment in `api/workflows.ts`).
+  //
+  // Codex review on #1821 (ninth pass): `startedNodes`'s own doc comment says
+  // "absent must read as 'no start trail', never as 'nothing started'" — a
+  // host predating #1010/#382 sends nothing at all, which the `?? []`
+  // fallback below used to fold into "no node was mid-flight", so a
+  // cancelled run from that host always rendered the completed-cleanly
+  // sentence even though the run's actual boundary is unrecorded and
+  // unknowable. `knowsStartTrail` keeps that distinction: known-absent
+  // trail (`[]`, nothing had started) and unknown trail (`undefined`) are
+  // not the same fact.
+  const knowsStartTrail = run.startedNodes !== undefined;
   const midFlightNode = (run.startedNodes ?? []).find(
     (nodeId) => !nodes.some((n) => n.nodeId === nodeId),
   );
@@ -799,13 +810,22 @@ export function RunHistoryRow({
           .{" "}
           {midFlightNode
             ? "The steps above completed; the one still running was stopped where it was."
-            : // Codex review on #1821 (eighth pass): the legend definition
-              // above was fixed to say the mid-flight step "normally ran to
-              // completion and was recorded" — but this sentence still
-              // claimed unconditionally that a step was cut off, which is
-              // only true when `midFlightNode` names one. Most cancels land
-              // cleanly at a boundary with nothing interrupted at all.
-              "Every step that had started completed and was recorded before the stop took effect."}{" "}
+            : knowsStartTrail
+              ? // Codex review on #1821 (eighth pass): the legend definition
+                // above was fixed to say the mid-flight step "normally ran to
+                // completion and was recorded" — but this sentence still
+                // claimed unconditionally that a step was cut off, which is
+                // only true when `midFlightNode` names one. Most cancels land
+                // cleanly at a boundary with nothing interrupted at all.
+                "Every step that had started completed and was recorded before the stop took effect."
+              : // Codex review on #1821 (ninth pass): a host predating
+                // #1010/#382 sends no `startedNodes` at all, and its own doc
+                // comment says that must read as "no start trail", never as
+                // "nothing started" — so it must not be folded into the same
+                // claim as a settled run whose receipt confirms every started
+                // step finished. This run's actual cancel boundary is
+                // unrecorded and unknowable from here.
+                "Whether the step in progress when the stop landed finished is not recorded for this run."}{" "}
           Any approvals it had already raised are still waiting for you.
         </p>
       ) : isBlocked(run) ? (

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -822,7 +822,15 @@ export function RunHistoryRow({
             : " before any step finished"}
           .{" "}
           {midFlightNode
-            ? "The steps above completed; the one still running was stopped where it was."
+            ? // Codex review on #1821 (tenth pass): `WorkflowNodeFinished` is
+              // appended best-effort — a failed append is logged and the run
+              // proceeds unaffected (`runner.rs`'s progress collector) — so an
+              // unmatched `startedNodes` entry is not proof the node was cut
+              // off; it is equally consistent with a node that completed
+              // normally but whose own finish record silently failed to
+              // journal. Naming a definitive hard abort overclaimed what a
+              // missing row alone can prove.
+              "The steps above completed; the one still running was either stopped where it was or finished without its own record being saved — its actual outcome isn't confirmed here."
             : knowsStartTrail
               ? // Codex review on #1821 (eighth pass): the legend definition
                 // above was fixed to say the mid-flight step "normally ran to

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -807,12 +807,32 @@ export function RunHistoryRow({
               destructive error framing. Keeping it outside gives the neutral
               control its ordinary token treatment.
 
-              `failedNode` gates it too (Codex review on #1821, eighth pass):
+              `failedNode` gated it too (Codex review on #1821, eighth pass):
               the copilot re-wires the WORKFLOW, so offering it for a run that
               never traced to a step — a host restart, a failed capability
               build, an uncompilable graph — offers to fix something the run
-              gave no evidence was broken. */}
-          {onFixWithCopilot && run.runId && failedNode && (
+              gave no evidence was broken.
+
+              Codex review on #1821 (twelfth pass): that premise doesn't hold.
+              `failedNode` comes from `failedNodeOf(run)`, which finds nothing
+              when the failing node's own `WorkflowNodeFinished` never
+              journaled (best-effort append, `runner.rs`) — the exact case the
+              tenth/eleventh-pass fixes above already established `nodes`
+              being empty does not prove nothing ran. The backend endpoint
+              this button drives (`fix_from_run` → `resolve_fix_error`) never
+              required a `failed_node_id` either: it only needs `run.error`
+              non-empty (guaranteed here, inside the `run.error ?` branch) and
+              works from the error text alone when no node is named — the
+              request this callback sends doesn't even carry a node id. The
+              copilot itself is the one that reads the error text and decides
+              automatable-or-not (`fix_evidence_prompt` in
+              `workflow_build.rs` tells it plainly: "If the failure cannot be
+              fixed by re-wiring the graph … say so"), surfaced back here as
+              `fixReason` when it declines. That is the explicit,
+              failure-text-grounded classification the button's gate should
+              defer to — not a frontend guess off a best-effort per-node
+              record that can go missing for a node that genuinely failed. */}
+          {onFixWithCopilot && run.runId && (
             <div className="mt-1.5">
               <Button
                 size="sm"

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -719,14 +719,25 @@ export function RunHistoryRow({
             <p className="mt-1 text-2xs text-muted-foreground">
               {failedNode
                 ? "Review the error details, then correct the workflow and run it again."
-                : // Codex review on #1821 (eighth pass): `failedNode` is null in
-                  // exactly the cases the legend definition above already hedges
-                  // on — a host restart, a capability that failed to build, or a
-                  // graph that would not compile — none of which a workflow edit
-                  // fixes. This sentence still said "correct the workflow"
-                  // unconditionally, contradicting the definition two rounds ago
-                  // fixed to say the opposite for this same run.
-                  "Review the error details — nothing in the graph got the chance to run, so this may be a host or capability problem rather than the workflow. Run it again once you've ruled that out."}
+                : nodes.length > 0
+                  ? // Codex review on #1821 (ninth pass): `failedNode` null does
+                    // NOT mean nothing ran — a host restart can interrupt a run
+                    // after one or more nodes already completed, and none of
+                    // those finish rows carries an error (the synthetic outcome
+                    // the boot sweep writes belongs to no node). `nodes.length`
+                    // is the same signal `failureLocation` in `graph.ts` already
+                    // branches on for this exact case; this sentence collapsed
+                    // it into "nothing in the graph got the chance to run",
+                    // which is only true when `nodes` is empty too.
+                    `Review the error details — ${nodes.length} step${nodes.length === 1 ? "" : "s"} completed before this run was interrupted, so this may be a host or capability problem rather than the workflow. Run it again once you've ruled that out.`
+                  : // Codex review on #1821 (eighth pass): `failedNode` is null in
+                    // exactly the cases the legend definition above already hedges
+                    // on — a host restart, a capability that failed to build, or a
+                    // graph that would not compile — none of which a workflow edit
+                    // fixes. This sentence still said "correct the workflow"
+                    // unconditionally, contradicting the definition two rounds ago
+                    // fixed to say the opposite for this same run.
+                    "Review the error details — nothing in the graph got the chance to run, so this may be a host or capability problem rather than the workflow. Run it again once you've ruled that out."}
             </p>
             <details className="mt-1">
               <summary className="cursor-pointer text-2xs text-muted-foreground">

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
+  PopoverTitle,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import type { OpenCompanyClient } from "@/api/client";
@@ -135,7 +136,15 @@ function statusDotTitle(label: string): string {
  * one keyboard- and touch-reachable affordance" (see the "make the parked
  * badge discoverable" commit), was itself unreachable by touch. `Popover`
  * opens on press out of the box; `openOnHover` keeps the existing hover
- * discovery for the mouse case. */
+ * discovery for the mouse case.
+ *
+ * Codex review on #1821 (sixth pass): the heading below used to be a plain
+ * `span`. `Popover.Popup` renders `role="dialog"` and only wires its own
+ * `aria-labelledby` when a `Popover.Title` is present to supply the id — a
+ * bare `span` supplies nothing, so a screen-reader user who opened this
+ * dialog heard an unnamed one. `PopoverTitle` is the primitive's own heading
+ * component for exactly this; using it is what makes the popup register the
+ * id in the first place. */
 function RunStatusLegend() {
   return (
     <Popover>
@@ -153,7 +162,7 @@ function RunStatusLegend() {
         <Info className="size-3.5" aria-hidden="true" />
       </PopoverTrigger>
       <PopoverContent className="flex max-h-(--available-height) max-w-xs flex-col items-start gap-1 overflow-y-auto text-left">
-        <span className="font-medium">What these statuses mean</span>
+        <PopoverTitle>What these statuses mean</PopoverTitle>
         {RUN_STATUS_LEGEND.map((term) => (
           <span key={term} className="block">
             <span className="font-medium">{term}</span> —{" "}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -707,7 +707,16 @@ export function RunHistoryRow({
                 : `This run failed: ${errorMessage}`}
             </p>
             <p className="mt-1 text-2xs text-muted-foreground">
-              Review the error details, then correct the workflow and run it again.
+              {failedNode
+                ? "Review the error details, then correct the workflow and run it again."
+                : // Codex review on #1821 (eighth pass): `failedNode` is null in
+                  // exactly the cases the legend definition above already hedges
+                  // on — a host restart, a capability that failed to build, or a
+                  // graph that would not compile — none of which a workflow edit
+                  // fixes. This sentence still said "correct the workflow"
+                  // unconditionally, contradicting the definition two rounds ago
+                  // fixed to say the opposite for this same run.
+                  "Review the error details — nothing in the graph got the chance to run, so this may be a host or capability problem rather than the workflow. Run it again once you've ruled that out."}
             </p>
             <details className="mt-1">
               <summary className="cursor-pointer text-2xs text-muted-foreground">
@@ -720,8 +729,14 @@ export function RunHistoryRow({
           </div>
           {/* Issue #840 (PR-3): correction is an action, not part of the
               destructive error framing. Keeping it outside gives the neutral
-              control its ordinary token treatment. */}
-          {onFixWithCopilot && run.runId && (
+              control its ordinary token treatment.
+
+              `failedNode` gates it too (Codex review on #1821, eighth pass):
+              the copilot re-wires the WORKFLOW, so offering it for a run that
+              never traced to a step — a host restart, a failed capability
+              build, an uncompilable graph — offers to fix something the run
+              gave no evidence was broken. */}
+          {onFixWithCopilot && run.runId && failedNode && (
             <div className="mt-1.5">
               <Button
                 size="sm"

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -12,10 +12,10 @@ import { Badge } from "@/components/ui/badge";
 import { observatoryHref } from "@/views/observatory/hash";
 import { Button } from "@/components/ui/button";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   fetchRunArtifacts,
@@ -120,15 +120,27 @@ function statusDotTitle(label: string): string {
 }
 
 /** The discoverable half of issue #1798: an info affordance in the panel header
- * whose tooltip is a short key to the run statuses. The per-badge hover titles
+ * whose popover is a short key to the run statuses. The per-badge hover titles
  * answer "what is THIS one"; this answers "what are all of them" for an
- * operator who does not know a badge is hoverable. Reuses the app's tooltip
- * primitive, so it themes and positions like every other tooltip in the
- * console. */
+ * operator who does not know a badge is hoverable.
+ *
+ * Codex review on #1821 (fifth pass): Base UI's `Tooltip.Trigger` only opens
+ * on hover or focus — by design, per Base UI's own split between Tooltip
+ * (glance-only) and Popover (press-activatable, and the one that focuses the
+ * popup itself rather than the virtual keyboard when opened by touch). A tap
+ * satisfies neither, and `closeOnClick` on the tooltip trigger actively
+ * cancels a pending open on click rather than starting one — so on a
+ * touch-only device this affordance, the ONE place the parked/blocked/
+ * stranded/not-delivered definitions previously described as "the panel's
+ * one keyboard- and touch-reachable affordance" (see the "make the parked
+ * badge discoverable" commit), was itself unreachable by touch. `Popover`
+ * opens on press out of the box; `openOnHover` keeps the existing hover
+ * discovery for the mouse case. */
 function RunStatusLegend() {
   return (
-    <Tooltip>
-      <TooltipTrigger
+    <Popover>
+      <PopoverTrigger
+        openOnHover
         render={
           <button
             type="button"
@@ -139,8 +151,8 @@ function RunStatusLegend() {
         }
       >
         <Info className="size-3.5" aria-hidden="true" />
-      </TooltipTrigger>
-      <TooltipContent className="flex max-h-(--available-height) max-w-xs flex-col items-start gap-1 overflow-y-auto text-left">
+      </PopoverTrigger>
+      <PopoverContent className="flex max-h-(--available-height) max-w-xs flex-col items-start gap-1 overflow-y-auto text-left">
         <span className="font-medium">What these statuses mean</span>
         {RUN_STATUS_LEGEND.map((term) => (
           <span key={term} className="block">
@@ -148,8 +160,8 @@ function RunStatusLegend() {
             {RUN_STATUS_DEFINITIONS[term]}
           </span>
         ))}
-      </TooltipContent>
-    </Tooltip>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -81,9 +81,9 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   running: "Still working through its steps — nothing here is final yet.",
   ok: "Finished, and every report reached its destination.",
   failed:
-    "A step errored and the run stopped. Review the error, correct the workflow, and run it again.",
+    "The run ended in error — usually a step that failed, but sometimes nothing in the graph got the chance to run. Review the error, correct the workflow, and run it again.",
   stopped:
-    "An operator stopped this run before it finished; the step that was mid-flight was dropped where it was.",
+    "An operator stopped this run before it finished; the step that was mid-flight normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was.",
   blocked:
     "A step is waiting on your approval before the run can go on — decide it in Approvals.",
   stranded:

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -85,7 +85,7 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   stopped:
     "An operator stopped this run before it finished; the step that was mid-flight normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was.",
   blocked:
-    "A step is waiting on your approval before the run can go on — decide it in Approvals.",
+    "A step is waiting on you before the run can go on — usually a card sitting in Approvals, but a call that could not be queued for approval at all leaves nothing there to decide; that case needs a workflow or policy change instead.",
   stranded:
     "The run paused for an approval, but nothing is waiting on you any more and no decision left can move it. Run it again if you still need it.",
   "not delivered":

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -740,7 +740,20 @@ export function RunHistoryRow({
                     // branches on for this exact case; this sentence collapsed
                     // it into "nothing in the graph got the chance to run",
                     // which is only true when `nodes` is empty too.
-                    `Review the error details — ${nodes.length} step${nodes.length === 1 ? "" : "s"} completed before this run was interrupted, so this may be a host or capability problem rather than the workflow. Run it again once you've ruled that out.`
+                    //
+                    // Codex review on #1821 (tenth pass): `WorkflowNodeFinished`
+                    // is appended best-effort (`runner.rs`'s progress collector
+                    // — a failed append is `warn!`-logged and the run proceeds
+                    // unaffected), so a missing finish row is NOT proof the
+                    // node behind it never failed; the append for the actual
+                    // culprit can silently drop while `run.error` still lands.
+                    // Naming a specific alternate cause ("host or capability
+                    // problem") overclaimed what an absent row can prove — this
+                    // now says only that the record may be incomplete, the same
+                    // epistemic stance the legend definition above already
+                    // takes ("Read the error before assuming the workflow needs
+                    // correcting").
+                    `Review the error details — ${nodes.length} step${nodes.length === 1 ? "" : "s"} completed before this run ended. What actually went wrong may not be fully recorded here, so read the error before deciding whether the workflow needs a fix.`
                   : // Codex review on #1821 (eighth pass): `failedNode` is null in
                     // exactly the cases the legend definition above already hedges
                     // on — a host restart, a capability that failed to build, or a

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -530,6 +530,16 @@ export function RunHistoryRow({
   // worse than a parked one — there is no card to click.
   const unparkable = blocked.reduce((n, b) => n + (b.unparkable ?? 0), 0);
   const failedNode = failedNodeOf(run);
+  // Codex review on #1821 (eighth pass): `RunCancel` stops a run at the next
+  // node boundary — the node already executing normally finishes and is
+  // journaled, per the legend definition's own hedge ("only a step stuck
+  // waiting on an outside call is cut off where it was"). `startedNodes`
+  // names what the run was standing on; a settled run pairs every entry with
+  // a `nodes` finish row UNLESS that node is the one the stop actually cut
+  // off mid-flight (see `startedNodes`'s own doc comment in `api/workflows.ts`).
+  const midFlightNode = (run.startedNodes ?? []).find(
+    (nodeId) => !nodes.some((n) => n.nodeId === nodeId),
+  );
   const errorMessage = run.error ? stripEnginePrefixes(run.error) : null;
   const duration = runDuration(run, now);
   // Completed, quiet runs are the common case. They need enough separation to
@@ -762,9 +772,11 @@ export function RunHistoryRow({
       ) : run.cancelled ? (
         // Issue #383, the third terminal reading. Deliberately not a
         // destructive Alert: nothing went wrong, somebody decided they had seen
-        // enough. It says "stopped", not "finished", because the node that was
-        // executing was dropped where it was rather than allowed to complete —
-        // so a side effect it had started may be half-done.
+        // enough. It says "stopped", not "finished", because a node still
+        // mid-flight when the stop lands — named by `midFlightNode` — is cut
+        // off rather than allowed to complete, and a side effect it had
+        // started may be half-done. `RunCancel` stops at the next node
+        // boundary otherwise, so that is the exception, not the rule.
         <p
           className="text-2xs text-muted-foreground"
           data-testid="workflow-run-cancelled"
@@ -773,8 +785,17 @@ export function RunHistoryRow({
           {nodes.length > 0
             ? ` after ${nodes.length} step${nodes.length === 1 ? "" : "s"}`
             : " before any step finished"}
-          . The steps above completed; the one still running was stopped where
-          it was. Any approvals it had already raised are still waiting for you.
+          .{" "}
+          {midFlightNode
+            ? "The steps above completed; the one still running was stopped where it was."
+            : // Codex review on #1821 (eighth pass): the legend definition
+              // above was fixed to say the mid-flight step "normally ran to
+              // completion and was recorded" — but this sentence still
+              // claimed unconditionally that a step was cut off, which is
+              // only true when `midFlightNode` names one. Most cancels land
+              // cleanly at a boundary with nothing interrupted at all.
+              "Every step that had started completed and was recorded before the stop took effect."}{" "}
+          Any approvals it had already raised are still waiting for you.
         </p>
       ) : isBlocked(run) ? (
         // Issue #881, the fourth terminal reading — and the one that had NO

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -140,7 +140,7 @@ function RunStatusLegend() {
       >
         <Info className="size-3.5" aria-hidden="true" />
       </TooltipTrigger>
-      <TooltipContent className="flex max-w-xs flex-col items-start gap-1 text-left">
+      <TooltipContent className="flex max-h-(--available-height) max-w-xs flex-col items-start gap-1 overflow-y-auto text-left">
         <span className="font-medium">What these statuses mean</span>
         {RUN_STATUS_LEGEND.map((term) => (
           <span key={term} className="block">

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -780,7 +780,19 @@ export function RunHistoryRow({
                     // fixes. This sentence still said "correct the workflow"
                     // unconditionally, contradicting the definition two rounds ago
                     // fixed to say the opposite for this same run.
-                    "Review the error details — nothing in the graph got the chance to run, so this may be a host or capability problem rather than the workflow. Run it again once you've ruled that out."}
+                    //
+                    // Codex review on #1821 (twelfth pass): `nodes` being empty is
+                    // not proof nothing ran, for the same reason the sibling arm
+                    // above was fixed in the tenth pass — `WorkflowNodeFinished` is
+                    // appended best-effort (`runner.rs`), so the FIRST failing
+                    // node's own finish row can silently fail to journal while
+                    // `run.error` still lands, leaving `nodes` empty even though
+                    // that node executed. Naming "nothing in the graph got the
+                    // chance to run" as the reading overclaimed what an empty trail
+                    // can prove, the same overclaim the tenth pass removed from the
+                    // `nodes.length > 0` arm. This now says only that the record may
+                    // be incomplete, matching that arm's epistemic stance.
+                    "Review the error details — no step is recorded as having completed, but an empty trail here isn't proof nothing ran: a step's own record can fail to save even when it executed. Read the error before deciding whether this is a host/capability problem or the workflow itself."}
             </p>
             <details className="mt-1">
               <summary className="cursor-pointer text-2xs text-muted-foreground">

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -79,7 +79,7 @@ const DELIVERY_TONE: Record<DeliveryStatus, string> = {
  */
 const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   running: "Still working through its steps — nothing here is final yet.",
-  ok: "Finished, and every report reached its destination.",
+  ok: "Finished, with nothing left undelivered and nobody waiting on you — every report either reached its destination or didn't need to (a dry run, or one an earlier run already delivered).",
   failed:
     "The run ended in error — usually a step that failed and the workflow needs a fix, but sometimes nothing in the graph got the chance to run at all, and the error can be a host restart or a capability that failed to build rather than anything wrong with the workflow. Read the error before assuming the workflow needs correcting.",
   stopped:

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -910,7 +910,20 @@ export function RunHistoryRow({
                 // claimed unconditionally that a step was cut off, which is
                 // only true when `midFlightNode` names one. Most cancels land
                 // cleanly at a boundary with nothing interrupted at all.
-                "Every step that had started completed and was recorded before the stop took effect."
+                //
+                // Codex review on #1821 (thirteenth pass): `WorkflowNodeStarted`
+                // is ALSO appended best-effort (`runner.rs`'s progress
+                // collector) — the same fire-and-forget semantics the
+                // tenth-pass fix already established for
+                // `WorkflowNodeFinished`. A node whose own start silently
+                // failed to journal never appears in `startedNodes` at all,
+                // so it can never become `midFlightNode` even if it was
+                // genuinely running when the stop landed. "Every step that
+                // had started completed" therefore only speaks for the steps
+                // the record actually captured, not for every step that in
+                // fact started — scoped the claim to what was recorded and
+                // added the hedge instead of promising the wider one.
+                "Every step recorded as started also finished and was recorded before the stop took effect — though a step whose own start silently failed to journal wouldn't appear here at all, so this can't rule out one being cut off unseen."
               : // Codex review on #1821 (ninth pass): a host predating
                 // #1010/#382 sends no `startedNodes` at all, and its own doc
                 // comment says that must read as "no start trail", never as

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -85,7 +85,7 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   stopped:
     "An operator stopped this run before it finished; the step that was mid-flight normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was.",
   blocked:
-    "A step is waiting on you before the run can go on — usually a card sitting in Approvals, but a call that could not be queued for approval at all leaves nothing there to decide; that case needs a workflow or policy change instead.",
+    "A step is waiting on you before the run can go on — usually a card sitting in Approvals, but a call that could not be queued for approval at all leaves nothing there to decide. That isn't always a workflow problem — the approvals queue itself can refuse the write, and no workflow change fixes that.",
   stranded:
     "The run paused for an approval, but nothing is waiting on you any more and no decision left can move it. Run it again if you still need it.",
   "not delivered":

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -83,8 +83,18 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   ok: "Finished, with nothing left undelivered and nobody waiting on you — every report either reached its destination or didn't need to (a dry run, or one an earlier run already delivered).",
   failed:
     "The run ended in error — usually a step that failed and the workflow needs a fix, but sometimes nothing in the graph got the chance to run at all, and the error can be a host restart or a capability that failed to build rather than anything wrong with the workflow. Read the error before assuming the workflow needs correcting.",
+  // Codex review on #1821 (eleventh pass): this still asserted "the step
+  // that was mid-flight" as if every stopped run has one. A run cancelled
+  // before it ever reached the graph — `a_run_cancelled_before_it_starts_
+  // does_not_walk_the_graph` in `runner.rs` is exactly this path, and
+  // `RunHistoryPanel`'s own row body already treats an empty `startedNodes`
+  // as its own case — has no mid-flight step to speak of, so the row body's
+  // vacuous "every step that had started completed" holds trivially over
+  // zero steps, but this definite description does not: it names a step
+  // that, for that run, never existed. The trailing sentence states that
+  // case rather than leaving it implied by an empty set.
   stopped:
-    "An operator stopped this run before it finished; the step that was mid-flight normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was.",
+    "An operator stopped this run before it finished. A step that was mid-flight when the stop landed normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was. A run stopped before any step began has no such step at all.",
   blocked:
     "A step is waiting on you before the run can go on — usually a card sitting in Approvals, but a call that could not be queued for approval at all leaves nothing there to decide. That isn't always a workflow problem — the approvals queue itself can refuse the write, and no workflow change fixes that.",
   stranded:

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -81,7 +81,7 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   running: "Still working through its steps — nothing here is final yet.",
   ok: "Finished, and every report reached its destination.",
   failed:
-    "The run ended in error — usually a step that failed, but sometimes nothing in the graph got the chance to run. Review the error, correct the workflow, and run it again.",
+    "The run ended in error — usually a step that failed and the workflow needs a fix, but sometimes nothing in the graph got the chance to run at all, and the error can be a host restart or a capability that failed to build rather than anything wrong with the workflow. Read the error before assuming the workflow needs correcting.",
   stopped:
     "An operator stopped this run before it finished; the step that was mid-flight normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was.",
   blocked:

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -548,6 +548,20 @@ export function RunHistoryRow({
   // itself failed or the excess was dropped past the per-turn cap. Strictly
   // worse than a parked one — there is no card to click.
   const unparkable = blocked.reduce((n, b) => n + (b.unparkable ?? 0), 0);
+  // Codex review on #1821 (twelfth pass): `unparkable` sums two outcomes
+  // (`caps/mod.rs`'s `park_gated_calls`) that are NOT the same failure —
+  // `discarded` (this run's turn asked for more gated calls than one batch
+  // may raise, so the excess was dropped before the queue ever saw it —
+  // `MAX_APPROVAL_REQUESTS_PER_TURN`) and `parkFailed` (the queue itself
+  // refused the write, or this runtime has none wired). Only `run.approvals`
+  // — never `WorkflowBlockedNode.unparkable`, which the sum above reads —
+  // keeps the two apart, via `outcome`. The closing remedy sentence below
+  // named "the approvals queue itself may have refused it" as the cause for
+  // BOTH, which is wrong for a discarded call: it was never offered to the
+  // queue at all.
+  const runApprovals = run.approvals ?? [];
+  const discardedCalls = runApprovals.filter((a) => a.outcome === "discarded").length;
+  const parkFailedCalls = runApprovals.filter((a) => a.outcome === "parkFailed").length;
   const failedNode = failedNodeOf(run);
   // Codex review on #1821 (eighth pass): `RunCancel` stops a run at the next
   // node boundary — the node already executing normally finishes and is
@@ -972,7 +986,25 @@ export function RunHistoryRow({
                 // workflow change fixes that"). "Change the policy" names a
                 // cause that is never the one in either code path; nothing
                 // about policy content is what failed here.
-                "Nothing here could be queued for approval — the approvals queue itself may have refused it, which no workflow change fixes. Run it again once that's resolved."}
+                //
+                // Codex review on #1821 (twelfth pass): this named "the
+                // approvals queue itself may have refused it" as the cause
+                // even when every unparkable call was `discarded` — dropped
+                // by the per-turn cap before the queue ever saw it, a
+                // different and distinguishable cause (`run.approvals`'
+                // `outcome`, computed above). A run with ONLY `discarded`
+                // calls (and at least one, so the classification is positive
+                // rather than absent) gets its own sentence; a run with any
+                // `discarded` alongside `parkFailed` calls names both; every
+                // other case — `parkFailed` only, or a run whose `approvals`
+                // rows predate this classification and carry neither outcome
+                // — keeps the original sentence, which is this default
+                // rather than a claim this fold cannot back.
+                discardedCalls > 0 && parkFailedCalls === 0
+                  ? "Nothing here could be queued for approval — this run's turn asked for more approvals than one batch may raise, so the excess was dropped before the queue ever saw it. Run it again — a turn that asks for fewer approvals at once will queue cleanly."
+                  : discardedCalls > 0 && parkFailedCalls > 0
+                    ? "Nothing here could be queued for approval — some were dropped because this run's turn asked for more approvals than one batch may raise, and the rest because the approvals queue itself may have refused them, which no workflow change fixes. Run it again once you've cut how many approvals one turn asks for and confirmed the queue is healthy."
+                    : "Nothing here could be queued for approval — the approvals queue itself may have refused it, which no workflow change fixes. Run it again once that's resolved."}
         </p>
         {/* Issue #1014 (PR-B): the gated tool names per blocked node and a link
             per parked card to the Approvals queue — the sentence above says

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -541,11 +541,19 @@ export function RunHistoryRow({
         {/* Issue #1798: the run's verdict is otherwise a colour with no word.
             Its hover title names the state and defines it — the same one-liner
             the header legend lists — so the dot stops being a signal only a
-            reader who already knows the palette can act on. */}
+            reader who already knows the palette can act on. `title` alone is a
+            mouse-only affordance (Codex review on #1821, fifth pass): a
+            non-focusable, unlabelled span gives keyboard, touch and
+            screen-reader users nothing, since the header legend defines the
+            terms but never says which one applies to THIS row. `role="img"` +
+            `aria-label` puts the same one-liner in the accessibility tree, the
+            way any other status icon this console labels. */}
         <span
           className={`size-1.5 rounded-full ${tone.dot}`}
           data-testid="workflow-run-status-dot"
           title={statusDotTitle(tone.label)}
+          role="img"
+          aria-label={statusDotTitle(tone.label)}
         />
         {run.scheduled && (
           <Badge variant="outline" className="h-4 px-1.5 text-3xs font-normal">

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -93,8 +93,15 @@ const RUN_STATUS_DEFINITIONS: Record<string, string> = {
   // zero steps, but this definite description does not: it names a step
   // that, for that run, never existed. The trailing sentence states that
   // case rather than leaving it implied by an empty set.
+  // Codex review on #1821 (thirteenth pass): `WorkflowNodeFinished` is
+  // appended best-effort (`runner.rs`'s progress collector logs a failed
+  // append and lets the run proceed unaffected) — the row body's
+  // `midFlightNode` hedge already treats a missing finish row as inconclusive
+  // rather than as proof a step was cut off. This definition still promised
+  // the mid-flight step's own completion "was recorded", unconditionally —
+  // true only when that node's finish append happened to succeed.
   stopped:
-    "An operator stopped this run before it finished. A step that was mid-flight when the stop landed normally ran to completion and was recorded — only a step stuck waiting on an outside call is cut off where it was. A run stopped before any step began has no such step at all.",
+    "An operator stopped this run before it finished. A step that was mid-flight when the stop landed normally ran to completion — only a step stuck waiting on an outside call is cut off where it was — though its own completion record can go missing if that journal write silently failed. A run stopped before any step began has no such step at all.",
   blocked:
     "A step is waiting on you before the run can go on — usually a card sitting in Approvals, but a call that could not be queued for approval at all leaves nothing there to decide. That isn't always a workflow problem — the approvals queue itself can refuse the write, and no workflow change fixes that.",
   stranded:

--- a/frontend/test/unit/styleguide-popover-accessible-name.test.ts
+++ b/frontend/test/unit/styleguide-popover-accessible-name.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// Codex review on #1821: the styleguide's own Popover example is the
+// canonical pattern operators and future contributors copy. If the example
+// itself omits `PopoverTitle`, Base UI still opens its popup as
+// `role="dialog"` but never wires an `aria-labelledby` (`Popover.Popup` only
+// reads the id back from `Popover.Title`'s generated one) — so the
+// "recommended" pattern would demonstrate an unnamed dialog to a
+// screen-reader user, and anyone copying it reproduces exactly the gap the
+// run-status legend popover was just fixed for
+// (`workflow-run-status-legend.test.ts`).
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { StyleguideView } from "@/views/StyleguideView";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+/**
+ * See `styleguide-back-link.test.ts` — the styleguide's component-section
+ * preview reaches for `window.matchMedia` unguarded via `useIsMobile`, and
+ * jsdom ships none.
+ */
+function stubMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+    }),
+  });
+}
+
+beforeEach(() => {
+  stubMatchMedia();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the styleguide's Popover example names itself for assistive technology", () => {
+  it("labels the dialog via aria-labelledby pointing at the heading", async () => {
+    act(() => root.render(createElement(StyleguideView)));
+
+    const trigger = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("Click or hover me"));
+    expect(trigger).not.toBeUndefined();
+
+    await act(async () => {
+      trigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+
+    const labelledBy = dialog?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+
+    const heading = labelledBy ? document.getElementById(labelledBy) : null;
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toBe("Popover");
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -704,12 +704,30 @@ describe("the cancelled-run sentence matches whether a step was actually cut off
     const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
     expect(row?.textContent).not.toContain("was stopped where it was");
     expect(row?.textContent).toContain(
-      "Every step that had started completed and was recorded before the stop took effect.",
+      "Every step recorded as started also finished and was recorded before the stop took effect",
     );
     // The approvals sentence is unconditional and must survive either branch.
     expect(row?.textContent).toContain(
       "Any approvals it had already raised are still waiting for you.",
     );
+  });
+
+  // Codex review on #1821 (thirteenth pass): `WorkflowNodeStarted` is ALSO
+  // appended best-effort (`runner.rs`'s progress collector) — the same
+  // fire-and-forget semantics the tenth-pass fix already established for
+  // `WorkflowNodeFinished`. A node whose own start silently failed to
+  // journal never appears in `startedNodes` at all, so it can never become
+  // `midFlightNode` even if it was genuinely running when the stop landed.
+  // The unconditional "every step that had started completed" therefore only
+  // speaks for the steps the record actually captured, not for every step
+  // that in fact started — this sentence must not promise the wider claim.
+  it("hedges the known-complete sentence instead of promising nothing else was cut off unseen", async () => {
+    await renderHistory(cancelledAtBoundaryRun());
+    const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
+    expect(row?.textContent).not.toContain(
+      "Every step that had started completed and was recorded before the stop took effect.",
+    );
+    expect(row?.textContent).toContain("can't rule out one being cut off unseen");
   });
 });
 
@@ -747,7 +765,7 @@ describe("the cancelled-run sentence hedges when the start trail itself is missi
     );
     const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
     expect(row?.textContent).toContain(
-      "Every step that had started completed and was recorded before the stop took effect.",
+      "Every step recorded as started also finished and was recorded before the stop took effect",
     );
   });
 });

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -156,6 +156,23 @@ describe("the run-status legend affordance", () => {
     // with no accessible name is not discoverable to a screen reader.
     expect(legend?.getAttribute("aria-label")).toBeTruthy();
   });
+
+  // Codex review on #1821 (eleventh pass): the trigger was a bare `<button>`
+  // with no padding, height or width, so its hit box was only its `size-3.5`
+  // (~14×14px) `Info` child — well below a touch-reliable target, even though
+  // switching to `Popover` (fifth pass, above) made a tap capable of opening
+  // it at all. `icon-xs` is the smallest sized hit-area the button scale
+  // already defines (`size-6`, 24×24px) — the same convention
+  // `TaskDetailView`'s redact trigger and the styleguide's own Popover
+  // example already use for an icon-only trigger, rather than a one-off pixel
+  // value invented here.
+  it("gives the legend trigger a touch-sized hit area, not just its icon's box", async () => {
+    await renderHistory(baseRun());
+    const legend = container.querySelector(
+      '[data-testid="workflow-run-legend"]',
+    );
+    expect(legend?.className ?? "").toMatch(/\bsize-6\b/);
+  });
 });
 
 describe("the status dot defines the run's verdict on hover", () => {

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -76,6 +76,26 @@ function undeliveredRun(): WorkflowRunOutcome {
   });
 }
 
+/** A dry run: its one delivery is `skipped` with reason `dry-run` —
+ * `isUndelivered` (`run-health.ts`) deliberately exempts that reason, so
+ * `undeliveredCount` is 0 and `verdictOf` reads this run as `ok`, the same as
+ * a run that actually sent something. Nothing was attempted, on purpose. */
+function dryRunOkRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 6,
+    deliveries: [
+      {
+        node: "digest",
+        kind: "channel",
+        target: "engineering",
+        status: "skipped",
+        reason: "dry-run",
+        detail: "dry run — nothing sent",
+      },
+    ],
+  });
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -203,6 +223,23 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).not.toContain("decide it in Approvals");
     // The hedge names the case that has no card, and what to do about it.
     expect(title).toContain("nothing there to decide");
+  });
+
+  // Codex review on #1821: `isUndelivered` (`run-health.ts`) exempts a
+  // `skipped` row whose reason is `dry-run` — a test run attempted nothing,
+  // on purpose — so `verdictOf` reads it as `ok` the same as a run that
+  // actually sent something. The old wording claimed "every report reached
+  // its destination", which is false for a report that was never attempted.
+  it("does not claim every report was delivered for a dry run read as ok", async () => {
+    await renderHistory(dryRunOkRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).toContain("ok");
+    expect(title).not.toContain("every report reached its destination");
+    // The hedge covers the report that was never attempted, not just refused.
+    expect(title).toContain("didn't need to");
   });
 });
 

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -59,6 +59,33 @@ function blockedUnparkableRun(): WorkflowRunOutcome {
   });
 }
 
+/** A blocked run whose one unparkable call was `discarded` — the per-turn
+ * approval cap dropped it before the queue ever saw it (`caps/mod.rs`'s
+ * `park_gated_calls`), never refused by the queue. `blockedUnparkableRun()`
+ * above carries no `approvals` rows at all, so it cannot exercise this
+ * outcome; `run.approvals` is the only place `discarded` and `parkFailed`
+ * are told apart (issue #1821, twelfth pass). */
+function discardedOnlyBlockedRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 14,
+    blockedNodes: [{ nodeId: "notify_ops", tools: ["send_slack_message"], unparkable: 1 }],
+    approvals: [{ outcome: "discarded" }],
+  });
+}
+
+/** A blocked run whose two unparkable calls mix a `discarded` overflow and a
+ * genuine `parkFailed` — both causes are real for this run at once. */
+function mixedUnparkableBlockedRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 15,
+    blockedNodes: [{ nodeId: "notify_ops", tools: ["send_slack_message"], unparkable: 2 }],
+    approvals: [
+      { outcome: "discarded" },
+      { outcome: "parkFailed", nodeId: "notify_ops", tool: "send_slack_message" },
+    ],
+  });
+}
+
 /** A finished run whose one output report was refused — `undeliveredCount` is 1,
  * so the row falls to the delivery block and badges "1 not delivered". */
 function undeliveredRun(): WorkflowRunOutcome {
@@ -721,5 +748,31 @@ describe("the unparkable-only blocked remedy stops naming a policy cause", () =>
     const row = container.querySelector('[data-testid="workflow-run-blocked"]');
     expect(row?.textContent).not.toContain("change the policy");
     expect(row?.textContent).toContain("approvals queue itself may have refused it");
+  });
+});
+
+describe("the unparkable-only blocked remedy distinguishes a discarded overflow from a park failure", () => {
+  // Codex review on #1821 (twelfth pass): `discarded` (the per-turn approval
+  // cap dropped the excess before the queue ever saw it) and `parkFailed`
+  // (the queue itself refused the write, or none is wired) were both told as
+  // "the approvals queue itself may have refused it" — true for `parkFailed`,
+  // false for `discarded`, which the queue never saw at all. `run.approvals`'
+  // `outcome` is what lets the row tell them apart
+  // (`blockedUnparkableRun()`, used above, carries no `approvals` rows and so
+  // cannot exercise this).
+  it("names the per-turn cap, not the queue, when every unparkable call was discarded", async () => {
+    await renderHistory(discardedOnlyBlockedRun());
+    const row = container.querySelector('[data-testid="workflow-run-blocked"]');
+    expect(row?.textContent).not.toContain(
+      "approvals queue itself may have refused it",
+    );
+    expect(row?.textContent).toContain("more approvals than one batch may raise");
+  });
+
+  it("names both causes when the unparkable calls are a mix of discarded and parkFailed", async () => {
+    await renderHistory(mixedUnparkableBlockedRun());
+    const row = container.querySelector('[data-testid="workflow-run-blocked"]');
+    expect(row?.textContent).toContain("more approvals than one batch may raise");
+    expect(row?.textContent).toContain("approvals queue itself may have refused them");
   });
 });

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -443,6 +443,24 @@ describe("the legend trigger opens without hover or focus", () => {
   });
 });
 
+describe("the legend is limited to terms RUN_STATUS_DEFINITIONS actually defines", () => {
+  // CodeRabbit review on PR #1821: RUN_STATUS_DEFINITIONS was typed
+  // Record<string, string> and RUN_STATUS_LEGEND readonly string[], so
+  // TypeScript accepted a legend entry with no matching definition — and the
+  // legend's own render site (`RUN_STATUS_DEFINITIONS[term]`, no fallback)
+  // has no guard against one landing there silently. This is a type-only
+  // regression, proven the same way `tsconfig.e2e.json`'s docblock describes
+  // for its suite: `noUnusedLocals` turns an `@ts-expect-error` that suppresses
+  // nothing into a compile error, so `npm run typecheck:unit` goes red the
+  // moment the legend's element type widens back to bare `string`.
+  it("rejects a legend entry that is not a defined term (type-level)", () => {
+    type LegendTerm = (typeof RUN_STATUS_LEGEND)[number];
+    // @ts-expect-error - "not-a-real-status" has no entry in RUN_STATUS_DEFINITIONS
+    const bogus: LegendTerm = "not-a-real-status";
+    expect(bogus).toBe("not-a-real-status");
+  });
+});
+
 describe("the legend popup names itself for assistive technology", () => {
   // Codex review on #1821 (sixth pass): `Popover.Popup` renders `role="dialog"`
   // and only sets its own `aria-labelledby` when a `Popover.Title` supplied the

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -513,6 +513,13 @@ function failedAfterNodesRun(): WorkflowRunOutcome {
 // already completed collapsed into the same "nothing in the graph got the
 // chance to run" claim as a run that never started at all — contradicting
 // the finish rows sitting right above it in the same card.
+//
+// Codex review on #1821 (tenth pass): the ninth-pass fix then named a
+// specific alternate cause ("a host or capability problem") for that same
+// case — but `WorkflowNodeFinished` is appended best-effort (`runner.rs`),
+// so a missing finish row is not proof the culprit node's own failure never
+// happened; its append can silently drop while `run.error` still lands. The
+// sentence now stops naming a cause it cannot actually rule in or out.
 describe("the failed-run remedy distinguishes an interrupted run from one that never started", () => {
   it("names the steps that completed instead of claiming nothing ran", async () => {
     await renderHistory(failedAfterNodesRun());
@@ -520,9 +527,10 @@ describe("the failed-run remedy distinguishes an interrupted run from one that n
     expect(row?.textContent).not.toContain(
       "nothing in the graph got the chance to run",
     );
-    expect(row?.textContent).toContain(
-      "2 steps completed before this run was interrupted",
-    );
+    expect(row?.textContent).toContain("2 steps completed before this run ended");
+    // Does not commit to a specific alternate cause a missing row cannot prove.
+    expect(row?.textContent).not.toContain("host or capability problem");
+    expect(row?.textContent).toContain("may not be fully recorded here");
   });
 
   it("still says nothing ran for a run that failed with no nodes at all", async () => {

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -542,3 +542,19 @@ describe("the cancelled-run sentence matches whether a step was actually cut off
     );
   });
 });
+
+describe("the unparkable-only blocked remedy stops naming a policy cause", () => {
+  // Codex review on #1821 (eighth pass, same site as the sixth): `parkFailed`
+  // fires both when the approvals queue refused the write and when this
+  // runtime never wired one at all (`docs/modules/server/workflow-routes.md`)
+  // — neither is a policy-content problem, and the frontend has no field
+  // naming which happened, exactly as the legend definition's own hedge
+  // (tested above) already accounts for. The row body still told the operator
+  // to "change the policy" for the very same run.
+  it("does not tell the operator to change the policy", async () => {
+    await renderHistory(blockedUnparkableRun());
+    const row = container.querySelector('[data-testid="workflow-run-blocked"]');
+    expect(row?.textContent).not.toContain("change the policy");
+    expect(row?.textContent).toContain("approvals queue itself may have refused it");
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -225,6 +225,24 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).toContain("nothing there to decide");
   });
 
+  // Codex review on #1821 (third pass, same site): `unparkable` is set both
+  // when the workflow never wired an approvals queue AND when the store
+  // itself refused the write (`docs/modules/server/workflow-routes.md`'s
+  // `parkFailed`: "the store refused the write, or no approvals queue is
+  // wired"). The frontend has no field naming which one happened, so telling
+  // the operator this "needs a workflow or policy change" is only true for
+  // one of the two causes and misdirects them for the other.
+  it("does not unconditionally prescribe a workflow change for a call that could not be queued", async () => {
+    await renderHistory(blockedUnparkableRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).not.toContain("that case needs a workflow or policy change");
+    // The hedge names the infra cause a workflow edit can't fix.
+    expect(title).toContain("approvals queue itself can refuse the write");
+  });
+
   // Codex review on #1821: `isUndelivered` (`run-health.ts`) exempts a
   // `skipped` row whose reason is `dry-run` — a test run attempted nothing,
   // on purpose — so `verdictOf` reads it as `ok` the same as a run that

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -490,3 +490,55 @@ describe("the failed-run remedy matches whether a node was actually at fault", (
     ).toBeNull();
   });
 });
+
+/** A run cancelled cleanly at a node boundary: every node it started also
+ * finished, so `RunCancel`'s own contract — the active step normally
+ * completes and is journaled — held, and nothing was actually cut off. */
+function cancelledAtBoundaryRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 9,
+    cancelled: true,
+    startedNodes: ["n_3"],
+    nodes: [{ nodeId: "n_3", status: "ok", elapsedMs: 40 }],
+  });
+}
+
+/** A run cancelled while a node was genuinely mid-flight: `n_3` started but
+ * never finished, so it IS the node the stop cut off — the positive control
+ * for the "stopped where it was" sentence. */
+function cancelledMidFlightRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 10,
+    cancelled: true,
+    startedNodes: ["n_3"],
+    nodes: [],
+  });
+}
+
+describe("the cancelled-run sentence matches whether a step was actually cut off", () => {
+  it("still says a step was stopped where it was when one genuinely was mid-flight", async () => {
+    await renderHistory(cancelledMidFlightRun());
+    const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
+    expect(row?.textContent).toContain(
+      "the one still running was stopped where it was",
+    );
+  });
+
+  // Codex review on #1821 (eighth pass): the legend definition (fixed earlier
+  // this round, tested above) says the mid-flight step "normally ran to
+  // completion and was recorded" — true for `cancelledAtBoundaryRun`, whose
+  // one started node also finished. This sentence claimed the opposite for
+  // the very same run.
+  it("does not claim a step was cut off when every started node also finished", async () => {
+    await renderHistory(cancelledAtBoundaryRun());
+    const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
+    expect(row?.textContent).not.toContain("was stopped where it was");
+    expect(row?.textContent).toContain(
+      "Every step that had started completed and was recorded before the stop took effect.",
+    );
+    // The approvals sentence is unconditional and must survive either branch.
+    expect(row?.textContent).toContain(
+      "Any approvals it had already raised are still waiting for you.",
+    );
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -362,3 +362,37 @@ describe("the legend trigger opens without hover or focus", () => {
     }
   });
 });
+
+describe("the legend popup names itself for assistive technology", () => {
+  // Codex review on #1821 (sixth pass): `Popover.Popup` renders `role="dialog"`
+  // and only sets its own `aria-labelledby` when a `Popover.Title` supplied the
+  // id via the shared store — a heading rendered as a plain element supplies
+  // nothing, and React drops an `undefined` attribute rather than emitting an
+  // empty one. So a screen-reader user who opened this dialog heard "dialog"
+  // with no name at all. Proven against the popup Base UI actually renders
+  // (not the heading text alone, which was already present either way) —
+  // reverting the `PopoverTitle` swap in `RunHistoryPanel.tsx` fails this on
+  // the `aria-labelledby` assertion while leaving the "opens on click" test
+  // above green, which is exactly the gap the earlier test didn't catch.
+  it("labels the dialog via aria-labelledby pointing at the heading", async () => {
+    await renderHistory(baseRun());
+    const trigger = container.querySelector<HTMLElement>(
+      '[data-testid="workflow-run-legend"]',
+    );
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+
+    const labelledBy = dialog?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+
+    const heading = labelledBy
+      ? document.getElementById(labelledBy)
+      : null;
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toBe("What these statuses mean");
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -556,7 +556,7 @@ function cancelledAtBoundaryRun(): WorkflowRunOutcome {
 
 /** A run cancelled while a node was genuinely mid-flight: `n_3` started but
  * never finished, so it IS the node the stop cut off — the positive control
- * for the "stopped where it was" sentence. */
+ * for the mid-flight branch (hedged, tenth pass — see below). */
 function cancelledMidFlightRun(): WorkflowRunOutcome {
   return baseRun({
     seq: 10,
@@ -567,12 +567,19 @@ function cancelledMidFlightRun(): WorkflowRunOutcome {
 }
 
 describe("the cancelled-run sentence matches whether a step was actually cut off", () => {
-  it("still says a step was stopped where it was when one genuinely was mid-flight", async () => {
+  it("names the mid-flight step as a possible cut-off when one genuinely was mid-flight", async () => {
     await renderHistory(cancelledMidFlightRun());
     const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
+    expect(row?.textContent).toContain("stopped where it was");
+    // Codex review on #1821 (tenth pass): `WorkflowNodeFinished` is appended
+    // best-effort, so an unmatched `startedNodes` entry is equally
+    // consistent with a node that finished normally but whose own record
+    // silently failed to journal — a definitive "was stopped where it was"
+    // overclaims what a missing row alone can prove.
     expect(row?.textContent).toContain(
-      "the one still running was stopped where it was",
+      "finished without its own record being saved",
     );
+    expect(row?.textContent).toContain("isn't confirmed here");
   });
 
   // Codex review on #1821 (eighth pass): the legend definition (fixed earlier

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { WorkflowRunOutcome } from "@/api/workflows";
-import { RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
+import { RUN_STATUS_LEGEND, RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
 
 /**
  * Issue #1798: a run row's at-a-glance signals — the coloured status dot, the
@@ -91,6 +91,23 @@ function dryRunOkRun(): WorkflowRunOutcome {
         status: "skipped",
         reason: "dry-run",
         detail: "dry run — nothing sent",
+      },
+    ],
+  });
+}
+
+/** A run parked one approval and it is still on the Approvals page:
+ * `liveParkedApprovalCount` (`decidableApprovalCount` minus the stranded
+ * count, both 0 here) is 1, so the row's "parked" badge renders. */
+function parkedRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 7,
+    approvals: [
+      {
+        outcome: "parked",
+        approvalId: "a1",
+        nodeId: "notify_ops",
+        tool: "send_slack_message",
       },
     ],
   });
@@ -258,6 +275,31 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).not.toContain("every report reached its destination");
     // The hedge covers the report that was never attempted, not just refused.
     expect(title).toContain("didn't need to");
+  });
+});
+
+describe("the parked badge's definition is reachable without a mouse", () => {
+  // Codex review on #1821: the parked badge's definition lives only in its
+  // native `title` (a non-focusable span). The panel's ONE keyboard- and
+  // touch-reachable affordance is the header `RunStatusLegend` tooltip
+  // button, which lists only `RUN_STATUS_LEGEND` — and that array used to
+  // omit "parked", so a keyboard or touch user could see the badge but never
+  // learn what it means. Asserted against the exported array rather than the
+  // rendered tooltip popup, which portals to `document.body` and would not
+  // be reachable off `container` anyway.
+  it("lists parked in the keyboard-accessible header legend", () => {
+    expect(RUN_STATUS_LEGEND).toContain("parked");
+  });
+
+  it("still carries the definition on the badge itself, for the mouse case", async () => {
+    await renderHistory(parkedRun());
+    const badge = Array.from(container.querySelectorAll("[title]")).find(
+      (el) => el.textContent?.includes("parked"),
+    );
+    expect(badge).toBeTruthy();
+    expect(badge?.getAttribute("title")).toBe(
+      "The run filed this into the Approvals queue for you to decide.",
+    );
   });
 });
 

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -264,6 +264,23 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).toContain("no such step at all");
   });
 
+  // Codex review on #1821 (thirteenth pass): `WorkflowNodeFinished` is
+  // appended best-effort (`runner.rs`'s progress collector logs a failed
+  // append and lets the run proceed) — the same fire-and-forget semantics
+  // the row body's `midFlightNode` hedge (tenth pass) already accounts for.
+  // This definition still told every reader the mid-flight step's own
+  // completion "was recorded", unconditionally — true only when that node's
+  // finish append happened to succeed.
+  it("does not promise the mid-flight step's completion was recorded", async () => {
+    await renderHistory(stoppedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).not.toContain("normally ran to completion and was recorded");
+    expect(title).toContain("completion record can go missing");
+  });
+
   // Codex review on #1821: `failureLocation`/`failedNodeOf` (`graph.ts`)
   // explicitly preserve the case where a run's `error` names no node at all —
   // a graph that would not compile, a capability that could not be built, or

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -491,6 +491,49 @@ describe("the failed-run remedy matches whether a node was actually at fault", (
   });
 });
 
+/** A run interrupted by a host restart after some nodes had already
+ * completed: none of those finish rows carries an error — the synthetic
+ * outcome the boot sweep writes belongs to no node — so `failedNodeOf` is
+ * null the same as `failedRun()`, but this run did NOT fail "before any node
+ * ran". `failureLocation` in `graph.ts` already distinguishes the two; the
+ * row body must too. */
+function failedAfterNodesRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 11,
+    error: "harness error: host restarted mid-run",
+    nodes: [
+      { nodeId: "start", status: "ok", elapsedMs: 5 },
+      { nodeId: "n_2", status: "ok", elapsedMs: 800 },
+    ],
+  });
+}
+
+// Codex review on #1821 (ninth pass): the eighth-pass fix above gated the
+// remedy sentence on `failedNode` alone, so a run interrupted after nodes
+// already completed collapsed into the same "nothing in the graph got the
+// chance to run" claim as a run that never started at all — contradicting
+// the finish rows sitting right above it in the same card.
+describe("the failed-run remedy distinguishes an interrupted run from one that never started", () => {
+  it("names the steps that completed instead of claiming nothing ran", async () => {
+    await renderHistory(failedAfterNodesRun());
+    const row = container.querySelector('[data-testid="workflow-run-row"]');
+    expect(row?.textContent).not.toContain(
+      "nothing in the graph got the chance to run",
+    );
+    expect(row?.textContent).toContain(
+      "2 steps completed before this run was interrupted",
+    );
+  });
+
+  it("still says nothing ran for a run that failed with no nodes at all", async () => {
+    await renderHistory(failedRun());
+    const row = container.querySelector('[data-testid="workflow-run-row"]');
+    expect(row?.textContent).toContain(
+      "nothing in the graph got the chance to run",
+    );
+  });
+});
+
 /** A run cancelled cleanly at a node boundary: every node it started also
  * finished, so `RunCancel`'s own contract — the active step normally
  * completes and is journaled — held, and nothing was actually cut off. */

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -46,6 +46,19 @@ function failedRun(): WorkflowRunOutcome {
   return baseRun({ seq: 4, error: "graph failed to compile" });
 }
 
+/** A run blocked on a gated call that never got a card at all: `unparkable` is
+ * set and `approvalIds` is absent, the shape `WorkflowBlockedNode.approvalIds`
+ * documents as "Absent when every park failed." `isBlocked` reads `true` off
+ * `blockedNodes.length`, and nothing here promotes the run to `stranded`
+ * (that reading only folds `pendingApprovals`/`strandedApprovals` — the
+ * gate shape, not this one — see `run-verdict.md`). */
+function blockedUnparkableRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 5,
+    blockedNodes: [{ nodeId: "notify_ops", tools: ["send_slack_message"], unparkable: 1 }],
+  });
+}
+
 /** A finished run whose one output report was refused — `undeliveredCount` is 1,
  * so the row falls to the delivery block and badges "1 not delivered". */
 function undeliveredRun(): WorkflowRunOutcome {
@@ -150,6 +163,25 @@ describe("the status dot defines the run's verdict on hover", () => {
     const title = dot?.getAttribute("title") ?? "";
     expect(title).toContain("failed");
     expect(title).not.toContain("A step errored");
+  });
+
+  // Codex review on #1821: a blocked node whose gated call could not be
+  // queued for approval at all (`unparkable`, not `stranded`) never gets a
+  // card in Approvals — `BlockedNodeApprovals`/the row's own body text
+  // already say so ("could not be queued for approval at all, so you will
+  // not be asked about it"). The old wording unconditionally told the
+  // operator to "decide it in Approvals" for every blocked run, which sends
+  // this one to a queue with nothing in it.
+  it("does not unconditionally promise a card in Approvals for a blocked run", async () => {
+    await renderHistory(blockedUnparkableRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).toContain("blocked");
+    expect(title).not.toContain("decide it in Approvals");
+    // The hedge names the case that has no card, and what to do about it.
+    expect(title).toContain("nothing there to decide");
   });
 });
 

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -396,3 +396,97 @@ describe("the legend popup names itself for assistive technology", () => {
     expect(heading?.textContent).toBe("What these statuses mean");
   });
 });
+
+/**
+ * Codex review on #1821 (eighth pass): three definitions above were reworded,
+ * over three earlier rounds, to stop presuming a cause the data doesn't
+ * support — but the ROW BODY text a few hundred lines further down
+ * `RunHistoryPanel.tsx` (the paragraph under the failed card, the cancelled
+ * sentence, the blocked-unparkable remedy) still spoke the old, unconditional
+ * story for the very same run, so a single row could show an accurate
+ * definition on hover and a contradicting remedy in the body at once. These
+ * tests pin the row body, not the `title` attribute the earlier rounds
+ * already cover above.
+ */
+
+/** A run whose error traces to a specific node — the ordinary failure case,
+ * kept as the positive control: the workflow-fault remedy and the copilot fix
+ * must both still show here. */
+function failedAtNodeRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 8,
+    runId: "run-failed-8",
+    error: "the writer agent has no model",
+    nodes: [{ nodeId: "n_3", status: "error", elapsedMs: 12 }],
+  });
+}
+
+describe("the failed-run remedy matches whether a node was actually at fault", () => {
+  it("still tells the operator to correct the workflow when a node errored", async () => {
+    await renderHistory(failedAtNodeRun());
+    const row = container.querySelector('[data-testid="workflow-run-row"]');
+    expect(row?.textContent).toContain(
+      "Review the error details, then correct the workflow and run it again.",
+    );
+  });
+
+  // Codex review on #1821 (eighth pass): `failedRun()` traces to no node at
+  // all — a graph that would not compile, a capability that could not be
+  // built, or a host restart — exactly what the legend definition (fixed two
+  // rounds ago, tested above) already says is "rather than anything wrong
+  // with the workflow". This paragraph still told the operator to correct the
+  // workflow unconditionally.
+  it("does not tell the operator to correct the workflow when no node was at fault", async () => {
+    await renderHistory(failedRun());
+    const row = container.querySelector('[data-testid="workflow-run-row"]');
+    expect(row?.textContent).not.toContain(
+      "correct the workflow and run it again",
+    );
+    expect(row?.textContent).toContain("may be a host or capability problem");
+  });
+
+  it("offers Fix with copilot for a node-level failure", async () => {
+    await act(async () => {
+      root.render(
+        createElement(RunHistoryPanel, {
+          runs: [failedAtNodeRun()],
+          graph: null,
+          workflowName: "Daily digest",
+          onClose: () => {},
+          selectedRunSeq: null,
+          onSelectRun: () => {},
+          onFixWithCopilot: () => {},
+        }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="workflow-run-fix-with-copilot"]'),
+    ).not.toBeNull();
+  });
+
+  // Codex review on #1821 (eighth pass): the copilot re-wires the workflow, so
+  // offering it here dangles the same wrong remedy as the sentence above for a
+  // run with no evidence the workflow was ever at fault.
+  it("does not offer Fix with copilot when no node was at fault", async () => {
+    // `runId` set explicitly: `failedRun()` omits it, and the button's OTHER
+    // guard (`run.runId`) would then hide it for a reason unrelated to this
+    // test — this run must satisfy every other guard so `failedNode` is the
+    // only thing left that can be under test.
+    await act(async () => {
+      root.render(
+        createElement(RunHistoryPanel, {
+          runs: [{ ...failedRun(), runId: "run-failed-no-node" }],
+          graph: null,
+          workflowName: "Daily digest",
+          onClose: () => {},
+          selectedRunSeq: null,
+          onSelectRun: () => {},
+          onFixWithCopilot: () => {},
+        }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="workflow-run-fix-with-copilot"]'),
+    ).toBeNull();
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { WorkflowRunOutcome } from "@/api/workflows";
+import { RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
+
+/**
+ * Issue #1798: a run row's at-a-glance signals — the coloured status dot, the
+ * "not delivered" badge — carried no definition, so an operator could not act on
+ * a status they could not read. Each now explains itself on hover, and the panel
+ * header carries a standing legend for the operator who does not know a badge is
+ * hoverable.
+ *
+ * A jsdom render because the claim is about what the panel PAINTS: a `title`
+ * attribute on the right element and a legend affordance in the header. The
+ * definitions themselves are a plain map and could be unit-tested directly, but
+ * the wiring — which element carries which title — is the part that regresses.
+ */
+
+function baseRun(over: Partial<WorkflowRunOutcome> = {}): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    workflowId: "daily_digest",
+    scheduled: false,
+    deliveries: [],
+    pendingApprovals: [],
+    ...over,
+  };
+}
+
+/** A run an operator stopped: `runTone` reads this as `stopped`. */
+function stoppedRun(): WorkflowRunOutcome {
+  return baseRun({ seq: 2, cancelled: true });
+}
+
+/** A finished run whose one output report was refused — `undeliveredCount` is 1,
+ * so the row falls to the delivery block and badges "1 not delivered". */
+function undeliveredRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 3,
+    deliveries: [
+      {
+        node: "digest",
+        kind: "channel",
+        target: "engineering",
+        status: "failed",
+        detail: "channel not wired",
+      },
+    ],
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderHistory(run: WorkflowRunOutcome) {
+  await act(async () => {
+    root.render(
+      createElement(RunHistoryPanel, {
+        runs: [run],
+        graph: null,
+        workflowName: "Daily digest",
+        onClose: () => {},
+        selectedRunSeq: null,
+        onSelectRun: () => {},
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the run-status legend affordance", () => {
+  it("renders an accessible legend trigger in the panel header", async () => {
+    await renderHistory(baseRun());
+    const legend = container.querySelector(
+      '[data-testid="workflow-run-legend"]',
+    );
+    expect(legend).not.toBeNull();
+    // It must carry a name — the whole point is a discoverable key, and an icon
+    // with no accessible name is not discoverable to a screen reader.
+    expect(legend?.getAttribute("aria-label")).toBeTruthy();
+  });
+});
+
+describe("the status dot defines the run's verdict on hover", () => {
+  it("titles a stopped run's dot with the word and its meaning", async () => {
+    await renderHistory(stoppedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    // The word an operator sees the colour for…
+    expect(title).toContain("stopped");
+    // …and a plain-English definition, not just the word again.
+    expect(title).toContain("stopped this run");
+  });
+});
+
+describe("the 'not delivered' delivery badge explains itself", () => {
+  it("carries a title defining a report that did not go out", async () => {
+    await renderHistory(undeliveredRun());
+    const badge = Array.from(container.querySelectorAll("[title]")).find((el) =>
+      el.textContent?.includes("not delivered"),
+    );
+    expect(badge).toBeTruthy();
+    expect(badge?.getAttribute("title")).toContain(
+      "never reached its destination",
+    );
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -472,13 +472,25 @@ describe("the failed-run remedy matches whether a node was actually at fault", (
   // rounds ago, tested above) already says is "rather than anything wrong
   // with the workflow". This paragraph still told the operator to correct the
   // workflow unconditionally.
-  it("does not tell the operator to correct the workflow when no node was at fault", async () => {
+  //
+  // Codex review on #1821 (twelfth pass): "nothing in the graph got the
+  // chance to run" itself overclaimed — `WorkflowNodeFinished` is appended
+  // best-effort, so an empty `nodes` can mean a node's own finish row simply
+  // failed to journal, not that execution never began (the same fact the
+  // tenth-pass fix already established for the `nodes.length > 0` sibling
+  // arm). The assertion below on the removed phrase is the regression proof:
+  // it fails against the pre-fix string, which asserted exactly that.
+  it("does not tell the operator to correct the workflow, and does not claim nothing ran, when no node was at fault", async () => {
     await renderHistory(failedRun());
     const row = container.querySelector('[data-testid="workflow-run-row"]');
     expect(row?.textContent).not.toContain(
       "correct the workflow and run it again",
     );
-    expect(row?.textContent).toContain("may be a host or capability problem");
+    expect(row?.textContent).not.toContain(
+      "nothing in the graph got the chance to run",
+    );
+    expect(row?.textContent).toContain("isn't proof nothing ran");
+    expect(row?.textContent).toContain("host/capability problem");
   });
 
   it("offers Fix with copilot for a node-level failure", async () => {
@@ -569,12 +581,20 @@ describe("the failed-run remedy distinguishes an interrupted run from one that n
     expect(row?.textContent).toContain("may not be fully recorded here");
   });
 
-  it("still says nothing ran for a run that failed with no nodes at all", async () => {
+  // Codex review on #1821 (twelfth pass): this test's own premise was the
+  // overclaim — an empty `nodes` is not proof "nothing ran", it can equally
+  // mean the FIRST node's own `WorkflowNodeFinished` silently failed to
+  // journal (the exact best-effort gap the tenth-pass comment above already
+  // names). The `nodes.length === 0` arm now hedges the same way the
+  // `nodes.length > 0` arm above already does, instead of asserting nothing
+  // ran.
+  it("hedges rather than asserting nothing ran for a run that failed with no nodes recorded", async () => {
     await renderHistory(failedRun());
     const row = container.querySelector('[data-testid="workflow-run-row"]');
-    expect(row?.textContent).toContain(
+    expect(row?.textContent).not.toContain(
       "nothing in the graph got the chance to run",
     );
+    expect(row?.textContent).toContain("isn't proof nothing ran");
   });
 });
 

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -514,12 +514,24 @@ describe("the failed-run remedy matches whether a node was actually at fault", (
 
   // Codex review on #1821 (eighth pass): the copilot re-wires the workflow, so
   // offering it here dangles the same wrong remedy as the sentence above for a
-  // run with no evidence the workflow was ever at fault.
-  it("does not offer Fix with copilot when no node was at fault", async () => {
+  // run with no evidence the workflow was ever at fault. Gated the button on
+  // `failedNode`.
+  //
+  // Codex review on #1821 (twelfth pass): that premise doesn't hold —
+  // `failedNode` is null in the SAME "finish row missing" case as the test
+  // above, not only in the genuine no-node-ran case, and the backend endpoint
+  // this button drives never required a node id (`resolve_fix_error` in
+  // `workflows.rs` only needs `run.error`; the request this callback sends
+  // carries no node id at all). The copilot itself reads the error text and
+  // replies `NotAutomatable` when it genuinely cannot help — the frontend
+  // gating pre-empted that classification with a guess a lost per-node
+  // record could falsify. The button now shows whenever there is a run to
+  // fix from; this test proves the flip against the exact pre-fix
+  // expectation.
+  it("offers Fix with copilot even when no node is named — the backend classifies automatable-or-not", async () => {
     // `runId` set explicitly: `failedRun()` omits it, and the button's OTHER
     // guard (`run.runId`) would then hide it for a reason unrelated to this
-    // test — this run must satisfy every other guard so `failedNode` is the
-    // only thing left that can be under test.
+    // test.
     await act(async () => {
       root.render(
         createElement(RunHistoryPanel, {
@@ -535,7 +547,7 @@ describe("the failed-run remedy matches whether a node was actually at fault", (
     });
     expect(
       container.querySelector('[data-testid="workflow-run-fix-with-copilot"]'),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 });
 

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -201,6 +201,25 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).not.toContain("was dropped where it was");
   });
 
+  // Codex review on #1821 (eleventh pass): the fix above stopped claiming the
+  // mid-flight step was unconditionally dropped, but still spoke of "the step
+  // that was mid-flight" as a step every stopped run has. `stoppedRun()` here
+  // carries no `nodes` and no `startedNodes` — the exact shape `runner.rs`'s
+  // `a_run_cancelled_before_it_starts_does_not_walk_the_graph` proves happens
+  // when the cancel signal is already fired before the graph is ever walked —
+  // so there was no mid-flight step for this run at all. Unlike the row
+  // body's "every step that had started completed", which is vacuously true
+  // over an empty set, a definite "the step that was mid-flight" presupposes
+  // one exists and is simply false here.
+  it("does not presuppose a mid-flight step for a run stopped before any step began", async () => {
+    await renderHistory(stoppedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).toContain("no such step at all");
+  });
+
   // Codex review on #1821: `failureLocation`/`failedNodeOf` (`graph.ts`)
   // explicitly preserve the case where a run's `error` names no node at all —
   // a graph that would not compile, a capability that could not be built, or

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -329,3 +329,36 @@ describe("the 'not delivered' delivery badge explains itself", () => {
     );
   });
 });
+
+describe("the legend trigger opens without hover or focus", () => {
+  // Codex review on #1821 (fifth pass): Base UI's `Tooltip.Trigger` only
+  // opens on hover or keyboard focus — by design, the same split Base UI
+  // documents between Tooltip (glance-only) and Popover (press-activatable).
+  // A tap on a touch-only device produces neither: `useHoverReferenceInteraction`
+  // is `mouseOnly`, and the trigger's own `onClick` handler *cancels* a
+  // pending hover-open rather than starting one. So the legend button — the
+  // affordance an earlier fix on this same PR called "the panel's one
+  // keyboard- and touch-reachable affordance" — was itself unreachable by
+  // touch. This fires a bare `click` with no prior `pointerenter`/`focus`,
+  // the same shape a touch tap dispatches, and proves the popup opens off
+  // that alone.
+  it("opens the popup on a bare click, the shape a touch tap dispatches", async () => {
+    await renderHistory(baseRun());
+    const trigger = container.querySelector<HTMLElement>(
+      '[data-testid="workflow-run-legend"]',
+    );
+    expect(trigger).not.toBeNull();
+    expect(document.body.textContent).not.toContain("What these statuses mean");
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(document.body.textContent).toContain("What these statuses mean");
+    // Every entry in the source-of-truth array actually rendered, not just
+    // the heading.
+    for (const term of RUN_STATUS_LEGEND) {
+      expect(document.body.textContent).toContain(term);
+    }
+  });
+});

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -165,6 +165,27 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).not.toContain("A step errored");
   });
 
+  // Codex review on #1821 (second pass): the previous fix above stopped
+  // claiming a step errored when the run failed with no node at fault, but
+  // left the remedy — "correct the workflow" — unconditional. `workflow_outcome.rs`'s
+  // `INTERRUPTED_BY_RESTART` is exactly this case and is deliberately worded
+  // as a host fact, not a workflow fault ("nothing about the graph went
+  // wrong, the process holding it went away... an operator reading this
+  // should go looking at the deployment, not at their nodes"). Telling that
+  // operator to correct the workflow sends them to fix something that was
+  // never broken.
+  it("does not unconditionally tell the operator to correct the workflow", async () => {
+    await renderHistory(failedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).toContain("failed");
+    expect(title).not.toContain("correct the workflow, and run it again");
+    // The hedge names a case where the failure isn't the workflow's fault.
+    expect(title).toContain("host restart");
+  });
+
   // Codex review on #1821: a blocked node whose gated call could not be
   // queued for approval at all (`unparkable`, not `stranded`) never gets a
   // card in Approvals — `BlockedNodeApprovals`/the row's own body text

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -171,6 +171,20 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).toContain("stopped this run");
   });
 
+  // Codex review on #1821 (fifth pass): `title` is a mouse-hover affordance.
+  // The dot was a non-focusable, unlabelled span, so a keyboard, touch or
+  // screen-reader user had nothing that named THIS row's verdict — the header
+  // legend defines the terms but never says which one applies here. `role="img"`
+  // plus `aria-label` puts the same one-liner in the accessibility tree.
+  it("gives the dot an accessible name matching its hover title", async () => {
+    await renderHistory(stoppedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    expect(dot?.getAttribute("role")).toBe("img");
+    expect(dot?.getAttribute("aria-label")).toBe(dot?.getAttribute("title"));
+  });
+
   // Codex review on #1821: `RunCancel` (`src/ports/workflow_runner.rs`) stops
   // a run at the next node boundary — the node already executing normally
   // finishes and is journaled. Only a node wedged past the hard-abort grace

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -37,6 +37,15 @@ function stoppedRun(): WorkflowRunOutcome {
   return baseRun({ seq: 2, cancelled: true });
 }
 
+/** A run that failed before any node ran at all — a graph that would not
+ * compile, or a capability that could not be built (`graph.ts`'s
+ * `failureLocation`/`failedNodeOf` name this case explicitly: `nodes` is
+ * empty and no node is at fault). `verdictOf` reads a run with `error` set as
+ * `failed` regardless of whether any node ran. */
+function failedRun(): WorkflowRunOutcome {
+  return baseRun({ seq: 4, error: "graph failed to compile" });
+}
+
 /** A finished run whose one output report was refused — `undeliveredCount` is 1,
  * so the row falls to the delivery block and badges "1 not delivered". */
 function undeliveredRun(): WorkflowRunOutcome {
@@ -110,6 +119,37 @@ describe("the status dot defines the run's verdict on hover", () => {
     expect(title).toContain("stopped");
     // …and a plain-English definition, not just the word again.
     expect(title).toContain("stopped this run");
+  });
+
+  // Codex review on #1821: `RunCancel` (`src/ports/workflow_runner.rs`) stops
+  // a run at the next node boundary — the node already executing normally
+  // finishes and is journaled. Only a node wedged past the hard-abort grace
+  // period is actually dropped mid-flight. The old wording claimed the
+  // mid-flight step was *always* dropped, which misleads an operator into
+  // thinking its work or side effects never completed.
+  it("does not claim the mid-flight step was unconditionally dropped", async () => {
+    await renderHistory(stoppedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).toContain("normally ran to completion");
+    expect(title).not.toContain("was dropped where it was");
+  });
+
+  // Codex review on #1821: `failureLocation`/`failedNodeOf` (`graph.ts`)
+  // explicitly preserve the case where a run's `error` names no node at all —
+  // a graph that would not compile, a capability that could not be built, or
+  // an interrupted run the boot sweep recorded. The old wording said
+  // unconditionally "a step errored", misdiagnosing those runs.
+  it("does not claim a step errored when the run failed before any step ran", async () => {
+    await renderHistory(failedRun());
+    const dot = container.querySelector(
+      '[data-testid="workflow-run-status-dot"]',
+    );
+    const title = dot?.getAttribute("title") ?? "";
+    expect(title).toContain("failed");
+    expect(title).not.toContain("A step errored");
   });
 });
 

--- a/frontend/test/unit/workflow-run-status-legend.test.ts
+++ b/frontend/test/unit/workflow-run-status-legend.test.ts
@@ -586,6 +586,45 @@ describe("the cancelled-run sentence matches whether a step was actually cut off
   });
 });
 
+/** A run cancelled on a host predating #1010/#382: no `startedNodes` field at
+ * all, so whether the step in progress when the stop landed finished is
+ * genuinely unknowable — `WorkflowRunOutcome.startedNodes`'s own doc comment
+ * says absence must read as "no start trail", never as "nothing started". */
+function cancelledLegacyRun(): WorkflowRunOutcome {
+  return baseRun({
+    seq: 12,
+    cancelled: true,
+    nodes: [{ nodeId: "n_3", status: "ok", elapsedMs: 40 }],
+  });
+}
+
+// Codex review on #1821 (ninth pass): `midFlightNode` folded `run.startedNodes
+// ?? []` into "no node was mid-flight" for BOTH a settled run whose receipt
+// confirms every started step finished AND a legacy run with no receipt at
+// all — collapsing "known complete" and "unknown" into the same unconditional
+// completion claim.
+describe("the cancelled-run sentence hedges when the start trail itself is missing", () => {
+  it("does not claim every started step completed when startedNodes is absent", async () => {
+    await renderHistory(cancelledLegacyRun());
+    const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
+    expect(row?.textContent).not.toContain(
+      "Every step that had started completed",
+    );
+    expect(row?.textContent).not.toContain("stopped where it was");
+    expect(row?.textContent).toContain("is not recorded for this run");
+  });
+
+  it("still asserts completion when startedNodes is present and empty (known: nothing had started)", async () => {
+    await renderHistory(
+      baseRun({ seq: 13, cancelled: true, startedNodes: [] }),
+    );
+    const row = container.querySelector('[data-testid="workflow-run-cancelled"]');
+    expect(row?.textContent).toContain(
+      "Every step that had started completed and was recorded before the stop took effect.",
+    );
+  });
+});
+
 describe("the unparkable-only blocked remedy stops naming a policy cause", () => {
   // Codex review on #1821 (eighth pass, same site as the sixth): `parkFailed`
   // fires both when the approvals queue refused the write and when this

--- a/frontend/test/unit/workflow-switch-state-leak.test.ts
+++ b/frontend/test/unit/workflow-switch-state-leak.test.ts
@@ -106,7 +106,16 @@ const GRAPHS: Record<string, WorkflowGraph> = {
   [WF_B]: graph(WF_B, "Workflow B"),
 };
 
-/** A failed run — `error` is what puts the Fix affordance on the row. */
+/** A failed run — `error` is what puts the Fix affordance on the row.
+ *
+ * `nodes` names the node the failure traces to (matching each graph's own
+ * `start` trigger, the only node either defines). Codex review on #1821
+ * (eighth pass) made the Fix affordance conditional on `failedNodeOf(run)`
+ * finding one — a run whose `error` names no node (a host restart, an
+ * uncompilable graph) offers no fix the copilot could make, so the button no
+ * longer renders for it. This fixture is about the button leaking across a
+ * workflow switch, not about that distinction, so it keeps the ordinary,
+ * node-attributed shape that earns the button in the first place. */
 function failedRun(workflowId: string, seq: number): WorkflowRunOutcome {
   return {
     seq,
@@ -117,6 +126,7 @@ function failedRun(workflowId: string, seq: number): WorkflowRunOutcome {
     deliveries: [],
     pendingApprovals: [],
     error: `${workflowId} blew up`,
+    nodes: [{ nodeId: "start", status: "error", elapsedMs: 1 }],
   };
 }
 


### PR DESCRIPTION
## Summary
Add plain-English, discoverable definitions for the workflow run statuses that had none — "stranded", "not delivered", "blocked", "stopped", "parked" — so an operator can read a status they can't currently act on. Display-only; no status computation changed.

## Problem
Workflow run cards surface statuses like "Manual run stranded", "Manual run not delivered · 1 not delivered", "Scheduled run blocked" with no legend or tooltip. The verdict dot was colour-only. An operator can't act on a status whose meaning is undefined in the UI.

## Solution
In `frontend/src/views/workflows/RunHistoryPanel.tsx`:
- `RUN_STATUS_DEFINITIONS` — one source of truth mapping each status word (keyed by the labels `runTone()` returns) to a one-line definition.
- A header info-icon legend (`RunStatusLegend`, reusing the app's base-ui tooltip primitive) opening the full key.
- `title` tooltips on the status dot, the "not delivered" badge, and the "parked N approvals" badge.
- Definitions sourced from the existing semantics in `run-health.ts` (`isStranded`/`isUndelivered`/`isBlocked`/`liveParkedApprovalCount`), not guessed.

No change to `RunStatus`/verdict enums or any status computation.

## Submission Checklist
- [x] `npm run typecheck` + `typecheck:unit` + `typecheck:e2e` — all pass
- [x] `npx vitest run` — 3262 passed (new file: 3 passed)
- [x] `npm run build` — clean
- [x] Display-only; no status logic touched
- [x] New unit test covers the legend + hover definitions

## Impact
Operators can now read what "stranded" / "not delivered" / "blocked" / "stopped" / "parked" mean directly on the run row — no behavior change, purely legibility.

## Related
Closes #1798


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible popovers with configurable positioning, animations, and portal rendering.
  * Added a popover example to the style guide.
  * Improved run-status explanations, accessibility labels, and failure, cancellation, interruption, and approval messaging.
  * Repair actions are now available for identified run errors with a run ID.

* **Bug Fixes**
  * Run history now distinguishes approval-limit discards from approval-queue rejections and handles incomplete execution records more accurately.

* **Tests**
  * Added coverage for popover accessibility and run-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->