### PR TITLE
fix(desktop): stop discarding the session a remote sign-in just earned (#1855)

### DIFF
--- a/frontend/src/api/transport/desktop.ts
+++ b/frontend/src/api/transport/desktop.ts
@@ -102,6 +102,44 @@ export function registerConnection(
 }
 
 /**
+ * Hands a sign-in's session to the core, as `id`'s credential (issue #1855).
+ *
+ * The desktop cannot hold a session the way a hub console does: the proxy
+ * strips a webview-supplied `x-opencompany-session` (`RESERVED_HEADERS`) and
+ * the event stream never takes caller headers at all — both on purpose, so the
+ * page never decides what a request authenticates as. The one place a sign-in's
+ * token can live and work is the core, which is where pairing always kept it.
+ *
+ * Sequenced behind whatever is parked under this id, like `forgetConnection`:
+ * an adoption racing an in-flight `oc_connect` would otherwise be overwritten
+ * by a registration that read the keychain before the session was in it.
+ *
+ * The returned promise REJECTS on failure, unlike `registerConnection`'s
+ * swallowed one, because this caller is a sign-in with a person behind it — a
+ * session that could not be stored must surface where they can retry, not as a
+ * mysterious 401 three requests later. The map entry parks the settled-either-
+ * way promise so later calls still sequence and nothing resurfaces.
+ */
+export function adoptSessionIntoCore(id: string, session: string): Promise<void> {
+  const desktop = tauriCore();
+  if (!desktop) return Promise.resolve();
+  const previous = registrations.get(id) ?? Promise.resolve();
+  const adopted = previous.then(() =>
+    desktop.invoke<void>("oc_adopt_session", { connectionId: id, session }),
+  );
+  registrations.set(
+    id,
+    adopted.then(
+      () => undefined,
+      (error: unknown) => {
+        console.error(`[desktop] could not adopt the session for ${id}`, error);
+      },
+    ),
+  );
+  return adopted;
+}
+
+/**
  * Drops a host from the core.
  *
  * Sequenced after any registration still in flight. This and

--- a/frontend/src/api/transport/index.ts
+++ b/frontend/src/api/transport/index.ts
@@ -93,14 +93,21 @@ export function isAddressableBaseUrl(baseUrl: string): boolean {
  * different origin means no cookie is coming and the console has to hold a
  * token itself — which is what a hub console is built out of.
  *
- * False in the desktop whatever the address, and that is not an oversight: its
- * requests go through `ProxyTransport` to the Rust core, which attaches the
- * credential it holds in the keychain. Having the webview carry one too would
- * put a token in the page for no benefit, on the one runtime that had
- * successfully kept it out.
+ * True on the desktop too, for every cross-origin address, and the reason is
+ * one rung below the browser's: the core's HTTP client has no cookie jar —
+ * `reqwest` without the `cookies` feature — so the cookie a sign-in would
+ * otherwise set is discarded on arrival (issue #1855). Until this said so, the
+ * desktop signed in on the cookie path and was anonymous from the next request
+ * onward, which is the exact symptom the paragraph above warns about.
+ *
+ * What differs on the desktop is not whether the session is carried but WHO
+ * holds it: `adoptSession` hands it to the core, which stores it in the OS
+ * keychain and attaches it proxy-side — so the token still never lives in the
+ * page, which is the property this function's old desktop exemption was
+ * guarding. That exemption guarded it by making sign-in impossible; the core
+ * holding the token guards it while letting sign-in work.
  */
 export function needsCarriedSession(baseUrl: string): boolean {
-  if (isDesktopRuntime()) return false;
   // The empty string *is* same-origin, by the convention `ConsoleConfig` sets.
   if (baseUrl === "") return false;
   if (typeof window === "undefined") return false;

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -28,6 +28,7 @@ import {
   closeSshTunnel,
   forgetConnection,
   openSshTunnel,
+  adoptSessionIntoCore,
   registerConnection,
 } from "@/api/transport/desktop";
 import {
@@ -693,7 +694,30 @@ export function unpairConnection(id: ConnectionId): void {
  * Replaces the client, through `adoptCredential`, so every request after this
  * carries the new session rather than the one it was constructed with.
  */
-export function adoptSession(id: ConnectionId, session: string): void {
+export async function adoptSession(id: ConnectionId, session: string): Promise<void> {
+  // On the desktop the session goes to the CORE, not into this client
+  // (issue #1855). The webview cannot use it: the proxy strips a caller-
+  // supplied `x-opencompany-session` (`RESERVED_HEADERS`) and the event
+  // stream carries only the core-held credential — both deliberate, so the
+  // page never decides what a request authenticates as. The core stores it in
+  // the keychain under this connection id, which is exactly where a paired
+  // device's session lived and what `oc_connect` reads back on the next
+  // launch — so a sign-in here survives an app restart, which the browser's
+  // never could.
+  //
+  // Awaited by the caller before it probes: a probe that ran first would
+  // authenticate with the pre-sign-in credential and conclude the host still
+  // refuses us.
+  if (isDesktopRuntime()) {
+    await adoptSessionIntoCore(id, session);
+    // `device` rather than a webview-held `session`: the record says where the
+    // credential lives, and every check keyed off it — the insecure-transport
+    // refusal, what a probe may claim — already treats a core-held credential
+    // correctly under this kind. The ref names the pairing for a person; a
+    // sign-in has no device id, so it says what it is.
+    adoptCredential(id, { kind: "device", ref: "signed-in" });
+    return;
+  }
   adoptCredential(id, { kind: "session", value: session });
 }
 
@@ -961,6 +985,16 @@ async function runProbe(
       patch(id, { status: "live", companies: [], waking: false });
       return null;
     } catch (statusErr) {
+      // A 401 from the companies list outranks whatever the alias said
+      // (issue #1855). The fallback exists for single-company hosts, and on a
+      // platform host it answers 404 for everyone — so letting that 404 win
+      // reported "down" about a host that had answered, precisely, "sign in".
+      // `keepWaking` then retried `down` for the whole cloud wake window,
+      // which is the spinner-over-a-sign-in that `waking.ts` promises never
+      // to show.
+      if (listErr instanceof ApiError && listErr.status === 401) {
+        return statusFromError(listErr);
+      }
       return statusFromError(statusErr ?? listErr);
     }
   }

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -104,11 +104,22 @@ export function ConnectionConsole({
           try {
             await adoptSession(connectionId, result.session);
           } catch (error) {
-            // The session could not be stored (a keychain refusal, a plain-HTTP
-            // host the core will not carry a credential to). Probing anyway
-            // would 401 and land back on this sign-in screen with no
-            // explanation; the console names the reason instead.
-            console.error("[sign-in] the session could not be adopted", error);
+            // The session could not be kept — a locked keychain, a plain-HTTP
+            // host the core refuses to carry a credential to. Probing anyway
+            // would authenticate as nobody, 401, and land back on this screen
+            // wearing the generic "credential refused" face: a person who just
+            // signed in successfully, told their credential was wrong. So the
+            // sign-in view returns instead, carrying the refusal's own words —
+            // the core writes them for exactly this reading ("this host is not
+            // encrypted…" names an action; "sign-in failed" names nothing).
+            const reason =
+              error instanceof Error ? error.message : String(error ?? "the session could not be stored");
+            setPhase({
+              kind: "login",
+              company: defaultCompany,
+              notice: `You signed in, but this session could not be kept: ${reason}`,
+            });
+            return;
           }
         }
         await probe(connectionId);
@@ -116,7 +127,7 @@ export function ConnectionConsole({
         setBootEpoch((n) => n + 1);
       })();
     },
-    [connectionId],
+    [connectionId, defaultCompany],
   );
 
   useEffect(() => {

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -93,14 +93,28 @@ export function ConnectionConsole({
   const reBoot = useCallback(
     (result?: SignIn) => {
       // Store the session *before* probing. A cross-origin sign-in's token is
-      // the only proof this connection has — no cookie was set — and adopting
-      // it replaces the client, so a probe that ran first would authenticate
-      // with the pre-sign-in client and conclude the host still refuses us.
-      if (result?.session) adoptSession(connectionId, result.session);
-      void probe(connectionId).then(() => {
+      // the only proof this connection has — no cookie was set — and adoption
+      // replaces the credential (in the client here, in the core on the
+      // desktop), so a probe that ran first would authenticate with the
+      // pre-sign-in credential and conclude the host still refuses us. Hence
+      // awaited, not fired: on the desktop the adoption is an IPC round trip,
+      // and "before" has to mean before.
+      void (async () => {
+        if (result?.session) {
+          try {
+            await adoptSession(connectionId, result.session);
+          } catch (error) {
+            // The session could not be stored (a keychain refusal, a plain-HTTP
+            // host the core will not carry a credential to). Probing anyway
+            // would 401 and land back on this sign-in screen with no
+            // explanation; the console names the reason instead.
+            console.error("[sign-in] the session could not be adopted", error);
+          }
+        }
+        await probe(connectionId);
         setPhase({ kind: "loading" });
         setBootEpoch((n) => n + 1);
-      });
+      })();
     },
     [connectionId],
   );

--- a/frontend/test/unit/desktop-remote-signin.test.ts
+++ b/frontend/test/unit/desktop-remote-signin.test.ts
@@ -123,6 +123,28 @@ describe("adopting a sign-in on the desktop (#1855)", () => {
     expect(JSON.stringify(connection)).not.toContain("a-session-token");
   });
 
+  it("leaves the credential untouched when the core refuses the session", async () => {
+    // The core refuses for a reason it names — a locked keychain, a plain-HTTP
+    // remote host. Recording a `device` credential anyway would have every
+    // check treat this connection as signed-in while every request runs
+    // anonymous: the silence this whole issue is about, one layer up.
+    desktop(true, (cmd) =>
+      cmd === "oc_adopt_session"
+        ? Promise.reject(new Error("this host is not encrypted, so a credential cannot be sent to it"))
+        : Promise.resolve(),
+    );
+    const id = addConnection({
+      baseUrl: "https://acme.example.com",
+      transport: new RouteTransport({}),
+    });
+
+    await expect(adoptSession(id, "acme.a-session-token")).rejects.toThrow("not encrypted");
+
+    const connection = getConnection(id);
+    expect(connection?.credential.kind).not.toBe("device");
+    expect(JSON.stringify(connection)).not.toContain("a-session-token");
+  });
+
   it("keeps the browser path exactly as it was: the console holds the token", async () => {
     desktop(false);
     const id = addConnection({

--- a/frontend/test/unit/desktop-remote-signin.test.ts
+++ b/frontend/test/unit/desktop-remote-signin.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+//
+// Issue #1855: a desktop sign-in to a remote host must produce a credential
+// that actually works.
+//
+// The failure this pins was silent end to end. The desktop signed in on the
+// cookie path (`needsCarriedSession` said the desktop never carries a session),
+// the host answered with an `HttpOnly` cookie, and the Rust core — whose HTTP
+// client has no cookie jar — discarded it. Every request after a successful
+// sign-in was anonymous, the resulting 401 was masked to "down" by the
+// prosumer-alias fallback, and a `cloud` row then spun for the whole wake
+// window over a host that had answered, precisely, "sign in".
+//
+// Three rules, each of which failed quietly:
+//
+//   1. a cross-origin address needs a carried session in EVERY runtime — the
+//      desktop most of all, because it has no cookie jar anywhere;
+//   2. on the desktop the session goes to the CORE, never into the page —
+//      the proxy strips a webview-supplied session header by design, so a
+//      page-held token authenticates nothing;
+//   3. a 401 from the companies list is an answer, and no fallback's 404 may
+//      outrank it into "down".
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { needsCarriedSession } from "@/api/transport";
+import type { StreamHandlers, Transport, TransportRequest, TransportResponse } from "@/api/transport";
+import {
+  addConnection,
+  adoptSession,
+  getConnection,
+  probe,
+  resetConnections,
+} from "@/connections/registry";
+import { connectionConfig } from "@/connections/types";
+
+/** The v2 shape `isDesktopRuntime()` and `tauriCore()` read. */
+function desktop(present: boolean, invoke?: (cmd: string, args: unknown) => Promise<unknown>) {
+  if (present) {
+    (window as unknown as { __TAURI__: unknown }).__TAURI__ = {
+      core: { invoke: invoke ?? (() => Promise.resolve()), Channel: class {} },
+    };
+  } else {
+    delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
+  }
+}
+
+/** Answers each path with what the test staged; 404 for anything unstaged. */
+class RouteTransport implements Transport {
+  constructor(private readonly routes: Record<string, { status: number; text: string }>) {}
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    const path = new URL(req.url).pathname;
+    const staged = this.routes[path] ?? { status: 404, text: '{"error":"not found"}' };
+    return {
+      status: staged.status,
+      statusText: "",
+      url: req.url,
+      text: staged.text,
+      header: () => null,
+    };
+  }
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  resetConnections();
+});
+
+afterEach(() => {
+  desktop(false);
+  resetConnections();
+});
+
+describe("a cross-origin address needs a carried session in every runtime (#1855)", () => {
+  it("says so on the desktop, where the old exemption made sign-in impossible", () => {
+    desktop(true);
+    // jsdom's origin is localhost; a remote host is another origin entirely.
+    expect(needsCarriedSession("https://smoke1.staging.example.com")).toBe(true);
+  });
+
+  it("still lets a same-origin console keep its cookie", () => {
+    desktop(true);
+    // The empty string IS same-origin, by `ConsoleConfig`'s own convention —
+    // and the cookie stays the better credential wherever it works, because
+    // nothing in the page can read it.
+    expect(needsCarriedSession("")).toBe(false);
+  });
+
+  it("is unchanged in the browser", () => {
+    desktop(false);
+    expect(needsCarriedSession("https://smoke1.staging.example.com")).toBe(true);
+    expect(needsCarriedSession("")).toBe(false);
+  });
+});
+
+describe("adopting a sign-in on the desktop (#1855)", () => {
+  it("hands the session to the core and keeps the token out of the page", async () => {
+    const invokes: Array<{ cmd: string; args: unknown }> = [];
+    desktop(true, (cmd, args) => {
+      invokes.push({ cmd, args });
+      return Promise.resolve();
+    });
+    const id = addConnection({
+      baseUrl: "https://acme.example.com",
+      transport: new RouteTransport({}),
+    });
+
+    await adoptSession(id, "acme.a-session-token");
+
+    // The core got it, addressed to this connection.
+    const adopted = invokes.find((i) => i.cmd === "oc_adopt_session");
+    expect(adopted?.args).toMatchObject({ connectionId: id, session: "acme.a-session-token" });
+
+    // The page did not keep it: the credential records only WHERE the session
+    // lives, and the client this connection builds carries no session header —
+    // the proxy would strip one anyway, which is the whole point.
+    const connection = getConnection(id);
+    expect(connection?.credential.kind).toBe("device");
+    expect(connectionConfig(connection!).sessionHeader).toBeNull();
+    expect(JSON.stringify(connection)).not.toContain("a-session-token");
+  });
+
+  it("keeps the browser path exactly as it was: the console holds the token", async () => {
+    desktop(false);
+    const id = addConnection({
+      baseUrl: "https://acme.example.com",
+      transport: new RouteTransport({}),
+    });
+
+    await adoptSession(id, "acme.a-session-token");
+
+    const connection = getConnection(id);
+    expect(connection?.credential.kind).toBe("session");
+    expect(connectionConfig(connection!).sessionHeader).toBe("acme.a-session-token");
+  });
+});
+
+describe("a refused credential reads as a sign-in, not an outage (#1855)", () => {
+  it("lets the companies list's 401 outrank the prosumer alias's 404", async () => {
+    // A platform host that wants a sign-in: the list 401s, and the alias —
+    // which exists for single-company hosts — answers the 404 it answers
+    // everyone. Before the fix `statusFromError(statusErr ?? listErr)` let
+    // that 404 win, reported "down", and a cloud row then retried "down" for
+    // the whole 90s wake window: a spinner over a sign-in screen.
+    const id = addConnection({
+      baseUrl: "https://tenant.example.com",
+      transport: new RouteTransport({
+        "/spec": { status: 200, text: "{}" },
+        "/api/v1/companies": { status: 401, text: '{"error":"sign in"}' },
+        "/api/v1/company": { status: 404, text: '{"error":"not found"}' },
+      }),
+    });
+
+    await probe(id);
+
+    expect(getConnection(id)?.status).toBe("unauthenticated");
+  });
+
+  it("still reports a genuinely absent host as down", async () => {
+    // The fallback's own answer keeps mattering when the list's failure was
+    // not an auth refusal — a host with neither surface is still gone.
+    const id = addConnection({
+      baseUrl: "https://tenant.example.com",
+      transport: new RouteTransport({
+        "/spec": { status: 200, text: "{}" },
+        "/api/v1/companies": { status: 500, text: '{"error":"broken"}' },
+        "/api/v1/company": { status: 404, text: '{"error":"not found"}' },
+      }),
+    });
+
+    await probe(id);
+
+    expect(getConnection(id)?.status).toBe("down");
+  });
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -931,8 +931,7 @@ mod adopt_session_tests {
     async fn an_insecure_host_is_refused_before_anything_is_stored() {
         let proxy = registry_with("insecure-1", "http://192.168.1.20:8080").await;
 
-        let result =
-            adopt_session(&proxy, "insecure-1".to_string(), "acme.tok".to_string()).await;
+        let result = adopt_session(&proxy, "insecure-1".to_string(), "acme.tok".to_string()).await;
 
         let error = result.expect_err("a credential must not ride plain HTTP off-machine");
         assert!(error.contains("not encrypted"), "{error}");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -293,42 +293,80 @@ pub async fn oc_adopt_session(
     connection_id: String,
     session: String,
 ) -> Result<(), String> {
+    adopt_session(&proxy, connection_id, session).await
+}
+
+/// The body of [`oc_adopt_session`], off the `State` extractor so a test can
+/// drive it against a bare registry.
+///
+/// Ordered so that nothing durable happens until everything refusable has been
+/// refused, and everything durable is undone when a later step fails anyway:
+///
+/// 1. The connection is looked up first — adopting a session for a connection
+///    the core does not hold stores nothing.
+/// 2. The transport gate runs BEFORE the keychain write. `upsert` would refuse
+///    the credential afterwards, but by then the keychain would hold a session
+///    the next launch's `oc_connect` dutifully presents — and its `upsert`
+///    refuses the whole registration, leaving the connection unusable until
+///    someone finds the hidden keychain entry. The precheck is the same
+///    function `upsert` consults, so the two cannot disagree.
+/// 3. A read-back miss is an error, not a quiet `Credential::None`. The
+///    read-back exists to surface a write that did not survive; installing
+///    nothing and reporting success would have the console record a credential
+///    while every request runs anonymous — the exact silence this command was
+///    added to end.
+/// 4. An `upsert` refusal rolls the keychain entry back, best-effort, for the
+///    same reason as (2): a credential the registry refused must not ambush
+///    the next launch.
+pub(crate) async fn adopt_session(
+    proxy: &crate::proxy::ProxyRegistry,
+    connection_id: String,
+    session: String,
+) -> Result<(), String> {
     // Refused before anything is stored: a session that authenticates as
     // nobody must not survive into the keychain, where the next launch would
     // dutifully present it and read the host's 401 as a revoked sign-in.
     if session.trim().is_empty() {
         return Err("a sign-in session cannot be empty".to_string());
     }
-    crate::keychain::remember_device(&connection_id, &session)
-        .map_err(|error| error.to_string())?;
-
-    // Re-register so the credential takes effect without waiting for a reload,
-    // exactly as `oc_pair_device` does — and like there, the session is read
-    // back from the keychain rather than reused from the argument: what
-    // matters is what the store will hand out on the *next* boot, so a write
-    // that did not survive surfaces here rather than as a mysterious 401
-    // later.
     let base_url = proxy
         .base_url(&connection_id)
         .await
         .map_err(|error| error.to_string())?;
-    let credential = match crate::keychain::device_session(&connection_id) {
-        Some(session) => Credential::Device(session),
-        None => Credential::None,
+    if !may_carry_a_credential(&base_url) {
+        // The registry's own words for this refusal, so the sign-in screen and
+        // a failed registration name the problem identically.
+        return Err(crate::proxy::ProxyError::InsecureBaseUrl(base_url).to_string());
+    }
+
+    crate::keychain::remember_device(&connection_id, &session)
+        .map_err(|error| error.to_string())?;
+
+    // Read back from the store rather than reused from the argument: what
+    // matters is what the store will hand out on the *next* boot, so a write
+    // that did not survive surfaces here — as a failure, with the entry
+    // removed — rather than as a mysterious 401 later.
+    let Some(stored) = crate::keychain::device_session(&connection_id) else {
+        let _ = crate::keychain::forget_device(&connection_id);
+        return Err(
+            "the session was stored but could not be read back from the keychain".to_string(),
+        );
     };
-    // `upsert` re-runs the transport gate, so a plain-HTTP remote host refuses
-    // the credential here — at sign-in, where the person is still looking —
-    // rather than silently carrying a secret over a wire anyone can read.
     proxy
         .upsert(
-            connection_id,
+            connection_id.clone(),
             Connection {
                 base_url,
-                credential,
+                credential: Credential::Device(stored),
             },
         )
         .await
-        .map_err(|error| error.to_string())
+        .map_err(|error| {
+            // Best-effort: the refusal is the error worth reporting, and a
+            // failed tidy-up must not replace it.
+            let _ = crate::keychain::forget_device(&connection_id);
+            error.to_string()
+        })
 }
 
 /// Forgets this machine's stored session for a connection.
@@ -862,4 +900,87 @@ mod test {
 #[tauri::command]
 pub async fn oc_device_identity() -> Result<crate::identity::DeviceIdentity, String> {
     Ok(crate::identity::device_identity())
+}
+
+#[cfg(test)]
+mod adopt_session_tests {
+    use super::adopt_session;
+    use crate::proxy::{Connection, Credential, ProxyRegistry};
+
+    async fn registry_with(id: &str, base_url: &str) -> ProxyRegistry {
+        let proxy = ProxyRegistry::new();
+        proxy
+            .upsert(
+                id.to_string(),
+                Connection {
+                    base_url: base_url.to_string(),
+                    credential: Credential::None,
+                },
+            )
+            .await
+            .expect("a bare registration is always accepted");
+        proxy
+    }
+
+    /// The bricking sequence issue #1858's review named: a plain-HTTP remote
+    /// host's sign-in must be refused BEFORE the keychain write, because a
+    /// stored session the next launch's `oc_connect` presents makes `upsert`
+    /// refuse the whole registration — a connection unusable until someone
+    /// finds the hidden keychain entry.
+    #[tokio::test]
+    async fn an_insecure_host_is_refused_before_anything_is_stored() {
+        let proxy = registry_with("insecure-1", "http://192.168.1.20:8080").await;
+
+        let result =
+            adopt_session(&proxy, "insecure-1".to_string(), "acme.tok".to_string()).await;
+
+        let error = result.expect_err("a credential must not ride plain HTTP off-machine");
+        assert!(error.contains("not encrypted"), "{error}");
+        assert!(
+            crate::keychain::device_session("insecure-1").is_none(),
+            "nothing may survive into the keychain for the next launch to trip over"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_connection_stores_nothing() {
+        let proxy = ProxyRegistry::new();
+
+        let result = adopt_session(&proxy, "nobody-1".to_string(), "acme.tok".to_string()).await;
+
+        assert!(result.is_err());
+        assert!(crate::keychain::device_session("nobody-1").is_none());
+    }
+
+    #[tokio::test]
+    async fn an_empty_session_is_refused_outright() {
+        let proxy = registry_with("empty-1", "https://acme.example.com").await;
+
+        let result = adopt_session(&proxy, "empty-1".to_string(), "   ".to_string()).await;
+
+        assert!(result.is_err());
+        assert!(crate::keychain::device_session("empty-1").is_none());
+    }
+
+    /// The happy path, on the transports a credential may ride: https anywhere,
+    /// and plain HTTP only to this machine (the embedded host's own case).
+    #[tokio::test]
+    async fn a_session_is_kept_where_a_credential_may_travel() {
+        for (id, base_url) in [
+            ("kept-https", "https://acme.example.com"),
+            ("kept-local", "http://127.0.0.1:8080"),
+        ] {
+            let proxy = registry_with(id, base_url).await;
+
+            adopt_session(&proxy, id.to_string(), "acme.tok".to_string())
+                .await
+                .expect("a securely-reachable host keeps its sign-in");
+
+            assert_eq!(
+                crate::keychain::device_session(id).as_deref(),
+                Some("acme.tok"),
+                "the next launch's oc_connect reads this back"
+            );
+        }
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -271,6 +271,66 @@ pub async fn oc_pair_device(
     })
 }
 
+/// Adopts a session a sign-in just returned, as this connection's credential.
+///
+/// The desktop's sign-in flow asks the host for the header carrier — there is
+/// no cookie jar behind [`oc_request`], so the cookie the host would otherwise
+/// set has nowhere to live — and the readable session it gets back is handed
+/// here rather than kept in the webview. That is the property the proxy's
+/// `RESERVED_HEADERS` exists to hold: the page never holds a credential, so a
+/// script injected into rendered agent markdown cannot exfiltrate one, and it
+/// cannot choose what a request authenticates as either, because the proxy
+/// attaches the credential itself.
+///
+/// This is `oc_pair_device` minus the pairing ceremony. A sign-in's session and
+/// a paired device's are the same thing to every layer below: the host renders
+/// both as `<company>.<token>`, the keychain stores both under the connection
+/// id, and [`Credential::Device`] carries both in the same header. The claim
+/// step is the only difference, and the sign-in already did its own.
+#[tauri::command]
+pub async fn oc_adopt_session(
+    proxy: State<'_, SharedProxy>,
+    connection_id: String,
+    session: String,
+) -> Result<(), String> {
+    // Refused before anything is stored: a session that authenticates as
+    // nobody must not survive into the keychain, where the next launch would
+    // dutifully present it and read the host's 401 as a revoked sign-in.
+    if session.trim().is_empty() {
+        return Err("a sign-in session cannot be empty".to_string());
+    }
+    crate::keychain::remember_device(&connection_id, &session)
+        .map_err(|error| error.to_string())?;
+
+    // Re-register so the credential takes effect without waiting for a reload,
+    // exactly as `oc_pair_device` does — and like there, the session is read
+    // back from the keychain rather than reused from the argument: what
+    // matters is what the store will hand out on the *next* boot, so a write
+    // that did not survive surfaces here rather than as a mysterious 401
+    // later.
+    let base_url = proxy
+        .base_url(&connection_id)
+        .await
+        .map_err(|error| error.to_string())?;
+    let credential = match crate::keychain::device_session(&connection_id) {
+        Some(session) => Credential::Device(session),
+        None => Credential::None,
+    };
+    // `upsert` re-runs the transport gate, so a plain-HTTP remote host refuses
+    // the credential here — at sign-in, where the person is still looking —
+    // rather than silently carrying a secret over a wire anyone can read.
+    proxy
+        .upsert(
+            connection_id,
+            Connection {
+                base_url,
+                credential,
+            },
+        )
+        .await
+        .map_err(|error| error.to_string())
+}
+
 /// Forgets this machine's stored session for a connection.
 ///
 /// Local only. The session record on the host outlives it — revoking that is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::oc_connect,
             commands::oc_pair_device,
+            commands::oc_adopt_session,
             commands::oc_forget_device,
             commands::oc_disconnect,
             commands::oc_connections,


### PR DESCRIPTION
## Summary

Signing in to a remote host from the desktop succeeded on the host and was thrown away on the way back. The console asked for a cookie — `needsCarriedSession` exempted the desktop, a rule written when the desktop paired devices — and the Rust core, whose reqwest client is built without the `cookies` feature, discarded it. Every request after a successful sign-in was anonymous; `/healthz` kept working, which made sign-in look like the only broken thing when it was the only credential-free thing left. The resulting 401 was then masked to "down" by the prosumer-alias fallback, and a `cloud` row spun on "Connecting…" for the whole 90-second wake window over a host that had answered, precisely, "sign in".

Each link was executed, not inferred, against a local `auth_mode = email` host: the cookie-path sign-in yields no readable session where the carrier-header path yields one; a request with that session in `x-opencompany-session` answers 200 where no credential answers 401.

**Why the one-line fix cannot work.** Letting the webview carry the session dies against the proxy's own defences, both deliberate: `RESERVED_HEADERS` strips a caller-supplied `x-opencompany-session` so the page can never decide what a request authenticates as, and `subscribe()` takes no caller headers at all — a page-held token authenticates nothing, and the event stream least of all.

Both defences point the same way: on the desktop the credential must live in the core. That was always the design — `apply_credential`'s comment calls the header carrier the thing that "exists precisely because a desktop cannot use the cookie" — and every piece it needs survived pairing's removal, disconnected: the keychain storage, `Credential::Device`, the proxy-side attach on requests and the stream alike, and `oc_connect`'s keychain read at registration. This PR reconnects them; the sign-in's session is byte-for-byte the `<company>.<token>` form a paired device's was.

Closes #1855.

## API Or Behavior Changes

One new tauri command, `oc_adopt_session(connection_id, session)` — `oc_pair_device` minus the pairing ceremony: refuses an empty session, stores through the keychain, re-registers with the credential read back from the store so a write that did not survive surfaces at sign-in rather than as a mysterious 401 later. Registered in the invoke handler; reachable only from the webview like every other command.

Behavior:

- `needsCarriedSession` no longer exempts the desktop: a cross-origin address needs a carried session in every runtime, and what differs on the desktop is who holds it, not whether it is carried. Same-origin consoles keep their cookie; the browser build is byte-for-byte unchanged.
- `adoptSession` is now async and branches on runtime — the core on the desktop (recorded as a `device` credential, the kind every existing check already treats as core-held), the client in a hub console, unchanged. The sign-in view awaits the adoption before probing, because on the desktop it is an IPC round trip and "store before probing" has to mean before.
- A 401 from the companies list outranks the prosumer alias's 404 in the probe fallback: an auth refusal now reads "Sign-in needed" immediately instead of spinning through the cloud wake window as "down".
- Two things fall out for free: the event stream authenticates (the proxy attaches the same credential to `subscribe()`), and a sign-in survives an app restart (`oc_connect` has always read the keychain at registration; there was just never anything in it).

The token never enters webview state: the connection record says only where the credential lives, and the serialized connection is asserted not to contain it.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — and `--manifest-path src-tauri/Cargo.toml --locked --features opencompany/acp,opencompany/composio`, the release feature set CI pins
- [x] `cargo build --all-targets` — via the src-tauri test build; the root crate is untouched
- [x] `cargo test` — root suite untouched by this diff; `cargo test --manifest-path src-tauri/Cargo.toml --locked --features opencompany/acp,opencompany/composio` passes

Also run:

- `pnpm typecheck`, `typecheck:unit`, `typecheck:e2e`, and `pnpm test` — 3,316 across 357 files, including 7 new tests in `test/unit/desktop-remote-signin.test.ts`, one per silent failure: the desktop carries cross-origin, same-origin keeps its cookie, the browser is unchanged, the adopted session reaches the core while the serialized connection does not contain the token, the browser still holds its own, 401 → `unauthenticated`, and a 500+404 still reads `down`.
- End to end on the actual desktop app against a hosted staging tenant: sign-in lands, the row goes live, companies load. The same flow reproduced the original failure before the change.

Not covered by an automated test: `oc_adopt_session` itself, which is thin plumbing over `keychain::remember_device` + `upsert` — the keychain half talks to the OS store, and the command mirrors `oc_pair_device`'s tested shape line for line.

## Documentation

The reasoning lives at the code it explains, matching how this repo documents transport rules: `needsCarriedSession`'s doc now states the desktop's real cookie situation instead of the pairing-era exemption, `oc_adopt_session` carries the design argument, and the probe fallback's comment names the failure it prevents. Issue #1855 holds the full executed reproduction.
