### PR TITLE
feat(workflows): confirm permanent id at create (#1808)

### DIFF
--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -55,6 +55,16 @@ import { CronPreviewLine } from "@/views/CronPreviewLine";
 import { NodeConfigFields } from "@/views/workflows/NodeConfigFields";
 import type { TeamMemberDto } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -788,6 +798,19 @@ export function WorkflowCreateDialog({
    * a click, any caller added later — would both read `false` and both post. The
    * state stays because the render needs it; the ref is what actually guards. */
   const submittingRef = useRef(false);
+  /**
+   * Whether the create-time id confirm is on screen (issue #1808).
+   *
+   * The id is a permanent backend join key — it keys the overlay body, the
+   * revision store, the scheduler's armed state, run history, and cross-graph
+   * `sub_workflow` references — so the host answers 400 to a rename. Creation is
+   * the only moment it can be set, and in create mode it is silently derived
+   * from the name, so a name typo becomes a permanent id with no acknowledgement.
+   * `submit()` gates on this in create mode: the first Create shows the confirm,
+   * the confirm's own action runs the write. Never true in edit mode — the id is
+   * fixed there and the form field is read-only.
+   */
+  const [confirmingId, setConfirmingId] = useState(false);
   const [error, setError] = useState<string | null>(null);
   /** The submit-time error banner, so a failed submit can scroll it into view
    * and focus it rather than leave the message off-screen (#813 defect 6). */
@@ -932,6 +955,9 @@ export function WorkflowCreateDialog({
     let nextEdges = workflow ? draftEdges(workflow) : [];
     setError(null);
     setFieldErrors({});
+    // Issue #1808: a fresh open (or a re-hydrate) never carries a prior attempt's
+    // pending id confirm — the previewed id it named may not be this graph's.
+    setConfirmingId(false);
     // Issue #274: a fresh open (or a re-hydrate after a restore) must not carry
     // the previous graph's history. It re-loads on the next expand, and against
     // the freshly-restored body's version token.
@@ -1218,6 +1244,10 @@ export function WorkflowCreateDialog({
   function changeName(value: string) {
     setName(value);
     clearSubmitError();
+    // Issue #1808: the name derives the previewed id, so editing it after a
+    // Back invalidates whatever the confirm was showing — retire the pending
+    // confirm so a stale preview can't reappear on the next Create.
+    setConfirmingId(false);
     // Issue #1053: the form used to reject "Weekly digest" for a missing id,
     // then reject "weekly digest" for an unsafe one — twice, for something it
     // could derive. Derived only while the id is nobody's yet, and never in edit
@@ -1238,6 +1268,9 @@ export function WorkflowCreateDialog({
     // including when they clear it back to empty, which is a decision too.
     setAuthoredId(value);
     clearSubmitError();
+    // Issue #1808: the id the confirm would show just changed under it — retire
+    // the pending confirm so Back-then-edit re-derives the new one.
+    setConfirmingId(false);
   }
 
   function changeDescription(value: string) {
@@ -1680,25 +1713,18 @@ export function WorkflowCreateDialog({
     });
   }
 
-  async function submit() {
-    // Re-entrancy guard (issue #1005). The Create button disables while a write
-    // is in flight, but `disabled` is a property of one DOM node: a second
-    // activation landing in the same tick as the first, an Enter keypress, or
-    // any future caller would otherwise post the graph twice — and for create
-    // that means two workflows, or a 409 the operator did nothing to earn.
-    //
-    // It reads the REF, not `submitting`: the state value here is the one from
-    // the render that built this closure, so two calls in the same tick would
-    // both see `false` and the guard would pass twice. The ref is written below
-    // before the first `await`, which makes it true for every later caller.
-    if (submittingRef.current) return;
-    const problem = validate();
-    if (problem) {
-      showError(problem);
-      return;
-    }
-    // Set before the first `await` — after `validate()`, so a draft the client
-    // rejects never latches the guard and the operator can fix it and retry.
+  /**
+   * Assembles the graph and runs one write, carrying the submit-time guard,
+   * the spinner state, and the host-error handling (issue #1005/#1016).
+   *
+   * Both Create and Save go through here so there is a SINGLE write path: the
+   * re-entrancy guard, the `workflow_invalid` per-node mapping, and the 409
+   * conflict handoff live once. The caller supplies only the verb — `create()`
+   * posts, the edit branch of `submit()` puts — via `write`.
+   */
+  async function runWrite(write: (graph: WorkflowGraph) => Promise<void>) {
+    // Set before the first `await` — the caller has already run `validate()`, so
+    // a draft the client rejects never latches the guard.
     submittingRef.current = true;
     setSubmitting(true);
     setError(null);
@@ -1718,27 +1744,7 @@ export function WorkflowCreateDialog({
         showError(`${nodeLabel(assembled.node)}: ${assembled.error}`);
         return;
       }
-      const graph = assembled.graph;
-      if (workflow) {
-        // The id keys the saved graph, the schedule and the run history, so it
-        // is the graph's own id that is sent, not the (read-only) field —
-        // there is no path here that renames anything, and the host answers
-        // 400 if one ever appeared. `version` makes the write conditional: it
-        // means "save over the graph I was looking at", not "over whatever is
-        // there now". The response carries a fresh token, so a second save
-        // needs no intervening read.
-        const saved = await updateWorkflow(
-          client,
-          company,
-          workflow.id,
-          graph,
-          workflow.version,
-        );
-        onSaved?.(saved);
-      } else {
-        const created = await createWorkflow(client, company, graph);
-        onCreated?.(created);
-      }
+      await write(assembled.graph);
       onOpenChange(false);
     } catch (e) {
       // Issue #1016: a `workflow_invalid` refusal carries per-node `problems`.
@@ -1807,10 +1813,77 @@ export function WorkflowCreateDialog({
     } finally {
       submittingRef.current = false;
       setSubmitting(false);
+      // Issue #1808: the create-mode confirm steps aside on every terminal
+      // state. Success closes the whole dialog above; a failure surfaces the
+      // banner on the form the confirm was covering — either way the modal must
+      // not linger, or its inert backdrop swallows the next click. A no-op in
+      // edit mode, where `confirmingId` is never set.
+      setConfirmingId(false);
     }
   }
 
+  /**
+   * The create write, gated behind the id confirm (issue #1808). The confirm's
+   * primary action calls this; the shared guard in {@link runWrite} keeps it
+   * single-fire even though it is reachable only after the confirm opens.
+   */
+  async function create() {
+    if (submittingRef.current) return;
+    await runWrite(async (graph) => {
+      const created = await createWorkflow(client, company, graph);
+      onCreated?.(created);
+    });
+  }
+
+  async function submit() {
+    // Re-entrancy guard (issue #1005). The Create button disables while a write
+    // is in flight, but `disabled` is a property of one DOM node: a second
+    // activation landing in the same tick as the first, an Enter keypress, or
+    // any future caller would otherwise post the graph twice — and for create
+    // that means two workflows, or a 409 the operator did nothing to earn.
+    //
+    // It reads the REF, not `submitting`: the state value here is the one from
+    // the render that built this closure, so two calls in the same tick would
+    // both see `false` and the guard would pass twice.
+    if (submittingRef.current) return;
+    const problem = validate();
+    if (problem) {
+      showError(problem);
+      return;
+    }
+    // Issue #1808: create mode confirms the permanent id before it writes. The
+    // previewed id is valid by here (validate() passed), so the confirm shows a
+    // real id, and the confirm's own action runs `create()`. Edit mode falls
+    // straight through — the id keys the saved graph and the field is read-only,
+    // so there is nothing to confirm.
+    if (!editing) {
+      if (!confirmingId) {
+        setConfirmingId(true);
+        return;
+      }
+      await create();
+      return;
+    }
+    await runWrite(async (graph) => {
+      // The id keys the saved graph, the schedule and the run history, so it is
+      // the graph's own id that is sent, not the (read-only) field — there is no
+      // path here that renames anything, and the host answers 400 if one ever
+      // appeared. `version` makes the write conditional: "save over the graph I
+      // was looking at", not "over whatever is there now". The response carries a
+      // fresh token, so a second save needs no intervening read.
+      const saved = await updateWorkflow(
+        client,
+        company,
+        workflow!.id,
+        graph,
+        workflow!.version,
+      );
+      onSaved?.(saved);
+    });
+  }
+
   return (
+    <>
     <Dialog
       open={open}
       onOpenChange={(o) => {
@@ -2288,6 +2361,64 @@ export function WorkflowCreateDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+      {/* Issue #1808: the create-time id confirm. The id is a permanent backend
+          join key set only at creation and silently derived from the name, so a
+          typo becomes a permanent id with no acknowledgement — this is the one
+          moment to surface it. Create mode only; an edit has no id to set. An
+          AlertDialog (focus-trapped, labelled, matching the console) rather than
+          `window.confirm`, and it surfaces the exact id the write will send. */}
+      {!editing && (
+        <AlertDialog
+          open={confirmingId}
+          onOpenChange={(o) => {
+            // Opening is driven by `submit()`; only react to a dismiss — Esc, an
+            // outside click, or the Close primitive behind Back/Create.
+            if (!o) setConfirmingId(false);
+          }}
+        >
+          <AlertDialogContent data-testid="workflow-id-confirm">
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm the workflow ID</AlertDialogTitle>
+              <AlertDialogDescription>
+                The ID is permanent — it keys this workflow’s schedule and run
+                history and can’t be changed after creation. Check it now.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="grid gap-1 rounded-md border bg-muted/40 p-3 text-center">
+              {name.trim() && (
+                <span className="text-xs text-muted-foreground">{name.trim()}</span>
+              )}
+              <code
+                data-testid="workflow-id-confirm-value"
+                className="font-mono text-lg font-semibold break-all"
+              >
+                {id.trim()}
+              </code>
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                data-testid="workflow-id-confirm-back"
+                onClick={() => setConfirmingId(false)}
+                disabled={submitting}
+              >
+                Back
+              </AlertDialogCancel>
+              {/* Fire-and-forget, the repo idiom for an async confirm action:
+                  our handler runs before the primitive's Close, so the write is
+                  launched and the confirm dismisses in the same click. */}
+              <AlertDialogAction
+                data-testid="workflow-id-confirm-create"
+                onClick={() => void create()}
+                disabled={submitting}
+              >
+                {submitting && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+                Create workflow
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
   );
 }
 

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 /**
  * Issues #260 / #261 / #262: how the workflow create dialog validates input and
@@ -53,6 +53,19 @@ async function openCreateDialog(page: Page) {
   const dialog = page.getByRole("dialog");
   await expect(dialog.getByText("New workflow", { exact: true })).toBeVisible();
   return dialog;
+}
+
+/**
+ * Clicks Create through the id-confirm gate (issue #1808) and waits for the
+ * dialog to close. Create mode shows the confirm on the first click rather
+ * than writing; the confirm's own action — also rendered "Create workflow",
+ * but portalled onto `document.body` and reached by test id rather than
+ * `dialog`-scoped role — is the one that fires the write.
+ */
+async function submitCreate(page: Page, dialog: Locator) {
+  await dialog.getByRole("button", { name: "Create workflow" }).click();
+  await page.getByTestId("workflow-id-confirm-create").click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
 }
 
 /**
@@ -306,8 +319,7 @@ test("a condition's branches are picked, not typed, and the host checks the grap
   });
 
   // And the graph the pre-flight approved is the graph Create accepts.
-  await dialog.getByRole("button", { name: "Create workflow" }).click();
-  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  await submitCreate(page, dialog);
 });
 
 /**
@@ -398,8 +410,7 @@ test("a valid workflow still saves", async ({ page }) => {
   await dialog.getByLabel("Edge to").click();
   await page.getByRole("option", { name: "done", exact: true }).click();
 
-  await dialog.getByRole("button", { name: "Create workflow" }).click();
-  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  await submitCreate(page, dialog);
 });
 
 test("a new scheduled workflow discloses that it starts paused (#813)", async ({

--- a/frontend/test/e2e/workflow-node-config.spec.ts
+++ b/frontend/test/e2e/workflow-node-config.spec.ts
@@ -97,7 +97,12 @@ test("authoring a tool_call node's config through the form round-trips to the ho
     await dialog.getByRole("combobox", { name: "Edge to" }).click();
     await page.getByRole("option", { name: "act", exact: true }).click();
 
+    // Issue #1808: create mode gates the write behind an id-confirm. The first
+    // click only opens it (portalled onto `document.body`, so it is reached by
+    // test id on the page, not scoped to `dialog`); the confirm's own action —
+    // also rendered "Create workflow" — is what fires the write.
     await dialog.getByTestId(SUBMIT).click();
+    await page.getByTestId("workflow-id-confirm-create").click();
     await expect(dialog).toBeHidden({ timeout: 15_000 });
 
     // The host stored exactly the keys the form emitted — not the node-id

--- a/frontend/test/unit/workflow-create-feedback.test.ts
+++ b/frontend/test/unit/workflow-create-feedback.test.ts
@@ -108,6 +108,27 @@ async function fillValidDraft() {
   });
 }
 
+/** The confirm's own Create action (#1808), portalled onto `document.body`. */
+function confirmCreateButton(): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>(
+    '[data-testid="workflow-id-confirm-create"]',
+  );
+  expect(el, "the id confirm did not open").toBeTruthy();
+  return el as HTMLButtonElement;
+}
+
+/** Create now confirms the permanent id first (#1808): the form's Create opens a
+ * confirm, and the confirm's own action runs the write. This drives both, for
+ * the tests below whose subject is the write, not the confirm step itself. */
+async function submitThroughConfirm() {
+  await act(async () => {
+    submitButton().click();
+  });
+  await act(async () => {
+    confirmCreateButton().click();
+  });
+}
+
 beforeEach(() => {
   (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
     true;
@@ -138,9 +159,9 @@ describe("the create dialog while a create is in flight", () => {
     expect(dialogContent().getAttribute("aria-busy")).toBe("false");
     expect(submitButton().querySelector(".animate-spin")).toBeNull();
 
-    await act(async () => {
-      submitButton().click();
-    });
+    // Create opens the id confirm (#1808); the confirm's action runs the write,
+    // which is what puts the form in flight.
+    await submitThroughConfirm();
 
     expect(post).toHaveBeenCalledTimes(1);
     expect(dialogContent().getAttribute("aria-busy")).toBe("true");
@@ -182,24 +203,30 @@ describe("the create dialog while a create is in flight", () => {
     expect(document.querySelectorAll('[aria-label="Remove node"]').length).toBe(rowsBefore);
   });
 
-  it("posts once when the operator clicks Create twice in one tick", async () => {
+  it("posts once when the operator clicks the confirm Create twice in one tick", async () => {
     const post = vi.fn(() => new Promise<never>(() => {}));
     await open(stubClient(post));
     await fillValidDraft();
 
+    // Create opens the id confirm (#1808); the write is behind the confirm's
+    // own action, so the re-entrancy guard now lives on that click.
+    await act(async () => {
+      submitButton().click();
+    });
+
     // BOTH clicks inside ONE `act`, deliberately. React commits state at the
     // end of the block, so the button is still enabled for the second one and
-    // `submit()` is genuinely re-entered — which is the only way to reach the
+    // `create()` is genuinely re-entered — which is the only way to reach the
     // guard. Split across two `act`s the first commit has landed, `disabled` is
     // set, React drops the event on the disabled fiber, and the assertion below
-    // passes for a reason that has nothing to do with `submit()`.
+    // passes for a reason that has nothing to do with `create()`.
     //
     // So this is the assertion that pins `submittingRef`: against a guard
     // reading the `submitting` STATE both calls see the pre-commit `false` and
     // this fails with two posts.
     await act(async () => {
-      submitButton().click();
-      submitButton().click();
+      confirmCreateButton().click();
+      confirmCreateButton().click();
     });
 
     expect(post).toHaveBeenCalledTimes(1);
@@ -214,9 +241,7 @@ describe("the create dialog when the host refuses", () => {
     await open(stubClient(post));
     await fillValidDraft();
 
-    await act(async () => {
-      submitButton().click();
-    });
+    await submitThroughConfirm();
 
     const banner = inDialog<HTMLElement>('[data-testid="create-error"]');
     expect(banner).toBeTruthy();
@@ -257,9 +282,7 @@ describe("the create dialog when the host refuses", () => {
       ),
     );
     await fillValidDraft();
-    await act(async () => {
-      submitButton().click();
-    });
+    await submitThroughConfirm();
     expect(inDialog('[data-testid="create-error"]')).toBeTruthy();
   }
 
@@ -314,6 +337,9 @@ describe("the create dialog when the host refuses", () => {
     await act(async () => {
       type('[placeholder="display name"]', "Second node", 1);
     });
+    // The freshly-added agent node has no assignee yet, so `validate()` refuses
+    // client-side and the banner is back BEFORE the id-confirm gate — a plain
+    // submit is enough here (no confirm opens on a failed validate).
     await act(async () => {
       submitButton().click();
     });

--- a/frontend/test/unit/workflow-create-id-confirm.test.ts
+++ b/frontend/test/unit/workflow-create-id-confirm.test.ts
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { WorkflowGraph } from "@/api/workflows";
+import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
+
+/**
+ * The create-time id confirm (issue #1808).
+ *
+ * The workflow id is a permanent backend join key — it keys the overlay body,
+ * the revision store, the scheduler's armed state, run history, and cross-graph
+ * `sub_workflow` references — so a rename is a 400. Creation is the only moment
+ * it can be set, and in create mode it is silently derived from the name, so a
+ * name typo becomes a permanent id with no acknowledgement. This adds a confirm
+ * step in create mode ONLY: the first Create opens the confirm showing the exact
+ * id the write will send, and the confirm's own action runs the single write.
+ *
+ * These are claims about what the DOM does across a click sequence — a confirm
+ * that must appear, a write that must NOT fire until it is accepted, and a save
+ * path that must skip it entirely in edit mode — so they render the component
+ * the same way `workflow-create-problems.test.ts` and `ledger-retire-confirm`
+ * do, rather than a pure helper.
+ */
+
+/** The workflows write scope this fake client reports. */
+const SCOPE = "/api/v1/companies/acme";
+
+/**
+ * Stubs the client verbs the dialog reaches. `post` serves BOTH the debounced
+ * host pre-flight (`POST …/workflows/validate`) and the create write
+ * (`POST …/workflows`); they are told apart by path so `onCreate` only ever
+ * counts real creates. The optional-picker GETs and the roster reject, which
+ * the dialog degrades to free-text fallbacks — none of it blocks authoring.
+ */
+function stubClient(opts: {
+  onCreate?: (path: string, body: unknown) => void;
+  put?: (path: string, body?: unknown) => Promise<unknown>;
+}): OpenCompanyClient {
+  return {
+    scopeFor: () => SCOPE,
+    get: () => Promise.reject(new Error("not offered by this host")),
+    listTeam: () => Promise.reject(new Error("not offered by this host")),
+    post: (path: string, body?: unknown) => {
+      if (path.endsWith("/workflows/validate")) {
+        return Promise.resolve({ valid: true });
+      }
+      opts.onCreate?.(path, body);
+      return Promise.resolve(body as WorkflowGraph);
+    },
+    put: opts.put ?? (() => Promise.reject(new Error("no put expected"))),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let onOpenChange: ReturnType<typeof vi.fn>;
+
+function inDialog<T extends Element>(selector: string): T | null {
+  return document.querySelector<T>(`[data-slot="dialog-content"] ${selector}`);
+}
+
+/** The main form's Create/Save button. */
+function submitButton(): HTMLButtonElement {
+  return inDialog<HTMLButtonElement>('[data-testid="workflow-dialog-submit"]')!;
+}
+
+/** The confirm modal (portalled onto `document.body`), or null when it is closed. */
+function confirmDialog(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-testid="workflow-id-confirm"]');
+}
+
+function confirmValue(): string | null {
+  return (
+    document
+      .querySelector('[data-testid="workflow-id-confirm-value"]')
+      ?.textContent?.trim() ?? null
+  );
+}
+
+/** A button in the confirm modal by its testid. */
+function confirmButton(testid: string): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>(`[data-testid="${testid}"]`);
+  if (!el) throw new Error(`no “${testid}” in:\n${document.body.innerHTML}`);
+  return el;
+}
+
+/** Sets a controlled input the way a keystroke would. */
+function type(selector: string, value: string) {
+  const input = inDialog<HTMLInputElement>(selector);
+  expect(input, `no input matching ${selector}`).toBeTruthy();
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(input, value);
+  input!.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+const NAME_INPUT = 'input[placeholder="e.g. Campaign pipeline"]';
+const ID_INPUT = 'input[placeholder="e.g. campaign_pipeline"]';
+
+function idFieldValue(): string {
+  return inDialog<HTMLInputElement>(ID_INPUT)!.value;
+}
+
+async function openCreate(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(WorkflowCreateDialog, {
+        open: true,
+        onOpenChange,
+        client,
+        company: "acme",
+      }),
+    );
+  });
+}
+
+async function openEditing(client: OpenCompanyClient, workflow: WorkflowGraph) {
+  await act(async () => {
+    root.render(
+      createElement(WorkflowCreateDialog, {
+        open: true,
+        onOpenChange,
+        client,
+        company: "acme",
+        workflow,
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+  Element.prototype.scrollIntoView = vi.fn();
+  onOpenChange = vi.fn();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("create-time id confirm (issue #1808)", () => {
+  it("opens the confirm on Create and does not write, showing the derived id", async () => {
+    const onCreate = vi.fn();
+    await openCreate(stubClient({ onCreate }));
+
+    // A name derives the id (the field is untouched), so this is the exact
+    // silent path the confirm exists to surface.
+    await act(async () => {
+      type(NAME_INPUT, "Weekly Digest");
+    });
+    const derived = idFieldValue();
+    expect(derived, "the name should have derived a non-empty id").toBeTruthy();
+
+    await act(async () => {
+      submitButton().click();
+    });
+
+    // The write has NOT fired — the confirm stands between Create and the post.
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(confirmDialog(), "the confirm modal did not open").toBeTruthy();
+    // …and it surfaces the exact id that would be written.
+    expect(confirmValue()).toBe(derived);
+  });
+
+  it("writes exactly once with the shown id when the confirm is accepted, then closes", async () => {
+    const onCreate = vi.fn();
+    await openCreate(stubClient({ onCreate }));
+
+    await act(async () => {
+      type(NAME_INPUT, "Weekly Digest");
+    });
+    const shown = idFieldValue();
+
+    await act(async () => {
+      submitButton().click();
+    });
+    expect(confirmValue()).toBe(shown);
+
+    await act(async () => {
+      confirmButton("workflow-id-confirm-create").click();
+    });
+
+    // Exactly one create, carrying the id the confirm displayed, and the dialog
+    // closes on success.
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const posted = onCreate.mock.calls[0][1] as WorkflowGraph;
+    expect(posted.id).toBe(shown);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(confirmDialog()).toBeNull();
+  });
+
+  it("Back cancels without writing; re-Create after editing the id shows the NEW id", async () => {
+    const onCreate = vi.fn();
+    await openCreate(stubClient({ onCreate }));
+
+    await act(async () => {
+      type(NAME_INPUT, "Weekly Digest");
+    });
+    await act(async () => {
+      submitButton().click();
+    });
+    expect(confirmDialog()).toBeTruthy();
+
+    // Back — no write, confirm dismissed.
+    await act(async () => {
+      confirmButton("workflow-id-confirm-back").click();
+    });
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(confirmDialog()).toBeNull();
+
+    // Correct the id, then Create again — the confirm must show what would be
+    // written now, not the stale preview it showed before Back.
+    await act(async () => {
+      type(ID_INPUT, "weekly_digest_v2");
+    });
+    await act(async () => {
+      submitButton().click();
+    });
+    expect(confirmDialog()).toBeTruthy();
+    expect(confirmValue()).toBe("weekly_digest_v2");
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it("edit mode saves directly through updateWorkflow with no confirm", async () => {
+    const workflow: WorkflowGraph = {
+      id: "greeter",
+      name: "Greeter",
+      version: "v1",
+      nodes: [
+        { id: "start", kind: "trigger", name: "Start" },
+        { id: "greet", kind: "agent", name: "Greet", agent: "alice" },
+      ],
+      edges: [{ from: "start", to: "greet" }],
+    };
+    const put = vi.fn((_path: string, _body?: unknown) => Promise.resolve(workflow));
+    await openEditing(stubClient({ put }), workflow);
+
+    await act(async () => {
+      submitButton().click();
+    });
+
+    // The id is fixed in edit mode — the confirm never renders, and Save writes
+    // straight through.
+    expect(confirmDialog()).toBeNull();
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put.mock.calls[0][0]).toContain(`/workflows/${workflow.id}`);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("a client-validation failure blocks before any confirm or write", async () => {
+    const onCreate = vi.fn();
+    await openCreate(stubClient({ onCreate }));
+
+    // No name and no id — `validate()` refuses at the id check, before the
+    // confirm gate is ever reached.
+    await act(async () => {
+      submitButton().click();
+    });
+
+    expect(confirmDialog()).toBeNull();
+    expect(onCreate).not.toHaveBeenCalled();
+    const banner = inDialog<HTMLElement>('[data-testid="create-error"]');
+    expect(banner, "the validation banner did not render").toBeTruthy();
+    expect(banner!.textContent).toContain("id");
+  });
+});

--- a/frontend/test/unit/workflow-index-paused.test.ts
+++ b/frontend/test/unit/workflow-index-paused.test.ts
@@ -146,7 +146,10 @@ function type(selector: string, value: string) {
 
 /** Opens the New-workflow dialog, fills the smallest draft `validate()` accepts
  * (the starter trigger node already carries an id and a name), and submits. The
- * stub client answers the POST with whatever `makeClient` was given. */
+ * stub client answers the POST with whatever `makeClient` was given.
+ *
+ * Create confirms the permanent id first (#1808): the form's Create opens a
+ * confirm, and the confirm's own action runs the write — so this clicks both. */
 async function createThroughDialog() {
   await act(async () => {
     container.querySelector<HTMLButtonElement>('[data-testid="workflow-create"]')?.click();
@@ -160,6 +163,11 @@ async function createThroughDialog() {
   await act(async () => {
     document
       .querySelector<HTMLButtonElement>('[data-testid="workflow-dialog-submit"]')
+      ?.click();
+  });
+  await act(async () => {
+    document
+      .querySelector<HTMLButtonElement>('[data-testid="workflow-id-confirm-create"]')
       ?.click();
   });
 }


### PR DESCRIPTION
## Summary

A workflow's id is a permanent backend join key — it keys the saved overlay body, revision history, scheduler armed-state, run history, and cross-graph `sub_workflow` references, and a rename `400`s. It is editable at exactly one moment (creation), and in create mode it is silently derived from the name, so a name typo becomes a permanent id with no acknowledgement.

This adds a **create-time confirm step**: after validation, creating a workflow opens a focus-trapped `AlertDialog` surfacing the exact id (mono, large) alongside the name — "The ID is permanent — it keys this workflow's schedule and run history and can't be changed after creation. Check it now." — with **Back** and **Create workflow** actions. Edit mode is untouched (id already immutable/read-only there).

The write path was factored into a single `runWrite()` (re-entrancy guard, submitting state, shared error handling) that both create and edit go through; `confirmingId` is reset on open/re-hydrate and whenever the name or id changes, so the confirm can never show a stale id.

Backend rename/alias was considered and **rejected**: safe mutation would require an atomic multi-store migration plus rewriting every referencing graph — large scope, real correctness risk. This confirm fully closes "no prompt at the editable moment"; it reduces (cannot eliminate) typo-permanence.

Closes #1808

## API Or Behavior Changes

None (frontend only, create flow gains one confirm step). No API/schema/migration change; rename remains unsupported by design.

## Tests

Frontend-only; Rust gates not applicable.

- [x] `npm run typecheck` + `npm run typecheck:unit` — PASS
- [x] `npx vitest run` — PASS (349 files, 3264 tests) incl. new `workflow-create-id-confirm.test.ts` (confirm opens without writing; accept writes once with shown id; Back + edit shows new id; edit-mode saves with no confirm; validate-failure blocks before confirm). Two sibling create-flow tests adapted to route through the confirm.
- [x] `npm run build` — PASS (pre-existing chunk-size advisory only)
- [ ] `cargo *` — N/A: no Rust changed

## Documentation

None needed — dialog copy is self-documenting.