### PR TITLE
feat(companies): let the software company bill, held by nobody yet (#1854)

### DIFF
--- a/companies/agentic_software_company/agents/backend_engineer.toml
+++ b/companies/agentic_software_company/agents/backend_engineer.toml
@@ -43,3 +43,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/backend_engineer.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/customer_support.toml
+++ b/companies/agentic_software_company/agents/customer_support.toml
@@ -37,3 +37,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/customer_support.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/designer.toml
+++ b/companies/agentic_software_company/agents/designer.toml
@@ -36,3 +36,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/designer.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/devrel.toml
+++ b/companies/agentic_software_company/agents/devrel.toml
@@ -41,3 +41,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/devrel.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/docs_writer.toml
+++ b/companies/agentic_software_company/agents/docs_writer.toml
@@ -37,3 +37,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/docs_writer.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/frontend_engineer.toml
+++ b/companies/agentic_software_company/agents/frontend_engineer.toml
@@ -37,3 +37,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/frontend_engineer.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/product_manager.toml
+++ b/companies/agentic_software_company/agents/product_manager.toml
@@ -17,3 +17,10 @@ delegates_to = ["product_design"]
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/product_manager.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/qa_engineer.toml
+++ b/companies/agentic_software_company/agents/qa_engineer.toml
@@ -37,3 +37,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/qa_engineer.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/agents/security_engineer.toml
+++ b/companies/agentic_software_company/agents/security_engineer.toml
@@ -37,3 +37,10 @@ context = [
 # A missing path here is a manifest error rather than a skipped entry — a role
 # whose prompt was written around a briefing it never received fails silently.
 prompt_files = ["prompts/security_engineer.md"]
+
+# The company belt minus `chargebee` (#788, #1854). Stated explicitly rather
+# than left empty because an omitted `tools` line inherits the WHOLE company
+# grant, billing included — omission is how capability arrives here, not how it
+# is withheld. This member's desk states no ceiling, so an operator naming them
+# the biller from the console can add `chargebee` here.
+tools = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -29,7 +29,22 @@ human_role = "Product direction"
 #
 # Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
 # setting it to `0` pauses search without editing this list.
-allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*"]
+#
+# `chargebee` (#788) is a CEILING, not a grant: every agent in `agents/` states
+# a `tools` line that omits it, so nobody this template ships holds billing
+# tools. A software business that invoices its customers names the teammate who
+# does from the console — `PATCH {scope}/team/{agent_id}` with `chargebee`
+# added — and that edit is an overlay this manifest never sees.
+#
+# It is here at all because the alternative is that the capability is
+# unreachable: `[tools].allow` has no runtime write path, so a company booted
+# from this bundle could store a Chargebee key and still have it reach no
+# teammate, with nothing in the console able to fix it (#1854).
+#
+# `*` does not cover it. These tools mail invoices to a real business's real
+# customers, so the grant is opted into by name rather than ridden in on a
+# wildcard set for files and shell.
+allow = ["*", "workspace.*", "workspace.write", "media", "composio", "search", "mcp:*", "chargebee"]
 
 # There is deliberately no `[tools.composio].toolkits` here. Absent means "open
 # mode": defer to the backend's own server-enforced allowlist, which is every

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -536,6 +536,7 @@ fn a_deskless_teammate_minted_with_no_scope_never_inherits_billing() {
         "agentic_marketing_agency",
         "agentic_accounting_firm",
         "agentic_venture_studio",
+        "agentic_software_company",
     ] {
         let manifest = load_company(company);
         // The state that makes the escalation reachable: a minter scoped only by
@@ -893,6 +894,82 @@ fn a_marketing_biller_can_be_named_from_the_console() {
     assert!(
         grants_chargebee_explicit(&grants),
         "the console override naming the biller must survive the desk layer; \
+         effective grants: {grants:?}"
+    );
+}
+
+/// The software company ships the billing ceiling and nobody holding it.
+///
+/// The template had no `chargebee` at all until #1854, which made the
+/// capability unreachable rather than withheld: `[tools].allow` has no runtime
+/// write path, so a company booted from this bundle could store a Chargebee key
+/// and have it reach no teammate, with nothing in the console able to fix it.
+///
+/// Granting it needed every agent to state a belt first. All nine omitted their
+/// `tools` line, and an omitted line inherits the WHOLE company grant — so the
+/// one-line version of this change would have handed billing to the QA engineer
+/// and the docs writer rather than to nobody. This pins both halves: the
+/// ceiling exists, and no shipped teammate resolves to holding it.
+#[test]
+fn the_software_company_ships_billing_that_reaches_nobody_yet() {
+    let manifest = load_company("agentic_software_company");
+
+    assert!(
+        grants_chargebee_explicit(&manifest.tools.allow),
+        "the ceiling must exist, or an operator has no way to name a biller: {:?}",
+        manifest.tools.allow
+    );
+
+    // The exclusion must not live on a desk: desk ceilings are manifest-only,
+    // so an exclusion there could never be widened from the console — which
+    // would make the ceiling above decorative.
+    for chat in &manifest.group_chats {
+        assert!(
+            chat.tools.is_empty(),
+            "{}: the `chargebee` exclusion must not live on the desk ceiling              (an unwidenable layer); found {:?}",
+            chat.id,
+            chat.tools
+        );
+    }
+
+    for agent in &manifest.agents {
+        let desk_refs: Vec<&[String]> = manifest
+            .group_chats
+            .iter()
+            .filter(|chat| chat.members.contains(&agent.id))
+            .map(|chat| chat.tools.as_slice())
+            .collect();
+        let grants = agent_scoped_grants(&manifest.tools.allow, &desk_refs, &agent.tools);
+        assert!(
+            !grants_chargebee_explicit(&grants),
+            "{}: a shipped teammate must not hold billing tools; effective              grants: {grants:?}",
+            agent.id
+        );
+    }
+
+    // …and naming one from the console reaches the tools, which is the whole
+    // point of the ceiling being there.
+    let support = manifest
+        .agents
+        .iter()
+        .find(|agent| agent.id == "customer_support")
+        .expect("customer_support is on this roster");
+    let mut named = support.tools.clone();
+    named.push("chargebee".to_string());
+    let desk_refs: Vec<&[String]> = manifest
+        .group_chats
+        .iter()
+        .filter(|chat| {
+            chat.members
+                .iter()
+                .any(|member| member == "customer_support")
+        })
+        .map(|chat| chat.tools.as_slice())
+        .collect();
+    let grants = agent_scoped_grants(&manifest.tools.allow, &desk_refs, &named);
+    assert!(
+        grants_chargebee_explicit(&grants),
+        "an operator naming the biller from the console must reach billing; \
          effective grants: {grants:?}"
     );
 }


### PR DESCRIPTION
## Summary

`agentic_software_company` could not bill, and nothing outside the bundle could grant it. `[tools].allow` has **no runtime write path** — every mutation of it in the tree is inside a test — so a company booted from this template could store a Chargebee key, see the Finance panel confirm the site, and still have billing reach no teammate, with the panel's own remedy ("add `chargebee` to `[tools].allow` in the company's manifest") unreachable from a hosted console.

Found on staging rather than by reading: `tenant-smoke1` boots this bundle (`OPENCOMPANY_COMPANY=agentic_software_company`, registering `smoke1--agentic-software-company`), the tenant image ships `chargebee` in `TENANT_FEATURES`, and the capability was still unreachable. Not withheld by a decision — absent. The three templates that bill carry the ceiling, and nothing in this file said billing had been considered and declined.

Closes #1854.

### The part that made this nine files instead of one

Every one of this template's agents omitted its `tools` line, and none of its desks states a ceiling. An omitted line inherits the **whole** company grant (`agent_effective_grants`: `agent_tools.is_empty()` → `allow.to_vec()`).

So adding `chargebee` to `allow` alone would not have been a ceiling. It would have handed billing to all nine — the QA engineer and the docs writer included — which is the opposite of what the other templates do and the opposite of what the word "ceiling" claims. `analytics_analyst.toml` already says why:

> Stated explicitly rather than left empty because an omitted `tools` line inherits the WHOLE company grant, billing included — omission is how capability arrives here, not how it is withheld.

Each of the nine now states the company belt minus `chargebee`, carrying that same note. The template ships the ceiling and **no holder**: whoever invoices is the operator's call, named with `PATCH {scope}/team/{agent_id}`, intersected with the ceiling so it can never widen past it, and reversible without touching the manifest.

### The cost, stated up front

Those nine move from *inheriting* the belt to *restating* it, so a future change to the default belt will not reach them — nine more places to keep in step. That is the same trade the other three billing templates already made, and the one this file's own comment argues for: a restated line makes a narrowing "a visible edit rather than an inherited surprise". Worth a reviewer disagreeing with if they would rather the capability stay unreachable than accept the drift.

## API Or Behavior Changes

No API change. One behaviour change, scoped to companies booted from this template:

- `GET {scope}/billing/chargebee` reports `granted: true` where it reported `false`, so the Finance panel stops telling operators to edit a file they cannot reach.
- **No teammate gains a tool.** All nine resolve to exactly the belt they had; the difference is that it is now written down rather than inherited.
- Existing companies already booted from this bundle pick the ceiling up on their next boot — the manifest is re-read from the bundle each time (`manifest: self.manifest.clone()`) while overlays carry across — so no data migration and no lost console edits.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 3,882 pass

Two tests carry the change:

- `the_software_company_ships_billing_that_reaches_nobody_yet` pins both halves — the ceiling exists, no shipped teammate resolves to holding it under the three-level narrowing the roster build uses, the exclusion does not hide on the desk layer (unwidenable from the console, which would make the ceiling decorative), and naming a biller from the console reaches the tools.
- `a_deskless_teammate_minted_with_no_scope_never_inherits_billing` gains this template alongside the existing three, so the minted-teammate protection is asserted for it rather than assumed.

Not covered by a test: that a Chargebee call actually succeeds. That needs a live site and key, and is what the staging tenant is for.

## Documentation

The reasoning is in the manifest itself, where an operator editing the file will meet it: why the ceiling is there at all (the capability is otherwise unreachable), why `*` does not confer it, and how to name the biller. Each agent's `tools` line carries the one-sentence reason it is written out. No spec change — this adds no route, field or rule, it applies existing ones to a template that had been missed.
