### PR TITLE
design(console): let Overview's header say only what it needs to

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2745,7 +2745,6 @@ export function AppShell({
             <OperatorOverview
               client={client}
               company={company}
-              companyName={feed.status.name}
               feed={feed}
               scope={scope}
               // Issue #1015: re-read the run panels when a run parks or fails

--- a/frontend/src/views/OperatorOverview.tsx
+++ b/frontend/src/views/OperatorOverview.tsx
@@ -12,7 +12,6 @@ import { PageHeader } from "@/components/page-header";
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
-  companyName: string;
   feed: Pick<CompanyFeed, "approvals" | "queue">;
   scope: LocalScope;
   /**
@@ -48,7 +47,6 @@ const FAILED_READ_LIMIT = 200;
 export function OperatorOverview({
   client,
   company,
-  companyName,
   feed,
   scope,
   attemptEventTick,
@@ -243,8 +241,6 @@ export function OperatorOverview({
         gutter="px-5 sm:px-8"
         title="Overview"
         width="5xl"
-        eyebrow={companyName}
-        description="Start with the work that needs your judgment."
         actions={
           <a href="#/chat" className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90">
             <MessageSquare className="size-4" aria-hidden /> Start a conversation

--- a/frontend/test/unit/operator-overview.test.ts
+++ b/frontend/test/unit/operator-overview.test.ts
@@ -78,7 +78,6 @@ async function render(
       createElement(OperatorOverview, {
         client: host,
         company: "acme",
-        companyName: "Acme",
         feed,
         scope,
         ...(attemptEventTick === undefined ? {} : { attemptEventTick }),
@@ -173,7 +172,6 @@ describe("the operator overview landing page (#1321)", () => {
               url.includes("status=failed%2Cpaused") ? Promise.resolve([]) : Promise.resolve([run()]),
             ),
             company: "acme",
-            companyName: "Acme",
             feed: readyFeed,
             scope,
           }),
@@ -204,7 +202,6 @@ describe("the operator overview landing page (#1321)", () => {
         createElement(OperatorOverview, {
           client: client(Promise.resolve([])),
           company: "acme",
-          companyName: "Acme",
           feed: readyFeed,
           scope: scopeA,
         }),
@@ -223,7 +220,6 @@ describe("the operator overview landing page (#1321)", () => {
             url.includes("status=failed%2Cpaused") ? Promise.resolve([]) : Promise.resolve([failedAfterAOnly]),
           ),
           company: "acme",
-          companyName: "Acme",
           feed: readyFeed,
           scope: scopeB,
         }),
@@ -465,7 +461,6 @@ describe("the operator overview landing page (#1321)", () => {
         createElement(OperatorOverview, {
           client: host,
           company: "globex",
-          companyName: "Globex",
           feed: readyFeed,
           scope: { connection: "test-host", company: "globex" },
         }),


### PR DESCRIPTION
## What

The Overview header carried three lines where one does the work:

```
Agentic Marketing Agency        ← eyebrow
Overview                        ← title
Start with the work that needs your judgment.   ← description
```

Now it carries the title and its primary action.

## Why

**The eyebrow said what the sidebar already says.** `HostSwitcher` names the company on every page (`app-shell.tsx:2694`), so on the one page an operator lands on first, the company was named twice within a few hundred pixels. The name is not lost — it is still in the rail, once.

**The description described what the page demonstrates.** "Start with the work that needs your judgment" sits directly above the attention section, which *is* the work that needs their judgment. A sentence that narrates the thing immediately below it is a line the reader learns to skip, and it pushed the actual content down on the densest page in the console.

## Scope

`companyName` existed only to feed that eyebrow, so it goes with it rather than staying threaded through `app-shell.tsx` as an unused prop:

- `OperatorOverview.tsx` — eyebrow, description, and the prop from `Props` and the destructure
- `app-shell.tsx` — the `companyName={feed.status.name}` argument
- `operator-overview.test.ts` — the 5 lines passing it in

The title, the `Start a conversation` action, the `gutter` and the `width` are unchanged, so the page still satisfies the header guards from #1763 (`page-header-adoption`, `page-header-precedes-every-return`).

## Verification

- `npm run typecheck`, `typecheck:unit`, `typecheck:e2e` — all rc=0
- `npx vitest run` — 3553/3553
- Seen running in the desktop shell against this branch

## Not done

No screenshot in light mode yet — this was verified in the desktop app's dark theme only. Flagging rather than implying both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the company-name label from the Operator Overview page header.
  * Simplified the overview page display to rely on the existing company information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->