### PR TITLE
fix(runs): settle by-design workflow-build refusals as Declined, not Failed (#1809)

### DIFF
--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -25,6 +25,11 @@ import type { TimelineEntry } from "./tasks";
  * `paused` is currently unreachable from a delegation, so nothing in the UI may
  * *depend* on seeing it — but it is handled everywhere a status is, because a
  * status the console cannot render is worse than one it never meets.
+ *
+ * `declined` is terminal and means the workflow compiler declined *by design* to
+ * automate the work ("better done once than built into a workflow", issue
+ * #1809) — neither an error nor an ordinary success, so it must never render in
+ * a failure tone.
  */
 export type RunStatus =
   | "pending"
@@ -33,7 +38,8 @@ export type RunStatus =
   | "paused"
   | "succeeded"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "declined";
 
 /**
  * The coarse phase of a {@link RunStatus}, projected by the host.
@@ -219,6 +225,7 @@ export const RUN_STATUS_LABEL: Record<RunStatus, string> = {
   succeeded: "Succeeded",
   failed: "Failed",
   cancelled: "Cancelled",
+  declined: "Declined",
 };
 
 /**

--- a/frontend/src/views/observatory/AnalyticsLens.tsx
+++ b/frontend/src/views/observatory/AnalyticsLens.tsx
@@ -36,6 +36,8 @@ const config = {
   succeeded: { label: "Succeeded", color: "var(--status-done)" },
   failed: { label: "Failed", color: "var(--status-failed)" },
   blocked: { label: "Blocked", color: "var(--status-blocked)" },
+  // A by-design refusal (issue #1809) — never folded into "Succeeded".
+  declined: { label: "Declined", color: "var(--status-idle)" },
   n: { label: "Occurrences", color: "var(--chart-4)" },
 } satisfies ChartConfig;
 
@@ -137,7 +139,9 @@ export function AnalyticsLens({ runs }: { runs: ObservatoryRun[] }) {
           <CardTitle className="text-base">Where runs stop</CardTitle>
           <CardDescription>
             Outcomes per graph node. Blocked is kept apart from failed — a node
-            waiting on a person has not gone wrong.
+            waiting on a person has not gone wrong. Declined is kept apart from
+            succeeded — a node the compiler refused to automate has not
+            succeeded either.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -159,6 +163,7 @@ export function AnalyticsLens({ runs }: { runs: ObservatoryRun[] }) {
                 <ChartLegend content={<ChartLegendContent />} />
                 <Bar dataKey="succeeded" stackId="o" fill="var(--color-succeeded)" />
                 <Bar dataKey="blocked" stackId="o" fill="var(--color-blocked)" />
+                <Bar dataKey="declined" stackId="o" fill="var(--color-declined)" />
                 <Bar dataKey="failed" stackId="o" fill="var(--color-failed)" />
               </BarChart>
             </ChartContainer>

--- a/frontend/src/views/observatory/AttemptCard.tsx
+++ b/frontend/src/views/observatory/AttemptCard.tsx
@@ -21,6 +21,8 @@ const TONE = {
   failed: "border-l-[var(--status-failed)]",
   blocked: "border-l-[var(--status-blocked)]",
   running: "border-l-[var(--status-running)]",
+  // A declined attempt (issue #1809) — neutral, never green.
+  idle: "border-l-[var(--status-idle)]",
 } as const;
 
 /** Whether this attempt should start open. */

--- a/frontend/src/views/observatory/ObservatoryView.tsx
+++ b/frontend/src/views/observatory/ObservatoryView.tsx
@@ -399,7 +399,13 @@ function RunIndex({ runs }: { runs: ObservatoryRun[] }) {
               ? "blocked"
               : own.some((r) => runState(r) === "running")
                 ? "running"
-                : "done";
+                // A declined attempt (issue #1809) keeps the group's dot out
+                // of "done" green even when nothing failed — the workflow
+                // refused part of its own work, which is not the same claim
+                // as every attempt succeeding.
+                : own.some((r) => runState(r) === "idle")
+                  ? "idle"
+                  : "done";
           const started = Math.min(
             ...own.map((r) => r.startedAtMillis ?? r.createdAtMillis),
           );
@@ -415,6 +421,7 @@ function RunIndex({ runs }: { runs: ObservatoryRun[] }) {
                     worst === "failed" && "bg-[var(--status-failed)]",
                     worst === "blocked" && "bg-[var(--status-blocked)]",
                     worst === "running" && "bg-[var(--status-running)]",
+                    worst === "idle" && "bg-[var(--status-idle)]",
                     worst === "done" && "bg-[var(--status-done)]",
                   )}
                 />

--- a/frontend/src/views/observatory/README.md
+++ b/frontend/src/views/observatory/README.md
@@ -68,6 +68,12 @@ The two get different tones and are counted separately in `byNode`, because
 folding them sends an operator hunting a bug in the node that most often just
 needs a click.
 
+**Declined is not succeeded.** A by-design compiler refusal (issue #1809) is a
+clean terminal outcome, not a failure — but it did not succeed either. It gets
+the `idle` tone (the closed vocabulary's neutral word — never `done`'s green,
+never `failed`'s red) in `AttemptCard`, the waterfall span and a workflow run's
+summary dot, and its own `declined` column in `byNode`, apart from `succeeded`.
+
 ## Redacted vs raw
 
 A step carries both halves and the panes label which is which. `detail` and

--- a/frontend/src/views/observatory/StepRow.tsx
+++ b/frontend/src/views/observatory/StepRow.tsx
@@ -18,12 +18,19 @@ import type { ObservatoryStep } from "@/api/observatory";
 import { clampText, formatBytes, present } from "./clamp";
 import { stepState } from "./model";
 
-/** Tone per step state, matching the waterfall's vocabulary. */
+/**
+ * Tone per step state, matching the waterfall's vocabulary.
+ *
+ * `idle` is unreachable here — `stepState` never returns it, only `runState`
+ * does (issue #1809's decline is a run-level outcome, not a step one) — but
+ * `SpanState` is one shared type, so the map must stay exhaustive.
+ */
 const TONE = {
   done: "text-muted-foreground",
   failed: "text-[var(--status-failed-text)]",
   blocked: "text-[var(--status-blocked-text)]",
   running: "text-[var(--status-running-text)]",
+  idle: "text-[var(--status-idle-text)]",
 } as const;
 
 const GLYPH: Record<string, string> = {

--- a/frontend/src/views/observatory/WaterfallLens.tsx
+++ b/frontend/src/views/observatory/WaterfallLens.tsx
@@ -27,6 +27,8 @@ const TONE: Record<SpanState, string> = {
   failed: "bg-[var(--status-failed)]",
   blocked: "bg-[var(--status-blocked)]",
   running: "bg-[var(--status-running)]",
+  // A declined attempt (issue #1809) — neutral, never green.
+  idle: "bg-[var(--status-idle)]",
 };
 
 interface Props {

--- a/frontend/src/views/observatory/model.ts
+++ b/frontend/src/views/observatory/model.ts
@@ -14,6 +14,12 @@ export function runState(run: ObservatoryRun): SpanState {
   switch (run.status) {
     case "succeeded":
       return "done";
+    // A by-design decline (issue #1809) is a clean terminal outcome, not a
+    // failure and not still in flight — it paints "done" like a success, never
+    // red, and never the `default` "running" that would leave a settled attempt
+    // reading as live forever.
+    case "declined":
+      return "done";
     case "failed":
     case "cancelled":
       return "failed";

--- a/frontend/src/views/observatory/model.ts
+++ b/frontend/src/views/observatory/model.ts
@@ -15,11 +15,15 @@ export function runState(run: ObservatoryRun): SpanState {
     case "succeeded":
       return "done";
     // A by-design decline (issue #1809) is a clean terminal outcome, not a
-    // failure and not still in flight — it paints "done" like a success, never
-    // red, and never the `default` "running" that would leave a settled attempt
-    // reading as live forever.
+    // failure and not still in flight — but it is not a success either, so it
+    // must not paint "done"'s green. `RunTimeline` and `AgentRuns` already
+    // give `declined` the same neutral tone `cancelled` wears; here that is
+    // "idle", the closed vocabulary's own word for "nothing is happening and
+    // nothing went wrong" (the tone `stopped`/`stranded` wear in
+    // `run-health.ts`) — never red, and never the `default` "running" that
+    // would leave a settled attempt reading as live forever.
     case "declined":
-      return "done";
+      return "idle";
     case "failed":
     case "cancelled":
       return "failed";
@@ -183,6 +187,8 @@ export interface NodeOutcome {
   succeeded: number;
   failed: number;
   blocked: number;
+  /** By-design refusals (issue #1809) — never folded into `succeeded`. */
+  declined: number;
 }
 
 /**
@@ -190,17 +196,27 @@ export interface NodeOutcome {
  *
  * `blocked` is counted apart from `failed` deliberately: a node waiting on a
  * person has not gone wrong, and folding the two would send an operator hunting
- * a bug in the node that most often needs a click.
+ * a bug in the node that most often needs a click. `declined` is counted apart
+ * from `succeeded` for the same reason in reverse (issue #1809): a node the
+ * compiler refused to automate has not succeeded, and folding it in would tell
+ * an operator a gate is healthy when it is actually the one being declined.
  */
 export function byNode(runs: ObservatoryRun[]): NodeOutcome[] {
   const map = new Map<string, NodeOutcome>();
   for (const run of runs) {
     const nodeId = run.nodeId;
     if (!nodeId) continue;
-    const row = map.get(nodeId) ?? { nodeId, succeeded: 0, failed: 0, blocked: 0 };
+    const row = map.get(nodeId) ?? {
+      nodeId,
+      succeeded: 0,
+      failed: 0,
+      blocked: 0,
+      declined: 0,
+    };
     const state = runState(run);
     if (state === "failed") row.failed += 1;
     else if (state === "blocked") row.blocked += 1;
+    else if (state === "idle") row.declined += 1;
     else if (state === "done") row.succeeded += 1;
     map.set(nodeId, row);
   }

--- a/frontend/src/views/observatory/waterfall.ts
+++ b/frontend/src/views/observatory/waterfall.ts
@@ -14,8 +14,16 @@
  * is really parallel until you can see the overlap.
  */
 
-/** How a span should be tinted — the run-health vocabulary, not a new one. */
-export type SpanState = "done" | "failed" | "running" | "blocked";
+/**
+ * How a span should be tinted — the run-health vocabulary, not a new one.
+ *
+ * `idle` is the closed set's neutral word (docs/design-system/color.md): the
+ * tone `run-health.ts` already gives `stopped` and `stranded` for "nothing is
+ * happening and nothing went wrong". A by-design decline (issue #1809) reaches
+ * for it too — it is a clean terminal outcome, but not a success, so it must
+ * not share `done`'s green.
+ */
+export type SpanState = "done" | "failed" | "running" | "blocked" | "idle";
 
 /** One bar: an agent doing one thing over an interval. */
 export interface Span {

--- a/frontend/src/views/runs/RunTimeline.tsx
+++ b/frontend/src/views/runs/RunTimeline.tsx
@@ -49,6 +49,11 @@ import { cn } from "@/lib/utils";
  * The tone of a run's status chip. `waiting_approval` and `paused` share the
  * amber "parked" tone the waiting band already uses — they differ in *who*
  * unblocks them, not in whether the company is stuck.
+ *
+ * `declined` shares the neutral muted tone `cancelled` uses (issue #1809): a
+ * by-design compiler refusal is terminal but is neither a failure nor a
+ * success, so it must never take the red failure tone — nor the blue "running"
+ * tone the default arm would otherwise hand a status it did not recognise.
  */
 export function runStatusTone(status: RunStatus): string {
   switch (status) {
@@ -57,6 +62,7 @@ export function runStatusTone(status: RunStatus): string {
     case "failed":
       return "border-status-failed/40 text-status-failed-text";
     case "cancelled":
+    case "declined":
       return "border-muted-foreground/30 text-muted-foreground";
     case "waiting_approval":
     case "paused":

--- a/frontend/src/views/team/AgentRuns.tsx
+++ b/frontend/src/views/team/AgentRuns.tsx
@@ -122,6 +122,10 @@ function statusIcon(status: RunStatus) {
     case "failed":
       return <XCircle className="size-4" />;
     case "cancelled":
+    // A by-design decline (issue #1809) is terminal and neutral, so it takes the
+    // same quiet icon as a cancel — never the spinning `default`, which would
+    // paint a settled attempt as still running.
+    case "declined":
       return <Ban className="size-4" />;
     case "waiting_approval":
     case "paused":

--- a/frontend/test/unit/observatory-model.test.ts
+++ b/frontend/test/unit/observatory-model.test.ts
@@ -64,6 +64,20 @@ describe("runState", () => {
     expect(runState(run({ status: "succeeded" }))).toBe("done");
     expect(runState(run({ status: "running" }))).toBe("running");
   });
+
+  it("keeps a declined refusal out of the success tone (issue #1809)", () => {
+    // A by-design decline is neither a failure nor a success — `RunTimeline`
+    // and `AgentRuns` already paint it the same neutral tone `cancelled`
+    // gets, never green. Folding it into "done" here would paint an
+    // AttemptCard, the waterfall span and a workflow-run's summary dot green
+    // for a run that was refused, not completed — and would count it in
+    // `byNode`'s `succeeded` column. "idle" is the closed vocabulary's own
+    // neutral word (docs/design-system/color.md), the one `stopped` and
+    // `stranded` already wear for "nothing is happening, nothing went
+    // wrong" — not a sixth colour invented for this one status.
+    expect(runState(run({ status: "declined" }))).toBe("idle");
+    expect(runState(run({ status: "declined" }))).not.toBe("done");
+  });
 });
 
 describe("spansFromRuns", () => {
@@ -181,7 +195,27 @@ describe("byNode", () => {
       run({ id: "b", nodeId: "check", status: "waiting_approval" }),
       run({ id: "c", nodeId: "check", status: "succeeded" }),
     ]);
-    expect(rows[0]).toEqual({ nodeId: "check", succeeded: 1, failed: 1, blocked: 1 });
+    expect(rows[0]).toEqual({
+      nodeId: "check",
+      succeeded: 1,
+      failed: 1,
+      blocked: 1,
+      declined: 0,
+    });
+  });
+
+  it("keeps a declined refusal out of the succeeded column (issue #1809)", () => {
+    const rows = byNode([
+      run({ id: "a", nodeId: "gate", status: "declined" }),
+      run({ id: "b", nodeId: "gate", status: "succeeded" }),
+    ]);
+    expect(rows[0]).toEqual({
+      nodeId: "gate",
+      succeeded: 1,
+      failed: 0,
+      blocked: 0,
+      declined: 1,
+    });
   });
 
   it("ranks the node that stops runs most, first", () => {

--- a/src/harness/built_in/workflow_build.rs
+++ b/src/harness/built_in/workflow_build.rs
@@ -452,9 +452,9 @@ pub async fn run_workflow_build_pass(
     let spec = match draft.into_outcome() {
         BuildOutcome::NotAutomatable(reason) => {
             // Issue #873: a verdict, not a fault. `settle_not_automatable`
-            // settles the attempt Succeeded and converts the card to a `once`
-            // deliverable so the next dispatch reaches its assignee instead of
-            // re-entering this pass to draw the same conclusion again.
+            // settles the attempt Declined (issue #1809) and converts the card to
+            // a `once` deliverable so the next dispatch reaches its assignee
+            // instead of re-entering this pass to draw the same conclusion again.
             settle_not_automatable(
                 &runtime,
                 &task_id,
@@ -743,10 +743,15 @@ async fn settle_to_todo(
 /// bug: the same door served both, so a correct refusal was filed as a failure
 /// and then retried forever.
 ///
-/// 1. **The attempt settles `Succeeded`.** The builder was asked a question and
-///    answered it. Filing that as `Failed` made an honest "don't automate this"
-///    indistinguishable from a model timeout — to the console, to the attempt
-///    history, and to anything counting failures.
+/// 1. **The attempt settles [`Declined`](RunStatus::Declined)** (issue #1809).
+///    The builder was asked a question and answered it. Filing that as `Failed`
+///    made an honest "don't automate this" indistinguishable from a model
+///    timeout — to the console, to the attempt history, and to anything counting
+///    failures. #873 first moved it to `Succeeded`, which stopped the red but
+///    hid a decline among genuine completions and let the external "work that
+///    stopped" surface count it as work that finished. `Declined` is its own
+///    terminal state: neither an error nor an ordinary success, so the refusal
+///    reads as exactly what it is on every surface.
 /// 2. **The card's deliverable flips to `once`.** This is what breaks the loop.
 ///    `CompanyRuntime::dispatch_task` routes a `workflow`-deliverable card to
 ///    this very pass instead of to its assignee, so returning the card to To-do
@@ -804,7 +809,7 @@ async fn settle_not_automatable(
              In Progress until the next boot"
         );
     }
-    finish_run(runtime, run_id, RunStatus::Succeeded, None, usage).await;
+    finish_run(runtime, run_id, RunStatus::Declined, None, usage).await;
 }
 
 /// Settles the attempt row. Best-effort: the work (or its failure) has already

--- a/src/harness/built_in/workflow_build/test.rs
+++ b/src/harness/built_in/workflow_build/test.rs
@@ -432,8 +432,8 @@ fn the_outcome_resolves_graph_versus_not_automatable() {
 
     // Issue #873: no workflow, no reason and no refusal decided NOTHING, so it
     // is a non-answer rather than a verdict. The distinction is load-bearing —
-    // a verdict now settles Succeeded and converts the card to a one-off, and an
-    // empty object must do neither.
+    // a verdict now settles Declined (#1809) and converts the card to a one-off,
+    // and an empty object must do neither.
     let empty = parse_draft(r#"{"automatable":true}"#)
         .unwrap()
         .into_outcome();
@@ -1016,9 +1016,11 @@ async fn a_card_with_no_plan_builds_from_title_and_note() {
 /// A not-automatable answer returns the card to To-do with the reason and no
 /// proposal (decision D2c).
 ///
-/// Issue #873: the attempt settles **Succeeded**, and the card is converted to a
-/// `once` deliverable. It used to settle Failed and keep `workflow`, which is
-/// what trapped the card — see the loop test below.
+/// Issue #873 + #1809: the attempt settles **Declined** — its own terminal
+/// state, neither the failure it used to be (#873) nor the success that #873
+/// first repurposed — and the card is converted to a `once` deliverable. It used
+/// to settle Failed and keep `workflow`, which is what trapped the card — see the
+/// loop test below.
 #[tokio::test]
 async fn a_not_automatable_answer_returns_the_card_to_todo() {
     let reply = r#"{"automatable":false,"reason":"this only ever runs once"}"#;
@@ -1044,7 +1046,10 @@ async fn a_not_automatable_answer_returns_the_card_to_todo() {
         "no proposal on a not-automatable card"
     );
     assert!(after.note.unwrap().contains("done once"));
-    assert_eq!(run_status(&runtime, &run_id).await, RunStatus::Succeeded);
+    // Issue #1809: a by-design decline is its own terminal state, not a failure
+    // and not a plain success — so the external "work that stopped" surface stops
+    // bucketing the compiler's correct refusal as the product breaking.
+    assert_eq!(run_status(&runtime, &run_id).await, RunStatus::Declined);
 }
 
 /// The loop #873 reports, asserted at the seam that closes it.
@@ -1118,7 +1123,7 @@ async fn a_not_automatable_verdict_files_no_error_and_says_what_happened_to_the_
         .await
         .expect("read")
         .expect("the attempt row exists");
-    assert_eq!(row.status, RunStatus::Succeeded);
+    assert_eq!(row.status, RunStatus::Declined);
     assert!(
         row.error.is_none(),
         "a verdict is not an error: {:?}",

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -91,6 +91,17 @@ pub enum RunStatus {
     Failed,
     /// Terminal: the attempt was cancelled before it could settle.
     Cancelled,
+    /// Terminal: the workflow compiler **declined by design** to automate the
+    /// work — "better done once than built into a workflow" (issue #1809).
+    ///
+    /// Neither an error nor an ordinary success: the builder was asked whether
+    /// the card should become a workflow and its honest answer was "don't". It
+    /// used to settle `Failed` — which made a correct refusal indistinguishable
+    /// from a model timeout — and then `Succeeded` (#873), which hid it among
+    /// completed work. Its own terminal state keeps the external "work that
+    /// stopped" surface from bucketing the best thing the compiler does as the
+    /// product breaking, without pretending nothing happened.
+    Declined,
 }
 
 impl RunStatus {
@@ -104,6 +115,7 @@ impl RunStatus {
             Self::Succeeded => "succeeded",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
+            Self::Declined => "declined",
         }
     }
 
@@ -123,6 +135,7 @@ impl RunStatus {
             "succeeded" => Self::Succeeded,
             "failed" => Self::Failed,
             "cancelled" => Self::Cancelled,
+            "declined" => Self::Declined,
             _ => return None,
         })
     }
@@ -131,7 +144,10 @@ impl RunStatus {
     /// status — a re-run is a *new* attempt with its own ordinal, never a
     /// resurrection of this one.
     pub fn is_terminal(self) -> bool {
-        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::Declined
+        )
     }
 
     /// Which of the three coarse phases this status sits in: `active`,
@@ -198,7 +214,7 @@ impl RunStatus {
             Self::WaitingApproval | Self::Paused => {
                 next == Self::Running || next.is_parked() || next.is_terminal()
             }
-            Self::Succeeded | Self::Failed | Self::Cancelled => false,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::Declined => false,
         }
     }
 }
@@ -849,7 +865,7 @@ mod test {
     /// Every status, so a table-driven test cannot silently miss a new variant
     /// (adding one without extending this list fails the exhaustiveness check
     /// in [`all_statuses_are_listed`]).
-    const ALL: [RunStatus; 7] = [
+    const ALL: [RunStatus; 8] = [
         RunStatus::Pending,
         RunStatus::Running,
         RunStatus::WaitingApproval,
@@ -857,6 +873,7 @@ mod test {
         RunStatus::Succeeded,
         RunStatus::Failed,
         RunStatus::Cancelled,
+        RunStatus::Declined,
     ];
 
     #[test]
@@ -871,7 +888,8 @@ mod test {
                 | RunStatus::Paused
                 | RunStatus::Succeeded
                 | RunStatus::Failed
-                | RunStatus::Cancelled => (),
+                | RunStatus::Cancelled
+                | RunStatus::Declined => (),
             };
         }
         let mut seen: Vec<&str> = ALL.iter().map(|s| s.as_str()).collect();
@@ -927,6 +945,7 @@ mod test {
         assert_eq!(RunStatus::Succeeded.phase(), "terminal");
         assert_eq!(RunStatus::Failed.phase(), "terminal");
         assert_eq!(RunStatus::Cancelled.phase(), "terminal");
+        assert_eq!(RunStatus::Declined.phase(), "terminal");
     }
 
     /// The trap this whole projection exists for: a parked run has **no**

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -153,6 +153,7 @@ pub fn is_board_column(column: &str) -> bool {
 /// | [`Paused`](RunStatus::Paused) | [`COLUMN_PAUSED`] | resumed, not approved |
 /// | [`Failed`](RunStatus::Failed) | [`COLUMN_TODO`] | with the run's error on the card |
 /// | [`Cancelled`](RunStatus::Cancelled) | [`COLUMN_TODO`] | with the cancellation reason on the card |
+/// | [`Declined`](RunStatus::Declined) | [`COLUMN_TODO`] | a by-design decline (#1809); reason on the card, now a one-off |
 /// | [`Pending`](RunStatus::Pending) / [`Running`](RunStatus::Running) | — | not settled |
 ///
 /// # `Succeeded` lands in review, **not** in Done
@@ -222,6 +223,11 @@ pub fn column_for_settled_run(status: RunStatus) -> Option<&'static str> {
         // Not reviewable work. Epic #183 §3: a card that cannot proceed returns
         // to To-do carrying the reason, never into a stuck column of its own.
         RunStatus::Failed | RunStatus::Cancelled => Some(COLUMN_TODO),
+        // A by-design decline (issue #1809) also returns the card to To-do: the
+        // builder declined to automate it, the card body carries the reason, and
+        // the deliverable is flipped to `once` so its next dispatch reaches the
+        // assignee to do by hand rather than re-entering the builder.
+        RunStatus::Declined => Some(COLUMN_TODO),
         // Still in flight. Nothing to land.
         RunStatus::Pending | RunStatus::Running => None,
     }
@@ -1197,6 +1203,13 @@ mod test {
             column_for_settled_run(RunStatus::Cancelled),
             Some(COLUMN_TODO)
         );
+        // Issue #1809: a by-design decline returns the card to To-do, same as a
+        // failure or cancel — the reason is on the note and the card becomes a
+        // one-off, never a stuck column of its own.
+        assert_eq!(
+            column_for_settled_run(RunStatus::Declined),
+            Some(COLUMN_TODO)
+        );
         // Not settled — an in-flight attempt has no landing to write.
         assert_eq!(column_for_settled_run(RunStatus::Pending), None);
         assert_eq!(column_for_settled_run(RunStatus::Running), None);
@@ -1224,6 +1237,7 @@ mod test {
             RunStatus::Succeeded,
             RunStatus::Failed,
             RunStatus::Cancelled,
+            RunStatus::Declined,
         ] {
             assert_ne!(
                 column_for_settled_run(status),
@@ -1253,6 +1267,7 @@ mod test {
             RunStatus::Paused,
             RunStatus::Failed,
             RunStatus::Cancelled,
+            RunStatus::Declined,
         ] {
             assert_ne!(
                 column_for_settled_run(status),
@@ -1282,6 +1297,7 @@ mod test {
             RunStatus::Succeeded,
             RunStatus::Failed,
             RunStatus::Cancelled,
+            RunStatus::Declined,
         ] {
             if let Some(column) = column_for_settled_run(status) {
                 assert!(is_board_column(column), "{status} lands in '{column}'");

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -156,7 +156,7 @@ pub(crate) struct RunSummary {
     /// Which attempt at the card this is, 1-based.
     attempt: u32,
     /// Where it stands: `pending` · `running` · `waiting_approval` · `paused` ·
-    /// `succeeded` · `failed` · `cancelled`.
+    /// `succeeded` · `failed` · `cancelled` · `declined`.
     status: RunStatus,
     /// The coarse phase of `status`: `active`, `parked`, or `terminal`.
     ///
@@ -357,7 +357,7 @@ impl RunsQuery {
             let status = RunStatus::from_wire(word).ok_or_else(|| {
                 ApiError(OpenCompanyError::InvalidRequest(format!(
                     "unknown run status '{word}': expected one of pending, running, \
-                     waiting_approval, paused, succeeded, failed, cancelled"
+                     waiting_approval, paused, succeeded, failed, cancelled, declined"
                 )))
             })?;
             statuses.push(status);

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -5233,6 +5233,32 @@ pub async fn assert_run_store(runs: Arc<dyn crate::ports::runs::RunStore>) {
     assert_eq!(never_ran.status, RunStatus::Cancelled);
     assert_eq!(never_ran.started_at_millis, None);
 
+    // A by-design decline (issue #1809) is terminal and round-trips like any
+    // other settle: neither an error nor a plain success, so the store must
+    // persist and read it back exactly. Kept on its own company so it does not
+    // perturb the r1..r4 list-count assertions below.
+    let gamma = CompanyId::new("gamma");
+    runs.create_run(&gamma, spec("g1", "card")).await.unwrap();
+    let declined = runs
+        .finish_run(
+            &gamma,
+            "g1",
+            RunOutcome::new(RunStatus::Declined)
+                .with_error("better done once than built into a workflow"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(declined.status, RunStatus::Declined);
+    assert!(
+        declined.finished_at_millis.is_some(),
+        "Declined is terminal, so it carries a finish time"
+    );
+    assert_eq!(
+        runs.get_run(&gamma, "g1").await.unwrap(),
+        Some(declined),
+        "a declined run round-trips byte-identically"
+    );
+
     // -- the step trace ------------------------------------------------------
 
     let step = |run_id: &str, seq: u32, label: &str| RunStepRecord {


### PR DESCRIPTION
## Summary

When the workflow builder returns its by-design verdict `BuildOutcome::NotAutomatable` ("this is better done once than built into a workflow"), the run was settled with a terminal status that misrepresents it — the external OpenHuman "Overview → Work that stopped" surface buckets runs by wire status, so the best thing the compiler does read as the product breaking.

`RunStatus` had no terminal state meaning "declined by design" — only `Succeeded`, `Failed`, `Cancelled`. This adds a distinct **`Declined`** terminal status and settles the `NotAutomatable` path to it. `Declined` is neither a failure nor a plain success — it is an honest "the compiler correctly refused to automate this."

Note: on current `main`, issue #873 had already split the code path — `settle_not_automatable` was settling as `Succeeded` (a stopgap), while genuine faults go through `settle_to_todo` as `Failed`. The correct realization of this issue was to flip `settle_not_automatable`'s terminal status from `Succeeded` → `Declined`, leaving every genuine-defect callsite (unsupported node kind, could-not-assemble, courtesy-validate refusal, model error) on `Failed`.

## API Or Behavior Changes

- New terminal `RunStatus::Declined` (wire string `"declined"`), fully wired through `as_str` / `from_wire` / `is_terminal`, `column_for_settled_run` (returns the card to To-do), all store backends, and the `?status=` REST filter docs.
- A declined build now reports `declined` instead of `succeeded`/`failed`. The console renders it with a neutral (muted, non-red) tone.
- **Residual (out of this repo):** the external OpenHuman Overview "Work that stopped" surface must learn the `declined` wire status to fully drop these from its Failed bucket — this PR makes the OpenCompany side emit it; the external consumer needs a companion change. The internal `OperatorOverview.tsx` stopped-work filter (`paused || failed`) already excludes `declined` with no change.

## Tests

Rust (full-feature union `openhuman,mcp,composio,media`; `cargo clippy` with `--no-deps` to match `ci.yml`):

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --locked --features openhuman,mcp,composio,media --all-targets`
- [x] `cargo clippy --features openhuman,mcp,composio,media --all-targets --no-deps -- -D warnings`
- [x] `cargo test` — `ports::runs`+`ports::tasks` 36, `workflow_build` 63, `conformance_run_store` (fs+sqlite) 4, `server::ops::runs` 12 — all pass

Frontend (from `frontend/`):

- [x] `npm run typecheck` / `npm run typecheck:unit`
- [x] `npx vitest run` — 3309 pass (356 files)
- [x] `npm run build`

Tests assert: `Declined` round-trips through `from_wire`/`as_str`, partitions in `phases_partition_every_status`, the `NotAutomatable` path yields `Declined` (not `Failed`) with the card returned to To-do and the reason on the note, and every store persists/reads it. mongodb's round-trip runs in its CI lane via the shared `assert_run_store`.

## Documentation

`?status=` enumerations in `src/server/ops/runs.rs` updated to include `declined`. No spec-doc surface changed.

Closes #1809