### PR TITLE
fix(harness): seed recent desk chat history on chat-turn resume (#1840)

### DIFF
--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -1,0 +1,592 @@
+//! Recent-chat history seed for a resumed agent turn (issue #1840).
+//!
+//! # Why this exists
+//!
+//! One `Agent` is reused for every chat of a `(company, agent_id)` pair, and its
+//! in-memory `history` is cleared and re-bound on every chat switch
+//! ([`super::CompanyAgent::run_with_steer`]). The re-seed there originally went
+//! through OpenHuman's `seed_resume_from_thread_transcript`, which reads a
+//! per-thread OpenHuman **file** transcript — a file OpenCompany never writes for
+//! a `chat_id` (its web-channel session is built with `.auto_save(false)` and no
+//! thread binding). So the lookup always missed, the agent started every chat
+//! reply at `history_len = 0`, and the model answered without the recent
+//! conversation in front of it (the #1725/#1730 regression).
+//!
+//! OpenCompany already holds the authoritative transcript: the company
+//! [`EventLog`]. This module projects the last `window` messages **that belong to
+//! the incoming desk** out of that log into the lossy `(role, content)` shape
+//! [`Agent::seed_resume_from_messages`](openhuman_core::openhuman::agent::Agent::seed_resume_from_messages)
+//! accepts, so the switch branch can seed the correct thread's own recent turns
+//! directly instead of chasing a file that isn't there.
+//!
+//! # Isolation
+//!
+//! The ownership test is [`chat_history::owns`] — the *same* predicate the
+//! console's history surfaces use, so a seed contains exactly the lines the UI
+//! renders for that desk and nothing from any other. That reuse is deliberate:
+//! it gives DM (`dm:<id>`) vs named-desk parity for free and keeps a switch from
+//! ever leaking the previous chat's lines into the next one.
+
+use std::sync::Arc;
+
+use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::ports::{CompanyStore, EventLog};
+use crate::server::chat_history;
+use crate::server::ops::language::DEFAULT_DESK;
+
+/// How many of the most-recent owning messages a chat seed carries.
+///
+/// A conversational window, not the whole transcript: enough that a reply lands
+/// in the flow of the recent exchange, small enough that a resumed turn does not
+/// re-send an unbounded history on every switch. OpenHuman's own
+/// `max_history_messages` bound still applies on top of this (see
+/// `bound_cached_transcript_messages`), so this is an upper request, not a
+/// guarantee.
+pub const CHAT_SEED_WINDOW: usize = 30;
+
+/// How many raw journal events to pull per backward page while filtering down to
+/// owning messages. A busy company interleaves unrelated events between two chat
+/// turns, so the event page is larger than the message window — mirrors
+/// [`chat_history::history_for_desk`]'s `EVENT_PAGE`.
+const EVENT_PAGE: usize = 512;
+
+/// Resolves an incoming `chat_id` to the `(desk_id, desk_name)` pair
+/// [`chat_history::owns`] filters on, exactly as the REST history route's
+/// `resolve_desk` does (issue #65).
+///
+/// `owns` matches a stored event's chat id against *both* the desk id and the
+/// desk name, because a named desk's messages can be journaled under either
+/// spelling. Passing `(chat_id, chat_id)` for a desk the operator addressed by
+/// id would therefore silently miss any line stored under its name — a seed that
+/// "looks fixed" but is empty. So a non-General selector is resolved against the
+/// manifest's group chats the same way the console resolves it.
+///
+/// * `None` → the synthetic General/operator desk.
+/// * A General spelling (`"main"` / `"general"` / `""`) short-circuits: every
+///   spelling folds together in [`chat_history::same_conversation`], so no
+///   manifest read is needed and `(chat, chat)` already owns all of them.
+/// * Anything else is matched (case-insensitive, by id or name) against the
+///   manifest's group chats; an unmatched selector passes through as `(id, name)
+///   = (chat, chat)`, so an ad-hoc thread id still finds what was journaled under
+///   that exact string.
+pub async fn resolve_seed_desk(
+    store: &Arc<dyn CompanyStore>,
+    company: &CompanyId,
+    chat_id: Option<&str>,
+) -> (String, String) {
+    let Some(desk) = chat_id else {
+        return (DEFAULT_DESK.to_string(), DEFAULT_DESK.to_string());
+    };
+    if chat_history::is_general_chat(Some(desk)) {
+        return (desk.to_string(), desk.to_string());
+    }
+    match store.load(company).await {
+        Ok(Some(record)) => record
+            .manifest
+            .group_chats
+            .iter()
+            .find(|chat| chat.id.eq_ignore_ascii_case(desk) || chat.name.eq_ignore_ascii_case(desk))
+            .map(|chat| (chat.id.clone(), chat.name.clone()))
+            .unwrap_or_else(|| (desk.to_string(), desk.to_string())),
+        // A store miss or read error must not fail the turn — fall back to the
+        // verbatim selector, which still owns everything journaled under that
+        // exact string (the common case, where the console addresses id == name).
+        Ok(None) | Err(_) => (desk.to_string(), desk.to_string()),
+    }
+}
+
+/// Projects the last `window` messages owned by `(desk_id, desk_name)` out of the
+/// company [`EventLog`] into chronological `(role, content)` pairs for
+/// [`Agent::seed_resume_from_messages`](openhuman_core::openhuman::agent::Agent::seed_resume_from_messages).
+///
+/// Walks the log newest-first (`read_before`), keeps only the events
+/// [`chat_history::owns`] admits for this desk, maps each to a role
+/// (`OperatorMessage` → `user`, `AgentReply` → `agent`), stops once `window`
+/// messages are gathered, and reverses to chronological order. Non-conversational
+/// owned events (a settled-dispatch terminal, reactions, anything without body
+/// text) are skipped even when `owns` admits them — a seed needs role + text, not
+/// structural markers.
+///
+/// Best-effort: a read error yields an empty seed (the caller then falls back to
+/// the OpenHuman transcript lookup) rather than failing the turn.
+pub async fn build_chat_seed(
+    events: &Arc<dyn EventLog>,
+    company: &CompanyId,
+    desk_id: &str,
+    desk_name: &str,
+    window: usize,
+) -> Vec<(String, String)> {
+    if window == 0 {
+        return Vec::new();
+    }
+
+    // Newest-first accumulation; reversed to chronological before returning.
+    let mut collected: Vec<(String, String)> = Vec::with_capacity(window);
+    let mut cursor = None;
+
+    while collected.len() < window {
+        let page = match events.read_before(company, cursor, EVENT_PAGE).await {
+            Ok(page) => page,
+            Err(error) => {
+                tracing::warn!(
+                    company = %company,
+                    desk = desk_id,
+                    %error,
+                    "[chat-seed] event-log read failed; seeding no recent history (falling back to transcript lookup)"
+                );
+                return Vec::new();
+            }
+        };
+        if page.is_empty() {
+            break;
+        }
+        cursor = page.last().map(|event| event.seq);
+        for stored in page {
+            if !chat_history::owns(desk_id, desk_name, &stored.event) {
+                continue;
+            }
+            let mapped = match &stored.event {
+                CompanyEvent::OperatorMessage { text, .. } => Some(("user", text.as_str())),
+                CompanyEvent::AgentReply { text, .. } => Some(("agent", text.as_str())),
+                // `owns` also admits `DeskTaskCompleted` (a structural "finished →
+                // In review" marker), but it carries no conversational body — do
+                // not seed it as a turn.
+                _ => None,
+            };
+            let Some((role, text)) = mapped else { continue };
+            if text.trim().is_empty() {
+                continue;
+            }
+            collected.push((role.to_string(), text.to_string()));
+            if collected.len() == window {
+                break;
+            }
+        }
+    }
+
+    collected.reverse();
+    collected
+}
+
+/// Drops a trailing `("user", …)` entry whose text matches `current_message`.
+///
+/// The operator's current message is journaled **before** the harness turn runs
+/// (the server appends it, then the brain dispatches), so it is already the
+/// newest owning event when [`build_chat_seed`] reads the tail. Seeding it as
+/// prior history would duplicate it on the wire — `run_single` appends the
+/// current message to `history` itself. OpenHuman's `seed_resume_from_messages`
+/// performs the same drop, but it can only match against the *augmented* message
+/// the runner passes it; the raw operator text is only in scope here, so strip it
+/// here where the match is exact.
+pub fn strip_current_message(seed: &mut Vec<(String, String)>, current_message: &str) {
+    if let Some((role, text)) = seed.last()
+        && role == "user"
+        && text.trim() == current_message.trim()
+    {
+        seed.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use futures::stream::{self, BoxStream};
+
+    use crate::ports::events::EventStreamItem;
+    use crate::ports::types::{EventSeq, StoredEvent};
+
+    /// A log that replays a fixed history in ascending sequence order. The
+    /// trait's default `read_before` (forward-read + reverse + truncate) then
+    /// gives us newest-first paging for free — exactly what production backends
+    /// override but what a fixture does not need to.
+    struct FixedLog(Vec<StoredEvent>);
+
+    #[async_trait]
+    impl EventLog for FixedLog {
+        async fn append(&self, _id: &CompanyId, _event: CompanyEvent) -> crate::Result<EventSeq> {
+            unreachable!("the seed projector only reads")
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            seq: EventSeq,
+            limit: usize,
+        ) -> crate::Result<Vec<StoredEvent>> {
+            Ok(self
+                .0
+                .iter()
+                .filter(|e| e.seq.value() >= seq.value())
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, EventStreamItem> {
+            Box::pin(stream::empty())
+        }
+    }
+
+    /// A log whose reads always fail, to prove the projector degrades to an empty
+    /// seed rather than propagating.
+    struct BrokenLog;
+
+    #[async_trait]
+    impl EventLog for BrokenLog {
+        async fn append(&self, _id: &CompanyId, _event: CompanyEvent) -> crate::Result<EventSeq> {
+            unreachable!()
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> crate::Result<Vec<StoredEvent>> {
+            Err(OpenCompanyError::InvalidRequest("boom".to_string()))
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, EventStreamItem> {
+            Box::pin(stream::empty())
+        }
+    }
+
+    use crate::error::OpenCompanyError;
+
+    fn operator(seq: u64, chat: Option<&str>, text: &str) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(seq),
+            company: CompanyId::new("acme"),
+            event: CompanyEvent::OperatorMessage {
+                text: text.to_string(),
+                by: None,
+                chat: chat.map(str::to_string),
+                parent: None,
+                deliverable: None,
+                mentions: Vec::new(),
+                attachments: Vec::new(),
+            },
+            at_millis: seq,
+        }
+    }
+
+    fn reply(seq: u64, chat_id: &str, text: &str) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(seq),
+            company: CompanyId::new("acme"),
+            event: CompanyEvent::AgentReply {
+                chat_id: chat_id.to_string(),
+                agent_id: "ceo".to_string(),
+                text: text.to_string(),
+                steps: Vec::new(),
+                task_id: None,
+                parent: None,
+                mentions: Vec::new(),
+                mention_depth: 0,
+            },
+            at_millis: seq,
+        }
+    }
+
+    fn desk_completed(seq: u64, origin_chat_id: Option<&str>) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(seq),
+            company: CompanyId::new("acme"),
+            event: CompanyEvent::DeskTaskCompleted {
+                task_id: "t-1".to_string(),
+                desk: "eng".to_string(),
+                output: "shipped".to_string(),
+                column: "done".to_string(),
+                artifact_ids: Vec::new(),
+                origin_chat_id: origin_chat_id.map(str::to_string),
+            },
+            at_millis: seq,
+        }
+    }
+
+    async fn seed_of(
+        log: FixedLog,
+        desk_id: &str,
+        desk_name: &str,
+        window: usize,
+    ) -> Vec<(String, String)> {
+        let events: Arc<dyn EventLog> = Arc::new(log);
+        build_chat_seed(&events, &CompanyId::new("acme"), desk_id, desk_name, window).await
+    }
+
+    /// The core projection: a journal interleaving the General desk's own
+    /// operator/agent turns with an unrelated desk's message, a structural
+    /// dispatch terminal, and an empty reply. Only the General desk's real
+    /// conversational turns survive, in chronological order, with the right roles.
+    #[tokio::test]
+    async fn projects_only_owning_conversational_turns_in_order() {
+        let log = FixedLog(vec![
+            operator(0, Some("general"), "u1"),
+            reply(1, "general", "a1"),
+            // Another desk entirely — must never appear in General's seed.
+            operator(2, Some("engineering"), "OTHER-DESK"),
+            reply(3, "engineering", "OTHER-REPLY"),
+            // `owns` admits this (origin is General) but it is a structural
+            // marker, not a turn — the projector must skip it.
+            desk_completed(4, Some("general")),
+            // A blank reply carries no body to seed.
+            reply(5, "general", "   "),
+            operator(6, Some("general"), "u2"),
+        ]);
+
+        let seed = seed_of(log, "general", "general", CHAT_SEED_WINDOW).await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "u1".to_string()),
+                ("agent".to_string(), "a1".to_string()),
+                ("user".to_string(), "u2".to_string()),
+            ],
+            "only General's own operator/agent turns, chronological, correctly roled"
+        );
+    }
+
+    /// The General desk answers to every spelling of itself, so a reply journaled
+    /// under `"General"` and a `"main"` operator line both land in the seed for a
+    /// desk addressed as `"main"` — the folding `owns`/`same_conversation` give.
+    #[tokio::test]
+    async fn general_desk_folds_its_spellings() {
+        let log = FixedLog(vec![
+            operator(0, None, "unaddressed"),
+            reply(1, "General", "under-General"),
+            operator(2, Some("main"), "under-main"),
+        ]);
+
+        let seed = seed_of(log, "main", "main", CHAT_SEED_WINDOW).await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "unaddressed".to_string()),
+                ("agent".to_string(), "under-General".to_string()),
+                ("user".to_string(), "under-main".to_string()),
+            ],
+        );
+    }
+
+    /// DM parity: a `dm:<id>` thread is an opaque verbatim key, so its own turns
+    /// project and a sibling DM's do not.
+    #[tokio::test]
+    async fn dm_thread_projects_and_isolates() {
+        let log = FixedLog(vec![
+            operator(0, Some("dm:alice"), "hi alice"),
+            reply(1, "dm:alice", "hi back"),
+            operator(2, Some("dm:bob"), "hi bob"),
+        ]);
+
+        let seed = seed_of(log, "dm:alice", "dm:alice", CHAT_SEED_WINDOW).await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "hi alice".to_string()),
+                ("agent".to_string(), "hi back".to_string()),
+            ],
+            "only the addressed DM's own turns, never the sibling DM's"
+        );
+    }
+
+    /// A named desk's turns can be journaled under either its id or its name;
+    /// `owns` matches both, so passing the resolved `(id, name)` pair seeds every
+    /// line regardless of which spelling wrote it.
+    #[tokio::test]
+    async fn named_desk_matches_id_and_name() {
+        let log = FixedLog(vec![
+            operator(0, Some("eng-123"), "by id"),
+            reply(1, "Engineering", "by name"),
+            operator(2, Some("marketing"), "OTHER"),
+        ]);
+
+        let seed = seed_of(log, "eng-123", "Engineering", CHAT_SEED_WINDOW).await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "by id".to_string()),
+                ("agent".to_string(), "by name".to_string()),
+            ],
+        );
+    }
+
+    /// The window keeps the most-recent `window` owning turns and drops older
+    /// ones, even when unrelated events sit between them.
+    #[tokio::test]
+    async fn window_keeps_the_most_recent_turns() {
+        let mut events = Vec::new();
+        for n in 0..10u64 {
+            events.push(operator(n, Some("general"), &format!("m{n}")));
+        }
+        let log = FixedLog(events);
+
+        let seed = seed_of(log, "general", "general", 3).await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "m7".to_string()),
+                ("user".to_string(), "m8".to_string()),
+                ("user".to_string(), "m9".to_string()),
+            ],
+            "the three newest owning turns, in chronological order"
+        );
+    }
+
+    /// A read failure yields an empty seed, never a propagated error — the caller
+    /// then falls back to the OpenHuman transcript lookup.
+    #[tokio::test]
+    async fn read_failure_degrades_to_empty() {
+        let events: Arc<dyn EventLog> = Arc::new(BrokenLog);
+        let seed = build_chat_seed(
+            &events,
+            &CompanyId::new("acme"),
+            "general",
+            "general",
+            CHAT_SEED_WINDOW,
+        )
+        .await;
+        assert!(seed.is_empty());
+    }
+
+    #[test]
+    fn strip_current_message_drops_only_a_matching_trailing_user() {
+        let mut seed = vec![
+            ("user".to_string(), "u1".to_string()),
+            ("agent".to_string(), "a1".to_string()),
+            ("user".to_string(), "  current  ".to_string()),
+        ];
+        strip_current_message(&mut seed, "current");
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "u1".to_string()),
+                ("agent".to_string(), "a1".to_string()),
+            ],
+            "a trailing user line matching the current message (trim-insensitive) is dropped"
+        );
+
+        // A trailing agent line is never the current operator message.
+        let mut ends_in_agent = vec![("agent".to_string(), "current".to_string())];
+        strip_current_message(&mut ends_in_agent, "current");
+        assert_eq!(ends_in_agent.len(), 1, "an agent tail is never stripped");
+
+        // A non-matching trailing user line stays.
+        let mut different = vec![("user".to_string(), "something else".to_string())];
+        strip_current_message(&mut different, "current");
+        assert_eq!(different.len(), 1, "a non-matching user tail stays");
+    }
+
+    // ---- resolve_seed_desk ------------------------------------------------
+
+    struct RecordStore(Option<CompanyRecord>);
+
+    #[async_trait]
+    impl CompanyStore for RecordStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Ok(self.0.clone())
+        }
+        async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+            unreachable!("resolve only reads")
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            unreachable!("resolve only reads")
+        }
+        async fn append_ledger(
+            &self,
+            _id: &CompanyId,
+            _entry: crate::ports::types::LedgerEntry,
+        ) -> crate::Result<()> {
+            unreachable!("resolve only reads")
+        }
+    }
+
+    use crate::ports::types::{CompanyRecord, CompanySummary};
+
+    fn record_with_group_chat(id: &str, name: &str) -> CompanyRecord {
+        let manifest = toml::from_str(&format!(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction."
+
+[[group_chat]]
+id = "{id}"
+name = "{name}"
+"#,
+        ))
+        .expect("valid manifest");
+        CompanyRecord {
+            overlay_retired_agents: Vec::new(),
+            overlay_agent_edits: Vec::new(),
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            setup: None,
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            overlay_desk_tools: Default::default(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        }
+    }
+
+    async fn resolve(store: RecordStore, chat_id: Option<&str>) -> (String, String) {
+        let store: Arc<dyn CompanyStore> = Arc::new(store);
+        resolve_seed_desk(&store, &CompanyId::new("acme"), chat_id).await
+    }
+
+    #[tokio::test]
+    async fn resolve_none_is_the_general_desk() {
+        assert_eq!(
+            resolve(RecordStore(None), None).await,
+            (DEFAULT_DESK.to_string(), DEFAULT_DESK.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_general_spelling_short_circuits_without_a_store_read() {
+        // The store would panic on `save`/`list`, but a General spelling must not
+        // even reach `load` — it returns `(chat, chat)`, which owns folds.
+        assert_eq!(
+            resolve(RecordStore(None), Some("main")).await,
+            ("main".to_string(), "main".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_named_desk_by_id_returns_the_manifest_name() {
+        // Addressed by id; the seed must carry the name too, or a line journaled
+        // under the name would be missed. This is the exact "looks fixed but seeds
+        // nothing" trap the resolution guards against.
+        let store = RecordStore(Some(record_with_group_chat("eng-123", "Engineering")));
+        assert_eq!(
+            resolve(store, Some("eng-123")).await,
+            ("eng-123".to_string(), "Engineering".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_unmatched_selector_passes_through_verbatim() {
+        let store = RecordStore(Some(record_with_group_chat("eng-123", "Engineering")));
+        assert_eq!(
+            resolve(store, Some("ad-hoc-thread")).await,
+            ("ad-hoc-thread".to_string(), "ad-hoc-thread".to_string())
+        );
+    }
+}

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -229,10 +229,27 @@ pub async fn build_chat_seed(
 /// performs the same drop, but it can only match against the *augmented* message
 /// the runner passes it; the raw operator text is only in scope here, so strip it
 /// here where the match is exact.
+///
+/// `current_message` must be the raw, pre-memory-injection turn text (what
+/// [`ChatSeedRequest::raw_message`] carries) — a `starts_with`, not an exact
+/// match, because an attachment turns it into a *prefix* of what the journal
+/// holds. `HarnessBrain::cycle` composes the wire body operator text passes
+/// through `with_attachment_refs(text, attachments)` before it ever reaches a
+/// turn, appending `"\n\n[Attached file: …]"` markers after the operator's own
+/// words; the journaled `OperatorMessage.text` this seed reads is only the raw
+/// text, with no markers. An exact match therefore missed on any message with
+/// an attachment, leaving the un-stripped duplicate in the seed — `run_single`
+/// then appends the (augmented) current message again, so the model saw the
+/// operator's current request twice (codex review finding). `with_attachment_refs`
+/// only ever *appends* markers — the operator's text always leads the
+/// composition unless the 200k-char wire cap truncated it — so a prefix match
+/// catches the attachment case without needing the pre-augmentation text
+/// plumbed any further than it already is here.
 pub fn strip_current_message(seed: &mut Vec<(String, String)>, current_message: &str) {
     if let Some((role, text)) = seed.last()
         && role == "user"
-        && text.trim() == current_message.trim()
+        && !text.trim().is_empty()
+        && current_message.trim().starts_with(text.trim())
     {
         seed.pop();
     }
@@ -528,6 +545,32 @@ mod tests {
         let mut different = vec![("user".to_string(), "something else".to_string())];
         strip_current_message(&mut different, "current");
         assert_eq!(different.len(), 1, "a non-matching user tail stays");
+    }
+
+    /// Codex review finding: on a message with an attachment, `HarnessBrain`
+    /// passes `with_attachment_refs(text, attachments)` — the raw text plus an
+    /// appended `"\n\n[Attached file: …]"` marker — as the turn's message,
+    /// while the journaled `OperatorMessage` (what the seed reads) carries
+    /// only the raw text. An exact match therefore never drops the duplicate,
+    /// so the operator's current request reached the model twice: once from
+    /// the un-stripped seed tail, once as the augmented current message
+    /// `run_single` appends itself. RED on the old `==` comparison, GREEN with
+    /// the `starts_with` fix.
+    #[test]
+    fn strip_current_message_drops_a_trailing_user_line_augmented_with_an_attachment_marker() {
+        let mut seed = vec![
+            ("user".to_string(), "prior turn".to_string()),
+            ("user".to_string(), "please review this doc".to_string()),
+        ];
+        let augmented_with_attachment =
+            "please review this doc\n\n[Attached file: report.pdf]\nEXTRACTED TEXT";
+        strip_current_message(&mut seed, augmented_with_attachment);
+        assert_eq!(
+            seed,
+            vec![("user".to_string(), "prior turn".to_string())],
+            "the raw journaled text is a prefix of the attachment-augmented \
+             message, so the trailing duplicate must still be dropped"
+        );
     }
 
     // ---- resolve_seed_desk ------------------------------------------------

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -67,9 +67,11 @@ pub struct ChatSeedRequest {
 }
 
 impl ChatSeedRequest {
-    /// Projects this desk's recent history and strips the current message's
-    /// own duplicate, in one call — the two steps [`super::CompanyAgent::run_with_steer`]'s
-    /// switch branch needs, together.
+    /// Projects this desk's recent history — bounded at this turn's own
+    /// message so a concurrently-accepted later message never leaks in (see
+    /// [`build_chat_seed`]) — and strips the current message's own trailing
+    /// duplicate, in one call: the two steps
+    /// [`super::CompanyAgent::run_with_steer`]'s switch branch needs, together.
     pub async fn build(&self, company: &CompanyId, chat_id: &str) -> Vec<(String, String)> {
         let (desk_id, desk_name) = resolve_seed_desk(&self.store, company, Some(chat_id)).await;
         let mut seed = build_chat_seed(
@@ -78,6 +80,7 @@ impl ChatSeedRequest {
             &desk_id,
             &desk_name,
             CHAT_SEED_WINDOW,
+            &self.raw_message,
         )
         .await;
         strip_current_message(&mut seed, &self.raw_message);
@@ -158,6 +161,44 @@ pub async fn resolve_seed_desk(
 /// text) are skipped even when `owns` admits them — a seed needs role + text, not
 /// structural markers.
 ///
+/// An `OperatorMessage` with attachments is composed through the same
+/// [`with_attachment_refs`](crate::brain::medulla::effects::with_attachment_refs)
+/// formatter the live turn path uses, not just its raw `text` — otherwise a
+/// resumed turn's history quietly dropped every attachment a *prior* message
+/// carried, even though the current turn's own attachments always reach the
+/// model (codex review finding). This also means a seeded entry that turns out
+/// to be the current turn's own duplicate is composed identically to
+/// `ChatSeedRequest::raw_message`, so [`strip_current_message`] still matches
+/// it exactly.
+///
+/// `current_message` bounds the scan at THIS turn's own operator message
+/// (codex review finding on #1842): the chat route journals a message the
+/// instant it is accepted, before it queues on the per-company cycle lock, so
+/// two messages for the same desk accepted close together are both already in
+/// the journal by the time either turn actually reads it. Scanning from the
+/// unbounded tail let the earlier turn seed the later message as "prior
+/// history" — and because the later message's text never matches the earlier
+/// turn's `current_message`, [`strip_current_message`] cannot remove it
+/// either, so the model saw a request nobody made it plus its own current one
+/// twice over. The newest-first walk below therefore buffers every owning
+/// turn into `pending` until it matches a `("user", _)` entry whose text is a
+/// prefix-match of `current_message` (the same relationship
+/// [`strip_current_message`] uses, since an attachment makes `current_message`
+/// a superstring of the journaled text) — that match is this turn's own
+/// boundary, so `pending` (everything newer) is discarded and only the log
+/// content strictly at-or-before it is collected as history.
+///
+/// A boundary that is never matched — `current_message` empty, or a caller
+/// with no real current turn to bound against (tests, chiefly) — degrades to
+/// the unbounded-tail behaviour from before this bound existed: `pending`
+/// (capped at `window` throughout, so this costs nothing extra) becomes the
+/// answer. The bound is a tightening over that baseline, never a new way for
+/// the seed to come back emptier than it did before. The search itself is
+/// capped at a fixed raw-event budget so a boundary that is
+/// genuinely never found cannot walk the whole company history — in
+/// production the match is expected within the first page, since the message
+/// was just journaled moments before this projection runs.
+///
 /// Best-effort: a read error yields an empty seed (the caller then falls back to
 /// the OpenHuman transcript lookup) rather than failing the turn.
 pub async fn build_chat_seed(
@@ -166,16 +207,37 @@ pub async fn build_chat_seed(
     desk_id: &str,
     desk_name: &str,
     window: usize,
+    current_message: &str,
 ) -> Vec<(String, String)> {
+    /// Safety valve on the self-boundary search: past this many raw journal
+    /// events with no match, give up looking and fall back to the
+    /// unbounded-tail behaviour rather than walking the entire company
+    /// history for a boundary that may simply not exist in this desk's log.
+    const SELF_SEARCH_BUDGET: usize = EVENT_PAGE * 4;
+
     if window == 0 {
         return Vec::new();
     }
 
+    let current_message = current_message.trim();
+
     // Newest-first accumulation; reversed to chronological before returning.
+    // `pending` holds owning turns seen before the boundary above is matched;
+    // `collected` holds turns at-or-before it. Exactly one of the two ends up
+    // as the answer — see the boundary discussion above.
+    let mut pending: Vec<(String, String)> = Vec::new();
     let mut collected: Vec<(String, String)> = Vec::with_capacity(window);
+    let mut found_self = false;
+    let mut scanned_raw: usize = 0;
     let mut cursor = None;
 
-    while collected.len() < window {
+    loop {
+        if found_self && collected.len() >= window {
+            break;
+        }
+        if !found_self && scanned_raw >= SELF_SEARCH_BUDGET {
+            break;
+        }
         let page = match events.read_before(company, cursor, EVENT_PAGE).await {
             Ok(page) => page,
             Err(error) => {
@@ -191,14 +253,20 @@ pub async fn build_chat_seed(
         if page.is_empty() {
             break;
         }
+        scanned_raw += page.len();
         cursor = page.last().map(|event| event.seq);
         for stored in page {
             if !chat_history::owns(desk_id, desk_name, &stored.event) {
                 continue;
             }
             let mapped = match &stored.event {
-                CompanyEvent::OperatorMessage { text, .. } => Some(("user", text.as_str())),
-                CompanyEvent::AgentReply { text, .. } => Some(("agent", text.as_str())),
+                CompanyEvent::OperatorMessage {
+                    text, attachments, ..
+                } => Some((
+                    "user",
+                    crate::brain::medulla::effects::with_attachment_refs(text, attachments),
+                )),
+                CompanyEvent::AgentReply { text, .. } => Some(("agent", text.clone())),
                 // `owns` also admits `DeskTaskCompleted` (a structural "finished →
                 // In review" marker), but it carries no conversational body — do
                 // not seed it as a turn.
@@ -208,11 +276,33 @@ pub async fn build_chat_seed(
             if text.trim().is_empty() {
                 continue;
             }
-            collected.push((role.to_string(), text.to_string()));
+
+            if !found_self {
+                if role == "user"
+                    && !current_message.is_empty()
+                    && current_message.starts_with(text.trim())
+                {
+                    found_self = true;
+                    collected.push((role.to_string(), text));
+                } else {
+                    pending.push((role.to_string(), text));
+                    if pending.len() > window {
+                        pending.truncate(window);
+                    }
+                }
+                continue;
+            }
+
+            collected.push((role.to_string(), text));
             if collected.len() == window {
                 break;
             }
         }
+    }
+
+    if !found_self {
+        collected = pending;
+        collected.truncate(window);
     }
 
     collected.reverse();
@@ -336,6 +426,28 @@ mod tests {
         }
     }
 
+    fn operator_with_attachment(
+        seq: u64,
+        chat: Option<&str>,
+        text: &str,
+        attachment: crate::ports::types::Attachment,
+    ) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(seq),
+            company: CompanyId::new("acme"),
+            event: CompanyEvent::OperatorMessage {
+                text: text.to_string(),
+                by: None,
+                chat: chat.map(str::to_string),
+                parent: None,
+                deliverable: None,
+                mentions: Vec::new(),
+                attachments: vec![attachment],
+            },
+            at_millis: seq,
+        }
+    }
+
     fn reply(seq: u64, chat_id: &str, text: &str) -> StoredEvent {
         StoredEvent {
             seq: EventSeq::new(seq),
@@ -370,14 +482,28 @@ mod tests {
         }
     }
 
+    /// `current_message` empty means "no boundary to bound against" — the
+    /// tests exercising desk ownership, folding, and window truncation below
+    /// pass `""` on purpose, so they see the unbounded-tail fallback
+    /// [`build_chat_seed`]'s doc describes and are unaffected by the
+    /// self-boundary search.
     async fn seed_of(
         log: FixedLog,
         desk_id: &str,
         desk_name: &str,
         window: usize,
+        current_message: &str,
     ) -> Vec<(String, String)> {
         let events: Arc<dyn EventLog> = Arc::new(log);
-        build_chat_seed(&events, &CompanyId::new("acme"), desk_id, desk_name, window).await
+        build_chat_seed(
+            &events,
+            &CompanyId::new("acme"),
+            desk_id,
+            desk_name,
+            window,
+            current_message,
+        )
+        .await
     }
 
     /// The core projection: a journal interleaving the General desk's own
@@ -400,7 +526,7 @@ mod tests {
             operator(6, Some("general"), "u2"),
         ]);
 
-        let seed = seed_of(log, "general", "general", CHAT_SEED_WINDOW).await;
+        let seed = seed_of(log, "general", "general", CHAT_SEED_WINDOW, "").await;
 
         assert_eq!(
             seed,
@@ -410,6 +536,44 @@ mod tests {
                 ("user".to_string(), "u2".to_string()),
             ],
             "only General's own operator/agent turns, chronological, correctly roled"
+        );
+    }
+
+    /// Codex review finding: a prior operator message's attachment must survive
+    /// into the seed, not just its raw text — otherwise a follow-up like
+    /// "summarize that file again" loses the file context on a resumed turn,
+    /// even though the SAME message's attachment reached the model fine the
+    /// first time it was live (via `with_attachment_refs` on the current-turn
+    /// path). The seed must go through the identical formatter.
+    #[tokio::test]
+    async fn a_prior_message_with_an_attachment_keeps_its_attachment_marker_in_the_seed() {
+        let attachment = crate::ports::types::Attachment {
+            node_id: "node-1".to_string(),
+            name: "report.pdf".to_string(),
+            mime: "application/pdf".to_string(),
+            size: 1234,
+            extracted_text: Some("QUARTERLY_REPORT_MARKER".to_string()),
+        };
+        let log = FixedLog(vec![operator_with_attachment(
+            0,
+            Some("general"),
+            "please review this",
+            attachment,
+        )]);
+
+        let seed = seed_of(log, "general", "general", CHAT_SEED_WINDOW, "").await;
+
+        assert_eq!(seed.len(), 1, "the one owning message is seeded");
+        let (role, text) = &seed[0];
+        assert_eq!(role, "user");
+        assert!(
+            text.starts_with("please review this"),
+            "the operator's own words still lead: {text:?}"
+        );
+        assert!(
+            text.contains("QUARTERLY_REPORT_MARKER"),
+            "the attachment's extracted text must reach a resumed turn's \
+             context, exactly like it reaches a live one: {text:?}"
         );
     }
 
@@ -424,7 +588,7 @@ mod tests {
             operator(2, Some("main"), "under-main"),
         ]);
 
-        let seed = seed_of(log, "main", "main", CHAT_SEED_WINDOW).await;
+        let seed = seed_of(log, "main", "main", CHAT_SEED_WINDOW, "").await;
 
         assert_eq!(
             seed,
@@ -446,7 +610,7 @@ mod tests {
             operator(2, Some("dm:bob"), "hi bob"),
         ]);
 
-        let seed = seed_of(log, "dm:alice", "dm:alice", CHAT_SEED_WINDOW).await;
+        let seed = seed_of(log, "dm:alice", "dm:alice", CHAT_SEED_WINDOW, "").await;
 
         assert_eq!(
             seed,
@@ -469,7 +633,7 @@ mod tests {
             operator(2, Some("marketing"), "OTHER"),
         ]);
 
-        let seed = seed_of(log, "eng-123", "Engineering", CHAT_SEED_WINDOW).await;
+        let seed = seed_of(log, "eng-123", "Engineering", CHAT_SEED_WINDOW, "").await;
 
         assert_eq!(
             seed,
@@ -490,7 +654,7 @@ mod tests {
         }
         let log = FixedLog(events);
 
-        let seed = seed_of(log, "general", "general", 3).await;
+        let seed = seed_of(log, "general", "general", 3, "").await;
 
         assert_eq!(
             seed,
@@ -500,6 +664,76 @@ mod tests {
                 ("user".to_string(), "m9".to_string()),
             ],
             "the three newest owning turns, in chronological order"
+        );
+    }
+
+    /// Codex review finding (P1): the chat route journals an operator message
+    /// the instant it is accepted, before it queues on the per-company cycle
+    /// lock — so two messages for the same desk accepted close together are
+    /// both already in the journal by the time either turn's seed projection
+    /// actually runs. Scanning the unbounded tail let the FIRST message's turn
+    /// seed the SECOND message too, as if it were prior history — and because
+    /// the second message's text never matches the first turn's own text,
+    /// `strip_current_message` cannot remove it either. The seed for "my
+    /// message"'s turn must stop at its own boundary: everything journaled
+    /// after it is excluded, not just everything after the log's current tail.
+    #[tokio::test]
+    async fn a_concurrently_journaled_later_message_is_excluded_from_the_seed() {
+        let log = FixedLog(vec![
+            operator(0, Some("general"), "earlier turn"),
+            reply(1, "general", "earlier reply"),
+            operator(2, Some("general"), "my message"),
+            // Accepted by the chat route microseconds later, before either
+            // turn won this desk's per-company cycle lock — same shape as two
+            // browser tabs firing at once.
+            operator(3, Some("general"), "a second, concurrent message"),
+        ]);
+
+        let seed = seed_of(log, "general", "general", CHAT_SEED_WINDOW, "my message").await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "earlier turn".to_string()),
+                ("agent".to_string(), "earlier reply".to_string()),
+                ("user".to_string(), "my message".to_string()),
+            ],
+            "the later, concurrently-journaled message must not appear as \
+             prior history for the earlier message's own turn: {seed:?}"
+        );
+    }
+
+    /// The self-boundary in [`build_chat_seed`] degrades to the unbounded-tail
+    /// behaviour when it is never matched — a message with no owning entry in
+    /// this desk's log at all — rather than silently emptying the seed. This
+    /// is the fallback path every other test in this module exercises via
+    /// `seed_of`'s `current_message: ""`; this test names it explicitly with a
+    /// non-empty, non-matching message so the fallback is proven on its own
+    /// terms rather than only incidentally through the empty-string case.
+    #[tokio::test]
+    async fn an_unmatched_boundary_falls_back_to_the_unbounded_tail() {
+        let log = FixedLog(vec![
+            operator(0, Some("general"), "u1"),
+            reply(1, "general", "a1"),
+        ]);
+
+        let seed = seed_of(
+            log,
+            "general",
+            "general",
+            CHAT_SEED_WINDOW,
+            "no journaled message matches this text",
+        )
+        .await;
+
+        assert_eq!(
+            seed,
+            vec![
+                ("user".to_string(), "u1".to_string()),
+                ("agent".to_string(), "a1".to_string()),
+            ],
+            "an unmatched boundary must not come back emptier than the \
+             unbounded scan did: {seed:?}"
         );
     }
 
@@ -514,6 +748,7 @@ mod tests {
             "general",
             "general",
             CHAT_SEED_WINDOW,
+            "",
         )
         .await;
         assert!(seed.is_empty());

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -34,6 +34,57 @@ use crate::ports::{CompanyStore, EventLog};
 use crate::server::chat_history;
 use crate::server::ops::language::DEFAULT_DESK;
 
+/// What a chat turn needs to build its recent-history seed, carried into
+/// [`super::CompanyAgent::run_with_steer`] rather than an already-projected
+/// `Vec`.
+///
+/// The projection itself ([`build_chat_seed`]) is only done inside
+/// `run_with_steer`, after the chat-switch decision (under the same
+/// `bound_chat` lock) confirms a re-seed is actually needed — never for a
+/// turn that keeps the same bound chat as the one before it. Handing the
+/// caller-built `Vec` in unconditionally meant the (filesystem-backend-costly
+/// — see [`build_chat_seed`]'s docs) journal walk ran on *every* chat turn,
+/// switch or not, since the caller has no way to see the switch decision
+/// before it (codex review finding).
+///
+/// `None` for every non-chat turn — background, workflow, or [confined]
+/// (`confine::run_confined`) — which want no seed regardless of switch
+/// status, exactly like passing an empty seed did before this type existed.
+///
+/// [confined]: super::confine
+pub struct ChatSeedRequest {
+    /// The turn's raw, pre-memory-injection text — what
+    /// [`strip_current_message`] matches against. Deliberately NOT
+    /// `run_with_steer`'s own `message` argument: that one is the
+    /// memory-augmented turn text, which the journal never recorded (see
+    /// `strip_current_message`'s docs).
+    pub raw_message: String,
+    /// The company journal [`build_chat_seed`] projects the seed from.
+    pub events: Arc<dyn EventLog>,
+    /// Resolves the incoming chat id to its desk id/name pair (see
+    /// [`resolve_seed_desk`]).
+    pub store: Arc<dyn CompanyStore>,
+}
+
+impl ChatSeedRequest {
+    /// Projects this desk's recent history and strips the current message's
+    /// own duplicate, in one call — the two steps [`super::CompanyAgent::run_with_steer`]'s
+    /// switch branch needs, together.
+    pub async fn build(&self, company: &CompanyId, chat_id: &str) -> Vec<(String, String)> {
+        let (desk_id, desk_name) = resolve_seed_desk(&self.store, company, Some(chat_id)).await;
+        let mut seed = build_chat_seed(
+            &self.events,
+            company,
+            &desk_id,
+            &desk_name,
+            CHAT_SEED_WINDOW,
+        )
+        .await;
+        strip_current_message(&mut seed, &self.raw_message);
+        seed
+    }
+}
+
 /// How many of the most-recent owning messages a chat seed carries.
 ///
 /// A conversational window, not the whole transcript: enough that a reply lands

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -623,6 +623,7 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
             None,
             Some(stream_for("sports")),
             None,
+            Vec::new(),
         )
         .await
         .expect("task A runs");
@@ -653,7 +654,7 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
     // ── A bare "hi" on a DIFFERENT chat — the greeting fast path. ──
     let (outcome_b, _usage_b) = with_chat_only_hint(
         true,
-        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None),
+        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None, Vec::new()),
     )
     .await
     .expect("the greeting runs");
@@ -751,13 +752,19 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
 
     // ── Chat "sports", turn 1: binds bound_chat to "sports". ──
     agent
-        .run_with_steer("hello from sports", None, Some(stream_for("sports")), None)
+        .run_with_steer(
+            "hello from sports",
+            None,
+            Some(stream_for("sports")),
+            None,
+            Vec::new(),
+        )
         .await
         .expect("chat turn 1 runs");
 
     // ── The background task: unthreaded — `stream: None`, same shared Agent. ──
     let (outcome_bg, _usage_bg) = agent
-        .run_with_steer("run the background task", None, None, None)
+        .run_with_steer("run the background task", None, None, None, Vec::new())
         .await
         .expect("background task runs");
     assert!(
@@ -779,7 +786,13 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
     // ── Chat "sports", turn 2 — same chat id the background task ran under
     //    no binding for, so this must be treated as a switch and re-seed. ──
     agent
-        .run_with_steer("still there?", None, Some(stream_for("sports")), None)
+        .run_with_steer(
+            "still there?",
+            None,
+            Some(stream_for("sports")),
+            None,
+            Vec::new(),
+        )
         .await
         .expect("chat turn 2 runs");
 

--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -623,7 +623,7 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
             None,
             Some(stream_for("sports")),
             None,
-            Vec::new(),
+            None,
         )
         .await
         .expect("task A runs");
@@ -654,7 +654,7 @@ async fn a_greeting_after_a_task_runs_no_tools_and_leaks_no_prior_context() {
     // ── A bare "hi" on a DIFFERENT chat — the greeting fast path. ──
     let (outcome_b, _usage_b) = with_chat_only_hint(
         true,
-        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None, Vec::new()),
+        agent.run_with_steer("hi", None, Some(stream_for("smalltalk")), None, None),
     )
     .await
     .expect("the greeting runs");
@@ -757,14 +757,14 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
             None,
             Some(stream_for("sports")),
             None,
-            Vec::new(),
+            None,
         )
         .await
         .expect("chat turn 1 runs");
 
     // ── The background task: unthreaded — `stream: None`, same shared Agent. ──
     let (outcome_bg, _usage_bg) = agent
-        .run_with_steer("run the background task", None, None, None, Vec::new())
+        .run_with_steer("run the background task", None, None, None, None)
         .await
         .expect("background task runs");
     assert!(
@@ -786,13 +786,7 @@ async fn a_background_turn_does_not_leak_into_the_next_turn_on_its_bound_chat() 
     // ── Chat "sports", turn 2 — same chat id the background task ran under
     //    no binding for, so this must be treated as a switch and re-seed. ──
     agent
-        .run_with_steer(
-            "still there?",
-            None,
-            Some(stream_for("sports")),
-            None,
-            Vec::new(),
-        )
+        .run_with_steer("still there?", None, Some(stream_for("sports")), None, None)
         .await
         .expect("chat turn 2 runs");
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -775,8 +775,7 @@ impl CompanyAgent {
     /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
     /// turns never collide.
     pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
-        self.run_with_steer(message, None, None, None, Vec::new())
-            .await
+        self.run_with_steer(message, None, None, None, None).await
     }
 
     /// Runs one turn with an optional operator **steer** control installed
@@ -808,7 +807,7 @@ impl CompanyAgent {
         steer: Option<&SteerControl>,
         stream: Option<crate::turn_stream::TurnStreamCtx>,
         run_sink: Option<Arc<run_trace::RunTraceSink>>,
-        seed: Vec<(String, String)>,
+        chat_seed: Option<chat_seed::ChatSeedRequest>,
     ) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
         // Per-turn progress sink + an always-draining collector, so a burst of
         // events never blocks the turn loop on a full channel.
@@ -831,6 +830,11 @@ impl CompanyAgent {
             crate::turn_stream::LiveRoute::Chat { chat_id } => Some(chat_id.clone()),
             crate::turn_stream::LiveRoute::Workflow { .. } => None,
         });
+        // The company this turn's chat seed (if any) projects from — same
+        // "captured before `stream` moves" reasoning as `turn_chat_id` above.
+        // Only meaningful alongside `turn_chat_id`, so `None` for exactly the
+        // same turns.
+        let turn_company: Option<CompanyId> = stream.as_ref().map(|ctx| ctx.company.clone());
         let (tx, mut rx) = tokio::sync::mpsc::channel::<oh::agent::progress::AgentProgress>(1024);
         let collector = tokio::spawn(async move {
             let mut events = Vec::new();
@@ -904,19 +908,38 @@ impl CompanyAgent {
                 // Prefer OpenCompany's own EventLog-derived seed (issue #1840).
                 // OpenHuman never writes a file transcript for an OC `chat_id`, so
                 // `seed_resume_from_thread_transcript` always misses and the reply
-                // starts blind (the #1725/#1730 regression). When the caller
-                // projected this desk's recent owning turns from the company log,
-                // seed those directly; fall back to the transcript lookup only
-                // when the seed is empty (a background/workflow turn, or a desk
+                // starts blind (the #1725/#1730 regression). Project it HERE, now
+                // that `switched` is confirmed true — not by the caller for every
+                // turn — because the projection walks the company journal and is
+                // costly on the filesystem backend (`chat_seed::build_chat_seed`'s
+                // docs); building it unconditionally meant every ordinary
+                // same-desk reply paid for a journal scan its `switched == false`
+                // branch below would just throw away (codex review finding). This
+                // still runs inside the same `bound_chat`-locked section as the
+                // switch decision, so it is exactly as atomic as the eager build
+                // was — no turn can observe a `switched` verdict this projection
+                // doesn't match.
+                let seed = match (&chat_seed, turn_company.as_ref()) {
+                    (Some(request), Some(company)) => request.build(company, incoming).await,
+                    _ => Vec::new(),
+                };
+                tracing::debug!(
+                    chat = incoming,
+                    seeded = seed.len(),
+                    "[harness] built recent-chat seed for the incoming desk"
+                );
+                // Fall back to the transcript lookup only when the seed is empty
+                // (a background/workflow turn, no `chat_seed` request, or a desk
                 // with no recent history).
                 let seeded = if seed.is_empty() {
                     agent.seed_resume_from_thread_transcript(incoming)
                 } else {
                     // `message` is the augmented turn text; `seed_resume_from_messages`
-                    // drops a trailing user line matching it. The raw operator
-                    // message was already stripped caller-side (see
-                    // `chat_seed::strip_current_message`), so this is a defensive
-                    // no-op on the happy path and correct if augmentation was off.
+                    // drops a trailing user line matching it. `ChatSeedRequest::build`
+                    // (above) already stripped the raw duplicate against
+                    // `raw_message` (see `chat_seed::strip_current_message`), so
+                    // this is a defensive no-op on the happy path and correct if
+                    // augmentation was off.
                     match agent.seed_resume_from_messages(seed, message) {
                         Ok(()) => true,
                         Err(error) => {
@@ -2964,7 +2987,7 @@ impl HarnessPool {
         // reason (issue #1840): a confined turn is intentionally context-free, so
         // it carries none of the desk's recent history.
         let (outcome, turn_costs) = agent
-            .run_with_steer(message, None, stream_ctx, None, Vec::new())
+            .run_with_steer(message, None, stream_ctx, None, None)
             .await?;
 
         let provider_slug = deps.provider.telemetry_provider_id();
@@ -3226,38 +3249,37 @@ impl HarnessPool {
             LiveStream::Off => None,
         };
         // Recent-chat history seed (issue #1840): give a chat reply this desk's
-        // own recent turns so it isn't assembled blind on every switch. Built only
-        // for a chat turn and only when the company journal is wired. The current
-        // operator message is ALREADY journaled at this point (the server appends
-        // it before dispatch), so it is the newest owning event the projector
-        // sees; strip it — `run_single` re-appends the current message itself, so
-        // seeding it too would duplicate it on the wire.
-        let seed = match (seed_chat, deps.events.as_ref()) {
-            (Some(chat_id), Some(events)) => {
-                let (desk_id, desk_name) =
-                    chat_seed::resolve_seed_desk(&deps.store, company, chat_id).await;
-                let mut seed = chat_seed::build_chat_seed(
-                    events,
-                    company,
-                    &desk_id,
-                    &desk_name,
-                    chat_seed::CHAT_SEED_WINDOW,
-                )
-                .await;
-                chat_seed::strip_current_message(&mut seed, message);
-                tracing::debug!(
-                    company = %company,
-                    agent = agent_id,
-                    desk = %desk_id,
-                    seeded = seed.len(),
-                    "[harness] built recent-chat seed for the incoming desk"
-                );
-                seed
-            }
-            _ => Vec::new(),
+        // own recent turns so it isn't assembled blind on every switch. Only
+        // ever wanted for a chat turn with the company journal wired — never
+        // built here, though: `run_with_steer` projects it itself, and only
+        // once its `bound_chat`-locked switch check confirms this turn is
+        // actually a switch (a same-desk reply right after another one is not,
+        // and building it unconditionally on every chat turn made every
+        // ordinary reply pay for a journal scan whose result would just be
+        // thrown away — codex review finding). This is just the (cheap — two
+        // `Arc` clones, no I/O) request the projection needs when the switch
+        // check does land on `true`. The current operator message is ALREADY
+        // journaled at this point (the server appends it before dispatch), so
+        // it is the newest owning event the projector sees; `raw_message` is
+        // what `chat_seed::strip_current_message` matches to strip it —
+        // `run_single` re-appends the current message itself, so seeding it
+        // too would duplicate it on the wire.
+        let chat_seed_request = match (seed_chat, deps.events.as_ref()) {
+            (Some(_), Some(events)) => Some(chat_seed::ChatSeedRequest {
+                raw_message: message.to_string(),
+                events: events.clone(),
+                store: deps.store.clone(),
+            }),
+            _ => None,
         };
         let (outcome, turn_costs) = agent
-            .run_with_steer(&augmented, steer, stream_ctx, run_sink.clone(), seed)
+            .run_with_steer(
+                &augmented,
+                steer,
+                stream_ctx,
+                run_sink.clone(),
+                chat_seed_request,
+            )
             .await?;
         // Issue #242: fold this turn's spend into the attempt it belongs to.
         // Per turn, not once at the end, so a redirect re-run and a delegate's
@@ -6176,7 +6198,7 @@ description = "Builds the product."
         let control = SteerControl::new();
         control.request(SteerAction::Cancel);
         let (_outcome, usages) = agent
-            .run_with_steer("hi", Some(&control), None, None, Vec::new())
+            .run_with_steer("hi", Some(&control), None, None, None)
             .await
             .expect("runs");
         assert_eq!(
@@ -9040,10 +9062,24 @@ budget_usd_daily = 0.0
         /// An appendable in-memory journal. `read_from` returns ascending order,
         /// so the trait's default `read_before` yields the newest-first paging the
         /// seed projector walks.
+        ///
+        /// `reads` counts every `read_from` call (the default `read_before`'s
+        /// only path into a backend) — a stand-in for the filesystem backend's
+        /// whole-file JSONL scan (`store::fs::read_before`'s docs), so a test
+        /// can assert the seed projector only walks the journal when a chat
+        /// switch actually needs it, not on every chat turn (codex review
+        /// finding).
         #[derive(Default)]
-        struct InMemoryLog(StdMutex<Vec<StoredEvent>>);
+        struct InMemoryLog {
+            events: StdMutex<Vec<StoredEvent>>,
+            reads: std::sync::atomic::AtomicUsize,
+        }
 
         impl InMemoryLog {
+            fn reads(&self) -> usize {
+                self.reads.load(std::sync::atomic::Ordering::SeqCst)
+            }
+
             fn operator(&self, chat: &str, text: &str) {
                 self.push(CompanyEvent::OperatorMessage {
                     text: text.to_string(),
@@ -9068,7 +9104,7 @@ budget_usd_daily = 0.0
                 });
             }
             fn push(&self, event: CompanyEvent) {
-                let mut log = self.0.lock().unwrap();
+                let mut log = self.events.lock().unwrap();
                 let seq = EventSeq::new(log.len() as u64);
                 log.push(StoredEvent {
                     seq,
@@ -9086,7 +9122,7 @@ budget_usd_daily = 0.0
                 _id: &CompanyId,
                 event: CompanyEvent,
             ) -> crate::Result<EventSeq> {
-                let mut log = self.0.lock().unwrap();
+                let mut log = self.events.lock().unwrap();
                 let seq = EventSeq::new(log.len() as u64);
                 log.push(StoredEvent {
                     seq,
@@ -9102,8 +9138,9 @@ budget_usd_daily = 0.0
                 seq: EventSeq,
                 limit: usize,
             ) -> crate::Result<Vec<StoredEvent>> {
+                self.reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 Ok(self
-                    .0
+                    .events
                     .lock()
                     .unwrap()
                     .iter()
@@ -9280,6 +9317,54 @@ budget_usd_daily = 0.0
             assert!(
                 all.contains("DM_USER_MARKER") && all.contains("DM_AGENT_MARKER"),
                 "a DM thread's own history must be seeded (parity with named desks): {all:?}"
+            );
+        }
+
+        /// E — a second chat turn on the SAME desk, back to back, is not a
+        /// switch: `bound_chat` already points at it, so `run_with_steer`'s
+        /// switch check must skip both the re-seed AND the journal read that
+        /// builds it. RED on the pre-fix code, which built the (costly on the
+        /// filesystem backend — `chat_seed::build_chat_seed`'s docs) seed in
+        /// the caller for every chat turn, switch or not, and simply discarded
+        /// it on a non-switch turn; GREEN once the projection only runs inside
+        /// the confirmed-switch branch (codex review finding).
+        #[tokio::test]
+        async fn a_non_switch_chat_turn_does_not_re_read_the_journal() {
+            let (fx, log, _seen) = recording_fixture();
+            let rec = record();
+            log.operator("general", "PRIOR_USER_MARKER");
+            log.reply("general", "PRIOR_AGENT_MARKER");
+            // The current operator message for turn 1, journaled before it runs.
+            log.operator("general", "first");
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+            // Turn 1 on "general": a switch (bound_chat starts None) — must
+            // read the journal to build the seed.
+            pool.run(&rec.id, "ceo", "first", &fx.deps, Some("general"))
+                .await
+                .expect("first chat turn");
+            let reads_after_first = log.reads();
+            assert!(
+                reads_after_first > 0,
+                "the first (switching) turn must read the journal to build its seed"
+            );
+
+            // The current operator message for turn 2, journaled before it runs
+            // — same desk as turn 1, so `bound_chat` already matches it.
+            log.operator("general", "second");
+
+            // Turn 2 on "general" — NOT a switch. Must not touch the journal
+            // again to build a seed nothing downstream will use.
+            pool.run(&rec.id, "ceo", "second", &fx.deps, Some("general"))
+                .await
+                .expect("second chat turn");
+            assert_eq!(
+                log.reads(),
+                reads_after_first,
+                "a same-desk, non-switch chat turn must not re-read the \
+                 journal to build a seed the switch check will discard"
             );
         }
     }

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -45,6 +45,7 @@ pub mod build;
 pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;
+pub mod chat_seed;
 mod checkpoint;
 pub mod composio;
 /// Issue #410: how a Composio action catalogue is narrowed and rendered for an
@@ -774,7 +775,8 @@ impl CompanyAgent {
     /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
     /// turns never collide.
     pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
-        self.run_with_steer(message, None, None, None).await
+        self.run_with_steer(message, None, None, None, Vec::new())
+            .await
     }
 
     /// Runs one turn with an optional operator **steer** control installed
@@ -806,6 +808,7 @@ impl CompanyAgent {
         steer: Option<&SteerControl>,
         stream: Option<crate::turn_stream::TurnStreamCtx>,
         run_sink: Option<Arc<run_trace::RunTraceSink>>,
+        seed: Vec<(String, String)>,
     ) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
         // Per-turn progress sink + an always-draining collector, so a burst of
         // events never blocks the turn loop on a full channel.
@@ -898,12 +901,40 @@ impl CompanyAgent {
                     "[harness] chat switched — resetting agent history and re-binding to the incoming thread"
                 );
                 agent.clear_history();
-                let seeded = agent.seed_resume_from_thread_transcript(incoming);
+                // Prefer OpenCompany's own EventLog-derived seed (issue #1840).
+                // OpenHuman never writes a file transcript for an OC `chat_id`, so
+                // `seed_resume_from_thread_transcript` always misses and the reply
+                // starts blind (the #1725/#1730 regression). When the caller
+                // projected this desk's recent owning turns from the company log,
+                // seed those directly; fall back to the transcript lookup only
+                // when the seed is empty (a background/workflow turn, or a desk
+                // with no recent history).
+                let seeded = if seed.is_empty() {
+                    agent.seed_resume_from_thread_transcript(incoming)
+                } else {
+                    // `message` is the augmented turn text; `seed_resume_from_messages`
+                    // drops a trailing user line matching it. The raw operator
+                    // message was already stripped caller-side (see
+                    // `chat_seed::strip_current_message`), so this is a defensive
+                    // no-op on the happy path and correct if augmentation was off.
+                    match agent.seed_resume_from_messages(seed, message) {
+                        Ok(()) => true,
+                        Err(error) => {
+                            tracing::warn!(
+                                chat = incoming,
+                                %error,
+                                "[harness] chat-seed resume failed; turn starts without recent history"
+                            );
+                            false
+                        }
+                    }
+                };
                 // On a switch the agent-latest transcript is the WRONG thread, so
-                // never let the turn's fallback auto-resume run: a seed hit sets
-                // `cached_transcript_messages` (the fallback is skipped anyway); a
-                // miss must start fresh, NOT reload the previous chat's
-                // transcript and re-leak it (the exact screenshot bug).
+                // never let the turn's fallback auto-resume run: our explicit
+                // correct-thread seed (or a transcript hit) has already set
+                // `cached_transcript_messages`; a miss must start fresh, NOT reload
+                // the previous chat's transcript and re-leak it (the exact
+                // screenshot bug). Keep this true regardless of which seed path ran.
                 overrides.suppress_transcript_autoload = true;
                 tracing::debug!(
                     chat = incoming,
@@ -2929,9 +2960,11 @@ impl HarnessPool {
 
         // The message goes to the model AS SENT. This is the retrieve→inject
         // step's absence, and it is the difference between "grounded in one
-        // workflow" and "confined to one workflow".
+        // workflow" and "confined to one workflow". Empty seed for the same
+        // reason (issue #1840): a confined turn is intentionally context-free, so
+        // it carries none of the desk's recent history.
         let (outcome, turn_costs) = agent
-            .run_with_steer(message, None, stream_ctx, None)
+            .run_with_steer(message, None, stream_ctx, None, Vec::new())
             .await?;
 
         let provider_slug = deps.provider.telemetry_provider_id();
@@ -3155,6 +3188,14 @@ impl HarnessPool {
         // their frames would otherwise misattribute to the active chat (#125
         // review). Either way the durable `TurnStep`s still fold from the same
         // buffered events at turn end.
+        // The chat thread this turn answers, if any — captured before `live` is
+        // consumed by the `stream_ctx` match below. Only a chat turn (`On`) seeds
+        // recent history; a background task or workflow node carries no chat
+        // thread to bind history to (issue #1840).
+        let seed_chat: Option<Option<&str>> = match &live {
+            LiveStream::On { chat_id } => Some(*chat_id),
+            _ => None,
+        };
         let stream_ctx = match live {
             LiveStream::On { chat_id } => Some(crate::turn_stream::TurnStreamCtx {
                 company: company.clone(),
@@ -3184,8 +3225,39 @@ impl HarnessPool {
             }),
             LiveStream::Off => None,
         };
+        // Recent-chat history seed (issue #1840): give a chat reply this desk's
+        // own recent turns so it isn't assembled blind on every switch. Built only
+        // for a chat turn and only when the company journal is wired. The current
+        // operator message is ALREADY journaled at this point (the server appends
+        // it before dispatch), so it is the newest owning event the projector
+        // sees; strip it — `run_single` re-appends the current message itself, so
+        // seeding it too would duplicate it on the wire.
+        let seed = match (seed_chat, deps.events.as_ref()) {
+            (Some(chat_id), Some(events)) => {
+                let (desk_id, desk_name) =
+                    chat_seed::resolve_seed_desk(&deps.store, company, chat_id).await;
+                let mut seed = chat_seed::build_chat_seed(
+                    events,
+                    company,
+                    &desk_id,
+                    &desk_name,
+                    chat_seed::CHAT_SEED_WINDOW,
+                )
+                .await;
+                chat_seed::strip_current_message(&mut seed, message);
+                tracing::debug!(
+                    company = %company,
+                    agent = agent_id,
+                    desk = %desk_id,
+                    seeded = seed.len(),
+                    "[harness] built recent-chat seed for the incoming desk"
+                );
+                seed
+            }
+            _ => Vec::new(),
+        };
         let (outcome, turn_costs) = agent
-            .run_with_steer(&augmented, steer, stream_ctx, run_sink.clone())
+            .run_with_steer(&augmented, steer, stream_ctx, run_sink.clone(), seed)
             .await?;
         // Issue #242: fold this turn's spend into the attempt it belongs to.
         // Per turn, not once at the end, so a redirect re-run and a delegate's
@@ -6104,7 +6176,7 @@ description = "Builds the product."
         let control = SteerControl::new();
         control.request(SteerAction::Cancel);
         let (_outcome, usages) = agent
-            .run_with_steer("hi", Some(&control), None, None)
+            .run_with_steer("hi", Some(&control), None, None, Vec::new())
             .await
             .expect("runs");
         assert_eq!(
@@ -8944,5 +9016,271 @@ budget_usd_daily = 0.0
                 .await
                 .is_none()
         );
+    }
+
+    /// End-to-end proof that a chat reply is assembled WITH this desk's recent
+    /// journaled history in front of the model (issue #1840), driven through the
+    /// real `HarnessPool::run` path with only the model captured.
+    ///
+    /// Each test is RED on the pre-fix code: the old switch branch re-seeded via
+    /// OpenHuman's `seed_resume_from_thread_transcript`, which reads a file
+    /// OpenCompany never writes for a `chat_id`, so the model saw `history_len =
+    /// 0` and none of these markers reached it.
+    mod chat_seed_regression {
+        use super::*;
+
+        use std::sync::Mutex as StdMutex;
+
+        use futures::stream::{self, BoxStream};
+        use tinyagents::harness::model::{ModelRequest, ModelResponse};
+
+        use crate::ports::events::EventStreamItem;
+        use crate::ports::types::{CompanyEvent, EventSeq, StoredEvent};
+
+        /// An appendable in-memory journal. `read_from` returns ascending order,
+        /// so the trait's default `read_before` yields the newest-first paging the
+        /// seed projector walks.
+        #[derive(Default)]
+        struct InMemoryLog(StdMutex<Vec<StoredEvent>>);
+
+        impl InMemoryLog {
+            fn operator(&self, chat: &str, text: &str) {
+                self.push(CompanyEvent::OperatorMessage {
+                    text: text.to_string(),
+                    by: None,
+                    chat: Some(chat.to_string()),
+                    parent: None,
+                    deliverable: None,
+                    mentions: Vec::new(),
+                    attachments: Vec::new(),
+                });
+            }
+            fn reply(&self, chat_id: &str, text: &str) {
+                self.push(CompanyEvent::AgentReply {
+                    chat_id: chat_id.to_string(),
+                    agent_id: "ceo".to_string(),
+                    text: text.to_string(),
+                    steps: Vec::new(),
+                    task_id: None,
+                    parent: None,
+                    mentions: Vec::new(),
+                    mention_depth: 0,
+                });
+            }
+            fn push(&self, event: CompanyEvent) {
+                let mut log = self.0.lock().unwrap();
+                let seq = EventSeq::new(log.len() as u64);
+                log.push(StoredEvent {
+                    seq,
+                    company: CompanyId::new("acme"),
+                    event,
+                    at_millis: seq.value(),
+                });
+            }
+        }
+
+        #[async_trait]
+        impl EventLog for InMemoryLog {
+            async fn append(
+                &self,
+                _id: &CompanyId,
+                event: CompanyEvent,
+            ) -> crate::Result<EventSeq> {
+                let mut log = self.0.lock().unwrap();
+                let seq = EventSeq::new(log.len() as u64);
+                log.push(StoredEvent {
+                    seq,
+                    company: CompanyId::new("acme"),
+                    event,
+                    at_millis: seq.value(),
+                });
+                Ok(seq)
+            }
+            async fn read_from(
+                &self,
+                _id: &CompanyId,
+                seq: EventSeq,
+                limit: usize,
+            ) -> crate::Result<Vec<StoredEvent>> {
+                Ok(self
+                    .0
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter(|e| e.seq.value() >= seq.value())
+                    .take(limit)
+                    .cloned()
+                    .collect())
+            }
+            fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, EventStreamItem> {
+                Box::pin(stream::empty())
+            }
+        }
+
+        /// A model that records the full text of every request it is handed, so a
+        /// test can assert which prior turns reached the model's context.
+        #[derive(Default)]
+        struct RecordingProvider {
+            seen: Arc<StdMutex<Vec<String>>>,
+        }
+
+        #[async_trait]
+        impl ChatModel<()> for RecordingProvider {
+            async fn invoke(
+                &self,
+                _state: &(),
+                request: ModelRequest,
+            ) -> tinyagents::Result<ModelResponse> {
+                let joined = request
+                    .messages
+                    .iter()
+                    .map(|m| m.text())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                self.seen.lock().unwrap().push(joined);
+                // A fixed non-empty reply: empty would trip the empty-response
+                // retry wrapper into a second invoke.
+                Ok(ModelResponse::assistant("ok"))
+            }
+        }
+
+        impl HarnessModel for RecordingProvider {
+            fn telemetry_provider_id(&self) -> String {
+                "recording".to_string()
+            }
+        }
+
+        /// A fixture whose journal and model are observable: the returned `log` is
+        /// pre-populated by the test, and `seen` collects every model request.
+        fn recording_fixture() -> (Fixture, Arc<InMemoryLog>, Arc<StdMutex<Vec<String>>>) {
+            let mut fx = fixture();
+            let log = Arc::new(InMemoryLog::default());
+            let provider = Arc::new(RecordingProvider::default());
+            let seen = provider.seen.clone();
+            fx.deps.events = Some(log.clone());
+            fx.deps.provider = provider;
+            (fx, log, seen)
+        }
+
+        /// A — fresh process, first chat turn on `general` (bound = None): the
+        /// prior journaled exchange is seeded into the model, and the current
+        /// message (already journaled) is not duplicated.
+        #[tokio::test]
+        async fn first_chat_turn_seeds_prior_journaled_exchange() {
+            let (fx, log, seen) = recording_fixture();
+            let rec = record();
+            log.operator("general", "PRIOR_USER_MARKER");
+            log.reply("general", "PRIOR_AGENT_MARKER");
+            // The current operator message is journaled BEFORE the turn runs, just
+            // as the server does — so the projector sees it as the newest event.
+            log.operator("general", "CURRENT_MARKER");
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+            pool.run(&rec.id, "ceo", "CURRENT_MARKER", &fx.deps, Some("general"))
+                .await
+                .expect("chat turn runs");
+
+            let all = seen.lock().unwrap().join("\n===\n");
+            assert!(
+                all.contains("PRIOR_USER_MARKER") && all.contains("PRIOR_AGENT_MARKER"),
+                "the prior journaled exchange must reach the model: {all:?}"
+            );
+            assert_eq!(
+                all.matches("CURRENT_MARKER").count(),
+                1,
+                "the current message is stripped from the seed, so it appears once \
+                 (as this turn's user message), not duplicated: {all:?}"
+            );
+        }
+
+        /// B — an unthreaded (background) turn between two chat turns resets
+        /// `bound_chat` to None, making the next chat turn a switch. It must STILL
+        /// re-seed the desk's history — the exact "every background turn blinds the
+        /// next chat reply" failure the fix removes.
+        #[tokio::test]
+        async fn chat_turn_after_a_background_turn_still_seeds_history() {
+            let (fx, log, seen) = recording_fixture();
+            let rec = record();
+            log.operator("general", "HISTORY_USER_MARKER");
+            log.reply("general", "HISTORY_AGENT_MARKER");
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+            // First chat turn binds to general.
+            pool.run(&rec.id, "ceo", "first", &fx.deps, Some("general"))
+                .await
+                .expect("first chat turn");
+            // A background/unthreaded turn: resets bound_chat to None.
+            pool.run_background(&rec.id, "ceo", "background", &fx.deps, None)
+                .await
+                .expect("background turn");
+
+            let before = seen.lock().unwrap().len();
+            // Second chat turn on general — a switch again, because the background
+            // turn invalidated the binding.
+            pool.run(&rec.id, "ceo", "second", &fx.deps, Some("general"))
+                .await
+                .expect("second chat turn");
+
+            let after: Vec<String> = seen.lock().unwrap()[before..].to_vec();
+            let last = after
+                .last()
+                .expect("the second chat turn made a model call");
+            assert!(
+                last.contains("HISTORY_USER_MARKER") && last.contains("HISTORY_AGENT_MARKER"),
+                "a chat turn after a background turn must still see the desk's \
+                 recent history: {last:?}"
+            );
+        }
+
+        /// C — isolation: history on desk A must never leak into a turn on desk B.
+        #[tokio::test]
+        async fn a_switch_seeds_only_the_incoming_desks_history() {
+            let (fx, log, seen) = recording_fixture();
+            let rec = record();
+            log.operator("alpha", "ALPHA_USER_MARKER");
+            log.reply("alpha", "ALPHA_AGENT_MARKER");
+            log.operator("beta", "BETA_USER_MARKER");
+            log.reply("beta", "BETA_AGENT_MARKER");
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+            pool.run(&rec.id, "ceo", "hello beta", &fx.deps, Some("beta"))
+                .await
+                .expect("beta chat turn");
+
+            let all = seen.lock().unwrap().join("\n===\n");
+            assert!(
+                all.contains("BETA_USER_MARKER") && all.contains("BETA_AGENT_MARKER"),
+                "beta's own history must be seeded: {all:?}"
+            );
+            assert!(
+                !all.contains("ALPHA_USER_MARKER") && !all.contains("ALPHA_AGENT_MARKER"),
+                "alpha's history must NEVER leak into a beta turn: {all:?}"
+            );
+        }
+
+        /// D — DM parity: a `dm:<id>` thread seeds exactly like a named desk.
+        #[tokio::test]
+        async fn a_dm_thread_seeds_its_own_history() {
+            let (fx, log, seen) = recording_fixture();
+            let rec = record();
+            log.operator("dm:teammate", "DM_USER_MARKER");
+            log.reply("dm:teammate", "DM_AGENT_MARKER");
+
+            let pool = HarnessPool::new();
+            pool.ensure(&rec, &fx.deps).await.expect("ensure");
+            pool.run(&rec.id, "ceo", "hey there", &fx.deps, Some("dm:teammate"))
+                .await
+                .expect("dm chat turn");
+
+            let all = seen.lock().unwrap().join("\n===\n");
+            assert!(
+                all.contains("DM_USER_MARKER") && all.contains("DM_AGENT_MARKER"),
+                "a DM thread's own history must be seeded (parity with named desks): {all:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Agent replies in a DM/channel were blind to the recent conversation. The `#1725` conversation-isolation change clears agent history whenever the bound chat switches (and background/workflow turns force the next chat reply to count as a switch), then tries to restore context via `seed_resume_from_thread_transcript` — which reads OpenHuman file-transcripts that never exist for OC chats (agents are built `.auto_save(false)`). Net effect: the agent re-derived every reply from just the current message + memory-search hits, with no idea what was "being talked about recently" in the thread.

This wires the missing restore path. A new projector rebuilds the recent chat window from our own `EventLog` (the same events the console renders) and seeds it into the agent on a chat-turn switch, so replies carry the last exchanges of that specific desk.

## API Or Behavior Changes

No public API change. Behavior: on a chat turn, the agent is seeded with up to the last 30 owned messages of that desk (operator/person → user, agent reply → assistant), reconstructed from `EventLog` via the existing `chat_history::owns` ownership predicate (DM `dm:<id>` and named-desk id/name parity preserved). Background / workflow / confined turns seed nothing (unchanged isolation). `suppress_transcript_autoload` stays on; the old transcript lookup remains as a fallback only when the projected seed is empty.

## Tests

Run with the gated feature (`--features openhuman`, `RUST_MIN_STACK=8388608`) since the harness module is `#[cfg(feature="openhuman")]`.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo test --lib` → 3880 passed
- [x] `cargo test --features openhuman --lib harness::built_in` → 1154 passed
- [x] New projector unit suite (11) + regression A–D (fresh-process / chat-after-background / cross-desk isolation / DM parity), proven fail-on-old by neutralizing the seed branch → all 4 regressions fail, restore → green

## Documentation

None needed — internal harness behavior; no user-facing surface or config.

Closes #1840
