### PR TITLE
feat(company): make desk lead explicit with label, hint and set-lead action (#1802)

### DIFF
--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -94,6 +94,17 @@ export function DeskCreateDialog({
     );
   }
 
+  // Promote a selected teammate to the lead slot (index 0), which the whole
+  // stack treats as the desk's lead (`members[0]` — see `chat/model.ts` and
+  // `api/types.ts`). The others keep their relative order behind the new lead.
+  // No-ops (returns the same reference) when the id is already the lead, and no
+  // backend call — the choice is posted with the rest of the draft on Create.
+  function makeLead(id: string) {
+    setMembers((current) =>
+      current[0] === id ? current : [id, ...current.filter((m) => m !== id)],
+    );
+  }
+
   function memberLabel(id: string): string {
     const member = roster.find((r) => r.id === id);
     return member?.name ?? member?.role ?? id;
@@ -194,6 +205,10 @@ export function DeskCreateDialog({
 
         <div className="grid gap-2">
           <Label>Teammates</Label>
+          <p className="text-xs text-muted-foreground">
+            The top teammate leads the desk — add them in seniority order, or use “Make lead” to
+            promote anyone.
+          </p>
           {roster.length === 0 ? (
             <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
               No roster teammates to add — you can add them after the desk exists.
@@ -213,20 +228,27 @@ export function DeskCreateDialog({
               {visibleRoster.map((member) => {
                 const order = members.indexOf(member.id);
                 const selected = order !== -1;
+                const memberName = member.name ?? member.role;
                 return (
-                  <button
-                    type="button"
+                  // A row, not a button: the select/deselect toggle and the
+                  // "Make lead" promote control are siblings, because nesting an
+                  // interactive control inside the toggle button is invalid HTML
+                  // and would make a promote click also toggle selection.
+                  <div
                     key={member.id}
-                    onClick={() => toggleMember(member.id)}
-                    aria-pressed={selected}
                     className={cn(
-                      "flex items-center justify-between gap-2 rounded-md border px-2.5 py-1.5 text-left text-sm transition-colors",
+                      "flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm transition-colors",
                       selected
                         ? "border-primary/50 bg-primary/10"
                         : "hover:bg-muted/60",
                     )}
                   >
-                    <span className="flex min-w-0 items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={() => toggleMember(member.id)}
+                      aria-pressed={selected}
+                      className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                    >
                       <span
                         aria-hidden="true"
                         className={cn(
@@ -239,7 +261,7 @@ export function DeskCreateDialog({
                         {selected && <Check className="size-3" />}
                       </span>
                       <TeammateAvatar
-                        name={member.name ?? member.role}
+                        name={memberName}
                         avatar={avatarRef(member.avatar, member.id ?? member.name ?? "")}
                         tone={toneFor(member.id ?? member.name ?? "")}
                         className="size-5 shrink-0"
@@ -247,14 +269,27 @@ export function DeskCreateDialog({
                       {order === 0 && (
                         <Crown role="img" aria-label="Desk lead" className="size-3.5 shrink-0 text-muted-foreground" />
                       )}
-                      <span className="truncate">{member.name ?? member.role}</span>
-                    </span>
-                    {selected && (
-                      <span className="shrink-0 text-xs text-muted-foreground">
-                        {order === 0 ? "1 · Lead" : order + 1}
+                      <span className="truncate">{memberName}</span>
+                    </button>
+                    {order === 0 ? (
+                      <span
+                        data-testid="desk-lead-badge"
+                        className="shrink-0 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary"
+                      >
+                        Lead
                       </span>
-                    )}
-                  </button>
+                    ) : selected ? (
+                      <button
+                        type="button"
+                        onClick={() => makeLead(member.id)}
+                        data-testid="desk-make-lead"
+                        aria-label={`Make ${memberName} the desk lead`}
+                        className="shrink-0 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                      >
+                        Make lead
+                      </button>
+                    ) : null}
+                  </div>
                 );
               })}
               {visibleRoster.length === 0 && (

--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -279,15 +279,23 @@ export function DeskCreateDialog({
                         Lead
                       </span>
                     ) : selected ? (
-                      <button
-                        type="button"
-                        onClick={() => makeLead(member.id)}
-                        data-testid="desk-make-lead"
-                        aria-label={`Make ${memberName} the desk lead`}
-                        className="shrink-0 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-                      >
-                        Make lead
-                      </button>
+                      <span className="flex shrink-0 items-center gap-1.5">
+                        <span
+                          data-testid="desk-member-position"
+                          className="text-xs text-muted-foreground"
+                        >
+                          {order + 1}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => makeLead(member.id)}
+                          data-testid="desk-make-lead"
+                          aria-label={`Make ${memberName} the desk lead`}
+                          className="shrink-0 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                        >
+                          Make lead
+                        </button>
+                      </span>
                     ) : null}
                   </div>
                 );

--- a/frontend/src/views/company/DeskCreateDialog.tsx
+++ b/frontend/src/views/company/DeskCreateDialog.tsx
@@ -59,6 +59,9 @@ export function DeskCreateDialog({
   const [nameError, setNameError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
+  // Keyed by member id, so `makeLead` can move focus to a control that
+  // survives the promotion — see the comment there.
+  const toggleRefs = useRef(new Map<string, HTMLButtonElement>());
   const formId = useId();
   const nameErrorId = `${formId}-name-error`;
 
@@ -99,10 +102,20 @@ export function DeskCreateDialog({
   // `api/types.ts`). The others keep their relative order behind the new lead.
   // No-ops (returns the same reference) when the id is already the lead, and no
   // backend call — the choice is posted with the rest of the draft on Create.
+  //
+  // The row that owns the "Make lead" button the operator just activated
+  // loses that button on this render — the promoted row switches to the
+  // non-focusable "Lead" badge — so the focused element would otherwise be
+  // ripped out of the DOM and focus would drop to `document.body`, stranding
+  // a keyboard/AT user outside the dialog. The row's select/deselect toggle
+  // is keyed by the same `member.id` and renders for every visible row
+  // regardless of lead status, so it is the one control guaranteed to still
+  // be mounted after the promotion; hand focus to it.
   function makeLead(id: string) {
     setMembers((current) =>
       current[0] === id ? current : [id, ...current.filter((m) => m !== id)],
     );
+    toggleRefs.current.get(id)?.focus();
   }
 
   function memberLabel(id: string): string {
@@ -245,6 +258,10 @@ export function DeskCreateDialog({
                   >
                     <button
                       type="button"
+                      ref={(el) => {
+                        if (el) toggleRefs.current.set(member.id, el);
+                        else toggleRefs.current.delete(member.id);
+                      }}
                       onClick={() => toggleMember(member.id)}
                       aria-pressed={selected}
                       className="flex min-w-0 flex-1 items-center gap-1.5 text-left"

--- a/frontend/test/unit/desk-create-lead.test.ts
+++ b/frontend/test/unit/desk-create-lead.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { CreateDeskInput, DeskDto, TeamMemberDto } from "@/api/types";
+import { DeskCreateDialog } from "@/views/company/DeskCreateDialog";
+
+/**
+ * Choosing the desk lead (issue #1802).
+ *
+ * The whole stack treats `members[0]` as the desk's lead (`chat/model.ts`,
+ * `api/types.ts`). The creator used to encode that purely as selection order
+ * with a Crown and a terse "1 · Lead" string, and the only way to change the
+ * lead was to deselect everyone and re-pick. This makes the lead explicit: the
+ * top row wears a "Lead" badge, every other selected row offers "Make lead",
+ * and the summary names the current lead — all while keeping `members[0]` as
+ * the single source of truth, which is what the posted payload must reflect.
+ *
+ * These are assertions about a mounted component — which row holds the badge,
+ * what the summary says, and what actually gets posted — so they earn a jsdom
+ * render rather than a unit test of a helper.
+ */
+
+const ROSTER: TeamMemberDto[] = [
+  { id: "ada", name: "Ada", role: "engineer" },
+  { id: "grace", name: "Grace", role: "engineer" },
+  { id: "linus", name: "Linus", role: "engineer" },
+];
+
+function stubClient(createDesk: (...args: never[]) => Promise<DeskDto>) {
+  return {
+    listTeam: () => Promise.resolve(ROSTER),
+    createDesk,
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let onOpenChange: ReturnType<typeof vi.fn>;
+let onCreated: ReturnType<typeof vi.fn>;
+
+/** The dialog renders through a portal, so it is on `document`, not `container`. */
+function inDialog<T extends Element>(selector: string): T | null {
+  return document.querySelector<T>(`[data-slot="dialog-content"] ${selector}`);
+}
+
+/** The select/deselect toggle for a teammate — the row's `[aria-pressed]` button. */
+function toggle(name: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-slot="dialog-content"] [aria-pressed]'),
+  ).find((button) => button.textContent?.includes(name));
+  expect(match, `no roster toggle for ${name}`).toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
+/** The "Make lead" promote control in a teammate's row (a sibling of the toggle). */
+function makeLead(name: string): HTMLButtonElement | null {
+  const row = toggle(name).parentElement!;
+  return row.querySelector<HTMLButtonElement>('[data-testid="desk-make-lead"]');
+}
+
+/** True when the named teammate's row is the one wearing the "Lead" badge. */
+function isLead(name: string): boolean {
+  return Boolean(toggle(name).parentElement!.querySelector('[data-testid="desk-lead-badge"]'));
+}
+
+/** The "Lead: <name>" summary line under the picker. */
+function leadSummary(): string {
+  const line = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-slot="dialog-content"] p'),
+  ).find((p) => p.textContent?.startsWith("Lead:"));
+  return line?.textContent ?? "";
+}
+
+function nameInput(): HTMLInputElement {
+  const el = inDialog<HTMLInputElement>('[placeholder="e.g. Engineering"]');
+  expect(el, "the Name field did not render").toBeTruthy();
+  return el as HTMLInputElement;
+}
+
+function createButton(): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-slot="dialog-content"] button'),
+  ).find((b) => b.textContent?.trim().startsWith("Create desk"));
+  expect(match, 'no button labeled "Create desk"').toBeTruthy();
+  return match as HTMLButtonElement;
+}
+
+/** Sets a controlled input the way a keystroke would, so React's `onChange` fires. */
+function type(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function open(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(DeskCreateDialog, {
+        open: true,
+        onOpenChange,
+        onCreated,
+        client,
+        company: "acme",
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  Element.prototype.scrollIntoView = vi.fn();
+  onOpenChange = vi.fn();
+  onCreated = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the desk creator lead picker", () => {
+  it("makes the first-selected teammate the lead", async () => {
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+
+    await act(async () => {
+      toggle("Ada").click();
+      toggle("Grace").click();
+    });
+
+    // The first pick leads: it wears the badge and no "Make lead" of its own.
+    expect(isLead("Ada")).toBe(true);
+    expect(makeLead("Ada")).toBeNull();
+    // The other selected teammate offers promotion instead.
+    expect(isLead("Grace")).toBe(false);
+    expect(makeLead("Grace")).toBeTruthy();
+    // ...and the summary names the current lead.
+    expect(leadSummary()).toContain("Ada");
+  });
+
+  it("moves the lead when a non-lead is promoted", async () => {
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+
+    await act(async () => {
+      toggle("Ada").click();
+      toggle("Grace").click();
+    });
+    expect(isLead("Ada")).toBe(true);
+
+    await act(async () => {
+      makeLead("Grace")!.click();
+    });
+
+    // The badge and the summary both move to Grace; Ada now offers "Make lead".
+    expect(isLead("Grace")).toBe(true);
+    expect(isLead("Ada")).toBe(false);
+    expect(makeLead("Ada")).toBeTruthy();
+    expect(leadSummary()).toContain("Grace");
+  });
+
+  it("posts the promoted teammate as members[0]", async () => {
+    let captured: CreateDeskInput | undefined;
+    const createDesk = vi.fn((input: CreateDeskInput) => {
+      captured = input;
+      return Promise.resolve({ id: "desk-1", name: input.name } as DeskDto);
+    });
+    await open(stubClient(createDesk as (...args: never[]) => Promise<DeskDto>));
+
+    await act(async () => {
+      type(nameInput(), "Engineering");
+    });
+    await act(async () => {
+      toggle("Ada").click();
+      toggle("Grace").click();
+      toggle("Linus").click();
+    });
+    await act(async () => {
+      makeLead("Linus")!.click();
+    });
+    await act(async () => {
+      createButton().click();
+    });
+
+    expect(createDesk).toHaveBeenCalledTimes(1);
+    expect(captured?.members?.[0]).toBe("linus");
+    // The rest are still there, just behind the new lead.
+    expect(captured?.members).toContain("ada");
+    expect(captured?.members).toContain("grace");
+  });
+
+  it("promotes the next teammate when the current lead is deselected", async () => {
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+
+    await act(async () => {
+      toggle("Ada").click();
+      toggle("Grace").click();
+    });
+    expect(isLead("Ada")).toBe(true);
+
+    // Deselecting the lead hands the slot to the next-in-line.
+    await act(async () => {
+      toggle("Ada").click();
+    });
+
+    expect(isLead("Grace")).toBe(true);
+    expect(leadSummary()).toContain("Grace");
+    // Ada is no longer selected, so it has neither badge nor promote control.
+    expect(toggle("Ada").getAttribute("aria-pressed")).toBe("false");
+    expect(makeLead("Ada")).toBeNull();
+  });
+});

--- a/frontend/test/unit/desk-create-lead.test.ts
+++ b/frontend/test/unit/desk-create-lead.test.ts
@@ -67,6 +67,16 @@ function isLead(name: string): boolean {
   return Boolean(toggle(name).parentElement!.querySelector('[data-testid="desk-lead-badge"]'));
 }
 
+/**
+ * The numeric hierarchy position shown next to a selected non-lead teammate's
+ * "Make lead" control, or `null` if the row does not render one (unselected,
+ * or the lead itself — which wears the "Lead" badge instead).
+ */
+function position(name: string): string | null {
+  const el = toggle(name).parentElement!.querySelector('[data-testid="desk-member-position"]');
+  return el?.textContent ?? null;
+}
+
 /** The "Lead: <name>" summary line under the picker. */
 function leadSummary(): string {
   const line = Array.from(
@@ -146,6 +156,36 @@ describe("the desk creator lead picker", () => {
     expect(makeLead("Grace")).toBeTruthy();
     // ...and the summary names the current lead.
     expect(leadSummary()).toContain("Ada");
+  });
+
+  it("keeps each non-lead teammate's hierarchy position visible alongside Make lead", async () => {
+    // Regression for the Codex P2 finding on #1827: with 3+ selected, every
+    // non-lead row used to show only "Make lead", with no way to tell Grace
+    // (2nd) from Linus (3rd) — the seniority order the hint text asks the
+    // operator to build stopped being verifiable the moment a third teammate
+    // joined the selection.
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+
+    await act(async () => {
+      toggle("Ada").click();
+      toggle("Grace").click();
+      toggle("Linus").click();
+    });
+
+    expect(isLead("Ada")).toBe(true);
+    expect(position("Ada")).toBeNull();
+    expect(position("Grace")).toBe("2");
+    expect(position("Linus")).toBe("3");
+
+    // Promoting Linus reshuffles who is 2nd vs 3rd, not just who is lead.
+    await act(async () => {
+      makeLead("Linus")!.click();
+    });
+
+    expect(isLead("Linus")).toBe(true);
+    expect(position("Linus")).toBeNull();
+    expect(position("Ada")).toBe("2");
+    expect(position("Grace")).toBe("3");
   });
 
   it("moves the lead when a non-lead is promoted", async () => {

--- a/frontend/test/unit/desk-create-lead.test.ts
+++ b/frontend/test/unit/desk-create-lead.test.ts
@@ -188,6 +188,32 @@ describe("the desk creator lead picker", () => {
     expect(position("Grace")).toBe("3");
   });
 
+  it("keeps focus on the promoted teammate's row after Make lead", async () => {
+    // Regression for the Codex accessibility finding on #1827: clicking
+    // "Make lead" removes that very button from the DOM (the promoted row
+    // switches to the non-focusable "Lead" badge), which used to drop focus
+    // to document.body — stranding a keyboard/AT user outside the dialog in
+    // a long roster. Focus should land on the promoted row's persistent
+    // select/deselect toggle instead.
+    await open(stubClient(() => Promise.reject(new Error("must not be called"))));
+
+    await act(async () => {
+      toggle("Ada").click();
+      toggle("Grace").click();
+    });
+    expect(isLead("Ada")).toBe(true);
+
+    const promoteButton = makeLead("Grace")!;
+    await act(async () => {
+      promoteButton.focus();
+      promoteButton.click();
+    });
+
+    expect(isLead("Grace")).toBe(true);
+    // Focus followed the promotion to Grace's row, not out to document.body.
+    expect(document.activeElement).toBe(toggle("Grace"));
+  });
+
   it("moves the lead when a non-lead is promoted", async () => {
     await open(stubClient(() => Promise.reject(new Error("must not be called"))));
 

--- a/frontend/test/unit/desk-create-name-error.test.ts
+++ b/frontend/test/unit/desk-create-name-error.test.ts
@@ -231,10 +231,12 @@ describe("the desk creator teammate picker", () => {
     const lead = rosterButton("Teammate 0");
     const second = rosterButton("Teammate 2");
     expect(lead.getAttribute("aria-pressed")).toBe("true");
-    expect(lead.textContent).toContain("1 · Lead");
+    // The lead carries the "Lead" badge (a row sibling of the toggle), the
+    // non-lead carries a "Make lead" promote control instead.
+    expect(lead.parentElement!.querySelector('[data-testid="desk-lead-badge"]')).toBeTruthy();
     expect(lead.querySelector(".lucide-check")).toBeTruthy();
     expect(second.getAttribute("aria-pressed")).toBe("true");
-    expect(second.textContent).toContain("2");
+    expect(second.parentElement!.querySelector('[data-testid="desk-make-lead"]')).toBeTruthy();
 
     await act(async () => {
       type(filter!, "Teammate 2");


### PR DESCRIPTION
## Summary

Makes the desk **lead** explicit in the desk-create dialog. Previously the lead was whichever teammate sat first in the row (`members[0]`), signalled only by a small crown icon — invisible until you happened to spot it, and unchangeable except by deselecting every teammate and re-picking them in order.

- Row 0 now shows a labelled **"Lead"** badge (crown kept alongside).
- Selected non-lead rows get a **"Make lead"** button that promotes that member to index 0, preserving everyone else's relative order.
- A muted helper line states the rule: the top teammate leads; add in seniority order or use Make lead.

The `members[0] === lead` invariant that the rest of the console relies on is kept intact — this only surfaces and lets you control it. Post-creation desk reorder (#131) is deliberately out of scope.

Closes #1802

## API Or Behavior Changes

None (frontend UX only). The created-desk payload still ships `members` with the lead at index 0.

## Tests

Frontend-only; Rust gates not applicable.

- [x] `npm run typecheck:unit` — PASS
- [x] `npx vitest run` — PASS (349 files, 3263 tests) incl. new `desk-create-lead.test.ts` (badge, promote, `members[0]` at submit, deselect-lead-promotes-next)
- [x] `npm run build` — PASS (pre-existing chunk-size advisory only)
- [ ] `cargo *` — N/A: no Rust changed

## Documentation

None needed — self-contained dialog UX change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added lead selection when creating a desk.
  - Teammates can be reordered by promoting a selected member to lead.
  - Lead status and teammate positions are clearly displayed.
  - The next selected teammate is automatically promoted when the current lead is removed.

- **Tests**
  - Added coverage for lead assignment, promotion, resequencing, summaries, and create requests.
  - Updated teammate picker assertions for the new controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->