### PR TITLE
policy: declare the three hosting tools the vendor pin brought in

### DIFF
--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -286,12 +286,12 @@ const TOOL_LABELS: Readonly<Record<string, string>> = {
   // count is the whole difference between it and `edit` above.
   apply_patch: "Edit several files in its workspace at once",
   csv_export: "Save data as a spreadsheet file in its workspace",
-  // Hosting (issue #1079). Only the three that park need words here; the three
-  // read tools are `Reach::Nothing` and never reach an approval card.
+  // Hosting (issues #1079, #913). Only the tools that park need words here;
+  // the read tools are `Reach::Nothing` and never reach an approval card.
   //
   // Each label names the thing an operator is actually consenting to, because
-  // these are the cards where a vague one costs the most: two of them change
-  // what the public sees at an address, and the third can write secrets at a
+  // these are the cards where a vague one costs the most: three of them change
+  // what the public sees at an address, and the fourth can write secrets at a
   // third-party provider. "Use one of its tools" over a live deployment is the
   // failure this issue is about.
   hosting_launch_site: "Deploy a site to the public internet",
@@ -302,6 +302,17 @@ const TOOL_LABELS: Readonly<Record<string, string>> = {
   // afterwards for a build-time variable to take effect, so a label promising
   // one would be describing an act that has not happened.
   hosting_set_env: "Set environment variables on one of its sites",
+  // Worded as what the visitor gets, not as what the provider calls it. The
+  // provider's own verb is "promote", and an operator reading "Promote a
+  // deployment" on a card has to already know that promoting an old build is
+  // how a rollback is spelled. "Serve an earlier version" is the consequence:
+  // the site the public loads changes, and it changes to something older.
+  //
+  // No "(rollback)" gloss, and no mention of recovery. The card is read when
+  // the agent asks, which is not always after a bad deploy — an agent can
+  // propose this from a stale premise, and a label that pre-agrees it is a fix
+  // argues the operator into the approval the card exists to ask for.
+  hosting_rollback: "Serve an earlier version of one of its sites",
   // `mcp_registry_tool_call` is deliberately absent: EFFECT_LABELS already
   // names it and is consulted first, so an entry here would be unreachable.
 };

--- a/src/harness/built_in/hosting.rs
+++ b/src/harness/built_in/hosting.rs
@@ -1,5 +1,11 @@
-//! The agent-facing bridge for hosting (TinyHosts): six tools that put a
+//! The agent-facing bridge for hosting (TinyHosts): the tools that put a
 //! company's workspace on a real hosting provider.
+//!
+//! The count is deliberately not written down here. [`hosting_tools`] returns
+//! `Account::tools()` wholesale, so the set is whatever the vendored OpenHuman
+//! ships and it moves with the pin — a number in this sentence is a number that
+//! goes stale silently. `every_wired_hosting_tool_is_declared` below is what
+//! holds the set to something this crate has actually classified.
 //!
 //! # Why the credential is per company and resolved late
 //!
@@ -223,5 +229,64 @@ mod tests {
 
         assert_eq!(hosting.provider(), "vercel");
         assert_eq!(hosting.team(), Some("team_abc"));
+    }
+
+    /// **Every tool this bridge wires is classified in
+    /// [`crate::policy::consequence`].** Issue #913 is the reason this exists.
+    ///
+    /// `every_registered_tool_is_declared` in [`crate::harness::built_in`] is
+    /// the general version of this check and it cannot see these tools: it
+    /// enumerates a belt built by `build_agent`, and hosting is wired only when
+    /// a company has a *stored credential*, which no unit-test company has. So
+    /// the hosting belt was never covered by construction, and the standing
+    /// check was a hardcoded list of six names in `consequence.rs`.
+    ///
+    /// A hardcoded list fails when a row is deleted. It cannot fail when the
+    /// vendor pin adds a tool — and [`hosting_tools`] returns
+    /// `Account::tools()` wholesale, so a pin bump wires new tools onto live
+    /// agents with nothing in this repository mentioning them. That is what
+    /// happened: `hosting_rollback`, `hosting_list_deployments` and
+    /// `hosting_domain_status` went live undeclared. Undeclared is not inert —
+    /// the two reads parked (an approval for a read) and `hosting_rollback`
+    /// classified as `Other` rather than `Publish`, which is issue #1079's
+    /// defect returning through the pin instead of through an edit.
+    ///
+    /// Enumerating the belt is the fix, because it is the only form of this
+    /// check a pin bump cannot outrun.
+    ///
+    /// `Account::connect` builds a client and does no I/O, so the dummy
+    /// credential below never leaves the process.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn every_wired_hosting_tool_is_declared() {
+        let declared: std::collections::BTreeSet<&str> =
+            crate::policy::consequence::declared_tools().collect();
+
+        let config = TenantHosting {
+            provider: DEFAULT_PROVIDER.to_string(),
+            api_key: "not-a-real-key".to_string(),
+            team: None,
+        };
+        let wired: Vec<String> = hosting_tools(&config, std::path::PathBuf::from("/tmp"))
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+
+        // A vacuity guard: `hosting_tools` warns and returns an empty vec when
+        // the credential is unusable, and an empty belt would pass the check
+        // below while proving nothing.
+        assert!(
+            wired.contains(&"hosting_launch_site".to_string()),
+            "the hosting belt built no tools, so this check proves nothing: {wired:?}"
+        );
+
+        let undeclared: Vec<&String> = wired
+            .iter()
+            .filter(|name| !declared.contains(name.as_str()))
+            .collect();
+        assert!(
+            undeclared.is_empty(),
+            "these hosting tools came in with the vendor pin and are wired onto live              agents, but nobody has said what they can reach — so the gate is guessing              from their names, and a `hosting_` prefix defeats the read heuristic:              {undeclared:?}. Add them to `crate::policy::consequence::DECLARED`."
+        );
     }
 }

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -751,9 +751,9 @@ const DECLARED: &[Declared] = &[
         EffectGroup::Identity,
         Reach::Consequence,
     ),
-    // ---- Hosting (issue #1079) ---------------------------------------------
+    // ---- Hosting (issues #1079, #913) --------------------------------------
     //
-    // The six `hosting_*` tools openhuman ships in `src/openhuman/hosting/`.
+    // The nine `hosting_*` tools openhuman ships in `src/openhuman/hosting/`.
     // Declared here rather than left to `undeclared()`, which is what that
     // fallback's own doc asks for: it is "a courtesy for an unregistered read,
     // not a second classifier to trust with an unreviewed capability".
@@ -762,8 +762,8 @@ const DECLARED: &[Declared] = &[
     // get them right.** `undeclared()` decides "is this a read?" with
     // `READ_ONLY_PREFIXES` matched by `name.starts_with(p)`. Every name here
     // begins with `hosting_`, so `list`/`get`/`read` can never match — the
-    // prefix test cannot see past the namespace, and all six come back
-    // `Consequence`. Widening that test to look inside a namespace is the
+    // prefix test cannot see past the namespace, and every one of them comes
+    // back `Consequence`. Widening that test to look inside a namespace is the
     // tempting general fix and is the wrong one: the fallback runs ONLY for
     // tools no belt registered (a registered one is caught by
     // `every_registered_tool_is_declared`), so making it cleverer extends trust
@@ -772,8 +772,8 @@ const DECLARED: &[Declared] = &[
     // fail-OPEN one, an effect that reads as a read. Declaring is the fix the
     // file already prescribes.
     //
-    // Three reads, per openhuman's own `hosting/README.md`, which labels each
-    // of them "Read-only.". They ask the provider what exists and what it did;
+    // Five reads, per openhuman's own `hosting/README.md`, which labels each of
+    // them "Read-only.". They ask the provider what exists and what it did;
     // nothing leaves this company and nothing is spent.
     d(
         "hosting_deployment_status",
@@ -782,6 +782,20 @@ const DECLARED: &[Declared] = &[
     ),
     d("hosting_list_sites", EffectGroup::Other, Reach::Nothing),
     d("hosting_analytics", EffectGroup::Other, Reach::Nothing),
+    // `hosting_list_deployments` is the history behind `hosting_deployment_status`
+    // — "recent deployments, newest first, with their status, target and
+    // creation time" — and carries the same label for the same reason. It is
+    // also the tool that hands `hosting_rollback` its `deployment_id`, so
+    // parking it would cost an approval on the way to every recovery.
+    d(
+        "hosting_list_deployments",
+        EffectGroup::Other,
+        Reach::Nothing,
+    ),
+    // `hosting_domain_status` is the read half of `hosting_add_domain`: it
+    // reports whether a domain the company already attached has been verified
+    // and is serving. Attaching is the effect; asking is not.
+    d("hosting_domain_status", EffectGroup::Other, Reach::Nothing),
     // The public deployment itself: it spends money and changes what the world
     // sees at an address. `Publish` is the label an operator's card needs, and
     // the fallback gave it `Other` — its name contains no `deploy`, `publish` or
@@ -807,10 +821,21 @@ const DECLARED: &[Declared] = &[
     // this change exists to remove — so `Other`, and `Consequence` because it
     // still writes provider state and can store secrets write-only there.
     d("hosting_set_env", EffectGroup::Other, Reach::Consequence),
-    // NOTE: a `hosting_rollback` tool is in flight (issue #913). It will need a
-    // row here too — it is an outward effect on a live site, so `Publish` /
-    // `Consequence` is the shape to start from, but it is left to that change to
-    // declare rather than guessed at now.
+    // `hosting_rollback` is the tool the NOTE here used to hold a place for
+    // (issue #913). It arrived with the vendor pin, and the shape that note
+    // predicted is the one the tool asks for: it "points production traffic at
+    // an earlier deployment", and openhuman marks it `external_effect()` with
+    // the comment "Changes what the public sees on a live site, so it gates."
+    // That is `hosting_launch_site`'s sentence with the build removed, so it
+    // takes `hosting_launch_site`'s label — what the world sees at an address
+    // changes either way, and an operator's card should say so.
+    //
+    // It parks, and that is deliberate even though rollback is the *recovery*
+    // path and parking it delays a fix to a broken site. `supervised` exists to
+    // put a human in front of a change to what the public sees, and "the site
+    // is already broken" is an argument for approving quickly, not for not
+    // being asked. An operator who wants it unattended has `always_approve`.
+    d("hosting_rollback", EffectGroup::Publish, Reach::Consequence),
 ];
 
 /// A per-call declaration — the default. `const fn` so [`DECLARED`] stays a
@@ -2360,6 +2385,8 @@ mod tests {
             "hosting_deployment_status",
             "hosting_list_sites",
             "hosting_analytics",
+            "hosting_list_deployments",
+            "hosting_domain_status",
         ] {
             let consequence = c(tool);
             assert_eq!(
@@ -2382,6 +2409,7 @@ mod tests {
             "hosting_launch_site",
             "hosting_add_domain",
             "hosting_set_env",
+            "hosting_rollback",
         ] {
             let consequence = c(tool);
             assert_eq!(
@@ -2433,6 +2461,19 @@ mod tests {
     /// classify any of these correctly. If a row is dropped, the tool silently
     /// returns to that fallback rather than erroring — so the coverage is
     /// asserted directly.
+    ///
+    /// **This list is a floor, not the coverage guard, and issue #913 is why
+    /// the difference matters.** A hardcoded list only fails when a row is
+    /// *removed*; it says nothing when the vendor pin *adds* a tool. That is
+    /// exactly what happened — `hosting_rollback`, `hosting_list_deployments`
+    /// and `hosting_domain_status` arrived in the pin, were wired onto live
+    /// agents by `hosting_tools`, and this test stayed green while all three
+    /// fell through to `undeclared()`. The exhaustive check is
+    /// `every_wired_hosting_tool_is_declared` in
+    /// [`crate::harness::built_in::hosting`], which enumerates the belt itself;
+    /// it lives there because it needs the `openhuman` feature, and this file
+    /// compiles in lanes that do not have it. Keep both: this one holds in
+    /// every lane, that one is exhaustive in the lane that ships.
     #[test]
     fn every_hosting_tool_is_declared() {
         let declared: std::collections::BTreeSet<&str> = declared_tools().collect();
@@ -2440,9 +2481,12 @@ mod tests {
             "hosting_deployment_status",
             "hosting_list_sites",
             "hosting_analytics",
+            "hosting_list_deployments",
+            "hosting_domain_status",
             "hosting_launch_site",
             "hosting_add_domain",
             "hosting_set_env",
+            "hosting_rollback",
         ] {
             assert!(
                 declared.contains(tool),


### PR DESCRIPTION
## What this is

`src/harness/built_in/hosting.rs:161` returns `Account::tools()` wholesale, so the hosting tools wired onto a live agent are whatever `vendor/openhuman` ships. The pin at `01a436d` ships nine. This repository declares six.

The three that arrived with the pin — `hosting_rollback`, `hosting_list_deployments`, `hosting_domain_status` — are live on `main` right now with no row in `crate::policy::consequence::DECLARED`.

## Why that is not harmless

`undeclared()` decides "is this a read?" with `READ_ONLY_PREFIXES` matched by `name.starts_with`. Every name in this family begins with `hosting_`, so `list`/`get`/`read` can never match — the file says so itself at `src/policy/consequence.rs:758`, and pins it in `the_fallback_cannot_see_a_read_verb_behind_a_namespace`. So today:

| tool | what it is | what the gate says |
|---|---|---|
| `hosting_list_deployments` | "Read-only." | `Consequence` — parks, costs an approval |
| `hosting_domain_status` | "Read-only." | `Consequence` — parks, costs an approval |
| `hosting_rollback` | "External effect." | `Other` — no `deploy`/`publish`/`post` substring |

That is issue #1079's defect — reads parking, a live deployment classified `Other` — arriving through the vendor pin instead of through an edit.

## The rows

Classified from openhuman's own `hosting/README.md`, which labels each tool, the same source the six existing rows were argued from:

- **`hosting_list_deployments`** → `Other` / `Nothing`. "Read-only." It is also what hands `hosting_rollback` its deployment id, so parking it charges an approval on the way to every recovery.
- **`hosting_domain_status`** → `Other` / `Nothing`. "Read-only." The read half of `hosting_add_domain`: attaching is the effect, asking is not.
- **`hosting_rollback`** → `Publish` / `Consequence`. The shape the `NOTE` it replaces predicted. The tool marks itself `external_effect()` with the comment *"Changes what the public sees on a live site, so it gates"* — `hosting_launch_site`'s sentence with the build removed.

`hosting_rollback` parks, deliberately, even though rollback is the *recovery* path and parking delays a fix to a broken site. `supervised` exists to put a human in front of a change to what the public sees, and "the site is already broken" is an argument for approving quickly, not for not being asked. An operator who wants it unattended has `always_approve`.

It therefore also needs a `TOOL_LABELS` entry, or `every_consequence_tool_has_a_console_label` fails and the card reads "Use one of its tools" over a live site.

## The guard that should have caught this

`every_hosting_tool_is_declared` was a hardcoded list of six names. **A hardcoded list fails when a row is deleted. It cannot fail when the pin adds a tool** — which is why all three went live and CI stayed green.

This adds `every_wired_hosting_tool_is_declared`, which enumerates the belt `hosting_tools` actually builds and checks it against `declared_tools()`. Reverting just the `DECLARED` rows on this branch makes it name all three:

```
these hosting tools came in with the vendor pin and are wired onto live agents,
but nobody has said what they can reach [...]:
["hosting_list_deployments", "hosting_rollback", "hosting_domain_status"]
```

It is separate from `every_registered_tool_is_declared` because that test **cannot** see these tools: it enumerates a belt from `build_agent`, and hosting is wired only when a company has a *stored credential*, which no unit-test company has. That gap is the structural reason this drifted silently. `Account::connect` builds a client and does no I/O, so the dummy credential never leaves the process; the test has a vacuity guard for the empty-belt path.

The hardcoded list stays as the floor for lanes that do not have the `openhuman` feature.

## Verification

- `cargo test --features openhuman --tests` — 5735 + 32 pass, 0 fail (the CI lane's exact selection).
- `cargo test --lib policy::consequence` at default features — 55 pass.
- `cargo clippy --features openhuman --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Negative check above: the new test fails on the unpatched table and names exactly the three tools.

Not verified: `frontend` typecheck (no `node_modules` in this worktree). The frontend change is one entry in a `Readonly<Record<string, string>>` literal plus comment text.

## Scope

Three declaration rows, one console label, one test. **No vendor pin change** — the pin already carries these tools, so the cross-repo sequencing #913 warns about is already resolved.

This does **not** deliver #913, which is labeled `phase-2`. `hosting_deployment_logs` is still unbuilt and blocked on tinyhumansai/tinyhosts#4. Refs #913, #1079.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hosting rollback support, allowing an earlier site version to be served.
  - Added visibility into deployment information and domain status.
- **Safety Improvements**
  - Hosting rollbacks now require approval before they take effect.
  - Hosting actions are consistently tracked and declared, improving safeguards and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->