### PR TITLE
fix(harness): restore the gated build — chat_seed's CompanyRecord literal is missing three fields

### DIFF
--- a/src/harness/built_in/chat_seed.rs
+++ b/src/harness/built_in/chat_seed.rs
@@ -869,9 +869,12 @@ name = "{name}"
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_tool_grants: None,
             overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
+            name_confirmed: false,
+            activation_completed_at: None,
         }
     }
 


### PR DESCRIPTION
## Summary

**`Rust (openhuman, tinymemory)` does not compile on `main`.** `chat_seed.rs`'s test literal constructs `CompanyRecord` exhaustively and is missing three fields the struct now declares:

```
error[E0063]: missing fields `activation_completed_at`, `name_confirmed` and `overlay_tool_grants`
  in initializer of `ports::types::CompanyRecord`
  --> src/harness/built_in/chat_seed.rs:857:9
```

Three fields, the same values every other `CompanyRecord` test literal in the tree uses. Nothing else changes.

## Why main is red without anyone noticing

A textbook semantic conflict between two PRs that were each green in isolation:

| commit | what it did |
|---|---|
| `83126ff8c` | added `overlay_tool_grants`, `name_confirmed`, `activation_completed_at` to `CompanyRecord` |
| `b846a5c22` (#1840) | added `chat_seed.rs`, whose test builds `CompanyRecord` with an exhaustive literal |

Neither branch ever compiled against the other's change, and **main's own runs do not catch it**: the `Changed areas` gate selects the gated lane only for commits touching gated paths, so `Rust (openhuman, tinymemory)` was `skipped` on the merge commit (run `33045858043`). The first build to compile main's gated test code against main's new fields is any PR that edits `src/harness/**` — where it reads as *that PR's* fault. It is currently red on mine (#1872) for exactly this reason.

Raised separately from #1872 so the fix is reviewable on its own and unblocks every PR touching that path, rather than riding in as unrelated noise.

## API Or Behavior Changes

None. A test-only struct literal; no production code path and no wire shape is touched.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib --tests --features openhuman,tinymemory` — **the failing lane's build, now clean** (this is the command that reproduces the error above; it fails on `main` at `958a1f096` and passes here)
- [ ] `cargo clippy --all-targets -- -D warnings` — unchanged by a test-literal edit; CI's own lanes cover it
- [ ] `cargo test` — the default suite never compiled this file (it is behind `openhuman`), which is the whole reason the break was invisible

## Documentation

None needed — no behavior, API or architecture change.

### Worth a follow-up (not in this PR)

The gate that let this through is real: a gated lane skipped on main means gated code can be broken by a change that never compiles it, and the failure surfaces on an unrelated contributor's PR. Options a maintainer might weigh: always run the gated lane on `main` pushes, or have `Changed areas` treat a change to a struct that gated code constructs as touching that lane. Happy to open an issue if that is wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a group chat test fixture to include default values for additional company record fields.
  * No user-facing functionality or production behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->