### PR TITLE
fix(harness): read ACP's stop_reason instead of folding it away (#1853)

### DIFF
--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -99,6 +99,7 @@ impl AcpRunTurn {
 enum StopKind {
     EndTurn,
     MaxTokens,
+    MaxTurnRequests,
     Refusal,
     Cancelled,
     Other,
@@ -106,14 +107,21 @@ enum StopKind {
 
 /// Classifies ACP's raw `stopReason` into [`StopKind`].
 ///
-/// `max_turn_requests` folds into [`StopKind::MaxTokens`]: both mean the turn
-/// was cut off by a budget rather than by the model choosing to stop, and the
-/// operator-facing consequence — a resumable cap, not a clean finish — is the
-/// same for either.
+/// `max_tokens` and `max_turn_requests` stay distinct variants (PR #1880
+/// review) even though the note either produces reads similarly: only
+/// `max_turn_requests` is this protocol's analog of openhuman's
+/// tool-iteration cap — the number of agent/tool round trips in the turn hit
+/// a limit — and only that one may set
+/// [`TurnOutcome::hit_iteration_cap`](crate::harness::TurnOutcome::hit_iteration_cap).
+/// `max_tokens` is a token-generation budget on a single response, unrelated
+/// to how many tool calls ran; folding it into the same flag would make a
+/// workflow node's `LimitStop { limit: "max_tool_iterations" }` misreport
+/// which cap actually stopped the turn.
 fn classify_stop_reason(raw: &str) -> StopKind {
     match raw {
         "end_turn" => StopKind::EndTurn,
-        "max_tokens" | "max_turn_requests" => StopKind::MaxTokens,
+        "max_tokens" => StopKind::MaxTokens,
+        "max_turn_requests" => StopKind::MaxTurnRequests,
         "refusal" => StopKind::Refusal,
         "cancelled" => StopKind::Cancelled,
         _ => StopKind::Other,
@@ -131,8 +139,9 @@ fn classify_stop_reason(raw: &str) -> StopKind {
 fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> Option<String> {
     match kind {
         StopKind::EndTurn => None,
-        StopKind::MaxTokens => {
-            Some("[stopped: hit the token/iteration limit before finishing]".to_string())
+        StopKind::MaxTokens => Some("[stopped: hit the token limit before finishing]".to_string()),
+        StopKind::MaxTurnRequests => {
+            Some("[stopped: hit the tool-call limit before finishing]".to_string())
         }
         StopKind::Refusal => Some("[stopped: the agent declined to continue]".to_string()),
         StopKind::Cancelled => Some("[stopped: cancelled before finishing]".to_string()),
@@ -252,12 +261,16 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
     TurnOutcome {
         reply,
         steps,
-        // A max_tokens/max_turn_requests stop is exactly the shape issue #926
-        // describes: the tool loop was cut off by a budget rather than the
-        // model choosing to stop. Every other `StopKind` is not a cap —
+        // A max_turn_requests stop is exactly the shape issue #926 describes:
+        // the tool loop was cut off by a budget rather than the model
+        // choosing to stop. `max_tokens` is a different budget — a single
+        // response's token limit — and is deliberately excluded (PR #1880
+        // review): downstream (`workflows/caps`) reports this flag as
+        // "stopped at the max_tool_iterations cap", which would misdescribe a
+        // token-limited stop. Every other `StopKind` is not a cap —
         // `Refusal`/`Cancelled`/`Other` are surfaced as a step note instead,
         // and `EndTurn` needs no flag at all.
-        hit_iteration_cap: matches!(kind, StopKind::MaxTokens),
+        hit_iteration_cap: matches!(kind, StopKind::MaxTurnRequests),
         // Issue #1032: nor is there a spend halt to report. The stop hooks are
         // installed around THIS crate's `agent.turn`, and an ACP turn does not
         // run through it — the external process bills and stops on its own
@@ -440,16 +453,34 @@ mod test {
     }
 
     #[test]
-    fn an_empty_turn_with_max_tokens_is_a_cap_not_a_clean_success() {
-        // Issue #1853: the old fold ignored `stop_reason` entirely and
-        // hardcoded `hit_iteration_cap: false`, so a turn cut off by the
-        // token/iteration budget folded identically to a clean end_turn with
-        // nothing to say — the operator saw a blank reply with no cap signal
-        // to explain it.
-        let outcome = fold(turn_with_stop_reason(vec![], "max_tokens"));
+    fn a_max_turn_requests_stop_is_the_tool_step_cap() {
+        // Issue #1853 established that a stop must not fold identically to a
+        // clean end_turn — the operator needs a cap signal. PR #1880 review:
+        // `max_turn_requests` is ACP's analog of openhuman's tool-iteration
+        // cap, and is the only stop reason that may set `hit_iteration_cap`,
+        // because `workflows/caps` reports that flag as "stopped at the
+        // max_tool_iterations cap".
+        let outcome = fold(turn_with_stop_reason(vec![], "max_turn_requests"));
         assert!(
             outcome.hit_iteration_cap,
-            "a max_tokens stop is a cap, not a clean finish"
+            "max_turn_requests is the tool-step cap, not a clean finish"
+        );
+        assert!(
+            !outcome.reply.trim().is_empty(),
+            "a capped turn must say so, not fold to a blank reply"
+        );
+    }
+
+    #[test]
+    fn a_max_tokens_stop_is_not_the_tool_step_cap() {
+        // A token-generation budget on a single response is a different cap
+        // than the tool-iteration one (PR #1880 review) — conflating them
+        // would make a workflow node's `LimitStop{"max_tool_iterations"}`
+        // misreport which cap actually stopped the turn.
+        let outcome = fold(turn_with_stop_reason(vec![], "max_tokens"));
+        assert!(
+            !outcome.hit_iteration_cap,
+            "a max_tokens stop is not the tool-iteration cap"
         );
         assert!(
             !outcome.reply.trim().is_empty(),
@@ -550,7 +581,7 @@ mod test {
         assert_eq!(classify_stop_reason("max_tokens"), StopKind::MaxTokens);
         assert_eq!(
             classify_stop_reason("max_turn_requests"),
-            StopKind::MaxTokens
+            StopKind::MaxTurnRequests
         );
         assert_eq!(classify_stop_reason("refusal"), StopKind::Refusal);
         assert_eq!(classify_stop_reason("cancelled"), StopKind::Cancelled);

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -136,7 +136,21 @@ fn classify_stop_reason(raw: &str) -> StopKind {
 /// platform-generated notice into it would leave the operator unable to tell
 /// how much of the text the agent actually said. `EndTurn` returns `None`;
 /// callers only invoke this for a non-`EndTurn` [`StopKind`].
-fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> Option<String> {
+///
+/// Every arm is a **fixed** string — none of them interpolate
+/// `raw_stop_reason`, even the `Other` arm, which used to (PR #1880 review).
+/// A `stopReason` this fold does not recognise is unvalidated, unbounded text
+/// straight off the wire from an external ACP agent — the same class of risk
+/// the module doc already calls out for a tool call's `title` — and this
+/// `Note` step is not a private log line: it becomes an engine transcript
+/// entry (`workflows/caps::transcript_from_steps` maps `Note` to
+/// `"agent_message"`), which can be replayed as prior context for later
+/// engine reasoning. Interpolating the raw value there would hand an
+/// external agent a channel to inject diagnostic text, newlines, or an
+/// oversized payload into durable, operator- and agent-visible history. The
+/// raw value is still worth knowing for debugging — see `fold`'s bounded
+/// `tracing::warn!` right before this is called for `Other`.
+fn stop_reason_note(kind: StopKind) -> Option<String> {
     match kind {
         StopKind::EndTurn => None,
         StopKind::MaxTokens => Some("[stopped: hit the token limit before finishing]".to_string()),
@@ -145,11 +159,18 @@ fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> Option<String> {
         }
         StopKind::Refusal => Some("[stopped: the agent declined to continue]".to_string()),
         StopKind::Cancelled => Some("[stopped: cancelled before finishing]".to_string()),
-        StopKind::Other => Some(format!(
-            "[stopped: unrecognized stop reason \"{raw_stop_reason}\"]"
-        )),
+        StopKind::Other => Some("[stopped: unrecognized stop reason]".to_string()),
     }
 }
+
+/// Bound on the raw `stopReason` logged for `StopKind::Other` (PR #1880
+/// review). A log line is a reasonable place for the diagnostic value —
+/// unlike a `TurnStep` or an engine error message, it is not replayed as
+/// context and not returned to any client — but it is still unvalidated wire
+/// text, so it gets the same UTF-8-safe char-count bound the rest of the crate
+/// applies before logging or persisting external content, sized for "enough
+/// to recognise the reason, not enough to flood the log".
+const UNKNOWN_STOP_REASON_LOG_CHARS: usize = 120;
 
 /// Builds the reply for a turn that produced no `MessageChunk` text.
 ///
@@ -242,6 +263,23 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
     // answer.
     let kind = classify_stop_reason(&turn.stop_reason);
 
+    if kind == StopKind::Other {
+        // Diagnostic only (PR #1880 review) — never the source for anything
+        // durable. `stop_reason_note`'s `Other` arm and `abnormal_stop` below
+        // both deliberately drop the raw value; this bounded copy is the only
+        // place it survives, and only in a log line, char-capped so a
+        // malformed/oversized `stopReason` cannot flood it either.
+        let bounded: String = turn
+            .stop_reason
+            .chars()
+            .take(UNKNOWN_STOP_REASON_LOG_CHARS)
+            .collect();
+        tracing::warn!(
+            stop_reason = %bounded,
+            "[harness::acp] unrecognized ACP stop reason"
+        );
+    }
+
     if reply.trim().is_empty() {
         reply = synthesize_empty_reply(&steps).to_string();
     }
@@ -249,11 +287,12 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
     // PR #1880 review: the stop-reason notice is platform-generated, not
     // agent-authored, so it lands as its own step rather than blurring into
     // `reply` above.
-    if let Some(note) = stop_reason_note(kind, &turn.stop_reason) {
+    let note = stop_reason_note(kind);
+    if let Some(note) = &note {
         steps.push(TurnStep {
             kind: TurnStepKind::Note,
             status: TurnStepStatus::Ok,
-            label: note,
+            label: note.clone(),
             ..TurnStep::default()
         });
     }
@@ -271,6 +310,19 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         // `Refusal`/`Cancelled`/`Other` are surfaced as a step note instead,
         // and `EndTurn` needs no flag at all.
         hit_iteration_cap: matches!(kind, StopKind::MaxTurnRequests),
+        // PR #1880 review: `Refusal`/`Cancelled`/`Other` are not a resumable
+        // cap either — there is no checkpoint to continue from, unlike
+        // `hit_iteration_cap` above — so `HarnessAgentRunner` must not settle
+        // these as a plain `Succeeded`/`StopReason::Finished` the way it used
+        // to when `hit_iteration_cap == false` was the only signal it read.
+        // Reuses `note`'s text: both sinks want the same short, fixed,
+        // non-wire-derived notice, and `stop_reason_note`'s `Other` arm is
+        // already the one place that keeps the raw `stopReason` out of it.
+        abnormal_stop: matches!(
+            kind,
+            StopKind::Refusal | StopKind::Cancelled | StopKind::Other
+        )
+        .then(|| note.clone().unwrap_or_default()),
         // Issue #1032: nor is there a spend halt to report. The stop hooks are
         // installed around THIS crate's `agent.turn`, and an ACP turn does not
         // run through it — the external process bills and stops on its own
@@ -542,6 +594,30 @@ mod test {
             !outcome.hit_iteration_cap,
             "a refusal is not an iteration-cap pause"
         );
+        // PR #1880 review: `hit_iteration_cap == false` used to be the only
+        // signal `HarnessAgentRunner` read, so a refusal settled a workflow
+        // node `Succeeded`/`Finished` — indistinguishable from the agent
+        // having actually answered. This is the outcome-level fix, not just
+        // the note above: see `workflows::caps::mod::test::an_abnormal_acp_stop_fails_the_workflow_node`
+        // for the assertion that it actually stops the graph.
+        assert_eq!(
+            outcome.abnormal_stop.as_deref(),
+            Some("[stopped: the agent declined to continue]"),
+            "a refusal must carry a distinct abnormal-stop outcome, not just a note"
+        );
+    }
+
+    #[test]
+    fn a_cancelled_turn_also_carries_an_abnormal_stop() {
+        // Same shape as refusal, different trigger: an operator-initiated (or
+        // upstream) cancel is just as much "not a resumable cap, not a clean
+        // finish" as a refusal is.
+        let outcome = fold(turn_with_stop_reason(vec![], "cancelled"));
+        assert_eq!(
+            outcome.abnormal_stop.as_deref(),
+            Some("[stopped: cancelled before finishing]")
+        );
+        assert!(!outcome.hit_iteration_cap);
     }
 
     #[test]
@@ -552,27 +628,72 @@ mod test {
         let outcome = fold(turn(vec![AcpUpdate::MessageChunk("all done".into())]));
         assert_eq!(outcome.reply, "all done");
         assert!(!outcome.hit_iteration_cap);
+        assert_eq!(
+            outcome.abnormal_stop, None,
+            "a clean end_turn is not an abnormal stop"
+        );
+    }
+
+    #[test]
+    fn a_max_turn_requests_stop_is_a_cap_not_an_abnormal_stop() {
+        // The cap path (issue #926 / #1880's `hit_iteration_cap` split) and
+        // the abnormal-stop path (this PR's review) are deliberately
+        // disjoint: a capped turn has a real, resumable checkpoint, which is
+        // exactly what `abnormal_stop` says there is none of.
+        let outcome = fold(turn_with_stop_reason(vec![], "max_turn_requests"));
+        assert!(outcome.hit_iteration_cap);
+        assert_eq!(
+            outcome.abnormal_stop, None,
+            "the cap flag already covers this stop; abnormal_stop must stay None"
+        );
     }
 
     #[test]
     fn an_unrecognized_stop_reason_is_surfaced_not_swallowed() {
         // A stop_reason this fold has never heard of must not silently pass
-        // for a clean end_turn — the raw string is carried into a note step
-        // so the operator (and whoever reads the ticket) can see exactly what
-        // ACP reported, without it being mistaken for the agent's own words.
+        // for a clean end_turn — it is carried into a note step so the
+        // operator (and whoever reads the ticket) can see the turn stopped
+        // abnormally.
+        //
+        // PR #1880 review: the raw string itself must NOT appear — an
+        // unrecognized `stopReason` is unvalidated, unbounded text straight
+        // off the wire from an external ACP agent, and this note step is not
+        // a private log line: `workflows/caps::transcript_from_steps` maps a
+        // `Note` step to `"agent_message"` in the engine transcript, which
+        // can be replayed as prior context for later engine reasoning. The
+        // fixed notice below carries the abnormal-stop signal without
+        // reopening that channel.
+        let raw = "some_new_reason_acp_added_later__with_diagnostic_junk_🔥";
         let outcome = fold(turn_with_stop_reason(
             vec![AcpUpdate::MessageChunk("partial thought".into())],
-            "some_new_reason_acp_added_later",
+            raw,
         ));
         assert_eq!(outcome.reply, "partial thought");
         assert!(
             outcome.steps.iter().any(|s| s.kind == TurnStepKind::Note
-                && s.label
-                    == "[stopped: unrecognized stop reason \"some_new_reason_acp_added_later\"]"),
-            "the raw stop_reason must be visible, not swallowed: {:?}",
+                && s.label == "[stopped: unrecognized stop reason]"),
+            "an unrecognized stop must still be surfaced as a step: {:?}",
+            outcome.steps
+        );
+        assert!(
+            outcome.steps.iter().all(|s| !s.label.contains(raw)),
+            "the raw wire value must never appear in a persisted step: {:?}",
             outcome.steps
         );
         assert!(!outcome.hit_iteration_cap);
+        assert_eq!(
+            outcome.abnormal_stop.as_deref(),
+            Some("[stopped: unrecognized stop reason]"),
+            "an unrecognized stop must carry a distinct abnormal-stop outcome, not just a note"
+        );
+        assert!(
+            !outcome
+                .abnormal_stop
+                .as_deref()
+                .unwrap_or_default()
+                .contains(raw),
+            "the raw wire value must never appear in the abnormal-stop message either"
+        );
     }
 
     #[test]

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -142,22 +142,21 @@ fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> String {
 /// Never returns an empty string: a blank reply from a tool-only turn, or one
 /// cut short before the agent said anything, would read on the operator's
 /// timeline as "the agent had nothing to say" rather than what actually
-/// happened. Built from tool-call step **labels** only — never a step's
-/// `result` — because labels are host-derived (a tool's name), while a
-/// result can carry a tool's raw output or arguments; synthesizing a reply
-/// from those would leak into the reply text exactly what the redaction the
-/// rest of this fold performs is trying to avoid.
+/// happened. Says only **that** tools ran, never **what** they were (PR #1880
+/// review) — a tool call's `title` comes verbatim off the wire from the
+/// external ACP agent, with no host-side bounding or redaction (unlike the
+/// built-in harness's server-computed step label), so it can carry arbitrary
+/// upstream content. The titles themselves are already on the operator's
+/// timeline as this turn's [`TurnStep`]s; restating them in a field meant to
+/// read as the agent's own words would only duplicate that exposure for no
+/// new information.
 fn synthesize_empty_reply(steps: &[TurnStep], kind: StopKind, raw_stop_reason: &str) -> String {
-    let tool_labels: Vec<&str> = steps
-        .iter()
-        .filter(|step| step.kind == TurnStepKind::ToolCall)
-        .map(|step| step.label.as_str())
-        .collect();
+    let ran_tools = steps.iter().any(|step| step.kind == TurnStepKind::ToolCall);
 
-    let mut reply = if tool_labels.is_empty() {
-        String::new()
+    let mut reply = if ran_tools {
+        "[no reply text — see steps]".to_string()
     } else {
-        format!("Ran: {}", tool_labels.join(", "))
+        String::new()
     };
 
     if kind != StopKind::EndTurn {
@@ -457,10 +456,13 @@ mod test {
     }
 
     #[test]
-    fn a_tool_only_turn_synthesizes_its_reply_from_step_labels() {
+    fn a_tool_only_turn_gets_a_generic_reply_not_raw_tool_titles() {
         // No MessageChunk at all — the agent's entire turn was tool calls.
-        // The old fold left `reply == ""`; the operator's timeline showed
-        // nothing where two tool calls plainly ran.
+        // PR #1880 review: the reply must not copy the tools' raw ACP titles
+        // — unlike the built-in harness's step label, a title comes straight
+        // off the wire with no host-side bounding, and the timeline (already
+        // carrying each ToolCall step's own title) is where that content
+        // belongs, not a field meant to read as the agent's own words.
         let outcome = fold(turn(vec![
             AcpUpdate::ToolCall {
                 id: "t1".into(),
@@ -476,7 +478,9 @@ mod test {
                 title: "Write".into(),
             },
         ]));
-        assert_eq!(outcome.reply, "Ran: Read, Write");
+        assert_eq!(outcome.reply, "[no reply text — see steps]");
+        assert_eq!(outcome.steps[0].label, "Read");
+        assert_eq!(outcome.steps[1].label, "Write");
         // A clean end_turn needs no stop-reason note on top of the synthesis.
         assert!(!outcome.reply.contains("[stopped"));
     }

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -121,19 +121,24 @@ fn classify_stop_reason(raw: &str) -> StopKind {
 }
 
 /// The short, fixed note surfaced when a turn stopped for a reason other than
-/// `end_turn`. Appended regardless of whether there is prose alongside it, so
-/// a capped, refused, cancelled or unrecognized turn never reads like a clean
-/// finish. `EndTurn` returns an empty string; callers only invoke this for a
-/// non-`EndTurn` [`StopKind`].
-fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> String {
+/// `end_turn`. Landed as its own [`TurnStep`] of kind
+/// [`TurnStepKind::Note`], never concatenated into
+/// [`TurnOutcome::reply`](crate::harness::TurnOutcome::reply) (PR #1880
+/// review) — the reply is the agent's own words, and folding a
+/// platform-generated notice into it would leave the operator unable to tell
+/// how much of the text the agent actually said. `EndTurn` returns `None`;
+/// callers only invoke this for a non-`EndTurn` [`StopKind`].
+fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> Option<String> {
     match kind {
-        StopKind::EndTurn => String::new(),
+        StopKind::EndTurn => None,
         StopKind::MaxTokens => {
-            "[stopped: hit the token/iteration limit before finishing]".to_string()
+            Some("[stopped: hit the token/iteration limit before finishing]".to_string())
         }
-        StopKind::Refusal => "[stopped: the agent declined to continue]".to_string(),
-        StopKind::Cancelled => "[stopped: cancelled before finishing]".to_string(),
-        StopKind::Other => format!("[stopped: unrecognized stop reason \"{raw_stop_reason}\"]"),
+        StopKind::Refusal => Some("[stopped: the agent declined to continue]".to_string()),
+        StopKind::Cancelled => Some("[stopped: cancelled before finishing]".to_string()),
+        StopKind::Other => Some(format!(
+            "[stopped: unrecognized stop reason \"{raw_stop_reason}\"]"
+        )),
     }
 }
 
@@ -150,26 +155,14 @@ fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> String {
 /// timeline as this turn's [`TurnStep`]s; restating them in a field meant to
 /// read as the agent's own words would only duplicate that exposure for no
 /// new information.
-fn synthesize_empty_reply(steps: &[TurnStep], kind: StopKind, raw_stop_reason: &str) -> String {
+fn synthesize_empty_reply(steps: &[TurnStep]) -> &'static str {
     let ran_tools = steps.iter().any(|step| step.kind == TurnStepKind::ToolCall);
-
-    let mut reply = if ran_tools {
-        "[no reply text — see steps]".to_string()
+    if ran_tools {
+        "[no reply text — see steps]"
     } else {
-        String::new()
-    };
-
-    if kind != StopKind::EndTurn {
-        if !reply.is_empty() {
-            reply.push(' ');
-        }
-        reply.push_str(&stop_reason_note(kind, raw_stop_reason));
-    } else if reply.is_empty() {
         // A clean end with no text and no tool calls. Still never blank.
-        reply.push_str("[no reply]");
+        "[no reply]"
     }
-
-    reply
 }
 
 /// Folds a turn's updates into the outcome the company cycle expects.
@@ -241,10 +234,19 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
     let kind = classify_stop_reason(&turn.stop_reason);
 
     if reply.trim().is_empty() {
-        reply = synthesize_empty_reply(&steps, kind, &turn.stop_reason);
-    } else if kind != StopKind::EndTurn {
-        reply.push(' ');
-        reply.push_str(&stop_reason_note(kind, &turn.stop_reason));
+        reply = synthesize_empty_reply(&steps).to_string();
+    }
+
+    // PR #1880 review: the stop-reason notice is platform-generated, not
+    // agent-authored, so it lands as its own step rather than blurring into
+    // `reply` above.
+    if let Some(note) = stop_reason_note(kind, &turn.stop_reason) {
+        steps.push(TurnStep {
+            kind: TurnStepKind::Note,
+            status: TurnStepStatus::Ok,
+            label: note,
+            ..TurnStep::default()
+        });
     }
 
     TurnOutcome {
@@ -253,8 +255,8 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         // A max_tokens/max_turn_requests stop is exactly the shape issue #926
         // describes: the tool loop was cut off by a budget rather than the
         // model choosing to stop. Every other `StopKind` is not a cap —
-        // `Refusal`/`Cancelled`/`Other` are surfaced in the reply above
-        // instead, and `EndTurn` needs no flag at all.
+        // `Refusal`/`Cancelled`/`Other` are surfaced as a step note instead,
+        // and `EndTurn` needs no flag at all.
         hit_iteration_cap: matches!(kind, StopKind::MaxTokens),
         // Issue #1032: nor is there a spend halt to report. The stop hooks are
         // installed around THIS crate's `agent.turn`, and an ACP turn does not
@@ -486,25 +488,24 @@ mod test {
     }
 
     #[test]
-    fn a_refusal_is_surfaced_and_the_cap_stays_false() {
+    fn a_refusal_is_surfaced_as_a_note_step_and_the_cap_stays_false() {
         // The agent had prose to say, then declined to continue. The note
         // must land regardless — a refusal is not a clean finish even when
-        // there is a reply to read.
+        // there is a reply to read. PR #1880 review: it lands as a `Note`
+        // step, not appended onto the agent's own reply text.
         let outcome = fold(turn_with_stop_reason(
             vec![AcpUpdate::MessageChunk("I can't help with that.".into())],
             "refusal",
         ));
-        assert!(
-            outcome.reply.starts_with("I can't help with that."),
-            "the agent's own prose is kept: {}",
-            outcome.reply
+        assert_eq!(
+            outcome.reply, "I can't help with that.",
+            "the agent's own prose is kept verbatim, with nothing appended"
         );
         assert!(
-            outcome
-                .reply
-                .contains("[stopped: the agent declined to continue]"),
-            "the refusal must be surfaced, not silently swallowed: {}",
-            outcome.reply
+            outcome.steps.iter().any(|s| s.kind == TurnStepKind::Note
+                && s.label == "[stopped: the agent declined to continue]"),
+            "the refusal must be surfaced as a step, not silently swallowed: {:?}",
+            outcome.steps
         );
         assert!(
             !outcome.hit_iteration_cap,
@@ -525,19 +526,20 @@ mod test {
     #[test]
     fn an_unrecognized_stop_reason_is_surfaced_not_swallowed() {
         // A stop_reason this fold has never heard of must not silently pass
-        // for a clean end_turn — the raw string is carried into the note so
-        // the operator (and whoever reads the ticket) can see exactly what
-        // ACP reported.
+        // for a clean end_turn — the raw string is carried into a note step
+        // so the operator (and whoever reads the ticket) can see exactly what
+        // ACP reported, without it being mistaken for the agent's own words.
         let outcome = fold(turn_with_stop_reason(
             vec![AcpUpdate::MessageChunk("partial thought".into())],
             "some_new_reason_acp_added_later",
         ));
+        assert_eq!(outcome.reply, "partial thought");
         assert!(
-            outcome.reply.contains(
-                "[stopped: unrecognized stop reason \"some_new_reason_acp_added_later\"]"
-            ),
-            "the raw stop_reason must be visible, not swallowed: {}",
-            outcome.reply
+            outcome.steps.iter().any(|s| s.kind == TurnStepKind::Note
+                && s.label
+                    == "[stopped: unrecognized stop reason \"some_new_reason_acp_added_later\"]"),
+            "the raw stop_reason must be visible, not swallowed: {:?}",
+            outcome.steps
         );
         assert!(!outcome.hit_iteration_cap);
     }

--- a/src/harness/acp/run_turn.rs
+++ b/src/harness/acp/run_turn.rs
@@ -89,6 +89,90 @@ impl AcpRunTurn {
     }
 }
 
+/// How a turn ended, coarsened from ACP's raw `stopReason` string into the
+/// shapes this fold treats differently.
+///
+/// `EndTurn` is the only one that means "the agent said everything it meant
+/// to say"; every other value means the reply in hand — if any — is partial,
+/// and the fold must say so rather than let it pass for an ordinary answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StopKind {
+    EndTurn,
+    MaxTokens,
+    Refusal,
+    Cancelled,
+    Other,
+}
+
+/// Classifies ACP's raw `stopReason` into [`StopKind`].
+///
+/// `max_turn_requests` folds into [`StopKind::MaxTokens`]: both mean the turn
+/// was cut off by a budget rather than by the model choosing to stop, and the
+/// operator-facing consequence — a resumable cap, not a clean finish — is the
+/// same for either.
+fn classify_stop_reason(raw: &str) -> StopKind {
+    match raw {
+        "end_turn" => StopKind::EndTurn,
+        "max_tokens" | "max_turn_requests" => StopKind::MaxTokens,
+        "refusal" => StopKind::Refusal,
+        "cancelled" => StopKind::Cancelled,
+        _ => StopKind::Other,
+    }
+}
+
+/// The short, fixed note surfaced when a turn stopped for a reason other than
+/// `end_turn`. Appended regardless of whether there is prose alongside it, so
+/// a capped, refused, cancelled or unrecognized turn never reads like a clean
+/// finish. `EndTurn` returns an empty string; callers only invoke this for a
+/// non-`EndTurn` [`StopKind`].
+fn stop_reason_note(kind: StopKind, raw_stop_reason: &str) -> String {
+    match kind {
+        StopKind::EndTurn => String::new(),
+        StopKind::MaxTokens => {
+            "[stopped: hit the token/iteration limit before finishing]".to_string()
+        }
+        StopKind::Refusal => "[stopped: the agent declined to continue]".to_string(),
+        StopKind::Cancelled => "[stopped: cancelled before finishing]".to_string(),
+        StopKind::Other => format!("[stopped: unrecognized stop reason \"{raw_stop_reason}\"]"),
+    }
+}
+
+/// Builds the reply for a turn that produced no `MessageChunk` text.
+///
+/// Never returns an empty string: a blank reply from a tool-only turn, or one
+/// cut short before the agent said anything, would read on the operator's
+/// timeline as "the agent had nothing to say" rather than what actually
+/// happened. Built from tool-call step **labels** only — never a step's
+/// `result` — because labels are host-derived (a tool's name), while a
+/// result can carry a tool's raw output or arguments; synthesizing a reply
+/// from those would leak into the reply text exactly what the redaction the
+/// rest of this fold performs is trying to avoid.
+fn synthesize_empty_reply(steps: &[TurnStep], kind: StopKind, raw_stop_reason: &str) -> String {
+    let tool_labels: Vec<&str> = steps
+        .iter()
+        .filter(|step| step.kind == TurnStepKind::ToolCall)
+        .map(|step| step.label.as_str())
+        .collect();
+
+    let mut reply = if tool_labels.is_empty() {
+        String::new()
+    } else {
+        format!("Ran: {}", tool_labels.join(", "))
+    };
+
+    if kind != StopKind::EndTurn {
+        if !reply.is_empty() {
+            reply.push(' ');
+        }
+        reply.push_str(&stop_reason_note(kind, raw_stop_reason));
+    } else if reply.is_empty() {
+        // A clean end with no text and no tool calls. Still never blank.
+        reply.push_str("[no reply]");
+    }
+
+    reply
+}
+
 /// Folds a turn's updates into the outcome the company cycle expects.
 ///
 /// Separate from the trait impl so it is testable without an agent, and because
@@ -150,13 +234,29 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         }
     }
 
+    // Issue #1853: `stop_reason` is ACP's own signal for how the turn ended,
+    // and the old fold never read it — a tool-only turn folded to `reply ==
+    // ""`, and a max_tokens/refusal/cancelled turn folded identically to a
+    // clean `end_turn`, indistinguishable to the operator from an ordinary
+    // answer.
+    let kind = classify_stop_reason(&turn.stop_reason);
+
+    if reply.trim().is_empty() {
+        reply = synthesize_empty_reply(&steps, kind, &turn.stop_reason);
+    } else if kind != StopKind::EndTurn {
+        reply.push(' ');
+        reply.push_str(&stop_reason_note(kind, &turn.stop_reason));
+    }
+
     TurnOutcome {
         reply,
         steps,
-        // Issue #926: an ACP turn runs behind an external agent process, whose
-        // protocol carries no iteration-cap signal — there is nothing to read,
-        // and inventing `true` here would label every ACP reply a pause.
-        hit_iteration_cap: false,
+        // A max_tokens/max_turn_requests stop is exactly the shape issue #926
+        // describes: the tool loop was cut off by a budget rather than the
+        // model choosing to stop. Every other `StopKind` is not a cap —
+        // `Refusal`/`Cancelled`/`Other` are surfaced in the reply above
+        // instead, and `EndTurn` needs no flag at all.
+        hit_iteration_cap: matches!(kind, StopKind::MaxTokens),
         // Issue #1032: nor is there a spend halt to report. The stop hooks are
         // installed around THIS crate's `agent.turn`, and an ACP turn does not
         // run through it — the external process bills and stops on its own
@@ -329,6 +429,127 @@ mod test {
             updates,
             stop_reason: "end_turn".to_string(),
         }
+    }
+
+    fn turn_with_stop_reason(updates: Vec<AcpUpdate>, stop_reason: &str) -> AcpTurn {
+        AcpTurn {
+            updates,
+            stop_reason: stop_reason.to_string(),
+        }
+    }
+
+    #[test]
+    fn an_empty_turn_with_max_tokens_is_a_cap_not_a_clean_success() {
+        // Issue #1853: the old fold ignored `stop_reason` entirely and
+        // hardcoded `hit_iteration_cap: false`, so a turn cut off by the
+        // token/iteration budget folded identically to a clean end_turn with
+        // nothing to say — the operator saw a blank reply with no cap signal
+        // to explain it.
+        let outcome = fold(turn_with_stop_reason(vec![], "max_tokens"));
+        assert!(
+            outcome.hit_iteration_cap,
+            "a max_tokens stop is a cap, not a clean finish"
+        );
+        assert!(
+            !outcome.reply.trim().is_empty(),
+            "a capped turn must say so, not fold to a blank reply"
+        );
+    }
+
+    #[test]
+    fn a_tool_only_turn_synthesizes_its_reply_from_step_labels() {
+        // No MessageChunk at all — the agent's entire turn was tool calls.
+        // The old fold left `reply == ""`; the operator's timeline showed
+        // nothing where two tool calls plainly ran.
+        let outcome = fold(turn(vec![
+            AcpUpdate::ToolCall {
+                id: "t1".into(),
+                title: "Read".into(),
+            },
+            AcpUpdate::ToolCallUpdate {
+                id: "t1".into(),
+                status: "completed".into(),
+                result: Some("2.4 kB".into()),
+            },
+            AcpUpdate::ToolCall {
+                id: "t2".into(),
+                title: "Write".into(),
+            },
+        ]));
+        assert_eq!(outcome.reply, "Ran: Read, Write");
+        // A clean end_turn needs no stop-reason note on top of the synthesis.
+        assert!(!outcome.reply.contains("[stopped"));
+    }
+
+    #[test]
+    fn a_refusal_is_surfaced_and_the_cap_stays_false() {
+        // The agent had prose to say, then declined to continue. The note
+        // must land regardless — a refusal is not a clean finish even when
+        // there is a reply to read.
+        let outcome = fold(turn_with_stop_reason(
+            vec![AcpUpdate::MessageChunk("I can't help with that.".into())],
+            "refusal",
+        ));
+        assert!(
+            outcome.reply.starts_with("I can't help with that."),
+            "the agent's own prose is kept: {}",
+            outcome.reply
+        );
+        assert!(
+            outcome
+                .reply
+                .contains("[stopped: the agent declined to continue]"),
+            "the refusal must be surfaced, not silently swallowed: {}",
+            outcome.reply
+        );
+        assert!(
+            !outcome.hit_iteration_cap,
+            "a refusal is not an iteration-cap pause"
+        );
+    }
+
+    #[test]
+    fn an_end_turn_reply_is_left_verbatim() {
+        // The ordinary case — and the one the pre-existing seam test already
+        // pins — must not gain a note or any other alteration just because
+        // this fold now reads `stop_reason`.
+        let outcome = fold(turn(vec![AcpUpdate::MessageChunk("all done".into())]));
+        assert_eq!(outcome.reply, "all done");
+        assert!(!outcome.hit_iteration_cap);
+    }
+
+    #[test]
+    fn an_unrecognized_stop_reason_is_surfaced_not_swallowed() {
+        // A stop_reason this fold has never heard of must not silently pass
+        // for a clean end_turn — the raw string is carried into the note so
+        // the operator (and whoever reads the ticket) can see exactly what
+        // ACP reported.
+        let outcome = fold(turn_with_stop_reason(
+            vec![AcpUpdate::MessageChunk("partial thought".into())],
+            "some_new_reason_acp_added_later",
+        ));
+        assert!(
+            outcome.reply.contains(
+                "[stopped: unrecognized stop reason \"some_new_reason_acp_added_later\"]"
+            ),
+            "the raw stop_reason must be visible, not swallowed: {}",
+            outcome.reply
+        );
+        assert!(!outcome.hit_iteration_cap);
+    }
+
+    #[test]
+    fn classify_stop_reason_maps_the_known_shapes() {
+        assert_eq!(classify_stop_reason("end_turn"), StopKind::EndTurn);
+        assert_eq!(classify_stop_reason("max_tokens"), StopKind::MaxTokens);
+        assert_eq!(
+            classify_stop_reason("max_turn_requests"),
+            StopKind::MaxTokens
+        );
+        assert_eq!(classify_stop_reason("refusal"), StopKind::Refusal);
+        assert_eq!(classify_stop_reason("cancelled"), StopKind::Cancelled);
+        assert_eq!(classify_stop_reason("anything_else"), StopKind::Other);
+        assert_eq!(classify_stop_reason(""), StopKind::Other);
     }
 
     #[test]

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -9104,6 +9104,8 @@ members = ["eng1", "eng2"]
                 reply: self.label.clone(),
                 steps: Vec::new(),
                 hit_iteration_cap: false,
+                // Test fixture, not the ACP fold (PR #1880 review).
+                abnormal_stop: None,
                 halted_for_spend: None,
             })
         }
@@ -9384,6 +9386,8 @@ agent = "claude"
             reply: "here is what that node does".to_string(),
             steps: Vec::new(),
             hit_iteration_cap: false,
+            // Test fixture, not the ACP fold (PR #1880 review).
+            abnormal_stop: None,
             halted_for_spend: None,
         });
         assert_eq!(bubble.channel, "operator", "the destination is unchanged");

--- a/src/harness/built_in/mod.rs
+++ b/src/harness/built_in/mod.rs
@@ -699,6 +699,33 @@ pub struct TurnOutcome {
     /// ACP fold) — a refusal is not a pause, and labelling one as a cap hit
     /// would tell the operator to reply "continue" to a turn that never ran.
     pub hit_iteration_cap: bool,
+    /// A fixed, host-authored notice when this turn stopped for a reason that
+    /// is neither a clean finish nor a resumable cap (PR #1880 review) — on
+    /// the ACP fold, an agent-issued `refusal`, a `cancelled` turn, or a
+    /// `stopReason` this fold does not recognise.
+    ///
+    /// `None` on every other path, including [`hit_iteration_cap`] pauses,
+    /// which already have their own distinct, resumable-checkpoint signal and
+    /// must keep it — this field is for the opposite case, where there is no
+    /// checkpoint to resume. Before this field existed,
+    /// [`HarnessAgentRunner`](crate::workflows::caps::HarnessAgentRunner)
+    /// read only `hit_iteration_cap` to decide whether a workflow agent node
+    /// finished; it stayed `false` for all three of these stops too, so a
+    /// refused or cancelled turn settled the node `Succeeded` and reported
+    /// `StopReason::Finished` — indistinguishable from the agent actually
+    /// answering, and a declined or interrupted reply advanced the workflow
+    /// graph as if it were the deliverable.
+    ///
+    /// Always a short, host-authored string, **never** the raw
+    /// `stopReason`/error text an external agent sent (same reasoning as the
+    /// `Other` arm of `stop_reason_note` in `harness::acp::run_turn`, which
+    /// this field's message is drawn from): it ends up in
+    /// `EngineError::Capability`, a developer/operator-facing message, and an
+    /// unbounded wire string has no more business there than in a persisted
+    /// [`TurnStep`].
+    ///
+    /// [`hit_iteration_cap`]: Self::hit_iteration_cap
+    pub abnormal_stop: Option<String>,
     /// The in-turn **spend halt**, when one stopped this turn (issue #1032).
     ///
     /// `Some` exactly when the teammate declared a `budget_usd_daily`, the
@@ -1261,6 +1288,9 @@ impl CompanyAgent {
                 reply,
                 steps,
                 hit_iteration_cap,
+                // This is the built_in harness, not the ACP fold — the only
+                // path that produces an abnormal stop (PR #1880 review).
+                abnormal_stop: None,
                 halted_for_spend,
             },
             usages,
@@ -2987,6 +3017,12 @@ impl HarnessPool {
                                 // No model call ran, so no cap was reached
                                 // (issue #926). A refusal is not a pause.
                                 hit_iteration_cap: false,
+                                // This pre-turn refusal is its own, older
+                                // signal (the reply text itself names the
+                                // cap) — not the PR #1880 `abnormal_stop`,
+                                // which is scoped to the ACP fold's
+                                // refusal/cancelled/unrecognized stops.
+                                abnormal_stop: None,
                                 // And no in-turn hook fired, because no turn
                                 // ran (issue #1032). The reply already IS the
                                 // budget notice; labelling this as a halt too
@@ -3242,6 +3278,10 @@ impl HarnessPool {
                                     // No model call ran, so no cap was reached
                                     // (issue #926). A refusal is not a pause.
                                     hit_iteration_cap: false,
+                                    // Same reasoning as the total-ceiling
+                                    // refusal above: this is its own signal,
+                                    // not the PR #1880 ACP-only field.
+                                    abnormal_stop: None,
                                     // Same teammate cap, refused BEFORE the
                                     // turn (issue #1032). The in-turn brake
                                     // never armed, and the reply above already

--- a/src/harness/router.rs
+++ b/src/harness/router.rs
@@ -350,6 +350,8 @@ mod tests {
                 reply: self.label.clone(),
                 steps: Vec::new(),
                 hit_iteration_cap: false,
+                // Test fixture, not the ACP fold (PR #1880 review).
+                abnormal_stop: None,
                 halted_for_spend: None,
             })
         }
@@ -420,6 +422,8 @@ mod tests {
                 reply: self.label.clone(),
                 steps: Vec::new(),
                 hit_iteration_cap: false,
+                // Test fixture, not the ACP fold (PR #1880 review).
+                abnormal_stop: None,
                 halted_for_spend: None,
             })
         }

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -3975,6 +3975,9 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
                 // These fixtures script delegation shapes, not cap behaviour;
                 // the cap path is proved end-to-end in `cap_turn_test`.
                 hit_iteration_cap: false,
+                // Scripted delegation fixture, not the ACP fold — the only
+                // path that produces an abnormal stop (PR #1880 review).
+                abnormal_stop: None,
                 // Issue #1032: scripted, for the same reason — the real hook
                 // needs a real model turn to fire, which is proved end-to-end
                 // in `spend_halt_turn_test`. What these fixtures can prove, and

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -2329,6 +2329,7 @@ mod tests {
             reply: "ok".to_string(),
             steps: Vec::new(),
             hit_iteration_cap: false,
+            abnormal_stop: None,
             halted_for_spend: None,
         }
     }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1803,6 +1803,34 @@ impl HarnessAgentRunner {
             return Err(EngineError::Capability(diagnosis));
         }
 
+        // PR #1880 review: an ACP turn that stopped abnormally — a `refusal`,
+        // a `cancelled` turn, or an unrecognized `stopReason` — is not a cap
+        // pause (there is no resumable checkpoint to report, unlike
+        // `hit_iteration_cap` below) and is not a clean finish either.
+        // `hit_iteration_cap` alone could not say so: it stays `false` on
+        // every one of these, and until `abnormal_stop` existed this method
+        // read only that flag, so the node settled `Succeeded` here and
+        // `run` below reported `StopReason::Finished` — indistinguishable
+        // from the agent having actually answered, letting a declined or
+        // interrupted turn's reply advance the workflow graph as if it were
+        // the deliverable. `Err`, the same channel the #881 block above
+        // uses, rather than folding into the `LimitStop` shape below: a
+        // `LimitStop` still lets the engine bind the node's output
+        // downstream (with a warning) because a capped turn's checkpoint is
+        // real, partial work — there is no equivalent partial-but-real
+        // claim to make about a refusal or a cancellation, so `on_error`'s
+        // default "stop" is the honest outcome, not a tagged pass-through.
+        if let Some(reason) = &outcome.abnormal_stop {
+            let message = format!("harness agent '{agent_ref}': {reason}");
+            self.settle_attempt(
+                run_sink.as_ref(),
+                crate::ports::RunStatus::Failed,
+                Some(message.clone()),
+            )
+            .await;
+            return Err(EngineError::Capability(message));
+        }
+
         // Mirror the engine's `{ json, text, raw }` envelope shape: expose the
         // reply as `text` so a downstream `=item.text` binding resolves. A
         // workflow node carries no chat bubble, so the turn's steps are dropped
@@ -2466,6 +2494,112 @@ mod tests {
                 ),
             ],
             "a node with no graph id resolves lineage to the agent ref"
+        );
+    }
+
+    /// A [`RunTurn`] that always answers with a scripted outcome — standing in
+    /// for an ACP-backed harness whose turn stopped abnormally, without
+    /// needing a real ACP subprocess to produce one.
+    struct ScriptedTurn(crate::harness::TurnOutcome);
+
+    #[async_trait]
+    impl RunTurn for ScriptedTurn {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _chat_id: Option<&str>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            Ok(self.0.clone())
+        }
+
+        async fn run_steered(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _chat_id: Option<&str>,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            Ok(self.0.clone())
+        }
+
+        async fn run_steered_background(
+            &self,
+            _company: &CompanyId,
+            _agent_id: &str,
+            _message: &str,
+            _control: &crate::company::steer::SteerControl,
+            _run_sink: Option<Arc<crate::harness::run_trace::RunTraceSink>>,
+        ) -> crate::Result<crate::harness::TurnOutcome> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// PR #1880 review: "Propagate abnormal ACP stops beyond step notes." The
+    /// gap was that `HarnessAgentRunner::run_turn` read only
+    /// `hit_iteration_cap`, which stays `false` on an ACP `refusal`,
+    /// `cancelled`, or unrecognized `stopReason` — so the node settled
+    /// `Succeeded` here and `run` (the `AgentRunner` impl below) reported
+    /// `StopReason::Finished`, indistinguishable from the agent having
+    /// actually answered.
+    ///
+    /// Asserted on the **outcome**, not on whether a `Note` step exists —
+    /// `harness::acp::run_turn::fold` already put a note on the timeline
+    /// before this fix, and the finding was explicitly that the note alone
+    /// does not stop the workflow graph from advancing as if the turn
+    /// succeeded. This is that stronger claim: the node call itself must
+    /// fail.
+    #[tokio::test]
+    async fn an_abnormal_acp_stop_fails_the_workflow_node() {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-1880-")
+            .tempdir()
+            .expect("tempdir");
+        let (deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        let record = crate::workflows::gated_tool_turn_test::record();
+        let turn = Arc::new(ScriptedTurn(crate::harness::TurnOutcome {
+            reply: "I can't help with that.".to_string(),
+            steps: Vec::new(),
+            hit_iteration_cap: false,
+            abnormal_stop: Some("[stopped: the agent declined to continue]".to_string()),
+            halted_for_spend: None,
+        }));
+        let board_claim = Arc::new(deps.delegations.claim_board("run-1880"));
+        let publish_refusal_claim =
+            Arc::new(deps.pending_publishes.claim_refusals_for_run("run-1880"));
+        let runner = HarnessAgentRunner::new(
+            turn,
+            deps,
+            record,
+            CompanyId::new("acme"),
+            "wf-1".to_string(),
+            "run-1880".to_string(),
+            None,
+            RunNotices::default(),
+            RunBoard::default(),
+            RunBlocks::default(),
+            RunApprovals::default(),
+            RunArtifacts::default(),
+            board_claim,
+            publish_refusal_claim,
+        );
+
+        let result = runner
+            .run_turn("responder", json!({ "prompt": "do the thing" }))
+            .await;
+
+        let err = result.expect_err(
+            "a refused/cancelled/unrecognized ACP stop must fail the node, \
+             not settle it Succeeded/Finished",
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("the agent declined to continue"),
+            "the error must carry the abnormal-stop reason, not a generic failure: {message}"
         );
     }
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -2041,6 +2041,8 @@ mod tests {
                 reply: "Waiting for approval.".to_string(),
                 steps: Vec::new(),
                 hit_iteration_cap: false,
+                // Test fixture, not the ACP fold (PR #1880 review).
+                abnormal_stop: None,
                 halted_for_spend: None,
             })
         }
@@ -2196,6 +2198,8 @@ to = "done"
                 reply: self.label.to_string(),
                 steps: Vec::new(),
                 hit_iteration_cap: false,
+                // Test fixture, not the ACP fold (PR #1880 review).
+                abnormal_stop: None,
                 halted_for_spend: None,
             })
         }


### PR DESCRIPTION
## Summary
On the ACP lane, an empty or externally-truncated turn read as a clean success. `fold` accumulated only message chunks into the reply and never consulted `turn.stop_reason`, so a turn that did all its work through tool calls (no prose) folded to an empty reply, and a turn the peer cut short on `max_tokens`/`refusal`/`cancelled` folded identically to a clean `end_turn` — settling downstream as `Succeeded` / `in_review`.

## API Or Behavior Changes
- `fold` (`src/harness/acp/run_turn.rs`) now classifies `stop_reason` via a new local `StopKind` + `classify_stop_reason` (`end_turn` / `max_tokens`|`max_turn_requests` / `refusal` / `cancelled` / other).
- Empty reply is synthesized from the turn's tool-call **step labels** (host-derived, redaction-safe — never tool args/output); if there are no steps either, a reason-specific note, so the reply is never blank.
- Non-`end_turn` stop reasons are surfaced in the reply; an unrecognized reason is surfaced verbatim, never silently clean. An `end_turn` with real prose is left verbatim.
- `hit_iteration_cap` is now `true` for `max_tokens` (was hardcoded `false`), feeding the existing cap→pause consumers. `halted_for_spend` unchanged.
- No change to `ports/acp.rs`, `built_in/mod.rs`, `caps/mod.rs`, or `orchestrator.rs`. The `TurnOutcome` doc clause at `built_in/mod.rs:~692` goes one clause stale — flagged here rather than edited to keep this change isolated.

## Tests
- **Gate correction:** this module is `#[cfg(feature="acp")]` and `acp = ["openhuman"]` is one-directional, so `--features openhuman` silently matches 0 tests. Gates run with `--features acp`.
- `cargo test --features acp --lib harness::acp::run_turn` — **20 passed, 0 failed**.
- `cargo clippy --features acp --all-targets --no-deps -- -D warnings` — clean (only the pre-existing vendored `openhuman` warning, skipped by `--no-deps`).
- `cargo fmt --all -- --check` — clean.
- **RED-on-old proof:** `an_empty_turn_with_max_tokens_is_a_cap_not_a_clean_success` panics on unmodified `fold` (`a max_tokens stop is a cap, not a clean finish`); GREEN after the change. Plus tool-only synthesis, refusal-surfaced, end_turn-verbatim, unknown-reason-surfaced, and a `classify_stop_reason` table test.

## Documentation
Part of epic #1860 (Wave 1, independent). The stale `TurnOutcome` doc clause is noted above for a follow-up sweep.

Closes #1853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ACP turns now correctly handle stop reasons, including iteration limits, refusals, cancellations, and unknown outcomes.
  - Turns without message text receive a meaningful response instead of appearing blank.
  - Workflow steps now fail clearly when an agent stops abnormally, preventing false successful completion.
- **Tests**
  - Added coverage for all supported stop conditions and abnormal workflow outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->