### PR TITLE
feat(inference): add OpenRouter model picker

### DIFF
--- a/docs/spec/runtime/providers.md
+++ b/docs/spec/runtime/providers.md
@@ -137,7 +137,7 @@ What goes on the wire differs by path, and sending the wrong one fails
 | path | wire value | why |
 |---|---|---|
 | proxied | the tier name (`chat-v1`) | the platform's registry routes on it, pinning each tier to a sub-provider so its rate card stays exact |
-| direct | a concrete slug (`deepseek/deepseek-v4-flash`) | OpenRouter has never heard of `chat-v1` |
+| direct | a concrete slug (`anthropic/claude-sonnet-5`) | OpenRouter has never heard of `chat-v1` |
 
 On the direct path an unmapped tier takes `DEFAULT_TIER_MODELS`, which mirrors
 the platform's own OpenRouter bindings — so both paths reach the same models and

--- a/docs/spec/runtime/providers.md
+++ b/docs/spec/runtime/providers.md
@@ -174,8 +174,8 @@ resource shared by every tenant on the host, not something scoped per company.
 | property | value |
 |---|---|
 | cache lifetime | 1 hour (`MODEL_CATALOG_TTL`) |
-| fetch timeout | 10 seconds (`MODEL_CATALOG_TIMEOUT`) — a console page-load waits at most this long on a cold cache |
-| concurrent misses | coalesced onto a single upstream fetch (`ModelCatalogCache::fetch_lock`) — after startup or a TTL expiry, several console requests arriving together do not each fire their own OpenRouter call |
+| fetch timeout | 10 seconds (`MODEL_CATALOG_TIMEOUT`) — a console page-load waits at most this long on a cold cache, whatever its position in a `fetch_lock` queue |
+| concurrent misses | coalesced onto a single upstream fetch (`ModelCatalogCache::fetch_lock`) — after startup or a TTL expiry, several console requests arriving together do not each fire their own OpenRouter call. The lock wait and the fetch share one timeout budget per caller, so a caller queued behind others during an outage is not left waiting `N × MODEL_CATALOG_TIMEOUT` for its turn to fail too |
 | malformed entries | skipped individually rather than failing the whole response, so one bad record does not hide every valid model the registry returned |
 | response ordering | sorted by model id, distinct from the provider order `discover_models` preserves for the local/custom setup probe |
 

--- a/docs/spec/runtime/providers.md
+++ b/docs/spec/runtime/providers.md
@@ -160,6 +160,32 @@ wants a specific model through the proxy writes the `openrouter/…` form into
 
 ---
 
+## Model catalog
+
+`GET {scope}/inference/models` lists OpenRouter's public model registry for
+the console's picker — the operator-facing complement to `DEFAULT_TIER_MODELS`
+above, used when an operator wants to pick a *specific* model rather than
+accept a tier default.
+
+The route is authenticated like the rest of `{scope}/inference/*` but does not
+read the calling company's own config: the registry is a public, per-process
+resource shared by every tenant on the host, not something scoped per company.
+
+| property | value |
+|---|---|
+| cache lifetime | 1 hour (`MODEL_CATALOG_TTL`) |
+| fetch timeout | 10 seconds (`MODEL_CATALOG_TIMEOUT`) — a console page-load waits at most this long on a cold cache |
+| concurrent misses | coalesced onto a single upstream fetch (`ModelCatalogCache::fetch_lock`) — after startup or a TTL expiry, several console requests arriving together do not each fire their own OpenRouter call |
+| malformed entries | skipped individually rather than failing the whole response, so one bad record does not hide every valid model the registry returned |
+| response ordering | sorted by model id, distinct from the provider order `discover_models` preserves for the local/custom setup probe |
+
+A registry fetch failure (timeout, non-2xx, an empty catalog) surfaces as an
+error on this route rather than silently returning stale or empty data — the
+picker shows a failure state instead of an incomplete list that looks
+complete.
+
+---
+
 ## Outbound headers
 
 | header | when | why |
@@ -236,4 +262,5 @@ different payers, and merging them would tell the operator nothing.
 | resolution, scoping, aliasing | `src/company/inference.rs` |
 | the chat models and request plan | `src/harness/built_in/provider.rs` |
 | read/write plane | `src/server/ops/inference.rs` |
+| model catalog discovery, cache, single-flight | `src/server/inference_models.rs` |
 | the subscription proxy itself | the TinyHumans backend |

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -107,6 +107,13 @@ export interface InferenceMutation {
   note: string;
 }
 
+/** One model published by the OpenRouter registry. */
+export interface InferenceModel {
+  id: string;
+  name?: string;
+  contextLength?: number;
+}
+
 /** The live-probe result. */
 export interface InferenceTestResult {
   ok: boolean;
@@ -122,6 +129,14 @@ export function getInferenceStatus(
   company: string | null,
 ): Promise<InferenceStatus> {
   return client.get<InferenceStatus>(`${client.scopeFor(company)}/inference`);
+}
+
+/** The cached OpenRouter model catalog exposed by the company host. */
+export function listInferenceModels(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<InferenceModel[]> {
+  return client.get<InferenceModel[]>(`${client.scopeFor(company)}/inference/models`);
 }
 
 /** Set (or replace) the runtime provider override, optionally rotating the key. */

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -45,6 +45,15 @@ export interface InferenceStatus {
   baseUrl: string;
   /** Abstract-tier → concrete model id. */
   models: Record<string, string>;
+  /**
+   * The shipped tier → model defaults, independent of `provider`/`models`
+   * above. The console's OpenRouter preset used to hard-code its own copy of
+   * these ids so the form had something to prefill before an operator typed
+   * an override; that duplicate could silently drift from what the host
+   * actually defaults to. This is read off the host on every status load, so
+   * the preset is never more than one request stale.
+   */
+  defaultTierModels: Record<string, string>;
   /** Provenance badge. */
   source: InferenceSource;
   /** Whether an outbound key is stored — never the key itself. */

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -5,11 +5,13 @@ import { toast } from "sonner";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   getInferenceStatus,
+  listInferenceModels,
   restartInference,
   revertInference,
   setInference,
   testInference,
   type InferenceMutation,
+  type InferenceModel,
   type InferenceProvider,
   type InferenceStatus,
   type UsageMetering,
@@ -157,6 +159,27 @@ type TestState =
   | { kind: "ok"; note: string }
   | { kind: "error"; message: string };
 
+type ModelCatalogState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; models: InferenceModel[] }
+  | { kind: "empty" }
+  | { kind: "error" };
+
+/** Keep a stored custom id selectable even after the registry no longer lists it. */
+function optionsForTier(catalog: InferenceModel[], current: string): InferenceModel[] {
+  if (!current || catalog.some((model) => model.id === current)) return catalog;
+  return [{ id: current, name: "Current custom model" }, ...catalog];
+}
+
+function modelLabel(model: InferenceModel): string {
+  return model.name ? `${model.name} — ${model.id}` : model.id;
+}
+
+function modelItems(models: InferenceModel[]): Record<string, string> {
+  return Object.fromEntries(models.map((model) => [model.id, modelLabel(model)]));
+}
+
 /**
  * Bring-Your-Own-Key inference (issue #56). Shows the company's effective
  * provider (with a source badge + tier→model rows + a "key set" indicator), a
@@ -191,6 +214,7 @@ export function InferenceSection({
     "save" | "reset" | "test" | "removeKey" | "restart" | null
   >(null);
   const [test, setTest] = useState<TestState>({ kind: "idle" });
+  const [modelCatalog, setModelCatalog] = useState<ModelCatalogState>({ kind: "idle" });
 
   // Switch form.
   const [provider, setProvider] = useState<InferenceProvider>("managed");
@@ -273,6 +297,30 @@ export function InferenceSection({
     setLoad("loading");
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    let current = true;
+    if (provider !== "openrouter") {
+      setModelCatalog({ kind: "idle" });
+      return () => {
+        current = false;
+      };
+    }
+
+    setModelCatalog({ kind: "loading" });
+    void listInferenceModels(client, company)
+      .then((catalog) => {
+        if (!current) return;
+        setModelCatalog(catalog.length ? { kind: "ready", models: catalog } : { kind: "empty" });
+      })
+      .catch(() => {
+        if (current) setModelCatalog({ kind: "error" });
+      });
+
+    return () => {
+      current = false;
+    };
+  }, [client, company, provider]);
 
   function pickProvider(next: InferenceProvider) {
     setProvider(next);
@@ -702,20 +750,90 @@ export function InferenceSection({
                 </div>
 
                 {provider !== "managed" && (
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    {TIERS.map((tier) => (
-                      <div key={tier} className="space-y-1">
-                        <Label htmlFor={`inference-model-${tier}`} className="text-xs">
-                          {tier}
-                        </Label>
-                        <Input
-                          id={`inference-model-${tier}`}
-                          value={models[tier] ?? ""}
-                          placeholder="provider model id"
-                          onChange={(e) => setModel(tier, e.target.value)}
-                        />
-                      </div>
-                    ))}
+                  <div className="space-y-2">
+                    {provider === "openrouter" && modelCatalog.kind === "error" && (
+                      <p
+                        className="text-xs text-muted-foreground"
+                        data-testid="inference-model-catalog-fallback"
+                      >
+                        OpenRouter&apos;s model list could not be loaded. Enter model ids directly.
+                      </p>
+                    )}
+                    {provider === "openrouter" && modelCatalog.kind === "empty" && (
+                      <p
+                        className="text-xs text-muted-foreground"
+                        data-testid="inference-model-catalog-empty"
+                      >
+                        OpenRouter returned no models. Enter model ids directly.
+                      </p>
+                    )}
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {TIERS.map((tier) => {
+                        const value = models[tier] ?? "";
+                        const useFreeText =
+                          provider !== "openrouter" ||
+                          modelCatalog.kind === "error" ||
+                          modelCatalog.kind === "empty";
+                        const options =
+                          modelCatalog.kind === "ready"
+                            ? optionsForTier(modelCatalog.models, value)
+                            : value
+                              ? [{ id: value }]
+                              : [];
+
+                        return (
+                          <div key={tier} className="space-y-1">
+                            <Label htmlFor={`inference-model-${tier}`} className="text-xs">
+                              {tier}
+                            </Label>
+                            {useFreeText ? (
+                              <Input
+                                id={`inference-model-${tier}`}
+                                value={value}
+                                placeholder="provider model id"
+                                onChange={(e) => setModel(tier, e.target.value)}
+                              />
+                            ) : (
+                              <Select
+                                value={value || null}
+                                disabled={modelCatalog.kind !== "ready"}
+                                onValueChange={(next) => next && setModel(tier, String(next))}
+                                items={modelItems(options)}
+                              >
+                                <SelectTrigger
+                                  id={`inference-model-${tier}`}
+                                  className="w-full"
+                                  data-testid={`inference-model-select-${tier}`}
+                                >
+                                  <SelectValue
+                                    placeholder={
+                                      modelCatalog.kind === "loading"
+                                        ? "Loading OpenRouter models…"
+                                        : "Choose a model"
+                                    }
+                                  />
+                                  {modelCatalog.kind === "loading" && (
+                                    <Loader2 className="size-3.5 animate-spin" />
+                                  )}
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {options.map((model) => (
+                                    <SelectItem key={model.id} value={model.id}>
+                                      <span>{model.name ?? model.id}</span>
+                                      {model.name && (
+                                        <span className="font-mono text-xs text-muted-foreground">
+                                          {model.id}
+                                        </span>
+                                      )}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
                   </div>
                 )}
 

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -97,10 +97,15 @@ const PROVIDERS: Record<
     acceptsKey: true,
     requiresBaseUrl: false,
     keyKind: "an OpenRouter key (`sk-or-…`)",
-    // OpenRouter's recommended DeepSeek pairing, prefilled.
+    // Premium defaults, kept aligned with backend DEFAULT_TIER_MODELS.
     preset: {
       baseUrl: "",
-      models: { "chat-v1": "deepseek/deepseek-chat", "reasoning-v1": "deepseek/deepseek-r1" },
+      models: {
+        "chat-v1": "anthropic/claude-sonnet-5",
+        "reasoning-v1": "openai/gpt-5.6-sol-pro",
+        "agentic-v1": "anthropic/claude-opus-5",
+        "vision-v1": "qwen/qwen3.8-max",
+      },
     },
   },
   ollama: {

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -532,6 +532,20 @@ export function InferenceSection({
   if (load === "unavailable") return null;
 
   const modelRows = status ? Object.entries(status.models) : [];
+  /**
+   * Whether saving right now would ride the platform's subscription proxy
+   * rather than go straight to OpenRouter with a tenant key.
+   *
+   * The proxy only resolves an abstract tier (or its own `openrouter/…`
+   * passthrough form, off by default) — see `model_for_tier` in
+   * `src/company/inference.rs`. The catalog picker below stores the
+   * registry's raw `<author>/<model>` id verbatim, which is exactly the form
+   * the proxy rejects. `key` is write-only and never comes back from the
+   * host, so "no key typed" only means proxied when the stored config is not
+   * already a direct, keyed OpenRouter connection.
+   */
+  const wouldSaveProxied =
+    key.trim().length === 0 && !(status?.provider === "openrouter" && status.keyConfigured);
   return (
     <section className="space-y-3">
       <div className="flex items-center gap-2">
@@ -767,13 +781,26 @@ export function InferenceSection({
                         OpenRouter returned no models. Enter model ids directly.
                       </p>
                     )}
+                    {provider === "openrouter" &&
+                      modelCatalog.kind === "ready" &&
+                      wouldSaveProxied && (
+                        <p
+                          className="text-xs text-muted-foreground"
+                          data-testid="inference-model-catalog-proxied"
+                        >
+                          Without an OpenRouter key this runs on the shared subscription, which only
+                          resolves a tier name. Add a key above to pick a specific model, or enter a
+                          tier id directly.
+                        </p>
+                      )}
                     <div className="grid gap-2 sm:grid-cols-2">
                       {TIERS.map((tier) => {
                         const value = models[tier] ?? "";
                         const useFreeText =
                           provider !== "openrouter" ||
                           modelCatalog.kind === "error" ||
-                          modelCatalog.kind === "empty";
+                          modelCatalog.kind === "empty" ||
+                          wouldSaveProxied;
                         const options =
                           modelCatalog.kind === "ready"
                             ? optionsForTier(modelCatalog.models, value)

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -253,11 +253,21 @@ function modelItems(models: InferenceModel[]): Record<string, string> {
  * forward a raw registry id straight through under the same "already the
  * proxy's own form" exemption meant for ids the proxy actually accepts.
  * Counting the segments is what actually distinguishes the two shapes.
+ *
+ * Trimmed before any shape check (issue #1838 follow-up, seventh instance):
+ * this runs inside `stripProxyIncompatible`, which `save()` calls *before*
+ * its own trim pass over `models` (surrounding whitespace only gets cleaned
+ * up after this check would already have run). Untrimmed, a pasted
+ * ` openrouter/anthropic/model ` fails `startsWith("openrouter/")` on the
+ * leading space and gets classified as a raw catalog id — silently dropped
+ * here even though it is exactly the three-segment passthrough form the
+ * proxy accepts and the later trim would have normalized it to.
  */
 function isRawCatalogId(value: string): boolean {
-  if (!value.includes("/")) return false;
-  if (!value.startsWith("openrouter/")) return true;
-  return value.split("/").length < 3;
+  const trimmed = value.trim();
+  if (!trimmed.includes("/")) return false;
+  if (!trimmed.startsWith("openrouter/")) return true;
+  return trimmed.split("/").length < 3;
 }
 
 /**
@@ -266,6 +276,13 @@ function isRawCatalogId(value: string): boolean {
  * through, so the rule can't drift out of sync with itself between the
  * live-edit effect, `save()`, and `removeKey()` the way three separate partial
  * implementations of it already had (issue #1838 follow-up).
+ *
+ * Also the one place a kept value is trimmed (issue #1838 follow-up, seventh
+ * instance): `save()` trims `models` again after this runs, but `removeKey()`
+ * sends `carriedModels` straight to the wire with no trim pass of its own —
+ * so a kept id has to come out of here already normalized, or a pasted
+ * ` openrouter/anthropic/model ` would survive Remove Key with its whitespace
+ * intact even though it correctly survives the shape check.
  */
 function stripProxyIncompatible<T extends string>(
   models: Partial<Record<T, string>>,
@@ -273,7 +290,7 @@ function stripProxyIncompatible<T extends string>(
   const next = {} as Partial<Record<T, string>>;
   for (const key of Object.keys(models) as T[]) {
     const value = models[key];
-    if (value && !isRawCatalogId(value)) next[key] = value;
+    if (value && !isRawCatalogId(value)) next[key] = value.trim();
   }
   return next;
 }

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -1019,15 +1019,16 @@ export function InferenceSection({
                       </p>
                     )}
                     {provider === "openrouter" &&
-                      modelCatalog.kind === "ready" &&
+                      modelCatalog.kind !== "idle" &&
+                      modelCatalog.kind !== "loading" &&
                       wouldSaveProxied && (
                         <p
                           className="text-xs text-muted-foreground"
                           data-testid="inference-model-catalog-proxied"
                         >
                           Without an OpenRouter key this runs on the shared subscription, which only
-                          resolves a tier name. Add a key above to pick a specific model, or enter a
-                          tier id directly.
+                          resolves a tier name. A specific model id typed above will be dropped on
+                          Save. Add a key to pick a specific model, or enter a tier id directly.
                         </p>
                       )}
                     <div className="grid gap-2 sm:grid-cols-2">

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -1018,9 +1018,25 @@ export function InferenceSection({
                         OpenRouter returned no models. Enter model ids directly.
                       </p>
                     )}
+                    {/*
+                      `kind !== "idle"` is a no-op here — the effect above
+                      only ever sets "idle" when `provider !== "openrouter"`,
+                      which the surrounding check already excludes. Left in
+                      as a defensive guard against that invariant changing,
+                      not a live branch.
+
+                      "loading" used to be excluded like "idle", but a
+                      keyless company's free-text input (`useFreeText` below
+                      is true here because `wouldSaveProxied` is one of its
+                      conditions) is already editable and Save-able during a
+                      cold catalog fetch, which can run for up to ten
+                      seconds. Withholding the warning until "ready" left
+                      that whole window silent: an id typed and saved while
+                      still loading was dropped by `stripProxyIncompatible`
+                      with no explanation (issue #1838 follow-up).
+                    */}
                     {provider === "openrouter" &&
                       modelCatalog.kind !== "idle" &&
-                      modelCatalog.kind !== "loading" &&
                       wouldSaveProxied && (
                         <p
                           className="text-xs text-muted-foreground"

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -229,11 +229,28 @@ function modelItems(models: InferenceModel[]): Record<string, string> {
 }
 
 /**
- * Whether `value` has the shape of a raw OpenRouter registry id
- * (`<author>/<model>`) — the form `model_for_tier` forwards to the platform
- * proxy verbatim and the proxy rejects — as opposed to the proxy's own
- * explicit `openrouter/<author>/<model>` passthrough form, which it accepts,
- * or a bare tier id, which is not an override at all.
+ * Whether `value`, once trimmed, is one of the exact two shapes the
+ * platform's subscription proxy accepts for a tier override: a bare tier
+ * name (`model_for_tier` reads that as "not really an override — let the
+ * platform resolve this tier itself"), or the proxy's own explicit
+ * three-segment `openrouter/<author>/<model>` passthrough form. Everything
+ * else — including a raw OpenRouter registry id (`<author>/<model>`), which
+ * `model_for_tier` forwards to the proxy verbatim and the proxy rejects — is
+ * incompatible.
+ *
+ * Whitelisting the two accepted shapes, not blacklisting the one known-bad
+ * one (issue #1838 follow-up, ninth instance): an earlier version asked "is
+ * this shaped like a raw catalog id?" and treated everything else, including
+ * *any* slashless string, as a safe bare-tier passthrough. `model_for_tier`
+ * honours an override verbatim on the proxied path regardless of its shape
+ * (see `src/company/inference.rs`), so an operator typing a real but
+ * unnamespaced model id out of direct-path habit — `gpt-4o`, `llama3`, no
+ * `/` in sight — read as "a bare tier id, not an override at all" and rode
+ * straight through Save. The platform endpoint's curated tier registry does
+ * not know `gpt-4o`; the request fails instead of the incompatible value
+ * being dropped the way the console's own warning promises. Naming the tier
+ * names outright closes that gap without reopening the ones the shape-based
+ * check below still exists to catch.
  *
  * Shape-based rather than catalog-membership-based on purpose (issue #1838
  * follow-up, third and fourth instance): checking membership in the loaded
@@ -259,15 +276,16 @@ function modelItems(models: InferenceModel[]): Record<string, string> {
  * its own trim pass over `models` (surrounding whitespace only gets cleaned
  * up after this check would already have run). Untrimmed, a pasted
  * ` openrouter/anthropic/model ` fails `startsWith("openrouter/")` on the
- * leading space and gets classified as a raw catalog id — silently dropped
- * here even though it is exactly the three-segment passthrough form the
- * proxy accepts and the later trim would have normalized it to.
+ * leading space and gets classified as incompatible — silently dropped here
+ * even though it is exactly the three-segment passthrough form the proxy
+ * accepts and the later trim would have normalized it to.
  */
-function isRawCatalogId(value: string): boolean {
+function isProxyCompatible(value: string): boolean {
   const trimmed = value.trim();
+  if ((TIERS as readonly string[]).includes(trimmed)) return true;
   if (!trimmed.includes("/")) return false;
-  if (!trimmed.startsWith("openrouter/")) return true;
-  return trimmed.split("/").length < 3;
+  if (!trimmed.startsWith("openrouter/")) return false;
+  return trimmed.split("/").length >= 3;
 }
 
 /**
@@ -290,7 +308,7 @@ function stripProxyIncompatible<T extends string>(
   const next = {} as Partial<Record<T, string>>;
   for (const key of Object.keys(models) as T[]) {
     const value = models[key];
-    if (value && !isRawCatalogId(value)) next[key] = value.trim();
+    if (value && isProxyCompatible(value)) next[key] = value.trim();
   }
   return next;
 }

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -99,7 +99,10 @@ const PROVIDERS: Record<
     acceptsKey: true,
     requiresBaseUrl: false,
     keyKind: "an OpenRouter key (`sk-or-…`)",
-    // Premium defaults, kept aligned with backend DEFAULT_TIER_MODELS.
+    // Fallback only, used before the first status read resolves —
+    // `presetFor` prefers the host's own `defaultTierModels` once it has
+    // loaded, so this copy cannot drift from `DEFAULT_TIER_MODELS` and stay
+    // wrong (issue #1838 follow-up).
     preset: {
       baseUrl: "",
       models: {
@@ -145,11 +148,22 @@ const METERING_NOTES: Record<UsageMetering, string> = {
 };
 
 /** Per-provider form defaults applied when the operator picks a provider. */
-function presetFor(provider: InferenceProvider): {
+function presetFor(
+  provider: InferenceProvider,
+  defaultTierModels?: Partial<Record<Tier, string>>,
+): {
   baseUrl: string;
   models: Partial<Record<Tier, string>>;
 } {
-  return PROVIDERS[provider].preset;
+  const preset = PROVIDERS[provider].preset;
+  // The host's own `defaultTierModels` (from `GET …/inference`) is the source
+  // of truth once it has loaded; `PROVIDERS.openrouter.preset.models` is only
+  // the fallback used before that first status read resolves, so switching to
+  // OpenRouter still has something to prefill with immediately.
+  if (provider === "openrouter" && defaultTierModels && Object.keys(defaultTierModels).length > 0) {
+    return { ...preset, models: defaultTierModels };
+  }
+  return preset;
 }
 
 type Load = "loading" | "ready" | "unavailable" | "error";
@@ -190,6 +204,21 @@ function optionsForTier(catalog: InferenceModel[], current: string): InferenceMo
  * tier (issue #1838 follow-up).
  */
 const TIER_DEFAULT_MODEL = "__tier_default__";
+
+/**
+ * The tier model select's value for "the operator wants to type an id
+ * themselves rather than pick one off the registry."
+ *
+ * The catalog select otherwise only ever offers ids OpenRouter's registry
+ * already lists. `optionsForTier` keeps an *already-stored* custom id
+ * selectable once it is there, but nothing let an operator enter a *new* one
+ * once the catalog loaded — and the registry can lag a model OpenRouter only
+ * just published, or list it under a slightly different slug. `model_for_tier`
+ * forwards any concrete override verbatim, so the runtime has always accepted
+ * an unlisted id; only the picker stopped offering a way to type one (issue
+ * #1838 follow-up).
+ */
+const CUSTOM_MODEL = "__custom_model__";
 
 function modelLabel(model: InferenceModel): string {
   return model.name ? `${model.name} — ${model.id}` : model.id;
@@ -289,6 +318,13 @@ export function InferenceSection({
   const [provider, setProvider] = useState<InferenceProvider>("managed");
   const [baseUrl, setBaseUrl] = useState("");
   const [models, setModels] = useState<Partial<Record<Tier, string>>>({});
+  /**
+   * Tiers the operator switched from the catalog select into free-text entry
+   * via the "Enter a model id" option, so a registry that has not caught up
+   * to a newly published model does not leave them stuck picking from a list
+   * that will never contain it (issue #1838 follow-up).
+   */
+  const [manualEntryTiers, setManualEntryTiers] = useState<ReadonlySet<Tier>>(new Set());
   const [key, setKey] = useState("");
   const [pendingProvider, setPendingProvider] = useState<InferenceProvider | null>(null);
   /**
@@ -484,11 +520,12 @@ export function InferenceSection({
 
   function pickProvider(next: InferenceProvider) {
     setProvider(next);
-    const preset = presetFor(next);
+    const preset = presetFor(next, status?.defaultTierModels);
     setBaseUrl(preset.baseUrl);
     setModels(preset.models);
     setBaseline({ baseUrl: preset.baseUrl, models: preset.models });
     setTest({ kind: "idle" });
+    setManualEntryTiers(new Set());
   }
 
   /**
@@ -979,11 +1016,18 @@ export function InferenceSection({
                     <div className="grid gap-2 sm:grid-cols-2">
                       {TIERS.map((tier) => {
                         const value = models[tier] ?? "";
+                        // Whether this tier is in manual entry *by the
+                        // operator's own choice* — as opposed to the other
+                        // `useFreeText` reasons below, which are the catalog
+                        // giving out on its own and offer no way back to a
+                        // select this render.
+                        const manualEntry = manualEntryTiers.has(tier);
                         const useFreeText =
                           provider !== "openrouter" ||
                           modelCatalog.kind === "error" ||
                           modelCatalog.kind === "empty" ||
-                          wouldSaveProxied;
+                          wouldSaveProxied ||
+                          manualEntry;
                         const options =
                           modelCatalog.kind === "ready"
                             ? optionsForTier(modelCatalog.models, value)
@@ -997,22 +1041,49 @@ export function InferenceSection({
                               {tier}
                             </Label>
                             {useFreeText ? (
-                              <Input
-                                id={`inference-model-${tier}`}
-                                value={value}
-                                placeholder="provider model id"
-                                onChange={(e) => setModel(tier, e.target.value)}
-                              />
+                              <div className="space-y-1">
+                                <Input
+                                  id={`inference-model-${tier}`}
+                                  value={value}
+                                  placeholder="provider model id"
+                                  onChange={(e) => setModel(tier, e.target.value)}
+                                />
+                                {/* Only the operator's own "enter a model id"
+                                    choice gets a way back — the other
+                                    `useFreeText` reasons (no key, no catalog)
+                                    have no select to return to this render. */}
+                                {manualEntry && modelCatalog.kind === "ready" && (
+                                  <button
+                                    type="button"
+                                    className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+                                    data-testid={`inference-model-back-to-catalog-${tier}`}
+                                    onClick={() =>
+                                      setManualEntryTiers((prev) => {
+                                        const next = new Set(prev);
+                                        next.delete(tier);
+                                        return next;
+                                      })
+                                    }
+                                  >
+                                    Choose from the OpenRouter catalog instead
+                                  </button>
+                                )}
+                              </div>
                             ) : (
                               <Select
                                 value={value || null}
                                 disabled={modelCatalog.kind !== "ready"}
                                 onValueChange={(next) => {
                                   if (!next) return;
+                                  if (next === CUSTOM_MODEL) {
+                                    setManualEntryTiers((prev) => new Set(prev).add(tier));
+                                    return;
+                                  }
                                   setModel(tier, next === TIER_DEFAULT_MODEL ? "" : String(next));
                                 }}
                                 items={{
                                   [TIER_DEFAULT_MODEL]: "Use the tier default",
+                                  [CUSTOM_MODEL]: "Enter a model id…",
                                   ...modelItems(options),
                                 }}
                               >
@@ -1051,6 +1122,16 @@ export function InferenceSection({
                                       )}
                                     </SelectItem>
                                   ))}
+                                  {/* The registry can lag a model OpenRouter
+                                      only just published — this is the way out
+                                      of "pick from what the catalog happens to
+                                      list today" (issue #1838 follow-up). */}
+                                  <SelectItem
+                                    value={CUSTOM_MODEL}
+                                    data-testid={`inference-model-custom-${tier}`}
+                                  >
+                                    <span>Enter a model id…</span>
+                                  </SelectItem>
                                 </SelectContent>
                               </Select>
                             )}

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { BrainCircuit, Check, Loader2, RotateCcw, Save, Trash2, Zap } from "lucide-react";
 import { toast } from "sonner";
 
@@ -447,9 +447,34 @@ export function InferenceSection({
    * difference `hasTypedDraft()` saw. An automatic proxy-safety strip is no
    * more a typed draft than the preset it is correcting; `baseline` has to
    * move with it for the same reason it moves with the preset itself.
+   *
+   * Latched to the *edge* of entering a proxied window, not every render
+   * inside one (issue #1838 follow-up, sixth instance). `models` has to stay
+   * a dependency — it is what changed when a catalog pick or Remove Key's
+   * carry-over needs catching — but that means this effect also re-runs on
+   * every keystroke into the free-text input `wouldSaveProxied` itself put on
+   * screen (`useFreeText` below), because typing calls `setModel` the same as
+   * any other write to `models`. `openrouter/<author>/<model>` only reaches
+   * three segments once the id is complete, so a strip that fires on every
+   * render caught the field mid-word — after `openrouter/`, after
+   * `openrouter/a` — and cleared it before an operator typing one by hand
+   * could ever finish it. `stripProxyIncompatible` normalizes a *settled*
+   * value; applying it while the value is still being composed is the bug,
+   * not a stricter version of the fix. `strippedForWindow` records that the
+   * strip already ran for the current proxied window and skips re-running it
+   * until the window closes (provider leaves `openrouter`, or a key makes
+   * `wouldSaveProxied` false again) and a new one opens — which is exactly
+   * the set of transitions (`pickProvider`, typing then clearing a key) this
+   * effect exists to catch.
    */
+  const strippedForWindow = useRef(false);
   useEffect(() => {
-    if (provider !== "openrouter" || !wouldSaveProxied) return;
+    if (provider !== "openrouter" || !wouldSaveProxied) {
+      strippedForWindow.current = false;
+      return;
+    }
+    if (strippedForWindow.current) return;
+    strippedForWindow.current = true;
     const next = stripProxyIncompatible(models);
     const changed = TIERS.some((tier) => (next[tier] ?? "") !== (models[tier] ?? ""));
     if (!changed) return;

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -488,18 +488,32 @@ export function InferenceSection({
    * `<author>/<model>` id — a bare tier passthrough, or the proxy's own
    * `openrouter/<author>/<model>` form — is left alone either way.
    *
-   * Folds the strip into `baseline` in the same pass, not just `models`.
-   * `pickProvider` seeds both together from the same preset, so skipping
-   * `baseline` here left it holding the raw ids this effect had just
-   * stripped out of `models` — and `hasTypedDraft()` reads any such gap as
-   * an operator draft, however it got there. That flipped a same-tick
-   * `pickProvider("openrouter")` → `pickProvider(<something else>)` (typing
-   * a key in between, never touching Base URL or a model field) into an
-   * unwanted "Replace the provider draft?" confirmation, because this
-   * effect's own cleanup — not anything the operator typed — was the entire
-   * difference `hasTypedDraft()` saw. An automatic proxy-safety strip is no
-   * more a typed draft than the preset it is correcting; `baseline` has to
-   * move with it for the same reason it moves with the preset itself.
+   * Folds the strip into `baseline` in the same pass, not just `models` —
+   * but only for the tiers the strip actually touched. `pickProvider` seeds
+   * both together from the same preset, so skipping `baseline` here left it
+   * holding the raw ids this effect had just stripped out of `models` — and
+   * `hasTypedDraft()` reads any such gap as an operator draft, however it
+   * got there. That flipped a same-tick `pickProvider("openrouter")` →
+   * `pickProvider(<something else>)` (typing a key in between, never
+   * touching Base URL or a model field) into an unwanted "Replace the
+   * provider draft?" confirmation, because this effect's own cleanup — not
+   * anything the operator typed — was the entire difference `hasTypedDraft()`
+   * saw. An automatic proxy-safety strip is no more a typed draft than the
+   * preset it is correcting; `baseline` has to move with it for the same
+   * reason it moves with the preset itself.
+   *
+   * Merging only the *changed* tiers into `baseline.models` (not replacing
+   * the whole map with `next`) matters because `next` is a full snapshot of
+   * every tier, stripped or not. A keyless operator can edit several tiers
+   * in the same proxied window — say a hand-typed passthrough id on one
+   * tier that `stripProxyIncompatible` leaves alone, alongside a raw
+   * catalog id on another that it strips. Setting `baseline.models = next`
+   * wholesale would silently promote that untouched tier's draft into the
+   * baseline too, since `next` carries it through unchanged — and
+   * `hasTypedDraft()` would then see baseline and draft agree and let a
+   * provider switch discard it without the confirmation dialog, even though
+   * the operator never asked for that edit to become the new baseline
+   * (issue #1838 follow-up, eighth instance).
    *
    * Latched to the *edge* of entering a proxied window, not every render
    * inside one (issue #1838 follow-up, sixth instance). `models` has to stay
@@ -529,10 +543,16 @@ export function InferenceSection({
     if (strippedForWindow.current) return;
     strippedForWindow.current = true;
     const next = stripProxyIncompatible(models);
-    const changed = TIERS.some((tier) => (next[tier] ?? "") !== (models[tier] ?? ""));
-    if (!changed) return;
+    const changedTiers = TIERS.filter((tier) => (next[tier] ?? "") !== (models[tier] ?? ""));
+    if (changedTiers.length === 0) return;
     setModels(next);
-    setBaseline((b) => ({ ...b, models: next }));
+    setBaseline((b) => ({
+      ...b,
+      models: {
+        ...b.models,
+        ...Object.fromEntries(changedTiers.map((tier) => [tier, next[tier]])),
+      },
+    }));
   }, [provider, wouldSaveProxied, models]);
 
   function pickProvider(next: InferenceProvider) {

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -172,6 +172,25 @@ function optionsForTier(catalog: InferenceModel[], current: string): InferenceMo
   return [{ id: current, name: "Current custom model" }, ...catalog];
 }
 
+/**
+ * The tier model select's value for "no override — fall back to
+ * `model_for_tier`'s own default for this tier".
+ *
+ * Not `""`: an empty string is Base UI Select's own placeholder/unset
+ * sentinel, so a real option needs a value of its own — the same reason
+ * `AgentDetailView`'s `HARNESS_DEFAULT` exists. `""` is what `models[tier]`
+ * already uses to mean "no override" on the wire (`stripProxyIncompatible`,
+ * `save()`'s `cleanModels` filter), so the boundary is translated at the one
+ * point that crosses it, the select's `onValueChange` below.
+ *
+ * Without this item, a keyed company with a saved override had no way to
+ * clear it back to the tier default once the catalog loaded: the select only
+ * ever offered concrete models, selecting one only replaced the override, and
+ * Reset discards the whole provider configuration and key rather than one
+ * tier (issue #1838 follow-up).
+ */
+const TIER_DEFAULT_MODEL = "__tier_default__";
+
 function modelLabel(model: InferenceModel): string {
   return model.name ? `${model.name} — ${model.id}` : model.id;
 }
@@ -963,8 +982,14 @@ export function InferenceSection({
                               <Select
                                 value={value || null}
                                 disabled={modelCatalog.kind !== "ready"}
-                                onValueChange={(next) => next && setModel(tier, String(next))}
-                                items={modelItems(options)}
+                                onValueChange={(next) => {
+                                  if (!next) return;
+                                  setModel(tier, next === TIER_DEFAULT_MODEL ? "" : String(next));
+                                }}
+                                items={{
+                                  [TIER_DEFAULT_MODEL]: "Use the tier default",
+                                  ...modelItems(options),
+                                }}
                               >
                                 <SelectTrigger
                                   id={`inference-model-${tier}`}
@@ -983,6 +1008,14 @@ export function InferenceSection({
                                   )}
                                 </SelectTrigger>
                                 <SelectContent>
+                                  {value && (
+                                    <SelectItem
+                                      value={TIER_DEFAULT_MODEL}
+                                      data-testid={`inference-model-clear-${tier}`}
+                                    >
+                                      <span>Use the tier default</span>
+                                    </SelectItem>
+                                  )}
                                   {options.map((model) => (
                                     <SelectItem key={model.id} value={model.id}>
                                       <span>{model.name ?? model.id}</span>

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -196,9 +196,20 @@ function modelItems(models: InferenceModel[]): Record<string, string> {
  * the exact same way a catalog-picked one does. Keying off the shape instead
  * means every caller gets the same, correct answer with no dependency on a
  * network fetch having already resolved.
+ *
+ * The `openrouter/` prefix alone is not enough to confirm the passthrough
+ * shape (issue #1838 follow-up, fifth instance): OpenRouter's own registry
+ * owns two-segment ids under that same author name, such as
+ * `openrouter/auto`, and a plain `startsWith` mistook one for the proxy's
+ * three-segment `openrouter/<author>/<slug>` form. That let `model_for_tier`
+ * forward a raw registry id straight through under the same "already the
+ * proxy's own form" exemption meant for ids the proxy actually accepts.
+ * Counting the segments is what actually distinguishes the two shapes.
  */
 function isRawCatalogId(value: string): boolean {
-  return value.includes("/") && !value.startsWith("openrouter/");
+  if (!value.includes("/")) return false;
+  if (!value.startsWith("openrouter/")) return true;
+  return value.split("/").length < 3;
 }
 
 /**

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -181,6 +181,45 @@ function modelItems(models: InferenceModel[]): Record<string, string> {
 }
 
 /**
+ * Whether `value` has the shape of a raw OpenRouter registry id
+ * (`<author>/<model>`) — the form `model_for_tier` forwards to the platform
+ * proxy verbatim and the proxy rejects — as opposed to the proxy's own
+ * explicit `openrouter/<author>/<model>` passthrough form, which it accepts,
+ * or a bare tier id, which is not an override at all.
+ *
+ * Shape-based rather than catalog-membership-based on purpose (issue #1838
+ * follow-up, third and fourth instance): checking membership in the loaded
+ * catalog only answers the question once the catalog has actually loaded,
+ * and a raw `<author>/<model>` id breaks the proxy whether or not it happens
+ * to appear in whatever catalog snapshot we managed to fetch — an id the
+ * operator typed by hand that just isn't in the catalog (yet, or ever) fails
+ * the exact same way a catalog-picked one does. Keying off the shape instead
+ * means every caller gets the same, correct answer with no dependency on a
+ * network fetch having already resolved.
+ */
+function isRawCatalogId(value: string): boolean {
+  return value.includes("/") && !value.startsWith("openrouter/");
+}
+
+/**
+ * Drop tier overrides that the platform's subscription proxy would reject —
+ * the one place every "about to save under the proxy" call site funnels
+ * through, so the rule can't drift out of sync with itself between the
+ * live-edit effect, `save()`, and `removeKey()` the way three separate partial
+ * implementations of it already had (issue #1838 follow-up).
+ */
+function stripProxyIncompatible<T extends string>(
+  models: Partial<Record<T, string>>,
+): Partial<Record<T, string>> {
+  const next = {} as Partial<Record<T, string>>;
+  for (const key of Object.keys(models) as T[]) {
+    const value = models[key];
+    if (value && !isRawCatalogId(value)) next[key] = value;
+  }
+  return next;
+}
+
+/**
  * Bring-Your-Own-Key inference (issue #56). Shows the company's effective
  * provider (with a source badge + tier→model rows + a "key set" indicator), a
  * live "Test" probe, and a switch form with per-provider presets. The key input
@@ -342,7 +381,7 @@ export function InferenceSection({
     key.trim().length === 0 && !(status?.provider === "openrouter" && status.keyConfigured);
 
   /**
-   * Drop a catalog-picked tier override the moment the form would save
+   * Drop a catalog-shaped tier override the moment the form would save
    * proxied (issue #1838 follow-up).
    *
    * A keyless company can type a key, pick a model from the catalog select —
@@ -351,30 +390,29 @@ export function InferenceSection({
    * and the free-text input reappears, but nothing cleared the value it
    * inherited from the select, so Save still persists that raw id as an
    * override. `model_for_tier` honours overrides verbatim on *both* paths, so
-   * the proxy receives a model namespace it rejects.
+   * the proxy receives a model namespace it rejects. The same thing happens
+   * without ever touching a key at all: switching a keyless company onto
+   * OpenRouter installs that provider's raw-id presets (`PROVIDERS.openrouter
+   * .preset.models`) up front, and Save is not disabled while the catalog is
+   * still loading or has failed.
    *
-   * Only tiers whose current value is actually present in the loaded catalog
-   * are touched — a tier id the operator typed by hand (or the proxy's own
-   * `openrouter/<author>/<model>` passthrough form) is left alone, mirroring
-   * `model_for_tier`'s "an operator's own entry is honoured verbatim"
-   * contract rather than wiping the field outright.
+   * Runs off `stripProxyIncompatible`'s shape check, not catalog membership —
+   * an earlier version of this effect only stripped a value present in the
+   * *loaded* catalog, so it did nothing while `modelCatalog.kind` was
+   * `"loading"` or `"error"`, letting a raw preset or catalog-picked id ride
+   * straight through Save during that window (issue #1838 follow-up, third
+   * instance). A tier id the operator typed by hand that is not a raw
+   * `<author>/<model>` id — a bare tier passthrough, or the proxy's own
+   * `openrouter/<author>/<model>` form — is left alone either way.
    */
   useEffect(() => {
-    if (!wouldSaveProxied || modelCatalog.kind !== "ready") return;
-    const catalogIds = new Set(modelCatalog.models.map((m) => m.id));
+    if (provider !== "openrouter" || !wouldSaveProxied) return;
     setModels((current) => {
-      let changed = false;
-      const next = { ...current };
-      for (const tier of TIERS) {
-        const value = next[tier];
-        if (value && catalogIds.has(value)) {
-          delete next[tier];
-          changed = true;
-        }
-      }
+      const next = stripProxyIncompatible(current);
+      const changed = TIERS.some((tier) => (next[tier] ?? "") !== (current[tier] ?? ""));
       return changed ? next : current;
     });
-  }, [wouldSaveProxied, modelCatalog]);
+  }, [provider, wouldSaveProxied]);
 
   function pickProvider(next: InferenceProvider) {
     setProvider(next);
@@ -438,8 +476,19 @@ export function InferenceSection({
       if (provider === "managed" && !key.trim() && !status?.keyConfigured) {
         result = await revertInference(client, company);
       } else {
+        // Belt-and-suspenders alongside the live-edit effect above: that
+        // effect strips a proxy-incompatible draft value out of `models`
+        // asynchronously, after the state update that made
+        // `wouldSaveProxied` true has committed. Re-applying the same
+        // shape-based strip here means Save can never persist a raw
+        // catalog id under the proxy even in the window before that effect
+        // has run (issue #1838 follow-up).
+        const draftModels =
+          provider === "openrouter" && wouldSaveProxied
+            ? stripProxyIncompatible(models)
+            : models;
         const cleanModels = Object.fromEntries(
-          Object.entries(models)
+          Object.entries(draftModels)
             .map(([t, v]) => [t, (v ?? "").trim()])
             .filter(([, v]) => v.length > 0),
         );
@@ -491,25 +540,19 @@ export function InferenceSection({
       // an id saved while keyed survives this transition and breaks every
       // proxied call afterwards (issue #1838 follow-up).
       //
-      // Fetch the catalog fresh rather than trust the form's `modelCatalog`:
-      // that state tracks the *form's* selected provider, and Remove Key acts
-      // on `status.provider`, which the operator can have moved away from
-      // without saving — so the two can differ right when this runs. A tier
-      // id the operator typed by hand (not present in the catalog) is left
-      // alone, same as the live-edit effect: it is honoured verbatim even if
-      // it will fail, not silently rewritten.
+      // Shape-based (`stripProxyIncompatible`), not a fresh catalog fetch: an
+      // earlier version of this block fetched the registry here and, on
+      // failure, fell back to sending the stored overrides completely
+      // unfiltered — which is exactly the condition an unreachable registry
+      // produces, so the one case this fallback existed for was also the one
+      // case guaranteed to break every proxied tier (issue #1838 follow-up,
+      // fourth instance). `stripProxyIncompatible` needs nothing from the
+      // network, so there is no failure mode left to fall back from, and a
+      // tier id the operator typed by hand (not shaped like a raw catalog id)
+      // is still left alone, same as the live-edit effect.
       if (effective === "openrouter" && carriedModels) {
-        try {
-          const catalog = await listInferenceModels(client, company);
-          const catalogIds = new Set(catalog.map((m) => m.id));
-          const kept = Object.fromEntries(
-            Object.entries(carriedModels).filter(([, v]) => !catalogIds.has(v)),
-          );
-          carriedModels = Object.keys(kept).length ? kept : undefined;
-        } catch {
-          // Catalog fetch failed — fall back to sending the stored overrides
-          // verbatim rather than blocking Remove Key on an unrelated read.
-        }
+        const kept = stripProxyIncompatible(carriedModels);
+        carriedModels = Object.keys(kept).length ? (kept as Record<string, string>) : undefined;
       }
       await setInference(client, company, {
         provider: effective,

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -479,6 +479,38 @@ export function InferenceSection({
     setBusy("removeKey");
     const effective = (status?.provider as InferenceProvider) ?? provider;
     try {
+      let carriedModels =
+        status && Object.keys(status.models).length ? status.models : undefined;
+      // Clearing the key on OpenRouter flips this company onto the platform
+      // proxy immediately (`wouldSaveProxied` above). A catalog-picked raw
+      // `<author>/<model>` id is exactly what that proxy rejects —
+      // `model_for_tier` honours an override verbatim on both paths. The
+      // live-edit effect above already drops that id out of the *draft form*
+      // the moment the transition happens there, but Remove Key echoes back
+      // `status.models` — the *stored* config — straight past that effect, so
+      // an id saved while keyed survives this transition and breaks every
+      // proxied call afterwards (issue #1838 follow-up).
+      //
+      // Fetch the catalog fresh rather than trust the form's `modelCatalog`:
+      // that state tracks the *form's* selected provider, and Remove Key acts
+      // on `status.provider`, which the operator can have moved away from
+      // without saving — so the two can differ right when this runs. A tier
+      // id the operator typed by hand (not present in the catalog) is left
+      // alone, same as the live-edit effect: it is honoured verbatim even if
+      // it will fail, not silently rewritten.
+      if (effective === "openrouter" && carriedModels) {
+        try {
+          const catalog = await listInferenceModels(client, company);
+          const catalogIds = new Set(catalog.map((m) => m.id));
+          const kept = Object.fromEntries(
+            Object.entries(carriedModels).filter(([, v]) => !catalogIds.has(v)),
+          );
+          carriedModels = Object.keys(kept).length ? kept : undefined;
+        } catch {
+          // Catalog fetch failed — fall back to sending the stored overrides
+          // verbatim rather than blocking Remove Key on an unrelated read.
+        }
+      }
       await setInference(client, company, {
         provider: effective,
         // Only echo the resolved base URL back for the providers that require
@@ -486,7 +518,7 @@ export function InferenceSection({
         // a well-known default, and persisting the *displayed* value would pin
         // the company to it — silently overriding `OPENCOMPANY_INFERENCE_URL`.
         baseUrl: PROVIDERS[effective]?.requiresBaseUrl ? status?.baseUrl || undefined : undefined,
-        models: status && Object.keys(status.models).length ? status.models : undefined,
+        models: carriedModels,
         key: "",
       });
       toast.success("Removed the company key. Teammates fall back on their next turn.");

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -322,6 +322,60 @@ export function InferenceSection({
     };
   }, [client, company, provider]);
 
+  /**
+   * Whether saving right now would ride the platform's subscription proxy
+   * rather than go straight to OpenRouter with a tenant key.
+   *
+   * The proxy only resolves an abstract tier (or its own `openrouter/…`
+   * passthrough form, off by default) — see `model_for_tier` in
+   * `src/company/inference.rs`. The catalog picker below stores the
+   * registry's raw `<author>/<model>` id verbatim, which is exactly the form
+   * the proxy rejects. `key` is write-only and never comes back from the
+   * host, so "no key typed" only means proxied when the stored config is not
+   * already a direct, keyed OpenRouter connection.
+   *
+   * Hoisted above the early return below so the clear-on-transition effect
+   * that follows can depend on it — hooks cannot come after a conditional
+   * return.
+   */
+  const wouldSaveProxied =
+    key.trim().length === 0 && !(status?.provider === "openrouter" && status.keyConfigured);
+
+  /**
+   * Drop a catalog-picked tier override the moment the form would save
+   * proxied (issue #1838 follow-up).
+   *
+   * A keyless company can type a key, pick a model from the catalog select —
+   * which stores the registry's raw `<author>/<model>` id verbatim — and then
+   * clear the key again before Save. `wouldSaveProxied` flips back to `true`
+   * and the free-text input reappears, but nothing cleared the value it
+   * inherited from the select, so Save still persists that raw id as an
+   * override. `model_for_tier` honours overrides verbatim on *both* paths, so
+   * the proxy receives a model namespace it rejects.
+   *
+   * Only tiers whose current value is actually present in the loaded catalog
+   * are touched — a tier id the operator typed by hand (or the proxy's own
+   * `openrouter/<author>/<model>` passthrough form) is left alone, mirroring
+   * `model_for_tier`'s "an operator's own entry is honoured verbatim"
+   * contract rather than wiping the field outright.
+   */
+  useEffect(() => {
+    if (!wouldSaveProxied || modelCatalog.kind !== "ready") return;
+    const catalogIds = new Set(modelCatalog.models.map((m) => m.id));
+    setModels((current) => {
+      let changed = false;
+      const next = { ...current };
+      for (const tier of TIERS) {
+        const value = next[tier];
+        if (value && catalogIds.has(value)) {
+          delete next[tier];
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [wouldSaveProxied, modelCatalog]);
+
   function pickProvider(next: InferenceProvider) {
     setProvider(next);
     const preset = presetFor(next);
@@ -532,20 +586,6 @@ export function InferenceSection({
   if (load === "unavailable") return null;
 
   const modelRows = status ? Object.entries(status.models) : [];
-  /**
-   * Whether saving right now would ride the platform's subscription proxy
-   * rather than go straight to OpenRouter with a tenant key.
-   *
-   * The proxy only resolves an abstract tier (or its own `openrouter/…`
-   * passthrough form, off by default) — see `model_for_tier` in
-   * `src/company/inference.rs`. The catalog picker below stores the
-   * registry's raw `<author>/<model>` id verbatim, which is exactly the form
-   * the proxy rejects. `key` is write-only and never comes back from the
-   * host, so "no key typed" only means proxied when the stored config is not
-   * already a direct, keyed OpenRouter connection.
-   */
-  const wouldSaveProxied =
-    key.trim().length === 0 && !(status?.provider === "openrouter" && status.keyConfigured);
   return (
     <section className="space-y-3">
       <div className="flex items-center gap-2">

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -404,15 +404,28 @@ export function InferenceSection({
    * instance). A tier id the operator typed by hand that is not a raw
    * `<author>/<model>` id — a bare tier passthrough, or the proxy's own
    * `openrouter/<author>/<model>` form — is left alone either way.
+   *
+   * Folds the strip into `baseline` in the same pass, not just `models`.
+   * `pickProvider` seeds both together from the same preset, so skipping
+   * `baseline` here left it holding the raw ids this effect had just
+   * stripped out of `models` — and `hasTypedDraft()` reads any such gap as
+   * an operator draft, however it got there. That flipped a same-tick
+   * `pickProvider("openrouter")` → `pickProvider(<something else>)` (typing
+   * a key in between, never touching Base URL or a model field) into an
+   * unwanted "Replace the provider draft?" confirmation, because this
+   * effect's own cleanup — not anything the operator typed — was the entire
+   * difference `hasTypedDraft()` saw. An automatic proxy-safety strip is no
+   * more a typed draft than the preset it is correcting; `baseline` has to
+   * move with it for the same reason it moves with the preset itself.
    */
   useEffect(() => {
     if (provider !== "openrouter" || !wouldSaveProxied) return;
-    setModels((current) => {
-      const next = stripProxyIncompatible(current);
-      const changed = TIERS.some((tier) => (next[tier] ?? "") !== (current[tier] ?? ""));
-      return changed ? next : current;
-    });
-  }, [provider, wouldSaveProxied]);
+    const next = stripProxyIncompatible(models);
+    const changed = TIERS.some((tier) => (next[tier] ?? "") !== (models[tier] ?? ""));
+    if (!changed) return;
+    setModels(next);
+    setBaseline((b) => ({ ...b, models: next }));
+  }, [provider, wouldSaveProxied, models]);
 
   function pickProvider(next: InferenceProvider) {
     setProvider(next);

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -205,3 +205,60 @@ test("OpenRouter models are selected from the registry and persist through reloa
     page.getByText("Reverted to the committed manifest (or managed) configuration."),
   ).toBeVisible({ timeout: 30_000 });
 });
+
+test("a saved OpenRouter tier override can be cleared back to the tier default (issue #1838 follow-up)", async ({
+  page,
+}) => {
+  // Once a keyed company has picked a concrete model for a tier, the select
+  // used to offer no way back — every option only replaced the override, and
+  // Reset throws away the whole provider configuration and key rather than
+  // one tier's mapping. This proves the explicit "Use the tier default" item
+  // actually clears the stored override, end to end against a real host.
+  await page.route("**/inference/models", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        { id: "provider/catalog-chat", name: "Catalog Chat", contextLength: 128_000 },
+      ]),
+    });
+  });
+  await openConnections(page);
+  await expect(page.locator("#inference-provider")).toBeVisible({ timeout: 30_000 });
+
+  await pickProvider(page, "OpenRouter");
+  await page.locator("#inference-key").fill(`pw-e2e-${Date.now()}`);
+  const chat = page.getByTestId("inference-model-select-chat-v1");
+  await expect(chat).toBeEnabled();
+  await chat.click();
+  await page.getByRole("option", { name: /Catalog Chat/ }).click();
+  await page.getByTestId("inference-save").click();
+  await expect(
+    page.getByText(/Inference updated\.|Inference saved — restart the company/),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const saved = await page.request.get("/api/v1/company/inference");
+  expect(saved.ok()).toBeTruthy();
+  expect((await saved.json()).models["chat-v1"]).toBe("provider/catalog-chat");
+
+  // Reload so the picker is seeded straight from the stored override, then
+  // clear it through the select rather than typing anything.
+  await page.reload();
+  const chatAfterReload = page.getByTestId("inference-model-select-chat-v1");
+  await expect(chatAfterReload).toContainText("Catalog Chat", { timeout: 30_000 });
+  await chatAfterReload.click();
+  await page.getByRole("option", { name: "Use the tier default" }).click();
+  await page.getByTestId("inference-save").click();
+  await expect(
+    page.getByText(/Inference updated\.|Inference saved — restart the company/),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const cleared = await page.request.get("/api/v1/company/inference");
+  expect(cleared.ok()).toBeTruthy();
+  expect((await cleared.json()).models["chat-v1"]).toBeUndefined();
+
+  // Leave the shared E2E company on its committed default for later specs.
+  await page.getByRole("button", { name: "Reset to default" }).click();
+  await expect(
+    page.getByText("Reverted to the committed manifest (or managed) configuration."),
+  ).toBeVisible({ timeout: 30_000 });
+});

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -151,3 +151,47 @@ test("changing provider asks before replacing a typed endpoint or model", async 
   await expect(page.locator("#inference-base-url")).toHaveValue("https://models.example.test/v1");
   await expect(page.locator("#inference-model-chat-v1")).toHaveValue("operator-draft");
 });
+
+test("OpenRouter models are selected from the registry and persist through reload", async ({
+  page,
+}) => {
+  await page.route("**/inference/models", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        { id: "provider/catalog-chat", name: "Catalog Chat", contextLength: 128_000 },
+        { id: "provider/catalog-reasoning", name: "Catalog Reasoning" },
+      ]),
+    });
+  });
+  await openConnections(page);
+  await expect(page.locator("#inference-provider")).toBeVisible({ timeout: 30_000 });
+
+  await pickProvider(page, "OpenRouter");
+  const chat = page.getByTestId("inference-model-select-chat-v1");
+  await expect(chat).toBeEnabled();
+  await chat.click();
+  await page.getByRole("option", { name: /Catalog Chat/ }).click();
+  await page.getByTestId("inference-save").click();
+  await expect(
+    page.getByText(/Inference updated\.|Inference saved — restart the company/),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const saved = await page.request.get("/api/v1/company/inference");
+  expect(saved.ok()).toBeTruthy();
+  expect((await saved.json()).models["chat-v1"]).toBe("provider/catalog-chat");
+
+  await page.reload();
+  await expect(page.getByTestId("inference-model-select-chat-v1")).toContainText("Catalog Chat", {
+    timeout: 30_000,
+  });
+
+  await pickProvider(page, "Custom (OpenAI-compatible)");
+  await expect(page.locator("input#inference-model-chat-v1")).toBeVisible();
+
+  // Leave the shared E2E company on its committed default for later specs.
+  await page.getByRole("button", { name: "Reset to default" }).click();
+  await expect(
+    page.getByText("Reverted to the committed manifest (or managed) configuration."),
+  ).toBeVisible({ timeout: 30_000 });
+});

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -262,3 +262,38 @@ test("a saved OpenRouter tier override can be cleared back to the tier default (
     page.getByText("Reverted to the committed manifest (or managed) configuration."),
   ).toBeVisible({ timeout: 30_000 });
 });
+
+test("typing an OpenRouter passthrough id one keystroke at a time is not stripped mid-word (issue #1838 follow-up, sixth instance)", async ({
+  page,
+}) => {
+  // Unit coverage for this same regression (inference-model-picker.test.ts)
+  // dispatches synthetic input events; this spec is the proof against a real
+  // browser's actual keystroke-by-keystroke typing, which is what a prior
+  // regression on this same effect (the baseline/models divergence, #1838)
+  // slipped past unit tests and only an E2E run caught.
+  await openConnections(page);
+  await expect(page.locator("#inference-key")).toBeVisible({ timeout: 30_000 });
+
+  // A keyless switch to OpenRouter lands on the proxied, free-text path
+  // (issue #1838 follow-up): the provider's own raw-id presets get stripped
+  // immediately since there is no key to save them under, leaving the tier
+  // fields editable and empty.
+  await pickProvider(page, "OpenRouter");
+  const chatInput = page.locator("#inference-model-chat-v1");
+  await expect(chatInput).toBeVisible();
+  await expect(chatInput).toHaveValue("");
+
+  // Type the proxy's own passthrough id character by character. Every prefix
+  // shorter than the full three-segment id counts as a raw catalog id by
+  // segment count, so this is exactly the sequence a per-render strip used to
+  // clear mid-word.
+  const target = "openrouter/anthropic/claude-sonnet-5";
+  await chatInput.pressSequentially(target, { delay: 20 });
+  await expect(chatInput).toHaveValue(target);
+
+  // Leave the shared E2E company on its committed default for later specs.
+  await page.getByRole("button", { name: "Reset to default" }).click();
+  await expect(
+    page.getByText("Reverted to the committed manifest (or managed) configuration."),
+  ).toBeVisible({ timeout: 30_000 });
+});

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -278,8 +278,18 @@ test("typing an OpenRouter passthrough id one keystroke at a time is not strippe
   // (issue #1838 follow-up): the provider's own raw-id presets get stripped
   // immediately since there is no key to save them under, leaving the tier
   // fields editable and empty.
+  //
+  // Make that keyless precondition explicit rather than inherited from
+  // whatever a prior spec (or an aborted earlier run) left stored on the
+  // shared E2E company: the free-text `<input>` and the catalog `Select`
+  // trigger share the same `id={inference-model-${tier}}` (only one renders
+  // at a time), so `#inference-model-chat-v1` alone would just as happily
+  // match a leftover-key company's Select trigger — and `toHaveValue("")`
+  // against that gives a confusing "not an input" failure instead of naming
+  // the real problem. `input#…` only matches the free-text control, the same
+  // guard the OpenRouter-catalog spec above already uses.
   await pickProvider(page, "OpenRouter");
-  const chatInput = page.locator("#inference-model-chat-v1");
+  const chatInput = page.locator("input#inference-model-chat-v1");
   await expect(chatInput).toBeVisible();
   await expect(chatInput).toHaveValue("");
 

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -168,6 +168,16 @@ test("OpenRouter models are selected from the registry and persist through reloa
   await expect(page.locator("#inference-provider")).toBeVisible({ timeout: 30_000 });
 
   await pickProvider(page, "OpenRouter");
+  // A key is required before the catalog picker offers itself (issue #1838
+  // follow-up): with none typed and no key already stored server-side, a
+  // save would ride the platform's subscription proxy, which rejects the
+  // raw `<author>/<model>` id the catalog select writes — so the free-text
+  // inputs stay up instead until a key makes that pick safe to store. This
+  // spec runs against the shared E2E company, whose key state a prior spec
+  // in this file (or an earlier run of this one) can have left cleared, so
+  // typing one here is what makes the picker's availability deterministic
+  // rather than an accident of what state a previous test left behind.
+  await page.locator("#inference-key").fill(`pw-e2e-${Date.now()}`);
   const chat = page.getByTestId("inference-model-select-chat-v1");
   await expect(chat).toBeEnabled();
   await chat.click();

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -28,6 +28,7 @@ function status(over: Partial<InferenceStatus> = {}): InferenceStatus {
     slug: "managed",
     baseUrl: "https://openrouter.ai/api/v1",
     models: {},
+    defaultTierModels: {},
     source: "runtime",
     keyConfigured: true,
     cognition: "echo",

--- a/frontend/test/unit/inference-card-honesty.test.ts
+++ b/frontend/test/unit/inference-card-honesty.test.ts
@@ -50,7 +50,7 @@ function stubClient(replies: InferenceStatus[], mutation?: InferenceStatus) {
   return {
     scopeFor: (company: string | null) =>
       company ? `/api/v1/companies/${company}` : "/api/v1/company",
-    get: async () => read(),
+    get: async (path: string) => (path.endsWith("/inference/models") ? [] : read()),
     put: async () => ({ status: settled(), note: "" }),
     del: async () => ({ status: settled(), note: "" }),
     post: async () => ({ status: settled(), note: "" }),

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -212,6 +212,69 @@ describe("OpenRouter tier model pickers", () => {
   });
 });
 
+describe("raw OpenRouter registry ids vs the proxy's own passthrough shape (issue #1838 follow-up, fifth instance)", () => {
+  it("strips a two-segment OpenRouter-registry id (e.g. openrouter/auto) when Remove Key switches to the proxy", async () => {
+    // OpenRouter's own catalog has ids under the `openrouter/` author too —
+    // `openrouter/auto` is a real two-segment registry id, not the proxy's
+    // three-segment `openrouter/<author>/<slug>` passthrough form. A prefix
+    // check that only tests `startsWith("openrouter/")` mistakes the former
+    // for the latter and leaves it in place; `model_for_tier` then forwards
+    // it to the proxy verbatim, which rejects it.
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "openrouter/auto", "reasoning-v1": "reasoning-v1" },
+        true,
+      ),
+      [{ id: "openrouter/auto", name: "Auto" }],
+    );
+
+    await mount(client);
+
+    const button = container.querySelector('[data-testid="inference-remove-key"]') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { key?: string; models?: Record<string, string> };
+    expect(body.key).toBe("");
+    expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
+  });
+
+  it("keeps the proxy's genuine three-segment openrouter/<author>/<slug> passthrough id", async () => {
+    // The exemption exists for this shape specifically — an operator who
+    // enabled proxy passthrough and saved its own `openrouter/<author>/<slug>`
+    // form must not have it stripped out from under them by the same fix.
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "openrouter/anthropic/claude-3-opus", "reasoning-v1": "reasoning-v1" },
+        true,
+      ),
+      [{ id: "openrouter/anthropic/claude-3-opus", name: "Claude 3 Opus (passthrough)" }],
+    );
+
+    await mount(client);
+
+    const button = container.querySelector('[data-testid="inference-remove-key"]') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { key?: string; models?: Record<string, string> };
+    expect(body.models).toEqual({
+      "chat-v1": "openrouter/anthropic/claude-3-opus",
+      "reasoning-v1": "reasoning-v1",
+    });
+  });
+});
+
 describe("proxy-incompatible overrides survive an unready catalog (issue #1838 follow-up)", () => {
   it("strips a raw catalog id from the draft while the registry is still loading, before Save is clicked", async () => {
     // Third instance of the #1838 class: the earlier fix only stripped a

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -34,8 +34,9 @@ function status(
 function clientFor(
   inference: InferenceStatus,
   catalog: InferenceModel[] | Error,
-): { client: OpenCompanyClient; calls: string[] } {
+): { client: OpenCompanyClient; calls: string[]; puts: unknown[] } {
   const calls: string[] = [];
+  const puts: unknown[] = [];
   const client = {
     scopeFor: () => "/api/v1/companies/acme",
     get: async (path: string) => {
@@ -46,8 +47,12 @@ function clientFor(
       }
       return inference;
     },
+    put: async (_path: string, body: unknown) => {
+      puts.push(body);
+      return { status: inference, note: "" };
+    },
   } as unknown as OpenCompanyClient;
-  return { client, calls };
+  return { client, calls, puts };
 }
 
 async function mount(client: OpenCompanyClient) {
@@ -171,5 +176,38 @@ describe("OpenRouter tier model pickers", () => {
       "private/model",
     );
     expect(calls.some((path) => path.endsWith("/inference/models"))).toBe(false);
+  });
+
+  it("strips a catalog-picked id from the stored config when Remove Key is clicked", async () => {
+    // A keyed company saved a raw catalog id straight to OpenRouter (allowed
+    // while keyed — this is not the proxied path). Remove Key clears the key
+    // and, per `wouldSaveProxied`, immediately switches the company onto the
+    // platform proxy. `model_for_tier` honours the stored override verbatim on
+    // both paths, so the id it just carried over is exactly what the proxy
+    // rejects unless Remove Key strips it before saving. The hand-typed tier
+    // id on the other tier (not present in the catalog) must survive — Remove
+    // Key only clears what the catalog select itself wrote.
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "reasoning-v1" },
+        true,
+      ),
+      [{ id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" }],
+    );
+
+    await mount(client);
+
+    const button = container.querySelector('[data-testid="inference-remove-key"]') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { key?: string; models?: Record<string, string> };
+    expect(body.key).toBe("");
+    expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
   });
 });

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -275,6 +275,84 @@ describe("raw OpenRouter registry ids vs the proxy's own passthrough shape (issu
   });
 });
 
+describe("clearing a tier override back to the tier default (issue #1838 follow-up)", () => {
+  it("offers a 'Use the tier default' item in the catalog select for a tier with a saved override", async () => {
+    // A keyed OpenRouter company with a saved override and a loaded catalog
+    // used to only ever offer concrete models — no way to remove the one
+    // mapping and let `model_for_tier` fall back to its own default for that
+    // tier. Opening the select must show an explicit way out.
+    const { client } = clientFor(
+      status("openrouter", { "chat-v1": "anthropic/claude-sonnet-5" }, true),
+      [{ id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" }],
+    );
+
+    await mount(client);
+
+    const trigger = container.querySelector(
+      '[data-testid="inference-model-select-chat-v1"]',
+    ) as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    await act(async () => {
+      trigger.click();
+    });
+    await act(async () => {});
+
+    expect(document.body.querySelector('[data-testid="inference-model-clear-chat-v1"]')).not.toBeNull();
+  });
+
+  it("clears the tier override when 'Use the tier default' is picked, and Save drops it from the wire", async () => {
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "anthropic/agentic" },
+        true,
+      ),
+      [
+        { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" },
+        { id: "anthropic/agentic", name: "Agentic" },
+      ],
+    );
+
+    await mount(client);
+
+    const trigger = container.querySelector(
+      '[data-testid="inference-model-select-chat-v1"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      trigger.click();
+    });
+    await act(async () => {});
+
+    const clearItem = document.body.querySelector(
+      '[data-testid="inference-model-clear-chat-v1"]',
+    ) as HTMLElement;
+    expect(clearItem).not.toBeNull();
+    await act(async () => {
+      clearItem.click();
+    });
+    await act(async () => {});
+
+    // Cleared tier reverts to the placeholder select (no stored value); the
+    // untouched tier keeps its override and stays a select, not free text.
+    expect(container.querySelector("#inference-model-chat-v1")?.textContent).not.toContain(
+      "anthropic/claude-sonnet-5",
+    );
+    expect(container.querySelector("#inference-model-reasoning-v1")?.textContent).toContain(
+      "Agentic",
+    );
+
+    const save = container.querySelector('[data-testid="inference-save"]') as HTMLButtonElement;
+    await act(async () => {
+      save.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { models?: Record<string, string> };
+    expect(body.models).toEqual({ "reasoning-v1": "anthropic/agentic" });
+  });
+});
+
 describe("proxy-incompatible overrides survive an unready catalog (issue #1838 follow-up)", () => {
   it("strips a raw catalog id from the draft while the registry is still loading, before Save is clicked", async () => {
     // Third instance of the #1838 class: the earlier fix only stripped a

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -112,10 +112,31 @@ describe("OpenRouter tier model pickers", () => {
     await mount(client);
 
     expect(container.querySelector('[data-testid="inference-model-catalog-fallback"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="inference-model-catalog-proxied"]')).toBeNull();
     expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty(
       "value",
       "operator/custom-chat",
     );
+  });
+
+  it("also warns a keyless company that a typed model id is dropped when the registry fails to load", async () => {
+    // Companion to the fallback case above: that one has a stored key, so
+    // `wouldSaveProxied` is false and "Enter model ids directly" is accurate
+    // as written — a direct id really is what gets saved. Here there is no
+    // key, so Save resolves proxied and `stripProxyIncompatible` silently
+    // drops any `<author>/<model>` shaped id typed into the field the
+    // fallback copy just pointed the operator at. The proxied clarification
+    // must render alongside the fallback message in this state, not only
+    // once the catalog reaches `ready`.
+    const { client } = clientFor(
+      status("openrouter", { "chat-v1": "reasoning-v1" }, false),
+      new Error("offline"),
+    );
+
+    await mount(client);
+
+    expect(container.querySelector('[data-testid="inference-model-catalog-fallback"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="inference-model-catalog-proxied"]')).not.toBeNull();
   });
 
   it("keeps free-text inputs for a proxied OpenRouter company with no key configured", async () => {

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -129,6 +129,35 @@ describe("OpenRouter tier model pickers", () => {
     expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
   });
 
+  it("clears a catalog-picked id from the tier field once the form would save proxied", async () => {
+    // Mirrors what a key-clear leaves behind: a company stores a raw
+    // `<author>/<model>` id (exactly what the catalog select writes) while no
+    // key is configured. `model_for_tier` honours a tier override verbatim on
+    // *both* the direct and proxied paths, so this id would ride straight to
+    // the platform proxy, which only resolves an abstract tier name (or its
+    // own disabled-by-default `openrouter/<author>/<model>` passthrough) —
+    // the proxy rejects it. The free-text field that reappears here must not
+    // keep offering that id back to Save; a tier id the operator typed by
+    // hand (not present in the catalog) is unaffected.
+    const { client } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "reasoning-v1" },
+        false,
+      ),
+      [{ id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" }],
+    );
+
+    await mount(client);
+
+    expect(container.querySelector('[data-testid="inference-model-catalog-proxied"]')).not.toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty("value", "");
+    expect(container.querySelector("input#inference-model-reasoning-v1")).toHaveProperty(
+      "value",
+      "reasoning-v1",
+    );
+  });
+
   it("keeps free-text inputs for non-OpenRouter providers without fetching the registry", async () => {
     const { client, calls } = clientFor(
       status("openai_compatible", { "chat-v1": "private/model" }),

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -211,3 +211,124 @@ describe("OpenRouter tier model pickers", () => {
     expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
   });
 });
+
+describe("proxy-incompatible overrides survive an unready catalog (issue #1838 follow-up)", () => {
+  it("strips a raw catalog id from the draft while the registry is still loading, before Save is clicked", async () => {
+    // Third instance of the #1838 class: the earlier fix only stripped a
+    // tier value once `modelCatalog.kind === "ready"`, so a keyless company
+    // that already has a raw `<author>/<model>` override stored (from an
+    // earlier keyed session, or from switching onto OpenRouter's own preset)
+    // kept offering it back to Save for as long as the registry request was
+    // still in flight — which, on a slow network, can be indefinitely.
+    const calls: string[] = [];
+    const puts: unknown[] = [];
+    const inference = status(
+      "openrouter",
+      { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "reasoning-v1" },
+      false,
+    );
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) => {
+        calls.push(path);
+        if (path.endsWith("/inference/models")) {
+          // Never resolves — the registry request is permanently in flight
+          // for the duration of this test.
+          return new Promise(() => {});
+        }
+        return inference;
+      },
+      put: async (_path: string, body: unknown) => {
+        puts.push(body);
+        return { status: inference, note: "" };
+      },
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    // Still loading, never reached "ready".
+    expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty("value", "");
+    expect(container.querySelector("input#inference-model-reasoning-v1")).toHaveProperty(
+      "value",
+      "reasoning-v1",
+    );
+
+    const button = container.querySelector('[data-testid="inference-save"]') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { models?: Record<string, string> };
+    expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
+  });
+
+  it("does not let Save persist a raw catalog id when the registry failed to load", async () => {
+    // Same class, the "or has failed" half: a failed registry fetch also
+    // never reaches `kind === "ready"`.
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "reasoning-v1" },
+        false,
+      ),
+      new Error("registry unreachable"),
+    );
+
+    await mount(client);
+
+    expect(container.querySelector('[data-testid="inference-model-catalog-fallback"]')).not.toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty("value", "");
+
+    const button = container.querySelector('[data-testid="inference-save"]') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { models?: Record<string, string> };
+    expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
+  });
+
+  it("strips a raw catalog id from Remove Key's carried models when the registry fetch fails", async () => {
+    // Fourth instance: Remove Key used to fetch the registry itself to
+    // decide what to carry over, and fell back to sending the stored
+    // overrides completely unfiltered when that fetch failed — the one
+    // outcome guaranteed to break every proxied tier, on exactly the
+    // condition (registry unreachable) that triggers it.
+    const inference = status(
+      "openrouter",
+      { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "reasoning-v1" },
+      true,
+    );
+    const puts: unknown[] = [];
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) => {
+        if (path.endsWith("/inference/models")) throw new Error("registry unreachable");
+        return inference;
+      },
+      put: async (_path: string, body: unknown) => {
+        puts.push(body);
+        return { status: inference, note: "" };
+      },
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    const button = container.querySelector('[data-testid="inference-remove-key"]') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { key?: string; models?: Record<string, string> };
+    expect(body.key).toBe("");
+    expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
+  });
+});

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -473,3 +473,47 @@ describe("proxy-incompatible overrides survive an unready catalog (issue #1838 f
     expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
   });
 });
+
+describe("typing a passthrough id one keystroke at a time while proxied (issue #1838 follow-up, sixth instance)", () => {
+  it("does not strip an in-progress openrouter/<author>/<model> id before the operator finishes typing it", async () => {
+    // The auto-strip effect exists to catch a *settled* proxy-incompatible
+    // value — a catalog pick, a preset, or Remove Key's carried-over
+    // override — landing in `models` in one shot. It used to run on every
+    // render instead, including the renders a keystroke into the free-text
+    // input this same proxied state puts on screen produces. `openrouter/
+    // <author>/<model>` only reaches three segments once it is complete, so
+    // typing it by hand passes through `openrouter/` and `openrouter/a` —
+    // both counted as raw by segment count — and a per-render strip cleared
+    // the field before those segments could ever be finished.
+    //
+    // Each keystroke below is dispatched with the value a real browser would
+    // report: the field's *current* DOM value plus one more character — not
+    // the target string sliced up front. That is what actually reproduces a
+    // clear-mid-word: if the effect wipes the field between keystrokes, the
+    // DOM the next keystroke appends to is already empty, and the loop ends
+    // holding only the tail of the id instead of the whole thing.
+    const { client } = clientFor(status("openrouter", {}, false), [
+      { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" },
+    ]);
+
+    await mount(client);
+
+    const input = container.querySelector<HTMLInputElement>("input#inference-model-chat-v1");
+    expect(input).not.toBeNull();
+
+    const target = "openrouter/anthropic/claude-sonnet-5";
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    for (const ch of target) {
+      const next = (input as HTMLInputElement).value + ch;
+      await act(async () => {
+        setter?.call(input, next);
+        input?.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+    }
+
+    expect(input).toHaveProperty("value", target);
+  });
+});

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -275,6 +275,38 @@ describe("raw OpenRouter registry ids vs the proxy's own passthrough shape (issu
       "reasoning-v1": "reasoning-v1",
     });
   });
+
+  it("keeps a passthrough id with surrounding whitespace (issue #1838 follow-up, seventh instance)", async () => {
+    // The shape check used to run on the untrimmed value: a leading space
+    // fails `startsWith("openrouter/")`, so a pasted id with surrounding
+    // whitespace was misclassified as a raw catalog id and dropped here —
+    // even though `save()`'s own trim pass, which runs *after* this strip,
+    // would otherwise have normalized it to the exact same accepted form.
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "  openrouter/anthropic/claude-3-opus  ", "reasoning-v1": "reasoning-v1" },
+        true,
+      ),
+      [{ id: "openrouter/anthropic/claude-3-opus", name: "Claude 3 Opus (passthrough)" }],
+    );
+
+    await mount(client);
+
+    const button = container.querySelector('[data-testid="inference-remove-key"]') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { key?: string; models?: Record<string, string> };
+    expect(body.models).toEqual({
+      "chat-v1": "openrouter/anthropic/claude-3-opus",
+      "reasoning-v1": "reasoning-v1",
+    });
+  });
 });
 
 describe("clearing a tier override back to the tier default (issue #1838 follow-up)", () => {

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { InferenceModel, InferenceStatus } from "@/api/inference";
+import { InferenceSection } from "@/views/connections/InferenceSection";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function status(provider: string, models: Record<string, string>): InferenceStatus {
+  return {
+    provider,
+    slug: provider === "openai_compatible" ? "byok" : provider,
+    baseUrl: provider === "openai_compatible" ? "https://models.example/v1" : "https://openrouter.ai/api/v1",
+    models,
+    source: "runtime",
+    keyConfigured: true,
+    cognition: "harness",
+    usageMetering: "perTurn",
+    restartRequired: false,
+    harnessReachable: true,
+    canRebuildInPlace: true,
+  };
+}
+
+function clientFor(
+  inference: InferenceStatus,
+  catalog: InferenceModel[] | Error,
+): { client: OpenCompanyClient; calls: string[] } {
+  const calls: string[] = [];
+  const client = {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: async (path: string) => {
+      calls.push(path);
+      if (path.endsWith("/inference/models")) {
+        if (catalog instanceof Error) throw catalog;
+        return catalog;
+      }
+      return inference;
+    },
+  } as unknown as OpenCompanyClient;
+  return { client, calls };
+}
+
+async function mount(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(InferenceSection, { client, company: "acme", canManage: true }));
+  });
+  await act(async () => {});
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("OpenRouter tier model pickers", () => {
+  it("renders one registry-backed select per tier and preserves a custom stored id", async () => {
+    const { client } = clientFor(
+      status("openrouter", {
+        "chat-v1": "operator/custom-chat",
+        "reasoning-v1": "openai/reasoning",
+        "agentic-v1": "anthropic/agentic",
+        "vision-v1": "google/vision",
+      }),
+      [
+        { id: "openai/reasoning", name: "Reasoning" },
+        { id: "anthropic/agentic", name: "Agentic" },
+        { id: "google/vision", name: "Vision" },
+      ],
+    );
+
+    await mount(client);
+
+    for (const tier of ["chat-v1", "reasoning-v1", "agentic-v1", "vision-v1"]) {
+      expect(container.querySelector(`[data-testid="inference-model-select-${tier}"]`)).not.toBeNull();
+      expect(container.querySelector(`input#inference-model-${tier}`)).toBeNull();
+    }
+    expect(container.querySelector("#inference-model-chat-v1")?.textContent).toContain(
+      "operator/custom-chat",
+    );
+  });
+
+  it("falls back to editable model ids when the registry request fails", async () => {
+    const { client } = clientFor(
+      status("openrouter", { "chat-v1": "operator/custom-chat" }),
+      new Error("offline"),
+    );
+
+    await mount(client);
+
+    expect(container.querySelector('[data-testid="inference-model-catalog-fallback"]')).not.toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty(
+      "value",
+      "operator/custom-chat",
+    );
+  });
+
+  it("keeps free-text inputs for non-OpenRouter providers without fetching the registry", async () => {
+    const { client, calls } = clientFor(
+      status("openai_compatible", { "chat-v1": "private/model" }),
+      [],
+    );
+
+    await mount(client);
+
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty(
+      "value",
+      "private/model",
+    );
+    expect(calls.some((path) => path.endsWith("/inference/models"))).toBe(false);
+  });
+});

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -356,6 +356,41 @@ describe("raw OpenRouter registry ids vs the proxy's own passthrough shape (issu
       "reasoning-v1": "reasoning-v1",
     });
   });
+
+  it("strips a bare, unnamespaced model id typed on the proxied path (issue #1838 follow-up, ninth instance, PR #1838 review)", async () => {
+    // `model_for_tier` honours an override verbatim on the proxied path
+    // regardless of its shape — the platform endpoint's curated tier
+    // registry only knows the four tier names it mirrors from
+    // DEFAULT_TIER_MODELS. A slashless id like `gpt-4o` used to read as "a
+    // bare tier id, not an override at all" purely because it contained no
+    // `/`, and rode straight through Save. The endpoint does not recognize
+    // `gpt-4o` as a tier, so the request fails instead of the incompatible
+    // value being dropped the way the console's own warning promises. Only
+    // an *exact* tier name (`chat-v1`, `reasoning-v1`, `agentic-v1`,
+    // `vision-v1`) or the three-segment `openrouter/<author>/<model>`
+    // passthrough is actually proxy-safe.
+    const { client, puts } = clientFor(
+      status(
+        "openrouter",
+        { "chat-v1": "gpt-4o", "reasoning-v1": "reasoning-v1" },
+        true,
+      ),
+      [],
+    );
+
+    await mount(client);
+
+    const button = container.querySelector('[data-testid="inference-remove-key"]') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { key?: string; models?: Record<string, string> };
+    expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
+  });
 });
 
 describe("clearing a tier override back to the tier default (issue #1838 follow-up)", () => {
@@ -713,8 +748,11 @@ describe("proxy-incompatible overrides survive an unready catalog (issue #1838 f
     // already drops `chat-v1`'s raw catalog id, leaving `models` and
     // `baseline` in agreement — nothing to distinguish old vs. new behavior
     // yet. Typing a key closes the window; while it's closed, type a genuine
-    // hand-typed draft into `reasoning-v1` (not raw-catalog-shaped, so the
-    // strip never touches it) and a fresh raw catalog id into `chat-v1`.
+    // hand-typed draft into `reasoning-v1` — a *different* tier's bare name
+    // (`agentic-v1`), which `isProxyCompatible` keeps as-is since any of the
+    // four tier names is a valid proxy passthrough regardless of which field
+    // it was typed into, so the strip never touches it — and a fresh raw
+    // catalog id into `chat-v1`.
     // Clearing the key reopens the window: the strip effect fires again and
     // must fold *only* `chat-v1` into baseline. The old code replaced
     // `baseline.models` wholesale with the full stripped snapshot, which
@@ -755,13 +793,13 @@ describe("proxy-incompatible overrides survive an unready catalog (issue #1838 f
     expect(reasoningInput).not.toBeNull();
 
     await act(async () => setValue(keyInput, "sk-test")); // closes the proxied window
-    await act(async () => setValue(reasoningInput, "custom-draft")); // genuine operator draft
+    await act(async () => setValue(reasoningInput, "agentic-v1")); // genuine operator draft
     await act(async () => setValue(chatInput, "openai/reasoning")); // fresh raw id to strip
     await act(async () => setValue(keyInput, "")); // reopens the window; strip fires again
     await act(async () => {});
 
     expect(chatInput).toHaveProperty("value", "");
-    expect(reasoningInput).toHaveProperty("value", "custom-draft");
+    expect(reasoningInput).toHaveProperty("value", "agentic-v1");
 
     // Switching provider now must still ask before discarding reasoning-v1's
     // draft. If the strip effect wrongly promoted it into baseline, this
@@ -783,7 +821,7 @@ describe("proxy-incompatible overrides survive an unready catalog (issue #1838 f
     expect(document.body.querySelector('[data-slot="alert-dialog-content"]')).not.toBeNull();
     expect(container.querySelector<HTMLInputElement>("input#inference-model-reasoning-v1")).toHaveProperty(
       "value",
-      "custom-draft",
+      "agentic-v1",
     );
   });
 });

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -11,14 +11,18 @@ import { InferenceSection } from "@/views/connections/InferenceSection";
 let container: HTMLDivElement;
 let root: Root;
 
-function status(provider: string, models: Record<string, string>): InferenceStatus {
+function status(
+  provider: string,
+  models: Record<string, string>,
+  keyConfigured = true,
+): InferenceStatus {
   return {
     provider,
     slug: provider === "openai_compatible" ? "byok" : provider,
     baseUrl: provider === "openai_compatible" ? "https://models.example/v1" : "https://openrouter.ai/api/v1",
     models,
     source: "runtime",
-    keyConfigured: true,
+    keyConfigured,
     cognition: "harness",
     usageMetering: "perTurn",
     restartRequired: false,
@@ -105,6 +109,24 @@ describe("OpenRouter tier model pickers", () => {
       "value",
       "operator/custom-chat",
     );
+  });
+
+  it("keeps free-text inputs for a proxied OpenRouter company with no key configured", async () => {
+    // No stored key -> the platform's subscription proxy resolves the tier,
+    // which only accepts an abstract tier name (or its own disabled-by-default
+    // `openrouter/<author>/<model>` passthrough). The registry's raw catalog
+    // ids the select would save are exactly what that proxy rejects, so the
+    // picker must not offer them here even though the catalog loaded fine.
+    const { client } = clientFor(
+      status("openrouter", { "chat-v1": "chat-v1" }, false),
+      [{ id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" }],
+    );
+
+    await mount(client);
+
+    expect(container.querySelector('[data-testid="inference-model-catalog-proxied"]')).not.toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty("value", "chat-v1");
+    expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
   });
 
   it("keeps free-text inputs for non-OpenRouter providers without fetching the registry", async () => {

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -15,12 +15,14 @@ function status(
   provider: string,
   models: Record<string, string>,
   keyConfigured = true,
+  defaultTierModels: Record<string, string> = {},
 ): InferenceStatus {
   return {
     provider,
     slug: provider === "openai_compatible" ? "byok" : provider,
     baseUrl: provider === "openai_compatible" ? "https://models.example/v1" : "https://openrouter.ai/api/v1",
     models,
+    defaultTierModels,
     source: "runtime",
     keyConfigured,
     cognition: "harness",
@@ -350,6 +352,156 @@ describe("clearing a tier override back to the tier default (issue #1838 follow-
     expect(puts).toHaveLength(1);
     const body = puts[0] as { models?: Record<string, string> };
     expect(body.models).toEqual({ "reasoning-v1": "anthropic/agentic" });
+  });
+});
+
+describe("typing an id the registry does not list (issue #1838 follow-up)", () => {
+  it("offers an 'Enter a model id' escape hatch and lets Save persist an id absent from the catalog", async () => {
+    // Once the catalog loads, every tier becomes a select — `optionsForTier`
+    // only keeps an *already-stored* custom id selectable, so a keyed
+    // operator who wants a model the registry has not caught up to yet had no
+    // way to type one. The escape hatch flips that one tier's control to free
+    // text without touching the others.
+    const { client, puts } = clientFor(status("openrouter", {}, true), [
+      { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" },
+    ]);
+
+    await mount(client);
+
+    const trigger = container.querySelector(
+      '[data-testid="inference-model-select-chat-v1"]',
+    ) as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    await act(async () => {
+      trigger.click();
+    });
+    await act(async () => {});
+
+    const customItem = document.body.querySelector(
+      '[data-testid="inference-model-custom-chat-v1"]',
+    ) as HTMLElement;
+    expect(customItem).not.toBeNull();
+    await act(async () => {
+      customItem.click();
+    });
+    await act(async () => {});
+
+    // The select is gone; a plain text field takes its place.
+    expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
+    const input = container.querySelector<HTMLInputElement>("input#inference-model-chat-v1");
+    expect(input).not.toBeNull();
+
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    await act(async () => {
+      setter?.call(input, "moonshotai/kimi-k2-thinking");
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    // The other tier stays a select — the escape hatch is per-tier.
+    expect(container.querySelector('[data-testid="inference-model-select-reasoning-v1"]')).not.toBeNull();
+
+    const save = container.querySelector('[data-testid="inference-save"]') as HTMLButtonElement;
+    await act(async () => {
+      save.click();
+    });
+    await act(async () => {});
+
+    expect(puts).toHaveLength(1);
+    const body = puts[0] as { models?: Record<string, string> };
+    expect(body.models).toEqual({ "chat-v1": "moonshotai/kimi-k2-thinking" });
+  });
+
+  it("returns a tier to the catalog select via 'Choose from the OpenRouter catalog instead'", async () => {
+    const { client } = clientFor(status("openrouter", {}, true), [
+      { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet" },
+    ]);
+
+    await mount(client);
+
+    const trigger = container.querySelector(
+      '[data-testid="inference-model-select-chat-v1"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      trigger.click();
+    });
+    await act(async () => {});
+    const customItem = document.body.querySelector(
+      '[data-testid="inference-model-custom-chat-v1"]',
+    ) as HTMLElement;
+    await act(async () => {
+      customItem.click();
+    });
+    await act(async () => {});
+
+    const backLink = container.querySelector(
+      '[data-testid="inference-model-back-to-catalog-chat-v1"]',
+    ) as HTMLButtonElement;
+    expect(backLink).not.toBeNull();
+    await act(async () => {
+      backLink.click();
+    });
+    await act(async () => {});
+
+    expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).not.toBeNull();
+    expect(container.querySelector("input#inference-model-chat-v1")).toBeNull();
+  });
+});
+
+describe("the OpenRouter preset prefills from the host's own defaults (issue #1838 follow-up)", () => {
+  it("seeds the switch form from status.defaultTierModels rather than a hard-coded copy", async () => {
+    // The console used to duplicate `DEFAULT_TIER_MODELS` locally; a value
+    // that could only ever drift is not a fixture worth asserting against —
+    // this proves the picker actually reads the host's own answer.
+    //
+    // Status reports an already-keyed direct OpenRouter connection, so
+    // `wouldSaveProxied` stays false for the whole test — that guard exists
+    // to protect an *unkeyed* save from a raw catalog-shaped id it would
+    // save proxied (issue #1838 follow-up, sixth instance), which is a
+    // separate concern from what this test is proving. Switch through a
+    // second provider and back: the initial render seeds `models` straight
+    // from `status.models`, not through `presetFor`, so the preset only
+    // gets exercised on an actual provider pick.
+    const { client } = clientFor(
+      status("openrouter", {}, true, {
+        "chat-v1": "vendor-x/model-a",
+        "reasoning-v1": "vendor-x/model-b",
+        "agentic-v1": "vendor-x/model-c",
+        "vision-v1": "vendor-x/model-d",
+      }),
+      [],
+    );
+
+    await mount(client);
+
+    async function selectProvider(label: string) {
+      const trigger = container.querySelector("#inference-provider") as HTMLButtonElement;
+      expect(trigger).not.toBeNull();
+      await act(async () => {
+        trigger.click();
+      });
+      await act(async () => {});
+
+      const item = Array.from(
+        document.body.querySelectorAll('[data-slot="select-item"]'),
+      ).find((el) => el.textContent?.includes(label)) as HTMLElement | undefined;
+      expect(item).not.toBeUndefined();
+      await act(async () => {
+        item?.click();
+      });
+      await act(async () => {});
+    }
+
+    await selectProvider("Ollama");
+    await selectProvider("OpenRouter");
+
+    // No catalog entries, so the tier renders free text — the preset value
+    // shows up as the input's value, not as rendered text.
+    expect(
+      container.querySelector<HTMLInputElement>("input#inference-model-chat-v1"),
+    ).toHaveProperty("value", "vendor-x/model-a");
   });
 });
 

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -705,6 +705,87 @@ describe("proxy-incompatible overrides survive an unready catalog (issue #1838 f
     expect(body.key).toBe("");
     expect(body.models).toEqual({ "reasoning-v1": "reasoning-v1" });
   });
+
+  it("preserves an untouched tier draft when the strip effect updates baseline (issue #1838 follow-up, eighth instance)", async () => {
+    // Reproduces the "type a key, edit multiple tiers, clear the key again"
+    // class the effect's own docstring describes. Mount keyless so the
+    // proxied window is open from the first render and the mount-time strip
+    // already drops `chat-v1`'s raw catalog id, leaving `models` and
+    // `baseline` in agreement — nothing to distinguish old vs. new behavior
+    // yet. Typing a key closes the window; while it's closed, type a genuine
+    // hand-typed draft into `reasoning-v1` (not raw-catalog-shaped, so the
+    // strip never touches it) and a fresh raw catalog id into `chat-v1`.
+    // Clearing the key reopens the window: the strip effect fires again and
+    // must fold *only* `chat-v1` into baseline. The old code replaced
+    // `baseline.models` wholesale with the full stripped snapshot, which
+    // silently promoted `reasoning-v1`'s untouched draft into baseline too —
+    // `hasTypedDraft()` then saw no difference, and switching providers
+    // discarded that draft with no confirmation.
+    const inference = status(
+      "openrouter",
+      { "chat-v1": "anthropic/claude-sonnet-5", "reasoning-v1": "reasoning-v1" },
+      false,
+    );
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) => {
+        if (path.endsWith("/inference/models")) throw new Error("registry unreachable");
+        return inference;
+      },
+      put: async () => ({ status: inference, note: "" }),
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    // Mount-time strip already ran; baseline and models started equal so
+    // this pass has nothing left to prove.
+    expect(container.querySelector("input#inference-model-chat-v1")).toHaveProperty("value", "");
+
+    function setValue(input: HTMLInputElement | null, value: string) {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, value);
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    const keyInput = container.querySelector<HTMLInputElement>("input#inference-key");
+    const chatInput = container.querySelector<HTMLInputElement>("input#inference-model-chat-v1");
+    const reasoningInput = container.querySelector<HTMLInputElement>("input#inference-model-reasoning-v1");
+    expect(keyInput).not.toBeNull();
+    expect(chatInput).not.toBeNull();
+    expect(reasoningInput).not.toBeNull();
+
+    await act(async () => setValue(keyInput, "sk-test")); // closes the proxied window
+    await act(async () => setValue(reasoningInput, "custom-draft")); // genuine operator draft
+    await act(async () => setValue(chatInput, "openai/reasoning")); // fresh raw id to strip
+    await act(async () => setValue(keyInput, "")); // reopens the window; strip fires again
+    await act(async () => {});
+
+    expect(chatInput).toHaveProperty("value", "");
+    expect(reasoningInput).toHaveProperty("value", "custom-draft");
+
+    // Switching provider now must still ask before discarding reasoning-v1's
+    // draft. If the strip effect wrongly promoted it into baseline, this
+    // switches immediately with no confirmation dialog.
+    const providerTrigger = container.querySelector("#inference-provider") as HTMLButtonElement;
+    await act(async () => {
+      providerTrigger.click();
+    });
+    await act(async () => {});
+    const ollamaItem = Array.from(document.body.querySelectorAll('[data-slot="select-item"]')).find(
+      (el) => el.textContent?.includes("Ollama"),
+    ) as HTMLElement | undefined;
+    expect(ollamaItem).not.toBeUndefined();
+    await act(async () => {
+      ollamaItem?.click();
+    });
+    await act(async () => {});
+
+    expect(document.body.querySelector('[data-slot="alert-dialog-content"]')).not.toBeNull();
+    expect(container.querySelector<HTMLInputElement>("input#inference-model-reasoning-v1")).toHaveProperty(
+      "value",
+      "custom-draft",
+    );
+  });
 });
 
 describe("typing a passthrough id one keystroke at a time while proxied (issue #1838 follow-up, sixth instance)", () => {

--- a/frontend/test/unit/inference-model-picker.test.ts
+++ b/frontend/test/unit/inference-model-picker.test.ts
@@ -157,6 +157,34 @@ describe("OpenRouter tier model pickers", () => {
     expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
   });
 
+  it("shows the proxied warning while the catalog is still loading for a keyless company (PR #1838 review)", async () => {
+    // `wouldSaveProxied` already renders an editable free-text field and
+    // leaves Save enabled the instant `modelCatalog.kind` is "loading" — see
+    // `useFreeText` above, which includes `wouldSaveProxied` in its OR
+    // regardless of catalog state. The proxied clarification used to be
+    // gated to exclude "loading", so a keyless operator who typed a raw
+    // `<author>/<model>` id and hit Save during a cold catalog fetch (which
+    // can run for up to ten seconds) got no warning at all before
+    // `stripProxyIncompatible` silently dropped it.
+    const inference = status("openrouter", { "chat-v1": "chat-v1" }, false);
+    const client = {
+      scopeFor: () => "/api/v1/companies/acme",
+      get: async (path: string) => {
+        // Never resolves — the registry request is permanently in flight.
+        if (path.endsWith("/inference/models")) return new Promise(() => {});
+        return inference;
+      },
+      put: async () => ({ status: inference, note: "" }),
+    } as unknown as OpenCompanyClient;
+
+    await mount(client);
+
+    expect(container.querySelector('[data-testid="inference-model-select-chat-v1"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="inference-model-catalog-proxied"]'),
+    ).not.toBeNull();
+  });
+
   it("clears a catalog-picked id from the tier field once the form would save proxied", async () => {
     // Mirrors what a key-clear leaves behind: a company stores a raw
     // `<author>/<model>` id (exactly what the catalog select writes) while no

--- a/frontend/test/unit/inference-models-api.test.ts
+++ b/frontend/test/unit/inference-models-api.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { listInferenceModels } from "@/api/inference";
+
+describe("the inference model catalog client", () => {
+  it("gets the addressed company's model-list route", async () => {
+    const calls: string[] = [];
+    const client = {
+      scopeFor: (company: string | null) =>
+        company ? `/api/v1/companies/${company}` : "/api/v1/company",
+      get: async (path: string) => {
+        calls.push(path);
+        return [{ id: "provider/model", name: "Model" }];
+      },
+    } as unknown as OpenCompanyClient;
+
+    await expect(listInferenceModels(client, "acme")).resolves.toEqual([
+      { id: "provider/model", name: "Model" },
+    ]);
+    expect(calls).toEqual(["/api/v1/companies/acme/inference/models"]);
+  });
+});

--- a/frontend/test/unit/setup-dialog-inference.test.ts
+++ b/frontend/test/unit/setup-dialog-inference.test.ts
@@ -34,6 +34,7 @@ const HARNESS: InferenceStatus = {
   slug: "openrouter",
   baseUrl: "https://example.invalid/v1",
   models: {},
+  defaultTierModels: {},
   source: "manifest",
   keyConfigured: true,
   cognition: "harness",

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -1498,6 +1498,30 @@ mod tests {
         }
     }
 
+    /// `every_tier_resolves_to_a_concrete_model_id_on_the_direct_path` above
+    /// only proves each tier resolves to *some* concrete slug — it would still
+    /// pass if `chat-v1` and `agentic-v1` were swapped. These expected ids are
+    /// hardcoded rather than read back from [`DEFAULT_TIER_MODELS`]: asserting
+    /// a table against itself would pass no matter what the table said, so an
+    /// incorrect tier assignment needs a second, independent source of truth
+    /// to fail against.
+    #[test]
+    fn every_tier_resolves_to_its_documented_default_model() {
+        let none = BTreeMap::new();
+        for (tier, expected) in [
+            ("chat-v1", "anthropic/claude-sonnet-5"),
+            ("reasoning-v1", "openai/gpt-5.6-sol-pro"),
+            ("agentic-v1", "anthropic/claude-opus-5"),
+            ("vision-v1", "qwen/qwen3.8-max"),
+        ] {
+            assert_eq!(
+                model_for_tier(tier, &none, false),
+                expected,
+                "`{tier}` must resolve to the documented default `{expected}`"
+            );
+        }
+    }
+
     #[test]
     fn a_harness_override_beats_the_default_and_a_concrete_slug_passes_through() {
         let overrides =

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -146,10 +146,10 @@ pub const DEFAULT_PROVIDER: &str = "openrouter";
 /// The slugs mirror the platform's own OpenRouter bindings, so proxied and
 /// direct resolve to the same models by default.
 pub const DEFAULT_TIER_MODELS: &[(&str, &str)] = &[
-    ("chat-v1", "deepseek/deepseek-v4-flash"),
-    ("reasoning-v1", "deepseek/deepseek-v4-pro"),
-    ("agentic-v1", "deepseek/deepseek-v4-pro"),
-    ("vision-v1", "qwen/qwen3.7-plus"),
+    ("chat-v1", "anthropic/claude-sonnet-5"),
+    ("reasoning-v1", "openai/gpt-5.6-sol-pro"),
+    ("agentic-v1", "anthropic/claude-opus-5"),
+    ("vision-v1", "qwen/qwen3.8-max"),
 ];
 
 /// The concrete model id to put on the wire for `tier`.
@@ -1513,7 +1513,7 @@ mod tests {
         // An unmapped tier still takes the shipped default on the direct path.
         assert_eq!(
             model_for_tier("reasoning-v1", &overrides, false),
-            "deepseek/deepseek-v4-pro"
+            "openai/gpt-5.6-sol-pro"
         );
         // A caller naming a concrete slug is not treated as an unknown tier.
         assert_eq!(

--- a/src/harness/built_in/provider.rs
+++ b/src/harness/built_in/provider.rs
@@ -2293,7 +2293,7 @@ mod tests {
         )
         .await
         .expect("plan");
-        assert_eq!(defaulted.model, "deepseek/deepseek-v4-pro");
+        assert_eq!(defaulted.model, "openai/gpt-5.6-sol-pro");
 
         // A concrete slug is still forwarded untouched, so a caller can name any
         // model in OpenRouter's catalog.

--- a/src/metering/model.rs
+++ b/src/metering/model.rs
@@ -195,10 +195,8 @@ struct Vendor {
 /// The vendor table. See the [module docs](self) for the rule that governs
 /// what may be added to it.
 const VENDORS: &[Vendor] = &[
-    // Shipped by this repo: `DEFAULT_TIER_MODELS` binds `chat-v1` to
-    // `deepseek-v4-flash` and both `reasoning-v1` and `agentic-v1` to
-    // `deepseek-v4-pro` on the direct path, so these two are priced separately
-    // and are the pair a self-serve tenant's spend actually splits across.
+    // DeepSeek's flash and pro lines are priced separately, so retain the line
+    // split for operators who select either from the OpenRouter catalog.
     Vendor {
         slug: "deepseek",
         authors: &["deepseek"],
@@ -207,15 +205,21 @@ const VENDORS: &[Vendor] = &[
             ("v4-pro", "deepseek-v4-pro"),
         ],
     },
-    // Shipped by this repo: `DEFAULT_TIER_MODELS` binds `vision-v1` to
-    // `qwen/qwen3.7-plus`. The dot in the upstream id is not carried into the
-    // slug — a telemetry value is read by people and grouped by machines, and
-    // a point release must not mint a new one.
+    // `DEFAULT_TIER_MODELS` binds `vision-v1` to `qwen/qwen3.8-max`. The dot in
+    // the upstream id is not carried into the slug — a telemetry value is read
+    // by people and grouped by machines, and a point release must not mint a
+    // new one.
     Vendor {
         slug: "qwen",
         authors: &["qwen"],
-        lines: &[("3.7-plus", "qwen3-plus"), ("3-plus", "qwen3-plus")],
+        lines: &[
+            ("3.8-max", "qwen3-max"),
+            ("3-max", "qwen3-max"),
+            ("3.7-plus", "qwen3-plus"),
+            ("3-plus", "qwen3-plus"),
+        ],
     },
+    // The shipped chat and agentic defaults are Anthropic Sonnet and Opus.
     // Anthropic prices opus, sonnet and haiku separately and by an order of
     // magnitude; "what is Sonnet costing us versus Haiku?" is the question
     // issue #1749 is named after, and a vendor-level slug cannot answer it.
@@ -228,8 +232,9 @@ const VENDORS: &[Vendor] = &[
             ("haiku", "anthropic-haiku"),
         ],
     },
-    // OpenAI's reasoning (`o`-series) and chat (`gpt`) families are priced on
-    // different rate cards, which is the same split as above.
+    // The shipped reasoning default is an OpenAI GPT model. OpenAI's reasoning
+    // (`o`-series) and chat (`gpt`) families are priced on different rate cards,
+    // which is the same split as above.
     Vendor {
         slug: "openai",
         authors: &["openai", "gpt", "o1", "o3", "o4"],
@@ -375,6 +380,7 @@ mod tests {
             ("deepseek/deepseek-v4-flash", "deepseek-v4-flash"),
             ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
             ("deepseek/deepseek-r1", "deepseek"),
+            ("qwen/qwen3.8-max", "qwen3-max"),
             ("qwen/qwen3.7-plus", "qwen3-plus"),
             ("meta-llama/llama-4-70b", "meta-llama"),
             ("mistralai/mistral-large", "mistral"),

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -95,7 +95,17 @@ pub(crate) async fn discover_models(
     bearer: Option<&str>,
 ) -> Result<Vec<InferenceModel>, String> {
     let url = format!("{}/models", base_url.trim_end_matches('/'));
-    let mut request = reqwest::Client::new().get(&url);
+    // Bounded here, not left to each caller: reqwest's async client has no
+    // default timeout, so an endpoint that accepts the connection but never
+    // responds would otherwise hold this open indefinitely. `setup.rs`'s
+    // local/custom probe calls this directly (no wrapping timeout of its
+    // own), while `openrouter_models` below also wraps its call in
+    // `tokio::time::timeout` for a friendlier, registry-specific message.
+    let client = reqwest::Client::builder()
+        .timeout(MODEL_CATALOG_TIMEOUT)
+        .build()
+        .map_err(|error| format!("failed to build the model-discovery client: {error}"))?;
+    let mut request = client.get(&url);
     if let Some(bearer) = bearer.filter(|bearer| !bearer.trim().is_empty()) {
         request = request.bearer_auth(bearer);
     }

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -31,9 +31,14 @@ pub(crate) struct InferenceModel {
     pub(crate) context_length: Option<u64>,
 }
 
+/// Parsed leniently: `data` is decoded as raw JSON values first, so one
+/// malformed entry (a non-string `id`, a string-valued `context_length`, …)
+/// only drops that entry in [`parse_models`] instead of failing the whole
+/// response and hiding every valid model the endpoint actually returned.
 #[derive(Deserialize)]
 struct RegistryResponse {
-    data: Vec<RegistryModel>,
+    #[serde(default)]
+    data: Vec<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -46,9 +51,16 @@ struct RegistryModel {
 }
 
 /// Parse every concrete model in a standard OpenAI-compatible catalog.
+///
+/// Each `data` entry is decoded on its own so a single malformed record (bad
+/// field type, missing `id`, …) is skipped rather than rejecting entries this
+/// same response otherwise reported cleanly.
 fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
     let mut unique = BTreeMap::new();
-    for model in payload.data {
+    for entry in payload.data {
+        let Ok(model) = serde_json::from_value::<RegistryModel>(entry) else {
+            continue;
+        };
         let id = model.id.trim();
         if id.is_empty() {
             continue;
@@ -159,26 +171,10 @@ mod tests {
     fn catalog_parser_returns_every_non_empty_unique_model() {
         let parsed = parse_models(RegistryResponse {
             data: vec![
-                RegistryModel {
-                    id: " vendor/zeta ".to_string(),
-                    name: Some(" Zeta ".to_string()),
-                    context_length: Some(128_000),
-                },
-                RegistryModel {
-                    id: "vendor/alpha".to_string(),
-                    name: None,
-                    context_length: None,
-                },
-                RegistryModel {
-                    id: "vendor/zeta".to_string(),
-                    name: Some("duplicate".to_string()),
-                    context_length: None,
-                },
-                RegistryModel {
-                    id: "   ".to_string(),
-                    name: None,
-                    context_length: None,
-                },
+                serde_json::json!({"id": " vendor/zeta ", "name": " Zeta ", "context_length": 128_000}),
+                serde_json::json!({"id": "vendor/alpha"}),
+                serde_json::json!({"id": "vendor/zeta", "name": "duplicate"}),
+                serde_json::json!({"id": "   "}),
             ],
         });
 
@@ -187,6 +183,30 @@ mod tests {
         assert_eq!(parsed[1].id, "vendor/zeta");
         assert_eq!(parsed[1].name.as_deref(), Some("Zeta"));
         assert_eq!(parsed[1].context_length, Some(128_000));
+    }
+
+    /// Regression for a P2 review finding on #1838: a single malformed
+    /// record (here, a numeric `id`) used to fail `RegistryResponse`
+    /// deserialization outright — `discover_models` never reached
+    /// `parse_models` at all, so a valid model earlier or later in the same
+    /// `data` array was lost with it. `data` is now decoded as raw JSON
+    /// first, so only the bad entry drops out.
+    #[test]
+    fn catalog_parser_skips_malformed_entries_instead_of_rejecting_the_response() {
+        let payload: RegistryResponse = serde_json::from_str(
+            r#"{"data": [
+                {"id": "vendor/good-one"},
+                {"id": 12345},
+                {"id": "vendor/good-two", "context_length": "not-a-number"},
+                {"id": "vendor/good-three"}
+            ]}"#,
+        )
+        .expect("RegistryResponse itself must still deserialize leniently");
+
+        let parsed = parse_models(payload);
+
+        let ids: Vec<&str> = parsed.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["vendor/good-one", "vendor/good-three"]);
     }
 
     #[test]

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -175,38 +175,66 @@ pub(crate) fn openrouter_cache() -> &'static ModelCatalogCache {
 /// OpenRouter, and re-checks the cache after acquiring it, so only the first
 /// caller through actually fetches — everyone behind it reads what that
 /// fetch just stored instead of duplicating the upstream call.
+///
+/// Bounded across the *whole* queue-wait-plus-fetch, not just the fetch
+/// itself (issue #1838 follow-up): a failed fetch stores nothing, so during
+/// a registry outage each queued caller would otherwise acquire the lock in
+/// turn and run its own fresh `MODEL_CATALOG_TIMEOUT`-bounded attempt — the
+/// Nth caller through the queue waiting roughly `N * MODEL_CATALOG_TIMEOUT`
+/// before ever finding out, breaking the "a console page-load waits at most
+/// [`MODEL_CATALOG_TIMEOUT`]" contract this module documents
+/// (`docs/spec/runtime/providers.md`). Wrapping the lock acquisition and the
+/// fetch in one `tokio::time::timeout` keeps every individual caller's own
+/// wall-clock budget fixed at `MODEL_CATALOG_TIMEOUT`, however many callers
+/// are already ahead of it in the queue.
 pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
     let now = Instant::now();
     if let Some(models) = openrouter_cache().lookup(now) {
         return Ok(models);
     }
 
-    let _fetch_guard = openrouter_cache().fetch_lock.lock().await;
-    // Another caller may have already refilled the cache while we waited for
-    // the lock — re-check before fetching again.
-    let now = Instant::now();
-    if let Some(models) = openrouter_cache().lookup(now) {
-        return Ok(models);
-    }
+    let outcome = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, async {
+        let _fetch_guard = openrouter_cache().fetch_lock.lock().await;
+        // Another caller may have already refilled the cache while we waited
+        // for the lock — re-check before fetching again.
+        let now = Instant::now();
+        if let Some(models) = openrouter_cache().lookup(now) {
+            return Ok(models);
+        }
 
-    let fetch = discover_models(crate::company::inference::OPENROUTER_BASE_URL, None);
-    let mut models = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, fetch)
-        .await
-        .map_err(|_| {
-            format!(
-                "OpenRouter's model registry did not answer within {} seconds",
-                MODEL_CATALOG_TIMEOUT.as_secs()
-            )
-        })??;
-    if models.is_empty() {
-        return Err("OpenRouter's model registry returned no models".to_string());
+        let mut models = discover_models(crate::company::inference::OPENROUTER_BASE_URL, None)
+            .await
+            .map_err(FetchError::Failed)?;
+        if models.is_empty() {
+            return Err(FetchError::Failed(
+                "OpenRouter's model registry returned no models".to_string(),
+            ));
+        }
+        // Sorted here, not in `parse_models`: this is the operator-facing
+        // catalog picker's own copy, while `parse_models` also serves
+        // `setup.rs`'s local/custom probe, which relies on provider order.
+        models.sort_by(|a, b| a.id.cmp(&b.id));
+        openrouter_cache().store(models.clone(), now);
+        Ok(models)
+    })
+    .await;
+
+    match outcome {
+        Ok(Ok(models)) => Ok(models),
+        Ok(Err(FetchError::Failed(message))) => Err(message),
+        Err(_elapsed) => Err(format!(
+            "OpenRouter's model registry did not answer within {} seconds",
+            MODEL_CATALOG_TIMEOUT.as_secs()
+        )),
     }
-    // Sorted here, not in `parse_models`: this is the operator-facing
-    // catalog picker's own copy, while `parse_models` also serves
-    // `setup.rs`'s local/custom probe, which relies on provider order.
-    models.sort_by(|a, b| a.id.cmp(&b.id));
-    openrouter_cache().store(models.clone(), now);
-    Ok(models)
+}
+
+/// Distinguishes "the fetch itself failed" from the outer
+/// [`tokio::time::timeout`] elapsing in [`openrouter_models`], since both
+/// have to report through the same `Result` and the outer timeout's own
+/// message must win regardless of which inner step it interrupted.
+enum FetchError {
+    Failed(String),
 }
 
 #[cfg(test)]
@@ -391,5 +419,68 @@ mod tests {
             1,
             "only the first caller through fetch_lock should fetch; the rest must reuse its result"
         );
+    }
+
+    /// Regression for a P2 review finding on #1838's follow-up round, filed
+    /// against the single-flight fix directly above: `fetch_lock` serializes
+    /// misses, but a *failed* fetch stores nothing, so during a registry
+    /// outage every queued caller would previously run its own fresh
+    /// `bound`-length attempt after acquiring the lock — the Nth caller
+    /// through the queue waiting roughly `N * bound` before ever finding out,
+    /// which is exactly the docs/spec/runtime/providers.md "at most
+    /// `MODEL_CATALOG_TIMEOUT` seconds" promise this test defends. Mirrors
+    /// `openrouter_models`'s real composition (`tokio::time::timeout` wrapped
+    /// around lock-acquire + recheck + fetch) against the real
+    /// `ModelCatalogCache`, with a simulated fetch standing in for
+    /// `discover_models` so the assertion is deterministic instead of racing
+    /// a real HTTP timeout.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_queued_caller_never_waits_longer_than_the_catalog_timeout() {
+        use std::sync::Arc;
+
+        let cache = Arc::new(ModelCatalogCache::default());
+        // Short enough to keep the suite fast, long enough that three tasks
+        // queuing on one real `tokio::sync::Mutex` stay well-ordered.
+        let bound = Duration::from_millis(120);
+        let fetch_delay = Duration::from_millis(80);
+
+        async fn bounded_miss(
+            cache: Arc<ModelCatalogCache>,
+            bound: Duration,
+            fetch_delay: Duration,
+        ) {
+            let _ = tokio::time::timeout(bound, async {
+                let _fetch_guard = cache.fetch_lock.lock().await;
+                let now = Instant::now();
+                if cache.lookup(now).is_some() {
+                    return;
+                }
+                // Simulates a registry that is down: takes real time, then
+                // fails without storing anything — so the next caller through
+                // the lock faces the same empty cache this one did.
+                tokio::time::sleep(fetch_delay).await;
+            })
+            .await;
+        }
+
+        let handles: Vec<_> = (0..3)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                tokio::spawn(async move {
+                    let started = Instant::now();
+                    bounded_miss(cache, bound, fetch_delay).await;
+                    started.elapsed()
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let elapsed = handle.await.expect("task must not panic");
+            assert!(
+                elapsed <= bound + Duration::from_millis(40),
+                "a caller waited {elapsed:?}, which exceeds its own {bound:?} budget by more \
+                 than scheduling slack — queue position must not multiply the wait"
+            );
+        }
     }
 }

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -32,29 +32,29 @@ pub(crate) struct InferenceModel {
 
 /// Parsed leniently: `data` is decoded as raw JSON values first, so one
 /// malformed entry (a non-string `id`, a string-valued `context_length`, …)
-/// only drops that entry in [`parse_models`] instead of failing the whole
-/// response and hiding every valid model the endpoint actually returned.
+/// only drops that entry — or, for a malformed *optional* field, just that
+/// field — in [`parse_models`] instead of failing the whole response and
+/// hiding every valid model the endpoint actually returned.
 #[derive(Deserialize)]
 struct RegistryResponse {
     #[serde(default)]
     data: Vec<serde_json::Value>,
 }
 
-#[derive(Deserialize)]
-struct RegistryModel {
-    id: String,
-    #[serde(default)]
-    name: Option<String>,
-    #[serde(default)]
-    context_length: Option<u64>,
-}
-
 /// Parse every concrete model in a standard OpenAI-compatible catalog, in the
 /// order the provider listed them.
 ///
-/// Each `data` entry is decoded on its own so a single malformed record (bad
-/// field type, missing `id`, …) is skipped rather than rejecting entries this
-/// same response otherwise reported cleanly.
+/// Each `data` entry is read field-by-field rather than decoded in one shot
+/// into a struct. `id` is the only field an entry cannot survive without —
+/// everything downstream keys the tier mapping on it — so a missing or
+/// non-string `id` drops the entry. `name` and `context_length` are read
+/// leniently instead: a malformed optional field (a string-valued
+/// `context_length`, say) is treated as absent rather than failing, so it
+/// costs the entry that one field, not the id underneath it (issue #1838
+/// follow-up — decoding the whole entry into a struct in one shot used to let
+/// a bad *optional* field discard an otherwise-good `id` right along with it,
+/// same shape as the whole-response failure `RegistryResponse` above already
+/// guards against, one level deeper).
 ///
 /// Order is preserved rather than sorted here: `src/server/setup.rs`'s probe
 /// path takes `.next()` off this list to pick a local/custom endpoint's
@@ -67,20 +67,25 @@ fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
     let mut seen = std::collections::HashSet::new();
     let mut models = Vec::new();
     for entry in payload.data {
-        let Ok(model) = serde_json::from_value::<RegistryModel>(entry) else {
+        let Some(id) = entry.get("id").and_then(serde_json::Value::as_str) else {
             continue;
         };
-        let id = model.id.trim();
+        let id = id.trim();
         if id.is_empty() || !seen.insert(id.to_string()) {
             continue;
         }
+        let name = entry
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty());
+        let context_length = entry
+            .get("context_length")
+            .and_then(serde_json::Value::as_u64);
         models.push(InferenceModel {
             id: id.to_string(),
-            name: model
-                .name
-                .map(|name| name.trim().to_string())
-                .filter(|name| !name.is_empty()),
-            context_length: model.context_length,
+            name,
+            context_length,
         });
     }
     models
@@ -241,7 +246,6 @@ mod tests {
             r#"{"data": [
                 {"id": "vendor/good-one"},
                 {"id": 12345},
-                {"id": "vendor/good-two", "context_length": "not-a-number"},
                 {"id": "vendor/good-three"}
             ]}"#,
         )
@@ -251,6 +255,46 @@ mod tests {
 
         let ids: Vec<&str> = parsed.iter().map(|m| m.id.as_str()).collect();
         assert_eq!(ids, vec!["vendor/good-one", "vendor/good-three"]);
+    }
+
+    /// Regression for a P2 review finding on #1838's follow-up round: an
+    /// entry whose `id` is fine but whose *optional* `context_length` is not
+    /// used to lose the id right along with it. The old parser decoded each
+    /// `data` entry into `RegistryModel` in one shot, and serde fails that
+    /// whole decode on a type-mismatched field even when it is
+    /// `Option<u64>` — a string-valued `context_length` isn't "field
+    /// absent", it's "field present with the wrong type", and `Option`
+    /// deserialization does not paper over that. So this id used to vanish
+    /// from the catalog entirely instead of just losing its context length.
+    #[test]
+    fn catalog_parser_preserves_a_valid_id_with_malformed_optional_metadata() {
+        let payload: RegistryResponse = serde_json::from_str(
+            r#"{"data": [
+                {"id": "vendor/good-one"},
+                {"id": "vendor/good-two", "context_length": "not-a-number"},
+                {"id": "vendor/good-three", "name": 42}
+            ]}"#,
+        )
+        .expect("RegistryResponse itself must still deserialize leniently");
+
+        let parsed = parse_models(payload);
+
+        let ids: Vec<&str> = parsed.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["vendor/good-one", "vendor/good-two", "vendor/good-three"],
+            "a bad optional field must not discard the id sitting next to it"
+        );
+        let good_two = parsed
+            .iter()
+            .find(|m| m.id == "vendor/good-two")
+            .expect("vendor/good-two must survive");
+        assert_eq!(good_two.context_length, None);
+        let good_three = parsed
+            .iter()
+            .find(|m| m.id == "vendor/good-three")
+            .expect("vendor/good-three must survive");
+        assert_eq!(good_three.name, None);
     }
 
     #[test]

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -168,7 +168,10 @@ pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
     let mut models = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, fetch)
         .await
         .map_err(|_| {
-            "OpenRouter's model registry did not answer within 10 seconds".to_string()
+            format!(
+                "OpenRouter's model registry did not answer within {} seconds",
+                MODEL_CATALOG_TIMEOUT.as_secs()
+            )
         })??;
     if models.is_empty() {
         return Err("OpenRouter's model registry returned no models".to_string());

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -9,6 +9,7 @@ use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex as TokioMutex;
 
 /// How long a successful OpenRouter catalog stays fresh in this process.
 pub(crate) const MODEL_CATALOG_TTL: Duration = Duration::from_secs(60 * 60);
@@ -136,6 +137,16 @@ struct CacheEntry {
 #[derive(Default)]
 pub(crate) struct ModelCatalogCache {
     entry: Mutex<Option<CacheEntry>>,
+    /// Serializes cache-miss fetches (issue #1838 follow-up). Held across the
+    /// whole `discover_models` await, not just the cache write: without it,
+    /// every console request that lands after startup or a TTL expiry sees
+    /// the same empty/stale entry and fires its own upstream fetch, so a
+    /// multi-tenant host can burst several identical OpenRouter registry
+    /// calls at once — and any of them that gets rate-limited fails even
+    /// though a sibling fetch is about to populate the cache. A `tokio`
+    /// mutex, not `std`: the guard needs to survive the `.await` inside
+    /// [`openrouter_models`].
+    fetch_lock: TokioMutex<()>,
 }
 
 impl ModelCatalogCache {
@@ -158,7 +169,21 @@ pub(crate) fn openrouter_cache() -> &'static ModelCatalogCache {
 }
 
 /// Return the cached OpenRouter catalog, fetching it on a miss.
+///
+/// Single-flight on a miss (issue #1838 follow-up): every caller queues on
+/// [`ModelCatalogCache::fetch_lock`] rather than racing its own request to
+/// OpenRouter, and re-checks the cache after acquiring it, so only the first
+/// caller through actually fetches — everyone behind it reads what that
+/// fetch just stored instead of duplicating the upstream call.
 pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
+    let now = Instant::now();
+    if let Some(models) = openrouter_cache().lookup(now) {
+        return Ok(models);
+    }
+
+    let _fetch_guard = openrouter_cache().fetch_lock.lock().await;
+    // Another caller may have already refilled the cache while we waited for
+    // the lock — re-check before fetching again.
     let now = Instant::now();
     if let Some(models) = openrouter_cache().lookup(now) {
         return Ok(models);
@@ -311,5 +336,60 @@ mod tests {
             Some(vec![model("vendor/model")])
         );
         assert_eq!(cache.lookup(stored_at + MODEL_CATALOG_TTL), None);
+    }
+
+    /// Regression for a P2 review finding on #1838's follow-up round: without
+    /// `fetch_lock`, every concurrent caller that observed the same
+    /// empty/stale entry would independently "fetch" — a multi-tenant host
+    /// bursting several identical upstream calls at once. This exercises the
+    /// exact lock-then-recheck sequence [`openrouter_models`] runs (acquire
+    /// `fetch_lock`, re-`lookup`, only then do the (here, simulated) fetch),
+    /// against the real `ModelCatalogCache`, so a regression that drops the
+    /// lock or the re-check fails this test rather than only showing up as
+    /// upstream rate-limit noise in production.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_misses_coalesce_into_a_single_fetch() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let cache = Arc::new(ModelCatalogCache::default());
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let fetch_count = Arc::clone(&fetch_count);
+                tokio::spawn(async move {
+                    let now = Instant::now();
+                    if let Some(models) = cache.lookup(now) {
+                        return models;
+                    }
+                    let _fetch_guard = cache.fetch_lock.lock().await;
+                    let now = Instant::now();
+                    if let Some(models) = cache.lookup(now) {
+                        return models;
+                    }
+                    fetch_count.fetch_add(1, Ordering::SeqCst);
+                    // Hold the lock across a slow "upstream" call so every
+                    // other task is still queued on `fetch_lock` — the same
+                    // shape a real registry round-trip has.
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    let models = vec![model("vendor/single-flight")];
+                    cache.store(models.clone(), Instant::now());
+                    models
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let models = handle.await.expect("fetch task must not panic");
+            assert_eq!(models, vec![model("vendor/single-flight")]);
+        }
+
+        assert_eq!(
+            fetch_count.load(Ordering::SeqCst),
+            1,
+            "only the first caller through fetch_lock should fetch; the rest must reuse its result"
+        );
     }
 }

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -1,0 +1,204 @@
+//! OpenAI-compatible model catalog discovery and the OpenRouter registry cache.
+//!
+//! Both first-run setup and the inference settings picker consume the standard
+//! `{ "data": [{ "id": ... }] }` model-list shape. Keeping the fetch and parser
+//! here prevents setup from knowing only about the first entry while the picker
+//! grows a second interpretation of the same provider response.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// How long a successful OpenRouter catalog stays fresh in this process.
+pub(crate) const MODEL_CATALOG_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// Maximum time a console page-load waits for the registry on a cache miss.
+const MODEL_CATALOG_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// One model exposed to the operator console.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InferenceModel {
+    /// Provider model id written unchanged into the tier mapping.
+    pub(crate) id: String,
+    /// Provider display name, when published.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    /// Maximum context window, when published.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) context_length: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct RegistryResponse {
+    data: Vec<RegistryModel>,
+}
+
+#[derive(Deserialize)]
+struct RegistryModel {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    context_length: Option<u64>,
+}
+
+/// Parse every concrete model in a standard OpenAI-compatible catalog.
+fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
+    let mut unique = BTreeMap::new();
+    for model in payload.data {
+        let id = model.id.trim();
+        if id.is_empty() {
+            continue;
+        }
+        unique
+            .entry(id.to_string())
+            .or_insert_with(|| InferenceModel {
+                id: id.to_string(),
+                name: model
+                    .name
+                    .map(|name| name.trim().to_string())
+                    .filter(|name| !name.is_empty()),
+                context_length: model.context_length,
+            });
+    }
+    unique.into_values().collect()
+}
+
+/// Fetch every model from an OpenAI-compatible `{base_url}/models` endpoint.
+///
+/// `bearer` is used by local/custom setup probes; OpenRouter's public registry
+/// passes `None`.
+pub(crate) async fn discover_models(
+    base_url: &str,
+    bearer: Option<&str>,
+) -> Result<Vec<InferenceModel>, String> {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let mut request = reqwest::Client::new().get(&url);
+    if let Some(bearer) = bearer.filter(|bearer| !bearer.trim().is_empty()) {
+        request = request.bearer_auth(bearer);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|error| format!("request to {url} failed: {error}"))?
+        .error_for_status()
+        .map_err(|error| format!("request to {url} failed: {error}"))?;
+    let payload = response
+        .json::<RegistryResponse>()
+        .await
+        .map_err(|error| format!("model catalog from {url} was invalid: {error}"))?;
+    Ok(parse_models(payload))
+}
+
+struct CacheEntry {
+    at: Instant,
+    models: Vec<InferenceModel>,
+}
+
+/// Process-wide OpenRouter catalog cache.
+#[derive(Default)]
+pub(crate) struct ModelCatalogCache {
+    entry: Mutex<Option<CacheEntry>>,
+}
+
+impl ModelCatalogCache {
+    pub(crate) fn lookup(&self, now: Instant) -> Option<Vec<InferenceModel>> {
+        let entry = self.entry.lock().ok()?;
+        let entry = entry.as_ref()?;
+        (now.saturating_duration_since(entry.at) < MODEL_CATALOG_TTL).then(|| entry.models.clone())
+    }
+
+    pub(crate) fn store(&self, models: Vec<InferenceModel>, at: Instant) {
+        if let Ok(mut entry) = self.entry.lock() {
+            *entry = Some(CacheEntry { at, models });
+        }
+    }
+}
+
+pub(crate) fn openrouter_cache() -> &'static ModelCatalogCache {
+    static CACHE: OnceLock<ModelCatalogCache> = OnceLock::new();
+    CACHE.get_or_init(ModelCatalogCache::default)
+}
+
+/// Return the cached OpenRouter catalog, fetching it on a miss.
+pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
+    let now = Instant::now();
+    if let Some(models) = openrouter_cache().lookup(now) {
+        return Ok(models);
+    }
+
+    let fetch = discover_models(crate::company::inference::OPENROUTER_BASE_URL, None);
+    let models = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, fetch)
+        .await
+        .map_err(|_| {
+            "OpenRouter's model registry did not answer within 10 seconds".to_string()
+        })??;
+    if models.is_empty() {
+        return Err("OpenRouter's model registry returned no models".to_string());
+    }
+    openrouter_cache().store(models.clone(), now);
+    Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(id: &str) -> InferenceModel {
+        InferenceModel {
+            id: id.to_string(),
+            name: None,
+            context_length: None,
+        }
+    }
+
+    #[test]
+    fn catalog_parser_returns_every_non_empty_unique_model() {
+        let parsed = parse_models(RegistryResponse {
+            data: vec![
+                RegistryModel {
+                    id: " vendor/zeta ".to_string(),
+                    name: Some(" Zeta ".to_string()),
+                    context_length: Some(128_000),
+                },
+                RegistryModel {
+                    id: "vendor/alpha".to_string(),
+                    name: None,
+                    context_length: None,
+                },
+                RegistryModel {
+                    id: "vendor/zeta".to_string(),
+                    name: Some("duplicate".to_string()),
+                    context_length: None,
+                },
+                RegistryModel {
+                    id: "   ".to_string(),
+                    name: None,
+                    context_length: None,
+                },
+            ],
+        });
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0], model("vendor/alpha"));
+        assert_eq!(parsed[1].id, "vendor/zeta");
+        assert_eq!(parsed[1].name.as_deref(), Some("Zeta"));
+        assert_eq!(parsed[1].context_length, Some(128_000));
+    }
+
+    #[test]
+    fn cache_serves_only_fresh_catalogs() {
+        let cache = ModelCatalogCache::default();
+        let stored_at = Instant::now();
+        cache.store(vec![model("vendor/model")], stored_at);
+
+        assert_eq!(
+            cache.lookup(stored_at + MODEL_CATALOG_TTL - Duration::from_secs(1)),
+            Some(vec![model("vendor/model")])
+        );
+        assert_eq!(cache.lookup(stored_at + MODEL_CATALOG_TTL), None);
+    }
+}

--- a/src/server/inference_models.rs
+++ b/src/server/inference_models.rs
@@ -5,7 +5,6 @@
 //! here prevents setup from knowing only about the first entry while the picker
 //! grows a second interpretation of the same provider response.
 
-use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -50,33 +49,41 @@ struct RegistryModel {
     context_length: Option<u64>,
 }
 
-/// Parse every concrete model in a standard OpenAI-compatible catalog.
+/// Parse every concrete model in a standard OpenAI-compatible catalog, in the
+/// order the provider listed them.
 ///
 /// Each `data` entry is decoded on its own so a single malformed record (bad
 /// field type, missing `id`, …) is skipped rather than rejecting entries this
 /// same response otherwise reported cleanly.
+///
+/// Order is preserved rather than sorted here: `src/server/setup.rs`'s probe
+/// path takes `.next()` off this list to pick a local/custom endpoint's
+/// leading model, the same thing the pre-catalog `discover_local_model` did
+/// by taking the provider's first array entry. Sorting only matters for the
+/// operator-facing OpenRouter catalog, so [`openrouter_models`] sorts its own
+/// copy before caching it rather than this shared parser reordering every
+/// caller's result.
 fn parse_models(payload: RegistryResponse) -> Vec<InferenceModel> {
-    let mut unique = BTreeMap::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut models = Vec::new();
     for entry in payload.data {
         let Ok(model) = serde_json::from_value::<RegistryModel>(entry) else {
             continue;
         };
         let id = model.id.trim();
-        if id.is_empty() {
+        if id.is_empty() || !seen.insert(id.to_string()) {
             continue;
         }
-        unique
-            .entry(id.to_string())
-            .or_insert_with(|| InferenceModel {
-                id: id.to_string(),
-                name: model
-                    .name
-                    .map(|name| name.trim().to_string())
-                    .filter(|name| !name.is_empty()),
-                context_length: model.context_length,
-            });
+        models.push(InferenceModel {
+            id: id.to_string(),
+            name: model
+                .name
+                .map(|name| name.trim().to_string())
+                .filter(|name| !name.is_empty()),
+            context_length: model.context_length,
+        });
     }
-    unique.into_values().collect()
+    models
 }
 
 /// Fetch every model from an OpenAI-compatible `{base_url}/models` endpoint.
@@ -143,7 +150,7 @@ pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
     }
 
     let fetch = discover_models(crate::company::inference::OPENROUTER_BASE_URL, None);
-    let models = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, fetch)
+    let mut models = tokio::time::timeout(MODEL_CATALOG_TIMEOUT, fetch)
         .await
         .map_err(|_| {
             "OpenRouter's model registry did not answer within 10 seconds".to_string()
@@ -151,6 +158,10 @@ pub(crate) async fn openrouter_models() -> Result<Vec<InferenceModel>, String> {
     if models.is_empty() {
         return Err("OpenRouter's model registry returned no models".to_string());
     }
+    // Sorted here, not in `parse_models`: this is the operator-facing
+    // catalog picker's own copy, while `parse_models` also serves
+    // `setup.rs`'s local/custom probe, which relies on provider order.
+    models.sort_by(|a, b| a.id.cmp(&b.id));
     openrouter_cache().store(models.clone(), now);
     Ok(models)
 }
@@ -168,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_parser_returns_every_non_empty_unique_model() {
+    fn catalog_parser_returns_every_non_empty_unique_model_in_provider_order() {
         let parsed = parse_models(RegistryResponse {
             data: vec![
                 serde_json::json!({"id": " vendor/zeta ", "name": " Zeta ", "context_length": 128_000}),
@@ -179,10 +190,33 @@ mod tests {
         });
 
         assert_eq!(parsed.len(), 2);
-        assert_eq!(parsed[0], model("vendor/alpha"));
-        assert_eq!(parsed[1].id, "vendor/zeta");
-        assert_eq!(parsed[1].name.as_deref(), Some("Zeta"));
-        assert_eq!(parsed[1].context_length, Some(128_000));
+        assert_eq!(parsed[0].id, "vendor/zeta");
+        assert_eq!(parsed[0].name.as_deref(), Some("Zeta"));
+        assert_eq!(parsed[0].context_length, Some(128_000));
+        assert_eq!(parsed[1], model("vendor/alpha"));
+    }
+
+    /// Regression for a Minor review finding on #1838: the previous
+    /// `BTreeMap`-keyed parser returned ids in lexicographic order, so
+    /// `src/server/setup.rs` taking `.next()` off the result silently swapped
+    /// from "the provider's first-listed model" (what the deleted
+    /// `discover_local_model` returned) to "the alphabetically first model" —
+    /// an arbitrary pick on any multi-model host whose ids don't already
+    /// sort first-to-preferred.
+    #[test]
+    fn catalog_parser_does_not_alphabetize_a_local_hosts_leading_model() {
+        let parsed = parse_models(RegistryResponse {
+            data: vec![
+                serde_json::json!({"id": "zephyr-preferred"}),
+                serde_json::json!({"id": "alpaca-not-preferred"}),
+            ],
+        });
+
+        assert_eq!(
+            parsed.first().map(|m| m.id.as_str()),
+            Some("zephyr-preferred"),
+            "the provider's leading model must survive `.next()` in setup.rs, not lose to sort order"
+        );
     }
 
     /// Regression for a P2 review finding on #1838: a single malformed

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,6 +18,7 @@ pub mod feedback_board;
 pub mod graphql;
 pub mod hooks_chargebee;
 pub mod hub_identity;
+pub(crate) mod inference_models;
 // Console MCP OAuth callback (issue #90): the unauthenticated browser-redirect
 // landing route. Gated on `mcp` (it needs the OAuth token-exchange path).
 #[cfg(feature = "mcp")]

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -75,8 +75,24 @@ pub fn router() -> Router<AppState> {
         "/inference",
         get(get_status).put(set_config).delete(revert_config),
     )
+    .merge(scoped("/inference/models", get(list_models)))
     .merge(scoped("/inference/test", post(test_config)))
     .merge(scoped("/inference/restart", post(restart_runtime)))
+}
+
+/// `GET …/inference/models` — the cached public OpenRouter model registry.
+async fn list_models(
+    company: ScopedCompany,
+) -> Result<Json<Vec<crate::server::inference_models::InferenceModel>>, ApiError> {
+    let _ = company;
+    crate::server::inference_models::openrouter_models()
+        .await
+        .map(Json)
+        .map_err(|error| {
+            ApiError(OpenCompanyError::Store(format!(
+                "OpenRouter model registry unavailable: {error}"
+            )))
+        })
 }
 
 /// The company's effective inference status as the console renders it. **Never**
@@ -1183,6 +1199,28 @@ base_url = "https://byo.example/v1"
             serde_json::from_slice(&bytes).unwrap_or(Value::Null)
         };
         (status, value, raw)
+    }
+
+    #[tokio::test]
+    async fn model_catalog_route_returns_cached_openrouter_models() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+        crate::server::inference_models::openrouter_cache().store(
+            vec![crate::server::inference_models::InferenceModel {
+                id: "provider/real-model".to_string(),
+                name: Some("Real Model".to_string()),
+                context_length: Some(128_000),
+            }],
+            std::time::Instant::now(),
+        );
+
+        let (status, body, raw) =
+            send(&state, "GET", "/api/v1/company/inference/models", None).await;
+
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(body[0]["id"], "provider/real-model");
+        assert_eq!(body[0]["name"], "Real Model");
+        assert_eq!(body[0]["contextLength"], 128_000);
     }
 
     // ---------------------------------------------------------------------

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -1532,6 +1532,19 @@ base_url = "https://byo.example/v1"
         assert_eq!(dto["source"], "managed");
         assert_eq!(dto["keyConfigured"], false);
         assert!(dto.get("key").is_none(), "status DTO must not carry a key");
+        // `defaultTierModels` must actually be on the wire, not just the DTO
+        // struct — the frontend preset (issue #1838) reads it off this exact
+        // response, so a field that only exists in Rust and never serializes
+        // would leave the console silently falling back to a stale local copy.
+        let expected_chat_v1 = inference::DEFAULT_TIER_MODELS
+            .iter()
+            .find(|(tier, _)| *tier == "chat-v1")
+            .map(|(_, model)| *model)
+            .expect("chat-v1 must have a documented default");
+        assert_eq!(
+            dto["defaultTierModels"]["chat-v1"], expected_chat_v1,
+            "defaultTierModels must be present on the managed-default status response: {dto}"
+        );
 
         // Switch to OpenRouter with a write-only key + a tier→model map.
         let (status, resp, raw) = send(
@@ -1563,6 +1576,13 @@ base_url = "https://byo.example/v1"
         assert_eq!(dto["source"], "runtime");
         assert_eq!(dto["keyConfigured"], true);
         assert!(!raw.contains(TOKEN), "GET status leaked the token: {raw}");
+        // defaultTierModels is independent of the tenant's own `models` map —
+        // it must still be the shipped default here even though this company
+        // now has a runtime override with its own chat-v1/reasoning-v1 entries.
+        assert_eq!(
+            dto["defaultTierModels"]["chat-v1"], expected_chat_v1,
+            "defaultTierModels must not follow the tenant's own model override: {dto}"
+        );
     }
 
     #[tokio::test]

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -112,6 +112,17 @@ struct InferenceStatusDto {
     base_url: String,
     /// Abstract-tier → concrete model id.
     models: BTreeMap<String, String>,
+    /// The shipped tier → model defaults ([`inference::DEFAULT_TIER_MODELS`]),
+    /// independent of `provider`/`models` above.
+    ///
+    /// The console's OpenRouter preset used to hard-code its own copy of these
+    /// four ids so switching to OpenRouter had something to prefill the form
+    /// with before an operator typed an override — duplicated data that could
+    /// silently drift from this host's actual defaults the moment
+    /// `DEFAULT_TIER_MODELS` changed. Carrying the live values on every status
+    /// read means the preset is never more than one request stale, on a route
+    /// the console already polls.
+    default_tier_models: BTreeMap<String, String>,
     /// Where the effective config came from: `default` / `manifest` / `runtime`,
     /// or `managed` when nothing tenant-specific is configured.
     source: String,
@@ -447,12 +458,19 @@ async fn effective_status_with(
     // What the company actually booted onto, not what the config implies.
     let cognition = runtime.cognition();
     let restart_required = restart_pending(runtime, decl.is_some());
+    // Independent of `decl`: the shipped defaults are the same regardless of
+    // what (if anything) this company has configured.
+    let default_tier_models: BTreeMap<String, String> = inference::DEFAULT_TIER_MODELS
+        .iter()
+        .map(|(tier, model)| (tier.to_string(), model.to_string()))
+        .collect();
     Ok(match decl {
         Some(d) => InferenceStatusDto {
             provider: d.provider.clone(),
             slug: d.telemetry_slug().to_string(),
             base_url,
             models: d.models.clone(),
+            default_tier_models: default_tier_models.clone(),
             source: source_label(d.source).to_string(),
             key_configured: d.key_configured(),
             cognition: cognition.path.to_string(),
@@ -466,6 +484,7 @@ async fn effective_status_with(
             slug: "managed".to_string(),
             base_url,
             models: BTreeMap::new(),
+            default_tier_models,
             source: "managed".to_string(),
             key_configured: false,
             cognition: cognition.path.to_string(),

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -1154,7 +1154,12 @@ async fn probe_inference<E: EnvSource + Sync>(
         crate::company::inference::normalize_provider(&req.provider),
         "ollama" | "openai_compatible"
     ) {
-        discover_local_model(&decl).await
+        let bearer = decl.bearer().await.ok().flatten();
+        crate::server::inference_models::discover_models(&decl.base_url, bearer.as_deref())
+            .await
+            .ok()
+            .and_then(|models| models.into_iter().next())
+            .map(|model| model.id)
     } else {
         None
     };
@@ -1219,28 +1224,6 @@ async fn probe_inference<E: EnvSource + Sync>(
             "This build cannot reach a model — the agent harness is not compiled in.".to_string(),
         ),
     }
-}
-
-/// Reads the standard OpenAI-compatible model catalog and picks its first
-/// concrete model. Local servers generally require that id rather than the
-/// abstract `agentic-v1` tier OpenCompany uses internally.
-#[cfg(feature = "openhuman")]
-async fn discover_local_model(decl: &crate::company::inference::InferenceDecl) -> Option<String> {
-    let url = format!("{}/models", decl.base_url.trim_end_matches('/'));
-    let mut request = reqwest::Client::new().get(url);
-    if let Ok(Some(bearer)) = decl.bearer().await {
-        request = request.bearer_auth(bearer);
-    }
-    let response = request.send().await.ok()?.error_for_status().ok()?;
-    let payload: serde_json::Value = response.json().await.ok()?;
-    payload
-        .get("data")?
-        .as_array()?
-        .iter()
-        .filter_map(|entry| entry.get("id")?.as_str())
-        .map(str::trim)
-        .find(|id| !id.is_empty())
-        .map(str::to_string)
 }
 
 /// Turns a provider failure into one line an operator can act on.


### PR DESCRIPTION
## Summary

- Add a cached backend catalog for the public OpenRouter model registry.
- Add provider-gated model selectors for all four cognition tiers.
- Replace the invalid shipped model with four verified premium defaults.

## Problem

OpenRouter users had to enter opaque model IDs by hand, and the shipped `deepseek/deepseek-v4-pro` default does not exist in the OpenRouter registry. That invalid default causes requests to fail before users have a chance to correct it.

## Solution

The backend now fetches, normalizes, sorts, and caches the OpenRouter model registry for one hour behind the authenticated company API. Local-model discovery reuses the same generalized registry parser.

The inference settings UI fetches that catalog only for OpenRouter and renders one Select per cognition tier. Existing custom values remain selectable, loading and failure states are explicit, and Ollama plus OpenAI-compatible providers retain their free-text inputs. Saving still writes the same `models[tier]` strings.

The shipped defaults are now:

- chat-v1: `anthropic/claude-sonnet-5`
- reasoning-v1: `openai/gpt-5.6-sol-pro`
- agentic-v1: `anthropic/claude-opus-5`
- vision-v1: `qwen/qwen3.8-max`

All four IDs were verified against the live OpenRouter registry and through the new authenticated endpoint.

## Submission Checklist

- [x] Four logical micro-commits, each GPG-signed, with no AI co-author trailer
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo test --features openhuman`
- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run`
- [x] `npm run build`
- [x] Focused Playwright selection, persistence, reload, and provider-switch test
- [x] Live authenticated model-catalog endpoint smoke test

## Impact

OpenRouter users can choose valid models without memorizing IDs, while custom and local providers keep their existing configuration workflow. Existing persisted tier strings and the inference save path are unchanged. Registry failures degrade to the existing free-text editing experience.

## Related

Closes #1803

Closes #1811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenRouter model catalog for browsing and selecting available models during inference setup.
  * Added loading, empty, and error states, custom model entry, and restoring tier defaults.
  * Added filtering for models incompatible with proxied connections.
  * Updated default models across chat, reasoning, agentic, and vision tiers.
* **Bug Fixes**
  * Improved recognition of current Qwen variants.
  * Added catalog caching, duplicate filtering, and resilient handling of invalid catalog entries for more reliable loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->