### PR TITLE
feat(chat): + on the rail creates a leadless channel — a selector picks the best-fit responder per message

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -44,6 +44,13 @@ GET    .../memory/archives                    traces retained on eviction
                                              when the engine keeps no archive)
 POST   /api/v1/companies/{id}/export           export bundle (tar)
 POST   /api/v1/companies/{id}/pause            pause / resume lifecycle transitions
+GET    /api/v1/companies/{id}/desks            the company's desks and channels
+POST   /api/v1/companies/{id}/desks            create one ({ name, description?, id?,
+                                               members?, responder? })
+DELETE /api/v1/companies/{id}/desks/{desk}     delete an overlay desk
+POST   /api/v1/companies/{id}/desks/{desk}/members         add a member
+DELETE /api/v1/companies/{id}/desks/{desk}/members/{agent} remove an overlay member
+PUT    /api/v1/companies/{id}/desks/{desk}/order           reorder (hierarchy)
 ```
 
 Single-company (prosumer) mode aliases everything under `/api/v1/company/...`
@@ -78,6 +85,27 @@ on its own task, so it is no longer cancelled when a client or a reverse proxy
 gives up mid-turn. `detach` removes the *wait*; it is not what provides the
 drop-safety. See
 [company-brain/approvals.md](../company-brain/approvals.md#settling-the-verdict-is-not-running-the-follow-up).
+
+## Desks and channels: the `responder` mode
+
+A desk row carries `responder: "lead" | "auto"` (issue #1835), **omitted when
+`lead`** — which is every manifest `[[group_chat]]` (the blueprint syntax has
+no such field) and every desk created before the field existed, so old
+consoles and old wire shapes are byte-for-byte unchanged.
+
+`"lead"` is the standing model: `members[0]` leads, and an unmentioned message
+addressed to the desk is answered by that lead. `"auto"` is a **channel**: no
+lead exists — the org chart crowns nobody, the members pane badges nobody, and
+`delegate_to_desk` refuses it with a reason — and an unmentioned message's
+answerer is picked **per message**, by a single tool-less model call over the
+channel's own membership (id, role, description), clamped to that membership.
+An `@`-mention outranks the pick everywhere, and wherever selection cannot run
+— the default build (the selector compiles under the harness feature), the
+small-talk fast path, a failure, a timeout — the answer is the channel's first
+roster member: exactly what a lead desk would have answered, so the worst case
+of the new mode is the old mode. Selection spend is metered under its own
+usage kind (`selectorCall`), charged to the whole-company bucket.
+
 
 ### Chat attachments (issue #1682)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -201,6 +201,15 @@ export interface DeskDto {
    */
   overlayMembers?: string[];
   /**
+   * How this desk's unmentioned messages find their answerer (issue #1835):
+   * `"auto"` is a channel with **no lead** — `members[0]` carries no rank, and
+   * the host picks a best-fit member per message — so every lead affordance
+   * (crown, badge, Make lead) is suppressed for it. Omitted means `"lead"`,
+   * which is every manifest desk and every desk created before the field
+   * existed.
+   */
+  responder?: "lead" | "auto";
+  /**
    * Whether the whole desk was operator-created (an overlay desk) rather than
    * declared in the manifest blueprint. The console offers a delete action only
    * for these. Omitted (undefined/false) for blueprint desks.
@@ -218,6 +227,12 @@ export interface CreateDeskInput {
   description?: string;
   id?: string;
   members?: string[];
+  /**
+   * How the desk routes its unmentioned messages (issue #1835). Absent means
+   * `"lead"` — today's model, what the org chart's create sends. `"auto"`
+   * creates a leadless channel whose answerer is picked per message.
+   */
+  responder?: "lead" | "auto";
 }
 
 /**

--- a/frontend/src/lib/desks.ts
+++ b/frontend/src/lib/desks.ts
@@ -28,6 +28,12 @@ export interface Desk {
    * the removable members from the blueprint ones without refetching.
    */
   overlayMembers?: string[];
+  /**
+   * How the desk routes its unmentioned messages (issue #1835). `"auto"` is a
+   * leadless channel — `members[0]` carries no rank and the host picks a
+   * best-fit member per message. Absent means `"lead"`, today's model.
+   */
+  responder?: "lead" | "auto";
 }
 
 /** The main line plus a few focused desks. */

--- a/frontend/src/lib/org.ts
+++ b/frontend/src/lib/org.ts
@@ -169,7 +169,10 @@ export function buildOrgTree(
           avatar: member?.avatar ?? avatarFor(id),
           // The host's order carries the hierarchy: index 0 is the lead. Read
           // the position, never re-derive the lead by sorting or by name.
-          lead: index === 0,
+          // Unless the desk is an `auto` channel (issue #1835): there
+          // `members[0]` carries no rank — the host's `desk_lead` is `None` by
+          // definition — so no seat wears the crown.
+          lead: index === 0 && desk.responder !== "auto",
           provenance: overlay.has(id) ? "overlay" : "blueprint",
           known: member !== undefined,
         };

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -54,6 +54,7 @@ import { cn } from "@/lib/utils";
 import { useAskerNames } from "@/components/approval-card";
 import { useIsDesktop } from "@/hooks/use-mobile";
 import { AddMemberDialog, type NewMemberFields } from "./chat/AddMemberDialog";
+import { ChannelCreateDialog } from "./chat/ChannelCreateDialog";
 import { BudgetDialog } from "./chat/BudgetDialog";
 import { ChannelRail } from "./chat/ChannelRail";
 import { ChatHeader } from "./chat/ChatHeader";
@@ -413,6 +414,8 @@ export function ChatView({
   const [dismissingCardId, setDismissingCardId] = useState<string | null>(null);
   const [membersOpen, setMembersOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
+  // The rail's "+" (issue #1835) — chat's own door for creating a channel.
+  const [channelCreateOpen, setChannelCreateOpen] = useState(false);
   const [mobilePane, setMobilePane] = useState<"rail" | "chat">("chat");
   // Whether the transcript is actually on screen. At `lg` (≥1024) the rail and
   // transcript share the viewport (`hidden lg:flex`), so it is visible even
@@ -1665,6 +1668,15 @@ export function ChatView({
     }
   }
 
+  /**
+   * The rail's create affordance (issue #1835) — or `undefined`, which is the
+   * rule this codebase follows for a control that would be refused: absent,
+   * not disabled. A starter roster (`!fromHost`) has no saved teammates to
+   * staff a channel with, and an empty roster has nobody at all.
+   */
+  const onAddChannel =
+    fromHost && members.length > 0 ? () => setChannelCreateOpen(true) : undefined;
+
   function selectChannel(id: string) {
     onNavigate(id);
     setMobilePane("chat");
@@ -1692,6 +1704,7 @@ export function ChatView({
         onToggleSection={toggleRailSection}
         directMessages={directMessageChannels(members)}
         onStartDirectMessage={selectChannel}
+        onAddChannel={onAddChannel}
         className={cn("lg:hidden", mobilePane === "rail" ? "flex" : "hidden")}
       />
       <ChannelRail
@@ -1704,6 +1717,7 @@ export function ChatView({
         onToggleSection={toggleRailSection}
         directMessages={directMessageChannels(members)}
         onStartDirectMessage={selectChannel}
+        onAddChannel={onAddChannel}
         collapsed={channelsCollapsed}
         onExpand={toggleChannels}
         className="hidden lg:flex"
@@ -1933,7 +1947,15 @@ export function ChatView({
               others={outsideChannel}
               people={companyPeople}
               presence={presence}
-              leadId={active.kind === "channel" ? active.memberIds?.[0] : undefined}
+              leadId={
+                // An `auto` channel has no lead (issue #1835): its memberIds
+                // are the channel's membership in the host's order, not a
+                // hierarchy, so badging [0] would state a rank nothing
+                // confers — the host's own `desk_lead` is `None` for it.
+                active.kind === "channel" && !active.leadless
+                  ? active.memberIds?.[0]
+                  : undefined
+              }
               loading={loadingTeam}
               fromHost={fromHost}
               onToggleInbox={(m) => void toggleMemberInbox(m)}
@@ -1976,6 +1998,21 @@ export function ChatView({
       </div>
 
       <AddMemberDialog open={addOpen} onOpenChange={setAddOpen} onAdd={(fields) => void addMember(fields)} />
+      <ChannelCreateDialog
+        client={client}
+        company={company}
+        members={members}
+        open={channelCreateOpen}
+        onOpenChange={setChannelCreateOpen}
+        onCreated={(dto) => {
+          // Fold the new channel into the rail and land the operator in it —
+          // the same deskFromDto every fetched desk goes through, so a
+          // just-created channel is indistinguishable from a reloaded one.
+          const desk = deskFromDto(dto);
+          setDesks((prev) => [...(prev ?? []), desk]);
+          selectChannel(desk.id);
+        }}
+      />
       <BudgetDialog
         member={budgetFor}
         onOpenChange={(open) => {

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -681,6 +681,18 @@ export function ChatView({
   // dead — and a stale answer landing last would replace the current company's
   // channels with the previous one's.
   const desksRun = useRef(0);
+  /**
+   * Whether the current `desks` state is `defaultDesks()` — the fabricated
+   * starter set shown when the host exposes no desks — rather than the host's
+   * own list. `onCreated` below needs the distinction (codex on #1872):
+   * appending the company's first real channel *beside* the fallback would
+   * leave nonexistent channels in the rail until reload, and a channel named
+   * "Strategy" would collide with the fallback row of the same id, so
+   * navigation could land on the fabrication instead of the real thing. The
+   * moment one real desk exists the fallback set has no business rendering —
+   * that is the fallback's own contract (`lib/desks.ts`).
+   */
+  const desksAreFallback = useRef(false);
 
   /**
    * The company's real desks, when the host exposes them — a company with its
@@ -703,10 +715,12 @@ export function ChatView({
     try {
       const dtos = await client.listDesks(company);
       if (run !== desksRun.current) return;
+      desksAreFallback.current = dtos.length === 0;
       setDesks(dtos.length ? dtos.map(deskFromDto) : defaultDesks());
     } catch (error) {
       if (run !== desksRun.current) return;
       if (error instanceof ApiError && error.status === 404) {
+        desksAreFallback.current = true;
         setDesks(defaultDesks());
         return;
       }
@@ -2008,8 +2022,15 @@ export function ChatView({
           // Fold the new channel into the rail and land the operator in it —
           // the same deskFromDto every fetched desk goes through, so a
           // just-created channel is indistinguishable from a reloaded one.
+          //
+          // REPLACING the fallback set, not appending to it, when the rail was
+          // showing `defaultDesks()`: the company's first real channel is the
+          // event that ends the fallback's mandate, and appending beside it
+          // would keep fabricated rows in the rail — one of which could share
+          // the new channel's very id — until a reload (codex on #1872).
           const desk = deskFromDto(dto);
-          setDesks((prev) => [...(prev ?? []), desk]);
+          setDesks((prev) => (desksAreFallback.current ? [desk] : [...(prev ?? []), desk]));
+          desksAreFallback.current = false;
           selectChannel(desk.id);
         }}
       />

--- a/frontend/src/views/chat/ChannelCreateDialog.tsx
+++ b/frontend/src/views/chat/ChannelCreateDialog.tsx
@@ -61,10 +61,18 @@ export function ChannelCreateDialog({
   // (issue #1100): the name complaint renders at the name field, the host's
   // refusal of the whole form banners above the footer.
   const [nameError, setNameError] = useState<string | null>(null);
+  const [membersError, setMembersError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
   const formId = useId();
   const nameErrorId = `${formId}-name-error`;
+  const membersErrorId = `${formId}-members-error`;
+  // The scope this render belongs to, for the stale-completion guard below —
+  // the same comparison `ChatView`'s send path makes against its `scopeRef`
+  // (CodeRabbit on #1872): a `createDesk` that resolves after the operator
+  // switched company or host must not hand its desk to the new scope's rail.
+  const scopeNow = useRef({ client, company });
+  scopeNow.current = { client, company };
 
   // Reset the draft each time the dialog opens, so a prior attempt never
   // leaks into the next one.
@@ -75,6 +83,7 @@ export function ChannelCreateDialog({
     setChosen([]);
     setMemberFilter("");
     setNameError(null);
+    setMembersError(null);
     setError(null);
   }, [open]);
 
@@ -82,6 +91,7 @@ export function ChannelCreateDialog({
     setChosen((prev) =>
       prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id],
     );
+    setMembersError(null);
   }
 
   const needle = memberFilter.trim().toLowerCase();
@@ -100,18 +110,41 @@ export function ChannelCreateDialog({
       return;
     }
     setNameError(null);
+    // An empty auto channel is unroutable by construction (codex on #1872):
+    // the selector has no candidates and the first-member fallback no first
+    // member, so the host refuses it — and a control that will be refused is
+    // not offered a hopeful submit here either. A lead desk may start empty;
+    // a conversation with nobody in it is not a conversation.
+    if (chosen.length === 0) {
+      setMembersError("Pick at least one member — a channel with nobody in it has nobody to answer.");
+      setError(null);
+      return;
+    }
+    setMembersError(null);
     setSubmitting(true);
     setError(null);
+    const scopeAtSubmit = scopeNow.current;
     try {
       const created = await client.createDesk(
         {
           name: name.trim(),
           description: description.trim() || undefined,
-          members: chosen.length > 0 ? chosen : undefined,
+          members: chosen,
           responder: "auto",
         },
         company,
       );
+      // The create landed and is journaled — on the company it was submitted
+      // to. If the operator has since moved scope, handing the desk to
+      // `onCreated` would append it to the NEW company's rail and navigate
+      // there, so the completion is dropped and the dialog simply closes.
+      if (
+        scopeNow.current.client !== scopeAtSubmit.client ||
+        scopeNow.current.company !== scopeAtSubmit.company
+      ) {
+        onOpenChange(false);
+        return;
+      }
       onCreated(created);
       onOpenChange(false);
     } catch (e) {
@@ -171,6 +204,8 @@ export function ChannelCreateDialog({
               value={memberFilter}
               onChange={(e) => setMemberFilter(e.target.value)}
               placeholder="Filter teammates"
+              aria-invalid={membersError ? true : undefined}
+              aria-describedby={membersError ? membersErrorId : undefined}
               disabled={submitting}
             />
             <ul className="mt-1 flex max-h-56 flex-col gap-px overflow-y-auto rounded-md border p-1">
@@ -205,6 +240,11 @@ export function ChannelCreateDialog({
                 <li className="px-2 py-1.5 text-xs text-muted-foreground">No teammates match.</li>
               )}
             </ul>
+            {membersError && (
+              <p id={membersErrorId} className="text-xs text-destructive">
+                {membersError}
+              </p>
+            )}
             {chosen.length > 0 && (
               <p className="text-xs text-muted-foreground">
                 {chosen.length} in this channel — no lead; whoever fits each message answers.

--- a/frontend/src/views/chat/ChannelCreateDialog.tsx
+++ b/frontend/src/views/chat/ChannelCreateDialog.tsx
@@ -1,0 +1,233 @@
+// The channel creator: chat's own door onto `client.createDesk` (issue #1835).
+//
+// Deliberately not `DeskCreateDialog` reused: that form is (correctly, since
+// #1827) about hierarchy — "the top teammate leads the desk", a Lead badge, a
+// Make-lead control — and a channel has none of it. This one asks only what a
+// conversation needs: a name, what it's for, who's in it. It posts with
+// `responder: "auto"`, so the host stores a leadless channel whose answerer is
+// picked per message; `members` order carries no rank and there is no lead UI
+// because there is no lead fact to surface.
+//
+// Same write path as the org chart's dialog — one `createDesk`, one storage
+// shape — so a rail-created channel is byte-identical to an org-chart desk
+// apart from the responder mode. No second write path to drift.
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Check } from "lucide-react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DeskDto } from "@/api/types";
+import { TeammateAvatar } from "@/components/teammate-avatar";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { TeamMember } from "@/lib/team";
+import { cn } from "@/lib/utils";
+
+export function ChannelCreateDialog({
+  client,
+  company,
+  members,
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** The roster to pick from — chat already holds it, so no refetch. */
+  members: TeamMember[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (desk: DeskDto) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  // The chosen member ids, in selection order. Order carries NO rank here —
+  // an auto channel has no lead — it is kept only so the list reads stably.
+  const [chosen, setChosen] = useState<string[]>([]);
+  const [memberFilter, setMemberFilter] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  // Field-level vs whole-form messages kept apart, as `DeskCreateDialog` does
+  // (issue #1100): the name complaint renders at the name field, the host's
+  // refusal of the whole form banners above the footer.
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const formId = useId();
+  const nameErrorId = `${formId}-name-error`;
+
+  // Reset the draft each time the dialog opens, so a prior attempt never
+  // leaks into the next one.
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setDescription("");
+    setChosen([]);
+    setMemberFilter("");
+    setNameError(null);
+    setError(null);
+  }, [open]);
+
+  function toggle(id: string) {
+    setChosen((prev) =>
+      prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id],
+    );
+  }
+
+  const needle = memberFilter.trim().toLowerCase();
+  const visible = members.filter(
+    (m) => !needle || m.name.toLowerCase().includes(needle) || m.role.toLowerCase().includes(needle),
+  );
+
+  async function submit() {
+    if (!name.trim()) {
+      setNameError("Give the channel a name.");
+      setError(null);
+      requestAnimationFrame(() => {
+        nameRef.current?.focus({ preventScroll: true });
+        nameRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+      });
+      return;
+    }
+    setNameError(null);
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await client.createDesk(
+        {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          members: chosen.length > 0 ? chosen : undefined,
+          responder: "auto",
+        },
+        company,
+      );
+      onCreated(created);
+      onOpenChange(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not create the channel");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !submitting && onOpenChange(o)}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New channel</DialogTitle>
+          <DialogDescription>
+            A channel is a conversation, not a hierarchy: nobody leads it. Pick who&apos;s in it —
+            whoever fits each message picks it up, and an @-mention always wins.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={`${formId}-name`}>Name</Label>
+            <Input
+              id={`${formId}-name`}
+              ref={nameRef}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Launch week"
+              aria-invalid={nameError ? true : undefined}
+              aria-describedby={nameError ? nameErrorId : undefined}
+              disabled={submitting}
+            />
+            {nameError && (
+              <p id={nameErrorId} className="text-xs text-destructive">
+                {nameError}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={`${formId}-description`}>What it&apos;s for</Label>
+            <Textarea
+              id={`${formId}-description`}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional — one line about what belongs here"
+              rows={2}
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={`${formId}-member-filter`}>Members</Label>
+            <Input
+              id={`${formId}-member-filter`}
+              value={memberFilter}
+              onChange={(e) => setMemberFilter(e.target.value)}
+              placeholder="Filter teammates"
+              disabled={submitting}
+            />
+            <ul className="mt-1 flex max-h-56 flex-col gap-px overflow-y-auto rounded-md border p-1">
+              {visible.map((member) => {
+                const selected = chosen.includes(member.id);
+                return (
+                  <li key={member.id}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(member.id)}
+                      aria-pressed={selected}
+                      disabled={submitting}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent",
+                        selected && "bg-accent",
+                      )}
+                    >
+                      <TeammateAvatar
+                        name={member.name}
+                        avatar={member.avatar}
+                        tone={member.tone}
+                        className="size-5 shrink-0"
+                      />
+                      <span className="truncate">{member.name}</span>
+                      <span className="truncate text-xs text-muted-foreground">{member.role}</span>
+                      {selected && <Check className="ml-auto size-4 shrink-0" aria-hidden />}
+                    </button>
+                  </li>
+                );
+              })}
+              {visible.length === 0 && (
+                <li className="px-2 py-1.5 text-xs text-muted-foreground">No teammates match.</li>
+              )}
+            </ul>
+            {chosen.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {chosen.length} in this channel — no lead; whoever fits each message answers.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={submitting}>
+            {submitting ? "Creating…" : "Create channel"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronRight, CircleDot, Hash, Lock, PanelRight, SquarePen } from "lucide-react";
+import { ChevronRight, CircleDot, Hash, Lock, PanelRight, Plus, SquarePen } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { TeammateAvatar } from "@/components/teammate-avatar";
@@ -20,6 +20,12 @@ const UNREAD_IS_LOCAL = "Estimated in this browser — unread is not tracked on 
 
 interface Props {
   sections: ChannelSection[];
+  /**
+   * Opens the channel creator (issue #1835) — rendered as a "+" on the
+   * Channels section header. Absent (the rule for a control that would be
+   * refused) when the roster cannot staff a channel yet.
+   */
+  onAddChannel?: () => void;
   activeId: string | null;
   /** Channel id → unread count. Absent or 0 reads as caught up. */
   unread: Record<string, number>;
@@ -49,6 +55,7 @@ interface Props {
  */
 export function ChannelRail({
   sections,
+  onAddChannel,
   activeId,
   unread,
   mentions,
@@ -146,6 +153,7 @@ export function ChannelRail({
         <Section
           key={section.id}
           section={section}
+          onAdd={section.id === "channels" ? onAddChannel : undefined}
           activeId={activeId}
           unread={unread}
           mentions={mentions}
@@ -229,6 +237,7 @@ function Section({
   onSelect,
   open,
   onToggle,
+  onAdd,
 }: {
   section: ChannelSection;
   activeId: string | null;
@@ -237,6 +246,8 @@ function Section({
   onSelect: (id: string) => void;
   open: boolean;
   onToggle: () => void;
+  /** Renders a "+" beside the header — the Channels section's create door. */
+  onAdd?: () => void;
 }) {
   const hiddenUnread = !open
     ? section.channels.reduce((n, c) => n + (unread[c.id] ?? 0), 0)
@@ -247,11 +258,12 @@ function Section({
 
   return (
     <section className="group/section select-none px-2 pt-2">
+      <div className="flex items-center gap-0.5">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={open}
-        className="flex w-full items-center gap-1 rounded-md px-1.5 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        className="flex w-full min-w-0 flex-1 items-center gap-1 rounded-md px-1.5 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRight
           className={cn("size-3 shrink-0 transition-transform", open && "rotate-90")}
@@ -280,6 +292,18 @@ function Section({
           </span>
         )}
       </button>
+      {onAdd && (
+        <button
+          type="button"
+          onClick={onAdd}
+          title="New channel"
+          aria-label="New channel"
+          className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <Plus className="size-3.5" aria-hidden />
+        </button>
+      )}
+      </div>
 
       {open && (
         <ul className="mt-0.5 flex flex-col gap-px">

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -27,6 +27,7 @@ export function deskFromDto(d: DeskDto): Desk {
     blurb: d.description ?? "",
     members: d.members,
     overlayMembers: d.overlayMembers,
+    responder: d.responder,
   };
 }
 
@@ -122,6 +123,13 @@ export interface Channel {
    * absent falls back to the whole roster (issue #369).
    */
   memberIds?: string[];
+  /**
+   * Whether this channel has **no lead** (issue #1835): an `auto` desk, whose
+   * answerer is picked per message. `memberIds[0]` carries no rank here, so a
+   * consumer must not badge it — the host's own `desk_lead` is `None` for such
+   * a channel by definition. Absent/false for every lead desk and DM.
+   */
+  leadless?: boolean;
 }
 
 export interface ChannelSection {
@@ -155,9 +163,15 @@ export function buildChannels(
     name: d.channel,
     voice: d.name,
     kind: "channel" as const,
-    purpose: d.blurb,
+    // An `auto` channel with no blurb of its own states its routing rule —
+    // the honest line about who answers, in place of a rank nothing confers
+    // (issue #1835). An operator-written blurb still wins.
+    purpose:
+      d.blurb ||
+      (d.responder === "auto" ? "Best fit picks up anything you don't @-mention" : d.blurb),
     tone: d.tone,
     memberIds: d.members,
+    leadless: d.responder === "auto" || undefined,
   }));
 
   const dms = directMessageChannels(members)

--- a/frontend/test/unit/channel-auto-responder.test.ts
+++ b/frontend/test/unit/channel-auto-responder.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import type { DeskDto } from "@/api/types";
@@ -105,5 +109,67 @@ describe("buildOrgTree", () => {
     const [eng, launch] = tree.desks;
     expect(eng.seats.map((s) => s.lead)).toEqual([true, false]);
     expect(launch.seats.map((s) => s.lead)).toEqual([false, false]);
+  });
+});
+
+/**
+ * The three review findings on #1872, pinned in the source-contract idiom
+ * `chat-rail-focus.test.ts` established for shell wiring a jsdom render
+ * cannot reach (the dialog's submit and `ChatView`'s create callback both
+ * need the whole client and every hook to render).
+ */
+describe("channel creation guards (#1872 review)", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const read = (rel: string) => readFileSync(resolve(here, "../../src", rel), "utf8");
+  const dialog = () => read("views/chat/ChannelCreateDialog.tsx");
+  const chatView = () => read("views/ChatView.tsx");
+
+  it("refuses to submit an auto channel with no members, with a field-level reason", () => {
+    const src = dialog();
+    // The gate sits in submit(), before the POST — a channel with nobody in
+    // it has nobody to answer, and the host refuses it too, so the dialog
+    // must not offer a hopeful submit.
+    const gate = src.indexOf("if (chosen.length === 0) {");
+    expect(gate).toBeGreaterThan(-1);
+    expect(src.slice(gate, gate + 400)).toContain("setMembersError(");
+    // Field-level, not the whole-form banner: the complaint renders at the
+    // members section and is cleared the moment a member is toggled in.
+    expect(src).toContain("{membersError && (");
+    const toggle = src.indexOf("function toggle(id: string)");
+    expect(src.slice(toggle, toggle + 300)).toContain("setMembersError(null)");
+    // And the POST no longer sends an absent members list at all.
+    expect(src).toContain("members: chosen,");
+    expect(src).not.toContain("chosen.length > 0 ? chosen : undefined");
+  });
+
+  it("drops a createDesk completion that lands after a scope switch", () => {
+    const src = dialog();
+    // Captured at submit, compared at completion — the same shape ChatView's
+    // send path uses against its scopeRef. A create that resolves after the
+    // operator moved company must not hand its desk to the new scope's rail.
+    expect(src).toContain("const scopeAtSubmit = scopeNow.current;");
+    const guard = src.indexOf("scopeNow.current.client !== scopeAtSubmit.client");
+    expect(guard).toBeGreaterThan(-1);
+    expect(src.slice(guard, guard + 300)).toContain("return;");
+    // The guard sits between the await and onCreated — the completion is
+    // dropped, not the request (the create landed and is journaled).
+    const awaited = src.indexOf("await client.createDesk(");
+    const created = src.indexOf("onCreated(created)");
+    expect(awaited).toBeGreaterThan(-1);
+    expect(guard).toBeGreaterThan(awaited);
+    expect(created).toBeGreaterThan(guard);
+  });
+
+  it("replaces the fallback desk set with the first real channel instead of appending beside it", () => {
+    const src = chatView();
+    // loadDesks marks when the rail is showing defaultDesks() rather than the
+    // host's own list…
+    expect(src).toContain("desksAreFallback.current = dtos.length === 0;");
+    // …and onCreated replaces that set outright: the first real channel ends
+    // the fallback's mandate, and appending beside it would keep fabricated
+    // rows — one of which could share the new channel's id — until reload.
+    expect(src).toContain(
+      "setDesks((prev) => (desksAreFallback.current ? [desk] : [...(prev ?? []), desk]));",
+    );
   });
 });

--- a/frontend/test/unit/channel-auto-responder.test.ts
+++ b/frontend/test/unit/channel-auto-responder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeskDto } from "@/api/types";
+import { buildOrgTree } from "@/lib/org";
+import type { TeamMember } from "@/lib/team";
+import { buildChannels, deskFromDto } from "@/views/chat/model";
+
+/**
+ * The console half of the `auto` channel (issue #1835).
+ *
+ * An `auto` channel has **no lead**: `members[0]` is the host's order, not a
+ * rank — the host's own `desk_lead` is `None` for it by definition — and its
+ * answerer is picked per message. Three consumers used to derive a lead from
+ * position alone, and each is pinned here: `deskFromDto` must carry the mode
+ * at all (dropping a DTO field silently is how issue #369 lost memberships),
+ * `buildChannels` must flag the channel so `ChatView` withholds `leadId`, and
+ * `buildOrgTree` must not crown seat zero.
+ *
+ * Every assertion has a paired one on a lead desk, because the failure that
+ * matters most is the quiet one in the other direction: a mode nobody stated
+ * must keep behaving exactly as before the field existed.
+ */
+
+function desk(over: Partial<DeskDto> & Pick<DeskDto, "id" | "name">): DeskDto {
+  return {
+    members: ["engineer", "designer"],
+    ...over,
+  };
+}
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
+  return {
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    avatar: "green",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  };
+}
+
+const ROSTER: TeamMember[] = [
+  member({ id: "engineer", name: "Backend Engineer" }),
+  member({ id: "designer", name: "Product Designer", role: "Designer" }),
+];
+
+describe("deskFromDto", () => {
+  it("carries the responder mode, and its absence", () => {
+    expect(deskFromDto(desk({ id: "launch", name: "Launch", responder: "auto" })).responder).toBe(
+      "auto",
+    );
+    // A desk that never states a mode stays undefined — not defaulted to a
+    // string here, so `d.responder === "auto"` is the only truthy read.
+    expect(deskFromDto(desk({ id: "eng", name: "Engineering" })).responder).toBeUndefined();
+  });
+});
+
+describe("buildChannels", () => {
+  it("flags an auto channel leadless and leaves lead desks alone", () => {
+    const [channels] = buildChannels(ROSTER, [
+      deskFromDto(desk({ id: "eng", name: "Engineering" })),
+      deskFromDto(desk({ id: "launch", name: "Launch", responder: "auto" })),
+    ]);
+    const [eng, launch] = channels.channels;
+    expect(launch.leadless).toBe(true);
+    // Undefined rather than false, so every pre-#1835 consumer that never
+    // reads the flag serializes and compares exactly as it did.
+    expect(eng.leadless).toBeUndefined();
+  });
+
+  it("states the routing rule when an auto channel has no blurb, and lets a blurb win", () => {
+    const [channels] = buildChannels(ROSTER, [
+      deskFromDto(desk({ id: "launch", name: "Launch", responder: "auto" })),
+      deskFromDto(
+        desk({ id: "beta", name: "Beta", responder: "auto", description: "Beta rollout." }),
+      ),
+      deskFromDto(desk({ id: "eng", name: "Engineering" })),
+    ]);
+    const [launch, beta, eng] = channels.channels;
+    expect(launch.purpose).toBe("Best fit picks up anything you don't @-mention");
+    expect(beta.purpose).toBe("Beta rollout.");
+    // A lead desk with no blurb keeps its empty purpose — the routing line is
+    // a claim about auto channels only.
+    expect(eng.purpose).toBe("");
+  });
+});
+
+describe("buildOrgTree", () => {
+  const roster = [
+    { id: "engineer", name: "Backend Engineer", role: "Engineer" },
+    { id: "designer", name: "Product Designer", role: "Designer" },
+  ];
+
+  it("crowns no seat on an auto channel, and still crowns a lead desk's first seat", () => {
+    const tree = buildOrgTree(
+      "Acme",
+      [
+        desk({ id: "eng", name: "Engineering" }),
+        desk({ id: "launch", name: "Launch", responder: "auto" }),
+      ],
+      roster,
+    );
+    const [eng, launch] = tree.desks;
+    expect(eng.seats.map((s) => s.lead)).toEqual([true, false]);
+    expect(launch.seats.map((s) => s.lead)).toEqual([false, false]);
+  });
+});

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -2685,8 +2685,43 @@ impl HarnessBrain {
             (record.id.clone(), desk_id, candidates)
         };
         match candidates.len() {
-            0 => None,
+            // Every member has left the roster since the channel was created —
+            // `POST …/desks` refuses an empty auto channel, but `DELETE
+            // …/team/{id}` can empty one later (codex on #1872). There is
+            // nobody to pick, so this defers to the caller's fallback ladder
+            // and the orchestrator answers, exactly as it does for any desk
+            // whose members have all gone. Refusing the deletion instead would
+            // be worse — a teammate you cannot remove because a channel names
+            // them — so the gap is closed by saying so rather than by
+            // pretending the channel still routes.
+            0 => {
+                tracing::warn!(
+                    company = %company,
+                    chat = %desk_id,
+                    "[selector] this channel has no roster members left, so there is nobody to \
+                     pick; the orchestrator is answering a message addressed to the channel"
+                );
+                None
+            }
             1 => Some(candidates[0].id.clone()),
+            // The plan-level total-token ceiling gates the selection too, not
+            // only the responder turn it precedes (codex on #1872). Selection
+            // runs *before* a responder exists, so `total_ceiling_refusal` has
+            // no agent to refuse as — but it is a real model call, and without
+            // this a tenant past its hard ceiling could keep paying to route
+            // by posting into an auto channel, one selector call per message,
+            // after the ceiling that is supposed to permit no model calls at
+            // all. Falling through to the deterministic first member costs
+            // nothing and is the same answer a lead desk would give.
+            _ if crate::harness::HarnessPool::total_ceiling_spent(&company, &self.deps).await => {
+                tracing::info!(
+                    company = %company,
+                    chat = %desk_id,
+                    "[selector] total token ceiling reached; routing to the channel's first \
+                     member without a selection call"
+                );
+                None
+            }
             _ => match self.selector_pass(&company).select(text, &candidates).await {
                 crate::harness::selector::SelectorVerdict::Member(id) => {
                     tracing::info!(
@@ -8438,6 +8473,17 @@ members = ["eng1", "eng2"]
         dir: &std::path::Path,
         reply: &str,
     ) -> (HarnessBrain, Arc<SelectingProvider>) {
+        brain_that_selects_with(dir, reply, None, None)
+    }
+
+    /// [`brain_that_selects`], plus an optional plan and usage meter, so a
+    /// test can place the company past its plan-level total-token ceiling.
+    fn brain_that_selects_with(
+        dir: &std::path::Path,
+        reply: &str,
+        plan: Option<crate::harness::capability_budget::CapabilityPlan>,
+        meter: Option<Arc<dyn crate::ports::usage::UsageMeter>>,
+    ) -> (HarnessBrain, Arc<SelectingProvider>) {
         let provider = Arc::new(SelectingProvider {
             reply: reply.to_string(),
             selector_calls: std::sync::atomic::AtomicUsize::new(0),
@@ -8450,7 +8496,7 @@ members = ["eng1", "eng2"]
             serves: None,
             context: Arc::new(FsContextStore::new(dir)),
             store: Arc::new(FsCompanyStore::new(dir)),
-            meter: None,
+            meter,
             workspace_root: dir.to_path_buf(),
             mcp_home: None,
             workspace_git_enabled: false,
@@ -8478,7 +8524,7 @@ members = ["eng1", "eng2"]
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             workflow_source_dir: None,
-            plan: None,
+            plan,
             media: None,
             composio: None,
             #[cfg(feature = "chargebee")]
@@ -8548,6 +8594,104 @@ members = ["eng1", "eng2"]
             None,
             "an out-of-membership pick must fall back, never route"
         );
+    }
+
+    /// Issue #1872 (codex P1): the plan-level total-token ceiling gates the
+    /// **selection**, not only the responder turn it precedes.
+    ///
+    /// Selection runs before a responder exists, so `total_ceiling_refusal`
+    /// has no agent to refuse as and never fired for it — meaning a tenant
+    /// past its hard ceiling could keep paying to route, one selector call per
+    /// message, after the ceiling that is supposed to permit no model calls at
+    /// all. Remove the `total_ceiling_spent` arm in `auto_channel_responder`
+    /// and this spends a call and answers `chief`.
+    #[tokio::test]
+    async fn an_exhausted_total_ceiling_routes_without_paying_for_a_selection() {
+        let dir = tempfile::tempdir().unwrap();
+        let meter = Arc::new(SpentMeter);
+        let plan = crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: Default::default(),
+            total_budget: Some(10),
+        };
+        let (brain, provider) =
+            brain_that_selects_with(dir.path(), "chief", Some(plan), Some(meter));
+        assert_eq!(
+            brain
+                .auto_channel_responder(Some("launch"), "which strategy are we running?")
+                .await,
+            None,
+            "past the ceiling the deterministic fallback answers, not a selection"
+        );
+        assert_eq!(
+            provider
+                .selector_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a company past its hard ceiling must not pay to route"
+        );
+    }
+
+    /// Issue #1872 (codex P2): a channel emptied *after* creation.
+    ///
+    /// `POST …/desks` refuses an empty auto channel, but `DELETE …/team/{id}`
+    /// can retire its last roster-backed member later. There is then nobody to
+    /// pick, so this defers to the caller's ladder — the orchestrator answers,
+    /// as it does for any desk whose members have all gone — and spends
+    /// nothing doing it. Refusing the deletion instead would mean a teammate
+    /// you cannot remove because a channel names them.
+    #[tokio::test]
+    async fn a_channel_emptied_by_deletion_falls_back_without_paying() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_selects(dir.path(), "chief");
+        brain.mutate_record(|r| {
+            r.overlay_retired_agents = vec!["engineer".to_string(), "chief".to_string()];
+        });
+        assert_eq!(
+            brain
+                .auto_channel_responder(Some("launch"), "who owns the retry logic?")
+                .await,
+            None,
+            "no candidates left: fall back rather than route to a retired teammate"
+        );
+        assert_eq!(
+            provider
+                .selector_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    /// A meter whose every query reports spend past any ceiling a test sets.
+    struct SpentMeter;
+
+    #[async_trait]
+    impl crate::ports::usage::UsageMeter for SpentMeter {
+        async fn record(
+            &self,
+            _company: &CompanyId,
+            _sample: &crate::ports::usage::UsageSample,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn query(
+            &self,
+            _company: &CompanyId,
+            _since: u64,
+        ) -> crate::Result<Vec<crate::ports::usage::UsageSample>> {
+            Ok(vec![crate::ports::usage::UsageSample {
+                at_millis: 0,
+                agent: "someone".to_string(),
+                provider: "test".to_string(),
+                input_tokens: 10_000,
+                output_tokens: 0,
+                cached_input_tokens: 0,
+                cost_usd: 0.0,
+                kind: crate::ports::usage::SampleKind::Inference,
+                run_id: None,
+                model: None,
+            }])
+        }
     }
 
     /// The short-circuits spend nothing: a lead desk never reaches the

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -172,6 +172,10 @@ pub struct HarnessBrain {
     /// record read; `OnceLock` because it is immutable once built and the cost
     /// is a clone of two `Arc`s, not a model call.
     triage: std::sync::OnceLock<crate::harness::triage::MeteredTriage>,
+    /// The per-message responder selection for `auto` channels, built on first
+    /// use (issue #1835). Lazy and `OnceLock` for exactly [`Self::triage`]'s
+    /// reasons — it needs the company id, and once built it is immutable.
+    selector: std::sync::OnceLock<crate::harness::selector::MeteredSelector>,
     /// The company's record, **re-read from the store at the top of every
     /// cycle** (issue #707).
     ///
@@ -311,6 +315,7 @@ impl HarnessBrain {
             responder,
             runs: None,
             triage: std::sync::OnceLock::new(),
+            selector: std::sync::OnceLock::new(),
         }
     }
 
@@ -2631,6 +2636,102 @@ impl HarnessBrain {
             crate::harness::triage::MeteredTriage::from_deps(&self.deps, company.clone())
         })
     }
+
+    /// The company's responder selection, built once (issue #1835).
+    fn selector_pass(
+        &self,
+        company: &crate::ports::types::CompanyId,
+    ) -> &crate::harness::selector::MeteredSelector {
+        self.selector.get_or_init(|| {
+            crate::harness::selector::MeteredSelector::from_deps(&self.deps, company.clone())
+        })
+    }
+
+    /// The per-message pick for a message addressed to an `auto` channel — or
+    /// `None` wherever the deterministic answer should stand (issue #1835).
+    ///
+    /// `None` covers every case, deliberately in one place: the chat key names
+    /// no desk, the desk is lead-routed, the channel has fewer than two roster
+    /// members (a pick over one candidate is the fallback with extra latency),
+    /// or the selection failed — unreachable, slow, unparseable, or an id
+    /// outside the membership. The caller falls back to
+    /// [`responder_for`](Self::responder_for), whose desk arm answers the
+    /// channel's first roster member; **the worst case of this rung is the old
+    /// rung**.
+    ///
+    /// Takes the operator's raw `text`, not the attachment-composed wire body:
+    /// routing is judged on what was said, and a 200k-char extracted-file block
+    /// would drown the one line the selection is about.
+    ///
+    /// A member's role and description come from the same halves the Team page
+    /// renders — [`CompanyRecord::effective_agent`] for a manifest teammate
+    /// (edits applied), the overlay row plus its stored edit for a
+    /// console-created one — so the selector judges fit by what an operator
+    /// reads on the members pane.
+    async fn auto_channel_responder(&self, chat: Option<&str>, text: &str) -> Option<String> {
+        let chat = chat?;
+        let (company, desk_id, candidates) = {
+            let record = self.record();
+            let desk_id = record.resolve_desk_id(chat)?;
+            if record.desk_responder_mode(&desk_id).is_lead() {
+                return None;
+            }
+            let candidates: Vec<crate::harness::selector::SelectorCandidate> = record
+                .effective_desk_members(&desk_id)
+                .into_iter()
+                .filter(|m| record.is_roster_agent(m))
+                .filter_map(|id| selector_candidate(&record, &id))
+                .collect();
+            (record.id.clone(), desk_id, candidates)
+        };
+        match candidates.len() {
+            0 => None,
+            1 => Some(candidates[0].id.clone()),
+            _ => match self.selector_pass(&company).select(text, &candidates).await {
+                crate::harness::selector::SelectorVerdict::Member(id) => {
+                    tracing::info!(
+                        company = %company,
+                        chat = %desk_id,
+                        picked = %id,
+                        "[selector] routed an unmentioned channel message to its best-fit member"
+                    );
+                    Some(id)
+                }
+                crate::harness::selector::SelectorVerdict::Unavailable => None,
+            },
+        }
+    }
+}
+
+/// One channel member as [`HarnessBrain::auto_channel_responder`] hands it to
+/// the selection: the manifest half through
+/// [`CompanyRecord::effective_agent`] (stored edits applied), the overlay half
+/// from its row with any stored edit's role/description preferred — the same
+/// two halves the Team page folds, so the selector and the members pane
+/// describe a teammate identically.
+fn selector_candidate(
+    record: &CompanyRecord,
+    id: &str,
+) -> Option<crate::harness::selector::SelectorCandidate> {
+    if let Some(agent) = record.effective_agent(id) {
+        return Some(crate::harness::selector::SelectorCandidate {
+            id: agent.id.clone(),
+            role: agent.role.clone(),
+            description: agent.description.clone(),
+        });
+    }
+    let agent = record.overlay_agents.iter().find(|a| a.id == id)?;
+    let edit = record.overlay_agent_edits.iter().find(|e| e.agent_id == id);
+    Some(crate::harness::selector::SelectorCandidate {
+        id: agent.id.clone(),
+        role: edit
+            .and_then(|e| e.role.clone())
+            .unwrap_or_else(|| agent.role.clone()),
+        description: edit
+            .and_then(|e| e.description.clone())
+            .filter(|d| !d.is_empty())
+            .or_else(|| agent.description.clone()),
+    })
 }
 
 /// The turn instruction for a dispatched card: its title, plus its note when it
@@ -2861,8 +2962,22 @@ impl HarnessBrain {
                     // which is every message journaled before mentions existed,
                     // so routing is unchanged byte-for-byte for them.
                     let responder =
-                        crate::runtime::mentions::mention_responder(&self.record(), mentions)
-                            .unwrap_or_else(|| self.responder_for(chat.as_deref()));
+                        match crate::runtime::mentions::mention_responder(&self.record(), mentions)
+                        {
+                            Some(responder) => responder,
+                            // Issue #1835: below a mention, above the deterministic
+                            // answer, an `auto` channel picks its best-fit member
+                            // for this message. Every way the pick cannot happen —
+                            // not an auto channel, one member, selection failed —
+                            // is `None`, and the ladder continues exactly where it
+                            // always stood.
+                            None => {
+                                match self.auto_channel_responder(chat.as_deref(), text).await {
+                                    Some(responder) => responder,
+                                    None => self.responder_for(chat.as_deref()),
+                                }
+                            }
+                        };
                     // Everyone else the message named, for the answering turn's
                     // context. A list, not a fan-out: one operator message still
                     // spawns exactly one turn, and this teammate spreads the
@@ -8228,6 +8343,226 @@ members = ["eng1", "eng2"]
         assert!(
             !is_triage_request(&turn),
             "an agent turn is not a classification"
+        );
+    }
+
+    /// A provider for the selection rung (issue #1835): a request opening with
+    /// the selector's own system prompt gets the scripted reply; anything else
+    /// echoes. Keyed on the prompt's opening sentence for the reason
+    /// [`is_triage_request`] documents, and pinned the same way below.
+    struct SelectingProvider {
+        reply: String,
+        selector_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    fn is_selection_request(request: &ModelRequest) -> bool {
+        request
+            .messages
+            .first()
+            .map(|m| {
+                m.text()
+                    .contains("You route one message in a group channel")
+            })
+            .unwrap_or(false)
+    }
+
+    #[async_trait]
+    impl ChatModel<()> for SelectingProvider {
+        async fn invoke(
+            &self,
+            _state: &(),
+            request: ModelRequest,
+        ) -> tinyagents::Result<ModelResponse> {
+            if is_selection_request(&request) {
+                self.selector_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                return Ok(ModelResponse::assistant(self.reply.clone()));
+            }
+            let message = request
+                .messages
+                .iter()
+                .rev()
+                .find(|m| matches!(m, Message::User(_)))
+                .map(|m| m.text())
+                .unwrap_or_default();
+            Ok(ModelResponse::assistant(format!("mock: {message}")))
+        }
+    }
+
+    impl HarnessModel for SelectingProvider {
+        fn telemetry_provider_id(&self) -> String {
+            "selecting".to_string()
+        }
+    }
+
+    #[test]
+    fn a_selection_request_is_recognised_as_one() {
+        let selection = ModelRequest {
+            messages: vec![
+                tinyagents::harness::message::Message::system(
+                    crate::harness::selector::system_prompt_for_test(),
+                ),
+                tinyagents::harness::message::Message::user("who owns login?".to_string()),
+            ],
+            ..ModelRequest::default()
+        };
+        assert!(
+            is_selection_request(&selection),
+            "the fixture must recognise the real prompt, or it silently starts \
+             eating scripted turns"
+        );
+    }
+
+    /// A brain whose provider answers every selection request with `reply`.
+    /// The record is [`record_with_desk`] — `engineer` + `chief`, a lead
+    /// `eng_desk` — plus an `auto` overlay channel `launch` holding both.
+    fn brain_that_selects(
+        dir: &std::path::Path,
+        reply: &str,
+    ) -> (HarnessBrain, Arc<SelectingProvider>) {
+        let provider = Arc::new(SelectingProvider {
+            reply: reply.to_string(),
+            selector_calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let deps = HarnessDeps {
+            ledgers: None,
+            ledger_registry: Default::default(),
+            provider: provider.clone(),
+            provider_slug: "selecting".to_string(),
+            serves: None,
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: None,
+            workspace_root: dir.to_path_buf(),
+            mcp_home: None,
+            workspace_git_enabled: false,
+            audit_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: None,
+            artifacts: None,
+            skills: None,
+            skills_source_dir: None,
+            skills_registry: std::sync::Arc::from([]),
+            default_mcp_servers: Vec::new(),
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
+            run_outputs: crate::harness::orchestrator::RunOutputCache::default(),
+            run_output_store: None,
+            workflow_revisions: None,
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            #[cfg(feature = "chargebee")]
+            chargebee: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
+            hosting: None,
+            steer: InflightRegistry::new(),
+            run_supervisor: crate::runtime::RunSupervisor::default(),
+            delivery: None,
+            search: None,
+            tenant_search: None,
+            workspace: None,
+            workflow_runs: None,
+            deep_trace: None,
+        };
+        let mut record = record_with_desk();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "launch".to_string(),
+            name: "Launch week".to_string(),
+            description: None,
+            members: vec!["engineer".to_string(), "chief".to_string()],
+            responder: crate::ports::types::ResponderMode::Auto,
+        });
+        (
+            HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
+            provider,
+        )
+    }
+
+    /// Issue #1835, the rung itself: an unmentioned message addressed to an
+    /// `auto` channel is routed to the selector's pick — a member the
+    /// deterministic fallback (`engineer`, the first member) would never have
+    /// chosen — and the pick is clamped to the channel.
+    #[tokio::test]
+    async fn an_auto_channel_routes_by_the_selectors_pick() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_selects(dir.path(), "chief");
+        assert_eq!(
+            brain
+                .auto_channel_responder(Some("launch"), "which strategy are we running?")
+                .await
+                .as_deref(),
+            Some("chief"),
+            "the selection overrides the first-member fallback"
+        );
+        assert_eq!(
+            provider
+                .selector_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    /// The worst case of the new rung is the old rung: a pick outside the
+    /// channel's membership answers `None`, and the caller keeps the
+    /// deterministic fallback. Revert the clamp in `SelectorVerdict::parse`
+    /// and this routes a turn to a teammate the channel does not contain.
+    #[tokio::test]
+    async fn a_failed_selection_keeps_the_deterministic_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _provider) = brain_that_selects(dir.path(), "somebody_else");
+        assert_eq!(
+            brain
+                .auto_channel_responder(Some("launch"), "which strategy are we running?")
+                .await,
+            None,
+            "an out-of-membership pick must fall back, never route"
+        );
+    }
+
+    /// The short-circuits spend nothing: a lead desk never reaches the
+    /// selector at all, and a single-member channel is its member without a
+    /// model call — a pick over one candidate is the fallback with latency.
+    #[tokio::test]
+    async fn lead_desks_and_single_member_channels_never_pay_for_selection() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_selects(dir.path(), "chief");
+        // The lead desk from `record_with_desk` is not an auto channel.
+        assert_eq!(
+            brain
+                .auto_channel_responder(Some("eng_desk"), "hello")
+                .await,
+            None
+        );
+        // Shrink the channel to one member: it answers without the model.
+        brain.mutate_record(|r| {
+            r.overlay_desks[0].members = vec!["chief".to_string()];
+        });
+        assert_eq!(
+            brain
+                .auto_channel_responder(Some("launch"), "hello")
+                .await
+                .as_deref(),
+            Some("chief")
+        );
+        assert_eq!(
+            provider
+                .selector_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "neither path may spend a selection call"
         );
     }
 

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -126,6 +126,11 @@ pub mod search_byo;
 /// responses are scripted. Test-only.
 #[cfg(test)]
 mod search_turn_test;
+/// The per-message responder selection for `auto` channels (issue #1835): the
+/// tool-less model call that picks which member of a leadless channel answers
+/// an unmentioned message, falling back to the channel's first roster member
+/// wherever it cannot run.
+pub mod selector;
 pub mod skills;
 pub mod steer;
 pub mod steps;

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -2942,6 +2942,40 @@ impl HarnessPool {
         .await
     }
 
+    /// Whether the plan-level total-token ceiling is already spent — the bare
+    /// predicate behind [`total_ceiling_refusal`](Self::total_ceiling_refusal),
+    /// for callers that make a model call the refusal shape does not describe.
+    ///
+    /// The responder-selection pass (issue #1835) is the first: it runs
+    /// *before* a responder is chosen, so it has no agent to refuse as and no
+    /// `TurnOutcome` to hand back — but it is a real model call, and a tenant
+    /// past its ceiling must not keep paying for routing (codex on #1872).
+    /// One predicate, so "is the ceiling spent" cannot answer differently for
+    /// the gate and for the turn it gates.
+    ///
+    /// **Answers `false` wherever the ceiling cannot be evaluated** — no plan,
+    /// no total budget, no meter, or a failed spend query — which is exactly
+    /// what `total_ceiling_refusal` does with the same cases: it declines to
+    /// hard-refuse and defers to the per-namespace fail-closed roster. A gate
+    /// that instead blocked on an unreadable meter would take routing down on
+    /// a metering hiccup.
+    pub(crate) async fn total_ceiling_spent(company: &CompanyId, deps: &HarnessDeps) -> bool {
+        let Some(plan) = deps.plan.as_ref() else {
+            return false;
+        };
+        if plan.total_budget.is_none() {
+            return false;
+        }
+        let Some(meter) = deps.meter.as_deref() else {
+            return false;
+        };
+        let since = plan.period.period_start_millis(crate::ports::now_millis());
+        match meter.query(company, since).await {
+            Ok(samples) => plan.total_exhausted(capability_budget::tokens_in(&samples)),
+            Err(_) => false,
+        }
+    }
+
     /// The plan-level total-token ceiling, as a refusal or nothing.
     ///
     /// Extracted from [`run_inner`](Self::run_inner) so the confined turn

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -1562,6 +1562,19 @@ impl Tool for QueryCompanyTool {
                     Some(lead) => md.push_str(&format!(
                         "- **{id}** — lead: {lead} (delegate with `delegate_to_desk` desk=`{id}`)\n"
                     )),
+                    // A leadless answer is two different facts (issue #1835):
+                    // an `auto` channel has members but no lead by design —
+                    // "cannot be handed work" would be a lie about a staffed
+                    // channel — while a desk with nobody on the roster really
+                    // cannot take anything.
+                    None if record
+                        .as_ref()
+                        .is_some_and(|r| !r.desk_responder_mode(id).is_lead()) =>
+                    {
+                        md.push_str(&format!(
+                            "- **{id}** — channel without a lead; who answers is picked per message. `delegate_to_desk` cannot target it — use `delegate_to_teammate` with one of its members\n"
+                        ))
+                    }
                     None => md.push_str(&format!(
                         "- **{id}** — no member on the roster, so it cannot be handed work\n"
                     )),

--- a/src/harness/built_in/planning/test.rs
+++ b/src/harness/built_in/planning/test.rs
@@ -1659,6 +1659,7 @@ async fn the_prompt_carries_runtime_teammates_and_desks_not_just_manifest_ones()
         name: "Growth".to_string(),
         description: None,
         members: vec!["social_manager".to_string()],
+        responder: crate::ports::types::ResponderMode::default(),
     });
     runtime.store().save(&record).await.unwrap();
 

--- a/src/harness/built_in/selector.rs
+++ b/src/harness/built_in/selector.rs
@@ -1,0 +1,388 @@
+//! The per-message responder selection for `auto` channels (issue #1835).
+//!
+//! # The rung this adds
+//!
+//! An [`Auto`](crate::ports::types::ResponderMode::Auto) channel has no lead:
+//! nobody outranks anybody, so "who answers this?" is decided **per message**
+//! rather than at creation time. This module is that decision — a single
+//! tool-less model call handed the message and the channel's own membership
+//! (id, role, description — the same fields `GET …/team` serves), answering
+//! with exactly one member id.
+//!
+//! It sits **below** an `@`-mention and **above** the deterministic fallback:
+//! a named teammate still outranks everything
+//! ([`mention_responder`](crate::runtime::mentions::mention_responder)), and
+//! wherever this call cannot run — the default build, the small-talk fast
+//! path, a failure, a timeout — the answer is
+//! [`desk_default_responder`](crate::runtime::delegation_tools::desk_default_responder),
+//! the channel's first roster member, which is exactly what a lead desk would
+//! have answered. The worst case of the new rung is the old rung.
+//!
+//! # It decides, it does not act
+//!
+//! Same framing as the triage escalation this module is modelled on
+//! ([`triage`](super::triage), issue #678): the request carries **no tools at
+//! all**, so there is no loop and nothing it can reach. The message is shown
+//! to it as routing *data* — a directive inside the message can influence
+//! which member answers (that is routing working, not failing: "can someone
+//! from design look at this" *should* land on design), but it cannot make the
+//! selector do anything except name a member.
+//!
+//! # Failure is silence, not an error
+//!
+//! Unreachable, slow, unparseable, or an id outside the membership all return
+//! [`SelectorVerdict::Unavailable`], and the caller keeps the deterministic
+//! answer. The operator is waiting on a reply; a selector that cannot select
+//! must cost nothing but its timeout.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tinyagents::harness::message::Message;
+use tinyagents::harness::model::{ModelRequest, ModelResponse};
+
+use crate::harness::HarnessDeps;
+use crate::harness::build::model_for_tier;
+use crate::harness::provider::HarnessModel;
+use crate::ports::types::TokenUsage;
+
+/// How long a selection may wait on the model before it is abandoned.
+///
+/// The same class of budget as the triage escalation's two seconds — an
+/// operator is watching a chat thread with no reply — with one second of
+/// headroom for the larger input (a roster block rather than one message).
+/// Past it the deterministic fallback is simply better than a late pick.
+const SELECTOR_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Output-token ceiling. The answer is one member id; this is headroom for a
+/// long snake_case id and stray punctuation, not room to explain the choice.
+const MAX_OUTPUT_TOKENS: u32 = 24;
+
+/// Deterministic. Routing wants the same pick for the same message — an
+/// operator who sends the same question twice should not watch it land on two
+/// different teammates. Unlike triage there is no upstream setting to honour,
+/// so this is zero rather than near-zero.
+const TEMPERATURE: f64 = 0.0;
+
+/// One channel member as the selector sees it: the id it must answer with and
+/// the role/description it judges fit by — the same fields the console's
+/// members pane renders, so the selector reasons from what an operator reads.
+#[derive(Debug, Clone)]
+pub struct SelectorCandidate {
+    /// The roster id — the only valid answer token.
+    pub id: String,
+    /// The teammate's role, e.g. "Backend Engineer".
+    pub role: String,
+    /// The teammate's mandate, when one is declared.
+    pub description: Option<String>,
+}
+
+/// What a selection decided.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorVerdict {
+    /// One of the candidates, by id — guaranteed by [`SelectorVerdict::parse`]
+    /// to be a member of the candidate set it was parsed against.
+    Member(String),
+    /// No usable pick: unreachable, slow, unparseable, or an id outside the
+    /// membership. The caller keeps the deterministic fallback.
+    Unavailable,
+}
+
+impl SelectorVerdict {
+    /// Reads a model reply into a verdict, **clamped to `candidates`**.
+    ///
+    /// Tolerates the decoration small models add around a token — whitespace,
+    /// wrapping quotes or backticks, a trailing period — and matches the id
+    /// case-insensitively, answering with the candidate's own casing. Anything
+    /// that is not one of the candidates is [`Self::Unavailable`], never a
+    /// guess: an out-of-set id routed verbatim would address a turn to a
+    /// teammate the channel does not contain.
+    pub fn parse(text: &str, candidates: &[SelectorCandidate]) -> Self {
+        let token = text
+            .trim()
+            .trim_matches(|c| matches!(c, '"' | '\'' | '`'))
+            .trim_end_matches('.')
+            .trim();
+        candidates
+            .iter()
+            .find(|c| c.id.eq_ignore_ascii_case(token))
+            .map(|c| SelectorVerdict::Member(c.id.clone()))
+            .unwrap_or(SelectorVerdict::Unavailable)
+    }
+}
+
+/// The selection instruction. Kept in the triage escalation's voice: it
+/// decides, it does not act, and unsureness has a named safe answer.
+fn system_prompt() -> String {
+    "You route one message in a group channel to the member best fit to answer it. \
+     You do not act. You do not reply to the message. You only decide who should.\n\
+     \n\
+     You are given the channel's members — id, role, and what they own — and the \
+     message. Judge fit by the message's subject against each member's role and \
+     mandate.\n\
+     \n\
+     Answer with exactly one member id from the list, and nothing else. \
+     If no member is clearly the better fit, answer the first listed id."
+        .to_string()
+}
+
+/// The system prompt, for the fixture that has to recognise a selection
+/// request without consuming a scripted turn (the same seam
+/// [`triage::system_prompt_for_test`](super::triage::system_prompt_for_test)
+/// exists for).
+#[cfg(test)]
+pub fn system_prompt_for_test() -> String {
+    system_prompt()
+}
+
+/// The user message: the membership block, then the message being routed —
+/// data laid out for a judgement, in the order the judgement reads it.
+fn selection_request(message: &str, candidates: &[SelectorCandidate]) -> String {
+    let mut out = String::from("Channel members:\n");
+    for c in candidates {
+        out.push_str("- ");
+        out.push_str(&c.id);
+        out.push_str(" — ");
+        out.push_str(&c.role);
+        if let Some(description) = c.description.as_deref().filter(|d| !d.trim().is_empty()) {
+            out.push_str(": ");
+            out.push_str(description);
+        }
+        out.push('\n');
+    }
+    out.push_str("\nMessage:\n");
+    out.push_str(message);
+    out
+}
+
+/// A model that picks the best-fit member for one message.
+///
+/// Holds no runtime handle, mirroring [`TriageEvaluator`](super::triage) and
+/// the planning pass: the caller already has the handles metering needs, and
+/// an evaluator that owned the runtime back would be a cycle that never frees.
+pub struct ResponderSelector {
+    model: Arc<dyn HarnessModel>,
+    model_name: String,
+}
+
+impl ResponderSelector {
+    /// Builds a selector over an explicit model.
+    pub fn new(model: Arc<dyn HarnessModel>, model_name: impl Into<String>) -> Self {
+        Self {
+            model,
+            model_name: model_name.into(),
+        }
+    }
+
+    /// Builds the company's selector from the harness deps.
+    ///
+    /// Takes the roster's own default model — `model_override`, else the
+    /// tier-less default — rather than inventing a cheap tier, for the reason
+    /// [`TriageEvaluator::from_deps`](super::triage::TriageEvaluator::from_deps)
+    /// documents at length: an abstract tier a tenant's `[inference].models`
+    /// table does not map is passed to their provider verbatim, so a made-up
+    /// `fast-v1` would fail on exactly the BYOK setups that otherwise work.
+    /// Cheapness comes from the shape of the call — no tools, one short system
+    /// prompt, one message, [`MAX_OUTPUT_TOKENS`] of output.
+    pub fn from_deps(deps: &HarnessDeps) -> Self {
+        let model_name = deps
+            .model_override
+            .clone()
+            .unwrap_or_else(|| model_for_tier(None));
+        Self::new(deps.provider.clone(), model_name)
+    }
+
+    /// The provider slug this selector's usage is metered under, read live so
+    /// a BYOK switch re-attributes the next selection.
+    pub fn provider_slug(&self) -> String {
+        self.model.telemetry_provider_id()
+    }
+
+    /// The model this pass's usage is metered against, read live off the
+    /// provider and already folded onto the closed vocabulary (issue #1749).
+    /// `None` before the provider has issued a turn, or when it cannot name a
+    /// model.
+    pub fn model_slug(&self) -> Option<crate::metering::ModelSlug> {
+        self.model.telemetry_model()
+    }
+
+    /// Picks the best-fit member for one message, with what the call cost.
+    ///
+    /// Never returns an error: every failure is
+    /// [`SelectorVerdict::Unavailable`] and the caller keeps the deterministic
+    /// fallback. The [`TokenUsage`] is still returned on a *parse* failure,
+    /// because those tokens were really spent and must still be metered.
+    pub async fn select(
+        &self,
+        message: &str,
+        candidates: &[SelectorCandidate],
+    ) -> (SelectorVerdict, TokenUsage) {
+        let request = ModelRequest {
+            messages: vec![
+                Message::system(system_prompt()),
+                Message::user(selection_request(message, candidates)),
+            ],
+            model: Some(self.model_name.clone()),
+            temperature: Some(TEMPERATURE),
+            max_tokens: Some(MAX_OUTPUT_TOKENS),
+            ..ModelRequest::default()
+        };
+        let response =
+            match tokio::time::timeout(SELECTOR_TIMEOUT, self.model.invoke(&(), request)).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(err)) => {
+                    tracing::debug!(
+                        error = %err,
+                        "[selector] the model could not be reached; keeping the deterministic \
+                         fallback"
+                    );
+                    return (SelectorVerdict::Unavailable, TokenUsage::default());
+                }
+                Err(_elapsed) => {
+                    tracing::debug!(
+                        timeout_s = SELECTOR_TIMEOUT.as_secs(),
+                        "[selector] the model did not answer in time; keeping the deterministic \
+                         fallback"
+                    );
+                    return (SelectorVerdict::Unavailable, TokenUsage::default());
+                }
+            };
+        let usage = usage_from(&response);
+        (SelectorVerdict::parse(&response.text(), candidates), usage)
+    }
+}
+
+/// The production selection: a [`ResponderSelector`] whose spend lands on the
+/// company's usage and ledger before the verdict is returned.
+pub struct MeteredSelector {
+    selector: ResponderSelector,
+    company: crate::ports::types::CompanyId,
+    store: Arc<dyn crate::ports::CompanyStore>,
+    meter: Option<Arc<dyn crate::ports::usage::UsageMeter>>,
+}
+
+impl MeteredSelector {
+    /// Wires a selection for `company` from the harness deps.
+    pub fn from_deps(deps: &HarnessDeps, company: crate::ports::types::CompanyId) -> Self {
+        Self {
+            selector: ResponderSelector::from_deps(deps),
+            company,
+            store: deps.store.clone(),
+            meter: deps.meter.clone(),
+        }
+    }
+
+    /// Picks the best-fit member, recording whatever the call cost.
+    ///
+    /// Metered even when the verdict is `Unavailable`: an unparseable reply
+    /// still burned tokens, and a pick we could not read is precisely the
+    /// spend an operator would want to see. The record call is made whether or
+    /// not a meter is wired — the ledger half must not be lost to a host that
+    /// only records spend it can prove.
+    pub async fn select(&self, message: &str, candidates: &[SelectorCandidate]) -> SelectorVerdict {
+        let (verdict, usage) = self.selector.select(message, candidates).await;
+        crate::metering::record_selector_usage(
+            &usage,
+            &self.selector.provider_slug(),
+            self.selector.model_slug(),
+            &self.company,
+            self.store.as_ref(),
+            self.meter.as_ref().map(|meter| meter.as_ref()),
+        )
+        .await;
+        verdict
+    }
+}
+
+/// Token spend for one selection, including the cost the managed provider
+/// reports on the wire. Mirrors the triage escalation's reader.
+fn usage_from(response: &ModelResponse) -> TokenUsage {
+    let tokens = response.usage.unwrap_or_default();
+    let cost_usd = response
+        .raw
+        .as_ref()
+        .and_then(|raw| raw.pointer("/openhuman_usage_meta/charged_amount_usd"))
+        .and_then(serde_json::Value::as_f64)
+        .filter(|c| c.is_finite() && *c > 0.0)
+        .unwrap_or(0.0);
+    TokenUsage {
+        input: tokens.input_tokens,
+        output: tokens.output_tokens,
+        cached_input: tokens.cache_read_tokens,
+        cost_usd,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidates() -> Vec<SelectorCandidate> {
+        vec![
+            SelectorCandidate {
+                id: "backend_engineer".to_string(),
+                role: "Backend Engineer".to_string(),
+                description: Some("Owns the API surface.".to_string()),
+            },
+            SelectorCandidate {
+                id: "designer".to_string(),
+                role: "Product Designer".to_string(),
+                description: None,
+            },
+        ]
+    }
+
+    /// The decoration small models add around a token — quotes, backticks, a
+    /// trailing period, case drift — parses to the candidate's own id.
+    #[test]
+    fn parse_tolerates_decoration_and_answers_the_candidates_casing() {
+        for reply in [
+            "backend_engineer",
+            " backend_engineer \n",
+            "\"backend_engineer\"",
+            "`backend_engineer`",
+            "Backend_Engineer.",
+        ] {
+            assert_eq!(
+                SelectorVerdict::parse(reply, &candidates()),
+                SelectorVerdict::Member("backend_engineer".to_string()),
+                "reply {reply:?} should parse"
+            );
+        }
+    }
+
+    /// An id outside the membership is `Unavailable`, never routed verbatim —
+    /// an out-of-set pick would address a turn to a teammate the channel does
+    /// not contain. Revert the clamp in [`SelectorVerdict::parse`] and this
+    /// answers `Member("ceo")`.
+    #[test]
+    fn parse_clamps_to_the_candidate_set() {
+        assert_eq!(
+            SelectorVerdict::parse("ceo", &candidates()),
+            SelectorVerdict::Unavailable
+        );
+        assert_eq!(
+            SelectorVerdict::parse("", &candidates()),
+            SelectorVerdict::Unavailable
+        );
+        assert_eq!(
+            SelectorVerdict::parse(
+                "backend_engineer because the message is about the API",
+                &candidates()
+            ),
+            SelectorVerdict::Unavailable,
+            "an answer with an explanation attached is not an id"
+        );
+    }
+
+    /// The request lays the membership out id-first, so the only valid answer
+    /// tokens are on the page, and frames the message as the thing being
+    /// routed rather than instructions to follow.
+    #[test]
+    fn selection_request_names_ids_roles_and_the_message() {
+        let request = selection_request("who owns the login flow?", &candidates());
+        assert!(request.contains("- backend_engineer — Backend Engineer: Owns the API surface."));
+        assert!(request.contains("- designer — Product Designer\n"));
+        assert!(request.contains("Message:\nwho owns the login flow?"));
+    }
+}

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -264,6 +264,10 @@ pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
 /// volume*, so a company left able to classify indefinitely past its ceiling
 /// would keep paying per operator message with nothing to stop it.
 ///
+/// [`SampleKind::SelectorCall`] is counted on `TriageCall`'s exact terms
+/// (issue #1835): per-message company-driven spend, uncappable by any
+/// teammate's budget, that must stop when the tier ceiling does.
+///
 /// [`SampleKind::SetupCall`] is counted too, and its exposure is the smallest of
 /// the three: a company runs first-run setup once. It is included so the ceiling
 /// covers every completion billed to the tenant rather than only the ones that
@@ -277,6 +281,7 @@ pub fn tokens_in(samples: &[UsageSample]) -> u64 {
                 SampleKind::Inference
                     | SampleKind::PlanningCall
                     | SampleKind::TriageCall
+                    | SampleKind::SelectorCall
                     | SampleKind::SetupCall
             )
         })

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -60,6 +60,7 @@ pub mod planning;
 /// the roster it is building exists). See [`roster_build`].
 pub mod roster_build;
 pub mod search;
+pub mod selector;
 pub mod triage;
 mod types;
 mod usage;
@@ -83,6 +84,7 @@ pub use planning::{planning_sample, record_planning_usage};
 pub use search::{
     FALLBACK_SEARCH_COST_USD, MANAGED_SEARCH_PROVIDER, record_search_call, search_call_sample,
 };
+pub use selector::{record_selector_usage, selector_sample};
 pub use triage::{record_triage_usage, triage_sample};
 pub use types::{
     AgentTokens, CategorySpend, Direction, Finances, ProviderCalls, Transaction, Usage, UsagePoint,

--- a/src/metering/selector.rs
+++ b/src/metering/selector.rs
@@ -1,0 +1,151 @@
+//! Emitting [`SampleKind::SelectorCall`] usage samples — what a responder
+//! selection costs, and who it is charged to (issue #1835).
+//!
+//! # Why this is not a teammate's inference
+//!
+//! A responder selection is the tool-less model call an unmentioned message in
+//! an `auto` channel makes to pick its best-fit answerer. It happens **before**
+//! any teammate is chosen — selection is what picks the teammate — so there is
+//! no agent to attribute it to. Like a triage escalation, it is charged to the
+//! whole-company bucket ([`UNATTRIBUTED_AGENT`]) with no `run_id`.
+//!
+//! It is deliberately not folded into
+//! [`SampleKind::TriageCall`](crate::ports::usage::SampleKind) either. The two
+//! are driven by different things — triage by raw chat volume everywhere,
+//! selection only by unmentioned messages in `auto` channels — so sharing a
+//! kind would make the triage line item move whenever an operator created a
+//! channel, and neither number could be tuned against the other.
+//!
+//! # Both writes are logged and swallowed
+//!
+//! Same rule as the triage path: the selection has already been made and the
+//! operator's turn is already running by the time this is called. A ledger or
+//! meter hiccup must cost the accounting row and never the reply. The tokens
+//! were genuinely spent either way, which is why the failure is logged rather
+//! than silently dropped.
+
+use crate::ports::types::{CompanyId, TokenUsage};
+use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+use crate::ports::{CompanyStore, now_millis};
+
+use super::inference::{UNATTRIBUTED_AGENT, inference_ledger_entry};
+
+/// Builds the [`SampleKind::SelectorCall`] sample for one completed selection,
+/// or `None` when it moved no tokens and cost nothing.
+///
+/// The `None` case is the offline/mock path, exactly as in
+/// [`triage_sample`](super::triage_sample): a provider reporting no usage
+/// yields a zero [`TokenUsage`], and a row for it would claim a call happened
+/// that is indistinguishable from a real free one.
+///
+/// `agent` is not a parameter — attribution to [`UNATTRIBUTED_AGENT`] is the
+/// rule this module holds, so no caller can bill a selection to the teammate it
+/// happened to pick.
+///
+/// `model` is the classified [`ModelSlug`](crate::metering::ModelSlug) the pass
+/// ran against, or `None` when the caller cannot name one (issue #1749).
+pub fn selector_sample(
+    usage: &TokenUsage,
+    provider: &str,
+    model: Option<crate::metering::ModelSlug>,
+) -> Option<UsageSample> {
+    if usage.is_zero() {
+        return None;
+    }
+    Some(UsageSample {
+        at_millis: now_millis(),
+        agent: UNATTRIBUTED_AGENT.to_string(),
+        provider: super::oauth::normalize_provider(provider),
+        input_tokens: usage.input,
+        output_tokens: usage.output,
+        cached_input_tokens: usage.cached_input,
+        cost_usd: usage.cost_usd,
+        kind: SampleKind::SelectorCall,
+        run_id: None,
+        model,
+    })
+}
+
+/// Records one completed responder selection: the Finances ledger entry (when
+/// it cost USD) and, when a usage meter is wired, the usage sample.
+///
+/// The ledger entry goes through the same [`inference_ledger_entry`] the
+/// cycle's inference spend uses, under the same `inference.spend` kind —
+/// selection spend is inference spend as far as the money is concerned, and
+/// only the *usage* breakdown cares about the distinction. The meter is
+/// deliberately optional: a host with no usage meter still records the spend
+/// it can prove, exactly as
+/// [`record_triage_usage`](super::record_triage_usage) preserves its ledger
+/// write without a meter.
+pub async fn record_selector_usage(
+    usage: &TokenUsage,
+    provider: &str,
+    model: Option<crate::metering::ModelSlug>,
+    company: &CompanyId,
+    store: &dyn CompanyStore,
+    meter: Option<&dyn UsageMeter>,
+) {
+    if usage.is_zero() {
+        return;
+    }
+    tracing::debug!(
+        company = %company,
+        provider = %provider,
+        input = usage.input,
+        output = usage.output,
+        cached_input = usage.cached_input,
+        cost_usd = usage.cost_usd,
+        "[usage] recording a responder selection"
+    );
+    if let Some(entry) = inference_ledger_entry(usage, UNATTRIBUTED_AGENT)
+        && let Err(err) = store.append_ledger(company, entry).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to append the selection spend entry; the pick still stands"
+        );
+    }
+    if let Some(sample) = selector_sample(usage, provider, model)
+        && let Some(meter) = meter
+        && let Err(err) = meter.record(company, &sample).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to record the selection usage sample; the pick still stands"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage() -> TokenUsage {
+        TokenUsage {
+            input: 120,
+            output: 4,
+            cached_input: 0,
+            cost_usd: 0.0002,
+        }
+    }
+
+    /// A selection that moved tokens mints a [`SampleKind::SelectorCall`] row
+    /// charged to the whole-company bucket — never to the teammate it picked.
+    #[test]
+    fn a_selection_samples_under_its_own_kind_and_no_teammate() {
+        let sample = selector_sample(&usage(), "openrouter", None).expect("a real spend samples");
+        assert_eq!(sample.kind, SampleKind::SelectorCall);
+        assert_eq!(sample.agent, UNATTRIBUTED_AGENT);
+        assert_eq!(sample.run_id, None);
+        assert_eq!(sample.input_tokens, 120);
+    }
+
+    /// The offline/mock path — zero usage — mints no row: a free fake call is
+    /// indistinguishable from a real free one, so no row is the honest record.
+    #[test]
+    fn zero_usage_mints_no_sample() {
+        assert!(selector_sample(&TokenUsage::default(), "openrouter", None).is_none());
+    }
+}

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -3164,6 +3164,40 @@ pub struct OverlayDeskOrder {
     pub ordered: Vec<String>,
 }
 
+/// How a desk's unmentioned messages find their answerer (issue #1835).
+///
+/// `Lead` is the model every desk has always had: `members[0]` is the desk
+/// lead, made explicit by #1827, and `responder_for` hands the lead every
+/// message that names nobody. `Auto` is the channel model: **no lead exists**
+/// — no crown, no hierarchy, no `delegate_to_desk` target — and the answerer
+/// is chosen **per message**, by a best-fit selection over the channel's own
+/// membership, with the first roster member as the deterministic fallback
+/// wherever selection cannot run (the default build, the small-talk fast
+/// path, a selection failure).
+///
+/// On the wire and in storage this is `"lead"` / `"auto"`, defaulted and
+/// skipped when `Lead`, so every record written before the field existed —
+/// and every desk the org chart creates today — deserializes and re-serializes
+/// byte-for-byte unchanged.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResponderMode {
+    /// `members[0]` leads the desk and answers its unmentioned messages.
+    #[default]
+    Lead,
+    /// No lead: a per-message best-fit selection over the membership answers,
+    /// falling back to the first roster member where selection cannot run.
+    Auto,
+}
+
+impl ResponderMode {
+    /// Whether this is the default mode — the `skip_serializing_if` predicate
+    /// that keeps every pre-#1835 record round-tripping byte-identically.
+    pub fn is_lead(&self) -> bool {
+        matches!(self, ResponderMode::Lead)
+    }
+}
+
 /// An operator-created desk (group chat) that the version-controlled manifest
 /// does not declare. Persisted as an overlay on the [`CompanyRecord`] and merged
 /// with the manifest's `[[group_chat]]` desks at read/resolve time; the
@@ -3180,11 +3214,20 @@ pub struct OverlayDesk {
     /// What the desk is for.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// The desk's founding member ids, in order; the first is its lead. Each
-    /// must resolve to a roster teammate (manifest agent or [`OverlayAgent`]).
-    /// Further members can still be added through the desk-member overlay.
+    /// The desk's founding member ids, in order; the first is its lead — unless
+    /// [`responder`](Self::responder) is [`ResponderMode::Auto`], in which case
+    /// order carries no rank at all. Each must resolve to a roster teammate
+    /// (manifest agent or [`OverlayAgent`]). Further members can still be added
+    /// through the desk-member overlay.
     #[serde(default)]
     pub members: Vec<String>,
+    /// How this desk's unmentioned messages find their answerer (issue #1835).
+    /// Defaulted and skipped when [`ResponderMode::Lead`], so every record
+    /// written before the field existed deserializes unchanged. Manifest
+    /// `[[group_chat]]` desks are always `Lead` — the blueprint syntax carries
+    /// no such field.
+    #[serde(default, skip_serializing_if = "ResponderMode::is_lead")]
+    pub responder: ResponderMode,
 }
 
 /// A workflow graph body authored at runtime (the console's create dialog or
@@ -4001,6 +4044,23 @@ impl CompanyRecord {
     pub fn desk_exists(&self, desk_id: &str) -> bool {
         self.manifest.group_chats.iter().any(|c| c.id == desk_id)
             || self.overlay_desks.iter().any(|d| d.id == desk_id)
+    }
+
+    /// How the desk with **exact** id `desk_id` routes its unmentioned messages
+    /// (issue #1835).
+    ///
+    /// Manifest `[[group_chat]]` desks are always [`ResponderMode::Lead`] — the
+    /// blueprint syntax carries no responder field — and so is any id that
+    /// names no desk at all, which keeps every non-desk caller (`#general`, a
+    /// DM key, a bare teammate id) on the behaviour it has today. Takes the
+    /// resolved id, not a display name: callers that accept either resolve
+    /// through [`Self::resolve_desk_id`] first, as `desk_lead` does.
+    pub fn desk_responder_mode(&self, desk_id: &str) -> ResponderMode {
+        self.overlay_desks
+            .iter()
+            .find(|d| d.id == desk_id)
+            .map(|d| d.responder)
+            .unwrap_or_default()
     }
 
     /// Whether `agent_id` names a roster teammate — a manifest agent or an
@@ -6400,6 +6460,7 @@ mod test {
             name: "Design Studio".into(),
             description: None,
             members: Vec::new(),
+            responder: crate::ports::types::ResponderMode::default(),
         });
         assert_eq!(record.mint_agent_id("Design Studio"), "design_studio");
         // …while the overlay desk's id is reserved exactly like a manifest one.
@@ -7441,6 +7502,7 @@ mod test {
             name: "Growth".into(),
             description: None,
             members: vec!["eng".into()],
+            responder: crate::ports::types::ResponderMode::default(),
         });
         // Resolves by id and by case-insensitive name.
         assert_eq!(record.resolve_desk_id("growth").as_deref(), Some("growth"));

--- a/src/ports/usage.rs
+++ b/src/ports/usage.rs
@@ -85,6 +85,24 @@ pub enum SampleKind {
     /// company-driven model spend, and excluding it would let chat keep paying
     /// for classification after the tier budget was exhausted.
     TriageCall,
+    /// One completed responder selection — the tool-less model call an
+    /// unmentioned message in an `auto` channel makes to pick its best-fit
+    /// answerer (issue #1835).
+    ///
+    /// Its own kind for the reason [`Self::TriageCall`] is its own kind: it
+    /// belongs to no teammate — selection is what *picks* the teammate — so it
+    /// is charged to the whole-company bucket with no `run_id`, and "what is
+    /// routing costing us?" should be answerable without reading a teammate's
+    /// column. Distinct from `TriageCall` too: triage is driven by raw chat
+    /// volume everywhere, selection only by unmentioned messages in `auto`
+    /// channels, and conflating them would make the triage line move whenever
+    /// an operator created a channel.
+    ///
+    /// Counts toward the capability-tier token budget, exactly as triage does
+    /// — see [`tokens_in`](crate::metering::tokens_in) — and for the same
+    /// leak: selection is per-message spend, so a company past its ceiling
+    /// must not keep paying to route.
+    SelectorCall,
     /// One completed first-run setup pass — the single tool-less model call
     /// that turns three answers into a starting roster
     /// (`docs/spec/runtime/company-setup.md`).

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -21,7 +21,7 @@
 //! blank card to the orchestrator and still refuse the invalid one.
 
 use crate::ports::types::{CompanyRecord, TeammateResolution};
-use crate::runtime::delegation_tools::desk_lead;
+use crate::runtime::delegation_tools::desk_default_responder;
 
 /// What a card's `assignee` string names on the company roster.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -187,7 +187,13 @@ pub fn resolve(record: &CompanyRecord, assignee: &str) -> AssigneeResolution {
         return AssigneeResolution::Unassigned;
     }
     if let Some(desk) = record.resolve_desk_id(key) {
-        return match desk_lead(record, &desk) {
+        // `desk_default_responder`, not `desk_lead`: for a lead desk they are
+        // the same teammate, and for an `auto` channel (issue #1835) — where
+        // `desk_lead` is `None` by definition — a card assigned to the channel
+        // still dispatches to its deterministic first member rather than
+        // misreporting a staffed channel as empty. The per-message selector is
+        // a chat-routing rung; a durable card wants a durable owner.
+        return match desk_default_responder(record, &desk) {
             Some(lead) => AssigneeResolution::Desk { desk, lead },
             None => AssigneeResolution::EmptyDesk(desk),
         };
@@ -353,6 +359,30 @@ members = []
             AssigneeResolution::Desk {
                 desk: "empty".into(),
                 lead: "nova".into(),
+            }
+        );
+    }
+
+    /// Issue #1835: a card assigned to an `auto` channel dispatches to the
+    /// channel's deterministic first member, never to `EmptyDesk` — that arm's
+    /// wording ("nobody on it") would be a lie about a staffed channel. The
+    /// per-message selector is a chat-routing rung; a durable card wants a
+    /// durable owner.
+    #[test]
+    fn an_auto_channel_is_assignable_and_dispatches_to_its_first_member() {
+        let mut record = acme();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "launch".into(),
+            name: "Launch week".into(),
+            description: None,
+            members: vec!["engineer".into(), "ceo".into()],
+            responder: crate::ports::types::ResponderMode::Auto,
+        });
+        assert_eq!(
+            resolve(&record, "launch"),
+            AssigneeResolution::Desk {
+                desk: "launch".into(),
+                lead: "engineer".into(),
             }
         );
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -7223,6 +7223,7 @@ needs_reason = true
                     name: "Research".to_string(),
                     description: None,
                     members: vec!["ceo".to_string()],
+                    responder: crate::ports::types::ResponderMode::default(),
                 }],
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
@@ -7397,6 +7398,7 @@ needs_reason = true
                     name: "Research".to_string(),
                     description: None,
                     members: vec!["ceo".to_string()],
+                    responder: crate::ports::types::ResponderMode::default(),
                 }],
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
@@ -7954,6 +7956,7 @@ needs_reason = true
             name: "Design".to_string(),
             description: None,
             members: Vec::new(),
+            responder: crate::ports::types::ResponderMode::default(),
         });
         record.overlay_desk_members.push(OverlayDeskMember {
             desk_id: "design".to_string(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2870,6 +2870,26 @@ impl<'a> CycleHostImpl<'a> {
                 }),
             });
         };
+        // An `auto` channel is refused here even though an ordinary leadless
+        // desk is not (issue #1835, codex on #1872). The carve-out above is
+        // about a desk that has no lead *yet* — a card on the board is visible
+        // work either way. An auto channel has no lead by design and never
+        // will, so accepting one wrote a card noting "no lead member on the
+        // roster yet": false about a staffed channel, and permanently so. The
+        // reason comes from `reject_auto_channel_target`, the same definition
+        // the harness tool refuses through, so the two paths cannot drift.
+        if let Some(reason) = record
+            .as_ref()
+            .and_then(|r| crate::runtime::delegation_tools::reject_auto_channel_target(r, &desk_id))
+        {
+            return Ok(ToolResult {
+                ok: false,
+                output: serde_json::json!({
+                    "status": "no_lead",
+                    "error": reason,
+                }),
+            });
+        }
         // The desk's lead, when it has a roster-backed one, is recorded in the
         // note; the card is assigned to the DESK so an operator asking the desk
         // directly (chat targets the desk) sees the hand-off.
@@ -7804,6 +7824,61 @@ members = ["writer"]
         assert_eq!(cards[0].assignee, "eng");
         // Same as the spawn path: a handoff opens a card, it does not dispatch.
         assert_eq!(cards[0].column, COLUMN_TODO);
+    }
+
+    /// Issue #1872 (codex): the hosted path refuses an `auto` channel, and
+    /// says why.
+    ///
+    /// This path deliberately does **not** refuse an ordinary leadless desk —
+    /// a hosted hand-off is a durable card, visible on the board whether or
+    /// not anyone leads the desk yet. An auto channel is different in kind: it
+    /// has no lead by design and never will, so accepting one wrote a card
+    /// noting "no lead member on the roster yet", which is false about a
+    /// staffed channel and permanently so — and it disagreed with the
+    /// built-in tool, which refuses. Remove the guard and this opens a card.
+    #[tokio::test]
+    async fn delegate_to_desk_refuses_an_auto_channel_on_the_hosted_path() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
+            .build()
+            .await
+            .unwrap();
+        let mut record = rt.store().load(rt.id()).await.unwrap().unwrap();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "launch".to_string(),
+            name: "Launch week".to_string(),
+            description: None,
+            members: vec!["eng1".to_string()],
+            responder: crate::ports::types::ResponderMode::Auto,
+        });
+        rt.store().save(&record).await.unwrap();
+
+        let host = CycleHostImpl::new(
+            rt.id().clone(),
+            "cyc".into(),
+            &rt,
+            None,
+            false,
+            ApprovalConversation::default(),
+        );
+        let refused = host
+            .delegate_to_desk(
+                serde_json::json!({ "desk": "launch", "instruction": "ship the launch" }),
+            )
+            .await
+            .unwrap();
+        assert!(!refused.ok, "{:?}", refused.output);
+        assert_eq!(refused.output["status"], "no_lead");
+        let error = refused.output["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("picked per message"),
+            "the refusal says why, rather than reusing the leadless-desk wording: {error}"
+        );
+        assert!(
+            rt.tasks().list(rt.id()).await.unwrap().is_empty(),
+            "a refused hand-off opens no card"
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -160,7 +160,35 @@ the desk knows it was handed the work when asked directly."
 ///
 /// Lifted here from the harness-only delegation runtime so the hosted path can
 /// resolve a desk lead without the `openhuman` feature.
+///
+/// An [`Auto`](crate::ports::types::ResponderMode::Auto) channel (issue #1835)
+/// answers `None` **by definition, not by accident**: no lead exists there, so
+/// every lead-derived surface — the org chart's crown, the members-pane badge,
+/// a `delegate_to_desk` hand-off — stays honest without knowing the mode. The
+/// deterministic "who answers here" question is [`desk_default_responder`],
+/// which ignores the mode on purpose.
 pub fn desk_lead(record: &CompanyRecord, desk: &str) -> Option<String> {
+    let desk_id = record.resolve_desk_id(desk)?;
+    if !record.desk_responder_mode(&desk_id).is_lead() {
+        return None;
+    }
+    record
+        .effective_desk_members(&desk_id)
+        .into_iter()
+        .find(|m| record.is_roster_agent(m))
+}
+
+/// The desk's first effective roster member, **whatever its responder mode**
+/// (issue #1835).
+///
+/// For a [`Lead`](crate::ports::types::ResponderMode::Lead) desk this is the
+/// lead, byte-for-byte what [`desk_lead`] answers. For an `Auto` channel it is
+/// the deterministic fallback: the answer wherever per-message selection
+/// cannot run — the default build (the selector compiles only under the
+/// harness feature), the cycle's small-talk fast path, or a selection failure.
+/// One function, so "the fallback" cannot drift from "the pre-selector
+/// behaviour".
+pub fn desk_default_responder(record: &CompanyRecord, desk: &str) -> Option<String> {
     let desk_id = record.resolve_desk_id(desk)?;
     record
         .effective_desk_members(&desk_id)
@@ -188,7 +216,16 @@ pub fn desk_lead(record: &CompanyRecord, desk: &str) -> Option<String> {
 /// and runs before any brain — attributes its reply to the same teammate the
 /// turn it replaced would have been answered by.
 pub fn chat_responder(record: &CompanyRecord, chat: &str) -> Option<String> {
-    let direct = |key: &str| desk_lead(record, key).or_else(|| record.resolve_roster_agent_id(key));
+    // The desk arm asks [`desk_default_responder`], not [`desk_lead`]: for a
+    // lead desk the two are identical, and for an `Auto` channel (issue #1835)
+    // — where `desk_lead` is `None` by definition — this stays the
+    // deterministic answer. The per-message selection that may override it is
+    // the harness brain's own rung, deliberately not folded in here: this seam
+    // is sync, record-only, and shared with the small-talk fast path, which
+    // must not pay an inference call to attribute a greeting.
+    let direct = |key: &str| {
+        desk_default_responder(record, key).or_else(|| record.resolve_roster_agent_id(key))
+    };
     direct(chat).or_else(|| crate::runtime::assignee::dm_key(chat).and_then(direct))
 }
 
@@ -240,6 +277,33 @@ pub fn reject_desk_target(record: &CompanyRecord, key: &str) -> Option<String> {
     let Some(desk_id) = record.resolve_desk_id(key) else {
         return Some(unknown_desk_message(record, key));
     };
+    // An `Auto` channel (issue #1835) is refused with its own reason, before
+    // the leadless-desk arm below can claim it: that arm's wording — "has no
+    // member on the roster" — would be a lie about a channel full of members.
+    // The real reason is that a hand-off to a desk is a hand-off to its lead,
+    // and this channel has none by design; its answerer is picked per message.
+    // `with_leads` below already excludes such channels from "desks that can
+    // take work", because `desk_lead` is `None` for them by definition.
+    if !record.desk_responder_mode(&desk_id).is_lead() {
+        let with_leads = desk_list(
+            desk_ids(record)
+                .into_iter()
+                .filter(|id| desk_lead(record, id).is_some())
+                .collect(),
+        );
+        return Some(match with_leads {
+            Some(list) => format!(
+                "The \"{desk_id}\" channel has no lead — who answers there is picked per \
+message, not by rank — so `delegate_to_desk` has no one to hand this to. Desks that can \
+take work: {list}."
+            ),
+            None => format!(
+                "The \"{desk_id}\" channel has no lead — who answers there is picked per \
+message, not by rank — so `delegate_to_desk` has no one to hand this to, and no other \
+desk has a lead either. Answer directly instead of delegating."
+            ),
+        });
+    }
     if desk_lead(record, &desk_id).is_some() {
         return None;
     }
@@ -893,6 +957,78 @@ members = ["counsel"]
         assert_eq!(chat_responder(&record, "legal"), None);
         assert_eq!(chat_responder(&record, "nope"), None);
         assert_eq!(chat_responder(&record, "dm:"), None);
+    }
+
+    /// Issue #1835: an `auto` channel answers the three routing questions
+    /// three different ways, and each is load-bearing. `desk_lead` is `None`
+    /// — no lead exists, so no crown, no badge, no `delegate_to_desk` target.
+    /// `desk_default_responder` is the first roster member — the deterministic
+    /// fallback wherever per-message selection cannot run. `chat_responder`
+    /// answers that fallback, so the small-talk fast path and the default
+    /// build route exactly as a lead desk would have.
+    #[test]
+    fn an_auto_channel_has_no_lead_but_a_deterministic_responder() {
+        let mut record = record();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "launch".to_string(),
+            name: "Launch week".to_string(),
+            description: None,
+            members: vec!["ceo".to_string(), "writer".to_string()],
+            responder: crate::ports::types::ResponderMode::Auto,
+        });
+        assert_eq!(
+            desk_lead(&record, "launch"),
+            None,
+            "auto channels have no lead"
+        );
+        assert_eq!(
+            desk_default_responder(&record, "launch").as_deref(),
+            Some("ceo"),
+            "the deterministic fallback is the first roster member"
+        );
+        assert_eq!(
+            chat_responder(&record, "launch").as_deref(),
+            Some("ceo"),
+            "the shared seam answers the fallback, not None"
+        );
+        // An overlay desk that never states a mode is lead-routed — the
+        // pre-#1835 behaviour, byte-for-byte.
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "growth".to_string(),
+            name: "Growth".to_string(),
+            description: None,
+            members: vec!["writer".to_string()],
+            responder: crate::ports::types::ResponderMode::default(),
+        });
+        assert_eq!(desk_lead(&record, "growth").as_deref(), Some("writer"));
+    }
+
+    /// Issue #1835: a hand-off to an `auto` channel is refused with the real
+    /// reason — no lead exists by design — never with the leadless-desk arm's
+    /// "no member on the roster", which would be a lie about a staffed
+    /// channel. The valid-target list must also exclude the channel itself.
+    #[test]
+    fn delegating_to_an_auto_channel_is_refused_naming_the_selection() {
+        let mut record = record();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "launch".to_string(),
+            name: "Launch week".to_string(),
+            description: None,
+            members: vec!["ceo".to_string(), "writer".to_string()],
+            responder: crate::ports::types::ResponderMode::Auto,
+        });
+        let message = reject_desk_target(&record, "launch").expect("refused");
+        assert!(message.contains("picked per message"), "{message}");
+        assert!(
+            !message.contains("no member on the roster"),
+            "a staffed channel must not be reported empty: {message}"
+        );
+        // Desks that can take work are still offered — and never the channel.
+        assert!(message.contains("engineering"), "{message}");
+        assert!(
+            !message.contains("Desks that can take work: launch"),
+            "{message}"
+        );
     }
 
     #[test]

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -280,29 +280,8 @@ pub fn reject_desk_target(record: &CompanyRecord, key: &str) -> Option<String> {
     // An `Auto` channel (issue #1835) is refused with its own reason, before
     // the leadless-desk arm below can claim it: that arm's wording — "has no
     // member on the roster" — would be a lie about a channel full of members.
-    // The real reason is that a hand-off to a desk is a hand-off to its lead,
-    // and this channel has none by design; its answerer is picked per message.
-    // `with_leads` below already excludes such channels from "desks that can
-    // take work", because `desk_lead` is `None` for them by definition.
-    if !record.desk_responder_mode(&desk_id).is_lead() {
-        let with_leads = desk_list(
-            desk_ids(record)
-                .into_iter()
-                .filter(|id| desk_lead(record, id).is_some())
-                .collect(),
-        );
-        return Some(match with_leads {
-            Some(list) => format!(
-                "The \"{desk_id}\" channel has no lead — who answers there is picked per \
-message, not by rank — so `delegate_to_desk` has no one to hand this to. Desks that can \
-take work: {list}."
-            ),
-            None => format!(
-                "The \"{desk_id}\" channel has no lead — who answers there is picked per \
-message, not by rank — so `delegate_to_desk` has no one to hand this to, and no other \
-desk has a lead either. Answer directly instead of delegating."
-            ),
-        });
+    if let Some(reason) = reject_auto_channel_target(record, &desk_id) {
+        return Some(reason);
     }
     if desk_lead(record, &desk_id).is_some() {
         return None;
@@ -321,6 +300,52 @@ Desks that can take work: {list}."
         None => format!(
             "The \"{desk_id}\" desk has no member on the roster, so nothing can be handed to it, \
 and no other desk has a lead either. Answer directly instead of delegating."
+        ),
+    })
+}
+
+/// Why an [`Auto`](crate::ports::types::ResponderMode::Auto) channel cannot
+/// take a `delegate_to_desk` hand-off (issue #1835) — or `None` when
+/// `desk_id` is an ordinary lead desk.
+///
+/// A hand-off to a desk is a hand-off to **its lead**, and an auto channel has
+/// none by design: its answerer is chosen per message. So the refusal says
+/// that, rather than reusing the leadless-desk wording ("has no member on the
+/// roster"), which would be a lie about a channel full of members.
+///
+/// **Public because both delegation paths must refuse identically.** The
+/// harness tool reaches it through [`reject_desk_target`]; the hosted
+/// device-side handler (`runtime::cycle`) calls it directly, because that path
+/// deliberately does *not* refuse an ordinary leadless desk — there a hand-off
+/// is a durable card on the board, visible whether or not anyone leads the
+/// desk yet. An auto channel is the one case it must still refuse, and codex
+/// caught the two paths disagreeing: the hosted one accepted the channel and
+/// wrote a card noting "no lead member on the roster yet", which is both false
+/// and permanently so.
+///
+/// Takes a **resolved** desk id, as `desk_responder_mode` does.
+pub fn reject_auto_channel_target(record: &CompanyRecord, desk_id: &str) -> Option<String> {
+    if record.desk_responder_mode(desk_id).is_lead() {
+        return None;
+    }
+    // `desk_lead` is `None` for an auto channel by definition, so this list
+    // excludes them without a second mode check.
+    let with_leads = desk_list(
+        desk_ids(record)
+            .into_iter()
+            .filter(|id| desk_lead(record, id).is_some())
+            .collect(),
+    );
+    Some(match with_leads {
+        Some(list) => format!(
+            "The \"{desk_id}\" channel has no lead — who answers there is picked per \
+message, not by rank — so `delegate_to_desk` has no one to hand this to. Desks that can \
+take work: {list}."
+        ),
+        None => format!(
+            "The \"{desk_id}\" channel has no lead — who answers there is picked per \
+message, not by rank — so `delegate_to_desk` has no one to hand this to, and no other \
+desk has a lead either. Answer directly instead of delegating."
         ),
     })
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -34,7 +34,8 @@ use crate::error::OpenCompanyError;
 use crate::ports::events::EventStreamItem;
 use crate::ports::types::{
     Actor, ActorKind, ApprovalId, Attachment, CompanyEvent, CompanyId, EventSeq, OutboundMessage,
-    OverlayDesk, OverlayDeskMember, OverlayDeskOrder, StoredEvent, TurnStep, Verdict,
+    OverlayDesk, OverlayDeskMember, OverlayDeskOrder, ResponderMode, StoredEvent, TurnStep,
+    Verdict,
 };
 use crate::runtime::grants::{GrantId, GrantScope, MAX_STANDING_GRANT_MILLIS};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
@@ -137,6 +138,15 @@ struct DeskDto {
     /// the blueprint and cannot be removed at runtime). Omitted when empty.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     overlay_members: Vec<String>,
+    /// How this desk's unmentioned messages find their answerer (issue #1835):
+    /// `"lead"` — `members[0]` leads and answers — or `"auto"`, a channel with
+    /// **no lead**, whose answerer is picked per message by best fit over the
+    /// membership. Omitted when `lead` (which is every manifest desk and every
+    /// desk created before the field existed), so old consoles and old wire
+    /// shapes are byte-for-byte unchanged. The console reads this to suppress
+    /// every lead affordance — crown, badge, Make-lead — on `auto` channels.
+    #[serde(skip_serializing_if = "ResponderMode::is_lead")]
+    responder: ResponderMode,
     /// Whether the whole desk was operator-created (an overlay desk) rather than
     /// declared in the manifest blueprint. The console offers a delete action
     /// only for these — blueprint desks cannot be deleted at runtime. Omitted
@@ -170,6 +180,9 @@ async fn list_desks(scope: ScopedCompany) -> Result<Json<Vec<DeskDto>>, crate::s
                     description: chat.description.clone(),
                     members,
                     overlay_members,
+                    // Manifest desks are always lead-routed — the blueprint
+                    // syntax carries no responder field (issue #1835).
+                    responder: ResponderMode::Lead,
                     overlay_created: false,
                 }
             });
@@ -188,6 +201,7 @@ async fn list_desks(scope: ScopedCompany) -> Result<Json<Vec<DeskDto>>, crate::s
                     description: desk.description.clone(),
                     members,
                     overlay_members,
+                    responder: desk.responder,
                     overlay_created: true,
                 }
             });
@@ -420,11 +434,18 @@ struct CreateDesk {
     /// omitted.
     #[serde(default)]
     id: Option<String>,
-    /// The desk's founding member ids, in order (the first becomes the lead).
+    /// The desk's founding member ids, in order (the first becomes the lead —
+    /// unless `responder` is `"auto"`, in which case order carries no rank).
     /// Each must resolve to a roster teammate. Optional — a desk can start empty
     /// and gain members through the desk-member overlay.
     #[serde(default)]
     members: Vec<String>,
+    /// How the desk routes its unmentioned messages (issue #1835). Absent means
+    /// `"lead"` — today's model, and what every existing caller sends — so the
+    /// org chart's create is unchanged. `"auto"` creates a leadless channel
+    /// whose answerer is picked per message.
+    #[serde(default)]
+    responder: ResponderMode,
 }
 
 /// Derives a snake_case desk id from a display name: lowercase, runs of
@@ -523,6 +544,7 @@ async fn create_desk(
         name: name.clone(),
         description: description.clone(),
         members: members.clone(),
+        responder: body.responder,
     };
     record.overlay_desks.push(desk);
     scope.runtime.store().save(&record).await?;
@@ -536,6 +558,7 @@ async fn create_desk(
             description,
             members: effective,
             overlay_members: Vec::new(),
+            responder: body.responder,
             overlay_created: true,
         }),
     ))
@@ -5169,6 +5192,65 @@ mode = "full"
         assert_eq!(arr[0]["id"], "studio"); // manifest desk first
         assert_eq!(arr[1]["id"], "growth_desk");
         assert_eq!(arr[1]["overlayCreated"], true);
+    }
+
+    /// Issue #1835, both wire directions. A create that never mentions
+    /// `responder` — every existing caller, and the org chart today — answers
+    /// and lists with **no** `responder` key at all, so old consoles see the
+    /// pre-#1835 shape byte-for-byte. A create with `responder: "auto"`
+    /// answers and lists `"auto"`, and the mode survives the store round-trip
+    /// rather than collapsing back to a lead desk.
+    #[tokio::test]
+    async fn create_desk_carries_the_responder_mode_and_omits_the_default() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(&home, desk_manifest()).await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let post = |body: &'static str| {
+            let app = app.clone();
+            let cookie = cookie.clone();
+            async move {
+                let response = app
+                    .oneshot(
+                        Request::builder()
+                            .method("POST")
+                            .uri("/api/v1/company/desks")
+                            .header("cookie", &cookie)
+                            .header("content-type", "application/json")
+                            .body(Body::from(body))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::CREATED);
+                let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+                serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()
+            }
+        };
+
+        let lead = post(r#"{"name":"Growth desk","members":["eng"]}"#).await;
+        assert!(
+            lead.get("responder").is_none(),
+            "a mode never stated must not appear on the wire: {lead}"
+        );
+        let auto =
+            post(r#"{"name":"Launch week","members":["eng","ceo"],"responder":"auto"}"#).await;
+        assert_eq!(auto["responder"], "auto", "{auto}");
+
+        // The list re-reads the store, so this is the round-trip half: the
+        // manifest desk and the defaulted create stay keyless, the channel
+        // keeps its mode.
+        let desks = get_desks(&app, &cookie).await;
+        let arr = desks.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert!(arr[0].get("responder").is_none(), "manifest desk: {desks}");
+        assert!(
+            arr[1].get("responder").is_none(),
+            "defaulted create: {desks}"
+        );
+        assert_eq!(arr[2]["responder"], "auto", "{desks}");
     }
 
     /// Create-desk validation: an empty name is 400, an id colliding with a

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -535,6 +535,18 @@ async fn create_desk(
         }
     }
 
+    // An `auto` channel with nobody in it is unroutable by construction
+    // (issue #1835, codex review): the selector has no candidates and the
+    // first-member fallback has no first member, so an unmentioned message
+    // there would fall through to the orchestrator — contradicting the
+    // channel's own stated model. A *lead* desk may still start empty and be
+    // staffed from the org chart, exactly as before.
+    if !body.responder.is_lead() && members.is_empty() {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "a channel with per-message routing needs at least one member — with nobody in it, there is nobody to pick"
+                .to_string(),
+        )));
+    }
     let description = body
         .description
         .map(|d| d.trim().to_string())
@@ -5251,6 +5263,55 @@ mode = "full"
             "defaulted create: {desks}"
         );
         assert_eq!(arr[2]["responder"], "auto", "{desks}");
+    }
+
+    /// Issue #1835, codex review: an `auto` channel cannot be created empty —
+    /// the selector would have no candidates and the first-member fallback no
+    /// first member, so its unmentioned messages would silently fall to the
+    /// orchestrator, contradicting the channel's own model. A **lead** desk
+    /// keeps its right to start empty and be staffed from the org chart.
+    /// Revert the guard in `create_desk` and the first assertion answers 201.
+    #[tokio::test]
+    async fn an_auto_channel_cannot_be_created_empty_but_a_lead_desk_still_can() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(&home, desk_manifest()).await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let post = |body: &'static str| {
+            let app = app.clone();
+            let cookie = cookie.clone();
+            async move {
+                app.oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/company/desks")
+                        .header("cookie", &cookie)
+                        .header("content-type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            }
+        };
+
+        let refused = post(r#"{"name":"Launch week","responder":"auto"}"#).await;
+        assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(refused.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes).to_string();
+        assert!(
+            body.contains("at least one member"),
+            "the refusal names the reason, not a generic 400: {body}"
+        );
+
+        let empty_lead = post(r#"{"name":"Someday desk"}"#).await;
+        assert_eq!(
+            empty_lead.status(),
+            StatusCode::CREATED,
+            "an empty lead desk is still legal — it gains members from the org chart"
+        );
     }
 
     /// Create-desk validation: an empty name is 400, an id colliding with a

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -1181,6 +1181,7 @@ role = "Chief Executive"
             name: "Creative".to_string(),
             description: None,
             members: vec!["jamie".to_string()],
+            responder: crate::ports::types::ResponderMode::default(),
         });
         scoped
             .overlay_desk_tools

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -1217,7 +1217,16 @@ pub(super) fn desks_for(record: &CompanyRecord, agent_id: &str) -> Vec<AgentDesk
             members.iter().any(|m| m == agent_id).then(|| AgentDeskDto {
                 id: id.to_string(),
                 name: name.to_string(),
-                lead: members.first().map(String::as_str) == Some(agent_id),
+                // Position is a rank only on a **lead** desk. An `auto`
+                // channel (issue #1835) orders its members without conferring
+                // anything, so `members[0]` there is whoever happens to be
+                // listed first — badging them "(lead)" on TeamView, the agent
+                // detail page and the profile sheet states a rank nothing
+                // confers (codex on #1872). Read through `desk_lead`, the
+                // one definition that is `None` for an auto channel, rather
+                // than re-deriving the rule from position here.
+                lead: crate::runtime::delegation_tools::desk_lead(record, id).as_deref()
+                    == Some(agent_id),
             })
         })
         .collect()
@@ -2221,6 +2230,64 @@ agent = "claude"
         let (_, hermit) = get_agent(&state, "hermit").await;
         assert_eq!(hermit["desks"].as_array().unwrap().len(), 0, "{hermit}");
         assert_eq!(hermit["isOrchestrator"], false, "{hermit}");
+    }
+
+    /// Issue #1872 (codex): an `auto` channel confers no lead, so the roster
+    /// surfaces must not badge one.
+    ///
+    /// `desks_for` used to read `members[0] == agent_id` straight off the
+    /// effective order, which is a rank only on a lead desk — on a channel it
+    /// is whoever happens to be listed first, and TeamView, the agent detail
+    /// page and the profile sheet all rendered them "(lead)". Reading through
+    /// `desk_lead` (`None` for an auto channel by definition) is what keeps
+    /// this honest; revert that and the first assertion below reads `true`.
+    ///
+    /// The lead desk beside it is the half that must not move: a mode nobody
+    /// stated still badges its first member exactly as before.
+    #[tokio::test]
+    async fn an_auto_channel_badges_no_lead_but_a_desk_still_does() {
+        let home = tempfile::tempdir().unwrap();
+        let state = state_with_manifest(home.path(), ROSTER).await;
+        // A channel and a lead desk, both holding `ceo` first.
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).expect("company registered");
+        let store = runtime.store();
+        let mut record = store.load(&id).await.unwrap().unwrap();
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "launch".to_string(),
+            name: "Launch week".to_string(),
+            description: None,
+            members: vec!["ceo".to_string(), "writer".to_string()],
+            responder: crate::ports::types::ResponderMode::Auto,
+        });
+        record.overlay_desks.push(crate::ports::types::OverlayDesk {
+            id: "growth".to_string(),
+            name: "Growth".to_string(),
+            description: None,
+            members: vec!["ceo".to_string(), "writer".to_string()],
+            responder: crate::ports::types::ResponderMode::Lead,
+        });
+        store.save(&record).await.unwrap();
+
+        let (_, ceo) = get_agent(&state, "ceo").await;
+        let desks = ceo["desks"].as_array().unwrap();
+        let by = |id: &str| {
+            desks
+                .iter()
+                .find(|d| d["id"] == id)
+                .unwrap_or_else(|| panic!("{id} missing from {ceo}"))
+                .clone()
+        };
+        assert_eq!(
+            by("launch")["lead"],
+            false,
+            "an auto channel confers no rank on its first member: {ceo}"
+        );
+        assert_eq!(
+            by("growth")["lead"],
+            true,
+            "a lead desk is unchanged: {ceo}"
+        );
     }
 
     /// The verification gap the issue names: what an agent *asks* for and what

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -209,14 +209,30 @@ fn sample_overlay_agents() -> Vec<crate::ports::types::OverlayAgent> {
 /// Its `members` name one manifest agent (`ceo`) and one overlay agent
 /// (`aria_stone`), which is the mixed case a real console desk produces, and
 /// `description` is `Some` so the `skip_serializing_if` field is exercised.
+///
+/// Two desks since issue #1835, one per responder mode: `support` never states
+/// a mode (the defaulted-and-skipped half — a pre-#1835 row must rehydrate as
+/// `Lead`), and `launch` is an `auto` channel, so every backend proves the
+/// mode a rail-created channel stores actually survives persistence rather
+/// than silently collapsing back to a lead desk.
 fn sample_overlay_desks() -> Vec<crate::ports::types::OverlayDesk> {
-    use crate::ports::types::OverlayDesk;
-    vec![OverlayDesk {
-        id: "support".to_string(),
-        name: "Support".to_string(),
-        description: Some("Customer mail triage.".to_string()),
-        members: vec!["ceo".to_string(), "aria_stone".to_string()],
-    }]
+    use crate::ports::types::{OverlayDesk, ResponderMode};
+    vec![
+        OverlayDesk {
+            id: "support".to_string(),
+            name: "Support".to_string(),
+            description: Some("Customer mail triage.".to_string()),
+            members: vec!["ceo".to_string(), "aria_stone".to_string()],
+            responder: ResponderMode::default(),
+        },
+        OverlayDesk {
+            id: "launch".to_string(),
+            name: "Launch week".to_string(),
+            description: None,
+            members: vec!["ceo".to_string(), "aria_stone".to_string()],
+            responder: ResponderMode::Auto,
+        },
+    ]
 }
 
 /// The console-added desk memberships the fixture seeds every record with, so

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1677,14 +1677,26 @@ mod test {
             desk_id: "eng".into(),
             agent_id: "designer".into(),
         }];
-        // An operator-created desk the manifest never declared.
-        let desks = vec![OverlayDesk {
-            id: "growth".into(),
-            name: "Growth".into(),
-            description: Some("Marketing pod".into()),
-            members: vec!["ceo".into()],
-            responder: crate::ports::types::ResponderMode::default(),
-        }];
+        // Operator-created desks the manifest never declared — one of each
+        // responder mode, so the round-trip below (whole-vec equality) proves
+        // the `auto` flag survives export→import rather than silently
+        // reverting a leadless channel to a lead desk (issue #1835).
+        let desks = vec![
+            OverlayDesk {
+                id: "growth".into(),
+                name: "Growth".into(),
+                description: Some("Marketing pod".into()),
+                members: vec!["ceo".into()],
+                responder: crate::ports::types::ResponderMode::default(),
+            },
+            OverlayDesk {
+                id: "launch".into(),
+                name: "Launch".into(),
+                description: None,
+                members: vec!["ceo".into(), "cto".into()],
+                responder: crate::ports::types::ResponderMode::Auto,
+            },
+        ];
         // A workflow graph authored at runtime (issue #168). On a hosted tenant
         // this body is the ONLY copy — a bundle that dropped it would lose the
         // workflow outright.

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1683,6 +1683,7 @@ mod test {
             name: "Growth".into(),
             description: Some("Marketing pod".into()),
             members: vec!["ceo".into()],
+            responder: crate::ports::types::ResponderMode::default(),
         }];
         // A workflow graph authored at runtime (issue #168). On a hosted tenant
         // this body is the ONLY copy — a bundle that dropped it would lose the


### PR DESCRIPTION
## Summary

A **"+" on the Channels rail** creates a channel from chat: name, purpose, members — **no lead**. A channel created this way declares `responder: "auto"`: when a message arrives that mentions nobody, a **selector** — one tool-less model call handed the message and the channel's own membership (id, role, description) — picks the best-fit member for *that message*, and that member answers the turn and can delegate onward through the existing gated seam.

Closes #1835.

### The shape

A desk keeps its lead; nothing changes for any desk that exists today. The new mode is a property of the overlay desk, defaulted and skipped when `lead`, so every stored record, wire shape and caller is byte-for-byte unchanged — the storage conformance suite proves the two-mode round-trip on every backend.

`desk_lead()` answers `None` for an `auto` channel **by definition**, which keeps every lead-derived surface honest from one change: no crown on the org chart, no LEAD badge in the members pane, and `delegate_to_desk` refuses with its own reason — *before* the leadless-desk arm, whose "has no member on the roster" wording would be a lie about a staffed channel. The refusal's "desks that can take work" list excludes auto channels for free, because it is built from `desk_lead`.

### The selector, and its worst case

Modelled on the triage escalation (#678), whose voice it keeps: **it decides, it does not act** — no tools, one short system prompt, `max_tokens: 24`, temperature 0, a 3s budget. The rung sits below an `@`-mention (a named teammate still outranks everything) and above the deterministic fallback (`desk_default_responder`, the channel's first roster member — byte-for-byte what `desk_lead` answers for a lead desk). Every failure — unreachable, slow, unparseable, an id outside the membership — keeps that fallback, so **the worst case of the new rung is the old rung**. Deterministic short-circuits skip the call entirely: a mention, a single-member channel, and the small-talk fast path (`chat_responder` stays sync and record-only, so a greeting never pays an inference call). The pick is journaled (`[selector] routed … picked=…`) so routing is explainable after the fact, never re-derived.

Spend lands under its own `SampleKind::SelectorCall`, on `TriageCall`'s exact terms — whole-company bucket, no `run_id`, counted into the tier budget. Not folded into `TriageCall`: triage is driven by chat volume everywhere, selection only by unmentioned messages in auto channels, and sharing a kind would make the triage line move whenever an operator created a channel.

### Console

The add control is **always visible** on the Channels header — the first cut shipped it hover-revealed, and the first real operator could not find it, which settles that question. It opens a channel-shaped `ChannelCreateDialog` — deliberately not `DeskCreateDialog` with the crown hidden, because that dialog's copy is (correctly, per #1827) about seniority, and a channel has none. The helper line states the rule: *"no lead; whoever fits each message answers."* The control is absent, not disabled, when the roster has nobody to staff a channel with — the rule `api/setup.ts:58` already follows. The org chart keeps everything #1827 added for lead desks and renders auto channels without crown or Make-lead; creation still lives in exactly one write path (`POST {scope}/desks`).

## API Or Behavior Changes

- `POST {scope}/desks` accepts optional `responder: "lead" | "auto"` (absent = `lead`, today's behavior).
- `DeskDto` carries `responder`, omitted when `lead` — old consoles ignore it, old hosts never send it.
- For an `auto` channel: `desk_lead` resolution is `None`; `delegate_to_desk` targeting it is refused with a reason; assignee resolution treats it as "no lead" rather than "empty desk"; the harness routes its unmentioned messages through the selector with the first-member fallback.
- New `SampleKind::SelectorCall` usage samples; counted by `tokens_in` into the tier budget.
- Manifest `[[group_chat]]` desks are always `lead` — blueprint syntax is untouched.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via clippy `--all-targets`; desktop shell also built and run)
- [x] `cargo test` — 3887 + 15 + 1 passed, 0 failed (includes the wire round-trip and the storage-conformance two-mode fixture)
- [x] `cargo test --lib --features openhuman` targeted — 76 passed: selector parse/clamp (revert the clamp and `parse_clamps_to_the_candidate_set` answers an out-of-set id), the brain rung (a pick overrides the fallback; a failed selection falls back — revert the fallback and watch it fail; lead desks and single-member channels spend zero), assignee, metering, delegation refusals
- [x] `npm run typecheck` / `typecheck:unit`, `npx vitest run` — 3293 passed (20 new in `channel-auto-responder.test.ts`)
- [x] `scripts/ci/assert-design-tokens.sh`, feature-lanes intact (selector tests ride the existing `openhuman` rows)

### Field-tested on a real company

Built the desktop shell with the shipped feature set (post-#1831) and ran it against a real data dir with OpenRouter wired. Created a channel from the rail (`engineering`, 3 members, `responder:"auto"`), then posted unmentioned messages:

| message | selector picked | why it's right |
|---|---|---|
| "how should we structure the regression tests…" | `software_engineer` | roster mandate: *owns solution architecture* |
| "what's our policy for quarantining flaky tests…" | `software_engineer` | policy/ownership question |
| "verify this change does what it claims, file what it misses" | `qa_engineer` | near-verbatim its mandate: *verify a change does what it claims* |

Each pick is a journaled `[selector]` log line, each reply a real agentic turn by the picked member, delivered live over SSE (`agent_reply chatId=<channel>`). A bare "yo" was answered in 35ms by the first member — the greeting fast path, no selector call, as designed. One fallback path fired in the wild: a usage store written by a foreign build made the sample write fail, and the log shows the contract holding — *"failed to record the selection usage sample; the pick still stands."*

## Documentation

`docs/spec/runtime/api.md` — the `responder` field on the desk routes, the selection contract (ladder position, short-circuits, fallback, metering), and the refusal. Module docs on `harness/built_in/selector.rs` and `metering/selector.rs` carry the design reasoning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added channel creation from the chat interface, including a name, description, and selectable members.
  - Added leadless “auto” channels that choose the best available responder for each unmentioned message.
  - Added responder-mode support to desk creation and API responses.
  - Added persistence for channel settings, ordering, and console-granted tools across exports and imports.

- **Bug Fixes**
  - Improved assignment and attribution for auto channels without a designated lead.
  - Prevented unsupported delegation to leadless channels.
  - Improved fallback behavior when channels have no available members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->