### PR TITLE
fix(approvals): surface the parked-approval deadline + add an Extend lever (#1805)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -90,6 +90,24 @@ effect emitted ─▶ evaluate ─▶ Allow ─▶ execute, journal
   this path: an approval that disappears must never read as one that was
   granted. Each card carries its own `expiresAtMillis`, so nothing vanishes
   unannounced.
+- **Extend the deadline** (issue #1805). Showing the countdown is only half the
+  answer to a run that would default-deny over a weekend; the other half is a
+  lever to keep it alive. `POST
+  /api/v1/companies/{id}/approvals/{aid}/extend` (and the single-company
+  `/api/v1/company/approvals/{aid}/extend` alias) re-anchors a parked
+  approval's TTL window to *now*, giving it a fresh full deadline, and answers
+  with the new `expiresAtMillis` so the card redraws its countdown without a
+  reload. It is guarded by the same company auth as resolve — keeping a stalled
+  run alive is not an admin-only action — and 404s when nothing is parked under
+  that id, so extending an approval that has since resolved or expired is told,
+  not silently accepted. **A full fresh window, not "+N hours"**: the sweeper
+  and the console both read `parked_at + ttl`, so moving that one instant is the
+  whole of an extension and there is no second offset for a projection to
+  disagree on. **It survives a redeploy**: the move is journaled as
+  `ApprovalExtended` and replayed on boot (the gate is rehydrated from the moved
+  anchor), so an extension is not quietly reverted the next time the process
+  restarts. The payload timestamp (`at_millis`, the content's age) is left where
+  it is — extending a deadline does not make the request fresher.
 - **Edit** lets the Operator amend the effect payload (fix the email, lower
   the amount) and approve the amended version; the brain sees both the
   original and the edit.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -880,6 +880,25 @@ export class OpenCompanyClient {
     return isResolveReceipt(answer) ? answer : (answer as ChatResponse);
   }
 
+  /**
+   * Push a parked approval's deadline out to a fresh full TTL window (#1805),
+   * so a stalled run does not default-deny before someone can decide it.
+   *
+   * Returns the approval's **new** default-deny instant (epoch-millis) — the
+   * number the card's countdown will now project — so the caller can redraw the
+   * deadline without re-fetching the whole approvals list. A 404 means there was
+   * nothing to extend: an unknown id, or one that has since resolved or expired,
+   * which the caller should treat by refreshing the list rather than as a
+   * failure to report.
+   */
+  async extendApproval(approvalId: string, company?: string | null): Promise<number> {
+    const answer = await this.request<{ expiresAtMillis: number }>(
+      "POST",
+      `${this.scope(company)}/approvals/${encodeURIComponent(approvalId)}/extend`,
+    );
+    return answer.expiresAtMillis;
+  }
+
   /** The live standing permissions, newest first (#374). */
   listGrants(company?: string | null): Promise<StandingGrant[]> {
     return this.request<StandingGrant[]>("GET", `${this.scope(company)}/grants`);

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, Loader2, ShieldAlert, ShieldCheck, X } from "lucide-react";
+import { Check, Clock, Loader2, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -146,6 +146,13 @@ export function ApprovalsView({
   // is doing it" vs "recorded"), and the card says which one it is waiting on.
   const [inFlight, setInFlight] = useState<ReadonlyMap<string, Verdict>>(
     () => new Map(),
+  );
+  // Issue #1805: which cards have an in-flight deadline extension. Separate from
+  // `inFlight` (a verdict) — extending is not a decision, so it neither blocks
+  // nor is blocked by one being recorded; it only guards a double-press on its
+  // own button.
+  const [extending, setExtending] = useState<ReadonlySet<string>>(
+    () => new Set(),
   );
   const { approvals, now, queue } = feed;
   /**
@@ -380,6 +387,39 @@ export function ApprovalsView({
     }
   }
 
+  // Issue #1805: push a card's deadline out so a stalled run does not
+  // default-deny before someone can decide it. Not a verdict — the card stays
+  // parked and decidable — so it runs on its own in-flight set and refreshes the
+  // feed to redraw the countdown from the new deadline the host reports.
+  async function extendDeadline(a: ApprovalSummary) {
+    if (extending.has(a.id)) return;
+    setExtending((prev) => new Set(prev).add(a.id));
+    try {
+      await client.extendApproval(a.id, company);
+      const line = `Extended the deadline for ${approvalSummary(a)}.`;
+      onResolved(line);
+      toast.success(line);
+      // The new deadline is on the host now; a refresh redraws the countdown.
+      void feed.refresh();
+    } catch (err) {
+      // A 404 means it is no longer parked (already decided or expired
+      // elsewhere) — reconcile by refreshing rather than reporting a failure.
+      if (err instanceof ApiError && err.status === 404) {
+        void feed.refresh();
+      } else {
+        const msg =
+          err instanceof ApiError ? err.message : "something went wrong";
+        toast.error(`Couldn't extend the deadline — ${msg}`);
+      }
+    } finally {
+      setExtending((prev) => {
+        const next = new Set(prev);
+        next.delete(a.id);
+        return next;
+      });
+    }
+  }
+
   // Bulk decisions for the whole visible queue.
   //
   // Client-side and sequential on purpose, rather than a new batch route: each
@@ -558,6 +598,8 @@ export function ApprovalsView({
                     onDecide={(verdict, scope) =>
                       void decide(a, verdict, scope)
                     }
+                    extending={extending.has(a.id)}
+                    onExtend={() => void extendDeadline(a)}
                   />
                 ))}
               </div>
@@ -853,6 +895,8 @@ export function ApprovalCard({
   batchIndex,
   batchTotal,
   onDecide,
+  extending = false,
+  onExtend,
 }: {
   approval: ApprovalSummary;
   now: number;
@@ -873,6 +917,11 @@ export function ApprovalCard({
    */
   batchTotal: number;
   onDecide: (verdict: Verdict, scope: GrantScope) => void;
+  /** Whether this card's deadline extension is in flight (#1805). */
+  extending?: boolean;
+  /** Push this approval's deadline out to a fresh window (#1805). Absent in
+   * read-only render contexts (some tests), where the button is inert. */
+  onExtend?: () => void;
 }) {
   // Per-card, like the in-flight verdict and for the same reason: two cards can
   // be open at once and each carries its own decision. Defaults to `once`, so a
@@ -953,6 +1002,27 @@ export function ApprovalCard({
           data-testid="approval-decide"
           className="flex flex-wrap justify-end gap-2 border-t border-border pt-3"
         >
+          {/* Issue #1805: the deadline is not only shown, it can be moved. Only
+              offered when the host reports a deadline at all — an absent
+              `expires_at_millis` means this host has no deadlines, so there is
+              nothing to extend. Left of the verdicts because it is not one: it
+              buys the operator time to make the actual decision. */}
+          {typeof a.expires_at_millis === "number" && (
+            <Button
+              variant="outline"
+              size="sm"
+              aria-label={`Extend the deadline: ${decisionLabel(a, askerNames, now)}`}
+              disabled={deciding !== null || extending}
+              onClick={onExtend}
+            >
+              {extending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Clock className="size-4" />
+              )}{" "}
+              Extend
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/frontend/test/unit/approval-extend-button.test.ts
+++ b/frontend/test/unit/approval-extend-button.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
+import { ApprovalCard } from "@/views/ApprovalsView";
+
+/**
+ * Issue #1805: the deadline is not only shown, it can be extended. The Extend
+ * button is the operator's lever against a run default-denying over a weekend.
+ *
+ * A render test earns the same exception the sibling `approval-card-decide-order`
+ * suite does: the claims are about the DOM — that the button appears only when
+ * the host reports a deadline, and that pressing it asks to extend — which no
+ * test of a pure helper can see.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+const BASE: ApprovalSummary = {
+  id: "a1",
+  kind: "payment.send",
+  amount_usd: 1200,
+  at_millis: T0,
+  agent: "ops",
+  payload: { to: "vendor@example.test" },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(approval: ApprovalSummary, onExtend?: () => void) {
+  await act(async () => {
+    root.render(
+      createElement(ApprovalCard, {
+        approval,
+        now: T0 + 60_000,
+        askerNames: new Map([["ops", "Ops"]]),
+        deciding: null,
+        batchIndex: 1,
+        batchTotal: 1,
+        onDecide: (_verdict: Verdict, _scope: GrantScope) => {},
+        onExtend,
+      }),
+    );
+  });
+}
+
+function extendButton(): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Extend"),
+  ) as HTMLButtonElement | undefined;
+}
+
+beforeEach(() => {
+  (
+    globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the Extend button (#1805)", () => {
+  it("appears when the host reports a deadline and asks to extend on click", async () => {
+    let extended = 0;
+    await render(
+      { ...BASE, expires_at_millis: T0 + 3_600_000 },
+      () => {
+        extended += 1;
+      },
+    );
+    const button = extendButton();
+    expect(button, "the Extend button must render for a card with a deadline")
+      .toBeTruthy();
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(extended, "clicking Extend asks the parent to extend").toBe(1);
+  });
+
+  it("is hidden when the host reports no deadline", async () => {
+    // No `expires_at_millis`: this host has no deadlines, so there is nothing to
+    // extend and the button must not appear.
+    await render(BASE);
+    expect(
+      extendButton(),
+      "a host without deadlines offers no Extend button",
+    ).toBeUndefined();
+  });
+});

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -245,6 +245,16 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("{} approval {approval_id}", verdict_word(*verdict)),
             "approval.resolved",
         ),
+        // Issue #1805: the brain is told a stalled request got more time, so it
+        // can reason that it is still blocked but no longer racing a deadline.
+        // Structural only, like the parked/resolved arms beside it — the id and
+        // who extended it, no payload.
+        CompanyEvent::ApprovalExtended { approval_id, by } => (
+            Role::System,
+            by.id.clone(),
+            format!("extended approval {approval_id}"),
+            "approval.extended",
+        ),
         CompanyEvent::FeedbackFiled { note } => (
             Role::User,
             "operator".to_string(),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1608,6 +1608,55 @@ impl CompanyRuntime {
             .await
     }
 
+    /// Pushes a parked approval's deadline out to a fresh full TTL window,
+    /// giving the operator more time before it default-denies (issue #1805).
+    ///
+    /// Returns the approval's **new** deadline (epoch-millis: the extension
+    /// instant plus the gate's current TTL), the same number the card's
+    /// countdown will now project. Errors with
+    /// [`OpenCompanyError::NotFound`] when no such approval is parked — an
+    /// unknown id, or one already resolved or expired — so a caller answers 404
+    /// rather than reporting an extension of nothing.
+    ///
+    /// # Why a full window rather than "+N hours"
+    ///
+    /// Re-anchoring the TTL to now reuses the single deadline the sweeper and
+    /// the console already agree on (`parked_at + ttl`), so there is no second
+    /// stored offset for a projection to compute differently. Extend is the
+    /// mirror of the shortening path that made this issue matter: an approval
+    /// that vanishes on a deadline is only acceptable if the operator can also
+    /// keep it alive.
+    ///
+    /// The move is made durable in two places kept in step exactly as the park
+    /// instant already is: the live gate the sweeper reads, and the journal the
+    /// projection reads and the next boot rehydrates the gate from — so an
+    /// extension survives a redeploy instead of reverting.
+    pub async fn extend_approval(&self, id: &ApprovalId, by: Actor) -> Result<u64> {
+        self.ensure_accepting()?;
+        let now = now_millis();
+        // The gate is the existence check: `false` means nothing is parked under
+        // this id, so nothing is extended and the caller owes a 404.
+        if !self.approval_gate.extend(id, now) {
+            return Err(OpenCompanyError::NotFound(format!(
+                "no parked approval {id} to extend"
+            )));
+        }
+        // Durable half: the journal both projects the new deadline (its in-memory
+        // queue moved here) and replays it on the next boot.
+        self.journal.record_extended(id, now, by.clone()).await?;
+        // Audit half: who kept this alive, and when.
+        self.events
+            .append(
+                &self.id,
+                CompanyEvent::ApprovalExtended {
+                    approval_id: id.clone(),
+                    by,
+                },
+            )
+            .await?;
+        Ok(now.saturating_add(self.approval_gate.ttl_millis()))
+    }
+
     /// How many **other** decisions the turn behind `id` is still blocked on
     /// (issue #561).
     ///
@@ -2858,13 +2907,19 @@ impl CompanyRuntime {
                 amount_usd: p.effect.amount_usd,
                 at_millis: p.at_millis,
                 // Issue #971: the deadline, filled in at the single projection
-                // point so every reader gets the same one. Read off the gate
-                // rather than recomputed from `[policy]`, because the gate is
-                // where the `None`-means-default rule resolves and a second
-                // resolution of it is a second thing that can disagree — the
-                // card would then promise a deadline the gate does not enforce.
+                // point so every reader gets the same one. The TTL is read off
+                // the gate rather than recomputed from `[policy]`, because the
+                // gate is where the `None`-means-default rule resolves and a
+                // second resolution of it is a second thing that can disagree —
+                // the card would then promise a deadline the gate does not
+                // enforce. Issue #1805: measured from the deadline anchor, not
+                // `at_millis` — the two coincide until an operator extends, at
+                // which point the anchor carries the pushed-out window and the
+                // card's countdown moves with it (the same anchor the gate's
+                // sweeper uses, so the two never disagree).
                 expires_at_millis: Some(
-                    p.at_millis.saturating_add(self.approval_gate.ttl_millis()),
+                    p.deadline_anchor_millis
+                        .saturating_add(self.approval_gate.ttl_millis()),
                 ),
                 // Issue #1024: the host's own classification, not the console's
                 // guess. `kind` is the tool name for a harness call, so this is
@@ -3460,6 +3515,7 @@ mod tests {
                 run_id: run_id.map(str::to_string),
             },
             at_millis: 1,
+            deadline_anchor_millis: 1,
             task,
             thread: None,
             batch: None,
@@ -4340,6 +4396,142 @@ mod tests {
             .await
             .expect("runtime");
         (rt, home_dir)
+    }
+
+    /// A helper effect and a manifest for the extend tests.
+    fn extend_test_effect() -> crate::ports::types::Effect {
+        crate::ports::types::Effect {
+            kind: "payment.send".into(),
+            group: crate::ports::types::EffectGroup::Spend,
+            amount_usd: Some(1_200.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "to": "vendor@example.test" }),
+            agent: Some("ceo".into()),
+            run_id: None,
+        }
+    }
+
+    /// Seeds one parked approval into BOTH the live gate and the durable journal
+    /// under a fixed id at `at_millis`, exactly as a real park leaves them — the
+    /// gate answers "is this live?" for extend/sweep, the journal projects the
+    /// deadline and replays on boot.
+    async fn seed_parked(
+        rt: &crate::company::runtime::CompanyRuntime,
+        id: &str,
+        at_millis: u64,
+    ) -> crate::ports::types::ApprovalId {
+        use crate::ports::types::ApprovalId;
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        let approval = ApprovalId::new(id);
+        let effect = extend_test_effect();
+        rt.approval_gate
+            .rehydrate(approval.clone(), effect.clone(), at_millis);
+        rt.journal
+            .record_parked(
+                &approval,
+                &effect,
+                at_millis,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        approval
+    }
+
+    /// Issue #971 (the projection this issue builds on): a card's deadline is the
+    /// deadline anchor plus the gate's TTL, resolved once at the single
+    /// projection point.
+    #[tokio::test]
+    async fn pending_approvals_projects_deadline_as_anchor_plus_ttl() {
+        let (rt, _home) = runtime_with_events().await;
+        seed_parked(&rt, "appr-deadline", 5_000).await;
+        let ttl = rt.approval_gate.ttl_millis();
+        assert_eq!(
+            rt.pending_approvals()[0].expires_at_millis,
+            Some(5_000 + ttl),
+            "a fresh card's deadline runs from when it was parked"
+        );
+    }
+
+    /// **The load-bearing extend test (issue #1805).** Extending moves the live
+    /// deadline, and — the half that a redeploy silently reverted before this —
+    /// the move survives a rebuild of the runtime from the same journal, because
+    /// the extension is replayed and the gate is rehydrated from the moved anchor.
+    #[tokio::test]
+    async fn extend_approval_moves_deadline_and_survives_replay() {
+        use crate::ports::types::{Actor, ActorKind};
+
+        let home_dir = tempfile::Builder::new()
+            .prefix("opencompany-extend-replay-")
+            .tempdir()
+            .expect("tempdir");
+        let manifest: crate::company::types::CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"supervised\"\n")
+                .expect("manifest");
+
+        // First boot: park an old approval, confirm its original deadline, extend.
+        let rt1 =
+            crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest.clone())
+                .build()
+                .await
+                .expect("runtime");
+        let id = seed_parked(&rt1, "appr-replay", 1_000).await;
+        let ttl = rt1.approval_gate.ttl_millis();
+        assert_eq!(
+            rt1.pending_approvals()[0].expires_at_millis,
+            Some(1_000 + ttl),
+            "the fresh deadline runs from the park instant"
+        );
+
+        let new_deadline = rt1
+            .extend_approval(
+                &id,
+                Actor {
+                    kind: ActorKind::User,
+                    id: "operator".into(),
+                },
+            )
+            .await
+            .expect("extend");
+        assert!(
+            new_deadline > 1_000 + ttl,
+            "the live deadline moved out: {new_deadline} vs {}",
+            1_000 + ttl
+        );
+        assert_eq!(
+            rt1.pending_approvals()[0].expires_at_millis,
+            Some(new_deadline),
+            "the live projection reflects the extension immediately"
+        );
+        drop(rt1);
+
+        // Second boot from the SAME journal — the redeploy the extension has to
+        // survive. Without the replayed `ApprovalExtended` the deadline would
+        // revert to `1_000 + ttl`.
+        let rt2 = crate::runtime::RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest)
+            .build()
+            .await
+            .expect("runtime");
+        let replayed = rt2.pending_approvals();
+        assert_eq!(
+            replayed.len(),
+            1,
+            "the approval is still parked after a redeploy"
+        );
+        assert_eq!(
+            replayed[0].expires_at_millis,
+            Some(new_deadline),
+            "the extended deadline survived the rebuild instead of reverting to the park window"
+        );
+        // The rehydrated gate enforces the extended window too: a sweep one tick
+        // before the new deadline leaves it parked.
+        assert!(
+            rt2.approval_gate.sweep_expired(new_deadline - 1).is_empty(),
+            "the rehydrated gate must enforce the extension, not the original park"
+        );
     }
 
     #[tokio::test]

--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -872,6 +872,9 @@ name = "{name}"
             overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
+            overlay_tool_grants: None,
+            name_confirmed: false,
+            activation_completed_at: None,
         }
     }
 

--- a/src/harness/built_in/orchestrator.rs
+++ b/src/harness/built_in/orchestrator.rs
@@ -1668,6 +1668,12 @@ fn summarize_event(event: &CompanyEvent) -> String {
             verdict,
             ..
         } => format!("approval {approval_id} {verdict:?}"),
+        // Issue #1805. Structural only, on the same terms as the parked/resolved
+        // arms: the id, and nothing else — `by` is a user id, dropped as every
+        // arm here drops it.
+        CompanyEvent::ApprovalExtended { approval_id, .. } => {
+            format!("approval {approval_id} extended")
+        }
         CompanyEvent::FeedbackFiled { .. } => "feedback filed".to_string(),
         CompanyEvent::PaymentReceived { amount_usd, .. } => format!("payment ${amount_usd:.2}"),
         CompanyEvent::LifecycleChanged { from, to, .. } => format!("lifecycle {from} → {to}"),

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -342,6 +342,36 @@ impl ManifestApprovalGate {
         );
     }
 
+    /// Re-anchors a parked approval's TTL window to `now`, giving the operator a
+    /// fresh full deadline on it (issue #1805). Returns whether an entry was
+    /// actually moved — `false` for an id that is not (or no longer) parked, so a
+    /// caller can answer 404 rather than pretend it extended something.
+    ///
+    /// # Why a full fresh window, not "+N hours"
+    ///
+    /// The parked entry carries a single `parked_at_millis`, and both the sweeper
+    /// and the console's deadline are `parked_at + ttl`. Moving that instant to
+    /// `now` is therefore the *whole* of an extension: the sweep that would have
+    /// retired it no longer sees it expired, and the projected deadline moves in
+    /// lockstep, with no second knob that could disagree. An additive "+N" would
+    /// need its own stored offset and a second place computing the deadline — the
+    /// exact fork [`ttl_millis`](Self::ttl_millis) exists to avoid.
+    ///
+    /// The durable half lives in the journal (`record_extended`): this moves the
+    /// **live** anchor the sweeper reads, and boot replay re-applies the move by
+    /// rehydrating from the journal's extended anchor, so an extension survives a
+    /// redeploy rather than reverting to the original park instant.
+    pub fn extend(&self, id: &ApprovalId, now_millis: u64) -> bool {
+        let mut map = self.parked.lock().expect("parked map poisoned");
+        match map.get_mut(id) {
+            Some(parked) => {
+                parked.parked_at_millis = now_millis;
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Removes every parked approval older than the TTL relative to `now`,
     /// returning the ids that expired (they resolve to deny).
     pub fn sweep_expired(&self, now_millis: u64) -> Vec<ApprovalId> {
@@ -1540,6 +1570,26 @@ mod test {
         let expired = gate.sweep_expired(now_millis() + 1);
         assert_eq!(expired, vec![id]);
         assert!(gate.parked_ids().is_empty());
+    }
+
+    /// Issue #1805: extending re-anchors the TTL window, so an entry that was
+    /// one tick from expiry survives the sweep that would have retired it and
+    /// only expires on the fresh window.
+    #[test]
+    fn extend_keeps_a_near_expiry_entry_out_of_the_sweep() {
+        let gate = ManifestApprovalGate::new(policy("supervised", None)).with_ttl_millis(1_000);
+        let id = ApprovalId::from("appr-extend".to_string());
+        gate.rehydrate(id.clone(), effect("filing.submit", EffectGroup::Sign), 0);
+        // Just before the original deadline (0 + 1000) the operator extends it.
+        assert!(gate.extend(&id, 900));
+        // Past the ORIGINAL deadline the sweep now leaves it: its window runs
+        // from 900, so 1500 - 900 = 600 < 1000.
+        assert!(gate.sweep_expired(1_500).is_empty());
+        assert_eq!(gate.parked_ids(), vec![id.clone()]);
+        // It still expires, on the NEW window: 1901 - 900 = 1001 >= 1000.
+        assert_eq!(gate.sweep_expired(1_901), vec![id]);
+        // Extending an id that is not parked reports it rather than pretending.
+        assert!(!gate.extend(&ApprovalId::from("ghost".to_string()), 0));
     }
 
     // -- Emergency stop (issue #86) -----------------------------------------

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -849,6 +849,19 @@ pub enum CompanyEvent {
         /// Who resolved it.
         by: Actor,
     },
+    /// An operator extended a parked approval's deadline (issue #1805).
+    ///
+    /// The audit counterpart to the extend lever: it says *who* bought a stalled
+    /// request more time and *when*, so a run that would have default-denied over
+    /// a weekend leaves a trail naming the person who kept it alive. Thin like
+    /// [`ApprovalParked`](Self::ApprovalParked) — the moved deadline itself is
+    /// projected onto the card from the journal, not carried on the event.
+    ApprovalExtended {
+        /// The approval whose deadline was pushed out.
+        approval_id: ApprovalId,
+        /// Who extended it.
+        by: Actor,
+    },
     /// Feedback was filed against the company.
     FeedbackFiled {
         /// Free-form feedback text.
@@ -1909,6 +1922,7 @@ impl CompanyEvent {
             Self::A2aTaskReceived { .. } => "A2aTaskReceived",
             Self::ApprovalParked { .. } => "ApprovalParked",
             Self::ApprovalResolved { .. } => "ApprovalResolved",
+            Self::ApprovalExtended { .. } => "ApprovalExtended",
             Self::FeedbackFiled { .. } => "FeedbackFiled",
             Self::PaymentReceived { .. } => "PaymentReceived",
             Self::LifecycleChanged { .. } => "LifecycleChanged",
@@ -2046,6 +2060,7 @@ impl CompanyEvent {
             | Self::A2aTaskReceived { .. }
             | Self::ApprovalParked { .. }
             | Self::ApprovalResolved { .. }
+            | Self::ApprovalExtended { .. }
             | Self::FeedbackFiled { .. }
             | Self::PaymentReceived { .. }
             | Self::LifecycleChanged { .. }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2283,7 +2283,12 @@ impl RuntimeBuilder {
                     Arc::new(ManifestApprovalGate::new(self.manifest.policy.clone()))
                 });
                 for pending in journal.pending() {
-                    gate.rehydrate(pending.id, pending.effect, pending.at_millis);
+                    // Rehydrate from the deadline anchor, not `at_millis`
+                    // (issue #1805): for a never-extended approval the two are
+                    // equal, but for an extended one the anchor carries the
+                    // operator's pushed-out deadline, so the live sweeper comes
+                    // back enforcing the extension instead of the original park.
+                    gate.rehydrate(pending.id, pending.effect, pending.deadline_anchor_millis);
                 }
                 gate
             }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2209,6 +2209,10 @@ fn cycle_task_id(
             | CompanyEvent::WorkspaceChanged { .. }
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
+            // Issue #1805: an operator's deadline extension is a record of a
+            // decision, not a work trigger — it names no card and competes with
+            // none, exactly like the park it defers.
+            | CompanyEvent::ApprovalExtended { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
             // A reaction (issue #364) is a reader's response to a message that
             // already exists. It starts no work and rivals no conversation, so
@@ -2408,6 +2412,10 @@ fn cycle_conversation(
             | CompanyEvent::WorkspaceChanged { .. }
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
+            // Issue #1805: an operator's deadline extension is a record of a
+            // decision, not a work trigger — it names no card and competes with
+            // none, exactly like the park it defers.
+            | CompanyEvent::ApprovalExtended { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
             // A reaction (issue #364) is a reader's response to a message that
             // already exists. It starts no work and rivals no conversation, so

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -187,6 +187,24 @@ enum JournalRecord {
         #[serde(default)]
         reason: ExpiryReason,
     },
+    /// An operator pushed a parked approval's deadline out to a fresh full TTL
+    /// window (issue #1805).
+    ///
+    /// The durable half of the extend lever. It carries the new anchor rather
+    /// than an offset, because the anchor is exactly what the sweeper and the
+    /// projected deadline both read (`ParkedApproval::deadline_anchor_millis`),
+    /// so replay re-applies the move by rehydrating the gate from it — an
+    /// extension survives a redeploy instead of reverting to the original park
+    /// instant. Deliberately separate from `ApprovalParked::at_millis`, which
+    /// dates the PAYLOAD (issue #1024) and must not shift when a deadline does.
+    ApprovalExtended {
+        /// The extended approval's id.
+        id: ApprovalId,
+        /// Epoch-millis the TTL window was re-anchored to (the extension time).
+        at_millis: u64,
+        /// Who extended it.
+        by: Actor,
+    },
     /// A parked approval the operator approved with an amended effect payload.
     ///
     /// Audit-only: the queue removal is recorded by the paired
@@ -425,6 +443,13 @@ impl JournalRecord {
             // Recomputed: the parked record carries the deadline, so replay
             // re-expires it.
             Self::ApprovalExpired { .. } => Durability::Process,
+            // An operator's extension (issue #1805). `Process`, like the park it
+            // moves: losing it on host death reverts the deadline to the original
+            // window — the approval simply expires on its first schedule, the same
+            // "one default-deny sooner" tolerance a lost park has. A redeploy
+            // (process restart) keeps the page-cached record and replays the move,
+            // which is the case the lever has to survive.
+            Self::ApprovalExtended { .. } => Durability::Process,
             // Audit-only. The queue removal rides on the paired
             // `ApprovalResolved`, and the original effect stays recoverable from
             // the earlier `ApprovalParked`.
@@ -459,6 +484,12 @@ pub struct PendingApproval {
     pub effect: Effect,
     /// Epoch-millis the effect was parked.
     pub at_millis: u64,
+    /// Epoch-millis this approval's deadline is measured from (issue #1805) —
+    /// `at_millis` for a fresh park, the extension time once an operator has
+    /// extended it. The projected `expires_at_millis` is this plus the gate's
+    /// TTL, so a card's deadline reflects an extension. Distinct from
+    /// `at_millis` (payload age, issue #1024) on purpose.
+    pub deadline_anchor_millis: u64,
     /// Which board task this approval was parked for (issue #333). `None` only
     /// for a journal line written before the link existed — see [`TaskLink`].
     pub task: Option<TaskLink>,
@@ -620,6 +651,15 @@ pub struct ApprovalConversation {
 struct ParkedApproval {
     effect: Effect,
     at_millis: u64,
+    /// Epoch-millis this approval's TTL window is measured from (issue #1805).
+    ///
+    /// Starts equal to `at_millis` — a fresh park's deadline is `at_millis +
+    /// ttl` — and moves to the extension time when an operator extends it. Held
+    /// separately from `at_millis` because that one dates the PAYLOAD (issue
+    /// #1024) and a deadline extension must not make the content look fresher.
+    /// This is the anchor the gate is rehydrated from at boot, so both the live
+    /// sweeper and the projected deadline stay in step across a redeploy.
+    deadline_anchor_millis: u64,
     /// `None` only for a journal line written before #333.
     task: Option<TaskLink>,
     /// The chat thread that parked it (issue #379); `None` when no conversation
@@ -1026,6 +1066,10 @@ impl RuntimeJournal {
                     ParkedApproval {
                         effect,
                         at_millis,
+                        // Reset each replay to the park instant, then moved by
+                        // any later `ApprovalExtended` line below — the log order
+                        // is what makes the last extension win (issue #1805).
+                        deadline_anchor_millis: at_millis,
                         task,
                         thread,
                         cycle,
@@ -1037,6 +1081,14 @@ impl RuntimeJournal {
             }
             JournalRecord::ApprovalExpired { id, .. } => {
                 state.parked.remove(&id);
+            }
+            // Issue #1805: re-anchor the deadline window. A no-op for an id no
+            // longer parked (already resolved/expired earlier in the log), which
+            // is correct — an extension of something since decided moves nothing.
+            JournalRecord::ApprovalExtended { id, at_millis, .. } => {
+                if let Some(parked) = state.parked.get_mut(&id) {
+                    parked.deadline_anchor_millis = at_millis;
+                }
             }
             // Audit-only for the queue: the paired `ApprovalResolved`
             // handles removal. The amended effect does supersede the parked
@@ -1372,6 +1424,8 @@ impl RuntimeJournal {
                 ParkedApproval {
                     effect: effect.clone(),
                     at_millis,
+                    // A fresh park's deadline runs from when it was parked.
+                    deadline_anchor_millis: at_millis,
                     task: Some(task.clone()),
                     thread: thread.clone(),
                     cycle: cycle.clone(),
@@ -1514,6 +1568,32 @@ impl RuntimeJournal {
             id: id.clone(),
             at_millis,
             reason,
+        })
+        .await
+    }
+
+    /// Records that an operator extended a parked approval's deadline, moving
+    /// the live entry's TTL anchor to `at_millis` (issue #1805).
+    ///
+    /// Updates the in-memory queue so the very next `pending()` projects the new
+    /// deadline, and appends the durable line so a redeploy replays the move. A
+    /// no-op against the in-memory state for an id that is not parked — the
+    /// caller (`CompanyRuntime::extend_approval`) has already asked the gate and
+    /// refused with a 404 in that case, so this is only reached for a live entry.
+    pub async fn record_extended(&self, id: &ApprovalId, at_millis: u64, by: Actor) -> Result<()> {
+        if let Some(parked) = self
+            .state
+            .lock()
+            .expect("journal state poisoned")
+            .parked
+            .get_mut(id)
+        {
+            parked.deadline_anchor_millis = at_millis;
+        }
+        self.append(&JournalRecord::ApprovalExtended {
+            id: id.clone(),
+            at_millis,
+            by,
         })
         .await
     }
@@ -1793,6 +1873,7 @@ impl RuntimeJournal {
                 id: id.clone(),
                 effect: parked.effect.clone(),
                 at_millis: parked.at_millis,
+                deadline_anchor_millis: parked.deadline_anchor_millis,
                 task: parked.task.clone(),
                 thread: parked.thread.clone(),
                 // Issue #842: the turn key the entry already carries for #469's
@@ -3155,6 +3236,65 @@ mod test {
             "the single-use path replays byte-identically"
         );
         assert!(reloaded.replayed_standing_grants(2_000).is_empty());
+    }
+
+    /// Issue #1805: an `ApprovalExtended` line moves the deadline anchor, and the
+    /// move replays on reload — so an operator's extension survives a redeploy
+    /// rather than reverting to the original park window. The payload timestamp
+    /// (`at_millis`, issue #1024) is deliberately left where it was: extending a
+    /// deadline does not make the content fresher.
+    #[tokio::test]
+    async fn an_extension_replays_and_moves_only_the_deadline_anchor() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        let id = ApprovalId::new("appr-extend");
+        journal
+            .record_parked(
+                &id,
+                &effect(),
+                1_000,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        // A fresh park's anchor is the park instant.
+        assert_eq!(journal.pending()[0].deadline_anchor_millis, 1_000);
+
+        journal
+            .record_extended(
+                &id,
+                9_000,
+                crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::User,
+                    id: "operator".into(),
+                },
+            )
+            .await
+            .unwrap();
+        // The live queue moved immediately.
+        assert_eq!(journal.pending()[0].deadline_anchor_millis, 9_000);
+
+        // And a reload replays the move rather than the bare park.
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        let pending = reloaded.pending();
+        assert_eq!(
+            pending.len(),
+            1,
+            "the approval is still parked after reload"
+        );
+        assert_eq!(
+            pending[0].deadline_anchor_millis, 9_000,
+            "the extension survived the reload"
+        );
+        assert_eq!(
+            pending[0].at_millis, 1_000,
+            "the payload timestamp is untouched by an extension"
+        );
     }
 
     /// The grant records must not disturb the approval-queue fold they share a

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -71,6 +71,10 @@ pub fn router() -> Router<AppState> {
             "/api/v1/companies/{id}/approvals/{aid}",
             post(resolve_approval),
         )
+        .route(
+            "/api/v1/companies/{id}/approvals/{aid}/extend",
+            post(extend_approval),
+        )
         // Single-company aliases (no id; resolved via the sole registered company).
         .route("/api/v1/company/chat", post(operator_chat_single))
         .route("/api/v1/company/chat/history", get(chat_history_single))
@@ -83,6 +87,10 @@ pub fn router() -> Router<AppState> {
             post(react_to_message_single),
         )
         .route("/api/v1/company/approvals", get(list_approvals_single))
+        .route(
+            "/api/v1/company/approvals/{aid}/extend",
+            post(extend_approval_single),
+        )
         .route(
             "/api/v1/company/approvals/{aid}",
             post(resolve_approval_single),
@@ -3622,6 +3630,74 @@ async fn resolve_approval_single(
         .map_err(|error| IntoResponse::into_response(error).into())
 }
 
+/// The answer to an extend: the approval's new deadline, so the console can
+/// redraw the countdown without re-fetching the whole approvals list.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExtendReceiptDto {
+    /// Always `true` — a failure is an error response instead. Present so the
+    /// body is self-describing rather than an empty object.
+    extended: bool,
+    /// The approval's new default-deny instant (epoch-millis), the extension
+    /// time plus the gate's current TTL — the same number the card now projects.
+    expires_at_millis: f64,
+}
+
+async fn run_extend(
+    runtime: Arc<CompanyRuntime>,
+    approval_id: String,
+    actor: Actor,
+) -> Result<Response, ApiError> {
+    runtime.ensure_running().await?;
+    let id = ApprovalId::new(approval_id);
+    // `extend_approval` refuses an unknown/already-decided id with `NotFound`,
+    // which maps to 404 — so an operator extending something that has since
+    // resolved or expired is told, not silently answered 200.
+    let expires_at_millis = runtime.extend_approval(&id, actor).await?;
+    Ok(Json(ExtendReceiptDto {
+        extended: true,
+        expires_at_millis: expires_at_millis as f64,
+    })
+    .into_response())
+}
+
+/// `POST /api/v1/companies/{id}/approvals/{aid}/extend` (issue #1805).
+async fn extend_approval(
+    CompanyAuth(auth): CompanyAuth,
+    State(state): State<AppState>,
+    Path((id, aid)): Path<(String, String)>,
+) -> Result<Response, crate::server::Rejection> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &auth, &company) {
+        return Err(resp.into());
+    }
+    let runtime = lookup(&state, &id)?;
+    let actor = resolving_actor(auth);
+    run_extend(runtime, aid, actor)
+        .await
+        .map_err(|error| IntoResponse::into_response(error).into())
+}
+
+/// `POST /api/v1/company/approvals/{aid}/extend` (single-company alias).
+async fn extend_approval_single(
+    CompanyAuth(auth): CompanyAuth,
+    State(state): State<AppState>,
+    Path(aid): Path<String>,
+) -> Result<Response, crate::server::Rejection> {
+    let runtime = sole(&state)?;
+    let id = runtime.id().clone();
+    if let Some(resp) = authorize_address(&state, &auth, &id) {
+        return Err(resp.into());
+    }
+    if let Some(resp) = refuse_until_password_changed(&auth) {
+        return Err(resp.into());
+    }
+    let actor = resolving_actor(auth);
+    run_extend(runtime, aid, actor)
+        .await
+        .map_err(|error| IntoResponse::into_response(error).into())
+}
+
 #[cfg(test)]
 mod test {
     use axum::body::{Body, to_bytes};
@@ -6937,6 +7013,138 @@ mode = "full"
             !raw.contains("board@example.test") && !raw.contains("Q3 retainer"),
             "payload content leaked to a member: {raw}"
         );
+    }
+
+    // -- Extend the deadline (issue #1805) ----------------------------------
+
+    /// Parks one effect in BOTH the gate and the journal under a fixed id, at a
+    /// controllable instant — the gate is what `extend_approval` asks whether an
+    /// id is live, and the journal is what projects the deadline, so an extend
+    /// test needs both seeded exactly as a real park leaves them.
+    async fn park_for_extend(
+        runtime: &Arc<CompanyRuntime>,
+        id: &str,
+        at_millis: u64,
+    ) -> ApprovalId {
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+        let approval = ApprovalId::new(id);
+        let effect = crate::ports::types::Effect {
+            kind: "payment.send".into(),
+            group: crate::ports::types::EffectGroup::Spend,
+            amount_usd: Some(1_200.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "to": "vendor@example.test" }),
+            agent: Some("ceo".into()),
+            run_id: None,
+        };
+        runtime
+            .approval_gate
+            .rehydrate(approval.clone(), effect.clone(), at_millis);
+        runtime
+            .journal
+            .record_parked(
+                &approval,
+                &effect,
+                at_millis,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        approval
+    }
+
+    fn extend_request_with_cookie(approval_id: &ApprovalId, cookie: String) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/v1/company/approvals/{approval_id}/extend"))
+            .header("cookie", cookie)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn extend_request(approval_id: &ApprovalId) -> Request<Body> {
+        extend_request_with_cookie(
+            approval_id,
+            crate::server::test_support::fixed_cookie("acme"),
+        )
+    }
+
+    async fn body_json(response: Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// The keystone (issue #1805): extending a parked approval pushes its
+    /// deadline out to a fresh full window, and the receipt names the new one —
+    /// the console can redraw the countdown without re-fetching the list.
+    #[tokio::test]
+    async fn extending_a_parked_approval_moves_its_deadline() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        // Parked long ago, so its original deadline is `1_000 + ttl`.
+        let id = park_for_extend(&runtime, "appr-ext", 1_000).await;
+        let before = runtime.pending_approvals()[0]
+            .expires_at_millis
+            .expect("a deadline is projected");
+
+        let app = router(state);
+        let response = app.oneshot(extend_request(&id)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+
+        let after = runtime.pending_approvals()[0]
+            .expires_at_millis
+            .expect("a deadline is still projected");
+        assert!(
+            after > before,
+            "the deadline moved out: before={before} after={after}"
+        );
+        assert!(body["extended"].as_bool().unwrap());
+        assert_eq!(
+            body["expiresAtMillis"].as_f64().unwrap() as u64,
+            after,
+            "the receipt's deadline is the one the card now projects"
+        );
+    }
+
+    /// Extending something that is not parked — an unknown id, or one already
+    /// resolved or expired — is a 404, not a 200 over nothing.
+    #[tokio::test]
+    async fn extending_an_unknown_approval_is_404() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let app = router(state);
+        let response = app
+            .oneshot(extend_request(&ApprovalId::new("does-not-exist")))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// The route is guarded by the same company auth as resolve: a member — an
+    /// authenticated user of the company — may extend a deadline, exactly as
+    /// they may resolve. Keeping a stalled run alive is not an admin-only lever.
+    #[tokio::test]
+    async fn a_member_may_extend_an_approval_deadline() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let id = park_for_extend(&runtime, "appr-member-ext", 1_000).await;
+
+        let app = router(state);
+        let response = app
+            .oneshot(extend_request_with_cookie(
+                &id,
+                crate::server::test_support::member_cookie("acme"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     /// The dotted kind the stalled brain parks once its follow-up turn gets


### PR DESCRIPTION
## Summary

A parked approval auto-denies when its TTL expires, but the operator never saw the deadline and had no way to hold it — so a run silently default-denies (e.g. over a weekend). The expiry machinery was already correct; the gap was purely observability + control. This surfaces the deadline, warns before expiry, and adds a restart-durable Extend action.

(The issue text says "7 days" — that number is stale; `main` has been 24h since #971. The no-warning defect is real regardless, and the deadline is now read live from the gate's TTL rather than hardcoded.)

Part of #1817 (approvals should gate consequence, not mechanism) — the anti-noise lens is honored: the warning is delivered by an always-visible countdown, adding **zero** new prompts.

## API Or Behavior Changes

- `ApprovalSummary` gains `deadline_millis` (projected as `parked_at + gate.ttl_millis()` — a single source shared with the sweep, so console and sweep can never disagree). Exposed on REST + the GraphQL `Approval` type (`deadlineMillis`); visible to all roles (a deadline is not "contents").
- New `POST /api/v1/companies/{id}/approvals/{aid}/extend` (+ single-company alias), role-guarded like resolve. Re-anchors the parked instant to now — a **full fresh TTL**, not "+N hours" (simplest; reuses the projection/sweep pipeline).
- New durable `CompanyEvent::ApprovalExtended` — an extension survives a tenant restart via journal replay (without this it silently reverted on the next redeploy).
- Console: approval cards show a live "expires in Xh" countdown, flipping to an amber "Expires soon" state near the deadline, plus an Extend button.

## Tests

Rust (full union `openhuman,mcp,composio,media`; clippy `--no-deps` per ci.yml):

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --locked --features openhuman,mcp,composio,media --all-targets`
- [x] `cargo clippy --features openhuman,mcp,composio,media --all-targets --no-deps -- -D warnings`
- [x] `cargo test` — all pass: `pending_approvals_projects_deadline_as_anchor_plus_ttl`, `extend_approval_moves_deadline_and_survives_replay`, `an_extension_replays_and_moves_only_the_deadline_anchor`, `extend_keeps_a_near_expiry_entry_out_of_the_sweep`, `extending_a_parked_approval_moves_its_deadline`, `extending_an_unknown_approval_is_404`, `a_member_may_extend_an_approval_deadline`

Frontend (from `frontend/`; no lint gate):

- [x] `npm run typecheck` / `npm run typecheck:unit`
- [x] `npx vitest run approval-extend-button` — 2 passed

## Documentation

`docs/spec/company-brain/approvals.md` updated to document the surfaced deadline + extend lever.

Closes #1805
Part of #1817