### PR TITLE
fix(console): route #/work to the Work board (#1797)

### DIFF
--- a/frontend/src/lib/console-route-rewrites.ts
+++ b/frontend/src/lib/console-route-rewrites.ts
@@ -17,8 +17,13 @@ export const REWRITE_RETIRED = (
   if (head === "tasks" && taskIdFromSegment(sub) === null) return ["ledgers", BOARD_LEDGER];
   // `#/work` is where the "Work" nav row points in shared and bookmarked links;
   // the board itself lives at `#/ledgers/tasks`, so send the alias there rather
-  // than let it fall through to not-found (issue #1797).
-  if (head === "work") return ["ledgers", BOARD_LEDGER];
+  // than let it fall through to not-found (issue #1797). Bare only: the Work
+  // surface's real sub-pages are addressed under `#/ledgers/...` (for example
+  // `#/ledgers/manage`), never under `#/work/...`, so a `sub` here names
+  // nothing this alias can answer — swallowing it would silently show the
+  // board for an address that meant something else. Leave it to fall through
+  // to the same not-found handling any other unrecognized head gets.
+  if (head === "work" && !sub) return ["ledgers", BOARD_LEDGER];
   if (head === "memory") return ["settings", "brain"];
   // Settings owns a fixed table of sub-pages, unlike the entity ids beneath
   // Team and Workspace. Do not render General under an address that names no

--- a/frontend/src/lib/console-route-rewrites.ts
+++ b/frontend/src/lib/console-route-rewrites.ts
@@ -15,6 +15,10 @@ export const REWRITE_RETIRED = (
   sub: string | null,
 ): [View, string | null] | null => {
   if (head === "tasks" && taskIdFromSegment(sub) === null) return ["ledgers", BOARD_LEDGER];
+  // `#/work` is where the "Work" nav row points in shared and bookmarked links;
+  // the board itself lives at `#/ledgers/tasks`, so send the alias there rather
+  // than let it fall through to not-found (issue #1797).
+  if (head === "work") return ["ledgers", BOARD_LEDGER];
   if (head === "memory") return ["settings", "brain"];
   // Settings owns a fixed table of sub-pages, unlike the entity ids beneath
   // Team and Workspace. Do not render General under an address that names no

--- a/frontend/test/unit/console-routes.test.ts
+++ b/frontend/test/unit/console-routes.test.ts
@@ -147,6 +147,33 @@ describe("resolving an address", () => {
     expect(window.location.hash).toBe(`#/${view}/${sub}`);
   });
 
+  // #1867 review: `#/work` is a bare-only alias onto the ledgers board — the
+  // Work surface's real sub-pages are addressed under `#/ledgers/...` (for
+  // example `#/ledgers/manage`), never under `#/work/...`. Before this test,
+  // the rewrite ignored `sub` entirely, so a plausible-looking deep link like
+  // `#/work/manage` silently collapsed onto the bare board instead of the
+  // named page. That is worse than the address simply being unknown: it looks
+  // like it worked. An address with a sub-segment is unknown here and falls
+  // through to the same not-found handling any other unrecognized head gets.
+  it("does not swallow a deep link under the bare-only #/work alias (#1797)", async () => {
+    rewrite = REWRITE_RETIRED;
+    await visit("#/work/manage");
+    expect(seen).toEqual(["not-found", "work"]);
+    expect(window.location.hash).toBe("#/not-found/work");
+  });
+
+  // A trailing slash with nothing after it (`#/work/`) is not a deep link —
+  // `readSegments` in `use-hash-view.ts` filters the empty final segment out,
+  // so this is indistinguishable from the bare `#/work` and resolves the same
+  // way. Asserted explicitly so the decision is a passing test, not something
+  // left to fall out of string-splitting.
+  it("treats a trailing slash on #/work the same as the bare address (#1797)", async () => {
+    rewrite = REWRITE_RETIRED;
+    await visit("#/work/");
+    expect(seen).toEqual(["ledgers", "tasks"]);
+    expect(window.location.hash).toBe("#/ledgers/tasks");
+  });
+
   it("sends an empty address to the operator overview (#1321)", async () => {
     rewrite = undefined;
     await visit("/");

--- a/frontend/test/unit/console-routes.test.ts
+++ b/frontend/test/unit/console-routes.test.ts
@@ -138,6 +138,7 @@ describe("resolving an address", () => {
     ["#/oauth", "settings", "oauth"],
     ["#/mcp", "settings", "mcp"],
     ["#/people", "settings", "people"],
+    ["#/work", "ledgers", "tasks"],
     ["#/settings/not-a-page", "settings", "general"],
   ])("rewrites retired %s onto its replacement", async (hash, view, sub) => {
     rewrite = REWRITE_RETIRED;


### PR DESCRIPTION
## Summary

The sidebar **Work** row lands on `#/ledgers/tasks`, but the address a user assumes — `#/work` — was never a registered route. `work` is not a member of the console route allow-list `VIEWS` and had no rule in the retired-address resolver `REWRITE_RETIRED`, so `#/work` fell through the terminal catch-all to `not-found`. Any shared or bookmarked `#/work` link was dead.

This adds a single alias rule in `REWRITE_RETIRED` — `#/work` → `["ledgers", "tasks"]` — using the same retired-route convention already used for `#/tasks`, `#/memory`, `#/team`, `#/connections`. The router's canonicalize then rewrites the bar to `#/ledgers/tasks`, exactly where the Work nav row lands. Every existing `#/ledgers/*` link is untouched.

## API Or Behavior Changes

`#/work` now resolves to the Work board instead of the not-found page. No other route changes. The address bar still canonicalizes to `#/ledgers/tasks` after clicking Work (the alternative — renaming the `ledgers` view to `work` so the bar literally reads `#/work` — was rejected because it would break every existing `#/ledgers/*` link).

## Tests

Frontend (from `frontend/`; this repo has no frontend lint gate):

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npx vitest run` — 3310 tests pass; `console-routes.test.ts` 33/33 including the new `#/work` row
- [x] `npm run build`

New unit row `["#/work", "ledgers", "tasks"]` in `frontend/test/unit/console-routes.test.ts` locks the alias + address-bar canonicalization against regression.

## Documentation

None needed — internal route alias, no public API or spec surface.

Closes #1797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the retired `#/work` route as an alias for the board.
  * Users visiting `#/work` are now redirected to `#/ledgers/tasks` instead of seeing a not-found page.

* **Tests**
  * Added coverage to verify the route rewrite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->