### PR TITLE
Adopt the winner of a user-materialization race instead of refusing

### DIFF
--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -389,6 +389,60 @@ async fn eligibility(
     Ok(invite.filter(|i| i.is_redeemable(now)).map(|i| i.role))
 }
 
+/// Write `user`, or adopt the record that reached its address first.
+///
+/// Every caller below is find-then-create: look the address up, and mint a
+/// record when it is absent. That pair is not atomic, and each caller mints a
+/// **fresh `generate_id()`**, so two requests arriving together both miss the
+/// lookup and then present two different ids for one address. The store is
+/// right to refuse the second — `upsert_user` holds a lock and rejects an email
+/// already held by another id, which is the invariant that keeps
+/// `find_user_by_email` unambiguous — but the caller's question was wrong. It
+/// asked "may I create this user", when what it needed to know was "who owns
+/// this address now".
+///
+/// So a `Conflict` here is read as "somebody else materialized it", and the
+/// winner is returned. That is what makes the operation idempotent under
+/// concurrency, which is what both callers' doc comments already claim.
+///
+/// Issue #1833. On a desktop first boot three requests raced
+/// [`local_owner_record`]; one won and two were refused 16ms later, and
+/// `graphql::auth` turns that refusal into `GatesRefused` — so the console
+/// reported the healthy host it was talking to as "Unreachable" and offered no
+/// way in. A restart fixed it permanently, because by then the record existed.
+///
+/// **Only `Conflict` is adopted.** Every other error still propagates, so the
+/// store-outage refusal that `graphql::auth` deliberately makes fatal stays
+/// fatal: a store that cannot be read must not read as "this user is fine".
+///
+/// A `Conflict` with nothing behind it returns the original error rather than
+/// retrying. That means the winner was deleted between the write and the
+/// re-read, and looping on it would spin against a store doing something this
+/// function has no business papering over.
+pub(super) async fn insert_or_adopt(
+    runtime: &CompanyRuntime,
+    user: UserRecord,
+) -> Result<UserRecord, OpenCompanyError> {
+    let id = runtime.id();
+    match runtime.users().upsert_user(id, &user).await {
+        Ok(()) => Ok(user),
+        Err(OpenCompanyError::Conflict(conflict)) => {
+            match runtime.users().find_user_by_email(id, &user.email).await? {
+                Some(winner) => {
+                    tracing::debug!(
+                        company = %id,
+                        email = %user.email,
+                        "adopted the user record that won the materialization race"
+                    );
+                    Ok(winner)
+                }
+                None => Err(OpenCompanyError::Conflict(conflict)),
+            }
+        }
+        Err(other) => Err(other),
+    }
+}
+
 /// Returns the existing user for `email`, or materializes one from their
 /// eligibility.
 ///
@@ -418,7 +472,7 @@ async fn upsert_from_eligibility(
         last_seen_at_millis: Some(now),
         updated_at_millis: now,
     };
-    runtime.users().upsert_user(id, &user).await?;
+    let user = insert_or_adopt(runtime, user).await?;
     // Mark any real invite as redeemed. A manifest-bootstrapped admin has no
     // invite record, so this is a no-op for them.
     if let Some(mut invite) = runtime.users().find_invite_by_email(id, email).await? {
@@ -464,8 +518,7 @@ pub(crate) async fn local_owner_record(
         last_seen_at_millis: Some(now),
         updated_at_millis: now,
     };
-    runtime.users().upsert_user(id, &user).await?;
-    Ok(user)
+    insert_or_adopt(runtime, user).await
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -2278,3 +2278,130 @@ async fn a_profile_edit_needs_a_session() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
+
+// ---------------------------------------------------------------------------
+// Materialization races (issue #1833)
+// ---------------------------------------------------------------------------
+
+/// A runtime over a company with no `[users] admins`, which is all these need:
+/// `local_owner_record` answers a mode question nobody asks it, so the manifest
+/// only has to produce a store.
+async fn users_runtime(home: &std::path::Path) -> Arc<crate::CompanyRuntime> {
+    let (connections, _sender) = mail_connections();
+    let state = state_from(
+        home,
+        manifest_without_admins(),
+        AppConfig::default(),
+        connections,
+    )
+    .await;
+    state.registry().get(&CompanyId::new("acme")).unwrap()
+}
+
+/// The loser of a race adopts the winner rather than being refused.
+///
+/// Deterministic where the race itself is not: it stages the exact state a
+/// losing caller finds itself in — an address already held, by an id that is not
+/// the one this caller minted — and asserts the outcome is the winner's record
+/// rather than a `Conflict`.
+///
+/// Before #1833 this returned `Err(Conflict)`, `graphql::auth` turned that into
+/// `GatesRefused`, and the desktop console reported the healthy host it was
+/// talking to as "Unreachable".
+#[tokio::test]
+async fn a_lost_materialization_race_adopts_the_winner() {
+    use crate::ports::users::{UserRecord, UserRole, UserStatus};
+
+    let home = home();
+    let runtime = users_runtime(home.path()).await;
+    let id = runtime.id();
+    let email = crate::ports::users::LoginIdentity::Local.key();
+
+    let winner = UserRecord {
+        id: "winner-id".to_string(),
+        email: email.clone(),
+        display_name: None,
+        avatar: None,
+        role: UserRole::Admin,
+        status: UserStatus::Active,
+        password_hash: None,
+        must_change_password: false,
+        created_at_millis: 1,
+        last_seen_at_millis: Some(1),
+        updated_at_millis: 1,
+    };
+    runtime.users().upsert_user(id, &winner).await.unwrap();
+
+    // The loser: same address, its own freshly generated id — which is exactly
+    // what makes the store refuse it.
+    let loser = UserRecord {
+        id: "loser-id".to_string(),
+        created_at_millis: 2,
+        ..winner.clone()
+    };
+
+    let adopted = crate::server::users::routes::insert_or_adopt(&runtime, loser)
+        .await
+        .expect("a lost race is not an error — the owner exists");
+
+    assert_eq!(
+        adopted.id, "winner-id",
+        "the loser must return the record that won, not its own"
+    );
+
+    // And the store still holds exactly one owner: adopting must not have
+    // written the loser's id alongside the winner's.
+    let held = runtime.users().list_users(id).await.unwrap();
+    let owners: Vec<_> = held.iter().filter(|u| u.email == email).collect();
+    assert_eq!(owners.len(), 1, "exactly one owner record: {held:?}");
+    assert_eq!(owners[0].id, "winner-id");
+}
+
+/// Concurrent callers converge on one owner.
+///
+/// The shape of the original bug: N requests arrive together on a cold store,
+/// all miss `find_user_by_email`, and each presents a different `generate_id()`
+/// for one address. On the desktop's first boot three of them raced; one won and
+/// two were refused 16ms later.
+///
+/// Timing-dependent by nature — it cannot *guarantee* an interleaving — so it is
+/// the companion to the deterministic test above rather than the proof. What it
+/// does catch is a regression that reintroduces the shape, and it fails reliably
+/// against the pre-#1833 code at this width.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_local_owner_materialization_yields_one_record() {
+    let home = home();
+    let runtime = users_runtime(home.path()).await;
+
+    let racers = 16;
+    let mut tasks = Vec::with_capacity(racers);
+    for _ in 0..racers {
+        let runtime = Arc::clone(&runtime);
+        tasks.push(tokio::spawn(async move {
+            crate::server::users::routes::local_owner_record(&runtime).await
+        }));
+    }
+
+    let mut ids = Vec::with_capacity(racers);
+    for task in tasks {
+        let record = task
+            .await
+            .expect("no racer panics")
+            .expect("no racer is refused its own company's owner");
+        ids.push(record.id);
+    }
+
+    let first = &ids[0];
+    assert!(
+        ids.iter().all(|id| id == first),
+        "every racer must see one owner, got {ids:?}"
+    );
+
+    let held = runtime.users().list_users(runtime.id()).await.unwrap();
+    let key = crate::ports::users::LoginIdentity::Local.key();
+    assert_eq!(
+        held.iter().filter(|u| u.email == key).count(),
+        1,
+        "exactly one owner record survives the race: {held:?}"
+    );
+}


### PR DESCRIPTION
Fixes #1833.

## The bug

Two functions in `src/server/users/routes.rs` materialize a user on demand, and both are find-then-create with a **fresh `generate_id()` on every call**:

```rust
if let Some(user) = runtime.users().find_user_by_email(id, email).await? { return Ok(user); }
let user = UserRecord { id: generate_id(), email: /* … */ };
runtime.users().upsert_user(id, &user).await?;
```

That pair is not atomic. When N callers arrive together on a cold store they all miss the lookup, each mints its own id, and each presents a different id for one address.

**The store is not at fault.** `fs_ops.rs` takes a path lock and rejects an email already held by *another id* — the invariant that keeps `find_user_by_email` unambiguous. The caller asked the wrong question: "may I create this user", when what it needed was "who owns this address now".

## Why it mattered

On a desktop first boot, three requests raced `local_owner_record`. One won at `10:48:47.818`; two were refused 16ms later:

```
WARN server::graphql::auth: could not materialize the none-mode local owner
     error=conflict: another user already has the email local:owner
```

`graphql::auth:328` turns that into `GatesRefused`, so the console reported the **healthy host it was talking to** as "This computer — Unreachable", with "There is no sign-in here" and no way forward. `/healthz` answered 200 throughout.

A restart cured it permanently — the record exists by then — which is exactly what made it read as a fluke rather than a bug.

## The fix

`insert_or_adopt` reads a `Conflict` as "somebody else got there first" and returns the winner. That is the idempotence both call sites already **claim** in their own docs — `local_owner_record` says outright:

> Idempotent: the record is keyed by `LoginIdentity::Local`, so every request after the first is a read.

It is safe by construction here: `LoginIdentity::Local` is documented as *"the single implicit owner of a company that has no login at all"* — a reserved synthetic key, not a mailbox — so a `Conflict` on `local:owner` can only mean the local owner already exists.

**`upsert_from_eligibility` is fixed in the same change.** It has the identical shape on the email sign-in path — the one real users authenticate through — and leaving it would be knowingly shipping a latent copy of the bug just fixed.

### What is deliberately not changed

- **Only `Conflict` is adopted.** Every other error still propagates, so the store-outage refusal `graphql::auth` deliberately makes fatal stays fatal: a store that cannot be read must not read as "this user is fine".
- **A `Conflict` with nothing behind it returns the original error** rather than retrying. That means the winner was deleted between the write and the re-read, and looping would spin against a store doing something this function has no business papering over.

## Tests

A race cannot be proven by a racing test alone, so there are two:

| Test | Role |
|---|---|
| `a_lost_materialization_race_adopts_the_winner` | **Deterministic.** Stages the exact losing state — address held, by an id this caller did not mint — and asserts the winner comes back, and that only one record survives. |
| `concurrent_local_owner_materialization_yields_one_record` | 16 concurrent callers on a multi-thread runtime. Timing-dependent by nature, so it is the companion rather than the proof; it catches a regression that reintroduces the shape. |

Both **fail against the pre-fix code**, with the production error string:

```
no racer is refused its own company owner: Conflict("another user already has the email local:owner")
```

I verified that by reverting only the adopt arm and re-running — the failure is the one from the desktop log, not an artificial one.

## Verified locally

- `cargo test --lib server::users` — **154 passed, 0 failed**
- `cargo clippy -p opencompany --all-targets --no-deps -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Found while verifying #1738 (PR #1830); independent of that change and deliberately kept out of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple user creation requests occur simultaneously.
  * Conflicting requests now safely reuse the existing user record instead of failing.
  * Concurrent local-owner creation now converges on a single user record without errors or crashes.

* **Tests**
  * Added coverage for concurrent user creation and record adoption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->