### PR TITLE
fix(desktop): run the desktop we ship, not a leaner one (#1823)

### DIFF
--- a/scripts/desktop-dev.sh
+++ b/scripts/desktop-dev.sh
@@ -39,6 +39,12 @@ Environment:
                          leave your installed application's data alone:
 
     OPENCOMPANY_DATA_DIR=$PWD/target/desktop-dev ./scripts/desktop-dev.sh
+
+  DESKTOP_FEATURES       Cargo features for the shell. Defaults to the set the
+                         release workflow ships, so what you run matches what
+                         we ship. Set it empty to build the leaner default:
+
+    DESKTOP_FEATURES= ./scripts/desktop-dev.sh
 EOF
 }
 
@@ -126,15 +132,73 @@ else
     done
 fi
 
+# The feature set the SHIPPED desktop carries, read from the release workflow
+# that declares it (issue #1823).
+#
+# Without this the desktop you RUN is not the desktop we SHIP, and it differs in
+# exactly the surfaces the desktop exists to provide. `acp` gates
+# `RuntimeBuilder::with_acp_agents`, so a locally-run desktop resolved every
+# `transport = "local"` harness as unavailable — a `claude`-bound teammate could
+# not take a turn, on the one host that has an `AcpAgentFactory` to give.
+# `composio` gates whether the connector tiles are compiled at all, so they read
+# "this build was compiled without", which is not an instruction a desktop user
+# can follow.
+#
+# **Parsed rather than copied.** A second literal here is a third place to
+# forget: the release workflow and `ci.yml` already carry the same string with a
+# comment asking a human to keep them in step, and this script would have made
+# that promise harder to keep at exactly the moment it started to matter. The
+# workflow stays the source of truth; this reads it.
+#
+# Anchored on the key at the start of a line, so a mention of the name inside a
+# comment cannot be picked up instead. A miss is fatal rather than a silent
+# fall-back to no features: that would restore the very divergence this exists
+# to close, and do it quietly.
+RELEASE_WORKFLOW="${REPO_ROOT}/.github/workflows/release-desktop-macos.yml"
+# An explicitly-set `DESKTOP_FEATURES` wins, even when empty — that is someone
+# deliberately asking for the leaner build. Only an UNSET one is read from the
+# workflow, and a read that finds nothing is fatal: falling back to no features
+# would quietly restore the divergence this exists to close.
+#
+# The `+set` test has to happen BEFORE the assignment, because after it the
+# variable is set either way and the two cases are indistinguishable.
+if [ -z "${DESKTOP_FEATURES+set}" ]; then
+    DESKTOP_FEATURES=$(
+        sed -n 's/^[[:space:]]*DESKTOP_RELEASE_FEATURES:[[:space:]]*//p' \
+            "${RELEASE_WORKFLOW}" | head -n 1
+    )
+    if [ -z "${DESKTOP_FEATURES}" ]; then
+        echo "desktop-dev: could not read DESKTOP_RELEASE_FEATURES from ${RELEASE_WORKFLOW}" >&2
+        echo "desktop-dev: set DESKTOP_FEATURES=... to choose the set yourself" >&2
+        exit 1
+    fi
+fi
+if [ -n "${DESKTOP_FEATURES}" ]; then
+    echo "desktop-dev: building with --features ${DESKTOP_FEATURES}"
+else
+    echo "desktop-dev: building with no extra features (DESKTOP_FEATURES is empty)"
+fi
+
 # The CLI from `frontend/node_modules`, as `ci.yml` uses, falling back to a
 # `cargo install`ed one. Run from `src-tauri` so the CLI finds this project:
 # it searches *subfolders* of the working directory, so from `frontend/` it
 # would pick the console wrapper in `frontend/src-tauri/` instead — a different
 # application that happens to share this one's `productName`.
+#
+# `--features` is the CLI's own flag rather than the `-- --features` the release
+# build uses. Both reach cargo, but they reach it differently: on `dev` a bare
+# `--` means "arguments for the runner", and a reader has to already know the
+# runner is cargo to see that the features land anywhere. `tauri build` has no
+# such flag, which is why the workflow spells it the other way.
 TAURI_CLI="${REPO_ROOT}/frontend/node_modules/.bin/tauri"
 cd "${REPO_ROOT}/src-tauri"
-if [ -x "${TAURI_CLI}" ]; then
-    "${TAURI_CLI}" dev
+if [ -n "${DESKTOP_FEATURES}" ]; then
+    set -- --features "${DESKTOP_FEATURES}"
 else
-    cargo tauri dev
+    set --
+fi
+if [ -x "${TAURI_CLI}" ]; then
+    "${TAURI_CLI}" dev "$@"
+else
+    cargo tauri dev "$@"
 fi


### PR DESCRIPTION
## Summary

`release-desktop-macos.yml` names the feature set the shipped desktop carries. `scripts/desktop-dev.sh` passed nothing, so a locally-run desktop was built from `src-tauri/Cargo.toml` alone — **without `acp` and without `composio`**. The desktop you run was not the desktop we ship, and it differed in exactly the surfaces the desktop exists to provide.

It cost more than a missing feature, because it surfaced as a runtime error at the first turn rather than as an absent capability:

```
configuration error: agent software_engineer is bound to harness claude, but it is
an ACP harness and this build has no ACP transport wired — run it from the desktop
app, or bind these agents to a built_in harness.
```

…said to someone who was already in the desktop app. #1815 narrows this by not offering a CLI the build cannot run; this closes the mismatch underneath it.

**Parsed from the workflow, not copied.** A second literal here would be a third place to forget: the release workflow and `ci.yml` already carry the same string under a comment asking a human to keep them in step, and this script would have made that promise harder to keep at exactly the moment it started to matter. The workflow stays the source of truth.

**A read that finds nothing is fatal.** Falling back to no features would quietly restore the divergence this exists to close. An explicitly-set `DESKTOP_FEATURES` still wins — including an empty one, for anyone deliberately testing the leaner build — which is why the "was it set?" test runs *before* the assignment that sets it either way.

Uses the CLI's own `--features` flag rather than the `-- --features` the release build spells. Both reach cargo, but on `dev` a bare `--` means "arguments for the runner", and a reader has to already know the runner is cargo to see that the features land anywhere. `tauri build` has no such flag, which is why the workflow says it the other way.

Closes #1823.

## API Or Behavior Changes

No API change. One behaviour change, and it is the point: `./scripts/desktop-dev.sh` now builds with `opencompany/acp,opencompany/composio` — matching a release DMG — where it previously built without them. Cargo features here are pure `cfg` switches that pull no `dep:` entry (both are `= ["openhuman"]`, already on via `mcp`), so the dependency graph and `src-tauri/Cargo.lock` are unchanged; only compile time moves.

`DESKTOP_FEATURES=` opts back into the old, leaner build.

## Tests

This branch changes exactly one file, `scripts/desktop-dev.sh`, and no Rust — so the Rust gates below are unaffected by it rather than freshly run on this branch:

- [ ] `cargo fmt --all -- --check` — N/A, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A, no Rust changed
- [ ] `cargo build --all-targets` — N/A, no Rust changed
- [ ] `cargo test` — N/A, no Rust changed

What was run, on the script itself:

- `sh -n scripts/desktop-dev.sh` — clean.
- `./scripts/desktop-dev.sh` end to end on macOS/aarch64. It reports the set it parsed:
  ```
  desktop-dev: building with --features opencompany/acp,opencompany/composio
  ```
  the embedded host comes up with `acp_in_build: true` and `acp_transport_mounted: true` (it reported `false`/`false` before this change), and a teammate bound to the local `claude` harness takes a real turn and answers.
- `DESKTOP_FEATURES=` — builds with no extra features and says so.
- A workflow with no `DESKTOP_RELEASE_FEATURES` line exits non-zero naming the file, rather than silently building lean.

## Documentation

The script's own `usage()` documents `DESKTOP_FEATURES`, beside the `OPENCOMPANY_DATA_DIR` entry already there. The reasoning — why parsed rather than copied, why an empty parse is fatal, why the CLI flag rather than `--` — is in comments at the code it explains, which is where this repo keeps that kind of argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring desktop development features through the `DESKTOP_FEATURES` environment variable.
  * Automatically uses the default release feature set when no value is provided.
  * Supports explicitly disabling all optional features with an empty value.

* **Documentation**
  * Updated usage guidance to explain feature configuration, defaults, and empty-value behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->