### PR TITLE
fix(company): make teammate cards clickable

### DIFF
--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -613,7 +613,10 @@ function MemberCard({
   return (
     <Card
       data-testid="team-card"
-      className="transition-colors"
+      className={cn(
+        "relative transition-colors",
+        onOpen && "cursor-pointer hover:border-primary/40 hover:shadow-sm",
+      )}
     >
       <CardContent className="flex h-full flex-col gap-3 py-4">
         <div className="flex items-start gap-3">
@@ -631,7 +634,10 @@ function MemberCard({
             <button
               type="button"
               onClick={onOpen}
-              className="-m-1 min-w-0 flex-1 rounded-sm p-1 text-left hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              // Issue #1810: stretch the title's native button over the card,
+              // instead of turning a container with nested controls into a
+              // button. The menu and desk links sit above this layer below.
+              className="-m-1 min-w-0 flex-1 rounded-sm p-1 text-left after:absolute after:inset-0 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               data-testid="team-card-open"
             >
               <span className="block truncate font-medium">{member.name}</span>
@@ -665,7 +671,8 @@ function MemberCard({
               )}
             </div>
           )}
-          <div>
+          {/* Above the title button's stretched click target (issue #1810). */}
+          <div className="relative z-10">
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={<Button variant="ghost" size="icon" className="-mr-1 -mt-1 size-7" aria-label="Teammate actions" />}
@@ -730,7 +737,10 @@ function MemberCard({
               <Badge
                 key={desk.id}
                 variant="secondary"
-                className={cn("gap-1 text-3xs", onNavigateToDesk && "cursor-pointer")}
+                className={cn(
+                  "gap-1 text-3xs",
+                  onNavigateToDesk && "relative z-10 cursor-pointer",
+                )}
                 data-testid={`team-card-desk-${desk.id}`}
                 onClick={
                   onNavigateToDesk

--- a/frontend/test/e2e/team-desks.spec.ts
+++ b/frontend/test/e2e/team-desks.spec.ts
@@ -176,3 +176,27 @@ test("#1391 the teammate action is a focused title button, not an interactive ca
   await open.press("Enter");
   await expect(page).toHaveURL(/#\/team\/maya$/);
 });
+
+test("#1810 the teammate card opens without swallowing its actions menu", async ({ page }) => {
+  await mockApi(page);
+  await page.goto("/#/company");
+
+  const maya = card(page, "Maya");
+  await expect(maya).toBeVisible({ timeout: 30_000 });
+
+  // The description is deliberately plain card content, not the title button.
+  // Clicking it proves the stretched title action covers the card surface.
+  const description = await maya.getByTestId("team-card-description").boundingBox();
+  if (!description) throw new Error("Maya's description has no clickable bounds");
+  await page.mouse.click(description.x + 4, description.y + 4);
+  await expect(page).toHaveURL(/#\/team\/maya$/);
+
+  await page.goto("/#/company");
+  await expect(maya).toBeVisible({ timeout: 30_000 });
+
+  // The overflow stays above the stretched target: it opens Remove without
+  // navigating to the teammate underneath it.
+  await maya.getByRole("button", { name: "Teammate actions" }).click();
+  await expect(page.getByRole("menuitem", { name: "Remove" })).toBeVisible();
+  await expect(page).toHaveURL(/#\/company$/);
+});


### PR DESCRIPTION
## Summary

- Make the existing teammate title button cover the full card surface without turning the card into an interactive container.
- Keep the overflow menu and desk chips above that stretched click target so their actions remain independent.
- Add browser coverage for card navigation and the teammate actions menu.

Closes #1810

## API Or Behavior Changes

Clicking non-interactive content on a host-backed teammate card now opens that teammate's detail page. The title remains keyboard-accessible, while the `⋯` menu and desk chips keep their existing actions.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run`
- [x] `npm run build`
- [x] `PW_HOST_BINARY=... npx playwright test test/e2e/team-desks.spec.ts --grep '#1810|#1391|#1440 clicking'`

## Documentation

No documentation changes were needed for this focused interaction fix.
