### PR TITLE
e2e: match your own thread reply exactly, so the echo brain's quote cannot break strict mode

### DIFF
--- a/frontend/test/e2e/chat-thread-avatar.spec.ts
+++ b/frontend/test/e2e/chat-thread-avatar.spec.ts
@@ -112,7 +112,15 @@ test("your own line wears your own face in the thread panel too", async ({ page 
   // brain answers the reply below, so both voices end up in it.
   await thread.getByPlaceholder("Reply…").fill("and here is a reply");
   await thread.getByPlaceholder("Reply…").press("Enter");
-  await expect(thread.getByText("and here is a reply")).toBeVisible({ timeout: 30_000 });
+  // `exact` matters here for the same reason `hasNotText` does above: the echo
+  // brain quotes the reply back as `You said: and here is a reply`, so a
+  // substring match resolves to two lines the moment that answer lands, and the
+  // assertion dies of a strict-mode violation instead of waiting. Which of the
+  // two the console paints first is a race the runner's load decides, which is
+  // why the substring form passed here and failed on a busy CI runner.
+  await expect(thread.getByText("and here is a reply", { exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
   await expect(otherThreadTile(page)).toBeVisible({ timeout: 30_000 });
 
   // The bug: your line's face was the mascot hashed from the literal string


### PR DESCRIPTION
Part of #1885.

## What was red

`Console E2E` fails intermittently on `main` and on every PR that happens to run
while a runner is busy — most recently [PR #1884's run](https://github.com/tinyhumansai/opencompany/actions/runs/33069555900/job/98520315621)
and, from `main`, [run 33075620041](https://github.com/tinyhumansai/opencompany/actions/runs/33075620041).
Same signature both times:

```
1) test/e2e/chat-thread-avatar.spec.ts:68:1 › your own line wears your own face in the thread panel too

  Error: strict mode violation: locator('aside')…​.getByText('and here is a reply') resolved to 2 elements:
      1) <p>and here is a reply</p>
      2) <p>You said: and here is a reply</p>
```

## Why

Not a timeout — a **strict-mode violation**, so the 30s slack never helps.

The spec types a thread reply and waits for it with a substring match. The
offline echo brain answers by quoting the reply back (`You said: and here is a
reply`), and that answer's `<p>` contains the searched text too. The instant it
lands, the locator matches two nodes and Playwright fails immediately instead of
waiting. Which of the two the console paints first is a race the runner's load
decides, which is why the substring form passes locally every time.

The spec already guards this exact hazard for the main timeline, and says so:

```ts
// `hasNotText` matters: the echo brain's reply quotes the marker back, so a
// bare `hasText: marker` matches both bubbles.
```

That guard was simply never applied to the thread panel. `{ exact: true }` is it:
`and here is a reply` matches, `You said: and here is a reply` does not.

## Verification

Locally the spec passes either way, so the fix was proven by **forcing the race** —
awaiting the echo answer before the assertion under test:

| spec | result |
|---|---|
| substring (today's `main`) | fails with CI's exact strict-mode error |
| `{ exact: true }` (this PR) | passes |

Also passes unforced, and `npm run typecheck:e2e` is clean.

## Scope

#1885 names two specs. This fixes one of them.
`chat-detached-post-failure.spec.ts:165` fails for a genuinely different reason —
a 60s timeout with `element(s) not found`, a real wall-clock race on the held SSE
frame — and still needs the deterministic release signal the issue asks for. So
**#1885 stays open**; this PR does not close it.