### PR TITLE
ci(release): sign + notarize the macOS DMG, and generate release notes dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,9 @@ jobs:
               # `assert-single-tauri-app.sh` got in. `rust` already lists this
               # path; `frontend` is where the scripts actually execute.
               - 'scripts/ci/**'
+              # Same reasoning for the release-notes generator and its test,
+              # which also run in `Console`.
+              - 'scripts/release/**'
             desktop:
               - '.github/workflows/ci.yml'
               - 'src-tauri/**'
@@ -1584,6 +1587,19 @@ jobs:
       # rather than a build one. It rides the Console job because that job is
       # Node-only and cheap; the rule itself is repository-wide.
       - run: ./scripts/ci/assert-md-line-cap.sh
+
+      # The release-notes generator, which is otherwise only ever exercised by a
+      # `workflow_dispatch` release — the one moment nobody wants to discover a
+      # `TypeError` in it. `node --test` with no framework and no package.json:
+      # the script has no dependencies, and adding an npm project under
+      # `scripts/` to run a dozen assertions would put a second one in a
+      # repository that has exactly one (`frontend/`).
+      #
+      # Rides the Console job for the reason the checks above do: Node-only and
+      # cheap. The `frontend` path filter gains `scripts/release/**` alongside
+      # this step — without it a PR editing only the generator skips `Console`,
+      # and the test is the one thing its own diff cannot run.
+      - run: node --test scripts/release/generate-release-notes.test.mjs
 
       # Exactly one Tauri app, and no script that picks it by working directory
       # rather than by name.

--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -101,7 +101,18 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           if ! gh release view "$TAG" -R "$REPO" >/dev/null 2>&1; then
-            echo "::error::create_release=true but no GitHub Release exists for tag '$TAG'. Run the \`Release\` workflow (release.yml) for that tag first — it owns \`generate_release_notes\` — then re-dispatch this workflow to attach the DMGs." >&2
+            echo "::error::create_release=true but no GitHub Release exists for tag '$TAG'. Run the \`Release\` workflow (release.yml) for that tag first — it generates the notes and creates the draft — then re-dispatch this workflow to attach the DMGs and publish it." >&2
+            exit 1
+          fi
+
+          # IT MUST STILL BE A DRAFT. This repository has immutable releases
+          # enabled: publishing freezes the release AND its asset list, so
+          # `gh release upload` on a published one is rejected outright. Caught
+          # here, in seconds, because the alternative is discovering it after
+          # two ~40-minute builds have already signed and notarized — which is
+          # exactly how v0.0.1-rc.1 went.
+          if [ "$(gh release view "$TAG" -R "$REPO" --json isDraft --jq .isDraft)" != "true" ]; then
+            echo "::error::Release '$TAG' is already published. Immutable releases freeze the asset list at publish, so the DMGs can no longer be attached to it. Cut a new tag and re-run \`release.yml\`, which creates the release as a draft." >&2
             exit 1
           fi
 
@@ -310,17 +321,31 @@ jobs:
       # so the Release ends up carrying both DMGs. They upload as separate
       # assets and do not overwrite each other.
       #
-      # This action would CREATE the Release if none existed, which both legs
-      # could race. The `guard` job proves one already exists whenever
-      # `create_release` is true, so by here this step only ever ATTACHES —
-      # and two concurrent attaches of differently-named assets do not race.
-      # `release.yml` is what cuts the Release; it owns `generate_release_notes`.
-      - name: Attach signed DMG to release
+      # `gh release upload`, NOT `softprops/action-gh-release`.
+      #
+      # That action does not just upload assets: on every run it also PATCHes
+      # the release, and one field it sends is `target_commitish` derived from
+      # the dispatch ref. Against this repository that failed outright —
+      # "target_commitish cannot be changed when release is immutable" — and
+      # had it succeeded it would have been worse, silently retargeting a
+      # release cut from `main` at whatever branch the build was dispatched
+      # from. `gh release upload` touches the asset list and nothing else.
+      #
+      # The `guard` job proves a DRAFT release already exists whenever
+      # `create_release` is true, so this only ever attaches; it never creates.
+      # Two concurrent uploads of differently-named assets do not race — Tauri
+      # names the outputs per-arch, so the two legs cannot collide.
+      #
+      # `--clobber` makes a re-run of one leg idempotent rather than failing on
+      # an asset name that already exists from the previous attempt.
+      - name: Attach signed DMG to draft release
         if: inputs.create_release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ inputs.tag }}
-          files: ${{ steps.locate.outputs.dmg_path }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+          DMG_PATH: ${{ steps.locate.outputs.dmg_path }}
+        run: gh release upload "$TAG" "$DMG_PATH" -R "$REPO" --clobber
 
       # Otherwise upload the DMG (unsigned by default) as an Actions artifact.
       # The name carries the target, or the second leg to finish would collide
@@ -332,3 +357,34 @@ jobs:
           name: opencompany-macos-${{ matrix.target }}-dmg
           path: ${{ steps.locate.outputs.dmg_path }}
           if-no-files-found: error
+
+  # Publish the draft, once BOTH architectures have attached their DMG.
+  #
+  # This is the step that makes the release immutable, and it is deliberately
+  # the last thing that happens: from here the asset list is frozen, so it must
+  # not run until everything that belongs in the release is already in it.
+  #
+  # `needs: build` with the matrix's `fail-fast: false` means this job is
+  # reached only if EVERY leg succeeded — a failed Intel build leaves the draft
+  # unpublished rather than shipping a release that silently has one
+  # architecture. Fix the leg and re-dispatch; the draft is still there, and
+  # `--clobber` on the upload makes the successful leg's re-run harmless.
+  publish:
+    name: Publish release
+    needs: build
+    if: inputs.create_release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Assets attached to $TAG:"
+          gh release view "$TAG" -R "$REPO" --json assets --jq '.assets[].name'
+          gh release edit "$TAG" -R "$REPO" --draft=false
+          echo "Published $TAG"

--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -7,6 +7,14 @@
 # ever attached to a GitHub Release (`create_release`). An unsigned DMG never
 # goes to a public Release.
 #
+# THE RELEASE IS A DRAFT until this workflow finishes. `release.yml` creates it
+# that way on purpose: this repository has immutable releases enabled, so
+# publishing freezes the asset list and no DMG can be added afterwards. The
+# `publish` job at the bottom flips the draft public once BOTH architectures
+# have attached theirs, so a release becomes immutable and public in the same
+# moment — already complete. See the `Create draft release` step in
+# `release.yml` for the full argument.
+#
 # BOTH ARCHITECTURES, issue #1732 phase 2. The job is a matrix over `target`:
 # `aarch64-apple-darwin` and `x86_64-apple-darwin`. Both legs run on
 # `macos-latest`, which is Apple Silicon — the Intel leg CROSS-COMPILES rather
@@ -46,9 +54,11 @@ on:
         default: false
       create_release:
         description:
-          When true, attach the DMG to the GitHub Release named by `tag`. Only a
-          signed DMG may be attached, so this requires `sign` to also be true.
-          When false, upload the DMG as an Actions artifact instead.
+          When true, attach both DMGs to the DRAFT GitHub Release named by `tag`
+          and publish it. Only a signed DMG may be attached, so this requires
+          `sign` to also be true, and the draft must already exist — run
+          `release.yml` for the tag first. When false, upload the DMG as an
+          Actions artifact instead and touch no Release.
         type: boolean
         default: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,13 +156,49 @@ jobs:
       - name: Print notes to job summary
         run: cat release-notes.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Create release
+      # CREATED AS A DRAFT, and published only once the DMGs are attached.
+      #
+      # This repository has IMMUTABLE RELEASES enabled: at the moment a release
+      # is published, it and its asset list are frozen. `POST .../assets` on one
+      # is rejected, and so is any update that would move `target_commitish`.
+      # So the obvious ordering — publish here, have `release-desktop-macos.yml`
+      # attach the DMGs when they finish an hour later — cannot work at all.
+      # It failed exactly that way on v0.0.1-rc.1: both architectures signed,
+      # notarized and stapled, and both then failed to attach to a release that
+      # had been frozen 40 minutes earlier.
+      #
+      # A DRAFT is mutable. `release-desktop-macos.yml` uploads into this draft
+      # and its `publish` job flips `--draft=false` at the end, so the release
+      # becomes immutable at the moment it becomes public — already carrying
+      # both DMGs. That is the behaviour immutable releases are asking for: a
+      # published release is a complete one.
+      #
+      # A draft holds no git tag of its own, which is why `tag` must already
+      # exist as a real tag before this workflow is dispatched.
+      - name: Create draft release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ inputs.tag }}
           body_path: release-notes.md
+          draft: true
           # Anything with a pre-release suffix — `v0.1.0-rc.1`, `-beta.2` — is
           # marked as one, so it does not become the "Latest release" the
           # repository's front page points at and `--from latest-release` picks
           # up next time. A plain `vX.Y.Z` has no hyphen and is a full release.
           prerelease: ${{ contains(inputs.tag, '-') }}
+
+      # Say what has to happen next, in the run that created the draft. A draft
+      # release is invisible on the repository's front page, so a half-finished
+      # release otherwise looks like nothing happened at all.
+      - name: Explain the next step
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          {
+            echo "### Draft release created"
+            echo ""
+            echo "\`$TAG\` is a DRAFT and is not public yet."
+            echo ""
+            echo "Dispatch **Release Desktop (macOS DMG)** with \`tag=$TAG\`, \`sign=true\`, \`create_release=true\`."
+            echo "It attaches both signed DMGs to this draft and publishes it."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,22 @@ on:
         description: Tag to publish, for example v0.1.0
         required: true
         type: string
+      notes_from:
+        description:
+          Start of the release-notes range, EXCLUDED. `latest-release` resolves
+          the previous GitHub Release, and falls back to the repository's root
+          commit when there is none — pass an explicit tag or SHA to bound a
+          first release.
+        required: false
+        default: latest-release
+        type: string
+      notes_ai:
+        description:
+          Polish the generated notes with OpenAI. Requires OPENAI_API_KEY; the
+          run falls back to the deterministic renderer rather than failing.
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -23,8 +39,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      # `fetch-depth: 0`. The release-notes generator walks
+      # `<previous release>..<tag>` and reads EVERY author before the range to
+      # tell a first-time contributor from a returning one. Under the default
+      # shallow checkout that history is not present, `git log A..B` prints
+      # nothing for an unknown A, and the notes come out empty and green — the
+      # one failure mode worth paying a full clone to remove.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
           persist-credentials: false
           submodules: true
 
@@ -66,8 +90,74 @@ jobs:
           cargo build --locked --all-targets
           cargo test --locked
 
+      # ---- Release notes ------------------------------------------------------
+      # `generate_release_notes: true` used to do this, and what it produced was
+      # a flat "* <title> by @who in <url>" list in merge order. The generator
+      # below groups the same PRs into themed highlights and, unlike anything
+      # GitHub derives, names FIRST-TIME contributors — it reads history before
+      # the range, which the built-in list never does.
+      #
+      # Node is needed only for the generator; nothing else in this job uses it.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # `continue-on-error` plus the fallback below, not `||` inside one step:
+      # a failed OpenAI call must still leave a `release-notes.md` behind, and
+      # the two-step form makes WHICH renderer ran visible in the job log rather
+      # than hiding a degraded release behind a green step.
+      #
+      # The 5-minute cap is above the generator's own 300s abort, so a hung API
+      # is caught by the script (which then exits non-zero and hands over to the
+      # fallback) rather than by the step, which would kill the job outright.
+      - name: Generate release notes (AI)
+        id: ai-notes
+        if: inputs.notes_ai
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TAG: ${{ inputs.tag }}
+          NOTES_FROM: ${{ inputs.notes_from }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "::warning::OPENAI_API_KEY is empty — falling back to deterministic notes."
+            exit 1
+          fi
+          node scripts/release/generate-release-notes.mjs \
+            --from "$NOTES_FROM" \
+            --to "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --output release-notes.md
+
+      # Runs when AI notes were disabled, skipped, or failed. This one is NOT
+      # `continue-on-error`: if the deterministic renderer cannot produce notes
+      # either, something is wrong with the range itself and the release should
+      # not be cut with an empty body.
+      - name: Generate release notes (deterministic)
+        if: ${{ !inputs.notes_ai || steps.ai-notes.outcome != 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          NOTES_FROM: ${{ inputs.notes_from }}
+        run: |
+          set -euo pipefail
+          node scripts/release/generate-release-notes.mjs \
+            --from "$NOTES_FROM" \
+            --to "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --no-ai \
+            --output release-notes.md
+
+      # So the notes are readable without opening the Release, and so a bad
+      # range is diagnosable from the run that produced it.
+      - name: Print notes to job summary
+        run: cat release-notes.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ inputs.tag }}
-          generate_release_notes: true
+          body_path: release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,12 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
+          # Explicitly OFF. The generator has no dependencies and this job never
+          # runs `npm install`, so there is nothing to cache — but this job also
+          # holds `contents: write` and publishes what users download, which
+          # makes a restored cache a supply-chain surface for no benefit at all.
+          # Saying so here states the intent and clears the zizmor finding.
+          cache: false
 
       # `continue-on-error` plus the fallback below, not `||` inside one step:
       # a failed OpenAI call must still leave a `release-notes.md` behind, and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,3 +161,8 @@ jobs:
         with:
           tag_name: ${{ inputs.tag }}
           body_path: release-notes.md
+          # Anything with a pre-release suffix — `v0.1.0-rc.1`, `-beta.2` — is
+          # marked as one, so it does not become the "Latest release" the
+          # repository's front page points at and `--from latest-release` picks
+          # up next time. A plain `vX.Y.Z` has no hyphen and is a full release.
+          prerelease: ${{ contains(inputs.tag, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,19 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
-          # Explicitly OFF. The generator has no dependencies and this job never
-          # runs `npm install`, so there is nothing to cache — but this job also
-          # holds `contents: write` and publishes what users download, which
+          # `package-manager-cache`, NOT `cache`. The `cache` input takes a
+          # package-manager NAME (npm/yarn/pnpm), and the action's own check is
+          # `if (cache)` — the string "false" is truthy, so `cache: false` does
+          # not disable anything; it asks for a package manager called "false"
+          # and the step dies with "Caching for 'false' is not supported",
+          # taking the release job with it. `package-manager-cache` is the input
+          # that actually means off.
+          #
+          # Off because the generator has no dependencies and this job never
+          # runs `npm install`, so there is nothing to cache — while the job
+          # does hold `contents: write` and publishes what users download, which
           # makes a restored cache a supply-chain surface for no benefit at all.
-          # Saying so here states the intent and clears the zizmor finding.
-          cache: false
+          package-manager-cache: false
 
       # `continue-on-error` plus the fallback below, not `||` inside one step:
       # a failed OpenAI call must still leave a `release-notes.md` behind, and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,18 @@ jobs:
       # the two-step form makes WHICH renderer ran visible in the job log rather
       # than hiding a degraded release behind a green step.
       #
-      # The 5-minute cap is above the generator's own 300s abort, so a hung API
-      # is caught by the script (which then exits non-zero and hands over to the
-      # fallback) rather than by the step, which would kill the job outright.
+      # The step cap must sit ABOVE the generator's own 300s OpenAI abort, so
+      # that a hung API is caught by the SCRIPT — which names the timeout and
+      # exits non-zero — rather than by the step, which kills the process and
+      # reports only "timed out". At `timeout-minutes: 5` the two were both 300s
+      # and the step budget additionally covered `gh release view`, `git log`,
+      # and one `gh pr view` per PR, so the step always won and the script's
+      # error path was unreachable. 10 minutes leaves room for those lookups.
       - name: Generate release notes (AI)
         id: ai-notes
         if: inputs.notes_ai
         continue-on-error: true
-        timeout-minutes: 5
+        timeout-minutes: 10
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -1,0 +1,777 @@
+#!/usr/bin/env node
+// Dynamic release notes for OpenCompany, ported from the generator OpenHuman
+// has used since its v0.57 line (`scripts/release/generate-release-notes.mjs`
+// there).
+//
+// WHY NOT `generate_release_notes: true`. GitHub's built-in note generation
+// emits a flat "* <PR title> by @author in <url>" list in merge order. For a
+// release spanning a hundred PRs that is a changelog nobody reads and which
+// says nothing about what the release IS. This walks the same commit range but
+// resolves each PR through `gh`, groups the work into themed highlights, and
+// distinguishes FIRST-TIME contributors from returning ones — the one fact the
+// built-in list cannot derive, because it never looks at history before the
+// range.
+//
+// TWO RENDERERS, and the AI one is not required. `--no-ai` produces the whole
+// document deterministically from the keyword groups below; the OpenAI path
+// only rewrites that same payload into prose. `release.yml` calls the AI path
+// first and falls back to `--no-ai` on any failure, so a missing or rate-limited
+// `OPENAI_API_KEY` degrades the notes rather than failing the release.
+//
+// Every function that has a pure input and output is exported for
+// `generate-release-notes.test.mjs`; the git/gh/network ones are not.
+import { execFileSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_MODEL = 'gpt-5.2';
+const DEFAULT_FROM = 'latest-release';
+const DEFAULT_TO = 'latest-tag';
+// The prompt ceiling is ours, not the model's: a 300-PR range serialises to
+// megabytes of PR bodies, and the request is rejected at the API rather than
+// truncated. `serializeOpenAiPayload` sheds detail in stages to stay under it.
+const MAX_PROMPT_CHARS = 120_000;
+const MAX_PR_BODY_CHARS = 700;
+
+function usage() {
+  return `Usage: node scripts/release/generate-release-notes.mjs [options]
+
+Generate Markdown release notes from merged PRs between two refs.
+
+Options:
+  --from <tag>          Start tag/ref, excluded from the range. Defaults to ${DEFAULT_FROM}.
+                         Use latest-release to resolve the most recent GitHub Release tag.
+  --to <ref>            End ref, included. Defaults to ${DEFAULT_TO}. Use main for testing.
+  --repo <owner/repo>   GitHub repo. Defaults to the upstream/origin remote.
+  --model <model>       OpenAI model. Defaults to ${DEFAULT_MODEL}.
+  --output <file>       Write generated Markdown to a file instead of stdout.
+  --no-ai               Build deterministic Markdown without calling OpenAI.
+  --dry-run             Print the OpenAI request JSON without calling OpenAI.
+  --help                Show this help.
+
+Environment:
+  OPENAI_API_KEY        Preferred OpenAI API key variable.
+  OPENAI_API            Backward-compatible fallback API key variable.
+  OPENAI_MODEL          Overrides the default model.
+  GITHUB_REPOSITORY     Default for --repo (set for you inside Actions).
+
+Examples:
+  node scripts/release/generate-release-notes.mjs --to main --no-ai
+  node scripts/release/generate-release-notes.mjs --from v0.1.0 --to v0.2.0 -o notes.md
+`;
+}
+
+export function parseArgs(argv) {
+  if (argv[0] === '--') {
+    argv = argv.slice(1);
+  }
+
+  const options = {
+    from: process.env.RELEASE_NOTES_FROM || DEFAULT_FROM,
+    to: process.env.RELEASE_NOTES_TO || DEFAULT_TO,
+    repo: process.env.GITHUB_REPOSITORY || null,
+    model: process.env.OPENAI_MODEL || DEFAULT_MODEL,
+    output: null,
+    noAi: false,
+    dryRun: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = (name) => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${name} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    if (arg === '--help' || arg === '-h') {
+      return { ...options, help: true };
+    }
+    if (arg === '--from') {
+      options.from = readValue(arg);
+    } else if (arg === '--to') {
+      options.to = readValue(arg);
+    } else if (arg === '--repo') {
+      options.repo = readValue(arg);
+    } else if (arg === '--model') {
+      options.model = readValue(arg);
+    } else if (arg === '--output' || arg === '-o') {
+      options.output = readValue(arg);
+    } else if (arg === '--no-ai') {
+      options.noAi = true;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function runGit(args, options = {}) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', options.allowFailure ? 'pipe' : 'inherit'],
+  }).trim();
+}
+
+function runGh(args, options = {}) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', options.allowFailure ? 'pipe' : 'inherit'],
+  }).trim();
+}
+
+export function parseGitHubRepoFromRemote(remoteUrl) {
+  const cleaned = String(remoteUrl || '')
+    .trim()
+    .replace(/\.git$/, '');
+  const match = cleaned.match(/github\.com[:/]([^/\s]+\/[^/\s]+)$/);
+  return match ? match[1] : null;
+}
+
+// `upstream` FIRST. A contributor checkout has `origin` pointing at their fork,
+// and resolving the repo from it would ask `gh` for PR numbers that only exist
+// on the canonical repo — every lookup 404s and every PR falls back to its
+// commit subject. In Actions `GITHUB_REPOSITORY` short-circuits this entirely.
+function resolveRepo(explicitRepo) {
+  if (explicitRepo) {
+    return explicitRepo;
+  }
+  for (const remote of ['upstream', 'origin']) {
+    try {
+      const url = runGit(['remote', 'get-url', remote], { allowFailure: true });
+      const repo = parseGitHubRepoFromRemote(url);
+      if (repo) {
+        return repo;
+      }
+    } catch {
+      // Try the next remote.
+    }
+  }
+  throw new Error('Could not infer GitHub repo. Pass --repo owner/repo.');
+}
+
+function resolveEndRef(to) {
+  if (to !== 'latest-tag') {
+    return to;
+  }
+  const tag = runGit(['describe', '--tags', '--abbrev=0']);
+  if (!tag) {
+    throw new Error('Could not resolve latest tag');
+  }
+  return tag;
+}
+
+// The most recent RELEASE, not the most recent tag: the tag being published is
+// usually already pushed by the time this runs, so `git describe` would resolve
+// the start of the range to its end and produce an empty document.
+function resolveStartRef(repo, from) {
+  if (from !== 'latest-release') {
+    return from;
+  }
+  const tag = runGh(['release', 'view', '--repo', repo, '--json', 'tagName', '--jq', '.tagName']);
+  if (!tag) {
+    throw new Error(`Could not resolve latest GitHub Release tag for ${repo}`);
+  }
+  return tag;
+}
+
+// A shallow clone is the usual cause of a miss here, and its failure mode is
+// silent: `git log A..B` against an unknown A prints nothing, so the notes come
+// out empty and green. Say which end is missing instead.
+function assertRefExists(ref, label) {
+  try {
+    runGit(['rev-parse', '--verify', `${ref}^{commit}`], { allowFailure: true });
+  } catch {
+    throw new Error(`${label} ref not found: ${ref} (a shallow checkout needs fetch-depth: 0)`);
+  }
+}
+
+export function extractPullRequestNumbers(subject) {
+  const matches = [...String(subject || '').matchAll(/\(#(\d+)\)/g)];
+  return [...new Set(matches.map((match) => Number(match[1])).filter(Number.isInteger))];
+}
+
+// `%x1f` between fields and `%x1e` between records: both are ASCII separators
+// that cannot occur in a commit subject, an author name, or an email, so no
+// commit message can forge a record boundary the way a newline delimiter would.
+export function parseGitLog(logText) {
+  if (!logText.trim()) {
+    return [];
+  }
+
+  return logText
+    .split('\x1e')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [sha, subject, authorName, authorEmail, authoredAt] = entry.split('\x1f');
+      const prNumbers = extractPullRequestNumbers(subject);
+      return {
+        sha,
+        shortSha: sha.slice(0, 9),
+        subject,
+        authorName,
+        authorEmail,
+        authoredAt,
+        prNumbers,
+        // The LAST number wins. A squashed merge reads "fix: thing (#12) (#34)"
+        // when the branch itself referenced an issue; #34 is the merge.
+        primaryPrNumber: prNumbers.at(-1) || null,
+      };
+    });
+}
+
+function collectCommits(from, to) {
+  const format = '%H%x1f%s%x1f%an%x1f%ae%x1f%aI%x1e';
+  const output = runGit(['log', `${from}..${to}`, '--reverse', `--format=${format}`]);
+  return parseGitLog(output);
+}
+
+// Everything reachable from the START of the range. Anyone absent from this set
+// is a first-time contributor, which is the fact the built-in generator cannot
+// produce.
+function priorAuthorKeys(from) {
+  const output = runGit(['log', from, '--format=%an%x1f%ae%x1e']);
+  const keys = new Set();
+  for (const entry of output.split('\x1e')) {
+    const [name, email] = entry.trim().split('\x1f');
+    if (name || email) {
+      keys.add(authorKey({ authorName: name, authorEmail: email }));
+    }
+  }
+  return keys;
+}
+
+export function authorKey(author) {
+  return `${String(author.authorName || '').toLowerCase()} <${String(author.authorEmail || '').toLowerCase()}>`;
+}
+
+export function collectContributorStats(commits, priorKeys) {
+  const contributors = new Map();
+  for (const commit of commits) {
+    const key = authorKey(commit);
+    if (!contributors.has(key)) {
+      contributors.set(key, {
+        name: commit.authorName,
+        email: commit.authorEmail,
+        commits: 0,
+        prs: new Set(),
+        isNew: !priorKeys.has(key),
+      });
+    }
+    const contributor = contributors.get(key);
+    contributor.commits += 1;
+    if (commit.primaryPrNumber) {
+      contributor.prs.add(commit.primaryPrNumber);
+    }
+  }
+
+  return [...contributors.values()]
+    .map((contributor) => ({ ...contributor, prs: [...contributor.prs].sort((a, b) => a - b) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function collectPrCommits(commits) {
+  const byPr = new Map();
+  for (const commit of commits) {
+    if (!commit.primaryPrNumber) {
+      continue;
+    }
+    if (!byPr.has(commit.primaryPrNumber)) {
+      byPr.set(commit.primaryPrNumber, []);
+    }
+    byPr.get(commit.primaryPrNumber).push(commit);
+  }
+  return byPr;
+}
+
+// NEVER fatal. A PR can be unreachable for reasons that have nothing to do with
+// this release — a transferred issue, a deleted fork, a `gh` rate limit partway
+// through a hundred lookups. Falling back to the commit subject costs a title;
+// throwing would cost the whole release's notes.
+function fetchPullRequest(repo, number) {
+  try {
+    const json = runGh(
+      ['pr', 'view', String(number), '--repo', repo, '--json', 'number,title,url,author,mergedAt,body,labels'],
+      { allowFailure: true },
+    );
+    return JSON.parse(json);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      number,
+      title: null,
+      url: `https://github.com/${repo}/pull/${number}`,
+      author: null,
+      mergedAt: null,
+      body: null,
+      labels: [],
+      warning: `Failed to fetch PR metadata with gh: ${message}`,
+    };
+  }
+}
+
+function collectPullRequests(repo, commits) {
+  const prCommits = collectPrCommits(commits);
+  const numbers = [...prCommits.keys()].sort((a, b) => a - b);
+
+  return numbers.map((number) => {
+    const detail = fetchPullRequest(repo, number);
+    const commitsForPr = prCommits.get(number) || [];
+    const fallbackTitle =
+      commitsForPr.at(-1)?.subject.replace(/(?:\s+\(#\d+\))+\s*$/g, '') || `PR #${number}`;
+    return {
+      number,
+      title: detail.title || fallbackTitle,
+      url: detail.url || `https://github.com/${repo}/pull/${number}`,
+      author: detail.author?.login || commitsForPr.at(-1)?.authorName || null,
+      mergedAt: detail.mergedAt || commitsForPr.at(-1)?.authoredAt || null,
+      labels: (detail.labels || []).map((label) => label.name || label).filter(Boolean),
+      body: trimBody(detail.body),
+      commits: commitsForPr.map((commit) => ({
+        sha: commit.shortSha,
+        subject: commit.subject,
+        authorName: commit.authorName,
+      })),
+      warning: detail.warning,
+    };
+  });
+}
+
+// HTML comments go first: the PR template is mostly comments, and without this
+// the payload is dominated by boilerplate the model then tries to summarise.
+export function trimBody(body) {
+  if (!body || typeof body !== 'string') {
+    return '';
+  }
+  return body
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\r\n/g, '\n')
+    .trim()
+    .slice(0, MAX_PR_BODY_CHARS);
+}
+
+export function releaseTitle(from, to, resolvedTo) {
+  const toLabel = to === 'latest-tag' ? resolvedTo : to;
+  return `${from} to ${toLabel}`;
+}
+
+export function buildReleasePayload({ from, to, resolvedTo, repo, commits, pullRequests, contributors }) {
+  return {
+    repo,
+    range: {
+      from,
+      to,
+      resolvedTo,
+      compareUrl: `https://github.com/${repo}/compare/${from}...${resolvedTo}`,
+    },
+    totals: {
+      commits: commits.length,
+      pullRequests: pullRequests.length,
+      contributors: contributors.length,
+      newContributors: contributors.filter((contributor) => contributor.isNew).length,
+    },
+    contributors: contributors.map(({ name, commits: count, prs, isNew }) => ({
+      name,
+      commits: count,
+      prs,
+      isNew,
+    })),
+    pullRequests,
+    uncategorizedCommits: commits
+      .filter((commit) => commit.prNumbers.length === 0)
+      .map((commit) => ({ sha: commit.shortSha, subject: commit.subject, authorName: commit.authorName })),
+  };
+}
+
+export function buildOpenAiRequest({ model, title, payload }) {
+  const compactPayload = serializeOpenAiPayload(payload);
+
+  return {
+    model,
+    input: [
+      {
+        role: 'developer',
+        content:
+          'You write polished but concrete release notes for OpenCompany, an operator console and runtime that runs a company as agents, workflows and append-only ledgers. Keep the tone warm, crisp, factual, and celebratory. Use tasteful emojis in headings, but do not overdo them. Never invent changes not present in the input. Preserve every PR link somewhere in the output.',
+      },
+      {
+        role: 'user',
+        content: `Create Markdown release notes for "${title}" from this JSON payload.
+
+Required structure:
+- Start with a short, exciting H1 title that summarizes the whole release theme, like "# The Ledger Upgrade" or "# The Self-Running Company Upgrade". Do not use the tag range as the title.
+- Follow the title with a short celebratory paragraph and one tasteful emoji.
+- Add "## Highlights" with multiple high-level highlight subsections, such as "### Agents & workflows". Use tasteful emojis in subsection headings.
+- For each highlight subsection, write one or two short paragraphs maximum. Do not use highlight bullets.
+- Each highlight subsection should summarize a cluster of related work, then end with compact PR links and contributor thanks, for example "([#123](url), [#124](url)) — Thank you @alice and @bob!"
+- Across the highlight subsections, mention every PR in the payload exactly once if possible.
+- Add "## New Contributors" celebrating first-time contributors only when there are first-time contributors. If none, omit this section entirely.
+- For each new contributor, thank them and briefly describe what they contributed based on their PR titles.
+- End the New Contributors section with a short note hoping they join the community for contributor rewards.
+- Add "## Contributor Credits" thanking all contributors.
+- Do not add a "## Pull Requests" section.
+- Add "## Full Compare" with the compare URL.
+
+JSON payload:
+${compactPayload}`,
+      },
+    ],
+  };
+}
+
+// Three stages, each losing the least valuable thing left: full payload, then
+// PR bodies and commit lists, then whole PRs from the tail with a count of what
+// was dropped so the model can say so rather than silently omit them.
+export function serializeOpenAiPayload(payload) {
+  const fullPayload = JSON.stringify(payload);
+  if (fullPayload.length <= MAX_PROMPT_CHARS) {
+    return fullPayload;
+  }
+
+  const compact = {
+    ...payload,
+    contributors: payload.contributors.map(({ name, isNew }) => ({ name, isNew })),
+    pullRequests: payload.pullRequests.map(({ number, title, url, author, labels }) => ({
+      number,
+      title,
+      url,
+      author,
+      labels,
+    })),
+    uncategorizedCommits: payload.uncategorizedCommits.map(({ subject, authorName }) => ({
+      subject,
+      authorName,
+    })),
+  };
+  const compactPayload = JSON.stringify(compact);
+  if (compactPayload.length <= MAX_PROMPT_CHARS) {
+    return compactPayload;
+  }
+
+  const bounded = { ...compact, pullRequests: [], omittedPullRequests: compact.pullRequests.length };
+  for (const pullRequest of compact.pullRequests) {
+    bounded.pullRequests.push(pullRequest);
+    bounded.omittedPullRequests -= 1;
+    if (JSON.stringify(bounded).length > MAX_PROMPT_CHARS) {
+      bounded.pullRequests.pop();
+      bounded.omittedPullRequests += 1;
+      break;
+    }
+  }
+  return JSON.stringify(bounded);
+}
+
+function getOpenAiKey() {
+  if (process.env.OPENAI_API_KEY) {
+    return process.env.OPENAI_API_KEY;
+  }
+  if (process.env.OPENAI_API) {
+    console.error('[release-notes] Using OPENAI_API; prefer OPENAI_API_KEY.');
+    return process.env.OPENAI_API;
+  }
+  return null;
+}
+
+export function extractResponseText(responseJson) {
+  if (typeof responseJson.output_text === 'string') {
+    return responseJson.output_text;
+  }
+  const parts = [];
+  for (const item of responseJson.output || []) {
+    for (const content of item.content || []) {
+      if (typeof content.text === 'string') {
+        parts.push(content.text);
+      }
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+async function summarizeWithOpenAi(request) {
+  const key = getOpenAiKey();
+  if (!key) {
+    throw new Error('OPENAI_API_KEY is required unless --no-ai or --dry-run is used');
+  }
+
+  // A reasoning model on a hundred-PR payload is minutes, not seconds. The
+  // abort matters because `fetch` has no default timeout: without it a hung
+  // connection holds the release job open until the job timeout, and the
+  // `--no-ai` fallback in `release.yml` never gets its turn.
+  const timeoutMs = 300_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response;
+  try {
+    response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error(`OpenAI Responses API timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const body = await response.text();
+  let json = null;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    // Keep the raw body in the error below.
+  }
+
+  if (!response.ok) {
+    throw new Error(`OpenAI Responses API failed (${response.status}): ${json?.error?.message || body}`);
+  }
+
+  const text = extractResponseText(json);
+  if (!text) {
+    throw new Error('OpenAI response did not contain output text');
+  }
+  return text;
+}
+
+export function renderDeterministicNotes({ title, payload }) {
+  const newContributors = payload.contributors.filter((contributor) => contributor.isNew);
+  const newContributorsSection = newContributors.length
+    ? `
+## New Contributors 🌟
+
+${newContributors.map((contributor) => renderNewContributorLine(contributor, payload.pullRequests)).join('\n')}
+
+Hope you stick around — first patches are how most of this repository got written.
+`
+    : '';
+  const contributorLinks = payload.contributors.map((contributor) => {
+    const prList = contributor.prs.map((number) => `#${number}`).join(', ');
+    return `- ${contributor.name}${prList ? ` (${prList})` : ''}`;
+  });
+  const highlightSections = groupPullRequestsByHighlight(payload.pullRequests).map(
+    ({ title: groupTitle, summary, pullRequests }) => {
+      const links = pullRequests.map((pr) => `[#${pr.number}](${pr.url})`).join(', ');
+      const authors = [...new Set(pullRequests.map((pr) => pr.author).filter(Boolean))];
+      const thanks = authors.length
+        ? `Thank you ${formatHandleList(authors)}!`
+        : 'Thank you to everyone who contributed!';
+      return `### ${groupTitle}\n\n${summary} (${links}) — ${thanks}`;
+    },
+  );
+
+  return `# The OpenCompany Upgrade 🎉
+
+${title} brings ${payload.totals.pullRequests} PRs across ${payload.totals.commits} commits, with work across companies, agents, ledgers, the operator console, and the hosted platform. Thank you to everyone who contributed to this release. ✨
+
+## Highlights 🚀
+
+${highlightSections.join('\n\n') || 'No PRs found in this range.'}
+${newContributorsSection}
+
+## Contributor Credits 🙌
+
+${contributorLinks.map((line) => `${line} — thank you!`).join('\n') || '- No contributors found.'}
+
+## Full Compare 🧭
+
+${payload.range.compareUrl}
+`;
+}
+
+export function formatHandleList(handles) {
+  const names = handles.map((handle) => `@${handle}`);
+  if (names.length <= 2) {
+    return names.join(' and ');
+  }
+  return `${names.slice(0, -1).join(', ')}, and ${names.at(-1)}`;
+}
+
+// Keyword buckets over PR title + labels, in priority order — the FIRST group
+// whose keyword appears wins, so the more specific buckets are listed before
+// the catch-all. The last group is also the fallback for anything unmatched, so
+// no PR can be silently dropped from the document.
+//
+// These names track this repository's own module surfaces (see CLAUDE.md):
+// companies/globals, src/ledger, src/server + frontend, the hosted-platform
+// seams, and the Tauri desktop shell.
+export function groupPullRequestsByHighlight(pullRequests) {
+  const groups = [
+    {
+      title: '🏢 Companies, agents & workflows',
+      keywords: [
+        'company', 'companies', 'vertical', 'global', 'globals', 'agent', 'subagent',
+        'workflow', 'skill', 'skills', 'prompt', 'tool belt', 'toolbelt', 'brain',
+        'run', 'chat', 'inbox', 'task',
+      ],
+      summary:
+        'The company runtime itself moves forward — the agents a company starts with, the workflows they run, and the skills and tool belts they reach for.',
+      pullRequests: [],
+    },
+    {
+      title: '📒 Ledgers, records & data',
+      keywords: [
+        'ledger', 'record', 'derived', 'fold', 'append-only', 'schema', 'migration',
+        'mongodb', 'mongo', 'storage', 'persistence', 'port', 'seed', 'data',
+      ],
+      summary:
+        'Ledgers and the storage layer beneath them get sharper, from declared record shapes and the append-only fold through to the persistence ports each backend implements.',
+      pullRequests: [],
+    },
+    {
+      title: '🖥️ Operator console & UI',
+      keywords: [
+        'console', 'frontend', 'ui', 'ux', 'design', 'token', 'theme', 'page', 'view',
+        'component', 'react', 'vite', 'layout', 'nav', 'onboarding', 'logo', 'icon', 'legend',
+      ],
+      summary:
+        'The operator console gets clearer and calmer to work in, with interface polish, design-system work, and screens that explain more of what the runtime is doing.',
+      pullRequests: [],
+    },
+    {
+      title: '☁️ Hosting, auth & platform',
+      keywords: [
+        'tenant', 'hosting', 'hosted', 'manager', 'deploy', 'docker', 'container',
+        'healthz', 'auth', 'user', 'users', 'admin', 'invite', 'session', 'connect',
+        'grant', 'credential', 'secret', 'security', 'sentry',
+      ],
+      summary:
+        'Hosted operation is tightened across tenancy, sign-in and admin eligibility, connected-account grants, and the container seams the control plane injects into.',
+      pullRequests: [],
+    },
+    {
+      title: '🧰 Desktop, docs & developer foundations',
+      keywords: [
+        'tauri', 'desktop', 'dmg', 'macos', 'bundle', 'sign', 'notariz', 'release',
+        'ci', 'workflow file', 'clippy', 'fmt', 'test', 'docs', 'readme', 'spec',
+        'refactor', 'deps', 'dependency', 'bump', 'chore',
+      ],
+      summary:
+        'The desktop shell, documentation, and the build and release plumbing also move forward, keeping what ships reproducible and what it does written down.',
+      pullRequests: [],
+    },
+  ];
+
+  for (const pr of pullRequests) {
+    const haystack = `${pr.title} ${(pr.labels || []).join(' ')}`.toLowerCase();
+    const group = groups.find((candidate) => candidate.keywords.some((keyword) => haystack.includes(keyword)));
+    (group || groups.at(-1)).pullRequests.push(pr);
+  }
+
+  return groups.filter((group) => group.pullRequests.length > 0);
+}
+
+function renderNewContributorLine(contributor, pullRequests) {
+  const contributed = pullRequests
+    .filter((pr) => contributor.prs.includes(pr.number))
+    .map((pr) => `[#${pr.number}](${pr.url}) ${pr.title}`);
+  const brief = contributed.length ? ` for ${contributed.join('; ')}` : '';
+  return `- Welcome ${contributor.name}! Thank you${brief}.`;
+}
+
+// The prompt ASKS for every PR to appear; a language model is not a guarantee.
+// This is the guarantee: anything the model dropped is appended in its own
+// section rather than losing a contributor's credit to a summarisation choice.
+export function ensureAllPullRequestsLinked(markdown, pullRequests) {
+  const missing = pullRequests.filter((pr) => {
+    const byNumber = new RegExp(`\\[#${pr.number}\\]\\(`).test(markdown);
+    const byUrl = new RegExp(`${escapeRegExp(pr.url)}(?:\\)|\\s|$)`).test(markdown);
+    return !byNumber && !byUrl;
+  });
+  if (missing.length === 0) {
+    return markdown;
+  }
+
+  const links = missing.map((pr) => `[#${pr.number}](${pr.url})`).join(', ');
+  const authors = [...new Set(missing.map((pr) => pr.author).filter(Boolean))];
+  const thanks = authors.length
+    ? `Thank you ${formatHandleList(authors)}!`
+    : 'Thank you to everyone who contributed!';
+  const insertion = `\n### Additional highlights 🔗\n\nA few more focused contributions round out this release with targeted fixes and improvements that are worth calling out. (${links}) — ${thanks}\n`;
+
+  const sectionMatch = markdown.match(/\n## (New Contributors|Contributor Credits|Full Compare)\b/);
+  if (!sectionMatch || typeof sectionMatch.index !== 'number') {
+    return `${markdown.trim()}${insertion}`;
+  }
+  return `${markdown.slice(0, sectionMatch.index).trimEnd()}${insertion}${markdown.slice(sectionMatch.index)}`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`[release-notes] ${error.message}`);
+    console.error(usage());
+    process.exit(2);
+  }
+
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const repo = resolveRepo(options.repo);
+  const from = resolveStartRef(repo, options.from);
+  const resolvedTo = resolveEndRef(options.to);
+
+  assertRefExists(from, 'Start');
+  assertRefExists(resolvedTo, 'End');
+
+  console.error(`[release-notes] Collecting ${repo} changes from ${from} to ${resolvedTo}`);
+  const commits = collectCommits(from, resolvedTo);
+  const contributors = collectContributorStats(commits, priorAuthorKeys(from));
+  const pullRequests = collectPullRequests(repo, commits);
+  const payload = buildReleasePayload({
+    from,
+    to: options.to,
+    resolvedTo,
+    repo,
+    commits,
+    pullRequests,
+    contributors,
+  });
+  const title = releaseTitle(from, options.to, resolvedTo);
+
+  let markdown;
+  if (options.dryRun) {
+    markdown = JSON.stringify(buildOpenAiRequest({ model: options.model, title, payload }), null, 2);
+  } else if (options.noAi) {
+    markdown = renderDeterministicNotes({ title, payload });
+  } else {
+    markdown = await summarizeWithOpenAi(buildOpenAiRequest({ model: options.model, title, payload }));
+    markdown = ensureAllPullRequestsLinked(markdown, payload.pullRequests);
+  }
+
+  if (options.output) {
+    const outputPath = resolve(options.output);
+    if (existsSync(outputPath) && basename(outputPath).startsWith('.')) {
+      throw new Error(`Refusing to overwrite hidden file: ${outputPath}`);
+    }
+    writeFileSync(outputPath, markdown.endsWith('\n') ? markdown : `${markdown}\n`);
+    console.error(`[release-notes] Wrote ${outputPath}`);
+  } else {
+    process.stdout.write(markdown.endsWith('\n') ? markdown : `${markdown}\n`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[release-notes] ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -448,6 +448,7 @@ Required structure:
 - For each new contributor, thank them and briefly describe what they contributed based on their PR titles.
 - End the New Contributors section with a short note hoping they join the community for contributor rewards.
 - Add "## Contributor Credits" thanking all contributors.
+- IMPORTANT: \`contributors[].name\` is a git DISPLAY NAME, not a GitHub handle. Never prefix it with "@". Only \`pullRequests[].author\` is a real handle and may take an "@".
 - Do not add a "## Pull Requests" section.
 - Add "## Full Compare" with the compare URL.
 
@@ -800,7 +801,11 @@ async function main() {
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+// `process.argv[1]` is undefined under `node -e` and `node --input-type=module`,
+// and `pathToFileURL(undefined)` THROWS — so an unguarded check here turns any
+// programmatic import of this module into a crash before a single export is
+// read. Importing it must never run `main()`, and must never fail either.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(`[release-notes] ${error.message}`);
     process.exit(1);

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -213,9 +213,27 @@ function assertRefExists(ref, label) {
   }
 }
 
+// TWO merge styles, because this repository uses both.
+//
+// A squash merge leaves the number in the subject as `(#1234)`. A REGULAR merge
+// commit leaves `Merge pull request #1234 from owner/branch` and no parentheses
+// at all — and that is the style most PRs into `main` land in here: 25 of the
+// last 200 subjects are merge commits, and matching only the parenthesized form
+// dropped every one of them. Those PRs were then never fetched, never linked,
+// and their authors never credited, in a document whose entire purpose is to
+// link and credit them.
+//
+// Merge matches are appended AFTER the parenthesized ones so that when a
+// subject somehow carries both, the merge number is last and therefore wins as
+// `primaryPrNumber` — the merge is the PR; a `(#12)` inside it is the issue the
+// branch referenced.
 export function extractPullRequestNumbers(subject) {
-  const matches = [...String(subject || '').matchAll(/\(#(\d+)\)/g)];
-  return [...new Set(matches.map((match) => Number(match[1])).filter(Number.isInteger))];
+  const text = String(subject || '');
+  const numbers = [
+    ...[...text.matchAll(/\(#(\d+)\)/g)],
+    ...[...text.matchAll(/\bMerge pull request #(\d+)\b/g)],
+  ].map((match) => Number(match[1]));
+  return [...new Set(numbers.filter(Number.isInteger))];
 }
 
 // `%x1f` between fields and `%x1e` between records: both are ASCII separators
@@ -362,7 +380,15 @@ function collectPullRequests(repo, commits) {
       number,
       title: detail.title || fallbackTitle,
       url: detail.url || `https://github.com/${repo}/pull/${number}`,
-      author: detail.author?.login || commitsForPr.at(-1)?.authorName || null,
+      // A LOGIN OR NOTHING. `formatHandleList` prefixes whatever lands here
+      // with "@", so falling back to the commit's display name — as this did —
+      // publishes dead mentions like "@Jarno de Vries". The fallback fires
+      // exactly when `gh pr view` failed, which is the rate-limit and
+      // deleted-fork case this function is built to survive, so it is not rare.
+      // `authorName` below keeps the human-readable name for anything that
+      // wants to show it without pretending it is a handle.
+      author: detail.author?.login || null,
+      authorName: commitsForPr.at(-1)?.authorName || null,
       mergedAt: detail.mergedAt || commitsForPr.at(-1)?.authoredAt || null,
       labels: (detail.labels || []).map((label) => label.name || label).filter(Boolean),
       body: trimBody(detail.body),
@@ -569,6 +595,14 @@ async function summarizeWithOpenAi(request) {
     throw new Error(`OpenAI Responses API failed (${response.status}): ${json?.error?.message || body}`);
   }
 
+  // A 2xx that is not JSON — a proxy's HTML error page is the usual one.
+  // Without this, `extractResponseText(null)` throws "Cannot read properties of
+  // null", the raw body never reaches the log, and the release run reports a
+  // TypeError instead of what the API actually sent back.
+  if (!json) {
+    throw new Error(`OpenAI Responses API returned a non-JSON body (${response.status}): ${body.slice(0, 500)}`);
+  }
+
   const text = extractResponseText(json);
   if (!text) {
     throw new Error('OpenAI response did not contain output text');
@@ -694,9 +728,19 @@ export function groupPullRequestsByHighlight(pullRequests) {
     },
   ];
 
+  // Anchored to a WORD START, not a bare substring. `includes` put anything
+  // saying "support", "important" or "export" under Ledgers (via `port`), and
+  // anything saying "efficient" or "precision" under Desktop (via `ci`) — a PR
+  // filed under a heading that has nothing to do with it. Anchoring only the
+  // start keeps prefix keywords (`notariz`) and plurals (`skill` → `skills`)
+  // working, which a full `\b…\b` on both ends would break.
   for (const pr of pullRequests) {
     const haystack = `${pr.title} ${(pr.labels || []).join(' ')}`.toLowerCase();
-    const group = groups.find((candidate) => candidate.keywords.some((keyword) => haystack.includes(keyword)));
+    const group = groups.find((candidate) =>
+      candidate.keywords.some((keyword) =>
+        new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(keyword)}`).test(haystack),
+      ),
+    );
     (group || groups.at(-1)).pullRequests.push(pr);
   }
 

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -171,15 +171,35 @@ function resolveEndRef(to) {
 // The most recent RELEASE, not the most recent tag: the tag being published is
 // usually already pushed by the time this runs, so `git describe` would resolve
 // the start of the range to its end and produce an empty document.
+//
+// THE FIRST RELEASE has no previous one, and `gh release view` exits non-zero
+// rather than empty in that case. Falling back to the root commit is what makes
+// `--from latest-release` a safe default for a repository that has never cut a
+// release — which `tinyhumansai/opencompany` was when this landed. The range is
+// then the entire history, so the run is slow (one `gh pr view` per PR) and the
+// payload is shed hard by `serializeOpenAiPayload`; pass an explicit `--from`
+// for a first release you actually want to read.
 function resolveStartRef(repo, from) {
   if (from !== 'latest-release') {
     return from;
   }
-  const tag = runGh(['release', 'view', '--repo', repo, '--json', 'tagName', '--jq', '.tagName']);
-  if (!tag) {
-    throw new Error(`Could not resolve latest GitHub Release tag for ${repo}`);
+  let tag = '';
+  try {
+    tag = runGh(['release', 'view', '--repo', repo, '--json', 'tagName', '--jq', '.tagName'], {
+      allowFailure: true,
+    });
+  } catch {
+    tag = '';
   }
-  return tag;
+  if (tag) {
+    return tag;
+  }
+  const root = runGit(['rev-list', '--max-parents=0', 'HEAD']).split('\n').at(-1)?.trim();
+  if (!root) {
+    throw new Error(`No GitHub Release for ${repo} and no root commit to fall back to`);
+  }
+  console.error(`[release-notes] No previous release for ${repo}; ranging from the root commit ${root.slice(0, 9)}.`);
+  return root;
 }
 
 // A shallow clone is the usual cause of a miss here, and its failure mode is

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -526,7 +526,24 @@ export function serializeOpenAiPayload(payload) {
     return compactPayload;
   }
 
-  const bounded = { ...compact, pullRequests: [], omittedPullRequests: compact.pullRequests.length };
+  // The retained collections are trimmed FIRST. Spreading `compact` unchanged
+  // kept every contributor and every uncategorized commit, and only PRs were
+  // ever removed by the loop below — so a payload whose bulk was not PRs could
+  // never get under the cap no matter how many it dropped. On a first-release
+  // range that is not hypothetical: ~8,700 uncategorized commits serialize to
+  // roughly 900k characters against a 120k ceiling, and the request is rejected
+  // for size after the PRs it was supposed to describe have all been thrown
+  // away. Counts are kept so the model can say what was omitted.
+  const KEEP_UNCATEGORIZED = 25;
+  const bounded = {
+    ...compact,
+    contributors: compact.contributors.filter((contributor) => contributor.isNew),
+    omittedContributors: compact.contributors.filter((contributor) => !contributor.isNew).length,
+    uncategorizedCommits: compact.uncategorizedCommits.slice(0, KEEP_UNCATEGORIZED),
+    omittedUncategorizedCommits: Math.max(0, compact.uncategorizedCommits.length - KEEP_UNCATEGORIZED),
+    pullRequests: [],
+    omittedPullRequests: compact.pullRequests.length,
+  };
   for (const pullRequest of compact.pullRequests) {
     bounded.pullRequests.push(pullRequest);
     bounded.omittedPullRequests -= 1;
@@ -814,15 +831,28 @@ async function main() {
   }
 
   const repo = resolveRepo(options.repo);
-  const from = resolveStartRef(repo, options.from);
+  const { ref: from, fromRoot } = resolveStartRef(repo, options.from);
   const resolvedTo = resolveEndRef(options.to);
 
   assertRefExists(from, 'Start');
   assertRefExists(resolvedTo, 'End');
 
   console.error(`[release-notes] Collecting ${repo} changes from ${from} to ${resolvedTo}`);
-  const commits = collectCommits(from, resolvedTo);
-  const contributors = collectContributorStats(commits, priorAuthorKeys(from));
+  const commits = collectCommits(from, resolvedTo, fromRoot);
+
+  // An EMPTY RANGE is an error, not a document. Re-dispatching a release whose
+  // tag is already the latest published one makes start and end the same
+  // commit, and without this the generator cheerfully renders "0 PRs across 0
+  // commits" and `release.yml` publishes that as the release body. Failing here
+  // takes the deterministic fallback down with it, which is the intent: the
+  // range is wrong, and a release should not be cut with empty notes.
+  if (commits.length === 0) {
+    throw new Error(
+      `No commits between ${from} and ${resolvedTo} — nothing to write release notes about. Pass a --from that precedes the tag.`,
+    );
+  }
+
+  const contributors = collectContributorStats(commits, priorAuthorKeys(from, fromRoot));
   const pullRequests = collectPullRequests(repo, commits);
   const payload = buildReleasePayload({
     from,

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -269,8 +269,19 @@ function priorAuthorKeys(from) {
   return keys;
 }
 
+// Keyed on the DISPLAY NAME, not name+email as OpenHuman's original does.
+// Contributors here routinely commit under two addresses — a personal one and
+// GitHub's `…@users.noreply.github.com` — and a name+email key lists them
+// twice: once carrying their PRs, once as a bare credit line with none. Worse,
+// the second row also reads as a first-time contributor, so the same person is
+// welcomed to a project they have been committing to for months.
+//
+// Two distinct people sharing a display name would merge, which is the cost.
+// For a credits list that is the cheaper mistake, and the email is still on the
+// record for anyone who needs to tell them apart.
 export function authorKey(author) {
-  return `${String(author.authorName || '').toLowerCase()} <${String(author.authorEmail || '').toLowerCase()}>`;
+  const name = String(author.authorName || '').trim().toLowerCase();
+  return name || String(author.authorEmail || '').trim().toLowerCase();
 }
 
 export function collectContributorStats(commits, priorKeys) {

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -181,7 +181,7 @@ function resolveEndRef(to) {
 // for a first release you actually want to read.
 function resolveStartRef(repo, from) {
   if (from !== 'latest-release') {
-    return from;
+    return { ref: from, fromRoot: false };
   }
   let tag = '';
   try {
@@ -192,14 +192,20 @@ function resolveStartRef(repo, from) {
     tag = '';
   }
   if (tag) {
-    return tag;
+    return { ref: tag, fromRoot: false };
   }
   const root = runGit(['rev-list', '--max-parents=0', 'HEAD']).split('\n').at(-1)?.trim();
   if (!root) {
     throw new Error(`No GitHub Release for ${repo} and no root commit to fall back to`);
   }
-  console.error(`[release-notes] No previous release for ${repo}; ranging from the root commit ${root.slice(0, 9)}.`);
-  return root;
+  console.error(`[release-notes] No previous release for ${repo}; ranging over the full history from ${root.slice(0, 9)}.`);
+  // `fromRoot` matters because `A..B` is EXCLUSIVE of A. Ranging `root..tag`
+  // for a first release drops the repository's very first commit from notes
+  // that claim to cover everything, and worse, puts its author in the
+  // prior-author set — so the person who made the first commit is the one
+  // contributor the first release does not credit. Callers use this flag to
+  // range over the whole history instead.
+  return { ref: root, fromRoot: true };
 }
 
 // A shallow clone is the usual cause of a miss here, and its failure mode is
@@ -266,16 +272,22 @@ export function parseGitLog(logText) {
     });
 }
 
-function collectCommits(from, to) {
+function collectCommits(from, to, fromRoot = false) {
   const format = '%H%x1f%s%x1f%an%x1f%ae%x1f%aI%x1e';
-  const output = runGit(['log', `${from}..${to}`, '--reverse', `--format=${format}`]);
+  // `git log <to>` rather than `<root>..<to>`, so the root commit is included.
+  const range = fromRoot ? [to] : [`${from}..${to}`];
+  const output = runGit(['log', ...range, '--reverse', `--format=${format}`]);
   return parseGitLog(output);
 }
 
 // Everything reachable from the START of the range. Anyone absent from this set
 // is a first-time contributor, which is the fact the built-in generator cannot
 // produce.
-function priorAuthorKeys(from) {
+function priorAuthorKeys(from, fromRoot = false) {
+  // Nothing precedes a first release, so EVERY contributor in it is a new one.
+  if (fromRoot) {
+    return new Set();
+  }
   const output = runGit(['log', from, '--format=%an%x1f%ae%x1e']);
   const keys = new Set();
   for (const entry of output.split('\x1e')) {

--- a/scripts/release/generate-release-notes.test.mjs
+++ b/scripts/release/generate-release-notes.test.mjs
@@ -13,6 +13,7 @@ import { test } from 'node:test';
 
 import {
   buildOpenAiRequest,
+  serializeOpenAiPayload,
   buildReleasePayload,
   collectContributorStats,
   ensureAllPullRequestsLinked,
@@ -57,6 +58,23 @@ test('extractPullRequestNumbers takes the merge PR last', () => {
   assert.deepEqual(extractPullRequestNumbers('fix: thing (#12)'), [12]);
   assert.deepEqual(extractPullRequestNumbers('fix: closes (#12) (#34)'), [12, 34]);
   assert.deepEqual(extractPullRequestNumbers('chore: no pr'), []);
+});
+
+test('extractPullRequestNumbers reads regular merge-commit subjects', () => {
+  // This repository merges most PRs with a merge commit, not a squash: 25 of
+  // the last 200 subjects are this shape and carry no parenthesized number at
+  // all. Matching only `(#N)` dropped every one of them — unfetched, unlinked,
+  // and uncredited.
+  assert.deepEqual(
+    extractPullRequestNumbers('Merge pull request #1731 from theamazinghenk/feat/company-logo-backend'),
+    [1731],
+  );
+  // Both forms present: the merge is the PR, so it must be last and therefore
+  // primary. A `(#12)` inside is the issue the branch referenced.
+  assert.deepEqual(extractPullRequestNumbers('Merge pull request #34 from a/fix-(#12)'), [12, 34]);
+  assert.deepEqual(parseGitLog(
+    ['m1', 'Merge pull request #1731 from x/y', 'Ada', 'a@e.com', '2026-08-01T00:00:00Z'].join('\x1f'),
+  )[0].primaryPrNumber, 1731);
 });
 
 test('parseGitLog splits on ASCII separators', () => {
@@ -234,4 +252,61 @@ test('buildOpenAiRequest tells the model that contributor names are not handles'
   assert.equal(request.model, 'gpt-5.2');
   assert.match(request.input[1].content, /DISPLAY NAME, not a GitHub handle/);
   assert.match(request.input[1].content, /Never prefix it with "@"/);
+});
+
+test('groupPullRequestsByHighlight anchors keywords to word starts', () => {
+  // `includes` filed anything saying "support" under Ledgers (via `port`) and
+  // anything saying "efficient" under Desktop (via `ci`).
+  const prs = [
+    { number: 1, title: 'feat: add support for wide screens', url: 'u1', labels: [] },
+    { number: 2, title: 'perf: more efficient rendering', url: 'u2', labels: [] },
+  ];
+
+  const groups = groupPullRequestsByHighlight(prs);
+  const titleFor = (n) => groups.find((g) => g.pullRequests.some((pr) => pr.number === n)).title;
+  assert.doesNotMatch(titleFor(1), /Ledgers/);
+  assert.doesNotMatch(titleFor(2), /Desktop/);
+
+  // Prefix and plural keywords must still match.
+  const stillMatched = groupPullRequestsByHighlight([
+    { number: 3, title: 'chore: notarize the dmg', url: 'u3', labels: [] },
+    { number: 4, title: 'feat: new skills surface', url: 'u4', labels: [] },
+  ]);
+  assert.match(stillMatched.find((g) => g.pullRequests.some((pr) => pr.number === 3)).title, /Desktop/);
+  assert.match(stillMatched.find((g) => g.pullRequests.some((pr) => pr.number === 4)).title, /Companies/);
+});
+
+test('serializeOpenAiPayload trims non-PR collections to reach the cap', () => {
+  // A first-release range is mostly uncategorized commits. Trimming only PRs
+  // could never get under the ceiling, so the request was rejected for size
+  // after discarding the very PRs it existed to describe.
+  const payload = {
+    repo: 'tinyhumansai/opencompany',
+    range: { from: 'root', to: 'v1', resolvedTo: 'v1', compareUrl: 'https://x/compare' },
+    totals: { commits: 9000, pullRequests: 2, contributors: 400, newContributors: 1 },
+    contributors: Array.from({ length: 400 }, (_, i) => ({
+      name: `Person ${i}`,
+      commits: 1,
+      prs: [],
+      isNew: i === 0,
+    })),
+    pullRequests: [
+      { number: 1, title: 'a', url: 'https://x/1', author: 'ada', labels: [], body: 'b'.repeat(600), commits: [] },
+      { number: 2, title: 'b', url: 'https://x/2', author: 'bo', labels: [], body: 'b'.repeat(600), commits: [] },
+    ],
+    uncategorizedCommits: Array.from({ length: 8700 }, (_, i) => ({
+      sha: String(i),
+      subject: 'chore: something reasonably wordy '.repeat(3),
+      authorName: `Person ${i % 400}`,
+    })),
+  };
+
+  const serialized = serializeOpenAiPayload(payload);
+  assert.ok(serialized.length <= 120_000, `payload still ${serialized.length} chars`);
+
+  const parsed = JSON.parse(serialized);
+  assert.ok(parsed.uncategorizedCommits.length < 8700);
+  assert.ok(parsed.omittedUncategorizedCommits > 0);
+  // The PRs are what the notes are about — they must survive the trim.
+  assert.equal(parsed.pullRequests.length, 2);
 });

--- a/scripts/release/generate-release-notes.test.mjs
+++ b/scripts/release/generate-release-notes.test.mjs
@@ -1,0 +1,204 @@
+// `node --test scripts/release/` — no test framework, no dependency, because
+// this directory has no package.json and adding one to run four assertions
+// would put a second npm project in a repository that has exactly one
+// (`frontend/`). Run in CI by the `Console` job, alongside the other
+// repository-wide policy checks.
+//
+// Only the pure functions are covered. `collectCommits`, `fetchPullRequest`
+// and `summarizeWithOpenAi` shell out to git/gh or the network and are not
+// exported; what they produce is a plain object, and every transformation
+// applied to it after that point is tested here.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildReleasePayload,
+  collectContributorStats,
+  ensureAllPullRequestsLinked,
+  extractPullRequestNumbers,
+  extractResponseText,
+  formatHandleList,
+  groupPullRequestsByHighlight,
+  parseArgs,
+  parseGitHubRepoFromRemote,
+  parseGitLog,
+  releaseTitle,
+  renderDeterministicNotes,
+  trimBody,
+} from './generate-release-notes.mjs';
+
+test('parseArgs defaults and overrides', () => {
+  const defaults = parseArgs([]);
+  assert.equal(defaults.from, 'latest-release');
+  assert.equal(defaults.to, 'latest-tag');
+  assert.equal(defaults.noAi, false);
+
+  const custom = parseArgs(['--from', 'v0.1.0', '--to', 'main', '--no-ai', '-o', 'notes.md']);
+  assert.equal(custom.from, 'v0.1.0');
+  assert.equal(custom.to, 'main');
+  assert.equal(custom.noAi, true);
+  assert.equal(custom.output, 'notes.md');
+
+  assert.throws(() => parseArgs(['--nope']), /Unknown option/);
+  // A flag swallowing the next flag as its value is the silent failure here:
+  // `--from --no-ai` would otherwise set from='--no-ai' and produce an empty range.
+  assert.throws(() => parseArgs(['--from', '--no-ai']), /requires a value/);
+});
+
+test('parseGitHubRepoFromRemote handles ssh and https', () => {
+  assert.equal(parseGitHubRepoFromRemote('git@github.com:tinyhumansai/opencompany.git'), 'tinyhumansai/opencompany');
+  assert.equal(parseGitHubRepoFromRemote('https://github.com/tinyhumansai/opencompany'), 'tinyhumansai/opencompany');
+  assert.equal(parseGitHubRepoFromRemote('https://gitlab.com/a/b.git'), null);
+  assert.equal(parseGitHubRepoFromRemote(''), null);
+});
+
+test('extractPullRequestNumbers takes the merge PR last', () => {
+  assert.deepEqual(extractPullRequestNumbers('fix: thing (#12)'), [12]);
+  assert.deepEqual(extractPullRequestNumbers('fix: closes (#12) (#34)'), [12, 34]);
+  assert.deepEqual(extractPullRequestNumbers('chore: no pr'), []);
+});
+
+test('parseGitLog splits on ASCII separators', () => {
+  const log = [
+    ['aaaaaaaaaaaa1', 'feat: ledgers (#7)', 'Ada', 'ada@example.com', '2026-08-01T00:00:00Z'].join('\x1f'),
+    ['bbbbbbbbbbbb2', 'chore: tidy', 'Bo', 'bo@example.com', '2026-08-02T00:00:00Z'].join('\x1f'),
+  ].join('\x1e');
+
+  const commits = parseGitLog(log);
+  assert.equal(commits.length, 2);
+  assert.equal(commits[0].primaryPrNumber, 7);
+  assert.equal(commits[1].primaryPrNumber, null);
+  assert.equal(parseGitLog('   ').length, 0);
+});
+
+test('collectContributorStats flags first-time contributors', () => {
+  const commits = parseGitLog(
+    [
+      ['a1', 'feat: a (#1)', 'Ada', 'ada@example.com', '2026-08-01T00:00:00Z'].join('\x1f'),
+      ['b2', 'feat: b (#2)', 'Bo', 'bo@example.com', '2026-08-02T00:00:00Z'].join('\x1f'),
+      ['c3', 'feat: c (#3)', 'Ada', 'ada@example.com', '2026-08-03T00:00:00Z'].join('\x1f'),
+    ].join('\x1e'),
+  );
+  // Case-insensitive on purpose: git records whatever casing the author's
+  // config carries, and "Ada <ADA@example.com>" is not a new contributor.
+  const prior = new Set(['ada <ADA@example.com>'.toLowerCase()]);
+
+  const stats = collectContributorStats(commits, prior);
+  assert.deepEqual(
+    stats.map((s) => [s.name, s.commits, s.prs, s.isNew]),
+    [
+      ['Ada', 2, [1, 3], false],
+      ['Bo', 1, [2], true],
+    ],
+  );
+});
+
+test('groupPullRequestsByHighlight buckets by keyword and never drops a PR', () => {
+  const prs = [
+    { number: 1, title: 'feat: company logo backend', url: 'u1', labels: [] },
+    { number: 2, title: 'fix: ledger fold ordering', url: 'u2', labels: [] },
+    { number: 3, title: 'fix: run status legend', url: 'u3', labels: [] },
+    { number: 4, title: 'chore: notarize the dmg', url: 'u4', labels: [] },
+    { number: 5, title: 'something entirely unclassifiable', url: 'u5', labels: [] },
+  ];
+
+  const groups = groupPullRequestsByHighlight(prs);
+  const placed = groups.flatMap((group) => group.pullRequests.map((pr) => pr.number));
+  assert.deepEqual(placed.sort((a, b) => a - b), [1, 2, 3, 4, 5]);
+  assert.ok(groups.every((group) => group.pullRequests.length > 0));
+  // The unmatched PR falls into the last bucket rather than vanishing.
+  assert.ok(groups.at(-1).pullRequests.some((pr) => pr.number === 5));
+});
+
+test('renderDeterministicNotes emits every PR link and omits an empty new-contributor section', () => {
+  const commits = parseGitLog(
+    [
+      ['a1', 'feat: ledger fold (#1)', 'Ada', 'ada@example.com', '2026-08-01T00:00:00Z'].join('\x1f'),
+      ['b2', 'fix: console nav (#2)', 'Bo', 'bo@example.com', '2026-08-02T00:00:00Z'].join('\x1f'),
+    ].join('\x1e'),
+  );
+  const contributors = collectContributorStats(
+    commits,
+    new Set(['ada <ada@example.com>', 'bo <bo@example.com>']),
+  );
+  const pullRequests = [
+    { number: 1, title: 'feat: ledger fold', url: 'https://x/1', author: 'ada', labels: [], commits: [] },
+    { number: 2, title: 'fix: console nav', url: 'https://x/2', author: 'bo', labels: [], commits: [] },
+  ];
+  const payload = buildReleasePayload({
+    from: 'v0.1.0',
+    to: 'v0.2.0',
+    resolvedTo: 'v0.2.0',
+    repo: 'tinyhumansai/opencompany',
+    commits,
+    pullRequests,
+    contributors,
+  });
+
+  assert.equal(payload.totals.commits, 2);
+  assert.equal(payload.totals.newContributors, 0);
+  assert.equal(payload.range.compareUrl, 'https://github.com/tinyhumansai/opencompany/compare/v0.1.0...v0.2.0');
+
+  const markdown = renderDeterministicNotes({ title: releaseTitle('v0.1.0', 'v0.2.0', 'v0.2.0'), payload });
+  assert.match(markdown, /\[#1\]\(https:\/\/x\/1\)/);
+  assert.match(markdown, /\[#2\]\(https:\/\/x\/2\)/);
+  assert.match(markdown, /## Contributor Credits/);
+  assert.doesNotMatch(markdown, /## New Contributors/);
+  assert.match(markdown, /## Full Compare/);
+});
+
+test('renderDeterministicNotes celebrates first-time contributors when there are any', () => {
+  const commits = parseGitLog(
+    [['b2', 'fix: console nav (#2)', 'Bo', 'bo@example.com', '2026-08-02T00:00:00Z'].join('\x1f')].join('\x1e'),
+  );
+  const payload = buildReleasePayload({
+    from: 'v0.1.0',
+    to: 'v0.2.0',
+    resolvedTo: 'v0.2.0',
+    repo: 'tinyhumansai/opencompany',
+    commits,
+    pullRequests: [{ number: 2, title: 'fix: console nav', url: 'https://x/2', author: 'bo', labels: [], commits: [] }],
+    contributors: collectContributorStats(commits, new Set()),
+  });
+
+  const markdown = renderDeterministicNotes({ title: 'v0.1.0 to v0.2.0', payload });
+  assert.match(markdown, /## New Contributors/);
+  assert.match(markdown, /Welcome Bo!/);
+});
+
+test('ensureAllPullRequestsLinked appends only what the model dropped', () => {
+  const prs = [
+    { number: 1, title: 'a', url: 'https://x/1', author: 'ada' },
+    { number: 2, title: 'b', url: 'https://x/2', author: 'bo' },
+  ];
+  const complete = '# Notes\n\n[#1](https://x/1) and [#2](https://x/2)\n\n## Full Compare\n\nurl\n';
+  assert.equal(ensureAllPullRequestsLinked(complete, prs), complete);
+
+  const partial = '# Notes\n\n[#1](https://x/1)\n\n## Full Compare\n\nurl\n';
+  const repaired = ensureAllPullRequestsLinked(partial, prs);
+  assert.match(repaired, /### Additional highlights/);
+  assert.match(repaired, /\[#2\]\(https:\/\/x\/2\)/);
+  // Repaired in place, before the trailing sections — not stapled past them.
+  assert.ok(repaired.indexOf('Additional highlights') < repaired.indexOf('## Full Compare'));
+});
+
+test('formatHandleList reads as English at every length', () => {
+  assert.equal(formatHandleList(['a']), '@a');
+  assert.equal(formatHandleList(['a', 'b']), '@a and @b');
+  assert.equal(formatHandleList(['a', 'b', 'c']), '@a, @b, and @c');
+});
+
+test('trimBody strips PR-template comments and caps length', () => {
+  assert.equal(trimBody('<!-- template -->\nreal text'), 'real text');
+  assert.equal(trimBody(null), '');
+  assert.ok(trimBody('x'.repeat(5000)).length <= 700);
+});
+
+test('extractResponseText reads both Responses API shapes', () => {
+  assert.equal(extractResponseText({ output_text: 'hi' }), 'hi');
+  assert.equal(
+    extractResponseText({ output: [{ content: [{ text: 'a' }, { text: 'b' }] }] }),
+    'a\nb',
+  );
+  assert.equal(extractResponseText({}), '');
+});

--- a/scripts/release/generate-release-notes.test.mjs
+++ b/scripts/release/generate-release-notes.test.mjs
@@ -255,25 +255,29 @@ test('buildOpenAiRequest tells the model that contributor names are not handles'
 });
 
 test('groupPullRequestsByHighlight anchors keywords to word starts', () => {
-  // `includes` filed anything saying "support" under Ledgers (via `port`) and
-  // anything saying "efficient" under Desktop (via `ci`).
-  const prs = [
+  // `includes` filed anything saying "support" or "metadata" under Ledgers,
+  // via the `port` and `data` keywords. Note the last group doubles as the
+  // catch-all, so "not misfiled" is asserted against the SPECIFIC group the
+  // substring match wrongly chose, not against the fallback.
+  const titleFor = (groups, n) =>
+    groups.find((g) => g.pullRequests.some((pr) => pr.number === n)).title;
+
+  const misfiled = groupPullRequestsByHighlight([
     { number: 1, title: 'feat: add support for wide screens', url: 'u1', labels: [] },
-    { number: 2, title: 'perf: more efficient rendering', url: 'u2', labels: [] },
-  ];
+    { number: 2, title: 'fix: metadata handling', url: 'u2', labels: [] },
+  ]);
+  assert.doesNotMatch(titleFor(misfiled, 1), /Ledgers/);
+  assert.doesNotMatch(titleFor(misfiled, 2), /Ledgers/);
 
-  const groups = groupPullRequestsByHighlight(prs);
-  const titleFor = (n) => groups.find((g) => g.pullRequests.some((pr) => pr.number === n)).title;
-  assert.doesNotMatch(titleFor(1), /Ledgers/);
-  assert.doesNotMatch(titleFor(2), /Desktop/);
-
-  // Prefix and plural keywords must still match.
+  // Prefix and plural keywords must still match their real group.
   const stillMatched = groupPullRequestsByHighlight([
     { number: 3, title: 'chore: notarize the dmg', url: 'u3', labels: [] },
     { number: 4, title: 'feat: new skills surface', url: 'u4', labels: [] },
+    { number: 5, title: 'refactor: persistence ports', url: 'u5', labels: [] },
   ]);
-  assert.match(stillMatched.find((g) => g.pullRequests.some((pr) => pr.number === 3)).title, /Desktop/);
-  assert.match(stillMatched.find((g) => g.pullRequests.some((pr) => pr.number === 4)).title, /Companies/);
+  assert.match(titleFor(stillMatched, 3), /Desktop/);
+  assert.match(titleFor(stillMatched, 4), /Companies/);
+  assert.match(titleFor(stillMatched, 5), /Ledgers/);
 });
 
 test('serializeOpenAiPayload trims non-PR collections to reach the cap', () => {

--- a/scripts/release/generate-release-notes.test.mjs
+++ b/scripts/release/generate-release-notes.test.mjs
@@ -80,8 +80,8 @@ test('collectContributorStats flags first-time contributors', () => {
     ].join('\x1e'),
   );
   // Case-insensitive on purpose: git records whatever casing the author's
-  // config carries, and "Ada <ADA@example.com>" is not a new contributor.
-  const prior = new Set(['ada <ADA@example.com>'.toLowerCase()]);
+  // config carries, and "ADA" is not a new contributor.
+  const prior = new Set(['ADA'.toLowerCase()]);
 
   const stats = collectContributorStats(commits, prior);
   assert.deepEqual(
@@ -91,6 +91,25 @@ test('collectContributorStats flags first-time contributors', () => {
       ['Bo', 1, [2], true],
     ],
   );
+});
+
+test('collectContributorStats merges one person committing under two emails', () => {
+  // The real shape this guards: a contributor whose PR merges land under their
+  // personal address and whose web edits land under GitHub's noreply one. Keyed
+  // on name+email they appeared twice — once with the PRs, once as a bare line
+  // that also claimed to be a first-time contributor.
+  const commits = parseGitLog(
+    [
+      ['a1', 'feat: a (#1)', 'Ada', 'ada@example.com', '2026-08-01T00:00:00Z'].join('\x1f'),
+      ['a2', 'docs: b (#2)', 'Ada', '1234+ada@users.noreply.github.com', '2026-08-02T00:00:00Z'].join('\x1f'),
+    ].join('\x1e'),
+  );
+
+  const stats = collectContributorStats(commits, new Set(['ada']));
+  assert.equal(stats.length, 1);
+  assert.equal(stats[0].commits, 2);
+  assert.deepEqual(stats[0].prs, [1, 2]);
+  assert.equal(stats[0].isNew, false);
 });
 
 test('groupPullRequestsByHighlight buckets by keyword and never drops a PR', () => {
@@ -117,10 +136,7 @@ test('renderDeterministicNotes emits every PR link and omits an empty new-contri
       ['b2', 'fix: console nav (#2)', 'Bo', 'bo@example.com', '2026-08-02T00:00:00Z'].join('\x1f'),
     ].join('\x1e'),
   );
-  const contributors = collectContributorStats(
-    commits,
-    new Set(['ada <ada@example.com>', 'bo <bo@example.com>']),
-  );
+  const contributors = collectContributorStats(commits, new Set(['ada', 'bo']));
   const pullRequests = [
     { number: 1, title: 'feat: ledger fold', url: 'https://x/1', author: 'ada', labels: [], commits: [] },
     { number: 2, title: 'fix: console nav', url: 'https://x/2', author: 'bo', labels: [], commits: [] },

--- a/scripts/release/generate-release-notes.test.mjs
+++ b/scripts/release/generate-release-notes.test.mjs
@@ -12,6 +12,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  buildOpenAiRequest,
   buildReleasePayload,
   collectContributorStats,
   ensureAllPullRequestsLinked,
@@ -217,4 +218,20 @@ test('extractResponseText reads both Responses API shapes', () => {
     'a\nb',
   );
   assert.equal(extractResponseText({}), '');
+});
+
+test('buildOpenAiRequest tells the model that contributor names are not handles', () => {
+  // The first real release cut with this generator credited "@Cyrus Gray" and
+  // "@Jarno de Vries" — the model read `contributors[].name` as a GitHub login
+  // and @-prefixed a display name, producing dead mentions. Only
+  // `pullRequests[].author` is a handle.
+  const request = buildOpenAiRequest({
+    model: 'gpt-5.2',
+    title: 'v0.1.0 to v0.2.0',
+    payload: { contributors: [], pullRequests: [], uncategorizedCommits: [], totals: {}, range: {} },
+  });
+
+  assert.equal(request.model, 'gpt-5.2');
+  assert.match(request.input[1].content, /DISPLAY NAME, not a GitHub handle/);
+  assert.match(request.input[1].content, /Never prefix it with "@"/);
 });


### PR DESCRIPTION
## Summary

Two things, both about what a release actually produces.

**Signed, notarized DMGs.** `release-desktop-macos.yml` already had the whole
signing path built (issue #1732) but the six `APPLE_*` secrets it gates on were
never set on this repository, so `sign=true` failed the `guard` job every time
and no signed DMG was reachable. Those secrets — plus `OPENAI_API_KEY` for the
notes below — are now set at the repository level, taken from the same
Developer ID Application identity (`Steven Enamakel (V76768QVFE)`) that
OpenHuman ships with. No workflow change was needed for this half.

The app is a single-binary Tauri shell — no `externalBin`, no `frameworks`, no
extra `resources` — so `sign-and-notarize-macos.sh`'s top-level `codesign` is
sufficient here; OpenHuman's nested-framework pre-signing loop has nothing to
walk in this bundle, and `codesign --verify --deep --strict` would say so if
that changed.

**Dynamic release notes.** `release.yml` used `generate_release_notes: true`,
which emits a flat `* <title> by @who in <url>` list in merge order. Ported
OpenHuman's generator instead: it walks the same commit range, resolves each PR
through `gh`, groups the work into themed highlights, and names **first-time
contributors** — the one fact GitHub's built-in list cannot derive, because it
never reads history before the range.

- `scripts/release/generate-release-notes.mjs` — two renderers. `--no-ai`
  produces the whole document deterministically from keyword groups tracking
  this repo's own module surfaces (companies/agents, ledgers/storage, console,
  hosting/auth, desktop/docs). The OpenAI path only rewrites that same payload
  into prose, and `ensureAllPullRequestsLinked` re-appends anything the model
  dropped so no contributor loses credit to a summarisation choice.
- `release.yml` calls the AI path first with `continue-on-error`, then falls
  back to `--no-ai`. A missing or rate-limited `OPENAI_API_KEY` degrades the
  notes rather than failing the release, and the job log says which renderer
  ran.
- New `notes_from` / `notes_ai` dispatch inputs. `latest-release` falls back to
  the root commit when no release exists yet, so the default is safe on a
  repository that has never cut one — which this was.
- `fetch-depth: 0` and `ref: <tag>` on the checkout: the generator reads every
  author before the range, and a shallow `git log A..B` against an unknown A
  prints nothing and produces empty notes *green*.
- Hyphenated tags (`-rc.1`, `-beta.2`) are marked pre-release, so they do not
  become the "Latest release" that `--from latest-release` picks up next time.

### Divergences from the OpenHuman original

Contributors are keyed on display name rather than name+email. People here
routinely commit under both a personal address and GitHub's `…@users.noreply`
one, and the name+email key listed them twice — once carrying their PRs, once
as a bare credit line that *also* read as a first-time contributor. Two
distinct people sharing a display name would now merge; for a credits list that
is the cheaper mistake.

## Testing

- `node --test scripts/release/generate-release-notes.test.mjs` — 13 tests,
  covering arg parsing, remote parsing, the ASCII-separator git-log format,
  first-time-contributor detection, the two-email merge, highlight bucketing
  (including that no PR can be dropped), both renderer branches, and link
  repair. No framework and no `package.json`: the script has no dependencies,
  and adding an npm project under `scripts/` would put a second one in a repo
  that has exactly one.
- Wired into the `Console` CI job alongside the other repository-wide policy
  checks — Node-only and cheap — with `scripts/release/**` added to that job's
  path filter, or a PR editing only the generator would skip its own test.
- Smoke-tested against real history (`--from HEAD~25 --no-ai`): 16 PRs across
  401 commits, every PR linked exactly once, all five highlight groups
  populated.
- `./scripts/ci/assert-md-line-cap.sh` passes.

## Behavior changes

`release.yml` now checks out the tag being published rather than the dispatch
ref, so **the tag must exist before dispatching** — same rule
`release-desktop-macos.yml` already follows, and the reason is the same: an
unpinned checkout would build newer source and attach it to the older release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic and AI-assisted automatic release notes, including pull requests, contributors, highlights, and preserved links.
  * Added dry runs, file output, prerelease detection, and fallback handling.
  * Releases are now created as drafts for manual publishing.
  * Desktop artifacts are attached to draft releases and published after successful builds.

* **Bug Fixes**
  * Improved handling of missing metadata, unavailable AI generation, invalid references, and first releases.

* **Tests**
  * Added comprehensive release-note coverage and dedicated CI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->