### PR TITLE
fix(harness): let a tool's own step label reach the timeline

### DIFF
--- a/src/harness/built_in/iteration_cap_turn_test.rs
+++ b/src/harness/built_in/iteration_cap_turn_test.rs
@@ -317,6 +317,7 @@ async fn company_agent(
         agent_id: "ceo".to_string(),
         role: "Chief Executive".to_string(),
         budget_usd_daily,
+        step_labels: crate::harness::steps::StepLabels::from_tools(agent.tools()),
         agent: tokio::sync::Mutex::new(agent),
         bound_chat: tokio::sync::Mutex::new(None),
     }

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -602,6 +602,14 @@ pub struct CompanyAgent {
     /// The embedded openhuman session. A [`Mutex`] because a `turn` takes
     /// `&mut self` and one agent must serialise its own turns.
     agent: Mutex<Agent>,
+    /// The curated step labels of this agent's tools, captured from the built
+    /// tool set (see [`StepLabels`](steps::StepLabels) for why the turn loop
+    /// cannot supply them).
+    ///
+    /// Resolved once per agent build rather than per turn: the tool set is fixed
+    /// for the life of a pooled agent, and a rebuild — the only thing that can
+    /// change which search belt is wired — mints a new `CompanyAgent` anyway.
+    step_labels: steps::StepLabels,
     /// The chat/desk thread this pooled agent's in-memory history is currently
     /// bound to (issue #1725).
     ///
@@ -836,6 +844,14 @@ impl CompanyAgent {
         // same turns.
         let turn_company: Option<CompanyId> = stream.as_ref().map(|ctx| ctx.company.clone());
         let (tx, mut rx) = tokio::sync::mpsc::channel::<oh::agent::progress::AgentProgress>(1024);
+        // This agent's curated step labels, restored onto each tool-call start as
+        // it arrives. The turn loop labels a tool row from its *name* alone and
+        // never asks the tool what it calls itself, so a branded belt would
+        // otherwise render as the generic humanized name on every surface below
+        // (see `steps::StepLabels`). Applied here — once, at the single point the
+        // turn's events enter OpenCompany — so the live stream, the durable run
+        // trace, and the folded timeline cannot disagree about a step's name.
+        let step_labels = self.step_labels.clone();
         let collector = tokio::spawn(async move {
             let mut events = Vec::new();
             let mut seq: u64 = 0;
@@ -843,6 +859,7 @@ impl CompanyAgent {
             // emits the same "Thinking" rows the final folded one does.
             let mut thinking_open = false;
             while let Some(event) = rx.recv().await {
+                let event = step_labels.apply(event);
                 if let Some(ctx) = &stream
                     && let Some(frame) = steps::stream_event_from(&event, seq, &mut thinking_open)
                 {
@@ -3031,6 +3048,7 @@ impl HarnessPool {
             return Ok(refusal);
         }
 
+        let confined = confine::build_confined_agent(company, company_name, confinement, deps)?;
         let agent = CompanyAgent {
             agent_id: confine::CONFINED_AGENT_ID.to_string(),
             role: "Workflow copilot".to_string(),
@@ -3038,12 +3056,8 @@ impl HarnessPool {
             // per-agent daily cap to read; the company-wide ceiling above is the
             // one that applies to it.
             budget_usd_daily: None,
-            agent: Mutex::new(confine::build_confined_agent(
-                company,
-                company_name,
-                confinement,
-                deps,
-            )?),
+            step_labels: steps::StepLabels::from_tools(confined.tools()),
+            agent: Mutex::new(confined),
             bound_chat: Mutex::new(None),
         };
 
@@ -4127,6 +4141,7 @@ pub(crate) fn build_roster(
             agent_id: manifest_agent.id.clone(),
             role: manifest_agent.role.clone(),
             budget_usd_daily: effective_budget,
+            step_labels: steps::StepLabels::from_tools(agent.tools()),
             agent: Mutex::new(agent),
             bound_chat: Mutex::new(None),
         }));
@@ -4198,6 +4213,7 @@ pub(crate) fn build_roster(
             agent_id: manifest_agent.id.clone(),
             role: manifest_agent.role.clone(),
             budget_usd_daily: effective_budget,
+            step_labels: steps::StepLabels::from_tools(agent.tools()),
             agent: Mutex::new(agent),
             bound_chat: Mutex::new(None),
         }));

--- a/src/harness/built_in/search.rs
+++ b/src/harness/built_in/search.rs
@@ -1022,6 +1022,32 @@ mod tests {
         assert_eq!(resolve_provider(&response), "Exa");
     }
 
+    /// The label an operator actually reads for a call to `web_search`, folded
+    /// the way a real turn folds it: the loop supplies the humanized tool name,
+    /// [`StepLabels`] restores what the tool calls itself, and `fold_steps`
+    /// renders the row.
+    fn step_label(tools: &[Box<dyn Tool>]) -> String {
+        use crate::harness::steps::{StepLabels, fold_steps};
+        use oh::agent::progress::AgentProgress;
+
+        let labels = StepLabels::from_tools(tools);
+        let started = AgentProgress::ToolCallStarted {
+            call_id: "c1".into(),
+            tool_name: WEB_SEARCH_TOOL.into(),
+            // What the loop sends: no arguments, and a label derived from the
+            // name it was given.
+            arguments: Value::Null,
+            iteration: 1,
+            display_label: Some(oh::tools::traits::humanize_tool_name(WEB_SEARCH_TOOL)),
+            display_detail: None,
+        };
+        fold_steps(vec![labels.apply(started)])
+            .first()
+            .expect("a tool call folds to one step")
+            .label
+            .clone()
+    }
+
     #[test]
     fn the_tool_advertises_the_name_the_contract_pin_knows() {
         let tools = search_tools(
@@ -1044,6 +1070,11 @@ mod tests {
             tools[0].display_label(&json!({})).as_deref(),
             Some("Exa web search")
         );
+        // …and it survives the trip to the timeline. Asserting the trait method
+        // alone proved only that the tool holds an opinion: the turn loop labels
+        // a row from the tool's *name* and never asks, so the branded label
+        // reached no operator until `StepLabels` carried it across (#1857).
+        assert_eq!(step_label(&tools), "Exa web search");
         // The schema is the model's only instruction sheet for the budget.
         let schema = tools[0].parameters_schema();
         assert_eq!(

--- a/src/harness/built_in/search_byo.rs
+++ b/src/harness/built_in/search_byo.rs
@@ -606,8 +606,9 @@ mod tests {
                 api_key: Some("test-key".to_string()),
                 endpoint,
             };
-            let aliased = byo_search_tools(&config)
-                .into_iter()
+            let tools = byo_search_tools(&config);
+            let aliased = tools
+                .iter()
                 .find(|tool| tool.name() == crate::harness::search::WEB_SEARCH_TOOL)
                 .expect("every provider wires a canonical web_search");
             assert_eq!(
@@ -615,7 +616,37 @@ mod tests {
                 Some(label),
                 "{provider}"
             );
+            // And it reaches the operator. Every provider is aliased to the one
+            // canonical `web_search`, so the tool *name* the loop labels from
+            // carries no provider at all — only the tool's own label, restored by
+            // `StepLabels`, can tell these four rows apart.
+            assert_eq!(step_label(&tools), label, "{provider}");
         }
+    }
+
+    /// The label an operator actually reads for a `web_search` row, folded the
+    /// way a real turn folds it: the loop supplies the humanized tool name,
+    /// [`StepLabels`](crate::harness::steps::StepLabels) restores what the tool
+    /// calls itself, and `fold_steps` renders the row.
+    fn step_label(tools: &[Box<dyn openhuman_core::openhuman::tools::traits::Tool>]) -> String {
+        use crate::harness::search::WEB_SEARCH_TOOL;
+        use crate::harness::steps::{StepLabels, fold_steps};
+        use openhuman_core::openhuman as oh;
+
+        let labels = StepLabels::from_tools(tools);
+        let started = oh::agent::progress::AgentProgress::ToolCallStarted {
+            call_id: "c1".into(),
+            tool_name: WEB_SEARCH_TOOL.into(),
+            arguments: serde_json::Value::Null,
+            iteration: 1,
+            display_label: Some(oh::tools::traits::humanize_tool_name(WEB_SEARCH_TOOL)),
+            display_detail: None,
+        };
+        fold_steps(vec![labels.apply(started)])
+            .first()
+            .expect("a tool call folds to one step")
+            .label
+            .clone()
     }
 
     #[test]

--- a/src/harness/built_in/steps.rs
+++ b/src/harness/built_in/steps.rs
@@ -46,7 +46,10 @@
 //! carried, but only through the host's *existing* redactor:
 //!
 //! * **Label** comes from the tool's server-computed `display_label`, else its
-//!   tool *name* — never from arguments or output.
+//!   tool *name* — never from arguments or output. The loop does not ask a tool
+//!   for that label, so [`StepLabels`] restores it from the built tool set
+//!   before the event is folded; both halves are registry-derived, and neither
+//!   widens what a label may contain.
 //! * **Detail** (arguments) is passed through
 //!   [`approval_display::redact`](crate::runtime::approval_display::redact) —
 //!   issue #372's host-side redactor — and then bounded. This is a deliberate
@@ -82,11 +85,15 @@
 //! stays text-only — so a scrubbed detail can never be re-retrieved and
 //! re-injected into a later turn.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use openhuman_core::openhuman as oh;
 use serde_json::Value;
 
 use oh::agent::progress::AgentProgress;
 use oh::tools::status::{ClassifiedFailure, ToolFailureClass};
+use oh::tools::traits::humanize_tool_name;
 
 use crate::harness::policy::POLICY_NAME;
 use crate::ports::deep_trace::TurnStepDetail;
@@ -650,6 +657,142 @@ pub(crate) fn stream_event_from(
             None
         }
         _ => None,
+    }
+}
+
+/// The curated step labels of one agent's tools, keyed by tool name.
+///
+/// # Why this exists
+///
+/// A tool states its own operator-facing step label through
+/// [`Tool::display_label`](oh::tools::traits::Tool::display_label): the managed
+/// web search calls itself "Exa web search", and a BYO belt names the provider
+/// actually wired behind it ("Brave web search", "SearXNG web search").
+/// **Nothing asks it.** The crate-level `ToolStarted` event carries a call id
+/// and a tool *name* and nothing else, so the bridge that projects it into an
+/// [`AgentProgress`] fills `display_label` with a humanized form of that name —
+/// the same "Web Search" for every provider, on every tenant. The tool's own
+/// answer reaches no one, and `label_for` below then faithfully renders a
+/// label the tool never chose.
+///
+/// OpenCompany assembles the tool set ([`build_agent`](crate::harness::build)),
+/// so it is the one layer that *can* answer the question the loop does not ask.
+/// It captures each tool's label once, at build time, and puts it back onto the
+/// event as that event enters the collector. Everything downstream is unchanged
+/// and stays consistent by construction: the folded [`TurnStep`]s, the live
+/// stream frames, and the durable run trace all read the one rewritten event.
+///
+/// # What it holds, exactly
+///
+/// Labels are captured with `Value::Null` arguments — which is precisely what
+/// the loop itself has at `ToolStarted`, since it emits `arguments: Null` there
+/// too. So this map carries exactly what a loop that *did* ask would have
+/// computed at that moment, and no more: a tool that varies its label by
+/// argument contributes its argument-free form, the same one the loop would
+/// have gotten.
+///
+/// Only labels that **differ** from the humanized tool name are kept, so the map
+/// holds deliberate overrides rather than a second copy of the default. An agent
+/// whose tools all accept the default carries an empty map and costs nothing.
+#[derive(Debug, Default, Clone)]
+pub struct StepLabels(Arc<HashMap<String, String>>);
+
+impl StepLabels {
+    /// Capture the curated labels of `tools`.
+    pub fn from_tools(tools: &[Box<dyn oh::tools::traits::Tool>]) -> Self {
+        let curated = tools
+            .iter()
+            .filter_map(|tool| {
+                let name = tool.name();
+                tool.display_label(&Value::Null)
+                    .filter(|label| !label.trim().is_empty())
+                    // A label equal to the default is not an override; keeping it
+                    // would only make `apply` rewrite an event into itself.
+                    .filter(|label| *label != humanize_tool_name(name))
+                    .map(|label| (name.to_string(), label))
+            })
+            .collect();
+        Self(Arc::new(curated))
+    }
+
+    /// Restore the tool's own label on a tool-call start.
+    ///
+    /// Every other event passes through untouched. Applied once per event, at
+    /// the collector, so the three consumers of that stream cannot disagree
+    /// about what a step is called.
+    pub fn apply(&self, event: AgentProgress) -> AgentProgress {
+        match event {
+            AgentProgress::ToolCallStarted {
+                call_id,
+                tool_name,
+                arguments,
+                iteration,
+                display_label,
+                display_detail,
+            } => {
+                let display_label = self.resolve(&tool_name, display_label);
+                AgentProgress::ToolCallStarted {
+                    call_id,
+                    tool_name,
+                    arguments,
+                    iteration,
+                    display_label,
+                    display_detail,
+                }
+            }
+            // A sub-agent's registry is a filtered view of this same parent tool
+            // set (openhuman's sub-agent runner narrows it per archetype), so the
+            // one map is correct for both scopes. `fold_steps` renders only
+            // parent-scope rows today; the run trace and any later nested view
+            // read the same corrected event rather than a stale humanized one.
+            AgentProgress::SubagentToolCallStarted {
+                agent_id,
+                task_id,
+                call_id,
+                tool_name,
+                arguments,
+                iteration,
+                display_label,
+                display_detail,
+            } => {
+                let display_label = self.resolve(&tool_name, display_label);
+                AgentProgress::SubagentToolCallStarted {
+                    agent_id,
+                    task_id,
+                    call_id,
+                    tool_name,
+                    arguments,
+                    iteration,
+                    display_label,
+                    display_detail,
+                }
+            }
+            other => other,
+        }
+    }
+
+    /// The label to carry for `tool_name`, given what the loop supplied.
+    ///
+    /// A curated label replaces the loop's *default* — the humanized tool name,
+    /// or nothing at all. It does **not** replace a label the loop actually
+    /// chose for this call: the unknown-tool row reads "`<name>` (unavailable)",
+    /// and a loop that one day computes a real per-call label should outrank a
+    /// build-time snapshot. Deferring is safe in both directions, because a name
+    /// the loop labels specially is either absent from this map (it never
+    /// registered as a tool) or better described by the call than by the
+    /// registry.
+    fn resolve(&self, tool_name: &str, from_loop: Option<String>) -> Option<String> {
+        let Some(curated) = self.0.get(tool_name) else {
+            return from_loop;
+        };
+        let loop_chose_it = from_loop.as_deref().is_some_and(|label| {
+            !label.trim().is_empty() && label != humanize_tool_name(tool_name)
+        });
+        if loop_chose_it {
+            from_loop
+        } else {
+            Some(curated.clone())
+        }
     }
 }
 
@@ -1373,6 +1516,186 @@ mod tests {
         assert_eq!(steps[0].label, "Searching the web");
         assert_eq!(steps[0].detail.as_deref(), Some("brave · search"));
         assert_eq!(steps[0].elapsed_ms, Some(42));
+    }
+
+    /// A tool that answers `display_label` however a test needs it to.
+    struct LabelledTool {
+        name: &'static str,
+        label: Option<&'static str>,
+    }
+
+    impl LabelledTool {
+        fn boxed(
+            name: &'static str,
+            label: Option<&'static str>,
+        ) -> Box<dyn oh::tools::traits::Tool> {
+            Box::new(Self { name, label })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl oh::tools::traits::Tool for LabelledTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "a tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({ "type": "object" })
+        }
+
+        fn display_label(&self, _args: &Value) -> Option<String> {
+            self.label.map(str::to_string)
+        }
+
+        async fn execute(&self, _args: Value) -> anyhow::Result<oh::tools::traits::ToolResult> {
+            Ok(oh::tools::traits::ToolResult::success("ok"))
+        }
+    }
+
+    /// The whole reason [`StepLabels`] exists: the vendored turn loop labels a
+    /// tool row from the tool's **name**, and never asks the tool what it calls
+    /// itself.
+    ///
+    /// If this needle stops matching, upstream has changed how a row is
+    /// labelled — most likely by consulting `Tool::display_label` at last. Check
+    /// before deleting anything: `resolve` already defers to a label the loop
+    /// chose, so a correct upstream makes this shim inert rather than wrong, and
+    /// it can then go.
+    #[test]
+    fn the_vendored_loop_still_labels_a_tool_row_from_its_name_alone() {
+        let src = vendored("vendor/openhuman/src/openhuman/agent/tinyagents/observability.rs");
+        assert!(
+            src.contains("display_label: Some(humanize_tool_name(tool_name))"),
+            "the vendored loop no longer labels a tool row from its name — if it now asks \
+             the tool for its own label, `StepLabels` is redundant and should be removed \
+             rather than left to shadow the real answer"
+        );
+    }
+
+    #[test]
+    fn step_labels_keep_overrides_and_drop_the_default() {
+        // The default is the loop's own humanizer, which Title-Cases *every*
+        // word — "Spawn Task", not "Spawn task". Pinned here because the whole
+        // map hinges on recognising that string: read it as sentence case and
+        // every tool looks like it has an override.
+        assert_eq!(humanize_tool_name("spawn_task"), "Spawn Task");
+
+        let labels = StepLabels::from_tools(&[
+            LabelledTool::boxed("web_search", Some("Exa web search")),
+            // The trait default: humanizing its own name. Not an override.
+            LabelledTool::boxed("spawn_task", Some("Spawn Task")),
+            LabelledTool::boxed("file_read", None),
+            LabelledTool::boxed("file_write", Some("   ")),
+        ]);
+        let mut kept: Vec<_> = labels
+            .0
+            .iter()
+            .map(|(name, label)| (name.as_str(), label.as_str()))
+            .collect();
+        kept.sort_unstable();
+        assert_eq!(kept, vec![("web_search", "Exa web search")]);
+    }
+
+    /// The end-to-end shape of the bug: the loop hands the timeline the
+    /// humanized name, and the tool's own label puts it back.
+    #[test]
+    fn a_curated_label_replaces_the_loop_s_humanized_name() {
+        let labels =
+            StepLabels::from_tools(&[LabelledTool::boxed("web_search", Some("Exa web search"))]);
+        let steps = fold_steps(
+            vec![
+                // Exactly what the loop emits: `humanize_tool_name("web_search")`.
+                started("c1", "web_search", Some("Web Search")),
+                completed("c1", "web_search", true, "ok", None, None),
+            ]
+            .into_iter()
+            .map(|event| labels.apply(event))
+            .collect(),
+        );
+        assert_eq!(steps[0].label, "Exa web search");
+    }
+
+    /// A BYO tenant reads the provider actually wired behind the belt — the half
+    /// of the fix that branding on the tool *name* could never deliver, since
+    /// every provider is aliased to the one canonical `web_search`.
+    #[test]
+    fn each_provider_s_own_label_reaches_the_timeline_under_one_tool_name() {
+        for provider in [
+            "Brave web search",
+            "Querit web search",
+            "SearXNG web search",
+        ] {
+            let labels =
+                StepLabels::from_tools(&[LabelledTool::boxed("web_search", Some(provider))]);
+            let steps = fold_steps(
+                vec![
+                    started("c1", "web_search", Some("Web Search")),
+                    completed("c1", "web_search", true, "ok", None, None),
+                ]
+                .into_iter()
+                .map(|event| labels.apply(event))
+                .collect(),
+            );
+            assert_eq!(steps[0].label, provider);
+        }
+    }
+
+    #[test]
+    fn a_tool_without_an_override_is_left_alone() {
+        let labels =
+            StepLabels::from_tools(&[LabelledTool::boxed("web_search", Some("Exa web search"))]);
+        let steps = fold_steps(
+            vec![
+                started("c1", "spawn_task", Some("Spawn task")),
+                completed("c1", "spawn_task", true, "ok", None, None),
+            ]
+            .into_iter()
+            .map(|event| labels.apply(event))
+            .collect(),
+        );
+        assert_eq!(steps[0].label, "Spawn task");
+    }
+
+    /// A label the loop *chose* for this call outranks the build-time snapshot.
+    /// The unavailable-tool row is the live example: it names a tool that never
+    /// ran, and "Web Search" would hide why the row is there at all.
+    #[test]
+    fn a_label_the_loop_chose_survives() {
+        let labels =
+            StepLabels::from_tools(&[LabelledTool::boxed("web_search", Some("Exa web search"))]);
+        let steps = fold_steps(
+            vec![
+                started("c1", "web_search", Some("Web search (unavailable)")),
+                completed("c1", "web_search", false, "", None, None),
+            ]
+            .into_iter()
+            .map(|event| labels.apply(event))
+            .collect(),
+        );
+        assert_eq!(steps[0].label, "Web search (unavailable)");
+    }
+
+    /// Nothing but a tool-call start is touched, so the rewrite cannot perturb
+    /// the thinking/text folding the rest of this module depends on.
+    #[test]
+    fn apply_leaves_every_other_event_untouched() {
+        let labels =
+            StepLabels::from_tools(&[LabelledTool::boxed("web_search", Some("Exa web search"))]);
+        let events = vec![
+            thinking("hm"),
+            text("hello"),
+            completed("c1", "web_search", true, "ok", None, None),
+        ];
+        let applied: Vec<_> = events
+            .clone()
+            .into_iter()
+            .map(|event| labels.apply(event))
+            .collect();
+        assert_eq!(fold_steps(applied), fold_steps(events));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

[#1857](https://github.com/tinyhumansai/opencompany/pull/1857) taught the managed web search to call itself "Exa web search" and each BYO belt to name its own provider. Nothing changed on screen — **`Tool::display_label` is never called.**

The turn loop's `ToolStarted` event carries a call id and a tool *name* and nothing else ([`tinyagents/.../events/types.rs`](https://github.com/tinyhumansai/tinyagents)), so the bridge that projects it into an `AgentProgress` fills `display_label` with `humanize_tool_name(tool_name)` — the same "Web Search" for every provider, on every tenant — and `fold_steps` then faithfully renders a label the tool never chose. Grepping the call sites of `display_label` across this crate *and* openhuman finds only wrapper delegations (`audit.rs`, `checkpoint.rs`) and tests. The trait method has been vestigial since the tinyagents migration.

OpenCompany assembles the tool set, so it is the layer that can answer the question the loop does not ask. `StepLabels` captures each tool's label once, at build time — keeping only labels that *differ* from the humanized default — and puts it back onto the event as that event enters the collector.

That collector is the single site where `set_on_progress` is attached in the whole crate, so chat, dispatched tasks, workflow nodes, the confined copilot and ACP are all covered by the one seam. Nothing downstream changed signature: the folded `TurnStep`s, the live stream frames and the durable run trace read the same rewritten event, so they cannot disagree about a step's name.

**Branding on the tool name alone could not have done this.** Every BYO provider is aliased to the one canonical `web_search`, so the name the loop labels from carries no provider at all — only the tool's own label tells a Brave tenant from an Exa one.

## API Or Behavior Changes

A `web_search` row on the step timeline now reads "Exa web search" (managed) or the wired provider's name (BYO: Brave / Exa / Querit / SearXNG) instead of "Web Search". No wire-format, route or schema change; `TurnStep.label` was already a free string.

`StepLabels` deliberately does **not** override a label the loop actually chose for a call — the unavailable-tool row keeps "`<name>` (unavailable)", and a loop that one day computes a real per-call label outranks a build-time snapshot.

That is also this shim's exit condition. `the_vendored_loop_still_labels_a_tool_row_from_its_name_alone` pins the needle in the vendored source, so if openhuman starts asking tools for their own labels the test fires and says to delete this rather than let it shadow the real answer.

## ⚠️ Depends on #1877

`Rust (openhuman, tinymemory)` does not compile on `main`: `chat_seed.rs`'s `CompanyRecord` test literal is missing three fields. [#1877](https://github.com/tinyhumansai/opencompany/pull/1877) fixes it and is still open. As that PR notes, the break only surfaces on a PR touching `src/harness/**` — which this one does, so it will read as this PR's fault. **Please land #1877 first**; the local runs below were done with its three lines applied and then reverted, so this branch carries none of them.

## Tests

Tests now assert through `fold_steps` rather than on the trait method — the gap that let #1857 ship green while changing nothing an operator sees.

- 8 new tests in `steps.rs` (capture rule, the rewrite, per-provider labels under one tool name, pass-through, loop-chosen labels surviving, the vendored-source pin)
- `search.rs` / `search_byo.rs` label assertions extended to fold a real `ToolCallStarted` end to end

Run locally with `--features openhuman` (the harness is feature-gated, so the default lanes below do not compile this code):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --no-deps --features openhuman --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --features openhuman --lib --tests`)
- [x] `cargo test --features openhuman --lib` — **5734 passed, 0 failed, 3 ignored**

## Documentation

Module docs in `steps.rs` updated: the "Label" bullet in the security section now records that the loop does not ask a tool for its label and that `StepLabels` restores it, noting both halves stay registry-derived and neither widens what a label may contain. `StepLabels`' own doc carries the why, what it holds, and when to remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
