### PR TITLE
Build the dev desktop with the feature set the DMG ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,18 @@ jobs:
       - name: Assert merge-group CI wiring
         run: scripts/ci/assert-merge-group-workflow.sh
 
+      # Issue #1738. The desktop's shipped feature set lives on three command
+      # lines and in no manifest — `DESKTOP_RELEASE_FEATURES` in
+      # `release-desktop-macos.yml`, the `Desktop` lane's clippy and test steps
+      # below, and `scripts/desktop-dev.sh`. Until #1738 the dev script had no
+      # copy at all, so a developer ran the DEFAULT build and every user
+      # installed the release one. Here rather than in the `Desktop` job because
+      # this is a text check on repo config that needs no toolchain, and because
+      # `Desktop` is path-filtered on `src-tauri/**` — a drift introduced by
+      # editing only a workflow or only the dev script would not run that lane.
+      - name: Assert desktop feature sets agree
+        run: scripts/ci/assert-desktop-features.sh
+
   rust:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'

--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -72,16 +72,24 @@ adds no package and leaves `src-tauri/Cargo.lock` byte-identical, which is what
 lets a release still build `--locked`. A feature gating an optional dependency
 could not be passed this way and would have to move into the manifest.
 
-The cost of that arrangement is three copies of one string, and #1738 is what a
-missing copy looks like: `scripts/desktop-dev.sh` ran `tauri dev` bare, so a
+The cost of that arrangement is several copies of one string, and #1738 is what
+a missing copy looks like: `scripts/desktop-dev.sh` ran `tauri dev` bare, so a
 developer's shell was the manifest set and every DMG was the release set. The
 visible half was Connections — `in_build: cfg!(feature = "composio")` reported
 false, so eight provider tiles rendered "not available here" over a card asking
 the operator to paste a Composio token, on a build nobody ships. `acp` was dark
 the same way and less visibly (`acp_agents = None`, so every `transport =
-"local"` harness resolved `unavailable`; issue #1245). The script now passes the
-release string and `scripts/ci/assert-desktop-features.sh` fails the build if
-the three copies ever disagree.
+"local"` harness resolved `unavailable`; issue #1245).
+
+#1823 fixed the launcher without adding a copy: it **parses**
+`DESKTOP_RELEASE_FEATURES` out of the release workflow, with a
+`DESKTOP_FEATURES` override for the leaner build. A derived value cannot drift.
+
+`scripts/ci/assert-desktop-features.sh` guards what is still duplicated (the two
+`ci.yml` steps, `npm run tauri:build`, the by-hand command below), that the
+release `tauri build` still consumes the variable it declares — otherwise the
+source of truth is a lie — and that the launcher still derives rather than
+re-hardcoding a literal.
 
 `mcp` is the one that puts an agent harness in the app. It implies `openhuman`,
 which is what compiles `src/harness/` at all; without it the bundle boots, seeds

--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -49,14 +49,39 @@ either a second `tauri.conf.json` or a script that invokes a bare `tauri`.
 
 ## What the desktop compiles in
 
-The desktop links the host with an explicit feature set, declared on the
-`opencompany` dependency in `src-tauri/Cargo.toml`:
+The desktop links the host with an explicit feature set, and it is declared in
+**two** places — reading only the first is issue #1738. The manifest's list, on
+the `opencompany` dependency in `src-tauri/Cargo.toml`:
 
 ```toml
 opencompany = { path = "..", default-features = false, features = [
-  "sqlite", "platform-jwt", "oauth", "mcp",
+  "sqlite", "platform-jwt", "oauth", "mcp", "tinymemory",
 ] }
 ```
+
+and the shipped set, passed on the `tauri` command line as
+`DESKTOP_RELEASE_FEATURES` in `.github/workflows/release-desktop-macos.yml`:
+
+```text
+opencompany/acp,opencompany/composio
+```
+
+Those two are `= ["openhuman"]` in the root manifest — pure `cfg` switches that
+pull no `dep:` entry, and `mcp` already enables `openhuman` — so turning them on
+adds no package and leaves `src-tauri/Cargo.lock` byte-identical, which is what
+lets a release still build `--locked`. A feature gating an optional dependency
+could not be passed this way and would have to move into the manifest.
+
+The cost of that arrangement is three copies of one string, and #1738 is what a
+missing copy looks like: `scripts/desktop-dev.sh` ran `tauri dev` bare, so a
+developer's shell was the manifest set and every DMG was the release set. The
+visible half was Connections — `in_build: cfg!(feature = "composio")` reported
+false, so eight provider tiles rendered "not available here" over a card asking
+the operator to paste a Composio token, on a build nobody ships. `acp` was dark
+the same way and less visibly (`acp_agents = None`, so every `transport =
+"local"` harness resolved `unavailable`; issue #1245). The script now passes the
+release string and `scripts/ci/assert-desktop-features.sh` fails the build if
+the three copies ever disagree.
 
 `mcp` is the one that puts an agent harness in the app. It implies `openhuman`,
 which is what compiles `src/harness/` at all; without it the bundle boots, seeds
@@ -73,9 +98,18 @@ the vendored runtime. Features left off, each on purpose:
 | Off | Why |
 | --- | --- |
 | `tinycortex`, `tinymemory*` | In-pod memory engines. They carry tinycortex, `tinyagents/sqlite` and a second bundled SQLite into the bundle for a surface the desktop does not offer; the runtime keeps its fs-backed memory stores. |
-| `media`, `composio`, and the other managed backends | Each needs a platform credential the desktop has no way to hold, and each fails closed without one. |
-| `acp` | `src-tauri/src/acp/` is an ACP *client* and compiles without it (see below). Turning it on additionally wires `RuntimeBuilder::with_acp_agents`, which is a separate decision from having a harness. |
+| `media` | Unlike `composio` it is `["openhuman", "openhuman_core/media"]`, so it pulls an upstream domain nothing else here compiles, and its credential really is managed: the tools are wired only when a company grants the namespace **and** a platform credential is configured. There is no BYO tier, so no desktop operator has anything to supply, and `…/capabilities` answers `media_in_build: false`. |
 | `mongodb` | A per-tenant cluster is a hosting concern. |
+
+`composio` and `acp` are **not** in this table. They are shipped, by the command
+line above. The row that used to exclude them said the managed backends "need a
+platform credential the desktop has no way to hold", and that was never true of
+`composio`: `company::composio::resolve_credential` answers over three tiers and
+the platform identity is the *last* — the BYO `composio/token` override wins,
+then the company's own TinyHumans key. Tier one is exactly what a desktop
+operator can hold, and the Connections card already asks them for it. It also
+named a `search` feature, which does not exist; `search_in_build` derives from
+`cfg!(feature = "openhuman")`, which `mcp` already turns on.
 
 ### The `[patch]` table is replicated, not inherited
 

--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -166,8 +166,16 @@ package**:
 
 ```sh
 npm --prefix frontend run build     # from the repository root
-cargo tauri build                   # or: frontend/node_modules/.bin/tauri build
+cargo tauri build -- --features opencompany/acp,opencompany/composio
 ```
+
+The `--features` is not optional decoration. `tauri build` without it packages
+the **default** set, so a locally-packaged app has Composio and ACP compiled out
+while looking in every other respect like the shipped one — #1738 at the
+packaging entry point, and harder to spot there than in a dev window. `npm run
+tauri:build` carries the same string, and
+`scripts/ci/assert-desktop-features.sh` fails if the two drift from
+`DESKTOP_RELEASE_FEATURES`.
 
 `frontendDist` is resolved relative to `src-tauri/`, where `tauri.conf.json`
 lives, so it means the same thing from every working directory. A hook does not:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "e2e:visual": "PW_VISUAL=1 playwright test",
     "e2e:visual:update": "PW_VISUAL=1 playwright test --update-snapshots",
     "tauri:dev": "../scripts/desktop-dev.sh",
-    "tauri:build": "npm run build && cd ../src-tauri && ../frontend/node_modules/.bin/tauri build"
+    "tauri:build": "npm run build && cd ../src-tauri && ../frontend/node_modules/.bin/tauri build -- --features opencompany/acp,opencompany/composio"
   },
   "dependencies": {
     "@assistant-ui/react": "^0.15.16",

--- a/scripts/ci/assert-desktop-features.sh
+++ b/scripts/ci/assert-desktop-features.sh
@@ -37,9 +37,14 @@ DEV_SCRIPT=scripts/desktop-dev.sh
 # `=`, and a reordering is not a drift. Normalise before comparing so this
 # script fails on the thing that matters — a feature present in one place and
 # absent from another — rather than on a rewrite of the same set.
+# Empty input must come back empty, not abort: a call site passing NO features is
+# the failure this script is for, and `check` renders it `<none>`. `sed '/^$/d'`
+# rather than `grep -v '^$'` because grep exits 1 when it emits nothing, which
+# under `set -e -o pipefail` killed the script mid-run — it exited 1 without ever
+# naming the offending call site, which is the one thing a reader needs.
 normalise() {
   printf '%s' "$1" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
-    | grep -v '^$' | LC_ALL=C sort -u | paste -sd, -
+    | LC_ALL=C sort -u | sed '/^$/d' | paste -sd, -
 }
 
 expected_raw="$(
@@ -75,38 +80,66 @@ check() {
   fi
 }
 
-# `ci.yml`'s Desktop lane: every `--features` on a `--manifest-path
-# src-tauri/Cargo.toml` command. Both the clippy and the test step must carry
-# it — a lane that lints the shipped set but tests the default one is the same
-# hole in half.
-ci_lines="$(grep -n -- '--manifest-path src-tauri/Cargo.toml' "$CI_WORKFLOW" | grep -- '--features' || true)"
+# `ci.yml`'s Desktop lane: every cargo command run against the desktop manifest.
+# Both the clippy and the test step must carry the features — a lane that lints
+# the shipped set but tests the default one is the same hole in half.
+#
+# Selected by the CARGO COMMAND, never by the presence of `--features`. Filtering
+# on the flag was a hole big enough to drive the original bug through: a step
+# that dropped `--features` would not match, would therefore not be checked, and
+# the script would report the remaining step as "ok" and exit 0. The one thing
+# this exists to catch — a call site compiling the default set — was the one
+# thing it skipped.
+ci_lines="$(grep -nE 'cargo (clippy|test|check|build)[^|]*--manifest-path src-tauri/Cargo.toml' "$CI_WORKFLOW" || true)"
 if [ -z "$ci_lines" ]; then
-  echo "assert-desktop-features: no '--features' on any src-tauri cargo command in $CI_WORKFLOW." >&2
-  echo "  The Desktop lane would be compiling a feature set the release does not" >&2
-  echo "  ship, which is exactly what this script exists to catch." >&2
+  echo "assert-desktop-features: no cargo command against src-tauri/Cargo.toml in $CI_WORKFLOW." >&2
+  echo "  Either the Desktop lane stopped compiling the shell, or this script's" >&2
+  echo "  pattern is stale. Both need a human." >&2
   exit 1
 fi
 while IFS= read -r entry; do
   line="${entry%%:*}"
+  # No match leaves this empty, which `check` reports as `<none>` rather than
+  # skipping. That is the point of selecting by command above.
   value="$(printf '%s' "${entry#*:}" | sed -n 's/.*--features[= ]\{1,\}\([^ ]*\).*/\1/p')"
   check "$CI_WORKFLOW:$line" "$value"
 done <<< "$ci_lines"
 
-# The dev script's own copy. Read from its assignment rather than from the
-# `tauri dev` line, so the value is checked once and the command that consumes
-# it is free to spell the flag however the CLI wants.
+# The dev script's own copy of the string.
 dev_value="$(
   sed -n 's/^DESKTOP_RELEASE_FEATURES=\(.*\)$/\1/p' "$DEV_SCRIPT" \
     | head -1 | sed 's/^"//; s/"$//'
 )"
 check "$DEV_SCRIPT" "$dev_value"
 
-# A `tauri dev` that never reads the variable would pass every check above while
-# still launching the default build — the original bug, with a decorative
-# constant added. Assert the value is actually used.
-if ! grep -q 'tauri dev --features "\${DESKTOP_RELEASE_FEATURES}"' "$DEV_SCRIPT"; then
-  echo "  BAD $DEV_SCRIPT -> defines DESKTOP_RELEASE_FEATURES but no 'tauri dev' passes it" >&2
+# ...and every place that actually launches the shell must pass it. A constant
+# nothing reads would satisfy the check above while `tauri dev` still built the
+# default set — the original bug with a decorative variable added.
+#
+# EVERY branch, not any. `desktop-dev.sh` picks between a path-qualified CLI and
+# a `cargo tauri` fallback, so a `grep -q` for one spelling passes while the
+# other launches bare. The first version of this check looked for the literal
+# `tauri dev --features`, which matches ONLY the `cargo tauri dev` fallback —
+# `"${TAURI_CLI}" dev` does not contain that string — so the primary branch,
+# the one that actually runs on any checkout with the console installed, was
+# never verified at all.
+#
+# Comment lines are stripped first: this file's own prose names these
+# invocations, and so does the dev script's.
+dev_invocations="$(grep -vE '^[[:space:]]*#' "$DEV_SCRIPT" | grep -nE '(\$\{TAURI_CLI\}"?|cargo tauri)[[:space:]]+dev([[:space:]]|$)' || true)"
+if [ -z "$dev_invocations" ]; then
+  echo "  BAD $DEV_SCRIPT -> no 'tauri dev' invocation found; this check asserts nothing" >&2
   status=1
+else
+  while IFS= read -r invocation; do
+    text="${invocation#*:}"
+    if printf '%s' "$text" | grep -q '\${DESKTOP_RELEASE_FEATURES}'; then
+      echo "  ok  $DEV_SCRIPT launches with the features:$(printf '%s' "$text" | sed 's/^[[:space:]]*/ /')"
+    else
+      echo "  BAD $DEV_SCRIPT launches WITHOUT the features:$(printf '%s' "$text" | sed 's/^[[:space:]]*/ /')" >&2
+      status=1
+    fi
+  done <<< "$dev_invocations"
 fi
 
 if [ "$status" -ne 0 ]; then

--- a/scripts/ci/assert-desktop-features.sh
+++ b/scripts/ci/assert-desktop-features.sh
@@ -62,6 +62,25 @@ fi
 expected="$(normalise "$expected_raw")"
 echo "$RELEASE_WORKFLOW ships: $expected"
 
+# ...and the release build must actually PASS it. Everything below compares
+# against this value on the strength of it being what reaches a user, so a
+# `tauri build` that stopped consuming the variable would turn the source of
+# truth into a lie: the DMG would revert to the default set while CI and the dev
+# script kept `acp` and `composio`, and this script would report success. That is
+# #1738 again with the roles reversed, and it is the one drift no comparison here
+# could see. Symmetric with the `tauri dev` check further down.
+release_invocations="$(
+  grep -vE '^[[:space:]]*#' "$RELEASE_WORKFLOW" \
+    | grep -nE 'tauri build|--features' | grep -E 'tauri build|--features' || true
+)"
+if ! printf '%s' "$release_invocations" | grep -q 'DESKTOP_RELEASE_FEATURES'; then
+  echo "assert-desktop-features: $RELEASE_WORKFLOW declares DESKTOP_RELEASE_FEATURES" >&2
+  echo "  but its 'tauri build' never passes it, so the shipped DMG would carry" >&2
+  echo "  the default feature set while every other call site carries the release" >&2
+  echo "  one. Restore '--features \"\$DESKTOP_RELEASE_FEATURES\"' on the build." >&2
+  exit 1
+fi
+
 status=0
 found=0
 

--- a/scripts/ci/assert-desktop-features.sh
+++ b/scripts/ci/assert-desktop-features.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Fail if the desktop's shipped cargo feature set is not the one CI compiles and
+# not the one `scripts/desktop-dev.sh` runs.
+#
+# Issue #1738. `src-tauri/Cargo.toml`'s feature list is NOT what the desktop
+# ships. `acp` and `composio` are passed on the `tauri` command line — both are
+# `= ["openhuman"]` in the root manifest, pure `cfg` switches adding no package,
+# so a release can turn them on and still build `--locked`; the argument is on
+# the `DESKTOP_RELEASE_FEATURES` env block in `release-desktop-macos.yml`.
+#
+# The cost of that is three copies of one string, and until #1738 there were
+# only two: the dev script ran `tauri dev` bare. So a developer's desktop was
+# the DEFAULT feature set and every DMG was the release one, which made them
+# different products with nothing saying so. The visible half was Connections
+# reporting `in_build: false`: eight tiles reading "not available here" over a
+# card asking for a Composio token, on a build nobody ships.
+# #1738 was filed reading that as the product's intent, which is what a surface
+# only developers see and only users don't will keep producing.
+#
+# `ci.yml`'s copy already had a comment telling the next person to keep it in
+# step with the release workflow. This is that instruction, enforced. The
+# release workflow is the source of truth: it is the one whose value reaches a
+# user.
+#
+# To change the shipped set: edit `DESKTOP_RELEASE_FEATURES` in
+# `release-desktop-macos.yml`, run this script, and fix whatever it names.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+RELEASE_WORKFLOW=.github/workflows/release-desktop-macos.yml
+CI_WORKFLOW=.github/workflows/ci.yml
+DEV_SCRIPT=scripts/desktop-dev.sh
+
+# Comma-separated cargo feature lists are order-insensitive to cargo but not to
+# `=`, and a reordering is not a drift. Normalise before comparing so this
+# script fails on the thing that matters — a feature present in one place and
+# absent from another — rather than on a rewrite of the same set.
+normalise() {
+  printf '%s' "$1" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -v '^$' | LC_ALL=C sort -u | paste -sd, -
+}
+
+expected_raw="$(
+  sed -n 's/^[[:space:]]*DESKTOP_RELEASE_FEATURES:[[:space:]]*\(.*\)$/\1/p' \
+    "$RELEASE_WORKFLOW" | head -1 | sed 's/#.*//; s/[[:space:]]*$//; s/^"//; s/"$//'
+)"
+
+if [ -z "$expected_raw" ]; then
+  echo "assert-desktop-features: could not read DESKTOP_RELEASE_FEATURES from $RELEASE_WORKFLOW" >&2
+  echo "  Either the release build stopped naming its features there, or this" >&2
+  echo "  script's pattern is stale. Both need a human." >&2
+  exit 1
+fi
+
+expected="$(normalise "$expected_raw")"
+echo "$RELEASE_WORKFLOW ships: $expected"
+
+status=0
+found=0
+
+# One `check <where> <value>` per call site. `$value` may be empty — that is
+# the #1738 failure itself (a call site passing no features at all), so it must
+# report rather than be skipped.
+check() {
+  local where="$1" actual_raw="$2" actual
+  found=$((found + 1))
+  actual="$(normalise "$actual_raw")"
+  if [ "$actual" = "$expected" ]; then
+    echo "  ok  $where -> $actual"
+  else
+    echo "  BAD $where -> '${actual:-<none>}' (release ships '$expected')" >&2
+    status=1
+  fi
+}
+
+# `ci.yml`'s Desktop lane: every `--features` on a `--manifest-path
+# src-tauri/Cargo.toml` command. Both the clippy and the test step must carry
+# it — a lane that lints the shipped set but tests the default one is the same
+# hole in half.
+ci_lines="$(grep -n -- '--manifest-path src-tauri/Cargo.toml' "$CI_WORKFLOW" | grep -- '--features' || true)"
+if [ -z "$ci_lines" ]; then
+  echo "assert-desktop-features: no '--features' on any src-tauri cargo command in $CI_WORKFLOW." >&2
+  echo "  The Desktop lane would be compiling a feature set the release does not" >&2
+  echo "  ship, which is exactly what this script exists to catch." >&2
+  exit 1
+fi
+while IFS= read -r entry; do
+  line="${entry%%:*}"
+  value="$(printf '%s' "${entry#*:}" | sed -n 's/.*--features[= ]\{1,\}\([^ ]*\).*/\1/p')"
+  check "$CI_WORKFLOW:$line" "$value"
+done <<< "$ci_lines"
+
+# The dev script's own copy. Read from its assignment rather than from the
+# `tauri dev` line, so the value is checked once and the command that consumes
+# it is free to spell the flag however the CLI wants.
+dev_value="$(
+  sed -n 's/^DESKTOP_RELEASE_FEATURES=\(.*\)$/\1/p' "$DEV_SCRIPT" \
+    | head -1 | sed 's/^"//; s/"$//'
+)"
+check "$DEV_SCRIPT" "$dev_value"
+
+# A `tauri dev` that never reads the variable would pass every check above while
+# still launching the default build — the original bug, with a decorative
+# constant added. Assert the value is actually used.
+if ! grep -q 'tauri dev --features "\${DESKTOP_RELEASE_FEATURES}"' "$DEV_SCRIPT"; then
+  echo "  BAD $DEV_SCRIPT -> defines DESKTOP_RELEASE_FEATURES but no 'tauri dev' passes it" >&2
+  status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "assert-desktop-features: bring every call site to '$expected', or change" >&2
+  echo "  DESKTOP_RELEASE_FEATURES in $RELEASE_WORKFLOW if the release is the one" >&2
+  echo "  that is wrong. A desktop developers run and a desktop users install" >&2
+  echo "  must be the same build (issue #1738)." >&2
+  exit 1
+fi
+
+echo "All $found desktop feature call site(s) agree with $RELEASE_WORKFLOW."

--- a/scripts/ci/assert-desktop-features.sh
+++ b/scripts/ci/assert-desktop-features.sh
@@ -32,6 +32,8 @@ cd "$(dirname "$0")/../.."
 RELEASE_WORKFLOW=.github/workflows/release-desktop-macos.yml
 CI_WORKFLOW=.github/workflows/ci.yml
 DEV_SCRIPT=scripts/desktop-dev.sh
+CONSOLE_MANIFEST=frontend/package.json
+DESKTOP_DOC=docs/spec/runtime/desktop.md
 
 # Comma-separated cargo feature lists are order-insensitive to cargo but not to
 # `=`, and a reordering is not a drift. Normalise before comparing so this
@@ -159,6 +161,47 @@ else
       status=1
     fi
   done <<< "$dev_invocations"
+fi
+
+# The developer PACKAGING path. `npm run tauri:build` is how a developer builds
+# the app locally, and the command `docs/spec/runtime/desktop.md` documents does
+# the same thing by hand.
+#
+# This is the entry point #1738 did not reach and the dev-launcher fix did not
+# cover. A `tauri build` with no `--features` packages the DEFAULT set, so the
+# artifact has Composio and ACP compiled out while looking in every other respect
+# like the shipped app — worse than the dev-window version of the bug, because
+# there is no dev server or console banner to hint that this is not the real
+# thing. Someone reproducing a user report against a locally-packaged build would
+# be testing a different product and have no way to know.
+#
+# CI's own `Package` steps (`tauri build --debug --no-bundle`) are deliberately
+# NOT checked here. They exist to prove `tauri.conf.json` executes from two
+# working directories (issue #616), not to compile a feature set, and the
+# `Clippy`/`Test` steps above them already build the shipped one.
+manifest_build="$(
+  grep -oE '"tauri:build"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONSOLE_MANIFEST" || true
+)"
+if [ -z "$manifest_build" ]; then
+  echo "assert-desktop-features: no 'tauri:build' script in $CONSOLE_MANIFEST." >&2
+  echo "  Either the console stopped offering a packaging script, or this" >&2
+  echo "  script's pattern is stale. Both need a human." >&2
+  exit 1
+fi
+manifest_features="$(printf '%s' "$manifest_build" | sed -n 's/.*--features[= ]\{1,\}\([^ "]*\).*/\1/p')"
+check "$CONSOLE_MANIFEST (tauri:build)" "$manifest_features"
+
+# The documented by-hand equivalent, which a developer is at least as likely to
+# copy as to run the npm script.
+doc_build="$(grep -nE '^cargo tauri build' "$DESKTOP_DOC" || true)"
+if [ -z "$doc_build" ]; then
+  echo "  BAD $DESKTOP_DOC -> documents no 'cargo tauri build' command to check" >&2
+  status=1
+else
+  while IFS= read -r line; do
+    value="$(printf '%s' "${line#*:}" | sed -n 's/.*--features[= ]\{1,\}\([^ ]*\).*/\1/p')"
+    check "$DESKTOP_DOC:${line%%:*}" "$value"
+  done <<< "$doc_build"
 fi
 
 if [ "$status" -ne 0 ]; then

--- a/scripts/ci/assert-desktop-features.sh
+++ b/scripts/ci/assert-desktop-features.sh
@@ -71,15 +71,35 @@ echo "$RELEASE_WORKFLOW ships: $expected"
 # script kept `acp` and `composio`, and this script would report success. That is
 # #1738 again with the roles reversed, and it is the one drift no comparison here
 # could see. Symmetric with the `tauri dev` check further down.
-release_invocations="$(
-  grep -vE '^[[:space:]]*#' "$RELEASE_WORKFLOW" \
-    | grep -nE 'tauri build|--features' | grep -E 'tauri build|--features' || true
+# The command itself, not "some line in this file". Assembled by following
+# backslash continuations from the `tauri build` line, because the invocation is
+# wrapped across three of them and the features live on the last.
+#
+# Grepping the whole file was the first attempt and it was hollow: it collected
+# every line mentioning `tauri build` OR `--features` and passed if ANY of them
+# named the variable. Deleting the flag from the real build while any unrelated
+# line still mentioned `DESKTOP_RELEASE_FEATURES` — an `echo`, a comment that
+# survived the filter — left this green while the DMG reverted to the default
+# set. The check has to bind the variable to the command that ships.
+release_build="$(
+  awk '
+    /tauri build/ { collecting = 1 }
+    collecting     { command = command " " $0 }
+    collecting && !/\\[[:space:]]*$/ { print command; exit }
+  ' "$RELEASE_WORKFLOW"
 )"
-if ! printf '%s' "$release_invocations" | grep -q 'DESKTOP_RELEASE_FEATURES'; then
+if [ -z "$release_build" ]; then
+  echo "assert-desktop-features: no 'tauri build' command found in $RELEASE_WORKFLOW." >&2
+  echo "  Either the release stopped packaging with the Tauri CLI, or this" >&2
+  echo "  script's pattern is stale. Both need a human." >&2
+  exit 1
+fi
+if ! printf '%s' "$release_build" | grep -q 'DESKTOP_RELEASE_FEATURES'; then
   echo "assert-desktop-features: $RELEASE_WORKFLOW declares DESKTOP_RELEASE_FEATURES" >&2
-  echo "  but its 'tauri build' never passes it, so the shipped DMG would carry" >&2
+  echo "  but its 'tauri build' does not pass it, so the shipped DMG would carry" >&2
   echo "  the default feature set while every other call site carries the release" >&2
-  echo "  one. Restore '--features \"\$DESKTOP_RELEASE_FEATURES\"' on the build." >&2
+  echo "  one. The command found was:" >&2
+  printf '    %s\n' "$release_build" >&2
   exit 1
 fi
 
@@ -137,14 +157,25 @@ done <<< "$ci_lines"
 #
 # So the invariant is different in kind: it must DERIVE rather than duplicate,
 # and what it derives must reach cargo.
-dev_reads_workflow=0
-grep -q 'DESKTOP_RELEASE_FEATURES' "$DEV_SCRIPT" \
-  && grep -q 'release-desktop-macos.yml' "$DEV_SCRIPT" \
-  && dev_reads_workflow=1
-if [ "$dev_reads_workflow" -eq 1 ]; then
+# EXECUTABLE lines only. The first version grepped the whole file, and this
+# script's own subject documents itself at length — `desktop-dev.sh` explains the
+# derivation in a comment block naming both `DESKTOP_RELEASE_FEATURES` and the
+# workflow. So deleting the `sed` that actually extracts the value left the
+# comments behind, and the comments alone satisfied the check: green, while every
+# dev build ran with no features at all. A check a comment can satisfy is a
+# check about documentation, not behaviour.
+dev_code="$(grep -vE '^[[:space:]]*#' "$DEV_SCRIPT")"
+dev_names_workflow=0
+dev_extracts_key=0
+printf '%s' "$dev_code" | grep -q 'release-desktop-macos.yml' && dev_names_workflow=1
+# The extraction itself: executable code that pulls the key out of something.
+printf '%s' "$dev_code" | grep -qE '(sed|awk|grep|rg)[^|]*DESKTOP_RELEASE_FEATURES' && dev_extracts_key=1
+if [ "$dev_names_workflow" -eq 1 ] && [ "$dev_extracts_key" -eq 1 ]; then
   echo "  ok  $DEV_SCRIPT derives the features from $RELEASE_WORKFLOW"
 else
-  echo "  BAD $DEV_SCRIPT no longer reads DESKTOP_RELEASE_FEATURES from the release workflow" >&2
+  echo "  BAD $DEV_SCRIPT no longer extracts DESKTOP_RELEASE_FEATURES from the release workflow in code" >&2
+  [ "$dev_names_workflow" -eq 1 ] || echo "        (no executable line names release-desktop-macos.yml)" >&2
+  [ "$dev_extracts_key" -eq 1 ] || echo "        (no executable line extracts DESKTOP_RELEASE_FEATURES)" >&2
   status=1
 fi
 

--- a/scripts/ci/assert-desktop-features.sh
+++ b/scripts/ci/assert-desktop-features.sh
@@ -126,36 +126,56 @@ while IFS= read -r entry; do
   check "$CI_WORKFLOW:$line" "$value"
 done <<< "$ci_lines"
 
-# The dev script's own copy of the string.
-dev_value="$(
-  sed -n 's/^DESKTOP_RELEASE_FEATURES=\(.*\)$/\1/p' "$DEV_SCRIPT" \
-    | head -1 | sed 's/^"//; s/"$//'
-)"
-check "$DEV_SCRIPT" "$dev_value"
+# The dev launcher (`scripts/desktop-dev.sh`).
+#
+# It is checked DIFFERENTLY from every other call site, because #1823 gave it a
+# better shape than a copy: it *parses* `DESKTOP_RELEASE_FEATURES` out of the
+# release workflow at run time, with a `DESKTOP_FEATURES` override for someone
+# who deliberately wants the leaner build. There is no literal to compare, and
+# that is the point — a value derived from the source of truth cannot drift from
+# it, so demanding a copy here would make the script worse.
+#
+# So the invariant is different in kind: it must DERIVE rather than duplicate,
+# and what it derives must reach cargo.
+dev_reads_workflow=0
+grep -q 'DESKTOP_RELEASE_FEATURES' "$DEV_SCRIPT" \
+  && grep -q 'release-desktop-macos.yml' "$DEV_SCRIPT" \
+  && dev_reads_workflow=1
+if [ "$dev_reads_workflow" -eq 1 ]; then
+  echo "  ok  $DEV_SCRIPT derives the features from $RELEASE_WORKFLOW"
+else
+  echo "  BAD $DEV_SCRIPT no longer reads DESKTOP_RELEASE_FEATURES from the release workflow" >&2
+  status=1
+fi
 
-# ...and every place that actually launches the shell must pass it. A constant
-# nothing reads would satisfy the check above while `tauri dev` still built the
-# default set — the original bug with a decorative variable added.
-#
-# EVERY branch, not any. `desktop-dev.sh` picks between a path-qualified CLI and
-# a `cargo tauri` fallback, so a `grep -q` for one spelling passes while the
-# other launches bare. The first version of this check looked for the literal
-# `tauri dev --features`, which matches ONLY the `cargo tauri dev` fallback —
-# `"${TAURI_CLI}" dev` does not contain that string — so the primary branch,
-# the one that actually runs on any checkout with the console installed, was
-# never verified at all.
-#
-# Comment lines are stripped first: this file's own prose names these
-# invocations, and so does the dev script's.
-dev_invocations="$(grep -vE '^[[:space:]]*#' "$DEV_SCRIPT" | grep -nE '(\$\{TAURI_CLI\}"?|cargo tauri)[[:space:]]+dev([[:space:]]|$)' || true)"
+# A re-introduced literal is a regression even if it happens to be correct
+# today: it is a fourth copy of a string three other places already carry, and
+# the whole reason this script exists is that such copies drift. Comments may
+# name the features; a shell assignment may not.
+dev_literal="$(
+  grep -vE '^[[:space:]]*#' "$DEV_SCRIPT" | grep -nE '=[^|]*opencompany/[a-z-]+' || true
+)"
+if [ -n "$dev_literal" ]; then
+  echo "  BAD $DEV_SCRIPT hardcodes a feature literal instead of reading the workflow:" >&2
+  printf '        %s\n' "$dev_literal" >&2
+  status=1
+fi
+
+# ...and the derived value must actually reach the build. `desktop-dev.sh`
+# builds its argument list with `set -- --features "$DESKTOP_FEATURES"` and
+# forwards `"$@"`, so a bare `tauri dev` with no `"$@"` is the regression to
+# catch — that is precisely the shape #1738 was filed about.
+dev_invocations="$(
+  grep -vE '^[[:space:]]*#' "$DEV_SCRIPT" | grep -nE '(\$\{TAURI_CLI\}"?|cargo tauri)[[:space:]]+dev([[:space:]]|$)' || true
+)"
 if [ -z "$dev_invocations" ]; then
   echo "  BAD $DEV_SCRIPT -> no 'tauri dev' invocation found; this check asserts nothing" >&2
   status=1
 else
   while IFS= read -r invocation; do
     text="${invocation#*:}"
-    if printf '%s' "$text" | grep -q '\${DESKTOP_RELEASE_FEATURES}'; then
-      echo "  ok  $DEV_SCRIPT launches with the features:$(printf '%s' "$text" | sed 's/^[[:space:]]*/ /')"
+    if printf '%s' "$text" | grep -qE '(--features|"\$@")'; then
+      echo "  ok  $DEV_SCRIPT passes the features on:$(printf '%s' "$text" | sed 's/^[[:space:]]*/ /')"
     else
       echo "  BAD $DEV_SCRIPT launches WITHOUT the features:$(printf '%s' "$text" | sed 's/^[[:space:]]*/ /')" >&2
       status=1

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,8 +78,12 @@ path = "src/main.rs"
 # every desktop built WITHOUT that command line — which, until this issue, was
 # every developer's, because `scripts/desktop-dev.sh` ran `tauri dev` bare. The
 # dev shell and the shipped app were two different products and nothing said so.
-# The script now passes the release string, and
-# `scripts/ci/assert-desktop-features.sh` keeps all three call sites in step.
+# #1823 closed that half, and closed it better than a copy would have: the
+# script *parses* `DESKTOP_RELEASE_FEATURES` out of the release workflow, so the
+# launcher cannot drift from what ships. `scripts/ci/assert-desktop-features.sh`
+# guards the copies that remain — the two `ci.yml` steps, `tauri:build` and the
+# command `docs/spec/runtime/desktop.md` documents — and asserts the launcher
+# still derives rather than duplicates.
 #
 # Deliberately NOT compiled at all, in the default set or the release one, and
 # each for a reason rather than an oversight:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,19 +47,69 @@ path = "src/main.rs"
 # a desktop agent gets is exactly the minimal belt: built-in tools, MCP servers
 # and skills.
 #
-# Deliberately NOT here, and each for a reason rather than an oversight:
+# ## What is NOT in this list is not the same as what the app ships without
+#
+# `composio` and `acp` are **not** in the feature list below and they ARE in the
+# shipped application: `DESKTOP_RELEASE_FEATURES` in
+# `.github/workflows/release-desktop-macos.yml` passes
+# `opencompany/acp,opencompany/composio` on the `tauri build` command line, and
+# `ci.yml`'s `Desktop` lane compiles and tests that same string. Both are
+# `= ["openhuman"]` in the root manifest — pure `cfg` switches that pull no
+# `dep:` entry, and `mcp` above already enables `openhuman` — so turning them
+# on adds no package and leaves this crate's `Cargo.lock` byte-identical, and
+# that is what lets a release still build `--locked`. It is why they are passed
+# rather than written here; the argument is spelled out on that env block.
+#
+# What each buys is on that env block too, and the short version for `acp` is
+# worth keeping here because the comment this replaces got it backwards:
+# `src/acp/` in THIS crate is an ACP *client* and compiles either way, so the
+# feature looks inert from inside the manifest. What it actually gates is
+# `RuntimeBuilder::with_acp_agents` in the host — without it `acp_agents` is
+# forced to `None` and every `transport = "local"` harness resolves
+# `unavailable`, on the one host that has an `AcpAgentFactory` to hand over
+# (issue #1245). It is not a separate decision from having a harness; on the
+# desktop it is what makes the local harness lane exist.
+#
+# Reading this manifest as the whole story is issue #1738: it reported the
+# desktop's eight Connections tiles reading "not available here" over a card
+# inviting the operator to paste a Composio token, cited the exclusion comment
+# that used to sit here as the reason, and concluded the shipped app's
+# integration surface was dark. The DMG's surface is not dark. What was dark was
+# every desktop built WITHOUT that command line — which, until this issue, was
+# every developer's, because `scripts/desktop-dev.sh` ran `tauri dev` bare. The
+# dev shell and the shipped app were two different products and nothing said so.
+# The script now passes the release string, and
+# `scripts/ci/assert-desktop-features.sh` keeps all three call sites in step.
+#
+# Deliberately NOT compiled at all, in the default set or the release one, and
+# each for a reason rather than an oversight:
 #
 # * `tinycortex` / `tinymemory-embedded` — the in-pod memory engines. They carry
 #   tinycortex, `tinyagents/sqlite` and a second bundled SQLite build into the
 #   bundle for a surface the desktop does not offer; the runtime keeps its
 #   fs-backed memory stores.
-# * `media`, `composio`, `search` and the rest of the managed backends — they
-#   need a platform credential the desktop has no way to hold, and each fails
-#   closed anyway.
-# * `acp` — the local coding-harness lane. `src/acp/` here is an ACP *client*
-#   and compiles without it; turning it on would additionally wire
-#   `RuntimeBuilder::with_acp_agents`, which is a separate decision from having
-#   a harness at all.
+# * `media` — the image/video generation tools. Unlike `composio` it is
+#   `["openhuman", "openhuman_core/media"]`, so it does pull an upstream domain
+#   this build otherwise never compiles, and its credential really is managed:
+#   the tools are wired only when a company grants the namespace AND a
+#   *platform* credential is configured. There is no BYO tier, so no desktop
+#   operator has anything to supply, and `…/capabilities` answers
+#   `media_in_build: false`, which is the honest report of that.
+#
+# There is no `search` to exclude. The comment this replaces named one among
+# "the rest of the managed backends", but no such cargo feature exists —
+# `…/capabilities` derives `search_in_build` from `cfg!(feature =
+# "openhuman")`, which `mcp` already turns on. Search has been in this build
+# the whole time the comment claimed it was kept out.
+#
+# The claim that the excluded set "needs a platform credential the desktop has
+# no way to hold" was also wrong about `composio` specifically, which is worth
+# recording so it is not re-derived. `company::composio::resolve_credential` is
+# always compiled and answers over *three* tiers, the platform identity being
+# the LAST: the BYO `composio/token` override wins, else the company's own
+# TinyHumans key, else this instance's platform identity. Tier one is precisely
+# what a desktop operator can hold, and the Connections card already asks them
+# for it.
 #
 # `tinymemory` IS here, in the features below. It is the cheap half of the
 # memory seam — the hosted/remote driver registry (Supermemory, Mem0, Cognee,


### PR DESCRIPTION
Fixes #1738.

## RCA — the issue's premise is wrong, and the real defect is worse

#1738 reports that the desktop excludes `composio`, leaving the shipped app's connector surface dark, and that the exclusion comment's rationale is contradicted by `resolve_credential`. The second half is right. The first is not.

**The shipped DMG already has `composio` — and `acp`.** `release-desktop-macos.yml:177` sets `DESKTOP_RELEASE_FEATURES: opencompany/acp,opencompany/composio` and passes it to `tauri build`; `ci.yml` compiles and tests that same string. Neither is in `src-tauri/Cargo.toml`, deliberately — both are `= ["openhuman"]` in the root manifest, pure `cfg` switches pulling no `dep:` entry, with `openhuman` already on via `mcp`, so enabling them adds no package and leaves `src-tauri/Cargo.lock` byte-identical. That is what lets a release still build `--locked`.

**The actual bug: `scripts/desktop-dev.sh` ran `tauri dev` bare.** Every developer's desktop got the *default* feature set; every user's DMG got the release one. Two different products, nothing saying so — and the developer-facing one is the degraded one, which is the worse direction: it makes a shipped surface untestable by the people who change it.

That dev build is exactly what #1738 describes. `in_build: cfg!(feature = "composio")` is false, so all eight Connections tiles render "not available here" over a card inviting the operator to paste a Composio token, and `POST …/composio/authorize` answers 409 "Composio is not compiled into this build". `acp` was dark the same way and less visibly: `acp_agents = None`, so every `transport = "local"` harness resolves `unavailable` (#1245) — on the one host that has an `AcpAgentFactory` to hand over.

**The manifest comment was stale in three ways**, which is what led the reporter to read the exclusion as product intent:

1. It listed `composio` and `acp` as excluded. Both ship.
2. It listed `search`. There is no such cargo feature — `…/capabilities` derives `search_in_build` from `cfg!(feature = "openhuman")`, which `mcp` already turns on. Search has been in this build the whole time the comment claimed it was kept out.
3. Its credential rationale ("needs a platform credential the desktop has no way to hold") was never true of `composio`. `company::composio::resolve_credential` answers over three tiers and the platform identity is the *last*: the BYO `composio/token` override wins, then the company's own TinyHumans key. Tier one is precisely what a desktop operator can hold, and the Connections card already asks them for it. The rationale is accurate only for `media`.

## What this changes

- **`scripts/desktop-dev.sh`** passes the release feature string to `tauri dev`, so the shell a developer runs is the app a user installs.
- **`scripts/ci/assert-desktop-features.sh`** (new) makes `DESKTOP_RELEASE_FEATURES` the source of truth and fails if the `Desktop` lane's clippy step, its test step, or the dev script drift from it — including the #1738 shape, a call site passing no features at all, and a dev script that defines the constant but never passes it. `ci.yml` already carried a comment asking the next person to keep two of these in step; this is that instruction, enforced. Ordering is normalised, so a reordering is not a failure.
- **`ci.yml`** runs it in `actions-pinned` — no toolchain needed, and not path-filtered on `src-tauri/**`, so a drift introduced by editing only a workflow or only the dev script is still caught.
- **`src-tauri/Cargo.toml` and `docs/spec/runtime/desktop.md`** are corrected: the shipped set is stated alongside the manifest set, `media` keeps an accurate exclusion, `search` is removed, and the three-tier resolver is recorded so the wrong rationale is not re-derived. The doc's manifest snippet also gains `tinymemory`, which it had drifted from.

### What is deliberately *not* done

Writing the features into `src-tauri/Cargo.toml`. The command-line arrangement is a sound, documented decision — the `--locked` guarantee depends on it — and moving them into the manifest would still leave the two workflow copies unguarded. The divergence, not the location, was the bug.

The residual case where `inBuild: true` but no credential is set still routes tiles to `unavailable`/"not available here". That is `connectRoute`'s existing behaviour on every host, covered by the "No credential is available for this company yet" banner directly above, and out of scope here.

## Verified locally

- `cargo +1.96.1 test --manifest-path src-tauri/Cargo.toml --features opencompany/acp,opencompany/composio` — green (13 + 1 + 7 tests, 9 live-ACP tests ignored as designed).
- `cargo +1.96.1 check --manifest-path src-tauri/Cargo.toml --bin opencompany-desktop` with the feature set — clean.
- **Both `Cargo.lock` files untouched** after those builds, confirming the release comment's zero-package claim empirically.
- `scripts/ci/assert-desktop-features.sh` — passes; and fails as intended when the dev script drops `composio`, when it defines the constant but stops passing it, and when the release workflow adds a feature nobody follows. A pure reordering still passes.
- `assert-single-tauri-app.sh` (the dev script is one of its subjects) and `assert-md-line-cap.sh` — pass. `desktop.md` is 478/500.
- `tauri dev --features …` parse-probed against the real CLI, with an unknown-flag control to prove the probe discriminates.

Behaviour change: `scripts/desktop-dev.sh` (and `npm run tauri:dev`) now compiles two additional `cfg` gates. No dependency, packaging, or lockfile change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which capabilities are included in desktop development and release builds.
  * Documented Composio and ACP availability, credential handling, and feature configuration.
  * Corrected outdated desktop feature references.

* **Reliability**
  * Added automated checks to detect inconsistencies between desktop development, CI, and release configurations.

* **Developer Experience**
  * Desktop development now uses the same shipped feature set as release builds and reports the selected features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
