### PR TITLE
fix(harness,delegation): stop offering budget-pause redemptions that cannot work (#1846)

### DIFF
--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -425,7 +425,21 @@ export type CompanyStreamEvent =
  */
 export const BUDGET_PAUSE_NOTICE_PREFIX = "⏸ Paused — out of credits:";
 
-/** Whether a chat message's text is the unauthored budget-pause system notice. */
+/**
+ * Whether a chat message's text is the **redeemable** budget-pause system
+ * notice — the one that gets an "Add credits & resend" CTA.
+ *
+ * Issue #1846 review (Codex #3870562586 / #3870562590): the host has a
+ * deliberate SIBLING prefix, `BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX`
+ * ("⏸ Paused — out of credits (add credits, then start this again):"), for the
+ * two paths that pause with no marker this CTA can redeem — the confined
+ * workflow copilot (no marker is ever parked) and an approval continuation
+ * (its marker is parked `background: true`, which the redeem route refuses).
+ * That prefix must NOT match here: those notices render as ordinary system
+ * bubbles precisely so no unusable button is drawn. Do not "fix" the near-miss
+ * by loosening this to a substring check or by matching both prefixes — the
+ * near-miss is the mechanism.
+ */
 export function isBudgetPauseNotice(text: string): boolean {
   return text.startsWith(BUDGET_PAUSE_NOTICE_PREFIX);
 }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1118,8 +1118,10 @@ export function ChatView({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `client`/`company`
     // intentionally excluded: this effect's job is "a new notice appeared",
-    // not "the client changed"; a client/company change already clears
-    // `transcripts` (and therefore this map) via the boot/company-switch path.
+    // not "the client changed". A client/company change is handled by the
+    // reset effect above, which empties this map; `transcripts` resetting in
+    // `AppShell` then re-derives `budgetPauseMessageIdByAgent`, so this effect
+    // re-runs with the new scope's notices.
   }, [budgetPauseMessageIdByAgent]);
 
   // An open thread only makes sense while its parent is on screen; switching

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -156,6 +156,40 @@ pub(crate) fn budget_pause_notice(pause: &crate::harness::BudgetPause) -> String
     format!("{BUDGET_PAUSE_NOTICE_PREFIX} {}", pause.summary)
 }
 
+/// The non-redeemable sibling of [`BUDGET_PAUSE_NOTICE_PREFIX`] (issue #1846
+/// review, Codex #3870562586 / #3870562590).
+///
+/// The console renders its "Add credits & resend" CTA off
+/// [`BUDGET_PAUSE_NOTICE_PREFIX`] alone — there is no structured wire field to
+/// key on yet, as that constant's own doc says. Two paths pause WITHOUT a
+/// marker the generic chat redeem can honour:
+///
+/// * the **confined workflow copilot** — `run_confined` bypasses `run_inner`,
+///   the only place that parks a marker, and `CONFINED_AGENT_ID` names no
+///   addressable teammate, so there is nothing to redeem and nothing safe to
+///   replay; and
+/// * an **approval continuation** — it runs through `run_steered_background`,
+///   so `run_inner` parks its marker with `background: true`, a shape
+///   `redeem_budget_pause` refuses outright
+///   (`src/server/ops/budget_pause.rs`).
+///
+/// Emitting the redeemable prefix on either put a button on screen that could
+/// only ever fail — a 404 for the first (no marker exists), a 400 for the
+/// second (the marker exists and is refused). This prefix carries the SAME
+/// information and deliberately does not match the console's
+/// `isBudgetPauseNotice`, so the notice renders as an ordinary system bubble
+/// with no unusable action on it. Pinned by
+/// `a_confined_copilot_pause_offers_no_redeem_cta` and
+/// `an_approval_continuation_pause_offers_no_redeem_cta`.
+pub(crate) const BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX: &str =
+    "⏸ Paused — out of credits (add credits, then start this again):";
+
+/// The unauthored bubble for a budget pause that carries no redeemable marker.
+/// See [`BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX`].
+pub(crate) fn budget_pause_notice_no_resend(pause: &crate::harness::BudgetPause) -> String {
+    format!("{BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX} {}", pause.summary)
+}
+
 use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
@@ -324,13 +358,20 @@ fn confined_bubble(outcome: crate::harness::TurnOutcome) -> OutboundMessage {
 /// it to the copilot as an ordinary answer — exactly the #966 misattribution
 /// class `system_notice` exists to prevent, just one call site short of it.
 ///
-/// Emits the SAME unauthored notice copy the interactive path shows, with no
-/// CTA (nothing was parked to redeem) — the honest middle ground the review
-/// asked for, between a fabricated copilot reply and a redemption this agent
-/// id can never honour.
+/// Emits the unauthored notice through
+/// [`budget_pause_notice_no_resend`] — the honest middle ground between a
+/// fabricated copilot reply and a redemption this agent id can never honour.
+///
+/// Issue #1846 review (Codex #3870562586): this used to emit
+/// [`budget_pause_notice`], whose prefix is exactly what the console keys its
+/// "Add credits & resend" button off. The doc above already claimed "with no
+/// CTA" — but nothing enforced it, so the button rendered anyway and, with no
+/// marker ever parked for `CONFINED_AGENT_ID`, every click did a GET that
+/// returned `null` followed by a POST that 404'd. The no-resend prefix makes
+/// the claim true.
 fn confined_turn_bubble(outcome: crate::harness::TurnOutcome) -> OutboundMessage {
     match &outcome.budget_paused {
-        Some(pause) => system_notice(budget_pause_notice(pause)),
+        Some(pause) => system_notice(budget_pause_notice_no_resend(pause)),
         None => confined_bubble(outcome),
     }
 }
@@ -734,10 +775,21 @@ impl HarnessBrain {
             // fires, so the bubble rendered as a normal (if oddly-worded)
             // answer with no "Add credits & resend" CTA — even though a
             // marker was sitting there, parked and redeemable, the whole time.
-            // Swap in the SAME notice text the interactive and confined-turn
-            // paths already emit so the console recognises and renders it.
+            // Swap in the unauthored pause notice so the bubble reads as the
+            // runtime terminal state it is rather than as an answer.
+            //
+            // Issue #1846 review (Codex #3870562590): the NO-RESEND prefix,
+            // not the redeemable one. `run_steered_background` means
+            // `run_inner` parks this marker with `background: true`, and
+            // `redeem_budget_pause` refuses exactly that shape
+            // (`src/server/ops/budget_pause.rs`) — so offering the CTA here
+            // reserved the marker, restored it, and returned 400 on every
+            // click. Resuming an approval continuation needs the grant's own
+            // identity, which the generic chat-message redeem path does not
+            // carry; until it does, the honest surface is a notice with no
+            // button rather than a button that cannot work.
             Ok(outcome) => match &outcome.budget_paused {
-                Some(pause) => budget_pause_notice(pause),
+                Some(pause) => budget_pause_notice_no_resend(pause),
                 None => outcome.reply,
             },
             Err(err) => {
@@ -10383,16 +10435,90 @@ agent = "claude"
             "the pre-fix defect: falling through to confined_bubble would attribute the pause \
              notice to the copilot itself"
         );
+        // Issue #1846 review (Codex #3870562586): the NO-RESEND prefix. This
+        // assertion used to require `BUDGET_PAUSE_NOTICE_PREFIX`, which is
+        // precisely what the console keys its "Add credits & resend" button
+        // off — and `run_confined` never parks a marker, so that button could
+        // only ever 404. Asserting the negative too: the whole defect is the
+        // two prefixes being conflated, and a test that only checked the new
+        // one would still pass if the redeemable prefix were ever made a
+        // prefix of it.
         assert!(
-            bubble.text.starts_with(BUDGET_PAUSE_NOTICE_PREFIX),
-            "the console's SystemPill only renders the highlighted pause card for this exact \
-             prefix: {}",
+            bubble
+                .text
+                .starts_with(BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX),
+            "a confined pause parks no marker, so it must carry the non-redeemable prefix: {}",
+            bubble.text
+        );
+        assert!(
+            !bubble.text.starts_with(BUDGET_PAUSE_NOTICE_PREFIX),
+            "the pre-fix defect: this prefix renders an Add-Credits CTA whose GET returns null \
+             and whose POST 404s, because CONFINED_AGENT_ID never has a marker: {}",
             bubble.text
         );
         assert!(
             bubble.text.to_ascii_lowercase().contains("add credits"),
             "the actionable ask survives into the notice: {}",
             bubble.text
+        );
+    }
+
+    /// Issue #1846 review (Codex #3870562590) — **the regression.** An approval
+    /// continuation that pauses for credits must not advertise a redeem the
+    /// server refuses.
+    ///
+    /// The continuation runs through `run_steered_background`, so `run_inner`
+    /// parks its marker with `background: true`, and `redeem_budget_pause`
+    /// rejects exactly that shape with a 400 (`src/server/ops/budget_pause.rs`).
+    /// Emitting `BUDGET_PAUSE_NOTICE_PREFIX` therefore put a button on screen
+    /// that reserved the marker, restored it, and failed — every single click.
+    ///
+    /// This pins the notice BUILDER rather than driving a whole continuation:
+    /// the defect is entirely in which prefix that arm chooses, and the two
+    /// constants are what the console branches on.
+    #[test]
+    fn an_approval_continuation_pause_offers_no_redeem_cta() {
+        let pause = crate::harness::BudgetPause {
+            agent: "maya".to_string(),
+            summary: "Add credits to your account, then start this again.".to_string(),
+        };
+
+        let notice = budget_pause_notice_no_resend(&pause);
+
+        assert!(
+            notice.starts_with(BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX),
+            "{notice}"
+        );
+        assert!(
+            !notice.starts_with(BUDGET_PAUSE_NOTICE_PREFIX),
+            "the pre-fix defect: a background-parked marker is refused by the redeem route, so \
+             this prefix's CTA can only ever return 400: {notice}"
+        );
+        assert!(
+            notice.to_ascii_lowercase().contains("add credits"),
+            "the operator still has to be told the lever: {notice}"
+        );
+        assert!(
+            notice.contains(&pause.summary),
+            "the provider's own summary survives into the notice: {notice}"
+        );
+    }
+
+    /// The two prefixes must stay genuinely distinct: the console decides
+    /// whether to render an actionable button by `startsWith`, so if the
+    /// redeemable prefix were ever edited to become a prefix of the
+    /// non-redeemable one, every no-resend notice would silently regain the
+    /// broken CTA. Cheap coupling test, mirrored on the frontend by
+    /// `isBudgetPauseNotice`'s own fixtures.
+    #[test]
+    fn the_redeemable_and_no_resend_prefixes_are_not_prefixes_of_each_other() {
+        assert!(
+            !BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX.starts_with(BUDGET_PAUSE_NOTICE_PREFIX),
+            "a no-resend notice would match `isBudgetPauseNotice` and regain the CTA"
+        );
+        assert!(
+            !BUDGET_PAUSE_NOTICE_PREFIX.starts_with(BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX),
+            "a redeemable notice would stop matching and lose its working CTA"
         );
     }
 

--- a/src/harness/built_in/brain.rs
+++ b/src/harness/built_in/brain.rs
@@ -8056,11 +8056,17 @@ members = ["eng1", "eng2"]
     /// granting agent exactly as an ordinary paused message would — proven
     /// below by reading it straight off `BudgetPauseSet`. Before this fix, the
     /// bubble `redispatch_granted_call` built from that outcome carried
-    /// `outcome.reply` (the budget-paused placeholder text) verbatim, which
-    /// does not start with `BUDGET_PAUSE_NOTICE_PREFIX` — so the console's
-    /// `isBudgetPauseNotice` check never recognised it, and the operator saw
-    /// an ordinary-looking reply with no "Add credits & resend" CTA for a
-    /// marker that was sitting there, parked and redeemable, the whole time.
+    /// `outcome.reply` (the budget-paused placeholder text) verbatim, so the
+    /// operator saw an ordinary-looking reply rather than the runtime's own
+    /// pause notice.
+    ///
+    /// Issue #1846 review (Codex #3870562590): the notice it now carries is the
+    /// NO-RESEND one. The marker asserted below is real but not redeemable —
+    /// `run_steered_background` parks it with `background: true`, the one shape
+    /// `redeem_budget_pause` refuses (`src/server/ops/budget_pause.rs`) — so
+    /// the redeemable prefix would have drawn a CTA that returned 400 on every
+    /// click. Both prefixes are asserted: matching the new one is only half the
+    /// contract, since the console branches on the old one.
     #[tokio::test]
     async fn a_budget_paused_approval_continuation_surfaces_the_notice_and_parks_a_marker() {
         let dir = tempfile::tempdir().unwrap();
@@ -8101,9 +8107,17 @@ members = ["eng1", "eng2"]
         let bubble = &result.channel_responses[0];
         assert_eq!(bubble.channel, "ceo");
         assert!(
-            bubble.text.starts_with(BUDGET_PAUSE_NOTICE_PREFIX),
-            "the console's SystemPill only renders the highlighted pause card for this exact \
-             prefix — got: {}",
+            bubble
+                .text
+                .starts_with(BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX),
+            "an approval continuation parks a background marker the redeem route refuses, so \
+             its notice must carry the non-redeemable prefix — got: {}",
+            bubble.text
+        );
+        assert!(
+            !bubble.text.starts_with(BUDGET_PAUSE_NOTICE_PREFIX),
+            "the pre-fix defect: this prefix is what the console keys its \"Add credits & \
+             resend\" CTA off, and this marker's redeem returns 400: {}",
             bubble.text
         );
         assert!(
@@ -8112,9 +8126,9 @@ members = ["eng1", "eng2"]
             bubble.text
         );
 
-        // And a re-issue marker really was parked for the granting agent —
-        // the CTA this notice's text is asking the console to render would
-        // have nothing to redeem otherwise.
+        // And a re-issue marker really was parked for the granting agent: the
+        // notice is non-redeemable because of HOW it was parked (background),
+        // not because nothing was parked at all.
         let marker = crate::runtime::grants::budget_pauses_for(&CompanyId::new("acme"))
             .peek("ceo")
             .expect("run_steered_background parks a marker on the same terms run_inner does");

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1419,6 +1419,14 @@ impl<'a> DelegationRunner<'a> {
         // bubble lands in `bubbles`.
         let mut bubbles = Vec::new();
         let mut desk_replies: Vec<(String, String)> = Vec::new();
+        // Issue #1846 review (Codex #3870516681): whether a DESK paused, kept
+        // apart from the sticky `budget_paused` above. That one is already
+        // carrying the responder's OWN pause, and a responder that paused on
+        // the turn that queued the hand-off still got a real answer back from
+        // the desk — relaying it is correct there, and is what
+        // `a_responders_own_budget_pause_survives_the_relay_replacing_the_reply`
+        // pins. Only a desk that paused has failed to answer.
+        let mut desk_paused = false;
         // Issue #246: the first card this turn opened, which is what the
         // operator bubble reports. `get_or_insert` rather than assignment keeps
         // it the FIRST — a later spawn must not overwrite the id an earlier one
@@ -1445,6 +1453,7 @@ impl<'a> DelegationRunner<'a> {
             operator_steps.extend(desk.steps);
             hit_iteration_cap |= desk.hit_iteration_cap;
             halted_for_spend = halted_for_spend.or(desk.halted_for_spend);
+            desk_paused |= desk.budget_paused.is_some();
             budget_paused = budget_paused.or(desk.budget_paused);
             desk_replies.push((desk.member, desk.reply));
         }
@@ -1465,7 +1474,12 @@ impl<'a> DelegationRunner<'a> {
         // that would have worked. Skipped entirely instead; the fold below
         // keeps the delegate's own text on the operator bubble, so nothing the
         // operator would have read is lost.
-        if !desk_replies.is_empty() && budget_paused.is_none() {
+        //
+        // Gated on `desk_paused`, NOT on the sticky `budget_paused`: the latter
+        // also carries the RESPONDER's own pause, and a responder that paused
+        // on the turn that queued the hand-off still has a real desk answer to
+        // relay. Widening the gate to it would silently drop that answer.
+        if !desk_replies.is_empty() && !desk_paused {
             let relay_prompt = build_relay_prompt(message, &desk_replies);
             self.queue.clear();
             let relay = self
@@ -7353,8 +7367,15 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
     /// [`a_nested_delegates_spend_halt_reaches_the_operator_turn`]: a delegate
     /// two levels down pauses for lack of inference budget/credits, and the
     /// operator is told — because the pause folds into the member's answer
-    /// exactly as its reply and steps already do, and survives the relay
-    /// turn's overwrite the same way a spend halt does.
+    /// exactly as its reply and steps already do.
+    ///
+    /// Issue #1846 review (Codex #3870516681): the pause no longer survives a
+    /// relay OVERWRITE, because there is no relay turn to overwrite it. A desk
+    /// that paused has not answered, so the relay is skipped (see
+    /// [`a_delegates_budget_pause_does_not_launch_the_ceo_relay`]) and the
+    /// delegate's text is folded onto the operator bubble instead. This test
+    /// scripts only the three turns that actually run: a fourth would be the
+    /// relay, and `ScriptedTurns` running dry is how a regression surfaces.
     #[tokio::test]
     async fn a_nested_delegates_budget_pause_reaches_the_operator_turn() {
         let fx = Fixture::nested();
@@ -7374,7 +7395,6 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
                      stopped instead of failing silently. Add credits to your account, then \
                      resend your message to continue.",
                 ),
-                Turn::reply("Built. Research is paused for credits."),
             ],
         );
 
@@ -7392,9 +7412,18 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             "the notice must name the teammate that actually paused, not the one relaying it"
         );
         assert!(pause.summary.contains("add credits") || pause.summary.contains("Add credits"));
-        // The relay really did replace the reply — so the pause survived an
-        // overwrite rather than riding along on text that happened to persist.
-        assert_eq!(out.reply, "Built. Research is paused for credits.");
+        // The fold stands in for the relay: the delegate's own text still lands
+        // on the operator bubble, so skipping the relay drops nothing.
+        assert!(
+            out.reply.contains("engineer replied:"),
+            "the desk's answer must survive the skipped relay: {}",
+            out.reply
+        );
+        assert!(
+            out.reply.contains("researcher"),
+            "including the nested delegate's paused text: {}",
+            out.reply
+        );
     }
 
     /// Issue #1846 review (Codex #3864988176): the marker a delegated pause

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1453,7 +1453,19 @@ impl<'a> DelegationRunner<'a> {
         // plus the teammate reply, and surface THAT as the operator bubble — so
         // the orchestrator comes back with the answer in one coherent
         // conversation.
-        if !desk_replies.is_empty() {
+        //
+        // Issue #1846 review (Codex #3870516681): "answered" is the load-bearing
+        // word, and a desk that paused for lack of credits has NOT answered —
+        // `desk.reply` is the pause placeholder. Relaying it anyway fired a
+        // second inference call at the same exhausted provider, which paused
+        // too and parked a SECOND marker, this one for the responder. That
+        // marker has no notice pointing at it (the operator only ever sees the
+        // first delegate's pause), so it is unreachable, and being newer it can
+        // supersede a live CTA on an older notice — disabling the one button
+        // that would have worked. Skipped entirely instead; the fold below
+        // keeps the delegate's own text on the operator bubble, so nothing the
+        // operator would have read is lost.
+        if !desk_replies.is_empty() && budget_paused.is_none() {
             let relay_prompt = build_relay_prompt(message, &desk_replies);
             self.queue.clear();
             let relay = self
@@ -1570,6 +1582,15 @@ impl<'a> DelegationRunner<'a> {
                 );
             }
             budget_paused = budget_paused.or(relay.budget_paused);
+        } else if !desk_replies.is_empty() {
+            // The relay was skipped because a desk paused (see above). Fold the
+            // delegate's text onto the operator bubble directly, in the same
+            // shape `build_relay_prompt` would have handed the relay turn, so
+            // skipping it drops nothing — the pause itself is surfaced
+            // separately from `budget_paused` by the caller.
+            for (member, reply) in &desk_replies {
+                operator_reply.push_str(&format!("\n\n{member} replied:\n{reply}"));
+            }
         }
         // Drained after the relay, not before it: a relay turn carries the same
         // inline `create_workflow` tool, so draining at the responder's turn
@@ -7698,6 +7719,85 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             cards[0].column, COLUMN_PAUSED,
             "a pause must not read as a completed answer: {:?}",
             cards[0]
+        );
+    }
+
+    /// Issue #1846 review (Codex #3870516681) — **the regression.** A desk
+    /// that paused for lack of credits has not ANSWERED, so there is nothing
+    /// for the CEO relay to hand back.
+    ///
+    /// Before this fix the fold pushed the delegate's pause placeholder into
+    /// `desk_replies`, whose non-empty check launched the relay anyway: a
+    /// second inference call at the same exhausted provider, which paused too
+    /// and parked a SECOND marker — this one for the RESPONDER, with no notice
+    /// anywhere pointing at it. Being newer, that orphan supersedes the live
+    /// CTA on the delegate's own notice, disabling the one button that would
+    /// have worked.
+    ///
+    /// The script deliberately supplies only TWO turns: the responder's
+    /// hand-off and the delegate's pause. A relay would need a third, so if
+    /// the gate ever regresses, `ScriptedTurns` runs dry and this fails loudly
+    /// rather than silently parking an extra marker.
+    #[tokio::test]
+    async fn a_delegates_budget_pause_does_not_launch_the_ceo_relay() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                Turn::budget_paused(
+                    "Paused — engineer's turn ran out of inference budget/credits.",
+                    "engineer",
+                    "Paused — engineer's turn ran out of inference budget/credits, so it \
+                     stopped instead of failing silently.",
+                ),
+            ],
+        );
+
+        let out = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            out.budget_paused.is_some(),
+            "sanity: the delegate's pause still folds through to the operator"
+        );
+        assert_eq!(
+            out.budget_paused.as_ref().map(|p| p.agent.as_str()),
+            Some("engineer"),
+            "the pause named must be the delegate's, not a relay's: {:?}",
+            out.budget_paused
+        );
+
+        // Asserted on the CALLS, not on the parked markers: the marker
+        // registry is process-global and keyed by company id, and every
+        // `Fixture::nested()` shares the manifest's one id — so a sibling test
+        // parking for "chief" would make a marker assertion here pass or fail
+        // on test-execution order rather than on this behaviour. The relay
+        // launching at all is the defect; the orphan marker is its downstream
+        // consequence.
+        let calls = turns.calls();
+        assert_eq!(
+            calls.len(),
+            2,
+            "exactly two turns: the responder's hand-off and the delegate's paused turn. A \
+             third is the CEO relay firing into the same exhausted provider — the pre-fix \
+             defect, which parks a second, unreachable marker for the responder: {calls:?}"
+        );
+        assert!(
+            !calls
+                .iter()
+                .any(|(_, prompt)| prompt.contains("You delegated this to your team")),
+            "no call may carry a relay prompt — that sentence is `build_relay_prompt`'s and \
+             nothing else's: {calls:?}"
+        );
+
+        assert!(
+            out.reply.contains("engineer"),
+            "skipping the relay must not drop the delegate's text from the bubble: {}",
+            out.reply
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1847 (merged). Three budget-pause paths surfaced an "Add credits & resend"
CTA the server can never honour, or spent a second inference call on an already-exhausted
provider. All three are still present on `main` at `5037937`.

These were raised as review findings on #1847 and were still open when it merged.

## Problem

The console decides whether to draw the Add-Credits button by `isBudgetPauseNotice`, which
is `text.startsWith(BUDGET_PAUSE_NOTICE_PREFIX)` — there is no structured wire field for a
message's kind, so that prefix IS the contract. Two paths pause with no marker the generic
chat redeem can honour, but emitted the prefix anyway:

1. **Confined workflow copilot** (`confined_turn_bubble`). `run_confined` bypasses
   `run_inner`, the only place that parks a marker, and `CONFINED_AGENT_ID` names no
   addressable teammate. The function's own doc already claimed "with no CTA" — nothing
   enforced it. Every click did a GET returning `null`, then a POST that **404**'d.

2. **Approval continuation.** Runs through `run_steered_background`, so `run_inner` parks
   `background: true` — exactly the shape `redeem_budget_pause` refuses
   (`src/server/ops/budget_pause.rs`). Every click reserved the marker, restored it, and
   returned **400**.

3. **CEO relay after a delegated pause** (`delegation.rs`). "Answered" is the load-bearing
   word: a desk that paused has NOT answered — `desk.reply` is the placeholder — but the
   non-empty check launched the relay regardless. That fired a second call at the same
   exhausted provider, which paused too and parked a **second marker for the responder**
   that no notice points at. Being newer, it superseded the live CTA on the delegate's own
   notice — disabling the one button that would have worked.

## API Or Behavior Changes

- New `BUDGET_PAUSE_NOTICE_NO_RESEND_PREFIX` + `budget_pause_notice_no_resend()`: a sibling
  carrying the same information that deliberately does NOT match `isBudgetPauseNotice`, so
  those notices render as ordinary system bubbles with no unusable action. Paths (1) and (2)
  now use it.
- The CEO relay is gated on `budget_paused.is_none()`. The delegate's text is folded onto the
  operator bubble in the shape `build_relay_prompt` would have used, so skipping the relay
  drops nothing the operator would have read.

Resuming an approval continuation properly needs the grant's own identity, which the generic
chat-message redeem path does not carry. Until it does, a notice with no button is the honest
surface — stated rather than silently deferred.

## Tests

- **Rewrote** `a_confined_turns_budget_pause_is_a_system_notice_not_a_copilot_reply`, which
  asserted the *redeemable* prefix and therefore encoded the defect. Now asserts the
  no-resend prefix **and** the negative.
- `an_approval_continuation_pause_offers_no_redeem_cta`.
- `the_redeemable_and_no_resend_prefixes_are_not_prefixes_of_each_other` — a one-character
  edit to either constant silently restores the broken CTA.
- `a_delegates_budget_pause_does_not_launch_the_ceo_relay` — asserts on recorded calls, not
  parked markers: the marker registry is process-global and keyed by company id, and every
  `Fixture::nested()` shares one id, so a marker assertion passes or fails on test-execution
  order. Scripted with only two turns, so a regression makes `ScriptedTurns` run dry and fail
  loudly rather than quietly parking an extra marker.

Gates, all clean on this branch:

- `cargo check --features openhuman --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --features openhuman --all-targets --no-deps -- -D warnings`
- `npm run typecheck`; `npx vitest run` — **366 files / 3446 tests passed**

## Documentation

Also documents the deliberate near-miss on `isBudgetPauseNotice`, so the two prefixes are not
"helpfully" merged by a later change — the near-miss is the mechanism.

Includes one comment-only commit correcting a lint-suppression rationale in `ChatView.tsx`
that contradicted the comment thirty lines above it (raised by CodeRabbit on #1847, unaddressed
at merge).

## Note on CI

**Console E2E will likely fail on this PR, and it is not this branch.** `main` currently fails
that lane in roughly four runs out of six, always on the same two chat specs — tracked in #1885
with the run-by-run evidence. #1847 itself merged with that lane red. Please don't re-triage it
from scratch.

Related: #1846, #1847, #1885
